### PR TITLE
[RFR] Fix record value in SimpleFormIterator children

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -126,7 +126,7 @@ export class SimpleFormIterator extends Component {
                                                     input.props.label ||
                                                     input.props.source,
                                             })}
-                                            record={records[index]}
+                                            record={records && records[index]}
                                             resource={resource}
                                         />
                                     ))}

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -2,6 +2,7 @@ import React, { Children, cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import get from 'lodash/get';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
@@ -88,10 +89,12 @@ export class SimpleFormIterator extends Component {
             meta: { error, submitFailed },
             record,
             resource,
+            source,
             translate,
             disableAdd,
             disableRemove,
         } = this.props;
+        const records = get(record, source);
         return fields ? (
             <ul className={classes.root}>
                 {submitFailed && error && <span>{error}</span>}
@@ -112,7 +115,9 @@ export class SimpleFormIterator extends Component {
                                 <section className={classes.form}>
                                     {Children.map(children, input => (
                                         <FormInput
-                                            basePath={basePath}
+                                            basePath={
+                                                input.props.basePath || basePath
+                                            }
                                             input={cloneElement(input, {
                                                 source: `${member}.${
                                                     input.props.source
@@ -121,7 +126,7 @@ export class SimpleFormIterator extends Component {
                                                     input.props.label ||
                                                     input.props.source,
                                             })}
-                                            record={record}
+                                            record={records[index]}
                                             resource={resource}
                                         />
                                     ))}
@@ -171,6 +176,7 @@ SimpleFormIterator.propTypes = {
     fields: PropTypes.object,
     meta: PropTypes.object,
     record: PropTypes.object,
+    source: PropTypes.string,
     resource: PropTypes.string,
     translate: PropTypes.func,
     disableAdd: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/input/ArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.js
@@ -50,11 +50,12 @@ import sanitizeRestProps from './sanitizeRestProps';
  */
 export class ArrayInput extends Component {
     renderFieldArray = fieldProps => {
-        const { children, record, resource } = this.props;
+        const { children, record, resource, source } = this.props;
         return cloneElement(children, {
             ...fieldProps,
             record,
             resource,
+            source,
         });
     };
 


### PR DESCRIPTION
Imagine that `resource` is `posts`, `record` is `{ id: 123, comments: [{ id: 456, body: 'foobar' }] }`.

`<ArrayInput source="comments">` properly injects the `record` and `source` to `<SimpleFormIterator>`. But `<SimpleFormIterator>` injects this record (`{ id: 123, comments: [{ id: 456, body: 'foobar' }] }`) directly to its children, while in fact they're only interested in the sub records (`{ id: 456, body: 'foobar' }`).

This PR fixes that.

Closes #1835