### PR TITLE
Add addLabel to Writing Your Own Field example

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -699,9 +699,14 @@ import PropTypes from 'prop-types';
 const TextField = ({ source, record = {} }) => <span>{record[source]}</span>;
 
 TextField.propTypes = {
+    addLabel: PropTypes.bool,
     label: PropTypes.string,
     record: PropTypes.object,
     source: PropTypes.string.isRequired,
+};
+
+TextField.defaultProps = {
+  addLabel: true,
 };
 
 export default TextField;


### PR DESCRIPTION
When people copy paste the current example they don't get the labels right away. By adding these lines to the example potential confusion is prevented.