### PR TITLE
[RFR] Fix LongTextInput when used inside a TabbedForm

### DIFF
--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -153,6 +153,19 @@ export class TabbedForm extends Component {
                                 record,
                                 basePath,
                                 hidden: this.state.value !== index,
+                                /**
+                                 * Force redraw when the tab becomes active
+                                 * 
+                                 * This is because the fields, decorated by redux-form and connect,
+                                 * aren't redrawn by default when the tab becomes active.
+                                 * Unfortunately, some material-ui fields (like multiline TextField)
+                                 * compute their size based on the scrollHeight of a dummy DOM element,
+                                 * and scrollHeight is 0 in a hidden div. So they must be redrawn
+                                 * once the tab becomes active.
+                                 * 
+                                 * @ref https://github.com/marmelab/react-admin/issues/1956
+                                 */
+                                key: `${index}_${this.state.value !== index}`,
                             })
                     )}
                     {toolbar &&


### PR DESCRIPTION
The problem occurs when using `<LontTextInput>` inside a `<TabbedForm>`, but not if it's used in the first tab... The bug is due to a conjunction of:

- material-ui, which computes the field height based on the `scrollHeight` value of a dummy textarea,
- the way we hide inactive tabs with `display=none`, which makes all `scrollHeight` computation return 0
- the fact that we decorate fields with redux-form's `<FormField>`, which decorates the field with `connect()` and therefore makes them pure, and prevents a rerender when the tab becomes active.

I must confess the bug wasn't easy to locate, but the fix is a one liner. 

Closes #1956