### PR TITLE
[RFR] Memoize built-in validator to prevent some infinite renders

### DIFF
--- a/packages/ra-core/src/form/validate.js
+++ b/packages/ra-core/src/form/validate.js
@@ -1,3 +1,5 @@
+import lodashMemoize from 'lodash/memoize';
+
 /* eslint-disable no-underscore-dangle */
 /* @link http://stackoverflow.com/questions/46155/validate-email-address-in-javascript */
 const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; // eslint-disable-line no-useless-escape
@@ -18,82 +20,76 @@ const getMessage = (message, messageArgs, value, values, props) =>
               ...messageArgs,
           });
 
-export const required = (message = 'ra.validation.required') =>
+// If we define validation functions directly in JSX, it will
+// result in a new function at every render, and then trigger infinite re-render.
+// Hence, we memoize every built-in validator to prevent a "Maximum call stack" error.
+const memoize = fn => lodashMemoize(fn, (...args) => JSON.stringify(args));
+
+export const required = memoize((message = 'ra.validation.required') =>
     Object.assign(
         (value, values, props) =>
             isEmpty(value)
                 ? getMessage(message, undefined, value, values, props)
                 : undefined,
         { isRequired: true }
-    );
+    )
+);
 
-export const minLength = (min, message = 'ra.validation.minLength') => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && value.length < min
-        ? getMessage(message, { min }, value, values, props)
-        : undefined;
+export const minLength = memoize(
+    (min, message = 'ra.validation.minLength') => (value, values, props) =>
+        !isEmpty(value) && value.length < min
+            ? getMessage(message, { min }, value, values, props)
+            : undefined
+);
 
-export const maxLength = (max, message = 'ra.validation.maxLength') => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && value.length > max
-        ? getMessage(message, { max }, value, values, props)
-        : undefined;
+export const maxLength = memoize(
+    (max, message = 'ra.validation.maxLength') => (value, values, props) =>
+        !isEmpty(value) && value.length > max
+            ? getMessage(message, { max }, value, values, props)
+            : undefined
+);
 
-export const minValue = (min, message = 'ra.validation.minValue') => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && value < min
-        ? getMessage(message, { min }, value, values, props)
-        : undefined;
+export const minValue = memoize(
+    (min, message = 'ra.validation.minValue') => (value, values, props) =>
+        !isEmpty(value) && value < min
+            ? getMessage(message, { min }, value, values, props)
+            : undefined
+);
 
-export const maxValue = (max, message = 'ra.validation.maxValue') => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && value > max
-        ? getMessage(message, { max }, value, values, props)
-        : undefined;
+export const maxValue = memoize(
+    (max, message = 'ra.validation.maxValue') => (value, values, props) =>
+        !isEmpty(value) && value > max
+            ? getMessage(message, { max }, value, values, props)
+            : undefined
+);
 
-export const number = (message = 'ra.validation.number') => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && isNaN(Number(value))
-        ? getMessage(message, undefined, value, values, props)
-        : undefined;
+export const number = memoize(
+    (message = 'ra.validation.number') => (value, values, props) =>
+        !isEmpty(value) && isNaN(Number(value))
+            ? getMessage(message, undefined, value, values, props)
+            : undefined
+);
 
-export const regex = (pattern, message = 'ra.validation.regex') => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && typeof value === 'string' && !pattern.test(value)
-        ? getMessage(message, { pattern }, value, values, props)
-        : undefined;
+export const regex = memoize(
+    (pattern, message = 'ra.validation.regex') => (value, values, props) =>
+        !isEmpty(value) && typeof value === 'string' && !pattern.test(value)
+            ? getMessage(message, { pattern }, value, values, props)
+            : undefined
+);
 
-export const email = (message = 'ra.validation.email') =>
-    regex(EMAIL_REGEX, message);
+export const email = memoize((message = 'ra.validation.email') =>
+    regex(EMAIL_REGEX, message)
+);
 
 const oneOfTypeMessage = ({ list }, value, values, { translate }) => {
     translate('ra.validation.oneOf', {
         options: list.join(', '),
     });
 };
-export const choices = (list, message = oneOfTypeMessage) => (
-    value,
-    values,
-    props
-) =>
-    !isEmpty(value) && list.indexOf(value) === -1
-        ? getMessage(message, { list }, value, values, props)
-        : undefined;
+
+export const choices = memoize(
+    (list, message = oneOfTypeMessage) => (value, values, props) =>
+        !isEmpty(value) && list.indexOf(value) === -1
+            ? getMessage(message, { list }, value, values, props)
+            : undefined
+);


### PR DESCRIPTION
Refers to #1850. 

If we define validation functions directly in JSX, it will result in a new function at every render, and then trigger infinite re-render, as explained in [documentation](https://marmelab.com/react-admin/CreateEdit.html#validation). This PR memoizes every built-in validator to such an issue.

This way, we would be able to add some validations such as:

```js
<TextInput validate={required()} />
```

Instead of:

```js
const textValidation = required();
<TextInput validate={textValidation} />
```
Note it only affects react-admin validators. If we use some custom validators, we still need to pass via a variable. That's why I didn't update the documentation.