### PR TITLE
[RFR] Add Tooltips To Icon Buttons

### DIFF
--- a/examples/demo/src/categories/LinkToRelatedProducts.js
+++ b/examples/demo/src/categories/LinkToRelatedProducts.js
@@ -2,7 +2,7 @@ import React from 'react';
 import compose from 'recompose/compose';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
-import { Link } from 'react-admin';
+import { Link } from 'react-router-dom';
 import { translate } from 'react-admin';
 import { stringify } from 'query-string';
 
@@ -17,23 +17,24 @@ const styles = {
 };
 
 const LinkToRelatedProducts = ({ classes, record, translate }) => (
-    <Button color="primary">
-        <Link
-            to={{
-                pathname: '/products',
-                search: stringify({
-                    page: 1,
-                    perPage: 25,
-                    sort: 'id',
-                    order: 'DESC',
-                    filter: JSON.stringify({ category_id: record.id }),
-                }),
-            }}
-            className={classes.link}
-        >
-            <ProductIcon className={classes.icon} />
-            {translate('resources.categories.fields.products')}
-        </Link>
+    <Button
+        size="small"
+        color="primary"
+        component={Link}
+        to={{
+            pathname: '/products',
+            search: stringify({
+                page: 1,
+                perPage: 25,
+                sort: 'id',
+                order: 'DESC',
+                filter: JSON.stringify({ category_id: record.id }),
+            }),
+        }}
+        className={classes.link}
+    >
+        <ProductIcon className={classes.icon} />
+        {translate('resources.categories.fields.products')}
     </Button>
 );
 

--- a/examples/demo/src/products/GridList.js
+++ b/examples/demo/src/products/GridList.js
@@ -5,7 +5,8 @@ import GridListTileBar from '@material-ui/core/GridListTileBar';
 import { withStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import ContentCreate from '@material-ui/icons/Create';
-import { NumberField, Link } from 'react-admin';
+import { Link } from 'react-router-dom';
+import { NumberField } from 'react-admin';
 import { linkToRecord } from 'ra-core';
 
 const styles = {

--- a/examples/demo/src/reviews/AcceptButton.js
+++ b/examples/demo/src/reviews/AcceptButton.js
@@ -16,7 +16,7 @@ class AcceptButton extends Component {
     render() {
         const { record, translate } = this.props;
         return record && record.status === 'pending' ? (
-            <Button color="primary" onClick={this.handleApprove}>
+            <Button color="primary" size="small" onClick={this.handleApprove}>
                 <ThumbUp
                     color="primary"
                     style={{ paddingRight: '0.5em', color: 'green' }}

--- a/examples/demo/src/reviews/RejectButton.js
+++ b/examples/demo/src/reviews/RejectButton.js
@@ -16,7 +16,7 @@ class AcceptButton extends Component {
     render() {
         const { record, translate } = this.props;
         return record && record.status === 'pending' ? (
-            <Button color="primary" onClick={this.handleApprove}>
+            <Button color="primary" size="small" onClick={this.handleApprove}>
                 <ThumbDown
                     color="primary"
                     style={{ paddingRight: '0.5em', color: 'red' }}

--- a/examples/demo/src/segments/LinkToRelatedCustomers.js
+++ b/examples/demo/src/segments/LinkToRelatedCustomers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import compose from 'recompose/compose';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
-import { Link } from 'react-admin';
+import { Link } from 'react-router-dom';
 import { translate } from 'react-admin';
 import { stringify } from 'query-string';
 
@@ -18,6 +18,7 @@ const styles = {
 
 const LinkToRelatedCustomers = ({ classes, segment, translate }) => (
     <Button
+        size="small"
         color="primary"
         component={Link}
         to={{

--- a/examples/graphcool-demo/src/categories/LinkToRelatedProducts.js
+++ b/examples/graphcool-demo/src/categories/LinkToRelatedProducts.js
@@ -2,7 +2,8 @@ import React from 'react';
 import compose from 'recompose/compose';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
-import { Link, translate } from 'react-admin';
+import { Link } from 'react-router-dom';
+import { translate } from 'react-admin';
 import { stringify } from 'query-string';
 
 import { ProductIcon } from '../products';
@@ -17,6 +18,7 @@ const styles = {
 
 const LinkToRelatedProducts = ({ classes, record, translate }) => (
     <Button
+        size="small"
         color="primary"
         component={Link}
         to={{
@@ -24,6 +26,8 @@ const LinkToRelatedProducts = ({ classes, record, translate }) => (
             search: stringify({
                 page: 1,
                 perPage: 25,
+                sort: 'id',
+                order: 'DESC',
                 filter: JSON.stringify({ 'category.id': record.id }),
             }),
         }}

--- a/examples/graphcool-demo/src/reviews/AcceptButton.js
+++ b/examples/graphcool-demo/src/reviews/AcceptButton.js
@@ -16,7 +16,7 @@ class AcceptButton extends Component {
     render() {
         const { record, translate } = this.props;
         return record && record.status === 'pending' ? (
-            <Button color="primary" onClick={this.handleApprove}>
+            <Button color="primary" size="small" onClick={this.handleApprove}>
                 <ThumbUp color="primary" style={{ paddingRight: '0.5em' }} />
                 {translate('resources.Review.action.accept')}
             </Button>

--- a/examples/graphcool-demo/src/reviews/RejectButton.js
+++ b/examples/graphcool-demo/src/reviews/RejectButton.js
@@ -16,7 +16,7 @@ class AcceptButton extends Component {
     render() {
         const { record, translate } = this.props;
         return record && record.status === 'pending' ? (
-            <Button color="primary" onClick={this.handleApprove}>
+            <Button color="primary" size="small" onClick={this.handleApprove}>
                 <ThumbDown color="primary" style={{ paddingRight: '0.5em' }} />
                 {translate('resources.Review.action.reject')}
             </Button>

--- a/examples/graphcool-demo/src/segments/LinkToRelatedCustomers.js
+++ b/examples/graphcool-demo/src/segments/LinkToRelatedCustomers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import compose from 'recompose/compose';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
-import { Link } from 'react-admin';
+import { Link } from 'react-router-dom';
 import { translate } from 'react-admin';
 import { stringify } from 'query-string';
 
@@ -18,6 +18,7 @@ const styles = {
 
 const LinkToRelatedCustomers = ({ classes, record, translate }) => (
     <Button
+        size="small"
         color="primary"
         component={Link}
         to={{

--- a/examples/simple/src/posts/PostShow.js
+++ b/examples/simple/src/posts/PostShow.js
@@ -8,7 +8,6 @@ import {
     Datagrid,
     DateField,
     EditButton,
-    Link,
     NumberField,
     ReferenceArrayField,
     ReferenceManyField,
@@ -21,6 +20,7 @@ import {
     TextField,
     UrlField,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { Link } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import PostTitle from './PostTitle';
 

--- a/packages/ra-ui-materialui/src/Link.js
+++ b/packages/ra-ui-materialui/src/Link.js
@@ -10,6 +10,9 @@ const styles = theme => ({
         color: theme.palette.primary.main,
     },
 });
+/**
+ * @deprecated Use react-router-dom's Link instead
+ */
 const Link = ({ to, children, className, classes }) => (
     <RRLink to={to} className={classNames(classes.link, className)}>
         {children}

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import MuiButton from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
@@ -35,14 +36,16 @@ const Button = ({
 }) => (
     <Responsive
         small={
-            <IconButton
-                arial-label={label && translate(label, { _: label })}
-                className={className}
-                color={color}
-                {...rest}
-            >
-                {children}
-            </IconButton>
+            <Tooltip title={label && translate(label, { _: label })}>
+                <IconButton
+                    arial-label={label && translate(label, { _: label })}
+                    className={className}
+                    color={color}
+                    {...rest}
+                >
+                    {children}
+                </IconButton>
+            </Tooltip>
         }
         medium={
             <MuiButton

--- a/packages/ra-ui-materialui/src/button/CloneButton.js
+++ b/packages/ra-ui-materialui/src/button/CloneButton.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import shouldUpdate from 'recompose/shouldUpdate';
 import ContentCreate from '@material-ui/icons/Create';
+import { Link } from 'react-router-dom';
 
-import Link from '../Link';
 import Button from './Button';
 
 const omitId = ({ id, ...rest }) => rest;

--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -29,8 +29,8 @@ const styles = theme => ({
         display: 'inline-flex',
         alignItems: 'center',
     },
-    iconPaddingStyle: {
-        paddingRight: '0.5em',
+    label: {
+        paddingLeft: '0.5em',
     },
 });
 
@@ -40,6 +40,7 @@ const CreateButton = ({
     classes = {},
     translate,
     label = 'ra.action.create',
+    size = 'small',
     ...rest
 }) => (
     <Responsive
@@ -61,10 +62,13 @@ const CreateButton = ({
                 color="primary"
                 to={`${basePath}/create`}
                 className={classnames(classes.desktopLink, className)}
+                size={size}
                 {...rest}
             >
                 <ContentAdd className={classes.iconPaddingStyle} />
-                {label && translate(label)}
+                <span className={classes.label}>
+                    {label && translate(label)}
+                </span>
             </Button>
         }
     />
@@ -75,6 +79,7 @@ CreateButton.propTypes = {
     className: PropTypes.string,
     classes: PropTypes.object,
     label: PropTypes.string,
+    size: PropTypes.string,
     translate: PropTypes.func.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -6,10 +6,10 @@ import { withStyles } from '@material-ui/core/styles';
 import ContentAdd from '@material-ui/icons/Add';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
+import { Link } from 'react-router-dom';
 import { translate } from 'ra-core';
 
 import Responsive from '../layout/Responsive';
-import Link from '../Link';
 
 const styles = theme => ({
     floating: {

--- a/packages/ra-ui-materialui/src/button/EditButton.js
+++ b/packages/ra-ui-materialui/src/button/EditButton.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import shouldUpdate from 'recompose/shouldUpdate';
 import ContentCreate from '@material-ui/icons/Create';
+import { Link } from 'react-router-dom';
 import { linkToRecord } from 'ra-core';
 
-import Link from '../Link';
 import Button from './Button';
 
 const EditButton = ({

--- a/packages/ra-ui-materialui/src/button/ListButton.js
+++ b/packages/ra-ui-materialui/src/button/ListButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ActionList from '@material-ui/icons/List';
+import { Link } from 'react-router-dom';
 
-import Link from '../Link';
 import Button from './Button';
 
 const ListButton = ({ basePath = '', label = 'ra.action.list', ...rest }) => (

--- a/packages/ra-ui-materialui/src/button/ShowButton.js
+++ b/packages/ra-ui-materialui/src/button/ShowButton.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import shouldUpdate from 'recompose/shouldUpdate';
 import ImageEye from '@material-ui/icons/RemoveRedEye';
+import { Link } from 'react-router-dom';
 import { linkToRecord } from 'ra-core';
 
-import Link from '../Link';
 import Button from './Button';
 
 const ShowButton = ({

--- a/packages/ra-ui-materialui/src/layout/CardActions.js
+++ b/packages/ra-ui-materialui/src/layout/CardActions.js
@@ -15,6 +15,7 @@ const styles = {
 
 const CardActions = ({ classes, className, children, ...rest }) => (
     <MuiCardActions
+        disableActionSpacing
         className={classnames(classes.cardActions, className)}
         {...rest}
     >

--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -22,7 +22,11 @@ const Actions = ({
     showFilter,
     ...rest
 }) => (
-    <CardActions className={className} {...sanitizeListRestProps(rest)}>
+    <CardActions
+        className={className}
+        disableActionSpacing
+        {...sanitizeListRestProps(rest)}
+    >
         {bulkActions &&
             cloneElement(bulkActions, {
                 basePath,


### PR DESCRIPTION
The small version of action buttons shows not only on mobile, but also on desktop, on smaller screens. In these devices, we can use the "hover" behavior to add a tooltip and make the UI clearer.

I was exploring this approach after adding the `ExportButton`, because there are more and more cases when, on desktop, the action button breaks into 2 or 3 lines. We may have to consider using the small version all the time if we week adding buttons.

![kapture 2018-07-20 at 10 42 52](https://user-images.githubusercontent.com/99944/42992746-bbe7d6ec-8c09-11e8-9048-1138f6ce7530.gif)

- [x] Add tooltips to minimized action buttons
- [x] Do not use custom `Link` on buttons (not only was it useless, it also messed up with the mui `Tooltip`, which introspects its children to do some voodoo).
- [x] Remove spacing between actions to allow to pack more of them