### PR TITLE
[RFR] Fix FileInput documentation

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -445,7 +445,7 @@ Writing a custom field component for displaying the current value(s) is easy:  i
 
 When receiving **new** files, `FileInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display informations about size or mimetype inside a custom field.
 
-The `FileInput` component accepts all [react-dropzone properties](https://github.com/okonet/react-dropzone#features), in addition to those of react-admin. For instance, if you need to upload several files at once, just add the `multiple` DropZone attribute to your `<FileInput />` field.
+The `FileInput` component accepts an `options` prop into which you can pass all the [react-dropzone properties](https://github.com/okonet/react-dropzone#features). For instance, if you need to upload several files at once, just add the `options={{ multiple: true }}` DropZone attribute to your `<FileInput />` field.
 
 If the default Dropzone label doesn't fit with your need, you can pass a `placeholder` attribute to overwrite it. The attribute can be anything React can render (`PropTypes.node`):
 


### PR DESCRIPTION
Another option would be to get the DropZone supported props from the props transparently (using DropZone.propTypes).

Fix #2083