### PR TITLE
Add optional sortBy to ReferenceField

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -137,6 +137,7 @@ ReferenceField.propTypes = {
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -35,9 +35,9 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={field.props.source === currentSort.field}
+                    active={(field.props.sortBy || field.props.source) === currentSort.field}
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
-                    data-sort={field.props.source}
+                    data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}
                 >
                     <FieldTitle

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -35,7 +35,10 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={(field.props.sortBy || field.props.source) === currentSort.field}
+                    active={
+                        (field.props.sortBy || field.props.source) ===
+                        currentSort.field
+                    }
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
                     data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}


### PR DESCRIPTION
#### Features
:rocket: Add optional sortBy to ReferenceField to sort by other than source of reference

I could think of two ways to solve issue #1361:
- Add an optional field to ReferenceField that is used to generate the link in case it is present and let it always sort by `source`.
- Add an optional field to ReferenceField that is used to sort by in case it is present and let the link always be generated by `source`.

I opted for the second option here but implementing the first is also possible. Please let me know what you think and if you have any preferences with regards to the API of this project.