### PR TITLE
Update third-party module docs

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -12,9 +12,8 @@ title: "Ecosystem"
 
 ## Inputs and Fields
 
-- [dreinke/aor-color-input](https://github.com/dreinke/aor-color-input): a color input using [React Color](http://casesandberg.github.io/react-color/), a collection of color pickers.
+- [vascofg/react-admin-color-input](https://github.com/vascofg/react-admin-color-input): a color input using [React Color](http://casesandberg.github.io/react-color/), a collection of color pickers.
 - [LoicMahieu/aor-tinymce-input](https://github.com/LoicMahieu/aor-tinymce-input): a TinyMCE component, useful for editing HTML
-- [mhdsyrwan/aor-embedded-array](https://github.com/MhdSyrwan/aor-embedded-array): Field and Input for embedded arrays.
 
 ## Translations
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -1030,7 +1030,7 @@ const dateParser = v => {
 
 You can find components for react-admin in third-party repositories.
 
-* [dreinke/aor-color-input](https://github.com/dreinke/aor-color-input): a color input using [React Color](http://casesandberg.github.io/react-color/), a collection of color pickers.
+* [vascofg/react-admin-color-input](https://github.com/vascofg/react-admin-color-input): a color input using [React Color](http://casesandberg.github.io/react-color/), a collection of color pickers.
 * [LoicMahieu/aor-tinymce-input](https://github.com/LoicMahieu/aor-tinymce-input): a TinyMCE component, useful for editing HTML
 
 ## Writing Your Own Input Component


### PR DESCRIPTION
I've ported aor-color-input to react-admin v2.
Also removed aor-embedded-array from ecosystem since it's no longer required because of <ArrayInput>