### PR TITLE
Tutorial.md adding prop-types package external dependency

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -200,7 +200,6 @@ UrlField.propTypes = {
 export default UrlField;
 ```
 
-
 ## Handling Relationships
 
 In JSONPlaceholder, each `post` record includes a `userId` field, which points to a `user`:

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -200,6 +200,12 @@ UrlField.propTypes = {
 export default UrlField;
 ```
 
+To take advantage of the prop-types library, you can go ahead and install it.
+
+```sh
+yarn add prop-types
+```
+
 ## Handling Relationships
 
 In JSONPlaceholder, each `post` record includes a `userId` field, which points to a `user`:

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -20,7 +20,7 @@ React-admin uses React. We'll use Facebook's [create-react-app](https://github.c
 npm install -g create-react-app
 create-react-app test-admin
 cd test-admin/
-yarn add react-admin
+yarn add react-admin prop-types
 yarn start
 ```
 
@@ -200,11 +200,6 @@ UrlField.propTypes = {
 export default UrlField;
 ```
 
-To take advantage of the prop-types library, you can go ahead and install it.
-
-```sh
-yarn add prop-types
-```
 
 ## Handling Relationships
 


### PR DESCRIPTION
Prop types have become an external dependency so we should instruct a first-time user to install this externally using yarn. This change does just that adding two lines in order to complete this need.