### PR TITLE
[RFR] Remove warnings when using CheckboxGroupInput into ReferenceArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
@@ -11,7 +11,9 @@ import { withStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import { addField, translate, FieldTitle } from 'ra-core';
 
-import sanitizeRestProps from './sanitizeRestProps';
+import defaultSanitizeRestProps from './sanitizeRestProps';
+const sanitizeRestProps = ({ setFilter, setPagination, setSort, ...rest }) =>
+    defaultSanitizeRestProps(rest);
 
 const styles = theme => ({
     root: {},


### PR DESCRIPTION
**Steps to reproduce:**

Using the following code:
```jsx
<ReferenceArrayInput source="tag_ids" reference="tags">
    <CheckboxGroupInput optionText="name" />
</ReferenceArrayInput>
```