### PR TITLE
[RFR] Speed up webpack build in simple example

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -5,25 +5,24 @@
     "description": "",
     "main": "index.html",
     "scripts": {
-        "start":
-            "./node_modules/.bin/webpack-dev-server --progress --color --hot --watch --mode development",
-        "build":
-            "./node_modules/.bin/webpack-cli --color --mode development --hide-modules true",
+        "start": "./node_modules/.bin/webpack-dev-server --progress --color --hot --watch --mode development",
+        "build": "./node_modules/.bin/webpack-cli --color --mode development --hide-modules true",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "author": "",
     "license": "MIT",
     "devDependencies": {
+        "@material-ui/icons": "1.0.0-beta.42",
         "babel-core": "~6.26.0",
         "babel-loader": "~7.1.1",
         "babel-plugin-transform-react-jsx": "~6.24.1",
         "babel-polyfill": "~6.26.0",
         "babel-preset-react": "~6.24.1",
         "css-loader": "~0.28.4",
+        "hard-source-webpack-plugin": "^0.6.4",
         "html-loader": "~0.5.5",
         "html-webpack-plugin": "~3.2.0",
         "material-ui": "1.0.0-beta.42",
-        "@material-ui/icons": "1.0.0-beta.42",
         "ra-data-fakerest": "^2.0.0-RC1",
         "ra-input-rich-text": "^2.0.0-RC1",
         "ra-language-english": "^2.0.0-RC1",

--- a/examples/simple/webpack.config.js
+++ b/examples/simple/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 module.exports = {
     devtool: 'cheap-module-source-map',
@@ -26,6 +27,7 @@ module.exports = {
         new HtmlWebpackPlugin({
             template: './src/index.html',
         }),
+        new HardSourceWebpackPlugin(),
     ],
     resolve: {
         alias: {
@@ -35,7 +37,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-core',
-                'src'
+                'src',
             ),
             'ra-ui-materialui': path.join(
                 __dirname,
@@ -43,7 +45,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-ui-materialui',
-                'src'
+                'src',
             ),
             'react-admin': path.join(
                 __dirname,
@@ -51,7 +53,7 @@ module.exports = {
                 '..',
                 'packages',
                 'react-admin',
-                'src'
+                'src',
             ),
             'ra-data-fakerest': path.join(
                 __dirname,
@@ -59,7 +61,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-data-fakerest',
-                'src'
+                'src',
             ),
             'ra-input-rich-text': path.join(
                 __dirname,
@@ -67,7 +69,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-input-rich-text',
-                'src'
+                'src',
             ),
         },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4849,6 +4849,19 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+hard-source-webpack-plugin@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.6.4.tgz#d80575d42c53e6af6dadc92271577a61cda20b12"
+  dependencies:
+    lodash "^4.15.0"
+    mkdirp "^0.5.1"
+    node-object-hash "^1.2.0"
+    rimraf "^2.6.2"
+    tapable "^1.0.0-beta.5"
+    webpack-core "~0.6.0"
+    webpack-sources "^1.0.1"
+    write-json-file "^2.3.0"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -7182,6 +7195,10 @@ node-notifier@^5.0.2:
     semver "^5.4.1"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-object-hash@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.3.0.tgz#7f294f5afec6b08d713e40d40a95ec793e05baf3"
 
 node-polyglot@2.2.2:
   version "2.2.2"
@@ -9544,6 +9561,10 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-list-map@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
+
 source-map-resolve@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
@@ -9568,7 +9589,7 @@ source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.4.4:
+source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -9962,7 +9983,7 @@ tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
-tapable@^1.0.0:
+tapable@^1.0.0, tapable@^1.0.0-beta.5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
@@ -10619,6 +10640,13 @@ webpack-cli@~2.0.13:
     yeoman-environment "^2.0.0"
     yeoman-generator "^2.0.3"
 
+webpack-core@~0.6.0:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
+  dependencies:
+    source-list-map "~0.1.7"
+    source-map "~0.4.1"
+
 webpack-dev-middleware@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz#7ffd6d0192883c83d3f262e8d7dec822493c6166"
@@ -10887,7 +10915,7 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-json-file@^2.2.0:
+write-json-file@^2.2.0, write-json-file@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
   dependencies:


### PR DESCRIPTION
On my laptop:

- 1st run: 26s (no change)
- 2nd run: 4s

The plugin logs a warning in the console:

> DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

But, as it's already a [known issue](https://github.com/mzgoddard/hard-source-webpack-plugin/issues/299), we can imagine that it will be fixed in a minor release soon.