### PR TITLE
[RFR] Fix SelectArrayInput Chip label should render same as selected menu item option

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -216,7 +216,9 @@ export class SelectArrayInput extends Component {
                                 .map(choice => (
                                     <Chip
                                         key={get(choice, optionValue)}
-                                        label={get(choice, optionText)}
+                                        label={this.renderMenuItemOption(
+                                            choice
+                                        )}
                                         className={classes.chip}
                                     />
                                 ))}


### PR DESCRIPTION
**Steps to reproduce**

- use `SelectArrayInput` with props `optionText` containing a function or a React element
- select one element: `Chip` will be empty

I don't know how to test this fix.