### PR TITLE
[RFR] Use material design recommended margin for content

### DIFF
--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.js
@@ -1,18 +1,13 @@
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 
 import Labeled from '../input/Labeled';
 
-const styles = {
-    root: { padding: '0 1em 1em 1em' },
-};
-
 const sanitizeRestProps = ({
     children,
     className,
-    classes,
     record,
     resource,
     basePath,
@@ -58,14 +53,13 @@ export const SimpleShowLayout = ({
     basePath,
     className,
     children,
-    classes,
     record,
     resource,
     version,
     ...rest
 }) => (
-    <div
-        className={classnames(classes.root, className)}
+    <CardContent
+        className={className}
         key={version}
         {...sanitizeRestProps(rest)}
     >
@@ -103,17 +97,16 @@ export const SimpleShowLayout = ({
                     </div>
                 ) : null
         )}
-    </div>
+    </CardContent>
 );
 
 SimpleShowLayout.propTypes = {
     basePath: PropTypes.string,
     className: PropTypes.string,
     children: PropTypes.node,
-    classes: PropTypes.object,
     record: PropTypes.object,
     resource: PropTypes.string,
     version: PropTypes.number,
 };
 
-export default withStyles(styles)(SimpleShowLayout);
+export default SimpleShowLayout;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -2,19 +2,14 @@ import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Tabs from '@material-ui/core/Tabs';
 import Divider from '@material-ui/core/Divider';
-import { withStyles } from '@material-ui/core/styles';
+import CardContent from '@material-ui/core/CardContent';
 import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const styles = {
-    tab: { padding: '0 1em 1em 1em' },
-};
-
 const sanitizeRestProps = ({
     children,
     className,
-    classes,
     record,
     resource,
     basePath,
@@ -74,7 +69,6 @@ export class TabbedShowLayout extends Component {
             basePath,
             children,
             className,
-            classes,
             location,
             match,
             record,
@@ -114,7 +108,7 @@ export class TabbedShowLayout extends Component {
                     })}
                 </Tabs>
                 <Divider />
-                <div className={classes.tab}>
+                <CardContent>
                     {Children.map(
                         children,
                         (tab, index) =>
@@ -133,7 +127,7 @@ export class TabbedShowLayout extends Component {
                                 />
                             )
                     )}
-                </div>
+                </CardContent>
             </div>
         );
     }
@@ -142,7 +136,6 @@ export class TabbedShowLayout extends Component {
 TabbedShowLayout.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    classes: PropTypes.object,
     location: PropTypes.object,
     match: PropTypes.object,
     record: PropTypes.object,
@@ -155,7 +148,6 @@ TabbedShowLayout.propTypes = {
 
 const enhance = compose(
     withRouter,
-    withStyles(styles),
     translate
 );
 

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -3,22 +3,11 @@ import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import { withStyles } from '@material-ui/core/styles';
+import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { getDefaultValues, translate, REDUX_FORM_NAME } from 'ra-core';
 import FormInput from './FormInput';
 import Toolbar from './Toolbar';
-
-const styles = theme => ({
-    form: {
-        [theme.breakpoints.up('sm')]: {
-            padding: '0 1em 1em 1em',
-        },
-        [theme.breakpoints.down('xs')]: {
-            padding: '0 1em 5em 1em',
-        },
-    },
-});
 
 const sanitizeRestProps = ({
     anyTouched,
@@ -68,7 +57,6 @@ export class SimpleForm extends Component {
         const {
             basePath,
             children,
-            classes = {},
             className,
             invalid,
             pristine,
@@ -87,7 +75,7 @@ export class SimpleForm extends Component {
                 className={classnames('simple-form', className)}
                 {...sanitizeRestProps(rest)}
             >
-                <div className={classes.form} key={version}>
+                <CardContent key={version}>
                     {Children.map(children, input => (
                         <FormInput
                             basePath={basePath}
@@ -96,7 +84,7 @@ export class SimpleForm extends Component {
                             resource={resource}
                         />
                     ))}
-                </div>
+                </CardContent>
                 {toolbar &&
                     React.cloneElement(toolbar, {
                         basePath,
@@ -116,7 +104,6 @@ export class SimpleForm extends Component {
 SimpleForm.propTypes = {
     basePath: PropTypes.string,
     children: PropTypes.node,
-    classes: PropTypes.object,
     className: PropTypes.string,
     defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     handleSubmit: PropTypes.func, // passed by redux-form
@@ -152,8 +139,7 @@ const enhance = compose(
     reduxForm({
         enableReinitialize: true,
         keepDirtyOnReinitialize: true,
-    }),
-    withStyles(styles)
+    })
 );
 
 export default enhance(SimpleForm);

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -12,20 +12,13 @@ import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import Divider from '@material-ui/core/Divider';
 import Tabs from '@material-ui/core/Tabs';
+import CardContent from '@material-ui/core/CardContent';
 import { withStyles } from '@material-ui/core/styles';
 import { getDefaultValues, translate, REDUX_FORM_NAME } from 'ra-core';
 
 import Toolbar from './Toolbar';
 
 const styles = theme => ({
-    form: {
-        [theme.breakpoints.up('sm')]: {
-            padding: '0 1em 1em 1em',
-        },
-        [theme.breakpoints.down('xs')]: {
-            padding: '0 1em 5em 1em',
-        },
-    },
     errorTabButton: { color: theme.palette.error.main },
 });
 
@@ -151,7 +144,7 @@ export class TabbedForm extends Component {
                     })}
                 </Tabs>
                 <Divider />
-                <div className={classes.form}>
+                <CardContent>
                     {/* All tabs are rendered (not only the one in focus), to allow validation
                     on tabs not in focus. The tabs receive a `hidden` property, which they'll
                     use to hide the tab using CSS if it's not the one in focus.
@@ -189,19 +182,18 @@ export class TabbedForm extends Component {
                                 </Route>
                             )
                     )}
-                    {toolbar &&
-                        React.cloneElement(toolbar, {
-                            className: 'toolbar',
-                            handleSubmitWithRedirect: this
-                                .handleSubmitWithRedirect,
-                            handleSubmit: this.props.handleSubmit,
-                            invalid,
-                            pristine,
-                            redirect,
-                            saving,
-                            submitOnEnter,
-                        })}
-                </div>
+                </CardContent>
+                {toolbar &&
+                    React.cloneElement(toolbar, {
+                        className: 'toolbar',
+                        handleSubmitWithRedirect: this.handleSubmitWithRedirect,
+                        handleSubmit: this.props.handleSubmit,
+                        invalid,
+                        pristine,
+                        redirect,
+                        saving,
+                        submitOnEnter,
+                    })}
             </form>
         );
     }

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -8,6 +8,9 @@ import { SaveButton } from '../button';
 import Responsive from '../layout/Responsive';
 
 const styles = {
+    desktopToolbar: {
+        marginBottom: '0.5em',
+    },
     mobileToolbar: {
         position: 'fixed',
         bottom: 0,
@@ -75,7 +78,11 @@ const Toolbar = ({
             </MuiToolbar>
         }
         medium={
-            <MuiToolbar className={className} {...rest}>
+            <MuiToolbar
+                className={classnames(classes.desktopToolbar, className)}
+                disableGutters
+                {...rest}
+            >
                 {Children.count(children) === 0 ? (
                     <SaveButton
                         handleSubmitWithRedirect={handleSubmitWithRedirect}


### PR DESCRIPTION
In form and show layouts, the title, content and buttons weren't properly aligned because we didn't use the material design recommended margins for content. This PR fixes that.

Before:

![2018-08-01_1550](https://user-images.githubusercontent.com/99944/43525636-aa3144ae-95a2-11e8-8848-5c4643d97e96.png)


After:

![2018-08-01_1549](https://user-images.githubusercontent.com/99944/43525615-9c82bc52-95a2-11e8-819e-d16743897a5d.png)
