### PR TITLE
[RFR] Move Refresh to AppBar, Introduce UserMenu

### DIFF
--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -23,6 +23,7 @@ export default url => ({
         selectAll: '.select-all',
         selectedItem: '.select-item input:checked',
         selectItem: '.select-item input',
+        userMenu: 'button[title="Profile"]',
     },
 
     navigate() {
@@ -74,6 +75,7 @@ export default url => ({
     },
 
     logout() {
+        cy.get(this.elements.userMenu).click();
         cy.get(this.elements.logout).click();
     },
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -374,7 +374,7 @@ import MyAppBar from './MyAppBar';
 import MyMenu from './MyMenu';
 import MyNotification from './MyNotification';
 
-const MyLayout = (props) => <Layout 
+const MyLayout = props => <Layout 
     {...props}
     appBar={MyAppBar}
     menu={MyMenu}
@@ -382,6 +382,27 @@ const MyLayout = (props) => <Layout
 />;
 
 export default MyLayout;
+```
+
+You can add custom menu items to the default `AppBar` user menu by adding children to it:
+
+```js
+import { AppBar, MenuItemLink } from 'react-admin';
+import SettingsIcon from '@material-ui/icons/Settings';
+
+const MyAppBar = props => (
+    <AppBar {...props}>
+        <MenuItemLink
+            to="/configuration"
+            primaryText="Configuration"
+            leftIcon={<SettingsIcon />}
+        />
+    </AppBar>
+);
+const MyLayout = props => <Layout
+    {...props}
+    appBar={MyAppBar}
+/>;
 ```
 
 For more custom layouts, write a component from scratch. It must contain a `{children}` placeholder, where react-admin will render the resources. Use the [default layout](https://github.com/marmelab/react-admin/blob/master/src/mui/layout/Layout.js) as a starting point. Here is a simplified version (with no responsive support):

--- a/examples/demo/src/AppBar.js
+++ b/examples/demo/src/AppBar.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { AppBar, MenuItemLink, translate } from 'react-admin';
+import SettingsIcon from '@material-ui/icons/Settings';
+
+const CustomAppBar = ({ translate, ...props }) => (
+    <AppBar {...props}>
+        <MenuItemLink
+            to="/configuration"
+            primaryText={translate('pos.configuration')}
+            leftIcon={<SettingsIcon />}
+        />
+    </AppBar>
+);
+
+export default translate(CustomAppBar);

--- a/examples/demo/src/Layout.js
+++ b/examples/demo/src/Layout.js
@@ -1,5 +1,9 @@
+import React from 'react';
 import { connect } from 'react-redux';
 import { Layout } from 'react-admin';
+import AppBar from './AppBar';
+
+const CustomLayout = props => <Layout appBar={AppBar} {...props} />;
 
 const darkTheme = {
     palette: {
@@ -23,4 +27,4 @@ export default connect(
         theme: state.theme === 'dark' ? darkTheme : lightTheme,
     }),
     {}
-)(Layout);
+)(CustomLayout);

--- a/examples/demo/src/Menu.js
+++ b/examples/demo/src/Menu.js
@@ -49,11 +49,16 @@ const Menu = ({ onMenuClick, translate, logout }) => (
                 onClick={onMenuClick}
             />
         ))}
-        <MenuItemLink
-            to="/configuration"
-            primaryText={translate('pos.configuration')}
-            leftIcon={<SettingsIcon />}
-            onClick={onMenuClick}
+        <Responsive
+            xsmall={
+                <MenuItemLink
+                    to="/configuration"
+                    primaryText={translate('pos.configuration')}
+                    leftIcon={<SettingsIcon />}
+                    onClick={onMenuClick}
+                />
+            }
+            medium={null}
         />
         <Responsive xsmall={logout} medium={null} />
     </div>

--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -86,6 +86,7 @@ module.exports = {
             prev: 'Prev',
         },
         auth: {
+            user_menu: 'Profile',
             username: 'Username',
             password: 'Password',
             sign_in: 'Sign in',

--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -88,6 +88,7 @@ module.exports = {
             prev: 'Précédent',
         },
         auth: {
+            user_menu: 'Profile',
             username: 'Identifiant',
             password: 'Mot de passe',
             sign_in: 'Connexion',

--- a/packages/ra-ui-materialui/src/auth/Logout.js
+++ b/packages/ra-ui-materialui/src/auth/Logout.js
@@ -2,14 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import { withStyles } from '@material-ui/core/styles';
 import ExitIcon from '@material-ui/icons/PowerSettingsNew';
 import classnames from 'classnames';
 import { translate, userLogout as userLogoutAction } from 'ra-core';
-
-import Responsive from '../layout/Responsive';
 
 const styles = theme => ({
     menuItem: {
@@ -38,31 +35,16 @@ const sanitizeRestProps = ({
  * Used for the Logout Menu item in the sidebar
  */
 const Logout = ({ classes, className, translate, userLogout, ...rest }) => (
-    <Responsive
-        xsmall={
-            <MenuItem
-                className={classnames('logout', classes.menuItem, className)}
-                onClick={userLogout}
-                {...sanitizeRestProps(rest)}
-            >
-                <span className={classes.iconMenuPaddingStyle}>
-                    <ExitIcon />
-                </span>
-                {translate('ra.auth.logout')}
-            </MenuItem>
-        }
-        medium={
-            <Button
-                className={classnames('logout', className)}
-                onClick={userLogout}
-                size="small"
-                {...sanitizeRestProps(rest)}
-            >
-                <ExitIcon className={classes.iconPaddingStyle} />
-                {translate('ra.auth.logout')}
-            </Button>
-        }
-    />
+    <MenuItem
+        className={classnames('logout', classes.menuItem, className)}
+        onClick={userLogout}
+        {...sanitizeRestProps(rest)}
+    >
+        <span className={classes.iconMenuPaddingStyle}>
+            <ExitIcon />
+        </span>
+        {translate('ra.auth.logout')}
+    </MenuItem>
 );
 
 Logout.propTypes = {

--- a/packages/ra-ui-materialui/src/button/RefreshIconButton.js
+++ b/packages/ra-ui-materialui/src/button/RefreshIconButton.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import Tooltip from '@material-ui/core/Tooltip';
+import IconButton from '@material-ui/core/IconButton';
+import NavigationRefresh from '@material-ui/icons/Refresh';
+import { refreshView, translate } from 'ra-core';
+
+class RefreshButton extends Component {
+    static propTypes = {
+        className: PropTypes.string,
+        label: PropTypes.string,
+        refreshView: PropTypes.func.isRequired,
+        translate: PropTypes.func.isRequired,
+    };
+
+    static defaultProps = {
+        label: 'ra.action.refresh',
+    };
+
+    handleClick = event => {
+        event.preventDefault();
+        this.props.refreshView();
+    };
+
+    render() {
+        const {
+            className,
+            label,
+            refreshView,
+            translate,
+            ...rest
+        } = this.props;
+
+        return (
+            <Tooltip title={label && translate(label, { _: label })}>
+                <IconButton
+                    arial-label={label && translate(label, { _: label })}
+                    className={className}
+                    color="inherit"
+                    onClick={this.handleClick}
+                    {...rest}
+                >
+                    <NavigationRefresh />
+                </IconButton>
+            </Tooltip>
+        );
+    }
+}
+
+const enhance = compose(
+    connect(
+        null,
+        { refreshView }
+    ),
+    translate
+);
+export default enhance(RefreshButton);

--- a/packages/ra-ui-materialui/src/button/index.js
+++ b/packages/ra-ui-materialui/src/button/index.js
@@ -8,3 +8,4 @@ export ListButton from './ListButton';
 export SaveButton from './SaveButton';
 export ShowButton from './ShowButton';
 export RefreshButton from './RefreshButton';
+export RefreshIconButton from './RefreshIconButton';

--- a/packages/ra-ui-materialui/src/detail/EditActions.js
+++ b/packages/ra-ui-materialui/src/detail/EditActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { ShowButton, DeleteButton, RefreshButton } from '../button';
+import { ShowButton, DeleteButton } from '../button';
 import CardActions from '../layout/CardActions';
 
 const sanitizeRestProps = ({
@@ -22,13 +22,12 @@ const sanitizeRestProps = ({
  *
  * @example
  *     import Button from '@material-ui/core/Button';
- *     import { CardActions, ShowButton, DeleteButton, RefreshButton, Edit } from 'react-admin';
+ *     import { CardActions, ShowButton, DeleteButton, Edit } from 'react-admin';
  *
  *     const PostEditActions = ({ basePath, record, rseource }) => (
  *         <CardActions>
  *             <ShowButton basePath={basePath} record={record} />
  *             <DeleteButton basePath={basePath} record={record} resource={resource} />
- *             <RefreshButton />
  *             // Add your custom actions here //
  *             <Button color="primary" onClick={customAction}>Custom Action</Button>
  *         </CardActions>
@@ -51,7 +50,6 @@ const EditActions = ({
     <CardActions className={className} {...sanitizeRestProps(rest)}>
         {hasShow && <ShowButton basePath={basePath} record={data} />}
         <DeleteButton basePath={basePath} record={data} resource={resource} />
-        <RefreshButton />
     </CardActions>
 );
 

--- a/packages/ra-ui-materialui/src/detail/ShowActions.js
+++ b/packages/ra-ui-materialui/src/detail/ShowActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { EditButton, DeleteButton, RefreshButton } from '../button';
+import { EditButton, DeleteButton } from '../button';
 import CardActions from '../layout/CardActions';
 
 const sanitizeRestProps = ({
@@ -23,13 +23,12 @@ const sanitizeRestProps = ({
  *
  * @example
  *     import Button from '@material-ui/core/Button';
- *     import { CardActions, EditButton, DeleteButton, RefreshButton, Show } from 'react-admin';
+ *     import { CardActions, EditButton, DeleteButton, Show } from 'react-admin';
  *
  *     const PostShowActions = ({ basePath, record, resource }) => (
  *         <CardActions>
  *             <EditButton basePath={basePath} record={record} />
  *             <DeleteButton basePath={basePath} record={record} resource={resource} />
- *             <RefreshButton />
  *             // Add your custom actions here //
  *             <Button color="primary" onClick={customAction}>Custom Action</Button>
  *         </CardActions>
@@ -58,7 +57,6 @@ const ShowActions = ({
                 resource={resource}
             />
         )}
-        <RefreshButton />
     </CardActions>
 );
 

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -12,6 +12,7 @@ import compose from 'recompose/compose';
 import { toggleSidebar as toggleSidebarAction } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
+import UserMenu from './UserMenu';
 
 const styles = theme => ({
     appBar: {
@@ -44,9 +45,6 @@ const styles = theme => ({
     },
     title: {
         flex: 1,
-    },
-    logout: {
-        color: theme.palette.secondary.contrastText,
     },
 });
 
@@ -88,10 +86,7 @@ const AppBar = ({
                 {typeof title === 'string' ? title : React.cloneElement(title)}
             </Typography>
             <LoadingIndicator />
-            {logout &&
-                cloneElement(logout, {
-                    className: classes.logout,
-                })}
+            {logout && <UserMenu logout={logout} />}
         </Toolbar>
     </MuiAppBar>
 );

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -1,4 +1,4 @@
-import React, { cloneElement } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -45,17 +45,6 @@ const styles = theme => ({
     title: {
         flex: 1,
     },
-    loadingIndicator: {
-        position: 'absolute',
-        top: 0,
-        right: 0,
-        left: 0,
-        zIndex: 1200,
-        marginBottom: 14,
-        marginTop: 14,
-        marginLeft: 'auto',
-        marginRight: 'auto',
-    },
     logout: {
         color: theme.palette.secondary.contrastText,
     },
@@ -98,12 +87,12 @@ const AppBar = ({
             >
                 {typeof title === 'string' ? title : React.cloneElement(title)}
             </Typography>
+            <LoadingIndicator />
             {logout &&
                 cloneElement(logout, {
                     className: classes.logout,
                 })}
         </Toolbar>
-        <LoadingIndicator className={classes.loadingIndicator} />
     </MuiAppBar>
 );
 

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -49,6 +49,7 @@ const styles = theme => ({
 });
 
 const AppBar = ({
+    children,
     classes,
     className,
     logout,
@@ -86,12 +87,13 @@ const AppBar = ({
                 {typeof title === 'string' ? title : React.cloneElement(title)}
             </Typography>
             <LoadingIndicator />
-            {logout && <UserMenu logout={logout} />}
+            {logout && <UserMenu logout={logout}>{children}</UserMenu>}
         </Toolbar>
     </MuiAppBar>
 );
 
 AppBar.propTypes = {
+    children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
     logout: PropTypes.element,

--- a/packages/ra-ui-materialui/src/layout/AppBarMobile.js
+++ b/packages/ra-ui-materialui/src/layout/AppBarMobile.js
@@ -24,6 +24,7 @@ const styles = {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
+        flex: 1,
     },
     icon: {
         marginTop: 0,
@@ -33,12 +34,6 @@ const styles = {
     link: {
         color: '#fff',
         textDecoration: 'none',
-    },
-    loadingIndicator: {
-        position: 'absolute',
-        top: 0,
-        right: 0,
-        zIndex: 1200,
     },
 };
 
@@ -71,7 +66,7 @@ const AppBarMobile = ({
             >
                 {title}
             </Typography>
-            <LoadingIndicator className={classes.loadingIndicator} />
+            <LoadingIndicator />
         </Toolbar>
     </MuiAppBar>
 );

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -6,9 +6,11 @@ import { withStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import compose from 'recompose/compose';
 
+import RefreshIconButton from '../button/RefreshIconButton';
+
 const styles = {
     loader: {
-        margin: 16,
+        margin: 14,
     },
 };
 
@@ -17,11 +19,13 @@ export const LoadingIndicator = ({ classes, className, isLoading, ...rest }) =>
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
             color="inherit"
-            size={20}
-            thickness={4}
+            size={18}
+            thickness={5}
             {...rest}
         />
-    ) : null;
+    ) : (
+        <RefreshIconButton />
+    );
 
 LoadingIndicator.propTypes = {
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import IconButton from '@material-ui/core/IconButton';
+import AccountCircle from '@material-ui/icons/AccountCircle';
+import Menu from '@material-ui/core/Menu';
+
+class UserMenu extends React.Component {
+    state = {
+        auth: true,
+        anchorEl: null,
+    };
+
+    handleChange = (event, checked) => {
+        this.setState({ auth: checked });
+    };
+
+    handleMenu = event => {
+        this.setState({ anchorEl: event.currentTarget });
+    };
+
+    handleClose = () => {
+        this.setState({ anchorEl: null });
+    };
+
+    render() {
+        const { logout } = this.props;
+        const { anchorEl } = this.state;
+        const open = Boolean(anchorEl);
+
+        return (
+            <div>
+                <IconButton
+                    aria-owns={open ? 'menu-appbar' : null}
+                    aria-haspopup="true"
+                    onClick={this.handleMenu}
+                    color="inherit"
+                >
+                    <AccountCircle />
+                </IconButton>
+                <Menu
+                    id="menu-appbar"
+                    anchorEl={anchorEl}
+                    anchorOrigin={{
+                        vertical: 'top',
+                        horizontal: 'right',
+                    }}
+                    transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'right',
+                    }}
+                    open={open}
+                    onClose={this.handleClose}
+                >
+                    {logout}
+                </Menu>
+            </div>
+        );
+    }
+}
+
+UserMenu.propTypes = {
+    logout: PropTypes.node,
+};
+
+export default UserMenu;

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
@@ -8,14 +8,15 @@ import { translate } from 'ra-core';
 
 class UserMenu extends React.Component {
     static propTypes = {
+        children: PropTypes.node,
         label: PropTypes.string.isRequired,
         logout: PropTypes.node,
         translate: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
-        label: 'ra.auth.user_menu'
-    }
+        label: 'ra.auth.user_menu',
+    };
 
     state = {
         auth: true,
@@ -35,7 +36,7 @@ class UserMenu extends React.Component {
     };
 
     render() {
-        const { label, logout, translate } = this.props;
+        const { children, label, logout, translate } = this.props;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
 
@@ -66,6 +67,9 @@ class UserMenu extends React.Component {
                     open={open}
                     onClose={this.handleClose}
                 >
+                    {Children.map(children, menuItem =>
+                        cloneElement(menuItem, { onClick: this.handleClose })
+                    )}
                     {logout}
                 </Menu>
             </div>

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -1,10 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
-import AccountCircle from '@material-ui/icons/AccountCircle';
 import Menu from '@material-ui/core/Menu';
+import AccountCircle from '@material-ui/icons/AccountCircle';
+import { translate } from 'ra-core';
 
 class UserMenu extends React.Component {
+    static propTypes = {
+        label: PropTypes.string.isRequired,
+        logout: PropTypes.node,
+        translate: PropTypes.func.isRequired,
+    };
+
+    static defaultProps = {
+        label: 'ra.auth.user_menu'
+    }
+
     state = {
         auth: true,
         anchorEl: null,
@@ -23,20 +35,23 @@ class UserMenu extends React.Component {
     };
 
     render() {
-        const { logout } = this.props;
+        const { label, logout, translate } = this.props;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
 
         return (
             <div>
-                <IconButton
-                    aria-owns={open ? 'menu-appbar' : null}
-                    aria-haspopup="true"
-                    onClick={this.handleMenu}
-                    color="inherit"
-                >
-                    <AccountCircle />
-                </IconButton>
+                <Tooltip title={label && translate(label, { _: label })}>
+                    <IconButton
+                        arial-label={label && translate(label, { _: label })}
+                        aria-owns={open ? 'menu-appbar' : null}
+                        aria-haspopup="true"
+                        onClick={this.handleMenu}
+                        color="inherit"
+                    >
+                        <AccountCircle />
+                    </IconButton>
+                </Tooltip>
                 <Menu
                     id="menu-appbar"
                     anchorEl={anchorEl}
@@ -58,8 +73,4 @@ class UserMenu extends React.Component {
     }
 }
 
-UserMenu.propTypes = {
-    logout: PropTypes.node,
-};
-
-export default UserMenu;
+export default translate(UserMenu);

--- a/packages/ra-ui-materialui/src/layout/index.js
+++ b/packages/ra-ui-materialui/src/layout/index.js
@@ -17,4 +17,5 @@ export RecordTitle from './RecordTitle';
 export Responsive from './Responsive';
 export Sidebar from './Sidebar';
 export Title from './Title';
+export UserMenu from './UserMenu';
 export ViewTitle from './ViewTitle';

--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -4,7 +4,7 @@ import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import CardActions from '@material-ui/core/CardActions';
 import { sanitizeListRestProps } from 'ra-core';
 
-import { CreateButton, ExportButton, RefreshButton } from '../button';
+import { CreateButton, ExportButton } from '../button';
 
 const Actions = ({
     bulkActions,
@@ -50,7 +50,6 @@ const Actions = ({
             filter={filterValues}
             exporter={exporter}
         />
-        <RefreshButton />
     </CardActions>
 );
 


### PR DESCRIPTION
## Problem

The `RefreshButton` has a global action (it increases the app's `version`, used everywhere as `key` prop, and therefore forcing a reload) but it's positioned in the content, not in the shell. We should remove it from the content. That would free up space for content (especially in the List view, where there are too many buttons already).

## Solution

Move the RefreshButton to the AppBar.

But then the AppBar is too crowded, so we use the IconButton version instead of the Text+icon version (using tooltip and aria-label to make it still readable), and we place it over the loading indicator to take less space. But then the refresh button is dangerously close to the logout button so we put the logout button inside a User menu, and by the way why not allow users to add their own menu items there?

There, we've just invented the Profile menu.

## What it looks like

![kapture 2018-08-08 at 19 18 44](https://user-images.githubusercontent.com/99944/43853284-fdf4f11a-9b3f-11e8-90be-98fdf1c4ae1a.gif)
