### PR TITLE
[RFR] Replace react-datepicker by react-bootstrap-datetimepicker

### DIFF
--- a/app/Component/Field/DateField.js
+++ b/app/Component/Field/DateField.js
@@ -21,15 +21,15 @@ class InputField extends React.Component {
 
     render() {
         let {value, type} = this.props;
-
         let format = this.getFormat(type);
-        if (value) {
-            value = typeof(value) === 'string' ? moment(value, format) : moment(value);
+
+        if (!value) {
+            value = moment().format(format);
         }
 
         const attributes = {
             mode: type,
-            dateTime: value.format(format),
+            dateTime: value,
             format: format,
             inputFormat: format,
             onChange: this.onChange.bind(this)

--- a/app/Component/Field/DateField.js
+++ b/app/Component/Field/DateField.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import moment from 'moment/moment';
 import DateTimePicker from 'react-bootstrap-datetimepicker';
+import classNames from 'classnames';
 
 class InputField extends React.Component {
-    getFormat() {
+    getFormat(type) {
         let {field} = this.props;
 
         let format = field.format();
         if (!format) {
-            format = field.type() === 'date' ? 'YYYY-MM-DD' : 'YYYY-MM-DD HH:mm:ss';
+            format = 'datetime' === type ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD';
         }
 
         return format;
@@ -19,26 +20,24 @@ class InputField extends React.Component {
     }
 
     render() {
-        let {value} = this.props;
+        let {value, type} = this.props;
 
-        let format = this.getFormat();
+        let format = this.getFormat(type);
         if (value) {
             value = typeof(value) === 'string' ? moment(value, format) : moment(value);
         }
 
-        let attributes = {
-            dateTime: value,
+        const attributes = {
+            mode: type,
+            dateTime: value.format(format),
             format: format,
             inputFormat: format,
             onChange: this.onChange.bind(this)
         };
-
-        if ('date' === this.props.field.type()) {
-            attributes.mode = 'date';
-        }
+        const className = classNames('row', { 'col-sm-5': 'datetime' === type, 'col-sm-4': 'date' === type });
 
         return (
-            <div className="row col-sm-4">
+            <div className={className}>
                 <DateTimePicker {...attributes} />
             </div>
         );

--- a/app/Component/Field/DateField.js
+++ b/app/Component/Field/DateField.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment/moment';
-import DatePicker from 'react-datepicker/dist/react-datepicker.js';
+import DateTimePicker from 'react-bootstrap-datetimepicker';
 
 class InputField extends React.Component {
     getFormat() {
@@ -15,7 +15,7 @@ class InputField extends React.Component {
     }
 
     onChange(date) {
-        this.props.updateField(this.props.name, date.format(this.getFormat()));
+        this.props.updateField(this.props.name, date);
     }
 
     render() {
@@ -25,13 +25,23 @@ class InputField extends React.Component {
         if (value) {
             value = typeof(value) === 'string' ? moment(value, format) : moment(value);
         }
-        let onChange = this.onChange.bind(this);
 
-        return <DatePicker
-            selected={value}
-            dateFormat={format}
-            onChange={onChange}
-            />;
+        let attributes = {
+            dateTime: value,
+            format: format,
+            inputFormat: format,
+            onChange: this.onChange.bind(this)
+        };
+
+        if ('date' === this.props.field.type()) {
+            attributes.mode = 'date';
+        }
+
+        return (
+            <div className="row col-sm-4">
+                <DateTimePicker {...attributes} />
+            </div>
+        );
     }
 }
 

--- a/app/Component/Field/DateField.js
+++ b/app/Component/Field/DateField.js
@@ -3,7 +3,7 @@ import moment from 'moment/moment';
 import DateTimePicker from 'react-bootstrap-datetimepicker';
 import classNames from 'classnames';
 
-class InputField extends React.Component {
+class DateField extends React.Component {
     getFormat(type) {
         let {field} = this.props;
 
@@ -44,11 +44,11 @@ class InputField extends React.Component {
     }
 }
 
-InputField.propTypes = {
+DateField.propTypes = {
     field: React.PropTypes.object.isRequired,
     name: React.PropTypes.object.isRequired,
     value: React.PropTypes.any,
     updateField: React.PropTypes.func
 };
 
-export default InputField;
+export default DateField;

--- a/app/Field/DateFieldView.js
+++ b/app/Field/DateFieldView.js
@@ -17,7 +17,7 @@ class DateFieldView {
     }
 
     static getWriteWidget() {
-        return <DateField type={"date"} name={this.props.fieldName} field={this.props.field} value={this.props.value} updateField={this.props.updateField} />;
+        return <DateField type={this.props.field.type()} name={this.props.fieldName} field={this.props.field} value={this.props.value} updateField={this.props.updateField} />;
     }
 }
 

--- a/e2e/editionViewSpec.js
+++ b/e2e/editionViewSpec.js
@@ -83,24 +83,24 @@ describe('EditionView', function () {
         beforeEach(function() {
             browser.get(browser.baseUrl + '#/posts/edit/12').then(function () {
                 browser.driver.wait(function () {
-                    return browser.driver.isElementPresent(by.css('.datepicker__input'));
+                    return browser.driver.isElementPresent(by.css('.react-admin-field-published_at input'));
                 }, 10000); // wait 10s
             });
         });
 
         it('allows update from a calendar', function () {
-            $('input.datepicker__input').click().then(function () {
+            $('.react-admin-field-published_at .input-group-addon').click().then(function () {
                 // Wait for calendar to display
                 browser.driver.wait(function () {
-                    return browser.driver.isElementPresent(by.css('.datepicker__month .datepicker__day--selected'));
+                    return browser.driver.isElementPresent(by.css('.react-admin-field-published_at .bootstrap-datetimepicker-widget td.active'));
                 }, 2000);
 
-                $('.datepicker__month .datepicker__day--selected + div').click().then(function () {
+                $('.react-admin-field-published_at .bootstrap-datetimepicker-widget td.active + td').click().then(function () {
                     // Wait for calendar to hide
                     var displayed = true;
                     browser.driver.wait(function () {
-                        browser.driver.isElementPresent(by.css('.datepicker__container')).then(function (present) {
-                            displayed = present;
+                        $('.react-admin-field-published_at .bootstrap-datetimepicker-widget').isDisplayed().then(function (value) {
+                            displayed = value;
                         });
 
                         return !displayed;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "object-assign": "^2.1.1",
     "pace": "HubSpot/pace",
     "protractor": "^2.1.0",
-    "react-datepicker": "^0.8.0",
+    "react-bootstrap-datetimepicker": "0.0.17",
     "react-hot-loader": "^1.2.7",
     "react-immutable-render-mixin": "^0.8.1",
     "react-select": "^0.4.9",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 function getEntrySources() {
-    var sources = ['humane-js/themes/flatty.css'];
+    var sources = [];
 
     if (process.env.NODE_ENV !== 'production') { // for live reload
         sources.push('webpack-dev-server/client?http://0.0.0.0:8080');
@@ -11,7 +11,8 @@ function getEntrySources() {
 
     // vendor sources
     sources.push('pace/themes/blue/pace-theme-flash.css');
-    sources.push('react-datepicker/dist/react-datepicker.css');
+    sources.push('humane-js/themes/flatty.css');
+    sources.push('react-bootstrap-datetimepicker/css/bootstrap-datetimepicker.min.css');
 
     // react-admin sources
     sources.push('./styles/react-select-bootstrap.css');


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/582446/8206137/22fa45e6-14f7-11e5-92b6-2b7aa1a73fe3.png)

Bootstrap style and possibitilty to set time.

`datetime` field type implementation:
![image](https://cloud.githubusercontent.com/assets/582446/8206991/6db2eeec-14fe-11e5-9858-4e3c91df1994.png)
