### PR TITLE
Added in ability to create custom parameters

### DIFF
--- a/packages/ra-data-graphql-simple/src/index.js
+++ b/packages/ra-data-graphql-simple/src/index.js
@@ -12,6 +12,8 @@ export default options => {
         merge({}, defaultOptions, options)
     ).then(defaultDataProvider => {
         return (fetchType, resource, params) => {
+            const { customParameters } = options;
+            let customParams;
             // This provider does not support multiple deletions so instead we send multiple DELETE requests
             // This can be optimized using the apollo-link-batch-http link
             if (fetchType === DELETE_MANY) {
@@ -52,8 +54,11 @@ export default options => {
                     return { data };
                 });
             }
-
-            return defaultDataProvider(fetchType, resource, params);
+            
+            if (customParameters && typeof customParameters === 'function') {
+                customParams = customParameters(fetchType, resource, params)
+            }
+            return defaultDataProvider(fetchType, resource, customParams || params);
         };
     });
 };

--- a/packages/ra-data-graphql-simple/src/index.js
+++ b/packages/ra-data-graphql-simple/src/index.js
@@ -54,11 +54,14 @@ export default options => {
                     return { data };
                 });
             }
-            
             if (customParameters && typeof customParameters === 'function') {
-                customParams = customParameters(fetchType, resource, params)
+                customParams = customParameters(fetchType, resource, params);
             }
-            return defaultDataProvider(fetchType, resource, customParams || params);
+            return defaultDataProvider(
+                fetchType,
+                resource,
+                customParams || params
+            );
         };
     });
 };


### PR DESCRIPTION
customParameters option should take in a function.
In that function, you can do w/e with the provided data and return an object mirroring the params argument.

```javascript
console.log(params)
/*
{
     data: {someData},
     previousData: {someData},
     id
}
*/
```

```javascript
console.log(customParams)
/*
{
     data: {modifiedData},
     previousData: {someData},
     id
}
*/
```