### PR TITLE
[RFR] Allow to use <Admin> inside an external <Provider>

### DIFF
--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -24,13 +24,13 @@ import { routerMiddleware } from 'react-router-redux';
 import createSagaMiddleware from 'redux-saga';
 import { all, fork } from 'redux-saga/effects';
 import {
-    USER_LOGOUT,
-    createAppReducer,
     adminReducer,
     adminSaga,
-    i18nReducer,
+    createAppReducer,
     defaultI18nProvider,
+    i18nReducer,
     formMiddleware,
+    USER_LOGOUT,
 } from 'react-admin';
 
 export default ({

--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -3,110 +3,244 @@ layout: default
 title: "Including the Admin in Another App"
 ---
 
-# Including react-admin on another React app
+# Including React-Admin In Another Redux Application
 
-The `<Admin>` tag is a great shortcut got be up and running with react-admin in minutes. However, in many cases, you will want to embed the admin in another application, or customize the admin deeply. Fortunately, you can do all the work that `<Admin>` does on any React application.
-
-Beware that you need to know about [redux](http://redux.js.org/), [react-router](https://github.com/reactjs/react-router), and [redux-saga](https://github.com/yelouafi/redux-saga) to go further.
+The `<Admin>` tag is a great shortcut got be up and running with react-admin in minutes. However, in many cases, you will want to embed the admin in another application, or customize the admin redux store deeply.
 
 **Tip**: Before going for the Custom App route, explore all the options of [the `<Admin>` component](./Admin.md). They allow you to add custom routes, custom reducers, custom sagas, and customize the layout.
 
-Here is the main code for bootstrapping a barebones react-admin application with 3 resources: `posts`, `comments`, and `users`:
+Fortunately, the `<Admin>` component detects when it's used inside an existing Redux `<Provider>`, and skips its own store initialization. That means that react-admin will work out of the box inside another redux application - provided, of course, the store is compatible.
 
-```jsx
+Beware that you need to know about [redux](http://redux.js.org/), [react-router](https://github.com/reactjs/react-router), and [redux-saga](https://github.com/yelouafi/redux-saga) to go further.
+
+React-admin requires that the redux state contains at least 4 reducers: `admin`, `i18n`, `form`, and `routing`. You can add more, or replace some of them with your own, but you can't remove or rename them. As it relies on redux-form, react-router, and redux-saga, react-admin also expects the store to use their middlewares.
+
+Here is the default store creation for react-admin:
+
+```js
+// in src/createAdminStore.js
+import { combineReducers, createStore, compose, applyMiddleware } from 'redux';
+import { routerMiddleware } from 'react-router-redux';
+import createSagaMiddleware from 'redux-saga';
+import { all, fork } from 'redux-saga/effects';
+import {
+    USER_LOGOUT,
+    createAppReducer,
+    adminReducer,
+    adminSaga,
+    i18nReducer,
+    defaultI18nProvider,
+    formMiddleware,
+} from 'react-admin';
+
+export default ({
+    authProvider,
+    dataProvider,
+    i18nProvider = defaultI18nProvider,
+    history,
+    locale = 'en',
+}) => {
+    const reducer = combineReducers({
+        admin: adminReducer,
+        i18n: i18nReducer(locale, i18nProvider(locale)),
+        form: formReducer,
+        routing: routerReducer,
+        { /* add your own reducers here */ },
+    });
+    const resettableAppReducer = (state, action) =>
+        reducer(action.type !== USER_LOGOUT ? state : undefined, action);
+
+    const saga = function* rootSaga() {
+        yield all(
+            [
+                adminSaga(dataProvider, authProvider, i18nProvider),
+                // add your own sagas here
+            ].map(fork)
+        );
+    };
+    const sagaMiddleware = createSagaMiddleware();
+
+    const store = createStore(
+        resettableAppReducer,
+        { /* set your initial state here */ },
+        compose(
+            applyMiddleware(
+                sagaMiddleware,
+                routerMiddleware(history),
+                formMiddleware,
+                // add your own middlewares here
+            ),
+            typeof window !== 'undefined' && window.devToolsExtension
+                ? window.devToolsExtension()
+                : f => f
+            // add your own enhancers here
+        )
+    );
+    sagaMiddleware.run(saga);
+    return store;
+};
+```
+
+You can use this script as a base and then add your own middleares or enhancers, e.g. to allow store persistence with [redux-persist](https://github.com/rt2zz/redux-persist).
+
+Then, use the `<Admin>` component as you would in a standalone application. Here is an example with 3 resources: `posts`, `comments`, and `users`
+
+```js
 // in src/App.js
 import React from 'react';
-import PropTypes from 'prop-types';
-import { render } from 'react-dom';
-
-// redux, react-router, redux-form, saga, and material-ui
-// form the 'kernel' on which react-admin runs
-import { combineReducers, createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import createHistory from 'history/createHashHistory';
-import { Switch, Route } from 'react-router-dom';
-import { ConnectedRouter, routerReducer, routerMiddleware } from 'react-router-redux';
-import { reducer as formReducer } from 'redux-form';
-import createSagaMiddleware from 'redux-saga';
-import { MuiThemeProvider } from '@material-ui/core/styles';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-
-// prebuilt react-admin features
-import {
-    adminReducer,
-    i18nReducer,
-    adminSaga,
-    TranslationProvider,
-} from 'react-admin';
+import { Admin, Resource } from 'react-admin';
 import restProvider from 'ra-data-simple-rest';
 import defaultMessages from 'ra-language-english';
+
+import createAdminStore from './createAdminStore';
+import messages from './i18n';
 
 // your app components
 import Dashboard from './Dashboard';
 import { PostList, PostCreate, PostEdit, PostShow } from './Post';
 import { CommentList, CommentEdit, CommentCreate } from './Comment';
 import { UserList, UserEdit, UserCreate } from './User';
-// your app labels
-import messages from './i18n';
-
-// create a Redux app
-const reducer = combineReducers({
-    admin: adminReducer,
-    i18n: i18nReducer('en', messages['en']),
-    form: formReducer,
-    routing: routerReducer,
-});
-const sagaMiddleware = createSagaMiddleware();
-const history = createHistory();
-const store = createStore(reducer, undefined, compose(
-    applyMiddleware(sagaMiddleware, routerMiddleware(history)),
-    window.devToolsExtension ? window.devToolsExtension() : f => f,
-));
 
 // side effects
-const dataProvider = restProvider('http://path.to.my.api/');
 const authProvider = () => Promise.resolve();
+const dataProvider = restProvider('http://path.to.my.api/');
 const i18nProvider = locale => {
     if (locale !== 'en') {
         return messages[locale];
     }
     return defaultMessages;
 };
-sagaMiddleware.run(adminSaga(dataProvider, authProvider, i18nProvider));
+const history = createHistory();
 
-// bootstrap redux and the routes
 const App = () => (
-    <Provider store={store}>
-        <TranslationProvider>
-            <ConnectedRouter history={history}>
-                <MuiThemeProvider>
-                    <AppBar position="static" color="default">
-                        <Toolbar>
-                            <Typography variant="title" color="inherit">
-                                My admin
-                            </Typography>
-                        </Toolbar>
-                    </AppBar>
-                    <Switch>
-                        <Route exact path="/" component={Dashboard} />
-                        <Route exact path="/posts" hasCreate render={(routeProps) => <PostList resource="posts" {...routeProps} />} />
-                        <Route exact path="/posts/create" render={(routeProps) => <PostCreate resource="posts" {...routeProps} />} />
-                        <Route exact path="/posts/:id" hasShow render={(routeProps) => <PostEdit resource="posts" {...routeProps} />} />
-                        <Route exact path="/posts/:id/show" hasEdit render={(routeProps) => <PostShow resource="posts" {...routeProps} />} />
-                        <Route exact path="/comments" hasCreate render={(routeProps) => <CommentList resource="comments" {...routeProps} />} />
-                        <Route exact path="/comments/create" render={(routeProps) => <CommentCreate resource="comments" {...routeProps} />} />
-                        <Route exact path="/comments/:id" render={(routeProps) => <CommentEdit resource="comments" {...routeProps} />} />
-                        <Route exact path="/users" hasCreate render={(routeProps) => <UsersList resource="users" {...routeProps} />} />
-                        <Route exact path="/users/create" render={(routeProps) => <UsersCreate resource="users" {...routeProps} />} />
-                        <Route exact path="/users/:id" render={(routeProps) => <UsersEdit resource="users" {...routeProps} />} />
-                    </Switch>
-                </MuiThemeProvider>
-            </ConnectedRouter>
-        </TranslationProvider>
+    <Provider
+        store={createAdminStore({
+            authProvider,
+            dataProvider,
+            i18nProvider,
+            history,
+        })}
+    >
+        <Admin
+            authProvider={authProvider}
+            history={history}
+            title="My Admin"
+        >
+            <Resource name="posts" list={PostList} create={PostCreate} edit={PostEdit} show={PostShow} />
+            <Resource name="comments" list={CommentList} edit={CommentEdit} create={CommentCreate} />
+            <Resource name="users" list={UserList} edit={UserEdit} create={UserCreate} />
+        </Admin>
     </Provider>
 );
+
+export default App;
 ```
+
+**Tip**: One thing to pay attention to is that you must pass the same `history` and `authProvider` to both the redux Store creator and the `<Admin>` component. But you don't need to pass the `dataProvider` or the `i18nProvider`.
+
+## Not Using the `<Admin>` Components
+
+The `<Admin>` component takes care of defining the store (unless you provide one, as seen above), of setting the Translation and Authentication contexts, and of bootstrapping the Router. In case you need to override any of these, you can use your own component instead of `<Admin>`. 
+
+Here is the main code for bootstrapping a barebones react-admin application without `<Admin>`:
+
+```diff
+// in src/App.js
+import React from 'react';
+import { Provider } from 'react-redux';
+import createHistory from 'history/createHashHistory';
++import { ConnectedRouter } from 'react-router-redux';
++import { Switch, Route } from 'react-router-dom';
++import withContext from 'recompose/withContext';
+-import { Admin, Resource } from 'react-admin';
++import { TranslationProvider, Resource } from 'react-admin';
+import restProvider from 'ra-data-simple-rest';
+import defaultMessages from 'ra-language-english';
++import { MuiThemeProvider } from '@material-ui/core/styles';
++import AppBar from '@material-ui/core/AppBar';
++import Toolbar from '@material-ui/core/Toolbar';
++import Typography from '@material-ui/core/Typography';
+
+import createAdminStore from './createAdminStore';
+import messages from './i18n';
+
+// your app components
+import Dashboard from './Dashboard';
+import { PostList, PostCreate, PostEdit, PostShow } from './Post';
+import { CommentList, CommentEdit, CommentCreate } from './Comment';
+import { UserList, UserEdit, UserCreate } from './User';
+
+// side effects
+const authProvider = () => Promise.resolve();
+const dataProvider = restProvider('http://path.to.my.api/');
+const i18nProvider = locale => {
+    if (locale !== 'en') {
+        return messages[locale];
+    }
+    return defaultMessages;
+};
+const history = createHistory();
+
+const App = () => (
+    <Provider
+        store={createAdminStore({
+            authProvider,
+            dataProvider,
+            i18nProvider,
+            history,
+        })}
+    >
+-       <Admin
+-           authProvider={authProvider}
+-           history={history}
+-           title="My Admin"
+-       >
+-           <Resource name="posts" list={PostList} create={PostCreate} edit={PostEdit} show={PostShow} />
+-           <Resource name="comments" list={CommentList} edit={CommentEdit} create={CommentCreate} />
+-           <Resource name="users" list={UserList} edit={UserEdit} create={UserCreate} />
++       <TranslationProvider>
++           <ConnectedRouter history={history}>
++               <Resource name="posts" context="registration" />
++               <Resource name="comments" context="registration" />
++               <Resource name="users" context="registration" />
++               <MuiThemeProvider>
++                   <AppBar position="static" color="default">
++                       <Toolbar>
++                           <Typography variant="title" color="inherit">
++                               My admin
++                           </Typography>
++                       </Toolbar>
++                   </AppBar>
++                   <Switch>
++                       <Route exact path="/" component={Dashboard} />
++                       <Route exact path="/posts" hasCreate render={(routeProps) => <PostList resource="posts" {...routeProps} />} />
++                       <Route exact path="/posts/create" render={(routeProps) => <PostCreate resource="posts" {...routeProps} />} />
++                       <Route exact path="/posts/:id" hasShow render={(routeProps) => <PostEdit resource="posts" {...routeProps} />} />
++                       <Route exact path="/posts/:id/show" hasEdit render={(routeProps) => <PostShow resource="posts" {...routeProps} />} />
++                       <Route exact path="/comments" hasCreate render={(routeProps) => <CommentList resource="comments" {...routeProps} />} />
++                       <Route exact path="/comments/create" render={(routeProps) => <CommentCreate resource="comments" {...routeProps} />} />
++                       <Route exact path="/comments/:id" render={(routeProps) => <CommentEdit resource="comments" {...routeProps} />} />
++                       <Route exact path="/users" hasCreate render={(routeProps) => <UsersList resource="users" {...routeProps} />} />
++                       <Route exact path="/users/create" render={(routeProps) => <UsersCreate resource="users" {...routeProps} />} />
++                       <Route exact path="/users/:id" render={(routeProps) => <UsersEdit resource="users" {...routeProps} />} />
++                   </Switch>
++               </MuiThemeProvider>
++           </ConnectedRouter>
++       </TranslationProvider>
+-       </Admin>
+    </Provider>
+);
+
+-export default App;
++export default withContext(
++   {
++       authProvider: PropTypes.func,
++   },
++   () => ({ authProvider })
+```
+
+Note that this example still uses `<Resource>`, because this component lazily initializes the store for the resource data.
 
 This application has no sidebar, no theming, no [auth control](./Authentication.md#restricting-access-to-a-custom-page) - it's up to you to add these. From there on, you can customize pretty much anything you want.

--- a/packages/ra-core/src/CoreAdmin.js
+++ b/packages/ra-core/src/CoreAdmin.js
@@ -38,6 +38,10 @@ class CoreAdmin extends React.Component {
         title: PropTypes.node,
     };
 
+    static contextTypes = {
+        store: PropTypes.object,
+    };
+
     reduxIsAlreadyInitialized = false;
     history = null;
 

--- a/packages/ra-core/src/CoreAdmin.js
+++ b/packages/ra-core/src/CoreAdmin.js
@@ -1,80 +1,86 @@
 import React, { createElement } from 'react';
 import PropTypes from 'prop-types';
-import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import createHistory from 'history/createHashHistory';
 import { Switch, Route } from 'react-router-dom';
-import { ConnectedRouter, routerMiddleware } from 'react-router-redux';
-import createSagaMiddleware from 'redux-saga';
-import { all, fork } from 'redux-saga/effects';
+import { ConnectedRouter } from 'react-router-redux';
 import withContext from 'recompose/withContext';
 
-import { USER_LOGOUT } from './actions/authActions';
-
-import createAppReducer from './reducer';
-import { adminSaga } from './sideEffect';
-import { TranslationProvider, defaultI18nProvider } from './i18n';
-import formMiddleware from './form/formMiddleware';
+import createAdminStore from './createAdminStore';
+import TranslationProvider from './i18n/TranslationProvider';
 import CoreAdminRouter from './CoreAdminRouter';
 
-const CoreAdmin = ({
-    appLayout,
-    authProvider,
-    children,
-    customReducers = {},
-    customSagas = [],
-    customRoutes = [],
-    dashboard,
-    history,
-    menu, // deprecated, use a custom layout instead
-    catchAll,
-    dataProvider,
-    i18nProvider = defaultI18nProvider,
-    theme,
-    title = 'React Admin',
-    loading,
-    loginPage,
-    logoutButton,
-    initialState,
-    locale = 'en',
-}) => {
-    const messages = i18nProvider(locale);
-    const appReducer = createAppReducer(customReducers, locale, messages);
+const componentPropType = PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+]);
 
-    const resettableAppReducer = (state, action) =>
-        appReducer(action.type !== USER_LOGOUT ? state : undefined, action);
-    const saga = function* rootSaga() {
-        yield all(
-            [
-                adminSaga(dataProvider, authProvider, i18nProvider),
-                ...customSagas,
-            ].map(fork)
-        );
+class CoreAdmin extends React.Component {
+    static propTypes = {
+        appLayout: componentPropType,
+        authProvider: PropTypes.func,
+        children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+        catchAll: componentPropType,
+        customSagas: PropTypes.array,
+        customReducers: PropTypes.object,
+        customRoutes: PropTypes.array,
+        dashboard: componentPropType,
+        dataProvider: PropTypes.func,
+        history: PropTypes.object,
+        i18nProvider: PropTypes.func,
+        initialState: PropTypes.object,
+        loading: componentPropType,
+        locale: PropTypes.string,
+        loginPage: componentPropType,
+        logoutButton: componentPropType,
+        menu: componentPropType,
+        theme: PropTypes.object,
+        title: PropTypes.node,
     };
-    const sagaMiddleware = createSagaMiddleware();
-    const routerHistory = history || createHistory();
-    const store = createStore(
-        resettableAppReducer,
-        initialState,
-        compose(
-            applyMiddleware(
-                sagaMiddleware,
-                routerMiddleware(routerHistory),
-                formMiddleware
-            ),
-            typeof window !== 'undefined' && window.devToolsExtension
-                ? window.devToolsExtension()
-                : f => f
-        )
-    );
-    sagaMiddleware.run(saga);
 
-    const logout = authProvider ? createElement(logoutButton) : null;
+    reduxIsAlreadyInitialized = false;
+    history = null;
 
-    return (
-        <Provider store={store}>
+    constructor(props, context) {
+        super(props, context);
+        if (context.store) {
+            this.reduxIsAlreadyInitialized = true;
+            if (!props.history) {
+                throw new Error(`Missing history prop.
+When integrating react-admin inside an existing redux Provider, you must provide the same 'history' prop to the <Admin> as the one used to bootstrap your routerMiddleware.
+React-admin uses this history for its own ConnectedRouter.`);
+            }
+            this.history = props.history;
+        } else {
+            if (!props.dataProvider) {
+                throw new Error(`Missing dataProvider prop.
+React-admin requires a valid dataProvider function to work.`);
+            }
+            this.history = props.history || createHistory();
+        }
+    }
+
+    renderCore() {
+        const {
+            appLayout,
+            authProvider,
+            children,
+            customRoutes = [],
+            dashboard,
+            menu, // deprecated, use a custom layout instead
+            catchAll,
+            theme,
+            title = 'React Admin',
+            loading,
+            loginPage,
+            logoutButton,
+        } = this.props;
+
+        const logout = authProvider ? createElement(logoutButton) : null;
+
+        return (
             <TranslationProvider>
-                <ConnectedRouter history={routerHistory}>
+                <ConnectedRouter history={this.history}>
                     <Switch>
                         <Route
                             exact
@@ -109,36 +115,24 @@ const CoreAdmin = ({
                     </Switch>
                 </ConnectedRouter>
             </TranslationProvider>
-        </Provider>
-    );
-};
+        );
+    }
 
-const componentPropType = PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.string,
-]);
-
-CoreAdmin.propTypes = {
-    appLayout: componentPropType,
-    authProvider: PropTypes.func,
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-    catchAll: componentPropType,
-    customSagas: PropTypes.array,
-    customReducers: PropTypes.object,
-    customRoutes: PropTypes.array,
-    dashboard: componentPropType,
-    dataProvider: PropTypes.func.isRequired,
-    history: PropTypes.object,
-    i18nProvider: PropTypes.func,
-    initialState: PropTypes.object,
-    loading: componentPropType,
-    locale: PropTypes.string,
-    loginPage: componentPropType,
-    logoutButton: componentPropType,
-    menu: componentPropType,
-    theme: PropTypes.object,
-    title: PropTypes.node,
-};
+    render() {
+        return this.reduxIsAlreadyInitialized ? (
+            this.renderCore()
+        ) : (
+            <Provider
+                store={createAdminStore({
+                    ...this.props,
+                    history: this.history,
+                })}
+            >
+                {this.renderCore()}
+            </Provider>
+        );
+    }
+}
 
 export default withContext(
     {

--- a/packages/ra-core/src/createAdminStore.js
+++ b/packages/ra-core/src/createAdminStore.js
@@ -1,0 +1,52 @@
+import { createStore, compose, applyMiddleware } from 'redux';
+import { routerMiddleware } from 'react-router-redux';
+import createSagaMiddleware from 'redux-saga';
+import { all, fork } from 'redux-saga/effects';
+
+import { USER_LOGOUT } from './actions/authActions';
+import createAppReducer from './reducer';
+import { adminSaga } from './sideEffect';
+import { defaultI18nProvider } from './i18n';
+import formMiddleware from './form/formMiddleware';
+
+export default ({
+    authProvider,
+    customReducers = {},
+    customSagas = [],
+    dataProvider,
+    i18nProvider = defaultI18nProvider,
+    history,
+    initialState,
+    locale = 'en',
+}) => {
+    const messages = i18nProvider(locale);
+    const appReducer = createAppReducer(customReducers, locale, messages);
+
+    const resettableAppReducer = (state, action) =>
+        appReducer(action.type !== USER_LOGOUT ? state : undefined, action);
+    const saga = function* rootSaga() {
+        yield all(
+            [
+                adminSaga(dataProvider, authProvider, i18nProvider),
+                ...customSagas,
+            ].map(fork)
+        );
+    };
+    const sagaMiddleware = createSagaMiddleware();
+    const store = createStore(
+        resettableAppReducer,
+        initialState,
+        compose(
+            applyMiddleware(
+                sagaMiddleware,
+                routerMiddleware(history),
+                formMiddleware
+            ),
+            typeof window !== 'undefined' && window.devToolsExtension
+                ? window.devToolsExtension()
+                : f => f
+        )
+    );
+    sagaMiddleware.run(saga);
+    return store;
+};

--- a/packages/ra-core/src/form/index.js
+++ b/packages/ra-core/src/form/index.js
@@ -1,6 +1,7 @@
 export addField from './addField';
 export FormDataConsumer from './FormDataConsumer';
 export FormField, { isRequired } from './FormField';
+export formMiddleware from './formMiddleware';
 export getDefaultValues from './getDefaultValues';
 export withDefaultValue from './withDefaultValue';
 export * from './validate';

--- a/packages/ra-core/src/index.js
+++ b/packages/ra-core/src/index.js
@@ -27,5 +27,6 @@ export {
 export * from './sideEffect';
 export CoreAdmin from './CoreAdmin';
 export CoreAdminRouter from './CoreAdminRouter';
+export createAdminStore from './createAdminStore';
 export RoutesWithLayout from './RoutesWithLayout';
 export Resource from './Resource';


### PR DESCRIPTION
Despite offering the ability to pass `customReducers` and `customSagas`, users always ask for more customization of the Redux store. Some want to add custom middlewares, enhancers, or override the react-admin reducers... The best example is probably adding local persistance for the state through the redux-persist middleware.

This PR allows the `<Admin>` to be used inside an external `<Provider>`, which skips the creation of the store completely. 

```jsx
const App = () => (
    <Provider
        store={createAdminStore({
            authProvider,
            dataProvider,
            i18nProvider,
            history,
        })}
    >
        <Admin
            authProvider={authProvider}
            history={history}
            title="My Admin"
        >
            <Resource name="posts" list={PostList} create={PostCreate} edit={PostEdit} show={PostShow} />
            <Resource name="comments" list={CommentList} edit={CommentEdit} create={CommentCreate} />
            <Resource name="users" list={UserList} edit={UserEdit} create={UserCreate} />
        </Admin>
    </Provider>
);
```

As a consequence, the Custom Apps documentation changes radically. In most cases, using a custom `<Provider>` is enough. I still kept the part explaining how to skip using `<Resource>`, but I'm not sure it's still very necessary.

Comments are welcome.

Closes #2025