### PR TITLE
[RFR] Remove full-icu package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,15 +105,15 @@ test: build test-unit lint test-e2e ## launch all tests
 test-unit: ## launch unit tests
 	@if [ "$(CI)" != "true" ]; then \
 		echo "Running unit tests..."; \
-		NODE_ENV=test NODE_ICU_DATA=node_modules/full-icu ./node_modules/.bin/jest; \
+		NODE_ENV=test ./node_modules/.bin/jest; \
 	fi
 	@if [ "$(CI)" = "true" ]; then \
 		echo "Running unit tests in CI..."; \
-		NODE_ENV=test NODE_ICU_DATA=node_modules/full-icu ./node_modules/.bin/jest --runInBand; \
+		NODE_ENV=test ./node_modules/.bin/jest --runInBand; \
 	fi
 
 test-unit-watch: ## launch unit tests and watch for changes
-	@NODE_ENV=test NODE_ICU_DATA=node_modules/full-icu ./node_modules/.bin/jest --watch
+	@NODE_ENV=test ./node_modules/.bin/jest --watch
 
 test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "eslint-plugin-prettier": "~2.6.0",
         "eslint-plugin-react": "~7.7.0",
         "express": "~4.16.3",
-        "full-icu": "~1.2.1",
         "jest": "20.0.4",
         "lerna": "~2.9.1",
         "lolex": "~2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4786,10 +4786,6 @@ fsevents@^1.0.0, fsevents@^1.1.3, fsevents@^1.2.2:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-full-icu@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.2.1.tgz#28d7f1caafb14cac262364ca584fe7f2044a4ab2"
-
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
If the unit tests pass, it means that the node 10.5 installed on Travis is built with full icu by default, and we don't need the full_icu package anymore. 