### PR TITLE
[RFR] Decouples optimistic side effects from the action's type

### DIFF
--- a/cypress/integration/customFetch.js
+++ b/cypress/integration/customFetch.js
@@ -1,0 +1,42 @@
+import listPageFactory from '../support/ListPage';
+
+describe('Edit Page', () => {
+    const ListCommentPage = listPageFactory('/#/comments');
+
+    it('should handle successful custom FETCH actions', () => {
+        ListCommentPage.navigate();
+
+        // Check the first comment status
+        cy.get(ListCommentPage.elements.commentStatus(1)).should(el =>
+            expect(el.text()).to.contains('rejected')
+        );
+        // Click on the first comment approve button
+        cy.get(ListCommentPage.elements.commentApproveButton(1)).click();
+
+        // Check the first comment status
+        cy.get(ListCommentPage.elements.commentStatus(1)).should(el =>
+            expect(el.text()).to.contains('approved')
+        );
+    });
+
+    it('should handle failed custom FETCH actions', () => {
+        ListCommentPage.navigate();
+
+        // Check the second comment status
+        cy.get(ListCommentPage.elements.commentStatus(2)).should(el =>
+            expect(el.text()).to.contains('approved')
+        );
+        // Click on the second comment reject button
+        cy.get(ListCommentPage.elements.commentRejectButton(2)).click();
+
+        // Check the second comment status optimistic update
+        cy.get(ListCommentPage.elements.commentStatus(2)).should(el =>
+            expect(el.text()).to.contains('rejected')
+        );
+
+        // Check the second comment status undo
+        cy.get(ListCommentPage.elements.commentStatus(2), {
+            timeout: 10000, // Increase the timeout to wait for the API response
+        }).should(el => expect(el.text()).to.contains('approved'));
+    });
+});

--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -17,6 +17,11 @@ export default url => ({
         datagridHeaders: 'th',
         logout: '.logout',
         bulkActionsToolbar: '[data-test=bulk-actions-toolbar]',
+        commentApproveButton: index =>
+            `.comment:nth-child(${index}) [data-testid="approve-button"]`,
+        commentRejectButton: index =>
+            `.comment:nth-child(${index}) [data-testid="reject-button"]`,
+        commentStatus: index => `.comment:nth-child(${index}) .comment-status`,
         customBulkActionsButton:
             '[data-test=bulk-actions-toolbar] button:first-child',
         deleteBulkActionsButton:

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -452,6 +452,46 @@ And that's all it takes to make a fetch action optimistic. Note that the `startU
 
 The fact that react-admin updates the internal store if you use custom actions with the `fetch` meta should be another motivation to avoid using raw `fetch`.
 
+## Custom fetch action
+
+There are cases when you'll have to use a custom `fetch` meta because you want to call a specific end point, especially when using GraphQL. Yet, you may already know the effect your action will have on your data and want it to be updated optimistically. You can leverage the `effect` and `effectData` metas for this.
+
+```jsx
+// in src/comment/commentActions.js
+import { UPDATE } from 'react-admin';
+
+export const commentApprove = (id, data, basePath) => ({
+    type: CRUD_UPDATE,
+    payload: { id, data: { endPointParameter: 'a value' } },
+    meta: {
+        fetch: 'COMMENT_APPROVE',
+        effect: UPDATE,
+        effectData: { ...data, is_approved: true },
+        resource: 'comments',
+    },
+});
+```
+
+Would you also need to handle side effects specific to your action:
+
+```jsx
+// in src/comment/commentActions.js
+import { UPDATE } from 'react-admin';
+
+export const COMMENT_APPROVE = 'COMMENT_APPROVE';
+
+export const commentApprove = (id, data, basePath) => ({
+    type: COMMENT_APPROVE,
+    payload: { id, data: { endPointParameter: 'a value' } },
+    meta: {
+        fetch: 'COMMENT_APPROVE',
+        effect: UPDATE,
+        effectData: { ...data, is_approved: true },
+        resource: 'comments',
+    },
+});
+```
+
 ## Altering the Form Values before Submitting
 
 Sometimes, you may want your custom action to alter the form values before actually sending them to the `dataProvider`. For those cases, you should know that every buttons inside a form [Toolbar](/CreateEdit.md#toolbar) receive two props:

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -456,16 +456,18 @@ The fact that react-admin updates the internal store if you use custom actions w
 
 There are cases when you'll have to use a custom `fetch` meta because you want to call a specific end point, especially when using GraphQL. Yet, you may already know the effect your action will have on your data and want it to be updated optimistically. You can leverage the `effect` and `effectData` metas for this.
 
-```jsx
+```js
 // in src/comment/commentActions.js
 import { UPDATE } from 'react-admin';
 
 export const commentApprove = (id, data, basePath) => ({
     type: CRUD_UPDATE,
-    payload: { id, data: { endPointParameter: 'a value' } },
+    // These are the parameters received by the data provider. They are specific to the custom end point
+    payload: { id, data: { status: 'approved' } },
     meta: {
         fetch: 'COMMENT_APPROVE',
         effect: UPDATE,
+        // Data used to optimistically update the record
         effectData: { ...data, is_approved: true },
         resource: 'comments',
     },
@@ -474,7 +476,7 @@ export const commentApprove = (id, data, basePath) => ({
 
 Would you also need to handle side effects specific to your action:
 
-```jsx
+```js
 // in src/comment/commentActions.js
 import { UPDATE } from 'react-admin';
 
@@ -482,14 +484,22 @@ export const COMMENT_APPROVE = 'COMMENT_APPROVE';
 
 export const commentApprove = (id, data, basePath) => ({
     type: COMMENT_APPROVE,
-    payload: { id, data: { endPointParameter: 'a value' } },
+    // These are the parameters received by the data provider. They are specific to the custom end point
+    payload: { id, data: { status: 'approved' } },
     meta: {
         fetch: 'COMMENT_APPROVE',
         effect: UPDATE,
+        // Data used to optimistically update the record
         effectData: { ...data, is_approved: true },
         resource: 'comments',
     },
 });
+```
+
+In both cases, the `dataProvider` will be called with the following parameters:
+
+```js
+'COMMENT_APPROVE', 'comments', { id, data: { status: 'approved' } }
 ```
 
 ## Altering the Form Values before Submitting

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -462,19 +462,18 @@ import { UPDATE } from 'react-admin';
 
 export const commentApprove = (id, data, basePath) => ({
     type: CRUD_UPDATE,
-    // These are the parameters received by the data provider. They are specific to the custom end point
-    payload: { id, data: { status: 'approved' } },
+    // These are the parameters received by the data provider
+    payload: { id, status: 'approved' },
     meta: {
         fetch: 'COMMENT_APPROVE',
-        effect: UPDATE,
-        // Data used to optimistically update the record
-        effectData: { ...data, is_approved: true },
+        effect: UPDATE, // Intruct react-admin that this action should be handled as an UPDATE
         resource: 'comments',
     },
 });
 ```
 
-Would you also need to handle side effects specific to your action:
+Sometimes, the action payload doesn't match the data which should be updated on the targeted resource(s). For those cases where
+`startUndoable` wouldn't be able to optimistically update the local data, you can use the `effectData` meta:
 
 ```js
 // in src/comment/commentActions.js
@@ -485,7 +484,7 @@ export const COMMENT_APPROVE = 'COMMENT_APPROVE';
 export const commentApprove = (id, data, basePath) => ({
     type: COMMENT_APPROVE,
     // These are the parameters received by the data provider. They are specific to the custom end point
-    payload: { id, data: { status: 'approved' } },
+    payload: { id },
     meta: {
         fetch: 'COMMENT_APPROVE',
         effect: UPDATE,
@@ -496,11 +495,7 @@ export const commentApprove = (id, data, basePath) => ({
 });
 ```
 
-In both cases, the `dataProvider` will be called with the following parameters:
-
-```js
-'COMMENT_APPROVE', 'comments', { id, data: { status: 'approved' } }
-```
+In that `UPDATE` case, your backend must still returns the updated comment.
 
 ## Altering the Form Values before Submitting
 

--- a/examples/simple/src/comments/ApproveButton.js
+++ b/examples/simple/src/comments/ApproveButton.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import CheckCircle from '@material-ui/icons/CheckCircle';
+import { Button, startUndoable as startUndoableAction } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { commentApprove } from './actions';
+class ApproveButtonView extends Component {
+    handleClick = () => {
+        this.props.startUndoable(commentApprove(this.props.record));
+    };
+
+    render() {
+        return (
+            <Button
+                data-testid="approve-button"
+                label="simple.action.approve"
+                onClick={this.handleClick}
+            >
+                <CheckCircle />
+            </Button>
+        );
+    }
+}
+
+export default connect(
+    undefined,
+    { startUndoable: startUndoableAction }
+)(ApproveButtonView);

--- a/examples/simple/src/comments/CommentList.js
+++ b/examples/simple/src/comments/CommentList.js
@@ -3,7 +3,7 @@ import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import PersonIcon from '@material-ui/icons/Person';
 import Avatar from '@material-ui/core/Avatar';
-import Button from '@material-ui/core/Button';
+import MuiButton from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
@@ -13,6 +13,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import { withStyles } from '@material-ui/core/styles';
 import { unparse as convertToCSV } from 'papaparse/papaparse.min';
 import {
+    ChipField,
     DateField,
     EditButton,
     Filter,
@@ -29,6 +30,8 @@ import {
     downloadCSV,
     translate,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import ApproveButton from './ApproveButton';
+import RejectButton from './RejectButton';
 
 const CommentFilter = props => (
     <Filter {...props}>
@@ -69,24 +72,24 @@ const CommentPagination = translate(
             nbPages > 1 && (
                 <Toolbar>
                     {page > 1 && (
-                        <Button
+                        <MuiButton
                             color="primary"
                             key="prev"
                             onClick={() => setPage(page - 1)}
                         >
                             <ChevronLeft />&nbsp;
                             {translate('ra.navigation.prev')}
-                        </Button>
+                        </MuiButton>
                     )}
                     {page !== nbPages && (
-                        <Button
+                        <MuiButton
                             color="primary"
                             key="next"
                             onClick={() => setPage(page + 1)}
                         >
                             {translate('ra.navigation.next')}&nbsp;
                             <ChevronRight />
-                        </Button>
+                        </MuiButton>
                     )}
                 </Toolbar>
             )
@@ -117,10 +120,9 @@ const CommentGrid = withStyles(listStyles)(
     translate(({ classes, ids, data, basePath, translate }) => (
         <Grid spacing={16} container style={{ padding: '0 1em' }}>
             {ids.map(id => (
-                <Grid item key={id} sm={12} md={6} lg={4}>
+                <Grid item key={id} sm={12} md={6} lg={4} className="comment">
                     <Card className={classes.card}>
                         <CardHeader
-                            className="comment"
                             title={
                                 <TextField
                                     record={data[id]}
@@ -157,6 +159,14 @@ const CommentGrid = withStyles(listStyles)(
                                 />
                             </ReferenceField>
                         </CardContent>
+                        <CardContent className={classes.cardContent}>
+                            <ChipField
+                                className="comment-status"
+                                record={data[id]}
+                                source="status"
+                            />
+                        </CardContent>
+
                         <CardActions className={classes.cardActions}>
                             <EditButton
                                 resource="posts"
@@ -164,6 +174,16 @@ const CommentGrid = withStyles(listStyles)(
                                 record={data[id]}
                             />
                             <ShowButton
+                                resource="posts"
+                                basePath={basePath}
+                                record={data[id]}
+                            />
+                            <ApproveButton
+                                resource="posts"
+                                basePath={basePath}
+                                record={data[id]}
+                            />
+                            <RejectButton
                                 resource="posts"
                                 basePath={basePath}
                                 record={data[id]}

--- a/examples/simple/src/comments/RejectButton.js
+++ b/examples/simple/src/comments/RejectButton.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import CheckCircle from '@material-ui/icons/CheckCircle';
+import { Button, startUndoable as startUndoableAction } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { commentReject } from './actions';
+class RejectButtonView extends Component {
+    handleClick = () => {
+        this.props.startUndoable(commentReject(this.props.record));
+    };
+
+    render() {
+        return (
+            <Button
+                data-testid="reject-button"
+                label="simple.action.reject"
+                onClick={this.handleClick}
+            >
+                <CheckCircle />
+            </Button>
+        );
+    }
+}
+
+export default connect(
+    undefined,
+    { startUndoable: startUndoableAction }
+)(RejectButtonView);

--- a/examples/simple/src/comments/actions.js
+++ b/examples/simple/src/comments/actions.js
@@ -1,0 +1,51 @@
+import { UPDATE } from 'react-admin';
+
+export const COMMENT_APPROVE = 'COMMENT_APPROVE';
+
+export const commentApprove = record => ({
+    type: COMMENT_APPROVE,
+    // These are the parameters received by the data provider. They are specific to the custom end point
+    payload: { id: record.id },
+    meta: {
+        fetch: COMMENT_APPROVE,
+        effect: UPDATE,
+        // Data used to optimistically update the record
+        effectData: { ...record, status: 'approved' },
+        resource: 'comments',
+        onSuccess: {
+            notification: {
+                body: 'simple.notification.approved',
+                level: 'info',
+            },
+            refresh: true,
+        },
+    },
+});
+
+export const COMMENT_REJECT = 'COMMENT_REJECT';
+
+export const commentReject = record => ({
+    type: COMMENT_REJECT,
+    // These are the parameters received by the data provider. They are specific to the custom end point
+    payload: { id: record.id },
+    meta: {
+        fetch: COMMENT_REJECT,
+        effect: UPDATE,
+        // Data used to optimistically update the record
+        effectData: { ...record, status: 'rejected' },
+        resource: 'comments',
+        onSuccess: {
+            notification: {
+                body: 'simple.notification.rejected',
+                level: 'info',
+            },
+            refresh: true,
+        },
+        onFailure: {
+            notification: {
+                body: 'simple.notification.rejected_error',
+                level: 'warning',
+            },
+        },
+    },
+});

--- a/examples/simple/src/data.js
+++ b/examples/simple/src/data.js
@@ -274,6 +274,7 @@ export default {
             body:
                 "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
             created_at: new Date('2012-08-02'),
+            status: 'approved',
         },
         {
             id: 2,
@@ -285,6 +286,7 @@ export default {
             body:
                 "White Rabbit: it was indeed: she was out of the ground--and I should frighten them out of its right paw round, 'lives a March Hare. 'Sixteenth,'.",
             created_at: new Date('2012-08-08'),
+            status: 'review',
         },
         {
             id: 3,
@@ -295,6 +297,7 @@ export default {
             body:
                 "I'm not Ada,' she said, 'and see whether it's marked \"poison\" or.",
             created_at: new Date('2012-08-02'),
+            status: 'rejected',
         },
         {
             id: 4,
@@ -305,6 +308,7 @@ export default {
             body:
                 "Dormouse. 'Fourteenth of March, I think I can say.' This was such a noise inside, no one else seemed inclined.",
             created_at: new Date('2014-09-24'),
+            status: 'approved',
         },
         {
             id: 5,
@@ -315,6 +319,7 @@ export default {
             body:
                 "I ought to tell me your history, you know,' the Hatter and the happy summer days. THE.",
             created_at: new Date('2012-08-07'),
+            status: 'approved',
         },
         {
             id: 6,
@@ -325,6 +330,7 @@ export default {
             body:
                 'Duchess asked, with another hedgehog, which seemed to be lost: away went Alice after it, never once considering how in the other. In the very tones of.',
             created_at: new Date('2012-08-09'),
+            status: 'rejected',
         },
         {
             id: 7,
@@ -335,6 +341,7 @@ export default {
             body:
                 "While the Panther were sharing a pie--' [later editions continued as follows.",
             created_at: new Date('2012-09-06'),
+            status: 'approved',
         },
         {
             id: 8,
@@ -345,6 +352,7 @@ export default {
             body:
                 "I tell you, you coward!' and at once and put it more clearly,' Alice.",
             created_at: new Date('2012-10-03'),
+            status: 'approved',
         },
         {
             id: 9,
@@ -355,6 +363,7 @@ export default {
             body:
                 "THAT. Then again--\"BEFORE SHE HAD THIS FIT--\" you never tasted an egg!' 'I HAVE tasted eggs, certainly,' said Alice, as she spoke. Alice did not like to have it.",
             created_at: new Date('2012-11-06'),
+            status: 'rejected',
         },
         {
             id: 10,
@@ -365,6 +374,7 @@ export default {
             body:
                 "I'd been the whiting,' said the Hatter, it woke up again with a T!' said the Gryphon. '--you advance twice--' 'Each with a growl, And concluded the banquet--] 'What IS the fun?' said.",
             created_at: new Date('2012-12-07'),
+            status: 'approved',
         },
         {
             id: 11,
@@ -375,6 +385,7 @@ export default {
             body:
                 "I don't want to be?' it asked. 'Oh, I'm not Ada,' she said, 'and see whether it's marked \"poison\" or not'; for she had asked it aloud; and in despair she put her hand on the end of the.",
             created_at: new Date('2012-08-05'),
+            status: 'rejected',
         },
     ],
     tags: [

--- a/examples/simple/src/dataProvider.js
+++ b/examples/simple/src/dataProvider.js
@@ -2,23 +2,46 @@ import jsonRestProvider from 'ra-data-fakerest';
 
 import data from './data';
 import addUploadFeature from './addUploadFeature';
+import { COMMENT_APPROVE, COMMENT_REJECT } from './comments/actions';
 
 const dataProvider = jsonRestProvider(data, true);
-const uploadCapableDataProvider = addUploadFeature(dataProvider);
-const sometimesFailsDataProvider = (type, resource, params) =>
+
+const withRandomFailure = dataProvider => (type, resource, params) =>
     new Promise((resolve, reject) => {
         // add rejection by type or resource here for tests, e.g.
         // if (type === 'DELETE' && resource === 'posts') {
         //     return reject('deletion error');
         // }
-        return resolve(uploadCapableDataProvider(type, resource, params));
+        return resolve(dataProvider(type, resource, params));
     });
-const delayedDataProvider = (type, resource, params) =>
+
+const withDelay = dataProvider => (type, resource, params) =>
     new Promise(resolve =>
-        setTimeout(
-            () => resolve(sometimesFailsDataProvider(type, resource, params)),
-            1000
-        )
+        setTimeout(() => resolve(dataProvider(type, resource, params)), 1000)
     );
 
-export default delayedDataProvider;
+const withCustomFetchType = dataProvider => (type, resource, params) => {
+    if (type === COMMENT_APPROVE) {
+        // Simulate a successfull call to a custom API route
+        return dataProvider('UPDATE', resource, {
+            id: params.id,
+            data: { status: 'approved' },
+        });
+    }
+    if (type === COMMENT_REJECT) {
+        // Simulate a failed call to a custom API route
+        return Promise.reject({});
+    }
+
+    return dataProvider(type, resource, params);
+};
+
+const compose = (...enhancers) => dataProvider =>
+    enhancers.reduce((acc, enhancer) => enhancer(acc), dataProvider);
+
+export default compose(
+    addUploadFeature,
+    withRandomFailure,
+    withDelay,
+    withCustomFetchType
+)(dataProvider);

--- a/examples/simple/src/i18n/en.js
+++ b/examples/simple/src/i18n/en.js
@@ -7,8 +7,16 @@ export const messages = {
         action: {
             close: 'Close',
             resetViews: 'Reset views',
+            approve: 'Approve',
+            reject: 'Reject',
         },
         'create-post': 'New post',
+        notification: {
+            approved: 'The comment has been approved',
+            rejected: 'The comment has been rejected',
+            approved_error: 'The comment has not been approved',
+            rejected_error: 'The comment has not been rejected',
+        },
     },
     ...mergeTranslations(englishMessages, treeEnglishMessages),
     resources: {

--- a/examples/simple/src/i18n/fr.js
+++ b/examples/simple/src/i18n/fr.js
@@ -7,8 +7,16 @@ export default {
         action: {
             close: 'Fermer',
             resetViews: 'Réinitialiser des vues',
+            approve: 'Approuver',
+            reject: 'Rejeter',
         },
         'create-post': 'Nouveau post',
+        notification: {
+            approved: 'Le commentaire a été approuvé',
+            rejected: 'Le commentaire a été rejeté',
+            approved_error: "Le commentaire n'a pas été approuvé",
+            rejected_error: "Le commentaire n'a pas été rejeté",
+        },
     },
     ...mergeTranslations(frenchMessages, treeFrenchMessages),
     resources: {

--- a/packages/ra-core/src/actions/dataActions.js
+++ b/packages/ra-core/src/actions/dataActions.js
@@ -21,6 +21,7 @@ export const crudGetList = (resource, pagination, sort, filter) => ({
     meta: {
         resource,
         fetch: GET_LIST,
+        effect: GET_LIST,
         onFailure: {
             notification: {
                 body: 'ra.notification.http_error',
@@ -41,6 +42,7 @@ export const crudGetAll = (resource, sort, filter, maxResults, callback) => ({
     meta: {
         resource,
         fetch: GET_LIST,
+        effect: GET_LIST,
         onSuccess: {
             callback,
         },
@@ -64,6 +66,7 @@ export const crudGetOne = (resource, id, basePath, refresh = true) => ({
     meta: {
         resource,
         fetch: GET_ONE,
+        effect: GET_ONE,
         basePath,
         onFailure: {
             notification: {
@@ -87,6 +90,7 @@ export const crudCreate = (resource, data, basePath, redirectTo = 'edit') => ({
     meta: {
         resource,
         fetch: CREATE,
+        effect: CREATE,
         onSuccess: {
             notification: {
                 body: 'ra.notification.created',
@@ -126,6 +130,7 @@ export const crudUpdate = (
     meta: {
         resource,
         fetch: UPDATE,
+        effect: UPDATE,
         onSuccess: {
             notification: {
                 body: 'ra.notification.updated',
@@ -164,6 +169,7 @@ export const crudUpdateMany = (
     meta: {
         resource,
         fetch: UPDATE_MANY,
+        effect: UPDATE_MANY,
         cancelPrevious: false,
         onSuccess: {
             notification: {
@@ -204,6 +210,7 @@ export const crudDelete = (
     meta: {
         resource,
         fetch: DELETE,
+        effect: DELETE,
         onSuccess: {
             notification: {
                 body: 'ra.notification.deleted',
@@ -236,6 +243,7 @@ export const crudDeleteMany = (resource, ids, basePath, refresh = true) => ({
     meta: {
         resource,
         fetch: DELETE_MANY,
+        effect: DELETE_MANY,
         onSuccess: {
             notification: {
                 body: 'ra.notification.deleted',
@@ -297,6 +305,7 @@ export const crudGetMatching = (
         resource: reference,
         relatedTo,
         fetch: GET_LIST,
+        effect: GET_LIST,
         onFailure: {
             notification: {
                 body: 'ra.notification.http_error',
@@ -330,6 +339,7 @@ export const crudGetManyReference = (
         resource: reference,
         relatedTo,
         fetch: GET_MANY_REFERENCE,
+        effect: GET_MANY_REFERENCE,
         onFailure: {
             notification: {
                 body: 'ra.notification.http_error',

--- a/packages/ra-core/src/actions/dataActions.js
+++ b/packages/ra-core/src/actions/dataActions.js
@@ -21,7 +21,6 @@ export const crudGetList = (resource, pagination, sort, filter) => ({
     meta: {
         resource,
         fetch: GET_LIST,
-        effect: GET_LIST,
         onFailure: {
             notification: {
                 body: 'ra.notification.http_error',
@@ -42,7 +41,6 @@ export const crudGetAll = (resource, sort, filter, maxResults, callback) => ({
     meta: {
         resource,
         fetch: GET_LIST,
-        effect: GET_LIST,
         onSuccess: {
             callback,
         },
@@ -66,7 +64,6 @@ export const crudGetOne = (resource, id, basePath, refresh = true) => ({
     meta: {
         resource,
         fetch: GET_ONE,
-        effect: GET_ONE,
         basePath,
         onFailure: {
             notification: {
@@ -90,7 +87,6 @@ export const crudCreate = (resource, data, basePath, redirectTo = 'edit') => ({
     meta: {
         resource,
         fetch: CREATE,
-        effect: CREATE,
         onSuccess: {
             notification: {
                 body: 'ra.notification.created',
@@ -130,7 +126,6 @@ export const crudUpdate = (
     meta: {
         resource,
         fetch: UPDATE,
-        effect: UPDATE,
         onSuccess: {
             notification: {
                 body: 'ra.notification.updated',
@@ -169,7 +164,6 @@ export const crudUpdateMany = (
     meta: {
         resource,
         fetch: UPDATE_MANY,
-        effect: UPDATE_MANY,
         cancelPrevious: false,
         onSuccess: {
             notification: {
@@ -210,7 +204,6 @@ export const crudDelete = (
     meta: {
         resource,
         fetch: DELETE,
-        effect: DELETE,
         onSuccess: {
             notification: {
                 body: 'ra.notification.deleted',
@@ -243,7 +236,6 @@ export const crudDeleteMany = (resource, ids, basePath, refresh = true) => ({
     meta: {
         resource,
         fetch: DELETE_MANY,
-        effect: DELETE_MANY,
         onSuccess: {
             notification: {
                 body: 'ra.notification.deleted',
@@ -305,7 +297,6 @@ export const crudGetMatching = (
         resource: reference,
         relatedTo,
         fetch: GET_LIST,
-        effect: GET_LIST,
         onFailure: {
             notification: {
                 body: 'ra.notification.http_error',
@@ -339,7 +330,6 @@ export const crudGetManyReference = (
         resource: reference,
         relatedTo,
         fetch: GET_MANY_REFERENCE,
-        effect: GET_MANY_REFERENCE,
         onFailure: {
             notification: {
                 body: 'ra.notification.http_error',

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -101,12 +101,12 @@ export default (previousState = initialState, { payload, meta }) => {
     }
     if (
         !meta ||
-        (!meta.effect && !meta.fetch) ||
+        (!meta.effect && !meta.fetchResponse) ||
         meta.fetchStatus !== FETCH_END
     ) {
         return previousState;
     }
-    switch (meta.effect || meta.fetch) {
+    switch (meta.effect || meta.fetchResponse) {
         case GET_LIST:
         case GET_MANY:
         case GET_MANY_REFERENCE:

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -65,7 +65,7 @@ export default (previousState = initialState, { payload, meta }) => {
     if (meta.effect === UPDATE && meta.optimistic) {
         const updatedRecord = {
             ...previousState[payload.id],
-            ...(meta.optimisticData || payload.data),
+            ...(meta.effectData || payload.data),
         };
         const newState = addRecords([updatedRecord], previousState);
         return newState;
@@ -75,7 +75,7 @@ export default (previousState = initialState, { payload, meta }) => {
             .reduce((records, id) => records.concat(previousState[id]), [])
             .map(record => ({
                 ...record,
-                ...(meta.optimisticData || payload.data),
+                ...(meta.effectData || payload.data),
             }));
         return addRecords(updatedRecords, previousState);
     }
@@ -99,7 +99,7 @@ export default (previousState = initialState, { payload, meta }) => {
 
         return newState;
     }
-    if (!meta || !meta.fetchResponse || meta.fetchStatus !== FETCH_END) {
+    if (!meta || !meta.effect || meta.fetchStatus !== FETCH_END) {
         return previousState;
     }
     switch (meta.effect) {
@@ -111,6 +111,15 @@ export default (previousState = initialState, { payload, meta }) => {
         case UPDATE:
         case CREATE:
             return addRecords([payload.data], previousState);
+        case UPDATE_MANY: {
+            const updatedRecords = payload.ids
+                .reduce((records, id) => records.concat(previousState[id]), [])
+                .map(record => ({
+                    ...record,
+                    ...payload.data,
+                }));
+            return addRecords(updatedRecords, previousState);
+        }
         default:
             return previousState;
     }

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -70,6 +70,7 @@ export default (previousState = initialState, { payload, meta }) => {
         const newState = addRecords([updatedRecord], previousState);
         return newState;
     }
+
     if ((meta.effect || meta.fetch) === UPDATE_MANY && meta.optimistic) {
         const updatedRecords = payload.ids
             .reduce((records, id) => records.concat(previousState[id]), [])
@@ -79,6 +80,7 @@ export default (previousState = initialState, { payload, meta }) => {
             }));
         return addRecords(updatedRecords, previousState);
     }
+
     if ((meta.effect || meta.fetch) === DELETE && meta.optimistic) {
         const { [payload.id]: removed, ...newState } = previousState;
 
@@ -88,6 +90,7 @@ export default (previousState = initialState, { payload, meta }) => {
 
         return newState;
     }
+
     if ((meta.effect || meta.fetch) === DELETE_MANY && meta.optimistic) {
         const newState = Object.entries(previousState)
             .filter(([key]) => !payload.ids.includes(key))
@@ -99,6 +102,7 @@ export default (previousState = initialState, { payload, meta }) => {
 
         return newState;
     }
+
     if (
         !meta ||
         (!meta.effect && !meta.fetchResponse) ||
@@ -106,6 +110,7 @@ export default (previousState = initialState, { payload, meta }) => {
     ) {
         return previousState;
     }
+
     switch (meta.effect || meta.fetchResponse) {
         case GET_LIST:
         case GET_MANY:
@@ -114,13 +119,13 @@ export default (previousState = initialState, { payload, meta }) => {
         case GET_ONE:
         case UPDATE:
         case CREATE:
-            return addRecords([payload.data], previousState);
+            return addRecords([meta.effectData || payload.data], previousState);
         case UPDATE_MANY: {
             const updatedRecords = payload.ids
                 .reduce((records, id) => records.concat(previousState[id]), [])
                 .map(record => ({
                     ...record,
-                    ...payload.data,
+                    ...(meta.effectData || payload.data),
                 }));
             return addRecords(updatedRecords, previousState);
         }

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -62,7 +62,7 @@ export default (previousState = initialState, { payload, meta }) => {
         return previousState;
     }
 
-    if (meta.effect === UPDATE && meta.optimistic) {
+    if ((meta.effect || meta.fetch) === UPDATE && meta.optimistic) {
         const updatedRecord = {
             ...previousState[payload.id],
             ...(meta.effectData || payload.data),
@@ -70,7 +70,7 @@ export default (previousState = initialState, { payload, meta }) => {
         const newState = addRecords([updatedRecord], previousState);
         return newState;
     }
-    if (meta.effect === UPDATE_MANY && meta.optimistic) {
+    if ((meta.effect || meta.fetch) === UPDATE_MANY && meta.optimistic) {
         const updatedRecords = payload.ids
             .reduce((records, id) => records.concat(previousState[id]), [])
             .map(record => ({
@@ -79,7 +79,7 @@ export default (previousState = initialState, { payload, meta }) => {
             }));
         return addRecords(updatedRecords, previousState);
     }
-    if (meta.effect === DELETE && meta.optimistic) {
+    if ((meta.effect || meta.fetch) === DELETE && meta.optimistic) {
         const { [payload.id]: removed, ...newState } = previousState;
 
         Object.defineProperty(newState, 'fetchedAt', {
@@ -88,7 +88,7 @@ export default (previousState = initialState, { payload, meta }) => {
 
         return newState;
     }
-    if (meta.effect === DELETE_MANY && meta.optimistic) {
+    if ((meta.effect || meta.fetch) === DELETE_MANY && meta.optimistic) {
         const newState = Object.entries(previousState)
             .filter(([key]) => !payload.ids.includes(key))
             .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
@@ -99,10 +99,14 @@ export default (previousState = initialState, { payload, meta }) => {
 
         return newState;
     }
-    if (!meta || !meta.effect || meta.fetchStatus !== FETCH_END) {
+    if (
+        !meta ||
+        (!meta.effect && !meta.fetch) ||
+        meta.fetchStatus !== FETCH_END
+    ) {
         return previousState;
     }
-    switch (meta.effect) {
+    switch (meta.effect || meta.fetch) {
         case GET_LIST:
         case GET_MANY:
         case GET_MANY_REFERENCE:

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.js
@@ -1,16 +1,28 @@
 import assert from 'assert';
 
 import {
-    CRUD_DELETE_OPTIMISTIC,
+    CRUD_CREATE_SUCCESS,
     CRUD_DELETE_MANY_OPTIMISTIC,
-    CRUD_UPDATE_OPTIMISTIC,
+    CRUD_DELETE_OPTIMISTIC,
+    CRUD_GET_LIST_SUCCESS,
+    CRUD_GET_MANY_REFERENCE_SUCCESS,
+    CRUD_GET_MANY_SUCCESS,
+    CRUD_GET_ONE_SUCCESS,
+    CRUD_UPDATE_MANY,
     CRUD_UPDATE_MANY_OPTIMISTIC,
+    CRUD_UPDATE_OPTIMISTIC,
+    CRUD_UPDATE_SUCCESS,
 } from '../../../actions/dataActions';
 import {
     DELETE,
     DELETE_MANY,
     UPDATE,
     UPDATE_MANY,
+    CREATE,
+    GET_ONE,
+    GET_LIST,
+    GET_MANY,
+    GET_MANY_REFERENCE,
 } from '../../../dataFetchActions';
 
 import dataReducer, { addRecordsFactory } from './data';
@@ -109,6 +121,398 @@ describe('data addRecordsFactory', () => {
 });
 
 describe('Resources data reducer', () => {
+    describe('CRUD_GET_LIST_SUCCESS', () => {
+        it('adds the retrieved records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_LIST_SUCCESS,
+                    payload: {
+                        data: [
+                            { id: 'record3', prop: 'value' },
+                            { id: 'record2', prop: 'value' },
+                        ],
+                    },
+                    meta: {
+                        fetchResponse: GET_LIST,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+        it('updates the retrieved records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_LIST_SUCCESS,
+                    payload: {
+                        data: [
+                            { id: 'record3', prop: 'refreshed value 3' },
+                            { id: 'record2', prop: 'refreshed value 2' },
+                        ],
+                    },
+                    meta: {
+                        fetchResponse: GET_LIST,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'refreshed value 2' },
+                    record3: { id: 'record3', prop: 'refreshed value 3' },
+                }
+            );
+        });
+    });
+    describe('CRUD_GET_MANY_SUCCESS', () => {
+        it('adds the retrieved records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_MANY_SUCCESS,
+                    payload: {
+                        data: [
+                            { id: 'record3', prop: 'value' },
+                            { id: 'record2', prop: 'value' },
+                        ],
+                    },
+                    meta: {
+                        fetchResponse: GET_MANY,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+        it('updates the retrieved records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_MANY_SUCCESS,
+                    payload: {
+                        data: [
+                            { id: 'record3', prop: 'refreshed value 3' },
+                            { id: 'record2', prop: 'refreshed value 2' },
+                        ],
+                    },
+                    meta: {
+                        fetchResponse: GET_MANY,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'refreshed value 2' },
+                    record3: { id: 'record3', prop: 'refreshed value 3' },
+                }
+            );
+        });
+    });
+    describe('CRUD_GET_MANY_REFERENCE_SUCCESS', () => {
+        it('adds the retrieved records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_MANY_REFERENCE_SUCCESS,
+                    payload: {
+                        data: [
+                            { id: 'record3', prop: 'value' },
+                            { id: 'record2', prop: 'value' },
+                        ],
+                    },
+                    meta: {
+                        fetchResponse: GET_MANY_REFERENCE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+        it('updates the retrieved records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_MANY_REFERENCE_SUCCESS,
+                    payload: {
+                        data: [
+                            { id: 'record3', prop: 'refreshed value 3' },
+                            { id: 'record2', prop: 'refreshed value 2' },
+                        ],
+                    },
+                    meta: {
+                        fetchResponse: GET_MANY_REFERENCE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'refreshed value 2' },
+                    record3: { id: 'record3', prop: 'refreshed value 3' },
+                }
+            );
+        });
+    });
+    describe('CRUD_GET_ONE_SUCCESS', () => {
+        it('adds the retrieved record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_ONE_SUCCESS,
+                    payload: {
+                        data: { id: 'record3', prop: 'value' },
+                    },
+                    meta: {
+                        fetchResponse: GET_ONE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+        it('updates the retrieved record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_GET_ONE_SUCCESS,
+                    payload: {
+                        data: { id: 'record3', prop: 'refreshed value' },
+                    },
+                    meta: {
+                        fetchResponse: GET_ONE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value' },
+                    record3: { id: 'record3', prop: 'refreshed value' },
+                }
+            );
+        });
+    });
+    describe('CRUD_CREATE_SUCCESS', () => {
+        it('adds the created record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_CREATE_SUCCESS,
+                    payload: {
+                        data: { id: 'record3', prop: 'value' },
+                    },
+                    meta: {
+                        fetchResponse: CREATE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+    });
+    describe('CRUD_UPDATE_SUCCESS', () => {
+        it('updates the updated record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_UPDATE_SUCCESS,
+                    payload: {
+                        id: 'record2',
+                        data: { id: 'record2', prop: 'value updated' },
+                    },
+                    meta: {
+                        fetchResponse: UPDATE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+    });
+    describe('CRUD_UPDATE_MANY', () => {
+        it('updates the updated records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_UPDATE_MANY,
+                    payload: {
+                        ids: ['record3', 'record2'],
+                        data: { prop: 'value updated' },
+                    },
+                    meta: {
+                        fetchResponse: UPDATE_MANY,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value updated' },
+                }
+            );
+        });
+    });
     describe('CRUD_DELETE_OPTIMISTIC', () => {
         it('removes the deleted record', () => {
             const state = {

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.js
@@ -3,7 +3,15 @@ import assert from 'assert';
 import {
     CRUD_DELETE_OPTIMISTIC,
     CRUD_DELETE_MANY_OPTIMISTIC,
+    CRUD_UPDATE_OPTIMISTIC,
+    CRUD_UPDATE_MANY_OPTIMISTIC,
 } from '../../../actions/dataActions';
+import {
+    DELETE,
+    DELETE_MANY,
+    UPDATE,
+    UPDATE_MANY,
+} from '../../../dataFetchActions';
 
 import dataReducer, { addRecordsFactory } from './data';
 
@@ -112,6 +120,7 @@ describe('Resources data reducer', () => {
                 dataReducer(state, {
                     type: CRUD_DELETE_OPTIMISTIC,
                     payload: { id: 'record2' },
+                    meta: { effect: DELETE, optimistic: true },
                 }),
                 {
                     record1: { id: 'record1', prop: 'value' },
@@ -132,9 +141,160 @@ describe('Resources data reducer', () => {
                 dataReducer(state, {
                     type: CRUD_DELETE_MANY_OPTIMISTIC,
                     payload: { ids: ['record3', 'record2'] },
+                    meta: {
+                        effect: DELETE_MANY,
+                        optimistic: true,
+                    },
                 }),
                 {
                     record1: { id: 'record1', prop: 'value' },
+                }
+            );
+        });
+    });
+    describe('CRUD_UPDATE_OPTIMISTIC', () => {
+        it('updates the updated record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_UPDATE_OPTIMISTIC,
+                    payload: {
+                        id: 'record2',
+                        data: { prop: 'value updated' },
+                    },
+                    meta: { effect: UPDATE, optimistic: true },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+    });
+    describe('CRUD_UPDATE_MANY_OPTIMISTIC', () => {
+        it('updates the updated records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: CRUD_UPDATE_MANY_OPTIMISTIC,
+                    payload: {
+                        ids: ['record3', 'record2'],
+                        data: { prop: 'value updated' },
+                    },
+                    meta: {
+                        effect: UPDATE_MANY,
+                        optimistic: true,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value updated' },
+                }
+            );
+        });
+    });
+    describe('Custom action with optimistic data and an UPDATE effect', () => {
+        it('updates the updated record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: 'MY_CUSTOM_ACTION',
+                    payload: {
+                        id: 'record2',
+                        data: { endPointSpecificParam: 'value' },
+                    },
+                    meta: {
+                        effect: UPDATE,
+                        optimistic: true,
+                        optimisticData: { prop: 'value updated' },
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+    });
+    describe('Custom action with optimistic data and an UPDATE_MANY effect', () => {
+        it('updates the updated records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: 'MY_CUSTOM_ACTION',
+                    payload: {
+                        ids: ['record3', 'record2'],
+                        data: { endPointSpecificParam: 'value' },
+                    },
+                    meta: {
+                        effect: UPDATE_MANY,
+                        optimistic: true,
+                        optimisticData: { prop: 'value updated' },
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value updated' },
                 }
             );
         });

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.js
@@ -14,6 +14,7 @@ import {
 } from '../../../dataFetchActions';
 
 import dataReducer, { addRecordsFactory } from './data';
+import { FETCH_END } from '../../../actions/fetchActions';
 
 describe('data addRecordsFactory', () => {
     it('should call getFetchedAt with newRecords ids and oldRecordFetchedAt and return records returned by getFetchedAt', () => {
@@ -223,7 +224,7 @@ describe('Resources data reducer', () => {
             );
         });
     });
-    describe('Custom action with optimistic data and an UPDATE effect', () => {
+    describe('Custom optimistic action with an UPDATE effect', () => {
         it('updates the updated record', () => {
             const state = {
                 record1: { id: 'record1', prop: 'value' },
@@ -250,7 +251,7 @@ describe('Resources data reducer', () => {
                     meta: {
                         effect: UPDATE,
                         optimistic: true,
-                        optimisticData: { prop: 'value updated' },
+                        effectData: { prop: 'value updated' },
                     },
                 }),
                 {
@@ -261,7 +262,7 @@ describe('Resources data reducer', () => {
             );
         });
     });
-    describe('Custom action with optimistic data and an UPDATE_MANY effect', () => {
+    describe('Custom optimistic action with an UPDATE_MANY effect', () => {
         it('updates the updated records', () => {
             const state = {
                 record1: { id: 'record1', prop: 'value' },
@@ -288,7 +289,81 @@ describe('Resources data reducer', () => {
                     meta: {
                         effect: UPDATE_MANY,
                         optimistic: true,
-                        optimisticData: { prop: 'value updated' },
+                        effectData: { prop: 'value updated' },
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value updated' },
+                }
+            );
+        });
+    });
+    describe('Custom action with an UPDATE effect', () => {
+        it('updates the updated record', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: 'MY_CUSTOM_ACTION',
+                    payload: {
+                        id: 'record2',
+                        data: { id: 'record2', prop: 'value updated' },
+                    },
+                    meta: {
+                        effect: UPDATE,
+                        fetchStatus: FETCH_END,
+                    },
+                }),
+                {
+                    record1: { id: 'record1', prop: 'value' },
+                    record2: { id: 'record2', prop: 'value updated' },
+                    record3: { id: 'record3', prop: 'value' },
+                }
+            );
+        });
+    });
+    describe('Custom optimistic action with an UPDATE_MANY effect', () => {
+        it('updates the updated records', () => {
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+            };
+
+            const now = new Date();
+            Object.defineProperty(state, 'fetchedAt', {
+                value: {
+                    record3: now,
+                    record2: now,
+                    record1: now,
+                },
+            });
+
+            assert.deepEqual(
+                dataReducer(state, {
+                    type: 'MY_CUSTOM_ACTION',
+                    payload: {
+                        ids: ['record3', 'record2'],
+                        data: { prop: 'value updated' },
+                    },
+                    meta: {
+                        effect: UPDATE_MANY,
+                        fetchStatus: FETCH_END,
                     },
                 }),
                 {

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.js
@@ -1,15 +1,13 @@
 import uniq from 'lodash/uniq';
 import {
     CRUD_GET_LIST_SUCCESS,
-    CRUD_DELETE_OPTIMISTIC,
-    CRUD_DELETE_MANY_OPTIMISTIC,
     CRUD_GET_MANY_SUCCESS,
     CRUD_GET_MANY_REFERENCE_SUCCESS,
     CRUD_GET_ONE_SUCCESS,
     CRUD_CREATE_SUCCESS,
     CRUD_UPDATE_SUCCESS,
 } from '../../../../actions/dataActions';
-
+import { DELETE, DELETE_MANY } from '../../../../dataFetchActions';
 import getFetchedAt from '../../../../util/getFetchedAt';
 
 export const addRecordIdsFactory = getFetchedAt => (
@@ -29,7 +27,39 @@ export const addRecordIdsFactory = getFetchedAt => (
 
 const addRecordIds = addRecordIdsFactory(getFetchedAt);
 
-export default (previousState = [], { type, payload }) => {
+export default (previousState = [], { type, payload, meta }) => {
+    if (meta && (meta.effect || meta.fetch) === DELETE && meta.optimistic) {
+        const index = previousState
+            .map(el => el == payload.id) // eslint-disable-line eqeqeq
+            .indexOf(true);
+        if (index === -1) {
+            return previousState;
+        }
+        const newState = [
+            ...previousState.slice(0, index),
+            ...previousState.slice(index + 1),
+        ];
+
+        Object.defineProperty(newState, 'fetchedAt', {
+            value: previousState.fetchedAt,
+        });
+
+        return newState;
+    }
+
+    if (
+        meta &&
+        (meta.effect || meta.fetch) === DELETE_MANY &&
+        meta.optimistic
+    ) {
+        const newState = previousState.filter(el => !payload.ids.includes(el));
+        Object.defineProperty(newState, 'fetchedAt', {
+            value: previousState.fetchedAt,
+        });
+
+        return newState;
+    }
+
     switch (type) {
         case CRUD_GET_LIST_SUCCESS:
             return addRecordIds(payload.data.map(({ id }) => id), []);
@@ -45,34 +75,6 @@ export default (previousState = [], { type, payload }) => {
         case CRUD_CREATE_SUCCESS:
         case CRUD_UPDATE_SUCCESS:
             return addRecordIds([payload.data.id], previousState);
-        case CRUD_DELETE_OPTIMISTIC: {
-            const index = previousState
-                .map(el => el == payload.id) // eslint-disable-line eqeqeq
-                .indexOf(true);
-            if (index === -1) {
-                return previousState;
-            }
-            const newState = [
-                ...previousState.slice(0, index),
-                ...previousState.slice(index + 1),
-            ];
-
-            Object.defineProperty(newState, 'fetchedAt', {
-                value: previousState.fetchedAt,
-            });
-
-            return newState;
-        }
-        case CRUD_DELETE_MANY_OPTIMISTIC: {
-            const newState = previousState.filter(
-                el => !payload.ids.includes(el)
-            );
-            Object.defineProperty(newState, 'fetchedAt', {
-                value: previousState.fetchedAt,
-            });
-
-            return newState;
-        }
         default:
             return previousState;
     }

--- a/packages/ra-core/src/reducer/admin/resource/list/total.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/total.js
@@ -1,22 +1,26 @@
 import {
     CRUD_GET_ONE_SUCCESS,
     CRUD_GET_LIST_SUCCESS,
-    CRUD_DELETE_OPTIMISTIC,
-    CRUD_DELETE_MANY_OPTIMISTIC,
 } from '../../../../actions/dataActions';
+import { DELETE, DELETE_MANY } from '../../../../dataFetchActions';
 
-export default (previousState = 0, { type, payload }) => {
+export default (previousState = 0, { type, payload, meta }) => {
     if (type === CRUD_GET_ONE_SUCCESS) {
         return previousState == 0 ? 1 : previousState;
     }
     if (type === CRUD_GET_LIST_SUCCESS) {
         return payload.total;
     }
-    if (type === CRUD_DELETE_OPTIMISTIC) {
+    if (meta && (meta.effect || meta.fetch) === DELETE && meta.optimistic) {
         return previousState - 1;
     }
-    if (type === CRUD_DELETE_MANY_OPTIMISTIC) {
+    if (
+        meta &&
+        (meta.effect || meta.fetch) === DELETE_MANY &&
+        meta.optimistic
+    ) {
         return previousState - payload.ids.length;
     }
+
     return previousState;
 };


### PR DESCRIPTION
The idea is to allow custom actions to be handled by our reducers like the standard crud actions, regarding to their effect on data.

For example, we could have a custom action using a custom fetch type and yet have it update the resource(s) optimistically.

- [x] data reducer
- [x] list reducer
- [x] total reducer
- [x] Tests
- [x] Documentation