### PR TITLE
[RFR] Fix global validation on TabbedForm

### DIFF
--- a/e2e/pages/EditPage.js
+++ b/e2e/pages/EditPage.js
@@ -75,11 +75,6 @@ export default url => driver => ({
         return input.sendKeys(value);
     },
 
-    async getInputValue(name) {
-        const input = await driver.findElement(this.elements.input(name));
-        return await input.getAttribute('value');
-    },
-
     clickInput(name) {
         const input = driver.findElement(this.elements.input(name));
         input.click();

--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -126,9 +126,11 @@ describe('Permissions', () => {
         it('in Edit page', async () => {
             await EditPage.navigate();
             assert.deepEqual(await EditPage.getTabs(), ['SUMMARY', 'SECURITY']);
-            assert.deepEqual(await EditPage.getFields(), ['id', 'name']);
-            await EditPage.gotoTab(2);
-            assert.deepEqual(await EditPage.getFields(), ['role']);
+            assert.deepEqual(await EditPage.getFields(), [
+                'id',
+                'name',
+                'role',
+            ]);
         });
     });
 });

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -4,8 +4,10 @@ import FormInput from './FormInput';
 
 const sanitizeRestProps = ({ label, icon, ...rest }) => rest;
 
-const FormTab = ({ children, ...rest }) => (
-    <span>
+const hiddenStyle = { display: 'none' };
+
+const FormTab = ({ children, hidden, ...rest }) => (
+    <span style={hidden ? hiddenStyle : null}>
         {React.Children.map(
             children,
             input =>
@@ -18,6 +20,7 @@ const FormTab = ({ children, ...rest }) => (
 
 FormTab.propTypes = {
     children: PropTypes.node,
+    hidden: PropTypes.bool,
 };
 
 export default FormTab;

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -138,15 +138,19 @@ export class TabbedForm extends Component {
                 </Tabs>
                 <Divider />
                 <div className={classes.form}>
+                    {/* All tabs are rendered (not only the one in focus), to allow validation
+                    on tabs not in focus. The tabs receive a `hidden` property, which they'll
+                    use to hide the tab using CSS if it's not the one in focus.
+                    See https://github.com/marmelab/react-admin/issues/1866 */}
                     {Children.map(
                         children,
                         (tab, index) =>
                             tab &&
-                            this.state.value === index &&
                             React.cloneElement(tab, {
                                 resource,
                                 record,
                                 basePath,
+                                hidden: this.state.value !== index,
                             })
                     )}
                     {toolbar &&

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
@@ -23,7 +23,9 @@ describe('<TabbedForm />', () => {
         const tabsContainer = wrapper.find('WithStyles(Tabs)');
         assert.equal(tabsContainer.length, 1);
         const tabs = wrapper.find('FormTab');
-        assert.equal(tabs.length, 1);
+        assert.equal(tabs.length, 2);
+        assert.equal(tabs.at(0).prop('hidden'), false);
+        assert.equal(tabs.at(1).prop('hidden'), true);
     });
 
     it('should display <Toolbar />', () => {

--- a/packages/ra-ui-materialui/src/input/ArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.spec.js
@@ -59,7 +59,7 @@ describe('<ArrayInput />', () => {
         const MockChild = () => <span />;
         const DummyForm = () => (
             <form>
-                <ArrayInput source="foo" record="record">
+                <ArrayInput source="foo" record={{ iAmRecord: true }}>
                     <MockChild />
                 </ArrayInput>
             </form>
@@ -70,7 +70,9 @@ describe('<ArrayInput />', () => {
                 <DummyFormRF />
             </AppMock>
         );
-        expect(wrapper.find(MockChild).props().record).toBe('record');
+        expect(wrapper.find(MockChild).props().record).toEqual({
+            iAmRecord: true,
+        });
     });
 
     it('should pass redux-form fields to child', () => {


### PR DESCRIPTION
Closes #1866

Cons: the whole form is rerendered on state change, and not only the active tab, so this will slow down Edition and Creation forms a bit... Nothing noticeable during my tests, though.