### PR TITLE
[RFR] Add responsive column to simple example

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -486,25 +486,35 @@ export const PostList = (props) => (
 );
 ```
 
-**Tip**: If you want to override the `header` and `cell` styles independently for each column, use the `headerStyle` and `style` props in `<Field>` components:
+**Tip**: If you want to override the `header` and `cell` styles independently for each column, use the `headerClassName` and `cellClassName` props in `<Field>` components. For instance, to hide a certain column on small screens:
 
-{% raw %}
 ```jsx
-export const PostList = (props) => (
+import { withStyles } from 'material-ui/styles';
+
+const styles = theme => ({
+    hiddenOnSmallScreens: {
+        [theme.breakpoints.down('md')]: {
+            display: 'none',
+        },
+    },
+});
+
+const PostList = ({ classes, ...props }) => (
     <List {...props}>
         <Datagrid>
             <TextField source="id" />
             <TextField source="title" />
             <TextField
                 source="views"
-                style={{ textAlign: 'right' }}
-                headerStyle={{ textAlign: 'right' }}
+                headerClassName={classes.hiddenOnSmallScreens}
+                cellClassName={classes.hiddenOnSmallScreens}
             />
         </Datagrid>
     </List>
 );
+
+export default withStyles(styles)(PostList);
 ```
-{% endraw %}
 
 ### Row Style Function
 

--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -57,15 +57,20 @@ const PostFilter = props => (
     </Filter>
 );
 
-const styles = {
+const styles = theme => ({
     title: {
         maxWidth: '20em',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
     },
+    hiddenOnSmallScreens: {
+        [theme.breakpoints.down('md')]: {
+            display: 'none',
+        },
+    },
     publishedAt: { fontStyle: 'italic' },
-};
+});
 
 const PostListBulkActions = props => (
     <BulkActions {...props}>
@@ -120,6 +125,8 @@ const PostList = withStyles(styles)(({ classes, ...props }) => (
                         label="Tags"
                         reference="tags"
                         source="tags"
+                        cellClassName={classes.hiddenOnSmallScreens}
+                        headerClassName={classes.hiddenOnSmallScreens}
                     >
                         <SingleFieldList>
                             <ChipField source="name" />


### PR DESCRIPTION
Hiding columns on small screens used to be a ng-admin feature. It's easy to replicate using only CSS in react-admin - here is how.

- [x] Add example
- [x] Add doc