### PR TITLE
[RFR] [Demo] Fix edit icon in product gridlist on smaller screens

### DIFF
--- a/examples/demo/src/products/GridList.js
+++ b/examples/demo/src/products/GridList.js
@@ -3,7 +3,10 @@ import MuiGridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
 import { withStyles } from '@material-ui/core/styles';
-import { NumberField, EditButton } from 'react-admin';
+import IconButton from '@material-ui/core/IconButton';
+import ContentCreate from '@material-ui/icons/Create';
+import { NumberField, Link } from 'react-admin';
+import { linkToRecord } from 'ra-core';
 
 const styles = {
     root: {
@@ -47,14 +50,13 @@ const GridList = ({ classes, ids, data, basePath }) => (
                             </span>
                         }
                         actionIcon={
-                            <EditButton
-                                basePath={basePath}
-                                record={data[id]}
-                                label=""
-                                classes={{
-                                    button: classes.link,
-                                }}
-                            />
+                            <IconButton
+                                to={linkToRecord(basePath, data[id].id)}
+                                className={classes.link}
+                                component={Link}
+                            >
+                                <ContentCreate />
+                            </IconButton>
                         }
                     />
                 </GridListTile>


### PR DESCRIPTION
As we were really not using the `<EditButton>` as it was intended to be used, I switched to a custom link. It has the benefit of illustrating how to create a link without the react-admin buttons.

Closes #1945 
