### PR TITLE
Support hosting react-admin from a sub-directory

### DIFF
--- a/packages/ra-core/src/CoreAdmin.js
+++ b/packages/ra-core/src/CoreAdmin.js
@@ -23,6 +23,7 @@ const CoreAdmin = ({
     customReducers = {},
     customSagas = [],
     customRoutes = [],
+    basename,
     dashboard,
     history,
     menu,
@@ -69,7 +70,7 @@ const CoreAdmin = ({
     return (
         <Provider store={store}>
             <TranslationProvider>
-                <ConnectedRouter history={routerHistory}>
+                <ConnectedRouter basename={basename} history={routerHistory}>
                     <Switch>
                         <Route
                             exact


### PR DESCRIPTION
react-router supports hosting from a non-root directory of a web host using a prop called `basename`.
The idea is to expose this prop so users[1] can optionally configure per recommended guidelines[2], [3].

This proposal is intended to be a starting point for this discussion - not "final".
`<Admin>` seems like the most obvious place to put this but of course let's chat - what makes sense to you?

[1] https://stackoverflow.com/questions/50402692/mount-react-admin-under-admin
[2] https://reacttraining.com/react-router/web/api/BrowserRouter/basename-string
[3] https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#building-for-relative-paths