### PR TITLE
[RFR] Fix typo in Authorization documentation

### DIFF
--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -54,14 +54,9 @@ export default (type, params) => {
         return localStorage.getItem('token') ? Promise.resolve() : Promise.reject();
     }
     if (type === AUTH_GET_PERMISSIONS) {
-        const token = localStorage.getItem('token');
-        if (!token) {
-            return Promise.reject();
-        }
         const role = localStorage.getItem('role');
-        Promise.resolve(role);
+        return role ? Promise.resolve(role) : Promise.reject();
     }
-
     return Promise.reject('Unkown method');
 };
 ```


### PR DESCRIPTION
In the documentation, there is no return in the `AUTH_GET_PERMISSIONS` part of the first example.

https://marmelab.com/react-admin/Authorization.html#configuring-the-auth-client