### PR TITLE
Allow override of link and cache parameter in ra-data-graphql

### DIFF
--- a/packages/ra-data-graphql/src/buildApolloClient.js
+++ b/packages/ra-data-graphql/src/buildApolloClient.js
@@ -7,8 +7,8 @@ export default options => {
     }
 
     const { cache, link, uri, ...otherOptions } = options;
-    let finalLink = otherOptions.link;
-    let finalCache = otherOptions.cache;
+    let finalLink = link;
+    let finalCache = cache;
 
     if (!link && uri) {
         finalLink = new HttpLink({ uri });


### PR DESCRIPTION
I was having a hard time trying to set the Authorization header with ra-data-graphql-simple dataprovider. In buildApolloClient.js in ra-data-graphql the provided cache and link parameters in clientOptions are effectively ignored and setting link causes Apollo to complain about missing cache with "In order to initialize Apollo Client, you must specify link & cache properties on the config object.". This PR fixes the issue for me.

It seems to me like a simple mistake and not intended behavior, since "otherOptions" will never contain link or cache, so finalLink and finalCache will always be initialized to undefined here.