### PR TITLE
Fix validators memoization

### DIFF
--- a/packages/ra-core/src/form/validate.js
+++ b/packages/ra-core/src/form/validate.js
@@ -70,11 +70,14 @@ export const number = memoize(
             : undefined
 );
 
-export const regex = memoize(
+export const regex = lodashMemoize(
     (pattern, message = 'ra.validation.regex') => (value, values, props) =>
         !isEmpty(value) && typeof value === 'string' && !pattern.test(value)
             ? getMessage(message, { pattern }, value, values, props)
-            : undefined
+            : undefined,
+    (pattern, message) => {
+        return pattern.toString() + message;
+    }
 );
 
 export const email = memoize((message = 'ra.validation.email') =>

--- a/packages/ra-core/src/form/validate.spec.js
+++ b/packages/ra-core/src/form/validate.spec.js
@@ -201,6 +201,24 @@ describe('Validators', () => {
                 'not foo'
             );
         });
+
+        it('should memoize the validator when the regex pattren and message are the same', () => {
+            expect(regex(/foo/, 'placeholder')).toBe(
+                regex(/foo/, 'placeholder')
+            );
+        });
+
+        it('should create new validator when the regex pattren is different', () => {
+            expect(regex(/foo/, 'placeholder')).not.toBe(
+                regex(/notfoo/, 'placeholder')
+            );
+        });
+
+        it('should create new validator when message is different', () => {
+            expect(regex(/foo/, 'placeholder')).not.toBe(
+                regex(/foo/, 'another placeholder')
+            );
+        });
     });
     describe('email', () => {
         it('should return undefined if the value is empty', () => {


### PR DESCRIPTION
fixes #1989 
Add `.prettierrc` with the settings take from `.eslintrc` makes vscode (and all the other related tools?) more happy