### PR TITLE
[RFR] Fix fetch alert when response contains falsy data

### DIFF
--- a/packages/ra-core/src/sideEffect/fetch.js
+++ b/packages/ra-core/src/sideEffect/fetch.js
@@ -24,7 +24,7 @@ function validateResponseFormat(
     type,
     logger = console.error // eslint-disable-line no-console
 ) {
-    if (!response.data) {
+    if (!response.hasOwnProperty('data')) {
         logger(
             `The response to '${type}' must be like { data: ... }, but the received response does not have a 'data' key. The dataProvider is probably wrong for '${type}'.`
         );


### PR DESCRIPTION
My `dataProvider` handles custom verbs, for which the value of `data` is sometimes `false` or empty. Unfortunately, the check for the response format added in 2.2 thinks this means there is no data...