### PR TITLE
Fix the 'directory already exists' issue when re-making the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-react-admin:
 	@echo "Transpiling react-admin files...";
 	@rm -rf ./packages/react-admin/docs
 	@cd ./packages/react-admin && yarn -s build
-	@mkdir packages/react-admin/docs
+	@mkdir -p packages/react-admin/docs
 	@cp docs/*.md packages/react-admin/docs
 
 build-ra-data-fakerest:


### PR DESCRIPTION
I received an error message that the 'docs' directory already exists in packages, when updating the project with a new make (i.e. the folders were already there).