### PR TITLE
Add optional sortBy to ReferenceField

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -901,8 +901,7 @@ export const UserList = (props) => (
 );
 ```
 
-<<<<<<< HEAD
-**Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked.
+**Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked. In case you use the `source` property for additional purposes, the sorting can be overridden by the `sortBy` property on any `Field` component.
 
 ## Adding Label To Custom Field Components In The Show View
 
@@ -1027,6 +1026,3 @@ const UserShow = props => (
 ```
 
 And now you can use a regular Field component, and the label displays correctly in the Show view.
-=======
-**Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked. In case you use the `source` property for additional purposes, the sorting can be overridden by the `sortBy` property on any `Field` component.
->>>>>>> Add sortBy to propTypes definition of all Field components and add docs

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -494,7 +494,7 @@ To change the link from the `<Edit>` page to the `<Show>` page, set the `linkTyp
 By default, `<ReferenceField>` is sorted by its `source`. To specify another attribute to sort by, set the `sortBy` prop to the according attribute's name.
 
 ```jsx
-<ReferenceField label="User" source="userId" reference="users" sortBy="name">
+<ReferenceField label="User" source="userId" reference="users" sortBy="user.name">
     <TextField source="name" />
 </ReferenceField>
 ```

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -233,7 +233,7 @@ import { FunctionField } from 'react-admin'
 <FunctionField label="Name" render={record => `${record.first_name} ${record.last_name}`} />
 ```
 
-**Tip**: Technically, you can omit the `source` property for the `<FunctionField>` since you provide the render function. However, providing a `source` will allow the datagrid to make the column sortable, since when a user clicks on a column, the datagrid uses the `source` prop as sort field.
+**Tip**: Technically, you can omit the `source` and `sortBy` properties for the `<FunctionField>` since you provide the render function. However, providing a `source` or a `sortBy` will allow the datagrid to make the column sortable, since when a user clicks on a column, the datagrid uses these properties to sort. Should you provide both, `sortBy` will override `source` for sorting the column.
 
 ## `<ImageField>`
 
@@ -468,7 +468,7 @@ export const PostList = (props) => (
 );
 ```
 
-With this configuration, `<ReferenceField>` wraps the user title in a link to the related user `<Edit>` page.
+With this configuration, `<ReferenceField>` wraps the user's name in a link to the related user `<Edit>` page.
 
 ![ReferenceField](./img/reference-field.png)
 
@@ -487,6 +487,14 @@ To change the link from the `<Edit>` page to the `<Show>` page, set the `linkTyp
 
 ```jsx
 <ReferenceField label="User" source="userId" reference="users" linkType="show">
+    <TextField source="name" />
+</ReferenceField>
+```
+
+By default, `<ReferenceField>` is sorted by its `source`. To specify another attribute to sort by, set the `sortBy` prop to the according attribute's name.
+
+```jsx
+<ReferenceField label="User" source="userId" reference="users" sortBy="name">
     <TextField source="name" />
 </ReferenceField>
 ```
@@ -893,6 +901,7 @@ export const UserList = (props) => (
 );
 ```
 
+<<<<<<< HEAD
 **Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked.
 
 ## Adding Label To Custom Field Components In The Show View
@@ -1018,3 +1027,6 @@ const UserShow = props => (
 ```
 
 And now you can use a regular Field component, and the label displays correctly in the Show view.
+=======
+**Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked. In case you use the `source` property for additional purposes, the sorting can be overridden by the `sortBy` property on any `Field` component.
+>>>>>>> Add sortBy to propTypes definition of all Field components and add docs

--- a/docs/List.md
+++ b/docs/List.md
@@ -333,6 +333,34 @@ export const PostList = (props) => (
 ```
 {% endraw %}
 
+### Specify Sort Field
+
+By default, a column is sorted by the `source` property. To define another attribute to sort by, set it via the `sortBy` property:
+
+{% raw %}
+```jsx
+// in src/posts.js
+import React from 'react';
+import { List, Datagrid, TextField } from 'react-admin';
+
+export const PostList = (props) => (
+    <List {...props}>
+        <Datagrid>
+            <ReferenceField label="Post" source="id" reference="posts" sortBy="title">
+                <TextField source="title" />
+            </ReferenceField>
+            <FunctionField
+                label="Author"
+                sortBy="last_name"
+                render={record => `${record.author.first_name} ${record.author.last_name}`}
+            />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+```
+{% endraw %}
+
 ### Permanent Filter
 
 You can choose to always filter the list, without letting the user disable this filter - for instance to display only published posts. Write the filter to be passed to the REST client in the `filter` props:

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldController.js
@@ -88,6 +88,7 @@ ReferenceArrayFieldController.propTypes = {
     record: PropTypes.object.isRequired,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string.isRequired,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-core/src/controller/field/ReferenceFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceFieldController.js
@@ -92,6 +92,7 @@ ReferenceFieldController.propTypes = {
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
     resource: PropTypes.string,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
@@ -146,6 +146,7 @@ ReferenceManyFieldController.propTypes = {
         field: PropTypes.string,
         order: PropTypes.oneOf(['ASC', 'DESC']),
     }),
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     target: PropTypes.string.isRequired,
     isLoading: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/field/ArrayField.js
+++ b/packages/ra-ui-materialui/src/field/ArrayField.js
@@ -10,7 +10,7 @@ const initialState = {
 
 /**
  * Display a collection
- * 
+ *
  * Ideal for embedded arrays of objects, e.g.
  * {
  *   id: 123
@@ -19,10 +19,10 @@ const initialState = {
  *     { name: 'bar' }
  *   ]
  * }
- * 
+ *
  * The child must be an iterator component
  * (like <Datagrid> or <SingleFieldList>).
- * 
+ *
  * @example Display all the backlinks of the current post as a <Datagrid>
  * // post = {
  * //   id: 123
@@ -60,7 +60,7 @@ const initialState = {
  *
  * If you need to render a collection in a custom way, it's often simpler
  * to write your own component:
- * 
+ *
  * @example
  *     const TagsField = ({ record }) => (
  *          <ul>
@@ -128,6 +128,7 @@ ArrayField.propTypes = {
     children: PropTypes.element.isRequired,
     record: PropTypes.object,
     resource: PropTypes.string,
+    sortBy: PropTypes.string,
     source: PropTypes.string,
 };
 

--- a/packages/ra-ui-materialui/src/field/BooleanField.js
+++ b/packages/ra-ui-materialui/src/field/BooleanField.js
@@ -27,6 +27,7 @@ BooleanField.propTypes = {
     headerClassName: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ChipField.js
+++ b/packages/ra-ui-materialui/src/field/ChipField.js
@@ -31,6 +31,7 @@ ChipField.propTypes = {
     className: PropTypes.string,
     classes: PropTypes.object,
     elStyle: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     record: PropTypes.object,
 };

--- a/packages/ra-ui-materialui/src/field/DateField.js
+++ b/packages/ra-ui-materialui/src/field/DateField.js
@@ -81,6 +81,7 @@ DateField.propTypes = {
     options: PropTypes.object,
     record: PropTypes.object,
     showTime: PropTypes.bool,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/EmailField.js
+++ b/packages/ra-ui-materialui/src/field/EmailField.js
@@ -22,6 +22,7 @@ EmailField.propTypes = {
     headerClassName: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/FileField.js
+++ b/packages/ra-ui-materialui/src/field/FileField.js
@@ -75,6 +75,7 @@ FileField.propTypes = {
     cellClassName: PropTypes.string,
     headerClassName: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     src: PropTypes.string,
     title: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/FunctionField.js
+++ b/packages/ra-ui-materialui/src/field/FunctionField.js
@@ -23,6 +23,7 @@ FunctionField.propTypes = {
     label: PropTypes.string,
     render: PropTypes.func.isRequired,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string,
 };
 

--- a/packages/ra-ui-materialui/src/field/ImageField.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.js
@@ -77,6 +77,7 @@ ImageField.propTypes = {
     headerClassName: PropTypes.string,
     classes: PropTypes.object,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     src: PropTypes.string,
     title: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/NumberField.js
+++ b/packages/ra-ui-materialui/src/field/NumberField.js
@@ -93,6 +93,7 @@ NumberField.propTypes = {
     options: PropTypes.object,
     record: PropTypes.object,
     textAlign: PropTypes.string,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.js
@@ -105,6 +105,7 @@ ReferenceArrayField.propTypes = {
     record: PropTypes.object.isRequired,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string.isRequired,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -137,6 +137,7 @@ ReferenceField.propTypes = {
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.js
@@ -128,6 +128,7 @@ ReferenceManyField.propTypes = {
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string.isRequired,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     sort: PropTypes.shape({
         field: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/RichTextField.js
+++ b/packages/ra-ui-materialui/src/field/RichTextField.js
@@ -47,6 +47,7 @@ RichTextField.propTypes = {
     headerClassName: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     stripTags: PropTypes.bool,
 };

--- a/packages/ra-ui-materialui/src/field/SelectField.js
+++ b/packages/ra-ui-materialui/src/field/SelectField.js
@@ -110,6 +110,7 @@ SelectField.propTypes = {
     optionValue: PropTypes.string.isRequired,
     resource: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translate: PropTypes.func.isRequired,
     translateChoice: PropTypes.bool.isRequired,

--- a/packages/ra-ui-materialui/src/field/TextField.js
+++ b/packages/ra-ui-materialui/src/field/TextField.js
@@ -20,6 +20,7 @@ TextField.propTypes = {
     headerClassName: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/UrlField.js
+++ b/packages/ra-ui-materialui/src/field/UrlField.js
@@ -22,6 +22,7 @@ UrlField.propTypes = {
     headerClassName: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/sanitizeRestProps.js
+++ b/packages/ra-ui-materialui/src/field/sanitizeRestProps.js
@@ -12,6 +12,7 @@ export default ({
     record,
     resource,
     sortable,
+    sortBy,
     source,
     textAlign,
     translateChoice,

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -36,7 +36,10 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={(field.props.sortBy || field.props.source) === currentSort.field}
+                    active={
+                        (field.props.sortBy || field.props.source) ===
+                        currentSort.field
+                    }
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
                     data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -36,10 +36,7 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={
-                        (field.props.sortBy || field.props.source) ===
-                        currentSort.field
-                    }
+                    active={currentSort.field === (field.props.sortBy || field.props.source)}
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
                     data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -36,9 +36,9 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={field.props.source === currentSort.field}
+                    active={(field.props.sortBy || field.props.source) === currentSort.field}
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
-                    data-sort={field.props.source}
+                    data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}
                 >
                     <FieldTitle

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -36,7 +36,10 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={currentSort.field === (field.props.sortBy || field.props.source)}
+                    active={
+                        currentSort.field ===
+                        (field.props.sortBy || field.props.source)
+                    }
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
                     data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}


### PR DESCRIPTION
Reopen of https://github.com/marmelab/react-admin/pull/1746

#### Features
:rocket: Add optional sortBy to ReferenceField to sort by other than source of reference

I could think of two ways to solve issue #1361:
- Add an optional field to ReferenceField that is used to generate the link in case it is present and let it always sort by `source`.
- Add an optional field to ReferenceField that is used to sort by in case it is present and let the link always be generated by `source`.

I opted for the second option here but implementing the first is also possible. Please let me know what you think and if you have any preferences with regards to the API of this project.