### PR TITLE
[RFR] Support routing in TabbedForm & TabbedShowLayout

### DIFF
--- a/cypress/integration/tabs-with-routing.js
+++ b/cypress/integration/tabs-with-routing.js
@@ -1,0 +1,86 @@
+import editPageFactory from '../support/EditPage';
+import loginPageFactory from '../support/LoginPage';
+import showPageFactory from '../support/ShowPage';
+
+describe('Tabs with routing', () => {
+    const EditPage = editPageFactory('#/users/1');
+    const ShowPage = showPageFactory('#/users/1/show', 'name');
+    const LoginPage = loginPageFactory('#/login');
+
+    beforeEach(() => {
+        LoginPage.navigate();
+        LoginPage.login('admin', 'password');
+        cy.url().then(url => expect(url).to.contain('#/posts'));
+    });
+
+    describe('in TabbedLayout component', () => {
+        beforeEach(() => ShowPage.navigate());
+
+        it('allows to switch tabs using the buttons', () => {
+            cy.contains('Summary');
+            cy.contains('Security');
+            cy.contains('Id');
+            cy.contains('Name');
+            ShowPage.gotoTab(2);
+            cy
+                .url()
+                .then(url =>
+                    expect(url).to.match(/.*#\/users\/1\/show\/security/)
+                );
+            cy.contains('Role');
+            ShowPage.gotoTab(1);
+            cy.contains('Id');
+            cy.contains('Name');
+            cy.url().then(url => expect(url).to.match(/.*#\/users\/1\/show/));
+        });
+
+        it('allows to switch tabs using the browser history', () => {
+            cy.contains('Id');
+            cy.contains('Name');
+            ShowPage.gotoTab(2);
+            cy
+                .url()
+                .then(url =>
+                    expect(url).to.match(/.*#\/users\/1\/show\/security/)
+                );
+            cy.contains('Role');
+            cy.go('back');
+            cy.contains('Id');
+            cy.contains('Name');
+            cy.url().then(url => expect(url).to.match(/.*#\/users\/1\/show/));
+        });
+    });
+
+    describe('in TabbedForm component', () => {
+        beforeEach(() => EditPage.navigate());
+        it('allows to switch tabs using the buttons', () => {
+            cy.contains('Summary');
+            cy.contains('Security');
+            cy.contains('Id');
+            cy.contains('Name');
+            EditPage.gotoTab(2);
+            cy
+                .url()
+                .then(url => expect(url).to.match(/.*#\/users\/1\/security/));
+            cy.contains('Role');
+            EditPage.gotoTab(1);
+            cy.contains('Id');
+            cy.contains('Name');
+            cy.url().then(url => expect(url).to.match(/.*#\/users\/1/));
+        });
+
+        it('allows to switch tabs using the browser history', () => {
+            cy.contains('Id');
+            cy.contains('Name');
+            EditPage.gotoTab(2);
+            cy
+                .url()
+                .then(url => expect(url).to.match(/.*#\/users\/1\/security/));
+            cy.contains('Role');
+            cy.go('back');
+            cy.contains('Id');
+            cy.contains('Name');
+            cy.url().then(url => expect(url).to.match(/.*#\/users\/1/));
+        });
+    });
+});

--- a/cypress/support/EditPage.js
+++ b/cypress/support/EditPage.js
@@ -5,7 +5,7 @@ export default url => ({
         inputs: `.ra-input`,
         tabs: `.form-tab`,
         submitButton: ".edit-page button[type='submit']",
-        tab: index => `button.form-tab:nth-of-type(${index})`,
+        tab: index => `.form-tab:nth-of-type(${index})`,
         title: '.title',
     },
 

--- a/cypress/support/ShowPage.js
+++ b/cypress/support/ShowPage.js
@@ -6,7 +6,7 @@ export default (url, initialField = 'title') => ({
         fields: `.ra-field`,
         snackbar: 'div[role="alertdialog"]',
         tabs: `.show-tab`,
-        tab: index => `button.show-tab:nth-of-type(${index})`,
+        tab: index => `.show-tab:nth-of-type(${index})`,
     },
 
     navigate() {

--- a/examples/demo/src/visitors/ShowPage.js
+++ b/examples/demo/src/visitors/ShowPage.js
@@ -10,7 +10,7 @@ export default (url, initialField = 'title') => driver => ({
         fields: By.css(`.ra-field`),
         snackbar: By.css('div[role="alertdialog"]'),
         tabs: By.css(`.show-tab`),
-        tab: index => By.css(`button.show-tab:nth-of-type(${index})`),
+        tab: index => By.css(`.show-tab:nth-of-type(${index})`),
     },
 
     navigate() {

--- a/examples/simple/src/users/UserEdit.js
+++ b/examples/simple/src/users/UserEdit.js
@@ -1,7 +1,6 @@
 /* eslint react/jsx-key: off */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import {
     DisabledInput,
     Edit,
@@ -12,40 +11,21 @@ import {
 } from 'react-admin';
 import UserTitle from './UserTitle';
 
-const UserEdit = ({ permissions, ...props }) => {
-    // The last part of the pathname matching our tabs
-    const tabs = [
-        props.id, // First tab's pathname will be the id parameter of the edit route root
-        'security',
-    ];
-    const lastPartOfPathname = props.location.pathname.substr(
-        props.location.pathname.lastIndexOf('/') + 1
-    );
-    const tab = tabs.indexOf(lastPartOfPathname);
-    return (
-        <Edit title={<UserTitle />} {...props}>
-            <TabbedForm defaultValue={{ role: 'user' }} value={tab}>
-                <FormTab
-                    label="user.form.summary"
-                    component={Link}
-                    to={props.match.url}
-                >
-                    {permissions === 'admin' && <DisabledInput source="id" />}
-                    <TextInput source="name" validate={required()} />
+const UserEdit = ({ permissions, ...props }) => (
+    <Edit title={<UserTitle />} {...props}>
+        <TabbedForm defaultValue={{ role: 'user' }}>
+            <FormTab label="user.form.summary" path="">
+                {permissions === 'admin' && <DisabledInput source="id" />}
+                <TextInput source="name" validate={required()} />
+            </FormTab>
+            {permissions === 'admin' && (
+                <FormTab label="user.form.security" path="security">
+                    <TextInput source="role" validate={required()} />
                 </FormTab>
-                {permissions === 'admin' && (
-                    <FormTab
-                        label="user.form.security"
-                        component={Link}
-                        to={`${props.match.url}/security`}
-                    >
-                        <TextInput source="role" validate={required()} />
-                    </FormTab>
-                )}
-            </TabbedForm>
-        </Edit>
-    );
-};
+            )}
+        </TabbedForm>
+    </Edit>
+);
 
 UserEdit.propTypes = {
     id: PropTypes.any.isRequired,

--- a/examples/simple/src/users/UserEdit.js
+++ b/examples/simple/src/users/UserEdit.js
@@ -1,5 +1,7 @@
 /* eslint react/jsx-key: off */
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import {
     DisabledInput,
     Edit,
@@ -10,20 +12,46 @@ import {
 } from 'react-admin';
 import UserTitle from './UserTitle';
 
-const UserEdit = ({ permissions, ...props }) => (
-    <Edit title={<UserTitle />} {...props}>
-        <TabbedForm defaultValue={{ role: 'user' }}>
-            <FormTab label="user.form.summary">
-                {permissions === 'admin' && <DisabledInput source="id" />}
-                <TextInput source="name" validate={required()} />
-            </FormTab>
-            {permissions === 'admin' && (
-                <FormTab label="user.form.security">
-                    <TextInput source="role" validate={required()} />
+const UserEdit = ({ permissions, ...props }) => {
+    // The last part of the pathname matching our tabs
+    const tabs = [
+        props.id, // First tab's pathname will be the id parameter of the edit route root
+        'security',
+    ];
+    const lastPartOfPathname = props.location.pathname.substr(
+        props.location.pathname.lastIndexOf('/') + 1
+    );
+    const tab = tabs.indexOf(lastPartOfPathname);
+    return (
+        <Edit title={<UserTitle />} {...props}>
+            <TabbedForm defaultValue={{ role: 'user' }} value={tab}>
+                <FormTab
+                    label="user.form.summary"
+                    component={Link}
+                    to={props.match.url}
+                >
+                    {permissions === 'admin' && <DisabledInput source="id" />}
+                    <TextInput source="name" validate={required()} />
                 </FormTab>
-            )}
-        </TabbedForm>
-    </Edit>
-);
+                {permissions === 'admin' && (
+                    <FormTab
+                        label="user.form.security"
+                        component={Link}
+                        to={`${props.match.url}/security`}
+                    >
+                        <TextInput source="role" validate={required()} />
+                    </FormTab>
+                )}
+            </TabbedForm>
+        </Edit>
+    );
+};
+
+UserEdit.propTypes = {
+    id: PropTypes.any.isRequired,
+    location: PropTypes.object.isRequired,
+    match: PropTypes.object.isRequired,
+    permissions: PropTypes.string,
+};
 
 export default UserEdit;

--- a/examples/simple/src/users/UserShow.js
+++ b/examples/simple/src/users/UserShow.js
@@ -1,22 +1,50 @@
 /* eslint react/jsx-key: off */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Show, Tab, TabbedShowLayout, TextField } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { Link } from 'react-router-dom';
 import UserTitle from './UserTitle';
 
-const UserShow = ({ permissions, ...props }) => (
-    <Show title={<UserTitle />} {...props}>
-        <TabbedShowLayout>
-            <Tab label="user.form.summary">
-                <TextField source="id" />
-                <TextField source="name" />
-            </Tab>
-            {permissions === 'admin' && (
-                <Tab label="user.form.security">
-                    <TextField source="role" />
+// The last part of the pathname matching our tabs
+const tabs = [
+    'show', // First tab's pathname will be the show route root
+    'security',
+];
+
+const UserShow = ({ permissions, ...props }) => {
+    const lastPartOfPathname = props.location.pathname.substr(
+        props.location.pathname.lastIndexOf('/') + 1
+    );
+    const tab = tabs.indexOf(lastPartOfPathname);
+    return (
+        <Show title={<UserTitle />} {...props}>
+            <TabbedShowLayout value={tab}>
+                <Tab
+                    label="user.form.summary"
+                    component={Link}
+                    to={props.match.url}
+                >
+                    <TextField source="id" />
+                    <TextField source="name" />
                 </Tab>
-            )}
-        </TabbedShowLayout>
-    </Show>
-);
+                {permissions === 'admin' && (
+                    <Tab
+                        label="user.form.security"
+                        component={Link}
+                        to={`${props.match.url}/security`}
+                    >
+                        <TextField source="role" />
+                    </Tab>
+                )}
+            </TabbedShowLayout>
+        </Show>
+    );
+};
+
+UserShow.propTypes = {
+    location: PropTypes.object.isRequired,
+    match: PropTypes.object.isRequired,
+    permissions: PropTypes.string,
+};
 
 export default UserShow;

--- a/examples/simple/src/users/UserShow.js
+++ b/examples/simple/src/users/UserShow.js
@@ -2,44 +2,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Show, Tab, TabbedShowLayout, TextField } from 'react-admin'; // eslint-disable-line import/no-unresolved
-import { Link } from 'react-router-dom';
 import UserTitle from './UserTitle';
 
-// The last part of the pathname matching our tabs
-const tabs = [
-    'show', // First tab's pathname will be the show route root
-    'security',
-];
-
-const UserShow = ({ permissions, ...props }) => {
-    const lastPartOfPathname = props.location.pathname.substr(
-        props.location.pathname.lastIndexOf('/') + 1
-    );
-    const tab = tabs.indexOf(lastPartOfPathname);
-    return (
-        <Show title={<UserTitle />} {...props}>
-            <TabbedShowLayout value={tab}>
-                <Tab
-                    label="user.form.summary"
-                    component={Link}
-                    to={props.match.url}
-                >
-                    <TextField source="id" />
-                    <TextField source="name" />
+const UserShow = ({ permissions, ...props }) => (
+    <Show title={<UserTitle />} {...props}>
+        <TabbedShowLayout>
+            <Tab label="user.form.summary">
+                <TextField source="id" />
+                <TextField source="name" />
+            </Tab>
+            {permissions === 'admin' && (
+                <Tab label="user.form.security" path="security">
+                    <TextField source="role" />
                 </Tab>
-                {permissions === 'admin' && (
-                    <Tab
-                        label="user.form.security"
-                        component={Link}
-                        to={`${props.match.url}/security`}
-                    >
-                        <TextField source="role" />
-                    </Tab>
-                )}
-            </TabbedShowLayout>
-        </Show>
-    );
-};
+            )}
+        </TabbedShowLayout>
+    </Show>
+);
 
 UserShow.propTypes = {
     location: PropTypes.object.isRequired,

--- a/packages/ra-core/src/Resource.js
+++ b/packages/ra-core/src/Resource.js
@@ -78,7 +78,6 @@ export class Resource extends Component {
             <Switch>
                 {create && (
                     <Route
-                        exact
                         path={`${match.url}/create`}
                         render={routeProps => (
                             <WithPermissions
@@ -95,7 +94,6 @@ export class Resource extends Component {
                 )}
                 {show && (
                     <Route
-                        exact
                         path={`${match.url}/:id/show`}
                         render={routeProps => (
                             <WithPermissions
@@ -115,7 +113,6 @@ export class Resource extends Component {
                 )}
                 {edit && (
                     <Route
-                        exact
                         path={`${match.url}/:id`}
                         render={routeProps => (
                             <WithPermissions
@@ -135,7 +132,6 @@ export class Resource extends Component {
                 )}
                 {list && (
                     <Route
-                        exact
                         path={`${match.url}`}
                         render={routeProps => (
                             <WithPermissions

--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import MuiTab from '@material-ui/core/Tab';
+import { translate } from 'ra-core';
+import classnames from 'classnames';
 
 import Labeled from '../input/Labeled';
-import classnames from 'classnames';
+
+const sanitizeRestProps = ({ label, icon, value, translate, ...rest }) => rest;
 
 /**
  * Tab element for the SimpleShowLayout.
@@ -46,56 +51,72 @@ import classnames from 'classnames';
  *     );
  *     export default App;
  */
-const Tab = ({
-    children,
-    className,
-    component,
-    context,
-    icon,
-    label,
-    translate,
-    value,
-    ...rest
-}) => (
-    <span className={className}>
-        {React.Children.map(
-            children,
-            field =>
-                field && (
-                    <div
-                        key={field.props.source}
-                        className={classnames(
-                            'ra-field',
-                            `ra-field-${field.props.source}`,
-                            field.props.className
-                        )}
-                    >
-                        {field.props.addLabel ? (
-                            <Labeled
-                                {...rest}
-                                label={field.props.label}
-                                source={field.props.source}
-                            >
-                                {field}
-                            </Labeled>
-                        ) : typeof field.type === 'string' ? (
-                            field
-                        ) : (
-                            React.cloneElement(field, rest)
-                        )}
-                    </div>
-                )
-        )}
-    </span>
-);
+class Tab extends Component {
+    renderHeader = ({ className, label, icon, value, translate, ...rest }) => (
+        <MuiTab
+            key={label}
+            label={translate(label, { _: label })}
+            value={value}
+            icon={icon}
+            className={classnames('show-tab', className)}
+            component={Link}
+            to={value}
+            {...sanitizeRestProps(rest)}
+        />
+    );
+
+    renderContent = ({ className, children, ...rest }) => (
+        <span className={className}>
+            {React.Children.map(
+                children,
+                field =>
+                    field && (
+                        <div
+                            key={field.props.source}
+                            className={classnames(
+                                'ra-field',
+                                `ra-field-${field.props.source}`,
+                                field.props.className
+                            )}
+                        >
+                            {field.props.addLabel ? (
+                                <Labeled
+                                    label={field.props.label}
+                                    source={field.props.source}
+                                    {...sanitizeRestProps(rest)}
+                                >
+                                    {field}
+                                </Labeled>
+                            ) : typeof field.type === 'string' ? (
+                                field
+                            ) : (
+                                React.cloneElement(
+                                    field,
+                                    sanitizeRestProps(rest)
+                                )
+                            )}
+                        </div>
+                    )
+            )}
+        </span>
+    );
+
+    render() {
+        const { children, context, ...rest } = this.props;
+        return context === 'header'
+            ? this.renderHeader(rest)
+            : this.renderContent({ children, ...rest });
+    }
+}
 
 Tab.propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
-    component: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    context: PropTypes.oneOf(['header', 'content']),
     icon: PropTypes.element,
     label: PropTypes.string.isRequired,
-    value: PropTypes.number,
+    translate: PropTypes.func.isRequired,
+    value: PropTypes.string,
 };
 
-export default Tab;
+export default translate(Tab);

--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -49,12 +49,21 @@ import classnames from 'classnames';
  *     export default App;
  */
 class Tab extends Component {
-    renderHeader = ({ className, label, icon, value, translate, ...rest }) => (
+    renderHeader = ({
+        className,
+        component,
+        label,
+        icon,
+        value,
+        translate,
+        ...rest
+    }) => (
         <MuiTab
             key={label}
             label={translate(label, { _: label })}
             value={value}
             icon={icon}
+            component={component}
             className={classnames('show-tab', className)}
             {...rest}
         />
@@ -97,6 +106,7 @@ class Tab extends Component {
         const {
             children,
             className,
+            component,
             context,
             icon,
             label,
@@ -107,6 +117,7 @@ class Tab extends Component {
         return context === 'header'
             ? this.renderHeader({
                   className,
+                  component,
                   label,
                   icon,
                   value,
@@ -120,6 +131,7 @@ class Tab extends Component {
 Tab.propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
+    component: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
     context: PropTypes.oneOf(['header', 'content']),
     icon: PropTypes.element,
     label: PropTypes.string.isRequired,

--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -1,7 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import MuiTab from '@material-ui/core/Tab';
-import { translate } from 'ra-core';
 
 import Labeled from '../input/Labeled';
 import classnames from 'classnames';
@@ -48,95 +46,56 @@ import classnames from 'classnames';
  *     );
  *     export default App;
  */
-class Tab extends Component {
-    renderHeader = ({
-        className,
-        component,
-        label,
-        icon,
-        value,
-        translate,
-        ...rest
-    }) => (
-        <MuiTab
-            key={label}
-            label={translate(label, { _: label })}
-            value={value}
-            icon={icon}
-            component={component}
-            className={classnames('show-tab', className)}
-            {...rest}
-        />
-    );
-
-    renderContent = ({ className, children, ...rest }) => (
-        <span className={className}>
-            {React.Children.map(
-                children,
-                field =>
-                    field && (
-                        <div
-                            key={field.props.source}
-                            className={classnames(
-                                'ra-field',
-                                `ra-field-${field.props.source}`,
-                                field.props.className
-                            )}
-                        >
-                            {field.props.addLabel ? (
-                                <Labeled
-                                    {...rest}
-                                    label={field.props.label}
-                                    source={field.props.source}
-                                >
-                                    {field}
-                                </Labeled>
-                            ) : typeof field.type === 'string' ? (
-                                field
-                            ) : (
-                                React.cloneElement(field, rest)
-                            )}
-                        </div>
-                    )
-            )}
-        </span>
-    );
-
-    render() {
-        const {
+const Tab = ({
+    children,
+    className,
+    component,
+    context,
+    icon,
+    label,
+    translate,
+    value,
+    ...rest
+}) => (
+    <span className={className}>
+        {React.Children.map(
             children,
-            className,
-            component,
-            context,
-            icon,
-            label,
-            translate,
-            value,
-            ...rest
-        } = this.props;
-        return context === 'header'
-            ? this.renderHeader({
-                  className,
-                  component,
-                  label,
-                  icon,
-                  value,
-                  translate,
-                  ...rest,
-              })
-            : this.renderContent({ children, className, ...rest });
-    }
-}
+            field =>
+                field && (
+                    <div
+                        key={field.props.source}
+                        className={classnames(
+                            'ra-field',
+                            `ra-field-${field.props.source}`,
+                            field.props.className
+                        )}
+                    >
+                        {field.props.addLabel ? (
+                            <Labeled
+                                {...rest}
+                                label={field.props.label}
+                                source={field.props.source}
+                            >
+                                {field}
+                            </Labeled>
+                        ) : typeof field.type === 'string' ? (
+                            field
+                        ) : (
+                            React.cloneElement(field, rest)
+                        )}
+                    </div>
+                )
+        )}
+    </span>
+);
 
 Tab.propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
     component: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    context: PropTypes.oneOf(['header', 'content']),
     icon: PropTypes.element,
     label: PropTypes.string.isRequired,
-    translate: PropTypes.func.isRequired,
     value: PropTypes.number,
 };
 
-export default translate(Tab);
+export default Tab;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -1,8 +1,6 @@
 import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import Tabs from '@material-ui/core/Tabs';
-import MuiTab from '@material-ui/core/Tab';
 import Divider from '@material-ui/core/Divider';
 import { withStyles } from '@material-ui/core/styles';
 import { withRouter, Route } from 'react-router-dom';
@@ -136,6 +134,8 @@ TabbedShowLayout.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     classes: PropTypes.object,
+    location: PropTypes.object,
+    match: PropTypes.object,
     record: PropTypes.object,
     resource: PropTypes.string,
     basePath: PropTypes.string,

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -5,7 +5,7 @@ import Tabs from '@material-ui/core/Tabs';
 import MuiTab from '@material-ui/core/Tab';
 import Divider from '@material-ui/core/Divider';
 import { withStyles } from '@material-ui/core/styles';
-import { withRouter, Link, Route } from 'react-router-dom';
+import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
@@ -100,20 +100,10 @@ export class TabbedShowLayout extends Component {
                             ? `/${tab.props.path}`
                             : index > 0 ? `/${index}` : ''}`;
 
-                        return (
-                            <MuiTab
-                                key={tab.props.label}
-                                component={Link}
-                                to={tabPath}
-                                value={tabPath}
-                                {...tab.props}
-                                label={translate(tab.props.label, {
-                                    _: tab.props.label,
-                                })}
-                                icon={tab.props.icon}
-                                className={classnames('show-tab', className)}
-                            />
-                        );
+                        return cloneElement(tab, {
+                            context: 'header',
+                            value: tabPath,
+                        });
                     })}
                 </Tabs>
                 <Divider />
@@ -128,6 +118,7 @@ export class TabbedShowLayout extends Component {
                                         (index > 0 ? index : '')}`}
                                     render={() =>
                                         cloneElement(tab, {
+                                            context: 'content',
                                             resource,
                                             record,
                                             basePath,

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -68,7 +68,9 @@ export class TabbedShowLayout extends Component {
     }
 
     handleChange = (event, value) => {
-        this.setState({ value });
+        if (this.props.value == null) {
+            this.setState({ value });
+        }
     };
 
     render() {
@@ -80,8 +82,12 @@ export class TabbedShowLayout extends Component {
             resource,
             basePath,
             version,
+            value,
             ...rest
         } = this.props;
+
+        const tabValue = value != null ? value : this.state.value;
+
         return (
             <div
                 className={className}
@@ -90,7 +96,7 @@ export class TabbedShowLayout extends Component {
             >
                 <Tabs
                     scrollable
-                    value={this.state.value}
+                    value={tabValue}
                     onChange={this.handleChange}
                     indicatorColor="primary"
                 >
@@ -100,7 +106,7 @@ export class TabbedShowLayout extends Component {
                             tab &&
                             cloneElement(tab, {
                                 context: 'header',
-                                value: index,
+                                value: tab.props.value || index,
                             })
                     )}
                 </Tabs>
@@ -110,7 +116,7 @@ export class TabbedShowLayout extends Component {
                         children,
                         (tab, index) =>
                             tab &&
-                            this.state.value === index &&
+                            tabValue === (tab.props.value || index) &&
                             cloneElement(tab, {
                                 context: 'content',
                                 resource,
@@ -131,6 +137,7 @@ TabbedShowLayout.propTypes = {
     record: PropTypes.object,
     resource: PropTypes.string,
     basePath: PropTypes.string,
+    value: PropTypes.number,
     version: PropTypes.number,
     translate: PropTypes.func,
 };

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -25,6 +25,11 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
+const getTabFullPath = (tab, index, baseUrl) =>
+    `${baseUrl}${tab.props.path
+        ? `/${tab.props.path}`
+        : index > 0 ? `/${index}` : ''}`;
+
 /**
  * Tabbed Layout for a Show view, showing fields grouped in tabs.
  * 
@@ -88,15 +93,19 @@ export class TabbedShowLayout extends Component {
             >
                 <Tabs
                     scrollable
+                    // The location pathname will contain the page path including the current tab path
+                    // so we can use it as a way to determine the current tab
                     value={location.pathname}
-                    onChange={this.handleChange}
                     indicatorColor="primary"
                 >
                     {Children.map(children, (tab, index) => {
                         if (!tab) return null;
-                        const tabPath = `${match.url}${tab.props.path
-                            ? `/${tab.props.path}`
-                            : index > 0 ? `/${index}` : ''}`;
+
+                        // Builds the full tab tab which is the concatenation of the last matched route in the
+                        // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
+                        // and the tab path.
+                        // This will be used as the Tab's value
+                        const tabPath = getTabFullPath(tab, index, match.url);
 
                         return cloneElement(tab, {
                             context: 'header',
@@ -112,8 +121,7 @@ export class TabbedShowLayout extends Component {
                             tab && (
                                 <Route
                                     exact
-                                    path={`${match.url}/${tab.props.path ||
-                                        (index > 0 ? index : '')}`}
+                                    path={getTabFullPath(tab, index, match.url)}
                                     render={() =>
                                         cloneElement(tab, {
                                             context: 'content',

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FormInput from './FormInput';
 
-const sanitizeRestProps = ({ label, icon, ...rest }) => rest;
+const sanitizeRestProps = ({ label, icon, component, ...rest }) => rest;
 
 const hiddenStyle = { display: 'none' };
 

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -1,28 +1,61 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import MuiTab from '@material-ui/core/Tab';
+import classnames from 'classnames';
+import { translate } from 'ra-core';
+
 import FormInput from './FormInput';
 
-const sanitizeRestProps = ({ label, icon, component, ...rest }) => rest;
+const sanitizeRestProps = ({ label, icon, value, translate, ...rest }) => rest;
 
 const hiddenStyle = { display: 'none' };
 
-const FormTab = ({ children, hidden, ...rest }) => (
-    <span style={hidden ? hiddenStyle : null}>
-        {React.Children.map(
-            children,
-            input =>
-                input && (
-                    <FormInput input={input} {...sanitizeRestProps(rest)} />
-                )
-        )}
-    </span>
-);
+class FormTab extends Component {
+    renderHeader = ({ className, label, icon, value, translate, ...rest }) => (
+        <MuiTab
+            key={label}
+            label={translate(label, { _: label })}
+            value={value}
+            icon={icon}
+            className={classnames('form-tab', className)}
+            component={Link}
+            to={value}
+            {...sanitizeRestProps(rest)}
+        />
+    );
+
+    renderContent = ({ children, hidden, ...rest }) => (
+        <span style={hidden ? hiddenStyle : null}>
+            {React.Children.map(
+                children,
+                input =>
+                    input && (
+                        <FormInput input={input} {...sanitizeRestProps(rest)} />
+                    )
+            )}
+        </span>
+    );
+
+    render() {
+        const { children, context, ...rest } = this.props;
+        return context === 'header'
+            ? this.renderHeader(rest)
+            : this.renderContent({ children, ...rest });
+    }
+}
 
 FormTab.propTypes = {
+    className: PropTypes.string,
     children: PropTypes.node,
+    context: PropTypes.oneOf(['header', 'content']),
     hidden: PropTypes.bool,
-    label: PropTypes.string,
-    path: PropTypes.string,
+    icon: PropTypes.element,
+    label: PropTypes.string.isRequired,
+    translate: PropTypes.func.isRequired,
+    value: PropTypes.string,
 };
 
-export default FormTab;
+FormTab.displayName = 'FormTab';
+
+export default translate(FormTab);

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -21,6 +21,8 @@ const FormTab = ({ children, hidden, ...rest }) => (
 FormTab.propTypes = {
     children: PropTypes.node,
     hidden: PropTypes.bool,
+    label: PropTypes.string,
+    path: PropTypes.string,
 };
 
 export default FormTab;

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -112,7 +112,7 @@ export class TabbedForm extends Component {
                         if (!tab) return null;
                         const tabPath = `${match.url}${tab.props.path
                             ? `/${tab.props.path}`
-                            : index > 0 ? index : ''}`;
+                            : index > 0 ? `/${index}` : ''}`;
 
                         return (
                             <Tab

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -8,11 +8,10 @@ import {
     getFormSubmitErrors,
 } from 'redux-form';
 import { connect } from 'react-redux';
-import { withRouter, Link, Route } from 'react-router-dom';
+import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import Divider from '@material-ui/core/Divider';
 import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
 import { withStyles } from '@material-ui/core/styles';
 import { getDefaultValues, translate, REDUX_FORM_NAME } from 'ra-core';
 
@@ -189,6 +188,8 @@ TabbedForm.propTypes = {
     defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     handleSubmit: PropTypes.func, // passed by redux-form
     invalid: PropTypes.bool,
+    location: PropTypes.object,
+    match: PropTypes.object,
     pristine: PropTypes.bool,
     record: PropTypes.object,
     redirect: PropTypes.oneOfType([

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -69,6 +69,11 @@ const sanitizeRestProps = ({
     ...props
 }) => props;
 
+const getTabFullPath = (tab, index, baseUrl) =>
+    `${baseUrl}${tab.props.path
+        ? `/${tab.props.path}`
+        : index > 0 ? `/${index}` : ''}`;
+
 export class TabbedForm extends Component {
     handleSubmitWithRedirect = (redirect = this.props.redirect) =>
         this.props.handleSubmit(values => this.props.save(values, redirect));
@@ -104,14 +109,19 @@ export class TabbedForm extends Component {
             >
                 <Tabs
                     scrollable
+                    // The location pathname will contain the page path including the current tab path
+                    // so we can use it as a way to determine the current tab
                     value={location.pathname}
                     indicatorColor="primary"
                 >
                     {Children.map(children, (tab, index) => {
                         if (!tab) return null;
-                        const tabPath = `${match.url}${tab.props.path
-                            ? `/${tab.props.path}`
-                            : index > 0 ? `/${index}` : ''}`;
+
+                        // Builds the full tab tab which is the concatenation of the last matched route in the
+                        // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
+                        // and the tab path.
+                        // This will be used as the Tab's value
+                        const tabPath = getTabFullPath(tab, index, match.url);
 
                         return React.cloneElement(tab, {
                             context: 'header',
@@ -136,8 +146,7 @@ export class TabbedForm extends Component {
                             tab && (
                                 <Route
                                     exact
-                                    path={`${match.url}/${tab.props.path ||
-                                        (index > 0 ? index : '')}`}
+                                    path={getTabFullPath(tab, index, match.url)}
                                 >
                                     {routeProps =>
                                         React.cloneElement(tab, {

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -77,7 +77,9 @@ export class TabbedForm extends Component {
     }
 
     handleChange = (event, value) => {
-        this.setState({ value });
+        if (this.props.value == null) {
+            this.setState({ value });
+        }
     };
 
     handleSubmitWithRedirect = (redirect = this.props.redirect) =>
@@ -99,9 +101,12 @@ export class TabbedForm extends Component {
             tabsWithErrors,
             toolbar,
             translate,
+            value,
             version,
             ...rest
         } = this.props;
+
+        const tabValue = value != null ? value : this.state.value;
 
         return (
             <form
@@ -111,7 +116,7 @@ export class TabbedForm extends Component {
             >
                 <Tabs
                     scrollable
-                    value={this.state.value}
+                    value={tabValue}
                     onChange={this.handleChange}
                     indicatorColor="primary"
                 >
@@ -121,10 +126,13 @@ export class TabbedForm extends Component {
                             tab ? (
                                 <Tab
                                     key={tab.props.label}
+                                    {...tab.props}
                                     label={translate(tab.props.label, {
                                         _: tab.props.label,
                                     })}
-                                    value={index}
+                                    value={
+                                        tab.value != null ? tab.value : index
+                                    }
                                     icon={tab.props.icon}
                                     className={classnames(
                                         'form-tab',
@@ -208,6 +216,7 @@ TabbedForm.propTypes = {
     toolbar: PropTypes.element,
     translate: PropTypes.func,
     validate: PropTypes.func,
+    value: PropTypes.number,
     version: PropTypes.number,
 };
 

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -114,26 +114,15 @@ export class TabbedForm extends Component {
                             ? `/${tab.props.path}`
                             : index > 0 ? `/${index}` : ''}`;
 
-                        return (
-                            <Tab
-                                key={tab.props.label}
-                                component={Link}
-                                to={tabPath}
-                                value={tabPath}
-                                {...tab.props}
-                                label={translate(tab.props.label, {
-                                    _: tab.props.label,
-                                })}
-                                icon={tab.props.icon}
-                                className={classnames(
-                                    'form-tab',
-                                    tabsWithErrors.includes(tab.props.label) &&
-                                    location.pathname !== tabPath
-                                        ? classes.errorTabButton
-                                        : null
-                                )}
-                            />
-                        );
+                        return React.cloneElement(tab, {
+                            context: 'header',
+                            value: tabPath,
+                            className:
+                                tabsWithErrors.includes(tab.props.label) &&
+                                location.pathname !== tabPath
+                                    ? classes.errorTabButton
+                                    : null,
+                        });
                     })}
                 </Tabs>
                 <Divider />
@@ -153,6 +142,7 @@ export class TabbedForm extends Component {
                                 >
                                     {routeProps =>
                                         React.cloneElement(tab, {
+                                            context: 'content',
                                             resource,
                                             record,
                                             basePath,

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
@@ -9,28 +9,11 @@ const translate = label => label;
 const muiTheme = { textField: { errorColor: 'red' } };
 
 describe('<TabbedForm />', () => {
-    it('should render tabs', () => {
-        const wrapper = shallow(
-            <TabbedForm
-                translate={translate}
-                muiTheme={muiTheme}
-                tabsWithErrors={[]}
-            >
-                <FormTab />
-                <FormTab />
-            </TabbedForm>
-        );
-        const tabsContainer = wrapper.find('WithStyles(Tabs)');
-        assert.equal(tabsContainer.length, 1);
-        const tabs = wrapper.find('FormTab');
-        assert.equal(tabs.length, 2);
-        assert.equal(tabs.at(0).prop('hidden'), false);
-        assert.equal(tabs.at(1).prop('hidden'), true);
-    });
-
     it('should display <Toolbar />', () => {
         const wrapper = shallow(
             <TabbedForm
+                location={{}}
+                match={{}}
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={[]}
@@ -48,6 +31,8 @@ describe('<TabbedForm />', () => {
         const handleSubmit = () => {};
         const wrapper1 = shallow(
             <TabbedForm
+                location={{}}
+                match={{}}
                 translate={translate}
                 submitOnEnter={false}
                 handleSubmit={handleSubmit}
@@ -60,6 +45,8 @@ describe('<TabbedForm />', () => {
 
         const wrapper2 = shallow(
             <TabbedForm
+                location={{}}
+                match={{}}
                 translate={translate}
                 submitOnEnter
                 handleSubmit={handleSubmit}
@@ -74,6 +61,8 @@ describe('<TabbedForm />', () => {
     it('should set the style of an inactive Tab button with errors', () => {
         const wrapper = shallow(
             <TabbedForm
+                location={{ pathname: '/posts/12' }}
+                match={{ url: '/posts/12' }}
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={['tab2']}
@@ -94,6 +83,8 @@ describe('<TabbedForm />', () => {
     it('should not set the style of an active Tab button with errors', () => {
         const wrapper = shallow(
             <TabbedForm
+                location={{ pathname: '/posts/12' }}
+                match={{ url: '/posts/12' }}
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={['tab1']}

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
@@ -72,12 +72,12 @@ describe('<TabbedForm />', () => {
                 <FormTab label="tab2" />
             </TabbedForm>
         );
-        const tabs = wrapper.find('WithStyles(Tab)');
+        const tabs = wrapper.find('TranslatedComponent(FormTab)');
         const tab1 = tabs.at(0);
         const tab2 = tabs.at(1);
 
-        assert.equal(tab1.prop('className'), 'form-tab');
-        assert.equal(tab2.prop('className'), 'form-tab error');
+        assert.equal(tab1.prop('className'), null);
+        assert.equal(tab2.prop('className'), 'error');
     });
 
     it('should not set the style of an active Tab button with errors', () => {
@@ -98,8 +98,8 @@ describe('<TabbedForm />', () => {
         const tab1 = tabs.at(0);
         const tab2 = tabs.at(1);
 
-        assert.equal(tab1.prop('className'), 'form-tab');
-        assert.equal(tab2.prop('className'), 'form-tab');
+        assert.equal(tab1.prop('className'), null);
+        assert.equal(tab2.prop('className'), null);
     });
 
     describe('findTabsWithErrors', () => {


### PR DESCRIPTION
This PR adds support for routing driven tab selection both in `TabbedForm` and `TabbedShowLayout`.

- [x] Remove unecessary `exact` from `Resource` to allow urls such as `/posts/10/show/comments`
- [x] Support tab routing by default in `TabbedForm`. Use `path` prop if provided and fallback on tab index if not
- [x] Support tab routing by default in `TabbedShowLayout`. Use `path` prop if provided and fallback on tab index if not
- [x] Tests

![Screencast](https://i.imgur.com/O7qZALr.gif)