### PR TITLE
Exporting missing FormInput

### DIFF
--- a/packages/ra-ui-materialui/src/form/index.js
+++ b/packages/ra-ui-materialui/src/form/index.js
@@ -1,3 +1,4 @@
+export FormInput from './FormInput';
 export FormTab from './FormTab';
 export SimpleForm from './SimpleForm';
 export SimpleFormIterator from './SimpleFormIterator';


### PR DESCRIPTION
Just adding this so that we can import FormInput to our custom SimpleFormIterator.