### PR TITLE
[RFR] Fix ArrayInput defaultValue

### DIFF
--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -5,5 +5,7 @@
     "pluginsFile": "plugins/index.js",
     "screenshotsFolder": "screenshots",
     "supportFile": "support/index.js",
-    "videosFolder": "videos"
+    "videosFolder": "videos",
+    "viewportWidth": 1280,
+    "viewportHeight": 720
 }

--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -15,6 +15,17 @@ describe('Create Page', () => {
         );
     });
 
+    it('should put the ArrayInput default value', () => {
+        const currentDate = new Date();
+        const currentDateString = currentDate.toISOString().slice(0, 10);
+        cy.get(CreatePage.elements.input('backlinks[0].date')).should(el =>
+            expect(el).to.have.value(currentDateString)
+        );
+        cy.get(CreatePage.elements.input('backlinks[0].url')).should(el =>
+            expect(el).to.have.value('http://google.com')
+        );
+    });
+
     it('should redirect to show page after create success', () => {
         const values = [
             {

--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -56,7 +56,7 @@ describe('Create Page', () => {
         ); // new empty form
 
         ShowPage.navigate();
-        ShowPage.ShowPage.delete();
+        ShowPage.delete();
     });
 
     it('should allow to call a custom action updating values before submit', () => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -6,8 +6,12 @@ module.exports = on => {
     };
     on('before:browser:launch', (browser = {}, args) => {
         if (browser.name === 'chrome') {
-            args.push('--disable-gpu');
-            return args;
+            return [
+                ...args.filter(
+                    arg => arg !== '--disable-blink-features=RootLayerScrolling'
+                ),
+                '--disable-gpu',
+            ];
         }
     });
     on('file:preprocessor', wp(options));

--- a/cypress/start.js
+++ b/cypress/start.js
@@ -11,8 +11,11 @@ return server.start().then(listeningServer => {
                 video: false,
             },
         })
-        .then(() => {
+        .then(results => {
             // stop your server when it's complete
-            return listeningServer.close();
+            listeningServer.close();
+            if (results.totalFailed > 0) {
+                process.exit(1);
+            }
         });
 });

--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -3,15 +3,17 @@ import { connect } from 'react-redux';
 
 import RichTextInput from 'ra-input-rich-text';
 import {
-    crudCreate,
+    ArrayInput,
     BooleanInput,
     Create,
+    crudCreate,
     DateInput,
     FormDataConsumer,
     LongTextInput,
     NumberInput,
     SaveButton,
     SimpleForm,
+    SimpleFormIterator,
     TextInput,
     Toolbar,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
@@ -101,6 +103,20 @@ const PostCreate = props => (
             </FormDataConsumer>
             <DateInput source="published_at" defaultValue={getDefaultDate} />
             <BooleanInput source="commentable" defaultValue />
+            <ArrayInput
+                source="backlinks"
+                defaultValue={[
+                    {
+                        date: new Date().toISOString(),
+                        url: 'http://google.com',
+                    },
+                ]}
+            >
+                <SimpleFormIterator>
+                    <DateInput source="date" />
+                    <TextInput source="url" />
+                </SimpleFormIterator>
+            </ArrayInput>
         </SimpleForm>
     </Create>
 );

--- a/packages/ra-core/src/form/FormField.js
+++ b/packages/ra-core/src/form/FormField.js
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-
-import { initializeForm } from '../actions/formActions';
+import withDefaultValue from './withDefaultValue';
 
 export const isRequired = validate => {
     if (validate && validate.isRequired) return true;
@@ -13,62 +11,23 @@ export const isRequired = validate => {
     return false;
 };
 
-export class FormField extends Component {
-    static propTypes = {
-        component: PropTypes.any.isRequired,
-        defaultValue: PropTypes.any,
-        initializeForm: PropTypes.func.isRequired,
-        input: PropTypes.object,
-        source: PropTypes.string,
-        validate: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
-    };
+export const FormFieldView = ({ input, ...props }) =>
+    input ? ( // An ancestor is already decorated by Field
+        React.createElement(props.component, { input, ...props })
+    ) : (
+        <Field
+            {...props}
+            name={props.source}
+            isRequired={isRequired(props.validate)}
+        />
+    );
 
-    componentDidMount() {
-        const { defaultValue, input, initializeForm, source } = this.props;
-        if (typeof defaultValue === 'undefined' || input) {
-            return;
-        }
-        initializeForm({
-            [source]:
-                typeof defaultValue === 'function'
-                    ? defaultValue()
-                    : defaultValue,
-        });
-    }
+FormFieldView.propTypes = {
+    component: PropTypes.any.isRequired,
+    defaultValue: PropTypes.any,
+    input: PropTypes.object,
+    source: PropTypes.string,
+    validate: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
+};
 
-    componentWillReceiveProps(nextProps) {
-        const { defaultValue, input, initializeForm, source } = nextProps;
-        if (typeof defaultValue === 'undefined' || input) {
-            return;
-        }
-
-        if (defaultValue !== this.props.defaultValue) {
-            initializeForm({
-                [source]:
-                    typeof defaultValue === 'function'
-                        ? defaultValue()
-                        : defaultValue,
-            });
-        }
-    }
-
-    render() {
-        const { input, validate, component, ...props } = this.props;
-        return input ? ( // An ancestor is already decorated by Field
-            React.createElement(component, this.props)
-        ) : (
-            <Field
-                {...props}
-                name={props.source}
-                component={component}
-                validate={validate}
-                isRequired={isRequired(validate)}
-            />
-        );
-    }
-}
-
-export default connect(
-    undefined,
-    { initializeForm }
-)(FormField);
+export default withDefaultValue(FormFieldView);

--- a/packages/ra-core/src/form/FormField.spec.js
+++ b/packages/ra-core/src/form/FormField.spec.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import React from 'react';
-import { FormField } from './FormField';
+import { FormFieldView as FormField } from './FormField';
 
 describe('<FormField>', () => {
     const Foo = () => <div />;
@@ -17,68 +17,11 @@ describe('<FormField>', () => {
         assert.equal(component.length, 1);
         assert.equal(wrapper.prop('component'), Foo);
     });
-    it('should not initialize the form if no default value', () => {
-        const initializeForm = jest.fn();
-        shallow(
-            <FormField
-                source="title"
-                initializeForm={initializeForm}
-                component={Foo}
-            />
-        );
-        assert.equal(initializeForm.mock.calls.length, 0);
-    });
-    it('should initialize the form with default value on mount', () => {
-        const initializeForm = jest.fn();
-        shallow(
-            <FormField
-                source="title"
-                initializeForm={initializeForm}
-                component={Foo}
-                defaultValue={2}
-            />
-        );
-        assert.equal(initializeForm.mock.calls.length, 1);
-        assert.deepEqual(initializeForm.mock.calls[0][0], { title: 2 });
-    });
     it('should not render a <Field /> component the field has an input', () => {
         const wrapper = shallow(
             <FormField initializeForm={() => true} component={Foo} input={{}} />
         );
         const component = wrapper.find('Field');
         assert.equal(component.length, 0);
-    });
-
-    it('should call initializeForm if a defaultValue is set', () => {
-        const initializeForm = jest.fn();
-        shallow(
-            <FormField
-                component={Foo}
-                source="bar"
-                defaultValue="foo"
-                initializeForm={initializeForm}
-            />
-        );
-        assert.equal(initializeForm.mock.calls.length, 1);
-        assert.deepEqual(initializeForm.mock.calls[0][0], { bar: 'foo' });
-    });
-
-    it('should call initializeForm if a defaultValue changes', () => {
-        const initializeForm = jest.fn();
-        const wrapper = shallow(
-            <FormField
-                component={Foo}
-                source="bar"
-                defaultValue="foo"
-                initializeForm={initializeForm}
-            />
-        );
-        assert.equal(initializeForm.mock.calls.length, 1);
-        assert.deepEqual(initializeForm.mock.calls[0][0], { bar: 'foo' });
-
-        wrapper.setProps({ defaultValue: 'bar', initializeForm });
-
-        assert.equal(initializeForm.mock.calls.length, 2);
-        assert.deepEqual(initializeForm.mock.calls[1][0], { bar: 'bar' });
     });
 });

--- a/packages/ra-core/src/form/index.js
+++ b/packages/ra-core/src/form/index.js
@@ -2,5 +2,6 @@ export addField from './addField';
 export FormDataConsumer from './FormDataConsumer';
 export FormField, { isRequired } from './FormField';
 export getDefaultValues from './getDefaultValues';
+export withDefaultValue from './withDefaultValue';
 export * from './validate';
 export * from './constants';

--- a/packages/ra-core/src/form/withDefaultValue.js
+++ b/packages/ra-core/src/form/withDefaultValue.js
@@ -1,0 +1,60 @@
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
+
+import { connect } from 'react-redux';
+import { initializeForm as initializeFormAction } from '../actions/formActions';
+
+export class DefaultValue extends Component {
+    static propTypes = {
+        decoratedComponent: PropTypes.oneOfType([
+            PropTypes.element,
+            PropTypes.func,
+        ]),
+        defaultValue: PropTypes.any,
+        initializeForm: PropTypes.func.isRequired,
+        input: PropTypes.object,
+        source: PropTypes.string,
+        validate: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
+    };
+
+    componentDidMount() {
+        const { defaultValue, input, initializeForm, source } = this.props;
+        if (typeof defaultValue === 'undefined' || input) {
+            return;
+        }
+        initializeForm({
+            [source]:
+                typeof defaultValue === 'function'
+                    ? defaultValue()
+                    : defaultValue,
+        });
+    }
+
+    componentDidUpdate(prevProps) {
+        const { defaultValue, input, initializeForm, source } = this.props;
+        if (typeof defaultValue === 'undefined' || input) {
+            return;
+        }
+
+        if (defaultValue !== prevProps.defaultValue) {
+            initializeForm({
+                [source]:
+                    typeof defaultValue === 'function'
+                        ? defaultValue()
+                        : defaultValue,
+            });
+        }
+    }
+
+    render() {
+        const { initializeForm, decoratedComponent, ...props } = this.props;
+        return createElement(decoratedComponent, props);
+    }
+}
+
+export default DecoratedComponent => {
+    return connect(
+        () => ({ decoratedComponent: DecoratedComponent }),
+        { initializeForm: initializeFormAction }
+    )(DefaultValue);
+};

--- a/packages/ra-core/src/form/withDefaultValue.js
+++ b/packages/ra-core/src/form/withDefaultValue.js
@@ -52,9 +52,8 @@ export class DefaultValue extends Component {
     }
 }
 
-export default DecoratedComponent => {
-    return connect(
+export default DecoratedComponent =>
+    connect(
         () => ({ decoratedComponent: DecoratedComponent }),
         { initializeForm: initializeFormAction }
     )(DefaultValue);
-};

--- a/packages/ra-core/src/form/withDefaultValue.spec.js
+++ b/packages/ra-core/src/form/withDefaultValue.spec.js
@@ -1,0 +1,53 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { DefaultValue } from './withDefaultValue';
+
+describe('withDefaultValue', () => {
+    describe('<DefaultValue />', () => {
+        const BaseComponent = () => <div />;
+
+        it('should not initialize the form if no default value', () => {
+            const initializeForm = jest.fn();
+            shallow(
+                <DefaultValue
+                    initializeForm={initializeForm}
+                    decoratedComponent={BaseComponent}
+                    source="title"
+                />
+            );
+            assert.equal(initializeForm.mock.calls.length, 0);
+        });
+        it('should initialize the form with default value on mount', () => {
+            const initializeForm = jest.fn();
+            shallow(
+                <DefaultValue
+                    initializeForm={initializeForm}
+                    decoratedComponent={BaseComponent}
+                    source="title"
+                    defaultValue={2}
+                />
+            );
+            assert.equal(initializeForm.mock.calls.length, 1);
+            assert.deepEqual(initializeForm.mock.calls[0][0], { title: 2 });
+        });
+        it('should call initializeForm if a defaultValue changes', () => {
+            const initializeForm = jest.fn();
+            const wrapper = shallow(
+                <DefaultValue
+                    initializeForm={initializeForm}
+                    decoratedComponent={BaseComponent}
+                    source="bar"
+                    defaultValue="foo"
+                />
+            );
+            assert.equal(initializeForm.mock.calls.length, 1);
+            assert.deepEqual(initializeForm.mock.calls[0][0], { bar: 'foo' });
+
+            wrapper.setProps({ defaultValue: 'bar', initializeForm });
+
+            assert.equal(initializeForm.mock.calls.length, 2);
+            assert.deepEqual(initializeForm.mock.calls[1][0], { bar: 'bar' });
+        });
+    });
+});

--- a/packages/ra-core/src/form/withDefaultValue.spec.js
+++ b/packages/ra-core/src/form/withDefaultValue.spec.js
@@ -44,7 +44,7 @@ describe('withDefaultValue', () => {
             assert.equal(initializeForm.mock.calls.length, 1);
             assert.deepEqual(initializeForm.mock.calls[0][0], { bar: 'foo' });
 
-            wrapper.setProps({ defaultValue: 'bar', initializeForm });
+            wrapper.setProps({ defaultValue: 'bar' });
 
             assert.equal(initializeForm.mock.calls.length, 2);
             assert.deepEqual(initializeForm.mock.calls[1][0], { bar: 'bar' });

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -63,17 +63,17 @@ export class SimpleFormIterator extends Component {
         // we need a unique id for each field for a proper enter/exit animation
         // but redux-form doesn't provide one (cf https://github.com/erikras/redux-form/issues/2735)
         // so we keep an internal map between the field position and an autoincrement id
-        this.nextId = 0;
+        this.nextId = props.fields.length
+            ? props.fields.length
+            : props.defaultValue
+                ? props.defaultValue.length
+                : 0;
 
         // We check whether we have a defaultValue (which must be an array) before checking
         // the fields prop which will always be empty for a new record.
         // Without it, our ids wouldn't match the default value and we would get key warnings
         // on the CssTransition element inside our render method
-        this.ids = props.defaultValue
-            ? props.defaultValue.map(() => this.nextId++)
-            : props.fields
-                ? props.fields.map(() => this.nextId++)
-                : [];
+        this.ids = this.nextId > 0 ? Array.from(Array(this.nextId).keys()) : [];
     }
 
     removeField = index => () => {

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -64,7 +64,16 @@ export class SimpleFormIterator extends Component {
         // but redux-form doesn't provide one (cf https://github.com/erikras/redux-form/issues/2735)
         // so we keep an internal map between the field position and an autoincrement id
         this.nextId = 0;
-        this.ids = props.fields ? props.fields.map(() => this.nextId++) : [];
+
+        // We check whether we have a defaultValue (which must be an array) before checking
+        // the fields prop which will always be empty for a new record.
+        // Without it, our ids wouldn't match the default value and we would get key warnings
+        // on the CssTransition element inside our render method
+        this.ids = props.defaultValue
+            ? props.defaultValue.map(() => this.nextId++)
+            : props.fields
+                ? props.fields.map(() => this.nextId++)
+                : [];
     }
 
     removeField = index => () => {
@@ -164,6 +173,7 @@ SimpleFormIterator.defaultProps = {
 };
 
 SimpleFormIterator.propTypes = {
+    defaultValue: PropTypes.any,
     basePath: PropTypes.string,
     children: PropTypes.node,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/input/ArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.js
@@ -1,6 +1,6 @@
 import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
-import { isRequired, FieldTitle } from 'ra-core';
+import { isRequired, FieldTitle, withDefaultValue } from 'ra-core';
 import { FieldArray } from 'redux-form';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -61,6 +61,7 @@ export class ArrayInput extends Component {
     render() {
         const {
             className,
+            defaultValue,
             label,
             source,
             resource,
@@ -85,6 +86,7 @@ export class ArrayInput extends Component {
                 </InputLabel>
                 <FieldArray
                     name={source}
+                    defaultValue={defaultValue}
                     component={this.renderFieldArray}
                     validate={validate}
                     isRequired={isRequired(validate)}
@@ -97,6 +99,7 @@ export class ArrayInput extends Component {
 ArrayInput.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    defaultValue: PropTypes.any,
     isRequired: PropTypes.bool,
     label: PropTypes.string,
     resource: PropTypes.string,
@@ -110,4 +113,4 @@ ArrayInput.defaultProps = {
     options: {},
     fullWidth: true,
 };
-export default ArrayInput;
+export default withDefaultValue(ArrayInput);

--- a/packages/ra-ui-materialui/src/input/ArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.spec.js
@@ -25,7 +25,7 @@ const AppMock = ({ children }) => (
 
 describe('<ArrayInput />', () => {
     it('should render a FieldArray', () => {
-        const wrapper = shallow(<ArrayInput source="arr" record={{}} />);
+        const wrapper = shallow(<ArrayInputView source="arr" record={{}} />);
         expect(wrapper.find('translate(pure(FieldTitle))').length).toBe(1);
         expect(wrapper.find('FieldArray').length).toBe(1);
     });

--- a/packages/ra-ui-materialui/src/input/ArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.spec.js
@@ -5,7 +5,7 @@ import { createStore, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import { TranslationProvider } from 'ra-core';
 
-import { ArrayInput } from './ArrayInput';
+import ArrayInput, { ArrayInput as ArrayInputView } from './ArrayInput';
 import NumberInput from './NumberInput';
 import TextInput from './TextInput';
 import SimpleFormIterator from '../form/SimpleFormIterator';


### PR DESCRIPTION
Follow #2084 
Fixes #2046 

- [x] Introduce `withDefaultValue` to allow input components not using `addField` to dispatch the `initializeForm` action for their default values
- [x] Refactor FormField to use the new HOC
- [x] Use the new HOC in `ArrayInput`
- [x] Fix SimpleFormIterator so that it initializes correctly when it has default values
- [x] Tests