### PR TITLE
[RFR] Fix yarn.lock to match packages.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -85,7 +85,7 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@material-ui/core@1.0.0":
+"@material-ui/core@~1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.0.0.tgz#857b871038bb300f2d25594ce0cd250be944e71b"
   dependencies:
@@ -117,7 +117,7 @@
     scroll "^2.0.3"
     warning "^3.0.0"
 
-"@material-ui/icons@1.0.0":
+"@material-ui/icons@~1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.0.0.tgz#0cac779257de02538be8834e1b0e45b7cd2cb898"
   dependencies:


### PR DESCRIPTION
Just ran `yarn`, which I forgot to do after fa174b343599948ca5683f7aa3729cc6293dfee4