### PR TITLE
[RFR] Fix Quill autofocus

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -39,7 +39,7 @@ export class RichTextInput extends Component {
             theme: 'snow',
         });
 
-        this.quill.pasteHTML(value);
+        this.quill.setContents(this.quill.clipboard.convert(value));
 
         this.editor = this.divRef.querySelector('.ql-editor');
         this.quill.on('text-change', debounce(this.onTextChange, 500));


### PR DESCRIPTION
When a `RichTextInput` is below the fold, Quill autofocuses it and it makes the page scroll to it.

This fix prevents Quill from autofocusing.

See zenoamaro/react-quill#317 for details.