### PR TITLE
[RFR] Pass handleSubmit directly to buttons

### DIFF
--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -10,9 +10,9 @@ describe('Create Page', () => {
     it('should put the current date in the field by default', () => {
         const currentDate = new Date();
         const currentDateString = currentDate.toISOString().slice(0, 10);
-        cy
-            .get(CreatePage.elements.input('published_at'))
-            .should(el => expect(el).to.have.value(currentDateString));
+        cy.get(CreatePage.elements.input('published_at')).should(el =>
+            expect(el).to.have.value(currentDateString)
+        );
     });
 
     it('should redirect to show page after create success', () => {
@@ -51,11 +51,38 @@ describe('Create Page', () => {
         CreatePage.setValues(values);
         CreatePage.submitAndAdd();
         cy.url().then(url => expect(url).to.contain('/#/posts/create'));
-        cy
-            .get(CreatePage.elements.input('title'))
-            .should(el => expect(el).to.have.value('')); // new empty form
+        cy.get(CreatePage.elements.input('title')).should(el =>
+            expect(el).to.have.value('')
+        ); // new empty form
 
         ShowPage.navigate();
+        ShowPage.ShowPage.delete();
+    });
+
+    it.only('should allow to call a custom action updating values before submit', () => {
+        const values = [
+            {
+                type: 'input',
+                name: 'title',
+                value: 'Test title',
+            },
+            {
+                type: 'textarea',
+                name: 'teaser',
+                value: 'Test teaser',
+            },
+            {
+                type: 'checkbox',
+                name: 'commentable',
+                value: false,
+            },
+        ];
+
+        CreatePage.setValues(values);
+        CreatePage.submitWithAverageNote();
+        ShowPage.waitUntilVisible();
+        ShowPage.gotoTab(3);
+        cy.contains('10');
         ShowPage.delete();
     });
 

--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -59,7 +59,7 @@ describe('Create Page', () => {
         ShowPage.ShowPage.delete();
     });
 
-    it.only('should allow to call a custom action updating values before submit', () => {
+    it('should allow to call a custom action updating values before submit', () => {
         const values = [
             {
                 type: 'input',

--- a/cypress/support/CreatePage.js
+++ b/cypress/support/CreatePage.js
@@ -6,7 +6,9 @@ export default url => ({
         snackbar: 'div[role="alertdialog"]',
         submitButton: ".create-page button[type='submit']",
         submitAndAddButton:
-            ".create-page form>div:last-child button[type='button']",
+            ".create-page form>div:last-child button[type='button']:nth-child(2)",
+        submitCommentable:
+            ".create-page form>div:last-child button[type='button']:last-child",
         descInput: '.ql-editor',
     },
 
@@ -19,6 +21,12 @@ export default url => ({
     },
 
     setInputValue(type, name, value, clearPreviousValue = true) {
+        if (type === 'checkbox') {
+            if (value === true) {
+                return cy.get(this.elements.input(name, 'input')).check();
+            }
+            return cy.get(this.elements.input(name, 'input')).check();
+        }
         if (clearPreviousValue) {
             cy.get(this.elements.input(name, type)).clear();
         }
@@ -27,10 +35,12 @@ export default url => ({
 
     setValues(values, clearPreviousValue = true) {
         values.forEach(val => {
-            if (clearPreviousValue) {
-                cy.get(this.elements.input(val.name, val.type)).clear();
-            }
-            cy.get(this.elements.input(val.name, val.type)).type(val.value);
+            this.setInputValue(
+                val.type,
+                val.name,
+                val.value,
+                clearPreviousValue
+            );
         });
     },
 
@@ -43,6 +53,13 @@ export default url => ({
 
     submitAndAdd() {
         cy.get(this.elements.submitAndAddButton).click();
+        cy.get(this.elements.snackbar);
+        cy.get(this.elements.body).click(); // dismiss notification
+        cy.wait(200); // let the notification disappear (could block further submits)
+    },
+
+    submitWithAverageNote() {
+        cy.get(this.elements.submitCommentable).click();
         cy.get(this.elements.snackbar);
         cy.get(this.elements.body).click(); // dismiss notification
         cy.wait(200); // let the notification disappear (could block further submits)

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -462,7 +462,7 @@ Sometimes, you may want your custom action to alter the form values before actua
 - `handleSubmitWithRedirect` which calls the default form save methods
 - `handleSubmit` which is the same prop as in [`react-form`](https://redux-form.com/7.4.2/docs/api/props.md/#-code-handlesubmit-eventorsubmit-function-code-)
 
-Knowing this, you can dispatch a custom action with a button. For instance, in the `simple` example:
+Knowing this, you can dispatch a custom action with a button and still benefit from the default crud action side effects (notifications, optimistic ui, undo, etc.). For instance, in the `simple` example:
 
 ```jsx
 // A custom action creator which modifies the values before calling the default crudCreate action creator
@@ -515,8 +515,6 @@ const PostCreateToolbar = props => (
     </Toolbar>
 );
 ```
-
-The advantages of this is that we still benefit from the default `crudCreate` action side effects.
 
 ## Custom Sagas
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -462,7 +462,7 @@ Sometimes, you may want your custom action to alter the form values before actua
 - `handleSubmitWithRedirect` which calls the default form save methods
 - `handleSubmit` which is the same prop as in [`react-form`](https://redux-form.com/7.4.2/docs/api/props.md/#-code-handlesubmit-eventorsubmit-function-code-)
 
-Knowing this, we can dispatch a custom action with a button. For instance, in the `simple` example:
+Knowing this, you can dispatch a custom action with a button. For instance, in the `simple` example:
 
 ```jsx
 // A custom action creator which modifies the values before calling the default crudCreate action creator

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -465,6 +465,10 @@ Sometimes, you may want your custom action to alter the form values before actua
 Knowing this, you can dispatch a custom action with a button and still benefit from the default crud action side effects (notifications, optimistic ui, undo, etc.). For instance, in the `simple` example:
 
 ```jsx
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { crudCreate, SaveButton, Toolbar } from 'react-admin';
+
 // A custom action creator which modifies the values before calling the default crudCreate action creator
 const saveWithNote = (values, basePath, redirectTo) =>
     crudCreate('posts', { ...values, average_note: 10 }, basePath, redirectTo);

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -630,20 +630,14 @@ Here are the props received by the `Toolbar` component when passed as the `toolb
 Here are the props received by the `Toolbar` component when passed as the `toolbar` prop of the `SimpleForm` or `TabbedForm` components:
 
 * `handleSubmitWithRedirect`: The function to call in order to submit the form. It accepts a single parameter overriding the form's default redirect.
+* `handleSubmit` which is the same prop as in [`react-form`](https://redux-form.com/7.4.2/docs/api/props.md/#-code-handlesubmit-eventorsubmit-function-code-)
 * `invalid`: A boolean indicating whether the form is invalid
 * `pristine`: A boolean indicating whether the form is pristine (eg: no inputs have been changed yet)
 * `redirect`: The default form's redirect
 * `saving`: A boolean indicating whether a save operation is ongoing.
 * `submitOnEnter`: A boolean indicating whether the form should be submitted when pressing `enter`
 
-## Altering the Form Values before Submitting
-
-Sometimes, you may want your custom action to alter the form values before actually sending them to the `dataProvider`. For those cases, you should know that every buttons inside a form [Toolbar](/CreateEdit.html#toolbar) receive two props:
-
-- `handleSubmitWithRedirect` which calls the default form save methods
-- `handleSubmit` which is the same prop as in [`react-form`](https://redux-form.com/7.4.2/docs/api/props.md/#-code-handlesubmit-eventorsubmit-function-code-)
-
-Knowing this, we can dispatch a custom action with a button. For instance, in the `simple` example:
+**Tip**: To alter the form values before submitting, you should use the `handleSubmit` prop. For instance, in the `simple` example:
 
 ```jsx
 // A custom action creator which modifies the values before calling the default crudCreate action creator

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -637,61 +637,7 @@ Here are the props received by the `Toolbar` component when passed as the `toolb
 * `saving`: A boolean indicating whether a save operation is ongoing.
 * `submitOnEnter`: A boolean indicating whether the form should be submitted when pressing `enter`
 
-**Tip**: To alter the form values before submitting, you should use the `handleSubmit` prop. For instance, in the `simple` example:
-
-```jsx
-// A custom action creator which modifies the values before calling the default crudCreate action creator
-const saveWithNote = (values, basePath, redirectTo) =>
-    crudCreate('posts', { ...values, average_note: 10 }, basePath, redirectTo);
-
-class SaveWithNoteButtonView extends Component {
-    handleClick = () => {
-        const { basePath, handleSubmit, redirect, saveWithNote } = this.props;
-
-        return handleSubmit(values => {
-            saveWithNote(values, basePath, redirect);
-        });
-    };
-
-    render() {
-        const { handleSubmitWithRedirect, saveWithNote, ...props } = this.props;
-
-        return (
-            <SaveButton
-                handleSubmitWithRedirect={this.handleClick}
-                {...props}
-            />
-        );
-    }
-}
-
-const SaveWithNoteButton = connect(
-    undefined,
-    { saveWithNote }
-)(SaveWithNoteButtonView);
-```
-
-This button can be used in the `PostCreateToolbar` component:
-
-```jsx
-const PostCreateToolbar = props => (
-    <Toolbar {...props}>
-        <SaveButton
-            label="post.action.save_and_show"
-            redirect="show"
-            submitOnEnter={true}
-        />
-        <SaveWithNoteButton
-            label="post.action.save_with_average_note"
-            redirect="show"
-            submitOnEnter={false}
-            variant="flat"
-        />
-    </Toolbar>
-);
-```
-
-The advantages of this is that we still benefit from the default `crudCreate` action side effects.
+**Tip**: To alter the form values before submitting, you should use the `handleSubmit` prop. See [Altering the Form Values before Submitting](/Actions.html#altering-the-form-values-before-submitting) for more informations and example.
 
 ## Customizing Input Container Styles
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -636,6 +636,69 @@ Here are the props received by the `Toolbar` component when passed as the `toolb
 * `saving`: A boolean indicating whether a save operation is ongoing.
 * `submitOnEnter`: A boolean indicating whether the form should be submitted when pressing `enter`
 
+## Altering the Form Values before Submitting
+
+Sometimes, you may want your custom action to alter the form values before actually sending them to the `dataProvider`. For those cases, you should know that every buttons inside a form [Toolbar](/CreateEdit.html#toolbar) receive two props:
+
+- `handleSubmitWithRedirect` which calls the default form save methods
+- `handleSubmit` which is the same prop as in [`react-form`](https://redux-form.com/7.4.2/docs/api/props.md/#-code-handlesubmit-eventorsubmit-function-code-)
+
+Knowing this, we can dispatch a custom action with a button. For instance, in the `simple` example:
+
+```jsx
+// A custom action creator which modifies the values before calling the default crudCreate action creator
+const saveWithNote = (values, basePath, redirectTo) =>
+    crudCreate('posts', { ...values, average_note: 10 }, basePath, redirectTo);
+
+class SaveWithNoteButtonView extends Component {
+    handleClick = () => {
+        const { basePath, handleSubmit, redirect, saveWithNote } = this.props;
+
+        return handleSubmit(values => {
+            saveWithNote(values, basePath, redirect);
+        });
+    };
+
+    render() {
+        const { handleSubmitWithRedirect, saveWithNote, ...props } = this.props;
+
+        return (
+            <SaveButton
+                handleSubmitWithRedirect={this.handleClick}
+                {...props}
+            />
+        );
+    }
+}
+
+const SaveWithNoteButton = connect(
+    undefined,
+    { saveWithNote }
+)(SaveWithNoteButtonView);
+```
+
+This button can be used in the `PostCreateToolbar` component:
+
+```jsx
+const PostCreateToolbar = props => (
+    <Toolbar {...props}>
+        <SaveButton
+            label="post.action.save_and_show"
+            redirect="show"
+            submitOnEnter={true}
+        />
+        <SaveWithNoteButton
+            label="post.action.save_with_average_note"
+            redirect="show"
+            submitOnEnter={false}
+            variant="flat"
+        />
+    </Toolbar>
+);
+```
+
+The advantages of this is that we still benefit from the default `crudCreate` action side effects.
+
 ## Customizing Input Container Styles
 
 The input components are wrapped inside a `div` to ensure a good looking form by default. You can pass a `formClassName` prop to the input components to customize the style of this `div`. For example, here is how to display two inputs on the same line:

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -449,6 +449,9 @@
                                 <a href="#toolbar">Toolbar</a>
                             </li>
                             <li class="chapter">
+                                <a href="#altering-the-form-values-before-submitting">Altering the Form Values before Submitting</a>
+                            </li>
+                            <li class="chapter">
                                 <a href="#customizing-input-container-styles">Customize Input Containers Styles</a>
                             </li>
                             <li class="chapter">
@@ -656,13 +659,19 @@
                                 <a href="#using-a-custom-action-creator">Using a Custom Action Creator</a>
                             </li>
                             <li class="chapter">
-                                <a href="#handling-side-effects-with-a-custom-saga">Handling Side Effects With a Custom Saga</a>
+                                <a href="#handling-side-effects">Handling Side Effects</a>
                             </li>
                             <li class="chapter">
-                                <a href="#simplifying-side-effects-for-success">Simplifying side effects</a>
+                                <a href="#success-and-failure-side-effects">Success and Failure Side Effects</a>
                             </li>
                             <li class="chapter">
-                                <a href="#bonus-optimistic-rendering">Bonus: Optimistic Rendering</a>
+                                <a href="#optimistic-rendering-and-undo">Optimistic Rendering and Undo</a>
+                            </li>
+                            <li class="chapter">
+                                <a href="#altering-the-form-values-before-submitting">Altering the Form Values before Submitting</a>
+                            </li>
+                            <li class="chapter">
+                                <a href="#custom-sagas">Custom Sagas</a>
                             </li>
                             <li class="chapter">
                                 <a href="#using-a-custom-reducer">Using a Custom Reducer</a>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -449,9 +449,6 @@
                                 <a href="#toolbar">Toolbar</a>
                             </li>
                             <li class="chapter">
-                                <a href="#altering-the-form-values-before-submitting">Altering the Form Values before Submitting</a>
-                            </li>
-                            <li class="chapter">
                                 <a href="#customizing-input-container-styles">Customize Input Containers Styles</a>
                             </li>
                             <li class="chapter">

--- a/examples/simple/src/i18n/en.js
+++ b/examples/simple/src/i18n/en.js
@@ -64,6 +64,7 @@ export const messages = {
         },
         action: {
             save_and_add: 'Save and Add',
+            save_commentable: 'Save as Commentable',
             save_and_show: 'Save and Show',
         },
     },

--- a/examples/simple/src/i18n/en.js
+++ b/examples/simple/src/i18n/en.js
@@ -64,8 +64,8 @@ export const messages = {
         },
         action: {
             save_and_add: 'Save and Add',
-            save_commentable: 'Save as Commentable',
             save_and_show: 'Save and Show',
+            save_with_average_note: 'Save with Note',
         },
     },
     comment: {

--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -16,31 +16,31 @@ import {
     Toolbar,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
-const saveAsCommentable = (values, basePath, redirectTo) =>
-    crudCreate('posts', { ...values, commentable: true }, basePath, redirectTo);
+const saveWithNoteButton = (values, basePath, redirectTo) =>
+    crudCreate('posts', { ...values, average_note: 10 }, basePath, redirectTo);
 
-const SaveAsCommentableButton = connect(
+const SaveWithNoteButton = connect(
     undefined,
-    { saveAsCommentable }
+    { saveWithNoteButton }
 )(
-    class SaveAsCommentableButton extends Component {
+    class SaveWithNoteButton extends Component {
         handleClick = () => {
             const {
                 basePath,
                 handleSubmit,
                 redirect,
-                saveAsCommentable,
+                saveWithNoteButton,
             } = this.props;
 
             return handleSubmit(values => {
-                saveAsCommentable(values, basePath, redirect);
+                saveWithNoteButton(values, basePath, redirect);
             });
         };
 
         render() {
             const {
                 handleSubmitWithRedirect,
-                saveAsCommentable,
+                saveWithNoteButton,
                 ...props
             } = this.props;
 
@@ -67,8 +67,8 @@ const PostCreateToolbar = props => (
             submitOnEnter={false}
             variant="flat"
         />
-        <SaveAsCommentableButton
-            label="post.action.save_commentable"
+        <SaveWithNoteButton
+            label="post.action.save_with_average_note"
             redirect="show"
             submitOnEnter={false}
             variant="flat"

--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -16,43 +16,34 @@ import {
     Toolbar,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
-const saveWithNoteButton = (values, basePath, redirectTo) =>
+const saveWithNote = (values, basePath, redirectTo) =>
     crudCreate('posts', { ...values, average_note: 10 }, basePath, redirectTo);
+
+class SaveWithNoteButtonComponent extends Component {
+    handleClick = () => {
+        const { basePath, handleSubmit, redirect, saveWithNote } = this.props;
+
+        return handleSubmit(values => {
+            saveWithNote(values, basePath, redirect);
+        });
+    };
+
+    render() {
+        const { handleSubmitWithRedirect, saveWithNote, ...props } = this.props;
+
+        return (
+            <SaveButton
+                handleSubmitWithRedirect={this.handleClick}
+                {...props}
+            />
+        );
+    }
+}
 
 const SaveWithNoteButton = connect(
     undefined,
-    { saveWithNoteButton }
-)(
-    class SaveWithNoteButton extends Component {
-        handleClick = () => {
-            const {
-                basePath,
-                handleSubmit,
-                redirect,
-                saveWithNoteButton,
-            } = this.props;
-
-            return handleSubmit(values => {
-                saveWithNoteButton(values, basePath, redirect);
-            });
-        };
-
-        render() {
-            const {
-                handleSubmitWithRedirect,
-                saveWithNoteButton,
-                ...props
-            } = this.props;
-
-            return (
-                <SaveButton
-                    handleSubmitWithRedirect={this.handleClick}
-                    {...props}
-                />
-            );
-        }
-    }
-);
+    { saveWithNote }
+)(SaveWithNoteButtonComponent);
 
 const PostCreateToolbar = props => (
     <Toolbar {...props}>

--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -1,6 +1,9 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
 import RichTextInput from 'ra-input-rich-text';
-import React from 'react';
 import {
+    crudCreate,
     BooleanInput,
     Create,
     DateInput,
@@ -13,6 +16,44 @@ import {
     Toolbar,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
+const saveAsCommentable = (values, basePath, redirectTo) =>
+    crudCreate('posts', { ...values, commentable: true }, basePath, redirectTo);
+
+const SaveAsCommentableButton = connect(
+    undefined,
+    { saveAsCommentable }
+)(
+    class SaveAsCommentableButton extends Component {
+        handleClick = () => {
+            const {
+                basePath,
+                handleSubmit,
+                redirect,
+                saveAsCommentable,
+            } = this.props;
+
+            return handleSubmit(values => {
+                saveAsCommentable(values, basePath, redirect);
+            });
+        };
+
+        render() {
+            const {
+                handleSubmitWithRedirect,
+                saveAsCommentable,
+                ...props
+            } = this.props;
+
+            return (
+                <SaveButton
+                    handleSubmitWithRedirect={this.handleClick}
+                    {...props}
+                />
+            );
+        }
+    }
+);
+
 const PostCreateToolbar = props => (
     <Toolbar {...props}>
         <SaveButton
@@ -23,6 +64,12 @@ const PostCreateToolbar = props => (
         <SaveButton
             label="post.action.save_and_add"
             redirect={false}
+            submitOnEnter={false}
+            variant="flat"
+        />
+        <SaveAsCommentableButton
+            label="post.action.save_commentable"
+            redirect="show"
             submitOnEnter={false}
             variant="flat"
         />

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -20,6 +20,7 @@ const styles = {
 };
 
 const sanitizeRestProps = ({
+    basePath,
     className,
     classes,
     saving,
@@ -27,6 +28,7 @@ const sanitizeRestProps = ({
     invalid,
     variant,
     translate,
+    handleSubmit,
     handleSubmitWithRedirect,
     submitOnEnter,
     redirect,

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -99,7 +99,9 @@ export class SimpleForm extends Component {
                 </div>
                 {toolbar &&
                     React.cloneElement(toolbar, {
+                        basePath,
                         handleSubmitWithRedirect: this.handleSubmitWithRedirect,
+                        handleSubmit: this.props.handleSubmit,
                         invalid,
                         pristine,
                         redirect,

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -179,6 +179,7 @@ export class TabbedForm extends Component {
                             className: 'toolbar',
                             handleSubmitWithRedirect: this
                                 .handleSubmitWithRedirect,
+                            handleSubmit: this.props.handleSubmit,
                             invalid,
                             pristine,
                             redirect,

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -22,9 +22,11 @@ const valueOrDefault = (value, defaultValue) =>
     typeof value === 'undefined' ? defaultValue : value;
 
 const Toolbar = ({
+    basePath,
     children,
     classes,
     className,
+    handleSubmit,
     handleSubmitWithRedirect,
     invalid,
     pristine,
@@ -55,6 +57,8 @@ const Toolbar = ({
                         button =>
                             button
                                 ? React.cloneElement(button, {
+                                      basePath,
+                                      handleSubmit,
                                       handleSubmitWithRedirect,
                                       invalid,
                                       pristine,
@@ -86,6 +90,8 @@ const Toolbar = ({
                         button =>
                             button
                                 ? React.cloneElement(button, {
+                                      basePath,
+                                      handleSubmit,
                                       handleSubmitWithRedirect,
                                       invalid,
                                       pristine,
@@ -104,9 +110,11 @@ const Toolbar = ({
 );
 
 Toolbar.propTypes = {
+    basePath: PropTypes.string,
     children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
+    handleSubmit: PropTypes.func,
     handleSubmitWithRedirect: PropTypes.func,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/input/BooleanInput.js
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.js
@@ -24,14 +24,17 @@ export class BooleanInput extends Component {
             ...rest
         } = this.props;
 
+        const { value, ...inputProps } = input;
+
         return (
             <FormGroup className={className} {...sanitizeRestProps(rest)}>
                 <FormControlLabel
                     control={
                         <Switch
                             color="primary"
-                            checked={!!input.value}
+                            checked={!!value}
                             onChange={this.handleChange}
+                            {...inputProps}
                             {...options}
                         />
                     }


### PR DESCRIPTION
> No breaking changes, `handleSubmitWithRedirect` is still passed

## Use case

Having a custom save button which alter the values before actually saving them (see the `Save as Commentable` button in the `PostCreate` component of the `simple` example)

## Current issue

It's currently not possible to alter the form values before dispatching the save action:
- Dispatching a `redux-form` `change` action is asynchronous so we can't submit directly after changing the value
- Custom saga doesn't work either as it is not possible to dispatch a `redux-form` `submit` action because we don't have an `onSubmit` on our forms

## Solution

Passing the `redux-form` `handleSubmit` function to the buttons allows the user to do whatever he wants and still benefits from the default validation mechanisms

## TODO

- [x] Implementation
- [x] Tests
- [x] Documentation