### PR TITLE
Fix RadioButtonGroupInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
@@ -1,13 +1,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { FormControlLabel, FormHelperText } from 'material-ui/Form';
+import {
+    FormControl,
+    FormControlLabel,
+    FormHelperText,
+} from 'material-ui/Form';
+import { InputLabel } from 'material-ui/Input';
 import Radio, { RadioGroup } from 'material-ui/Radio';
+import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
-import { addField, translate } from 'ra-core';
+import { addField, translate, FieldTitle } from 'ra-core';
 
-import Labeled from './Labeled';
 import sanitizeRestProps from './sanitizeRestProps';
+
+const styles = {
+    label: {
+        position: 'relative',
+    },
+};
 
 /**
  * An Input component for a radio button group, using an array of objects for the options
@@ -87,7 +98,7 @@ export class RadioButtonGroupInput extends Component {
             <FormControlLabel
                 key={get(choice, optionValue)}
                 value={get(choice, optionValue)}
-                control={<Radio />}
+                control={<Radio color="primary" />}
                 label={
                     translateChoice
                         ? translate(choiceName, { _: choiceName })
@@ -99,6 +110,7 @@ export class RadioButtonGroupInput extends Component {
 
     render() {
         const {
+            classes,
             className,
             label,
             resource,
@@ -119,32 +131,45 @@ export class RadioButtonGroupInput extends Component {
         const { touched, error, helperText = false } = meta;
 
         return (
-            <Labeled
-                {...sanitizeRestProps(rest)}
+            <FormControl
+                component="fieldset"
+                required={isRequired}
                 className={className}
-                label={label}
-                resource={resource}
-                onChange={this.handleChange}
-                source={source}
-                isRequired={isRequired}
+                margin="normal"
+                {...sanitizeRestProps(rest)}
             >
+                <InputLabel
+                    component="legend"
+                    shrink
+                    required={isRequired}
+                    className={classes.label}
+                >
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                </InputLabel>
+
                 <RadioGroup
                     name={source}
-                    defaultSelected={input.value}
                     value={input.value}
+                    onChange={this.handleChange}
                     {...options}
                 >
                     {choices.map(this.renderRadioButton)}
                 </RadioGroup>
                 {touched && error && <FormHelperText>{error}</FormHelperText>}
                 {helperText && <FormHelperText>{helperText}</FormHelperText>}
-            </Labeled>
+            </FormControl>
         );
     }
 }
 
 RadioButtonGroupInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
+    classes: PropTypes.object,
     className: PropTypes.string,
     input: PropTypes.object,
     isRequired: PropTypes.bool,
@@ -164,6 +189,7 @@ RadioButtonGroupInput.propTypes = {
 };
 
 RadioButtonGroupInput.defaultProps = {
+    classes: {},
     choices: [],
     options: {},
     optionText: 'name',
@@ -171,4 +197,6 @@ RadioButtonGroupInput.defaultProps = {
     translateChoice: true,
 };
 
-export default compose(addField, translate)(RadioButtonGroupInput);
+export default compose(addField, translate, withStyles(styles))(
+    RadioButtonGroupInput
+);

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.spec.js
@@ -25,7 +25,7 @@ describe('<RadioButtonGroupInput />', () => {
             <RadioButtonGroupInput {...defaultProps} input={{ value: '2' }} />
         );
         const RadioGroupElement = wrapper.find('RadioGroup').first();
-        assert.equal(RadioGroupElement.prop('defaultSelected'), '2');
+        assert.equal(RadioGroupElement.prop('value'), '2');
     });
 
     it('should use the input parameter value as the selected value', () => {


### PR DESCRIPTION
The underlying material-ui components have changed their API in a backwards-incompatible way, so the `<RadioButtonGroupInput>` didn't work in `master`.

Closes #1807 
