### PR TITLE
[RFR] Fix changing id type in accumulate

### DIFF
--- a/packages/ra-core/src/sideEffect/accumulate.js
+++ b/packages/ra-core/src/sideEffect/accumulate.js
@@ -15,11 +15,11 @@ const addIds = (resource, ids) => {
         debouncedIds[resource] = {};
     }
     ids.forEach(id => {
-        debouncedIds[resource][id] = true;
+        debouncedIds[resource][id] = id;
     }); // fast UNIQUE
 };
 const getIds = resource => {
-    const ids = Object.keys(debouncedIds[resource]);
+    const ids = Object.values(debouncedIds[resource]);
     delete debouncedIds[resource];
     return ids;
 };


### PR DESCRIPTION
## Issue that fixed:
When you use GraphQl, id as Int and ReferenceField in DataGrid you get error:
![image](https://user-images.githubusercontent.com/2392977/39647586-37ea39e6-4fe8-11e8-9490-76d4068a6769.png)

* Object.keys changes type of id to string 
* Object.values don't change type
* Uniqueness not affected