### PR TITLE
[RFR]: Allow filter for ReferenceManyField to be function that takes current record 

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
@@ -90,12 +90,13 @@ export class ReferenceManyFieldController extends Component {
     ) {
         const { crudGetManyReference } = this.props;
         const pagination = { page: 1, perPage };
+        const filterData = getFilterData(filter, record);
         const relatedTo = nameRelatedTo(
             reference,
             record[source],
             resource,
             target,
-            filter
+            filterData
         );
         crudGetManyReference(
             reference,
@@ -104,7 +105,7 @@ export class ReferenceManyFieldController extends Component {
             relatedTo,
             pagination,
             this.state.sort,
-            filter
+            filterData
         );
     }
 
@@ -135,7 +136,7 @@ ReferenceManyFieldController.propTypes = {
     basePath: PropTypes.string.isRequired,
     children: PropTypes.func.isRequired,
     crudGetManyReference: PropTypes.func.isRequired,
-    filter: PropTypes.object,
+    filter: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     ids: PropTypes.array,
     perPage: PropTypes.number,
     record: PropTypes.object,
@@ -158,13 +159,16 @@ ReferenceManyFieldController.defaultProps = {
     source: 'id',
 };
 
+const getFilterData = (filter, record) =>
+    typeof filter === 'function' ? filter(record) : filter;
+
 function mapStateToProps(state, props) {
     const relatedTo = nameRelatedTo(
         props.reference,
         props.record[props.source],
         props.resource,
         props.target,
-        props.filter
+        getFilterData(props.filter, props.record)
     );
     return {
         data: getReferences(state, props.reference, relatedTo),

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.js
@@ -96,6 +96,12 @@ ReferenceManyFieldView.propTypes = {
  * <ReferenceManyField filter={{ is_published: true }} reference="comments" target="post_id">
  *    ...
  * </ReferenceManyField>
+ *
+ * The `filter` prop also allows a function which accepts the current record as argument.
+ * @example
+ * <ReferenceManyField filter={ record => ({ user: record.user_id })} reference="comments" target="post_id">
+ *    ...
+ * </ReferenceManyField>
  */
 export const ReferenceManyField = ({ children, ...props }) => {
     if (React.Children.count(children) !== 1) {
@@ -122,7 +128,7 @@ ReferenceManyField.propTypes = {
     children: PropTypes.element.isRequired,
     classes: PropTypes.object,
     className: PropTypes.string,
-    filter: PropTypes.object,
+    filter: PropTypes.oneOfType([PropTypes.object,PropTypes.func]),
     label: PropTypes.string,
     perPage: PropTypes.number,
     record: PropTypes.object,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.js
@@ -128,7 +128,7 @@ ReferenceManyField.propTypes = {
     children: PropTypes.element.isRequired,
     classes: PropTypes.object,
     className: PropTypes.string,
-    filter: PropTypes.oneOfType([PropTypes.object,PropTypes.func]),
+    filter: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     label: PropTypes.string,
     perPage: PropTypes.number,
     record: PropTypes.object,


### PR DESCRIPTION
I need additional filters on the `ReferenceManyField ` which are based on the current record being edited.  This PR allows the user to supply a function to filter in the form of `record => filterObject`
