### PR TITLE
fix checkbox ripple height in Datagrid

### DIFF
--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -22,9 +22,7 @@ const styles = {
     headerCell: {
         padding: '0 12px',
     },
-    checkbox: {
-        height: 'auto',
-    },
+    checkbox: {},
     row: {},
     rowEven: {},
     rowOdd: {},


### PR DESCRIPTION
Before / after:
![checkbox-ripple-before](https://user-images.githubusercontent.com/13808724/40439650-3df356ac-5ec4-11e8-9376-17b0cb9fec9e.gif) ![checkbox-ripple-after](https://user-images.githubusercontent.com/13808724/40439654-420df5ee-5ec4-11e8-80a9-baf5e50d97ad.gif)
