### PR TITLE
[RFR] Document how to prefill a create form based on another record

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -173,8 +173,12 @@ const commentDefaultValue = { nb_views: 0 };
 -export const CommentCreate = (props) => (
 +export const CommentCreate = ({ location, ...props}) => (
 -   <Create {...props}>
-+   <Create {...props} record={location.state || commentDefaultValue}>
-        <SimpleForm>
++   <Create
++       record={(location.state && location.state.record) || defaultValue}
++       location={location}
++       {...props}
++   >
+       <SimpleForm>
             <TextInput source="author" />
             <RichTextInput source="body" />
             <NumberInput source="nb_views" />
@@ -194,7 +198,10 @@ import { Link } from 'react-router-dom';
 const CreateRelatedCommentButton = ({ record }) => (
     <Button
         component={Link}
-        to={{ pathname: '/comments/create', state: { post_id: record.id } }}
+        to={{
+            pathname: '/comments/create',
+            state: { record: { post_id: record.id } },
+        }}
     >
         Write a comment for that post
     </Button>

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -145,6 +145,74 @@ export const PostEdit = (props) => (
 
 Using a custom `EditActions` component also allow to remove the `<DeleteButton>` if you want to prevent deletions from the admin.
 
+## Prefilling a `<Create>` Record
+
+By default, the `<Create>` view starts with an empty `record`. You can pass a custom `record` object to start with preset values:
+
+```jsx
+const commentDefaultValue = { nb_views: 0 };
+export const CommentCreate = (props) => (
+    <Create {...props} record={commentDefaultValue}>
+        <SimpleForm>
+            <TextInput source="author" />
+            <RichTextInput source="body" />
+            <NumberInput source="nb_views" />
+        </SimpleForm>
+    </Create>
+);
+```
+
+While using the `record` to set default values works here, it doesn't work with `<Edit>`. So it's recommended to use [the `defaultValue` prop in the Form component](#default-values) instead.
+
+However, there is a valid use case for presetting the `record` prop: to prepopulate a record based on a related record. For instance, in a `PostShow` component, you may want to display a button to create a comment related to the current post, that would lead to a `CommentCreate` page where the `post_id` is preset.
+
+To enable this, you must first update the `CommentCreate` component to read the record from the `location` object (which is injected by react-router):
+
+```diff
+const commentDefaultValue = { nb_views: 0 };
+-export const CommentCreate = (props) => (
++export const CommentCreate = ({ location, ...props}) => (
+-   <Create {...props}>
++   <Create {...props} record={location.state || commentDefaultValue}>
+        <SimpleForm>
+            <TextInput source="author" />
+            <RichTextInput source="body" />
+            <NumberInput source="nb_views" />
+        </SimpleForm>
+    </Create>
+);
+```
+
+To set this `location.state`, you have to create a link or a button using react-router's `<Link>` component:
+
+{% raw %}
+```jsx
+// in PostShow.js
+import Button from '@material-ui/core/Button';
+import { Link } from 'react-router-dom';
+
+const CreateRelatedCommentButton = ({ record }) => (
+    <Button
+        component={Link}
+        to={{ pathname: '/comments/create', state: { post_id: record.id } }}
+    >
+        Write a comment for that post
+    </Button>
+);
+
+export default PostShow = props => (
+    <Show {...props}>
+        <SimpleShowLayout>
+            ...
+            <CreateRelatedCommentButton />
+        </SimpleShowLayout>
+    </Show>
+)
+```
+{% endraw %}
+
+**Tip**: To style the button with the main color from the material-ui theme, use the `Link` component from the `react-admin` package rather than the one from `react-router`.
+
 ## The `<SimpleForm>` component
 
 The `<SimpleForm>` component receives the `record` as prop from its parent component. It is responsible for rendering the actual form. It is also responsible for validating the form data. Finally, it receives a `handleSubmit` function as prop, to be called with the updated record as argument when the user submits the form.
@@ -181,7 +249,7 @@ export const PostCreate = (props) => (
 
 ## The `<TabbedForm>` component
 
-Just like `<SimpleForm>`, `<TabbedForm>` receives the `record` prop, renders the actual form, and handles form validation on submit. However, the `<TabbedForm>` component renders inputs grouped by tab. The tabs are set by using `<FormTab>` components, which expect a `label` and an `icon` prop. Switching tabs will update the current url. By default, it uses the tabs indexes and the first tab will be displayed at the root url. You can customize the path by providing a `path` prop to each `Tab` component. If you'd like the first one to act as an index page, just omit the `path` prop.
+Just like `<SimpleForm>`, `<TabbedForm>` receives the `record` prop, renders the actual form, and handles form validation on submit. However, the `<TabbedForm>` component renders inputs grouped by tab. The tabs are set by using `<FormTab>` components, which expect a `label` and an `icon` prop.
 
 ![tabbed form](./img/tabbed-form.gif)
 
@@ -211,17 +279,17 @@ export const PostEdit = (props) => (
                 <TextInput source="title" validate={required()} />
                 <LongTextInput source="teaser" validate={required()} />
             </FormTab>
-            <FormTab label="body" path="body">
+            <FormTab label="body">
                 <RichTextInput source="body" validate={required()} addLabel={false} />
             </FormTab>
-            <FormTab label="Miscellaneous" path="miscellaneous">
+            <FormTab label="Miscellaneous">
                 <TextInput label="Password (if protected post)" source="password" type="password" />
                 <DateInput label="Publication date" source="published_at" />
                 <NumberInput source="average_note" validate={[ number(), minValue(0) ]} />
                 <BooleanInput label="Allow comments?" source="commentable" defaultValue />
                 <DisabledInput label="Nb views" source="views" />
             </FormTab>
-            <FormTab label="comments" path="comments">
+            <FormTab label="comments">
                 <ReferenceManyField reference="comments" target="post_id" addLabel={false}>
                     <Datagrid>
                         <TextField source="body" />

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -418,6 +418,12 @@
                                 <a href="#actions">Actions</a>
                             </li>
                             <li class="chapter">
+                                <a href="#prefilling-a-create-record">
+                                    Prefilling a
+                                    <code>&lt;Create&gt;</code> Record
+                                </a>
+                            </li>
+                            <li class="chapter">
                                 <a href="#the-simpleform-component">
                                     <code>&lt;SimpleForm&gt;</code>
                                 </a>

--- a/examples/simple/src/comments/CommentCreate.js
+++ b/examples/simple/src/comments/CommentCreate.js
@@ -12,9 +12,9 @@ import {
 import PostReferenceInput from './PostReferenceInput';
 
 const defaultValue = { created_at: new Date() };
-const CommentCreate = props => (
-    <Create {...props}>
-        <SimpleForm defaultValue={defaultValue}>
+const CommentCreate = ({ location, ...props }) => (
+    <Create record={location.state || defaultValue} {...props}>
+        <SimpleForm redirect={false}>
             <PostReferenceInput
                 source="post_id"
                 reference="posts"

--- a/examples/simple/src/comments/CommentCreate.js
+++ b/examples/simple/src/comments/CommentCreate.js
@@ -13,7 +13,11 @@ import PostReferenceInput from './PostReferenceInput';
 
 const defaultValue = { created_at: new Date() };
 const CommentCreate = ({ location, ...props }) => (
-    <Create record={location.state || defaultValue} {...props}>
+    <Create
+        record={(location.state && location.state.record) || defaultValue}
+        location={location}
+        {...props}
+    >
         <SimpleForm redirect={false}>
             <PostReferenceInput
                 source="post_id"

--- a/examples/simple/src/posts/PostShow.js
+++ b/examples/simple/src/posts/PostShow.js
@@ -7,6 +7,7 @@ import {
     Datagrid,
     DateField,
     EditButton,
+    Link,
     NumberField,
     ReferenceArrayField,
     ReferenceManyField,
@@ -19,7 +20,17 @@ import {
     TextField,
     UrlField,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import Button from '@material-ui/core/Button';
 import PostTitle from './PostTitle';
+
+const CreateRelatedComment = ({ record }) => (
+    <Button
+        component={Link}
+        to={{ pathname: '/comments/create', state: { post_id: record.id } }}
+    >
+        Add comment
+    </Button>
+);
 
 const PostShow = props => (
     <ShowController title={<PostTitle />} {...props}>
@@ -81,6 +92,7 @@ const PostShow = props => (
                                 <EditButton />
                             </Datagrid>
                         </ReferenceManyField>
+                        <CreateRelatedComment />
                     </Tab>
                 </TabbedShowLayout>
             </ShowView>

--- a/examples/simple/src/posts/PostShow.js
+++ b/examples/simple/src/posts/PostShow.js
@@ -26,7 +26,10 @@ import PostTitle from './PostTitle';
 const CreateRelatedComment = ({ record }) => (
     <Button
         component={Link}
-        to={{ pathname: '/comments/create', state: { post_id: record.id } }}
+        to={{
+            pathname: '/comments/create',
+            state: { record: { post_id: record.id } },
+        }}
     >
         Add comment
     </Button>


### PR DESCRIPTION
I think the `<CreateController>` should support `location.state` by default... But that would be a new feature, to be added to the `next` branch, while this PR documents the `master` branch.

Edit: well, implementing `location.state` support is a must have to enable #1892, so I guess I'll implement it (in another PR).

Closes #1930 