### PR TITLE
Remove 'label' class

### DIFF
--- a/packages/ra-ui-materialui/src/list/FilterButton.js
+++ b/packages/ra-ui-materialui/src/list/FilterButton.js
@@ -13,9 +13,6 @@ import Button from '../button/Button';
 
 const styles = {
     root: { display: 'inline-block' },
-    label: {
-        marginLeft: '0.5em',
-    },
 };
 
 export class FilterButton extends Component {


### PR DESCRIPTION
It does not seem to be used in the `<Button>` component.

Rather, it seems that a similar "paddingLeft" is used by default.

So its existence is deemed unnecessary.

Not sure about it though.
