### PR TITLE
[RFR] Remove babel warnings on Jest preprocessor

### DIFF
--- a/jest-preprocessor.js
+++ b/jest-preprocessor.js
@@ -3,7 +3,7 @@ var babel = require('babel-core');
 module.exports = {
   process: function (src, filename) {
     if ((filename.indexOf('node_modules') === -1 || filename.indexOf('admin-config')) && babel.canCompile(filename)) {
-      return babel.transform(src, { filename: filename, stage: 1, retainLines: true }).code;
+      return babel.transform(src, { filename: filename, stage: 1, retainLines: true, compact: false }).code;
     }
 
     return src;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,12 @@ module.exports = {
         ]
     },
     plugins: [
-        new webpack.NoErrorsPlugin()
+        new webpack.NoErrorsPlugin(),
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                warnings: false
+            }
+        })
     ],
     node: {
         fs: "empty"


### PR DESCRIPTION
Removes `[BABEL] Note: The code generator has deoptimised the styling of ...` warning for Jest tests.