### PR TITLE
[RFR] ensure redux-form does not destroy forms after they are remounted

### DIFF
--- a/packages/ra-core/src/CoreAdmin.js
+++ b/packages/ra-core/src/CoreAdmin.js
@@ -14,6 +14,7 @@ import { USER_LOGOUT } from './actions/authActions';
 import createAppReducer from './reducer';
 import { adminSaga } from './sideEffect';
 import { TranslationProvider, defaultI18nProvider } from './i18n';
+import formMiddleware from './form/formMiddleware';
 import CoreAdminRouter from './CoreAdminRouter';
 
 const CoreAdmin = ({
@@ -56,7 +57,11 @@ const CoreAdmin = ({
         resettableAppReducer,
         initialState,
         compose(
-            applyMiddleware(sagaMiddleware, routerMiddleware(routerHistory)),
+            applyMiddleware(
+                sagaMiddleware,
+                routerMiddleware(routerHistory),
+                formMiddleware
+            ),
             typeof window !== 'undefined' && window.devToolsExtension
                 ? window.devToolsExtension()
                 : f => f

--- a/packages/ra-core/src/form/formMiddleware.js
+++ b/packages/ra-core/src/form/formMiddleware.js
@@ -1,0 +1,39 @@
+import { actionTypes } from 'redux-form';
+
+const state = {};
+
+const handleDestroy = (action, next) => {
+    state[action.meta.form] = (state[action.meta.form] || 0) - 1;
+
+    if (state[action.meta.form] <= 0) {
+        return next(action);
+    }
+
+    // Drop the action
+    return false;
+};
+
+const handleInitialize = (action, next) => {
+    state[action.meta.form] = (state[action.meta.form] || 0) + 1;
+    return next(action);
+};
+
+const handleAction = (action, next) => {
+    switch (action.type) {
+        case actionTypes.DESTROY:
+            return handleDestroy(action, next);
+        case actionTypes.INITIALIZE:
+            return handleInitialize(action, next);
+        default:
+            return next(action);
+    }
+};
+
+/**
+ * This middleware ensure redux-form does not destroy forms after they are
+ * remounted. This happens in a List component with a child (Datagrid, Tree)
+ * containing forms as the List component clone them at each render, triggering a
+ * unmount/mount. Related to this redux-form bug:
+ * https://github.com/erikras/redux-form/issues/3435#issuecomment-359371803
+ */
+export default () => next => action => handleAction(action, next);


### PR DESCRIPTION
Related to this redux-form bug: https://github.com/erikras/redux-form/issues/3435#issuecomment-359371803