### PR TITLE
[RFR] Prepare for allowing forms inside List

### DIFF
--- a/packages/ra-ui-materialui/src/button/CloneButton.js
+++ b/packages/ra-ui-materialui/src/button/CloneButton.js
@@ -8,6 +8,13 @@ import Button from './Button';
 
 const omitId = ({ id, ...rest }) => rest;
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 export const CloneButton = ({
     basePath = '',
     label = 'ra.action.clone',
@@ -21,7 +28,7 @@ export const CloneButton = ({
             state: { record: omitId(record) },
         }}
         label={label}
-        {...rest}
+        {...sanitizeRestProps(rest)}
     >
         <ContentCreate />
     </Button>

--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -34,6 +34,13 @@ const styles = theme => ({
     },
 });
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 const CreateButton = ({
     basePath = '',
     className,
@@ -51,7 +58,7 @@ const CreateButton = ({
                 color="primary"
                 className={classnames(classes.floating, className)}
                 to={`${basePath}/create`}
-                {...rest}
+                {...sanitizeRestProps(rest)}
             >
                 <ContentAdd />
             </Button>
@@ -63,7 +70,7 @@ const CreateButton = ({
                 to={`${basePath}/create`}
                 className={classnames(classes.desktopLink, className)}
                 size={size}
-                {...rest}
+                {...sanitizeRestProps(rest)}
             >
                 <ContentAdd className={classes.iconPaddingStyle} />
                 <span className={classes.label}>

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -23,6 +23,13 @@ const styles = theme => ({
     },
 });
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 class DeleteButton extends Component {
     handleDelete = event => {
         event.preventDefault();
@@ -49,6 +56,7 @@ class DeleteButton extends Component {
             label = 'ra.action.delete',
             classes = {},
             className,
+            ...rest
         } = this.props;
         return (
             <Button
@@ -60,6 +68,7 @@ class DeleteButton extends Component {
                     className
                 )}
                 key="button"
+                {...sanitizeRestProps(rest)}
             >
                 <ActionDelete />
             </Button>

--- a/packages/ra-ui-materialui/src/button/EditButton.js
+++ b/packages/ra-ui-materialui/src/button/EditButton.js
@@ -7,6 +7,13 @@ import { linkToRecord } from 'ra-core';
 
 import Button from './Button';
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 const EditButton = ({
     basePath = '',
     label = 'ra.action.edit',
@@ -17,7 +24,7 @@ const EditButton = ({
         component={Link}
         to={linkToRecord(basePath, record.id)}
         label={label}
-        {...rest}
+        {...sanitizeRestProps(rest)}
     >
         <ContentCreate />
     </Button>

--- a/packages/ra-ui-materialui/src/button/ExportButton.js
+++ b/packages/ra-ui-materialui/src/button/ExportButton.js
@@ -13,9 +13,12 @@ const sanitizeRestProps = ({
     dispatch,
     exporter,
     filter,
+    handleSubmit,
+    handleSubmitWithRedirect,
     maxResults,
     resource,
     sort,
+    submitOnEnter,
     ...rest
 }) => rest;
 

--- a/packages/ra-ui-materialui/src/button/ListButton.js
+++ b/packages/ra-ui-materialui/src/button/ListButton.js
@@ -5,8 +5,20 @@ import { Link } from 'react-router-dom';
 
 import Button from './Button';
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 const ListButton = ({ basePath = '', label = 'ra.action.list', ...rest }) => (
-    <Button component={Link} to={basePath} label={label} {...rest}>
+    <Button
+        component={Link}
+        to={basePath}
+        label={label}
+        {...sanitizeRestProps(rest)}
+    >
         <ActionList />
     </Button>
 );

--- a/packages/ra-ui-materialui/src/button/RefreshButton.js
+++ b/packages/ra-ui-materialui/src/button/RefreshButton.js
@@ -6,6 +6,13 @@ import { refreshView as refreshViewAction } from 'ra-core';
 
 import Button from './Button';
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 class RefreshButton extends Component {
     static propTypes = {
         label: PropTypes.string,
@@ -25,7 +32,11 @@ class RefreshButton extends Component {
         const { label, refreshView, ...rest } = this.props;
 
         return (
-            <Button label={label} onClick={this.handleClick} {...rest}>
+            <Button
+                label={label}
+                onClick={this.handleClick}
+                {...sanitizeRestProps(rest)}
+            >
                 <NavigationRefresh />
             </Button>
         );

--- a/packages/ra-ui-materialui/src/button/ShowButton.js
+++ b/packages/ra-ui-materialui/src/button/ShowButton.js
@@ -7,6 +7,13 @@ import { linkToRecord } from 'ra-core';
 
 import Button from './Button';
 
+const sanitizeRestProps = ({
+    handleSubmit,
+    handleSubmitWithRedirect,
+    submitOnEnter,
+    ...rest
+}) => rest;
+
 const ShowButton = ({
     basePath = '',
     label = 'ra.action.show',
@@ -17,7 +24,7 @@ const ShowButton = ({
         component={Link}
         to={`${linkToRecord(basePath, record.id)}/show`}
         label={label}
-        {...rest}
+        {...sanitizeRestProps(rest)}
     >
         <ImageEye />
     </Button>


### PR DESCRIPTION
In the case of the incoming Tree component for example, we must allow all buttons inside the node edition forms. Most of them don't care about `handleSubmit`, `handleSubmitWithRedirect` and `submitOnEnter`.