### PR TITLE
[RFR] UI Diet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,5 +115,5 @@ test-e2e: ## launch end-to-end tests
 
 
 test-e2e-local: ## launch end-to-end tests for development
-	echo 'Starting e2e tests environment. Ensure you started the simple example first (make run-simple)'
-	cd cypress && yarn -s start
+	@echo 'Starting e2e tests environment. Ensure you started the simple example first (make run-simple)'
+	@cd cypress && yarn -s start

--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -1,4 +1,5 @@
 import createPageFactory from '../support/CreatePage';
+import editPageFactory from '../support/EditPage';
 import showPageFactory from '../support/ShowPage';
 import loginPageFactory from '../support/LoginPage';
 
@@ -6,6 +7,7 @@ describe('Create Page', () => {
     const CreatePage = createPageFactory('/#/posts/create');
     const UserCreatePage = createPageFactory('/#/users/create');
     const ShowPage = showPageFactory('/#/posts/14/show');
+    const EditPage = editPageFactory('/#/posts/14');
     const LoginPage = loginPageFactory('/#/login');
 
     beforeEach(() => {
@@ -74,7 +76,8 @@ describe('Create Page', () => {
         CreatePage.setValues(values);
         CreatePage.submit();
         ShowPage.waitUntilVisible();
-        ShowPage.delete();
+        EditPage.navigate();
+        EditPage.delete();
     });
 
     it('should stay at create page after create success with "Save and add"', () => {
@@ -97,8 +100,8 @@ describe('Create Page', () => {
             expect(el).to.have.value('')
         ); // new empty form
 
-        ShowPage.navigate();
-        ShowPage.delete();
+        EditPage.navigate();
+        EditPage.delete();
     });
 
     it('should allow to call a custom action updating values before submit', () => {
@@ -125,7 +128,8 @@ describe('Create Page', () => {
         ShowPage.waitUntilVisible();
         ShowPage.gotoTab(3);
         cy.contains('10');
-        ShowPage.delete();
+        EditPage.navigate();
+        EditPage.delete();
     });
 
     it('should not accept creation without required fields', () => {

--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -16,6 +16,10 @@ describe('Create Page', () => {
         CreatePage.navigate();
     });
 
+    it('should show the correct title in the appBar', () => {
+        cy.get(CreatePage.elements.title).contains('Create Post');
+    });
+
     it('should put the current date in the field by default', () => {
         const currentDate = new Date();
         const currentDateString = currentDate.toISOString().slice(0, 10);

--- a/cypress/integration/custom-forms.js
+++ b/cypress/integration/custom-forms.js
@@ -1,9 +1,9 @@
 import createPageFactory from '../support/CustomFormPage';
-import showPageFactory from '../support/ShowPage';
+import editPageFactory from '../support/EditPage';
 
 describe('Custom Forms', () => {
     const CreatePage = createPageFactory('#/comments/create');
-    const ShowPage = showPageFactory('#/posts/14/show');
+    const EditPage = editPageFactory('#/posts/14');
 
     beforeEach(() => CreatePage.navigate());
 
@@ -28,7 +28,7 @@ describe('Custom Forms', () => {
         CreatePage.setInputValue('textarea', 'teaser', 'Bazingaaaaaaaa!');
         cy.get(CreatePage.elements.modalSubmitButton).click();
         cy.contains('Bazinga!');
-        ShowPage.navigate();
-        ShowPage.delete();
+        EditPage.navigate();
+        EditPage.delete();
     });
 });

--- a/cypress/integration/customPages.js
+++ b/cypress/integration/customPages.js
@@ -8,7 +8,7 @@ describe('Custom Pages', () => {
     describe('Without Layout', () => {
         it('should not display the layout', () => {
             CustomPageNoLayout.navigate();
-            cy.contains('Example Admin').should(el => expect(el).to.not.exist);
+            cy.get('main').should(el => expect(el).to.not.exist);
         });
 
         it('should have retrieved the number of posts', () => {
@@ -19,7 +19,7 @@ describe('Custom Pages', () => {
     describe('With Layout', () => {
         it('should display the layout', () => {
             CustomPageWithLayout.navigate();
-            cy.contains('Example Admin');
+            cy.get('main').should(el => expect(el).to.exist);
         });
 
         it('should have retrieved the number of posts', () => {

--- a/cypress/integration/edit.js
+++ b/cypress/integration/edit.js
@@ -4,24 +4,30 @@ describe('Edit Page', () => {
     const EditPostPage = editPageFactory('/#/posts/5');
     const EditCommentPage = editPageFactory('/#/comments/5');
 
+    describe('Title', () => {
+        it('should show the correct title in the appBar', () => {
+            cy.get(EditPostPage.elements.title).contains(
+                'Post "Sed quo et et fugiat modi"'
+            );
+        });
+    });
+
     describe('TabbedForm', () => {
         beforeEach(() => EditPostPage.navigate());
 
         it('should display the title in a TextField', () => {
-            cy
-                .get(EditPostPage.elements.input('title'))
-                .should(el =>
-                    expect(el).to.have.value('Sed quo et et fugiat modi')
-                );
+            cy.get(EditPostPage.elements.input('title')).should(el =>
+                expect(el).to.have.value('Sed quo et et fugiat modi')
+            );
         });
 
         it('should allow to update elements', () => {
             EditPostPage.setInputValue('title', 'Lorem Ipsum');
             EditPostPage.submit();
             EditPostPage.navigate();
-            cy
-                .get(EditPostPage.elements.input('title'))
-                .should(el => expect(el).to.have.value('Lorem Ipsum'));
+            cy.get(EditPostPage.elements.input('title')).should(el =>
+                expect(el).to.have.value('Lorem Ipsum')
+            );
         });
 
         it('should redirect to list page after edit success', () => {
@@ -32,37 +38,35 @@ describe('Edit Page', () => {
 
         it('should allow to switch tabs', () => {
             EditPostPage.gotoTab(3);
-            cy
-                .get(EditPostPage.elements.input('average_note'))
-                .should(el => expect(el).to.have.value('3'));
+            cy.get(EditPostPage.elements.input('average_note')).should(el =>
+                expect(el).to.have.value('3')
+            );
         });
 
         it('should keep DateInput value after opening datapicker', () => {
             EditPostPage.gotoTab(3);
             const date = new Date('2012-08-05').toISOString().slice(0, 10);
-            cy
-                .get(EditPostPage.elements.input('published_at'))
-                .should(el => expect(el).to.have.value(date));
+            cy.get(EditPostPage.elements.input('published_at')).should(el =>
+                expect(el).to.have.value(date)
+            );
 
             EditPostPage.clickInput('published_at');
 
-            cy
-                .get(EditPostPage.elements.input('published_at'))
-                .should(el => expect(el).to.have.value(date));
+            cy.get(EditPostPage.elements.input('published_at')).should(el =>
+                expect(el).to.have.value(date)
+            );
         });
     });
 
     it('should fill form correctly even when switching from one form type to another', () => {
         EditCommentPage.navigate();
-        cy
-            .get(EditPostPage.elements.input('author.name'))
-            .should(el => expect(el).to.have.value('Edmond Schulist'));
+        cy.get(EditPostPage.elements.input('author.name')).should(el =>
+            expect(el).to.have.value('Edmond Schulist')
+        );
 
         EditPostPage.navigate();
-        cy
-            .get(EditPostPage.elements.input('title'))
-            .should(el =>
-                expect(el).to.have.value('Sed quo et et fugiat modi')
-            );
+        cy.get(EditPostPage.elements.input('title')).should(el =>
+            expect(el).to.have.value('Sed quo et et fugiat modi')
+        );
     });
 });

--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -9,6 +9,12 @@ describe('List Page', () => {
         ListPagePosts.navigate();
     });
 
+    describe('Title', () => {
+        it('should show the correct title in the appBar', () => {
+            cy.get(ListPagePosts.elements.title).contains('Posts List');
+        });
+    });
+
     describe('Pagination', () => {
         it('should display paginated list of available posts', () => {
             cy.contains('1-10 of 13');

--- a/cypress/support/CreatePage.js
+++ b/cypress/support/CreatePage.js
@@ -12,6 +12,7 @@ export default url => ({
             ".create-page form>div:last-child button[type='button']:last-child",
         descInput: '.ql-editor',
         tab: index => `.form-tab:nth-of-type(${index})`,
+        title: '#react-admin-title',
     },
 
     navigate() {

--- a/cypress/support/EditPage.js
+++ b/cypress/support/EditPage.js
@@ -8,7 +8,7 @@ export default url => ({
         snackbar: 'div[role="alertdialog"]',
         submitButton: ".edit-page button[type='submit']",
         tab: index => `.form-tab:nth-of-type(${index})`,
-        title: '.title',
+        title: '#react-admin-title',
     },
 
     navigate() {

--- a/cypress/support/EditPage.js
+++ b/cypress/support/EditPage.js
@@ -1,9 +1,11 @@
 export default url => ({
     elements: {
         body: 'body',
+        deleteButton: '.ra-delete-button',
         input: name => `.edit-page input[name='${name}']`,
         inputs: `.ra-input`,
         tabs: `.form-tab`,
+        snackbar: 'div[role="alertdialog"]',
         submitButton: ".edit-page button[type='submit']",
         tab: index => `.form-tab:nth-of-type(${index})`,
         title: '.title',
@@ -34,5 +36,12 @@ export default url => ({
 
     submit() {
         cy.get(this.elements.submitButton).click();
+    },
+
+    delete() {
+        cy.get(this.elements.deleteButton).click();
+        cy.get(this.elements.snackbar);
+        cy.get(this.elements.body).click(); // dismiss notification
+        cy.wait(200); // let the notification disappear (could block further submits)
     },
 });

--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -15,7 +15,6 @@ export default url => ({
         recordRows: '.datagrid-body tr',
         viewsColumn: '.datagrid-body tr td:nth-child(6)',
         datagridHeaders: 'th',
-        title: '.title',
         logout: '.logout',
         bulkActionsButton: '.bulk-actions-button',
         customBulkActionsButtonMenuItem: '.bulk-actions-menu-item:first-child',
@@ -24,6 +23,7 @@ export default url => ({
         selectedItem: '.select-item input:checked',
         selectItem: '.select-item input',
         userMenu: 'button[title="Profile"]',
+        title: '#react-admin-title',
     },
 
     navigate() {

--- a/cypress/support/ShowPage.js
+++ b/cypress/support/ShowPage.js
@@ -1,7 +1,6 @@
 export default (url, initialField = 'title') => ({
     elements: {
         body: 'body',
-        deleteButton: '.ra-delete-button',
         field: name => `.ra-field-${name} > div > div > span`,
         fields: `.ra-field`,
         snackbar: 'div[role="alertdialog"]',
@@ -19,12 +18,5 @@ export default (url, initialField = 'title') => ({
 
     gotoTab(index) {
         cy.get(this.elements.tab(index)).click();
-    },
-
-    delete() {
-        cy.get(this.elements.deleteButton).click();
-        cy.get(this.elements.snackbar);
-        cy.get(this.elements.body).click(); // dismiss notification
-        cy.wait(200); // let the notification disappear (could block further submits)
     },
 });

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -82,7 +82,6 @@ Or, in the `<Edit>` page, as a [custom action](./CreateEdit.md#actions):
 // in src/comments/CommentEditActions.js
 import React from 'react';
 import CardActions from '@material-ui/core/CardActions';
-import { DeleteButton } from 'react-admin';
 import ApproveButton from './ApproveButton';
 
 const cardActionStyle = {
@@ -94,7 +93,6 @@ const cardActionStyle = {
 const CommentEditActions = ({ basePath, data, resource }) => (
     <CardActions style={cardActionStyle}>
         <ApproveButton record={data} />
-        <DeleteButton basePath={basePath} record={data} resource={resource} />
     </CardActions>
 );
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -69,7 +69,7 @@ The `dataProvider` is also the ideal place to add custom HTTP headers, authentic
 
 ## `title`
 
-By default, the header of an admin app uses 'React Admin' as the main app title. It's probably the first thing you'll want to customize. The `title` prop serves exactly that purpose.
+On error pages, the header of an admin app uses 'React Admin' as the main app title. Use the `title` to customize it.
 
 ```jsx
 const App = () => (
@@ -81,17 +81,17 @@ const App = () => (
 
 ## `dashboard`
 
-By default, the homepage of an an admin app is the `list` of the first child `<Resource>`. But you can also specify a custom component instead. To fit in the general design, use Material UI's `<Card>` component, and react-admin's `<ViewTitle>` component:
+By default, the homepage of an an admin app is the `list` of the first child `<Resource>`. But you can also specify a custom component instead. To fit in the general design, use Material UI's `<Card>` component, and react-admin's `<Title>` component to set the title in teh AppBar:
 
 ```jsx
 // in src/Dashboard.js
 import React from 'react';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import { ViewTitle } from 'react-admin';
+import { Title } from 'react-admin';
 export default () => (
     <Card>
-        <ViewTitle title="Welcome to the administration" />
+        <Title title="Welcome to the administration" />
         <CardContent>Lorem ipsum sic dolor amet...</CardContent>
     </Card>
 );
@@ -110,26 +110,24 @@ const App = () => (
 
 ![Custom home page](./img/dashboard.png)
 
-**Tip**: Adding the `<ViewTitle>` component will also allow the header to be displayed in mobile resolutions.
-
 ## `catchAll`
 
 When users type URLs that don't match any of the children `<Resource>` components, they see a default "Not Found" page. 
 
 ![Not Found](./img/not-found.png)
 
-You can customize this page to use the component of your choice by passing it as the `catchAll` prop. To fit in the general design, use Material UI's `<Card>` component, and react-admin's `<ViewTitle>` component:
+You can customize this page to use the component of your choice by passing it as the `catchAll` prop. To fit in the general design, use Material UI's `<Card>` component, and react-admin's `<Title>` component:
 
 ```jsx
 // in src/NotFound.js
 import React from 'react';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import { ViewTitle } from 'react-admin';
+import { Title } from 'react-admin';
 
 export default () => (
     <Card>
-        <ViewTitle title="Not Found" />
+        <Title title="Not Found" />
         <CardContent>
             <h1>404: Page not found</h1>
         </CardContent>
@@ -423,11 +421,11 @@ to design the screen the way you want.
 import React from 'react';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import { ViewTitle } from 'react-admin';
+import { Title } from 'react-admin';
 
 const Foo = () => (
     <Card>
-        <ViewTitle title="My Page" />
+        <Title title="My Page" />
         <CardContent>
             ...
         </CardContent>

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -81,7 +81,7 @@ const App = () => (
 
 ## `dashboard`
 
-By default, the homepage of an an admin app is the `list` of the first child `<Resource>`. But you can also specify a custom component instead. To fit in the general design, use Material UI's `<Card>` component, and react-admin's `<Title>` component to set the title in teh AppBar:
+By default, the homepage of an admin app is the `list` of the first child `<Resource>`. But you can also specify a custom component instead. To fit in the general design, use Material UI's `<Card>` component, and react-admin's `<Title>` component to set the title in the AppBar:
 
 ```jsx
 // in src/Dashboard.js

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -210,11 +210,11 @@ The component provided as a [`dashboard`]('./Admin.md#dashboard) will receive th
 import React from 'react';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import { ViewTitle } from 'react-admin';
+import { Title } from 'react-admin';
 
 export default ({ permissions }) => (
     <Card>
-        <ViewTitle title="Dashboard" />
+        <Title title="Dashboard" />
         <CardContent>Lorem ipsum sic dolor amet...</CardContent>
         {permissions === 'admin'
             ? <CardContent>Sensitive data</CardContent>
@@ -235,12 +235,12 @@ You might want to check user permissions inside a [custom pages](./Admin.md#cust
 import React from 'react';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import { ViewTitle, WithPermissions } from 'react-admin';
+import { Title, WithPermissions } from 'react-admin';
 import { withRouter } from 'react-router-dom';
 
 const MyPage = ({ permissions }) => (
     <Card>
-        <ViewTitle title="My custom page" />
+        <Title title="My custom page" />
         <CardContent>Lorem ipsum sic dolor amet...</CardContent>
         {permissions === 'admin'
             ? <CardContent>Sensitive data</CardContent>

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -117,18 +117,11 @@ You can replace the list of default actions by your own element using the `actio
 
 ```jsx
 import Button from '@material-ui/core/Button';
-import {
-    CardActions,
-    ShowButton,
-    DeleteButton,
-    RefreshButton,
-} from 'react-admin';
+import { CardActions, ShowButton } from 'react-admin';
 
 const PostEditActions = ({ basePath, data, resource }) => (
     <CardActions>
         <ShowButton basePath={basePath} record={data} />
-        <DeleteButton basePath={basePath} record={data} resource={resource} />
-        <RefreshButton />
         {/* Add your custom actions */}
         <Button color="primary" onClick={customAction}>Custom Action</Button>
     </CardActions>

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -11,7 +11,7 @@ title: "Reference"
 * [`<Admin>`](./Admin.html)
 * `<AdminRoutes>`
 * `<AppBar>`
-* `<AppBarMobile>`
+* `<AppBarMobile>` (deprecated)
 * [`<ArrayField>`](./Fields.html#arrayfield)
 * [`<ArrayInput>`](./Inputs.html#arrayinput)
 * [`<Authenticated>`](./Authentication.html#restricting-access-to-a-custom-page)
@@ -93,7 +93,7 @@ title: "Reference"
 * `<Title>`
 * `<Toolbar>`
 * [`<UrlField>`](./Fields.html#urlfield)
-* `<ViewTitle>`
+* `<ViewTitle>` (deprecated)
 * [`<WithPermissions>`](./Authorization.html#withpermissions)
 
 </div>

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -92,7 +92,7 @@ You can replace the list of default actions by your own element using the `actio
 ```jsx
 import CardActions from '@material-ui/core/CardActions';
 import Button from '@material-ui/core/Button';
-import { EditButton, DeleteButton, RefreshButton } from 'react-admin';
+import { EditButton } from 'react-admin';
 
 const cardActionStyle = {
     zIndex: 2,
@@ -103,8 +103,6 @@ const cardActionStyle = {
 const PostShowActions = ({ basePath, data, resource }) => (
     <CardActions style={cardActionStyle}>
         <EditButton basePath={basePath} record={data} />
-        <DeleteButton basePath={basePath} record={data} resource={resource} />
-        <RefreshButton />
         {/* Add your custom actions */}
         <Button color="primary" onClick={customAction}>Custom Action</Button>
     </CardActions>

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -655,6 +655,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import ErrorIcon from '@material-ui/icons/Report';
 import History from '@material-ui/icons/History';
+import { Title } from 'react-admin';
 
 const MyError = ({
     error,
@@ -662,6 +663,7 @@ const MyError = ({
     ...rest
 }) => (
     <div>
+        <Title title="Error" />
         <h1><ErrorIcon /> Something Went Wrong </h1>
         <div>A client error occurred and your request couldn't be completed.</div>
         {process.env.NODE_ENV === 'development' && (

--- a/examples/demo/src/configuration/Configuration.js
+++ b/examples/demo/src/configuration/Configuration.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Button from '@material-ui/core/Button';
-import { translate, changeLocale, ViewTitle } from 'react-admin';
+import { translate, changeLocale, Title } from 'react-admin';
 import withStyles from '@material-ui/core/styles/withStyles';
 import compose from 'recompose/compose';
 import { changeTheme } from './actions';
@@ -22,7 +22,7 @@ const Configuration = ({
     translate,
 }) => (
     <Card>
-        <ViewTitle title={translate('pos.configuration')} />
+        <Title title={translate('pos.configuration')} />
         <CardContent>
             <div className={classes.label}>{translate('pos.theme.name')}</div>
             <Button

--- a/examples/demo/src/dashboard/Dashboard.js
+++ b/examples/demo/src/dashboard/Dashboard.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { GET_LIST, GET_MANY, Responsive, ViewTitle } from 'react-admin';
+import React, { Component, Fragment } from 'react';
+import { GET_LIST, GET_MANY, Responsive, Title } from 'react-admin';
 
 import Welcome from './Welcome';
 import MonthlyRevenue from './MonthlyRevenue';
@@ -148,12 +148,31 @@ class Dashboard extends Component {
             revenue,
         } = this.state;
         return (
-            <Responsive
-                xsmall={
-                    <div>
-                        <ViewTitle title="Posters Galore Admin" />
+            <Fragment>
+                <Title title="Posters Galore Admin" />
+                <Responsive
+                    xsmall={
+                        <div>
+                            <div style={styles.flexColumn}>
+                                <div style={{ marginBottom: '2em' }}>
+                                    <Welcome />
+                                </div>
+                                <div style={styles.flex}>
+                                    <MonthlyRevenue value={revenue} />
+                                    <NbNewOrders value={nbNewOrders} />
+                                </div>
+                                <div style={styles.singleCol}>
+                                    <PendingOrders
+                                        orders={pendingOrders}
+                                        customers={pendingOrdersCustomers}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    }
+                    small={
                         <div style={styles.flexColumn}>
-                            <div style={{ marginBottom: '2em' }}>
+                            <div style={styles.singleCol}>
                                 <Welcome />
                             </div>
                             <div style={styles.flex}>
@@ -167,58 +186,41 @@ class Dashboard extends Component {
                                 />
                             </div>
                         </div>
-                    </div>
-                }
-                small={
-                    <div style={styles.flexColumn}>
-                        <div style={styles.singleCol}>
-                            <Welcome />
-                        </div>
+                    }
+                    medium={
                         <div style={styles.flex}>
-                            <MonthlyRevenue value={revenue} />
-                            <NbNewOrders value={nbNewOrders} />
-                        </div>
-                        <div style={styles.singleCol}>
-                            <PendingOrders
-                                orders={pendingOrders}
-                                customers={pendingOrdersCustomers}
-                            />
-                        </div>
-                    </div>
-                }
-                medium={
-                    <div style={styles.flex}>
-                        <div style={styles.leftCol}>
-                            <div style={styles.flex}>
-                                <MonthlyRevenue value={revenue} />
-                                <NbNewOrders value={nbNewOrders} />
+                            <div style={styles.leftCol}>
+                                <div style={styles.flex}>
+                                    <MonthlyRevenue value={revenue} />
+                                    <NbNewOrders value={nbNewOrders} />
+                                </div>
+                                <div style={styles.singleCol}>
+                                    <Welcome />
+                                </div>
+                                <div style={styles.singleCol}>
+                                    <PendingOrders
+                                        orders={pendingOrders}
+                                        customers={pendingOrdersCustomers}
+                                    />
+                                </div>
                             </div>
-                            <div style={styles.singleCol}>
-                                <Welcome />
-                            </div>
-                            <div style={styles.singleCol}>
-                                <PendingOrders
-                                    orders={pendingOrders}
-                                    customers={pendingOrdersCustomers}
-                                />
-                            </div>
-                        </div>
-                        <div style={styles.rightCol}>
-                            <div style={styles.flex}>
-                                <PendingReviews
-                                    nb={nbPendingReviews}
-                                    reviews={pendingReviews}
-                                    customers={pendingReviewsCustomers}
-                                />
-                                <NewCustomers
-                                    nb={nbNewCustomers}
-                                    visitors={newCustomers}
-                                />
+                            <div style={styles.rightCol}>
+                                <div style={styles.flex}>
+                                    <PendingReviews
+                                        nb={nbPendingReviews}
+                                        reviews={pendingReviews}
+                                        customers={pendingReviewsCustomers}
+                                    />
+                                    <NewCustomers
+                                        nb={nbNewCustomers}
+                                        visitors={newCustomers}
+                                    />
+                                </div>
                             </div>
                         </div>
-                    </div>
-                }
-            />
+                    }
+                />
+            </Fragment>
         );
     }
 }

--- a/examples/demo/src/reviews/ReviewEditActions.js
+++ b/examples/demo/src/reviews/ReviewEditActions.js
@@ -1,22 +1,13 @@
 import React from 'react';
-import CardActions from '@material-ui/core/CardActions';
-import { DeleteButton, RefreshButton } from 'react-admin';
+import { CardActions } from 'react-admin';
 
 import AcceptButton from './AcceptButton';
 import RejectButton from './RejectButton';
 
-const cardActionStyle = {
-    zIndex: 2,
-    display: 'inline-block',
-    float: 'right',
-};
-
-const ReviewEditActions = ({ basePath, data, resource, refresh }) => (
-    <CardActions style={cardActionStyle}>
+const ReviewEditActions = ({ data }) => (
+    <CardActions>
         <AcceptButton record={data} />
         <RejectButton record={data} />
-        <DeleteButton basePath={basePath} record={data} resource={resource} />
-        <RefreshButton refresh={refresh} />
     </CardActions>
 );
 

--- a/examples/demo/src/segments/Segments.js
+++ b/examples/demo/src/segments/Segments.js
@@ -5,14 +5,14 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import { translate, ViewTitle } from 'react-admin';
+import { translate, Title } from 'react-admin';
 
 import LinkToRelatedCustomers from './LinkToRelatedCustomers';
 import segments from './data';
 
 export default translate(({ translate }) => (
     <Card>
-        <ViewTitle title={translate('resources.segments.name')} />
+        <Title title={translate('resources.segments.name')} />
         <Table>
             <TableHead>
                 <TableRow>

--- a/examples/graphcool-demo/src/configuration/Configuration.js
+++ b/examples/graphcool-demo/src/configuration/Configuration.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Button from '@material-ui/core/Button';
-import { translate, changeLocale, ViewTitle } from 'react-admin';
+import { translate, changeLocale, Title } from 'react-admin';
 
 import { changeTheme } from './actions';
 
@@ -20,7 +20,7 @@ const Configuration = ({
     translate,
 }) => (
     <Card>
-        <ViewTitle title={translate('pos.configuration')} />
+        <Title title={translate('pos.configuration')} />
         <CardContent>
             <div style={styles.label}>{translate('pos.theme.name')}</div>
             <Button

--- a/examples/graphcool-demo/src/dashboard/Dashboard.js
+++ b/examples/graphcool-demo/src/dashboard/Dashboard.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { GET_LIST, GET_MANY, Responsive, ViewTitle } from 'react-admin';
+import { GET_LIST, GET_MANY, Responsive, Title } from 'react-admin';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 
@@ -151,7 +151,7 @@ class Dashboard extends Component {
             <Responsive
                 xsmall={
                     <Card>
-                        <ViewTitle title="Posters Galore Admin" />
+                        <Title title="Posters Galore Admin" />
                         <CardContent>
                             <Welcome style={styles.welcome} />
                             <div style={styles.flex}>

--- a/examples/graphcool-demo/src/reviews/ReviewEditActions.js
+++ b/examples/graphcool-demo/src/reviews/ReviewEditActions.js
@@ -14,8 +14,6 @@ const ReviewEditActions = ({ basePath, data, hasShow, refresh, resource }) => (
     <CardActions style={cardActionStyle}>
         <AcceptButton record={data} />
         <RejectButton record={data} />
-        <DeleteButton basePath={basePath} record={data} resource={resource} />
-        <RefreshButton refresh={refresh} />
     </CardActions>
 );
 

--- a/examples/graphcool-demo/src/segments/Segments.js
+++ b/examples/graphcool-demo/src/segments/Segments.js
@@ -5,13 +5,13 @@ import TableBody from '@material-ui/core/TableBody';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
-import { translate, ViewTitle } from 'react-admin';
+import { translate, Title } from 'react-admin';
 
 import LinkToRelatedCustomers from './LinkToRelatedCustomers';
 
 export default translate(({ translate }) => (
     <Card>
-        <ViewTitle title={translate('resources.segments.name')} />
+        <Title title={translate('resources.segments.name')} />
         <Table>
             <TableHead>
                 <TableRow>

--- a/examples/simple/src/comments/CommentEdit.js
+++ b/examples/simple/src/comments/CommentEdit.js
@@ -13,6 +13,7 @@ import {
     ReferenceInput,
     SimpleForm,
     TextInput,
+    Title,
     minLength,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
@@ -25,12 +26,8 @@ const LinkToRelatedPost = ({ record }) => (
 );
 
 const editStyles = {
-    header: {
-        display: 'flex',
-        justifyContent: 'space-between',
-    },
     actions: {
-        height: 'auto',
+        float: 'right',
     },
     card: {
         marginTop: '1em',
@@ -42,17 +39,14 @@ const CommentEdit = withStyles(editStyles)(({ classes, ...props }) => (
     <EditController {...props}>
         {({ resource, record, redirect, save, basePath, version }) => (
             <div className="edit-page">
-                <div className={classes.header}>
-                    <Typography variant="headline">
-                        Comment #{record && record.id}
-                    </Typography>
+                <Title defaultTitle={`Comment #${record ? record.id : ''}`} />
+                <div className={classes.actions}>
                     <EditActions
                         basePath={basePath}
                         resource={resource}
                         data={record}
                         hasShow
                         hasList
-                        className={classes.actions}
                     />
                 </div>
                 <Card className={classes.card}>

--- a/examples/simple/src/comments/CommentList.js
+++ b/examples/simple/src/comments/CommentList.js
@@ -110,7 +110,7 @@ const listStyles = theme => ({
 
 const CommentGrid = withStyles(listStyles)(
     translate(({ classes, ids, data, basePath, translate }) => (
-        <Grid spacing={16} container style={{ padding: '0 1em' }}>
+        <Grid spacing={16} container style={{ padding: '1em' }}>
             {ids.map(id => (
                 <Grid item key={id} sm={12} md={6} lg={4}>
                     <Card className={classes.card}>

--- a/examples/simple/src/comments/CommentList.js
+++ b/examples/simple/src/comments/CommentList.js
@@ -110,7 +110,7 @@ const listStyles = theme => ({
 
 const CommentGrid = withStyles(listStyles)(
     translate(({ classes, ids, data, basePath, translate }) => (
-        <Grid spacing={16} container style={{ padding: '1em' }}>
+        <Grid spacing={16} container style={{ padding: '0 1em' }}>
             {ids.map(id => (
                 <Grid item key={id} sm={12} md={6} lg={4}>
                     <Card className={classes.card}>

--- a/examples/simple/src/customRouteLayout.js
+++ b/examples/simple/src/customRouteLayout.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { crudGetList as crudGetListAction } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { crudGetList as crudGetListAction, Title } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
 class CustomRouteLayout extends Component {
     componentWillMount() {
@@ -16,6 +16,7 @@ class CustomRouteLayout extends Component {
 
         return (
             <div>
+                <Title title="Example Admin" />
                 <h1>Posts</h1>
                 <p>
                     Found <span className="total">{total}</span> posts !

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -64,6 +64,7 @@ const Button = ({
                 {...rest}
             >
                 {alignIcon === 'left' &&
+                    children &&
                     React.cloneElement(children, {
                         className: classes[`${size}Icon`],
                     })}
@@ -76,6 +77,7 @@ const Button = ({
                     {label && translate(label, { _: label })}
                 </span>
                 {alignIcon === 'right' &&
+                    children &&
                     React.cloneElement(children, {
                         className: classes[`${size}Icon`],
                     })}
@@ -86,7 +88,7 @@ const Button = ({
 
 Button.propTypes = {
     alignIcon: PropTypes.string,
-    children: PropTypes.node.isRequired,
+    children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,
     color: PropTypes.string,

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -21,6 +21,15 @@ const styles = {
     labelRightIcon: {
         paddingRight: '0.5em',
     },
+    smallIcon: {
+        fontSize: 20,
+    },
+    mediumIcon: {
+        fontSize: 22,
+    },
+    largeIcon: {
+        fontSize: 24,
+    },
 };
 
 const Button = ({
@@ -54,7 +63,10 @@ const Button = ({
                 size={size}
                 {...rest}
             >
-                {alignIcon === 'left' && children}
+                {alignIcon === 'left' &&
+                    React.cloneElement(children, {
+                        className: classes[`${size}Icon`],
+                    })}
                 <span
                     className={classnames({
                         [classes.label]: alignIcon === 'left',
@@ -63,7 +75,10 @@ const Button = ({
                 >
                     {label && translate(label, { _: label })}
                 </span>
-                {alignIcon === 'right' && children}
+                {alignIcon === 'right' &&
+                    React.cloneElement(children, {
+                        className: classes[`${size}Icon`],
+                    })}
             </MuiButton>
         }
     />

--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
-import Button from '@material-ui/core/Button';
+import MuiButton from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
 import ContentAdd from '@material-ui/icons/Add';
 import compose from 'recompose/compose';
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 import { translate } from 'ra-core';
 
+import Button from './Button';
 import Responsive from '../layout/Responsive';
 
 const styles = theme => ({
@@ -25,13 +26,6 @@ const styles = theme => ({
     floatingLink: {
         color: 'inherit',
     },
-    desktopLink: {
-        display: 'inline-flex',
-        alignItems: 'center',
-    },
-    label: {
-        paddingLeft: '0.5em',
-    },
 });
 
 const CreateButton = ({
@@ -40,12 +34,11 @@ const CreateButton = ({
     classes = {},
     translate,
     label = 'ra.action.create',
-    size = 'small',
     ...rest
 }) => (
     <Responsive
         small={
-            <Button
+            <MuiButton
                 component={Link}
                 variant="fab"
                 color="primary"
@@ -54,21 +47,17 @@ const CreateButton = ({
                 {...rest}
             >
                 <ContentAdd />
-            </Button>
+            </MuiButton>
         }
         medium={
             <Button
                 component={Link}
-                color="primary"
                 to={`${basePath}/create`}
-                className={classnames(classes.desktopLink, className)}
-                size={size}
+                className={className}
+                label={label && translate(label)}
                 {...rest}
             >
-                <ContentAdd className={classes.iconPaddingStyle} />
-                <span className={classes.label}>
-                    {label && translate(label)}
-                </span>
+                <ContentAdd />
             </Button>
         }
     />

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -11,7 +11,6 @@ import { showNotification, translate } from 'ra-core';
 
 const styles = {
     button: {
-        margin: '10px 24px',
         position: 'relative',
     },
     iconPaddingStyle: {

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -4,7 +4,6 @@ import Card from '@material-ui/core/Card';
 import classnames from 'classnames';
 import { CreateController } from 'ra-core';
 
-import Header from '../layout/Header';
 import RecordTitle from '../layout/RecordTitle';
 
 const sanitizeRestProps = ({
@@ -48,22 +47,19 @@ export const CreateView = ({
         className={classnames('create-page', className)}
         {...sanitizeRestProps(rest)}
     >
+        <RecordTitle
+            title={title}
+            record={record}
+            defaultTitle={defaultTitle}
+        />
         <Card>
-            <Header
-                title={
-                    <RecordTitle
-                        title={title}
-                        record={record}
-                        defaultTitle={defaultTitle}
-                    />
-                }
-                actions={actions}
-                actionProps={{
+            {actions &&
+                React.cloneElement(actions, {
                     basePath,
                     resource,
                     hasList,
-                }}
-            />
+                })}
+
             {React.cloneElement(children, {
                 basePath,
                 record,

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -5,7 +5,7 @@ import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { CreateController } from 'ra-core';
 
-import RecordTitle from '../layout/RecordTitle';
+import TitleForRecord from '../layout/TitleForRecord';
 
 const sanitizeRestProps = ({
     actions,
@@ -48,7 +48,7 @@ export const CreateView = ({
         className={classnames('create-page', className)}
         {...sanitizeRestProps(rest)}
     >
-        <RecordTitle
+        <TitleForRecord
             title={title}
             record={record}
             defaultTitle={defaultTitle}

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { CreateController } from 'ra-core';
 
@@ -53,13 +54,15 @@ export const CreateView = ({
             defaultTitle={defaultTitle}
         />
         <Card>
-            {actions &&
-                React.cloneElement(actions, {
-                    basePath,
-                    resource,
-                    hasList,
-                })}
-
+            {actions && (
+                <CardContent>
+                    {React.cloneElement(actions, {
+                        basePath,
+                        resource,
+                        hasList,
+                    })}
+                </CardContent>
+            )}
             {React.cloneElement(children, {
                 basePath,
                 record,

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { CreateController } from 'ra-core';
 
 import TitleForRecord from '../layout/TitleForRecord';
+import CardContentInner from '../layout/CardContentInner';
 
 const sanitizeRestProps = ({
     actions,
@@ -55,13 +55,13 @@ export const CreateView = ({
         />
         <Card>
             {actions && (
-                <CardContent>
+                <CardContentInner>
                     {React.cloneElement(actions, {
                         basePath,
                         resource,
                         hasList,
                     })}
-                </CardContent>
+                </CardContentInner>
             )}
             {React.cloneElement(children, {
                 basePath,

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -62,14 +62,17 @@ export const EditView = ({
             defaultTitle={defaultTitle}
         />
         <Card>
-            {actions &&
-                React.cloneElement(actions, {
-                    basePath,
-                    data: record,
-                    hasShow,
-                    hasList,
-                    resource,
-                })}
+            {actions && (
+                <CardContent>
+                    {React.cloneElement(actions, {
+                        basePath,
+                        data: record,
+                        hasShow,
+                        hasList,
+                        resource,
+                    })}
+                </CardContent>
+            )}
             {record ? (
                 React.cloneElement(children, {
                     basePath,

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -37,7 +37,7 @@ const sanitizeRestProps = ({
 }) => rest;
 
 export const EditView = ({
-    actions = <DefaultActions />,
+    actions,
     basePath,
     children,
     className,
@@ -51,46 +51,51 @@ export const EditView = ({
     title,
     version,
     ...rest
-}) => (
-    <div
-        className={classnames('edit-page', className)}
-        {...sanitizeRestProps(rest)}
-    >
-        <TitleForRecord
-            title={title}
-            record={record}
-            defaultTitle={defaultTitle}
-        />
-        <Card>
-            {actions && (
-                <CardContent>
-                    {React.cloneElement(actions, {
+}) => {
+    if (typeof actions === 'undefined' && hasShow) {
+        actions = <DefaultActions />;
+    }
+    return (
+        <div
+            className={classnames('edit-page', className)}
+            {...sanitizeRestProps(rest)}
+        >
+            <TitleForRecord
+                title={title}
+                record={record}
+                defaultTitle={defaultTitle}
+            />
+            <Card>
+                {actions && (
+                    <CardContent>
+                        {React.cloneElement(actions, {
+                            basePath,
+                            data: record,
+                            hasShow,
+                            hasList,
+                            resource,
+                        })}
+                    </CardContent>
+                )}
+                {record ? (
+                    React.cloneElement(children, {
                         basePath,
-                        data: record,
-                        hasShow,
-                        hasList,
+                        record,
+                        redirect:
+                            typeof children.props.redirect === 'undefined'
+                                ? redirect
+                                : children.props.redirect,
                         resource,
-                    })}
-                </CardContent>
-            )}
-            {record ? (
-                React.cloneElement(children, {
-                    basePath,
-                    record,
-                    redirect:
-                        typeof children.props.redirect === 'undefined'
-                            ? redirect
-                            : children.props.redirect,
-                    resource,
-                    save,
-                    version,
-                })
-            ) : (
-                <CardContent>&nbsp;</CardContent>
-            )}
-        </Card>
-    </div>
-);
+                        save,
+                        version,
+                    })
+                ) : (
+                    <CardContent>&nbsp;</CardContent>
+                )}
+            </Card>
+        </div>
+    );
+};
 
 EditView.propTypes = {
     actions: PropTypes.element,

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -7,6 +7,7 @@ import { EditController } from 'ra-core';
 
 import DefaultActions from './EditActions';
 import TitleForRecord from '../layout/TitleForRecord';
+import CardContentInner from '../layout/CardContentInner';
 
 const sanitizeRestProps = ({
     actions,
@@ -67,7 +68,7 @@ export const EditView = ({
             />
             <Card>
                 {actions && (
-                    <CardContent>
+                    <CardContentInner>
                         {React.cloneElement(actions, {
                             basePath,
                             data: record,
@@ -75,7 +76,7 @@ export const EditView = ({
                             hasList,
                             resource,
                         })}
-                    </CardContent>
+                    </CardContentInner>
                 )}
                 {record ? (
                     React.cloneElement(children, {

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { EditController } from 'ra-core';
 
 import DefaultActions from './EditActions';
-import RecordTitle from '../layout/RecordTitle';
+import TitleForRecord from '../layout/TitleForRecord';
 
 const sanitizeRestProps = ({
     actions,
@@ -56,7 +56,7 @@ export const EditView = ({
         className={classnames('edit-page', className)}
         {...sanitizeRestProps(rest)}
     >
-        <RecordTitle
+        <TitleForRecord
             title={title}
             record={record}
             defaultTitle={defaultTitle}

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -5,7 +5,6 @@ import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { EditController } from 'ra-core';
 
-import Header from '../layout/Header';
 import DefaultActions from './EditActions';
 import RecordTitle from '../layout/RecordTitle';
 
@@ -57,24 +56,20 @@ export const EditView = ({
         className={classnames('edit-page', className)}
         {...sanitizeRestProps(rest)}
     >
+        <RecordTitle
+            title={title}
+            record={record}
+            defaultTitle={defaultTitle}
+        />
         <Card>
-            <Header
-                title={
-                    <RecordTitle
-                        title={title}
-                        record={record}
-                        defaultTitle={defaultTitle}
-                    />
-                }
-                actions={actions}
-                actionProps={{
+            {actions &&
+                React.cloneElement(actions, {
                     basePath,
                     data: record,
                     hasShow,
                     hasList,
                     resource,
-                }}
-            />
+                })}
             {record ? (
                 React.cloneElement(children, {
                     basePath,

--- a/packages/ra-ui-materialui/src/detail/EditActions.js
+++ b/packages/ra-ui-materialui/src/detail/EditActions.js
@@ -22,12 +22,11 @@ const sanitizeRestProps = ({
  *
  * @example
  *     import Button from '@material-ui/core/Button';
- *     import { CardActions, ShowButton, DeleteButton, Edit } from 'react-admin';
+ *     import { CardActions, ShowButton, Edit } from 'react-admin';
  *
  *     const PostEditActions = ({ basePath, record, rseource }) => (
  *         <CardActions>
  *             <ShowButton basePath={basePath} record={record} />
- *             <DeleteButton basePath={basePath} record={record} resource={resource} />
  *             // Add your custom actions here //
  *             <Button color="primary" onClick={customAction}>Custom Action</Button>
  *         </CardActions>

--- a/packages/ra-ui-materialui/src/detail/EditActions.js
+++ b/packages/ra-ui-materialui/src/detail/EditActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { ShowButton, DeleteButton } from '../button';
+import { ShowButton } from '../button';
 import CardActions from '../layout/CardActions';
 
 const sanitizeRestProps = ({
@@ -49,7 +49,6 @@ const EditActions = ({
 }) => (
     <CardActions className={className} {...sanitizeRestProps(rest)}>
         {hasShow && <ShowButton basePath={basePath} record={data} />}
-        <DeleteButton basePath={basePath} record={data} resource={resource} />
     </CardActions>
 );
 

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { ShowController } from 'ra-core';
 
 import DefaultActions from './ShowActions';
-import RecordTitle from '../layout/RecordTitle';
+import TitleForRecord from '../layout/TitleForRecord';
 
 const sanitizeRestProps = ({
     actions,
@@ -52,7 +52,7 @@ export const ShowView = ({
         className={classnames('show-page', className)}
         {...sanitizeRestProps(rest)}
     >
-        <RecordTitle
+        <TitleForRecord
             title={title}
             record={record}
             defaultTitle={defaultTitle}

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { ShowController } from 'ra-core';
 
-import Header from '../layout/Header';
 import DefaultActions from './ShowActions';
 import RecordTitle from '../layout/RecordTitle';
 
@@ -52,24 +52,24 @@ export const ShowView = ({
         className={classnames('show-page', className)}
         {...sanitizeRestProps(rest)}
     >
+        <RecordTitle
+            title={title}
+            record={record}
+            defaultTitle={defaultTitle}
+        />
         <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
-            <Header
-                title={
-                    <RecordTitle
-                        title={title}
-                        record={record}
-                        defaultTitle={defaultTitle}
-                    />
-                }
-                actions={actions}
-                actionProps={{
-                    basePath,
-                    data: record,
-                    hasList,
-                    hasEdit,
-                    resource,
-                }}
-            />
+            {actions && (
+                <CardContent>
+                    {React.cloneElement(actions, {
+                        basePath,
+                        data: record,
+                        hasList,
+                        hasEdit,
+                        resource,
+                    })}
+                </CardContent>
+            )}
+
             {record &&
                 React.cloneElement(children, {
                     resource,

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -34,7 +34,7 @@ const sanitizeRestProps = ({
 }) => rest;
 
 export const ShowView = ({
-    actions = <DefaultActions />,
+    actions,
     basePath,
     children,
     className,
@@ -47,39 +47,43 @@ export const ShowView = ({
     title,
     version,
     ...rest
-}) => (
-    <div
-        className={classnames('show-page', className)}
-        {...sanitizeRestProps(rest)}
-    >
-        <TitleForRecord
-            title={title}
-            record={record}
-            defaultTitle={defaultTitle}
-        />
-        <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
-            {actions && (
-                <CardContent>
-                    {React.cloneElement(actions, {
-                        basePath,
-                        data: record,
-                        hasList,
-                        hasEdit,
+}) => {
+    if (typeof actions === 'undefined' && hasEdit) {
+        actions = <DefaultActions />;
+    }
+    return (
+        <div
+            className={classnames('show-page', className)}
+            {...sanitizeRestProps(rest)}
+        >
+            <TitleForRecord
+                title={title}
+                record={record}
+                defaultTitle={defaultTitle}
+            />
+            <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
+                {actions && (
+                    <CardContent>
+                        {React.cloneElement(actions, {
+                            basePath,
+                            data: record,
+                            hasList,
+                            hasEdit,
+                            resource,
+                        })}
+                    </CardContent>
+                )}
+                {record &&
+                    React.cloneElement(children, {
                         resource,
+                        basePath,
+                        record,
+                        version,
                     })}
-                </CardContent>
-            )}
-
-            {record &&
-                React.cloneElement(children, {
-                    resource,
-                    basePath,
-                    record,
-                    version,
-                })}
-        </Card>
-    </div>
-);
+            </Card>
+        </div>
+    );
+};
 
 ShowView.propTypes = {
     actions: PropTypes.element,

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { ShowController } from 'ra-core';
 
 import DefaultActions from './ShowActions';
 import TitleForRecord from '../layout/TitleForRecord';
+import CardContentInner from '../layout/CardContentInner';
 
 const sanitizeRestProps = ({
     actions,
@@ -63,7 +63,7 @@ export const ShowView = ({
             />
             <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
                 {actions && (
-                    <CardContent>
+                    <CardContentInner>
                         {React.cloneElement(actions, {
                             basePath,
                             data: record,
@@ -71,7 +71,7 @@ export const ShowView = ({
                             hasEdit,
                             resource,
                         })}
-                    </CardContent>
+                    </CardContentInner>
                 )}
                 {record &&
                     React.cloneElement(children, {

--- a/packages/ra-ui-materialui/src/detail/ShowActions.js
+++ b/packages/ra-ui-materialui/src/detail/ShowActions.js
@@ -23,12 +23,11 @@ const sanitizeRestProps = ({
  *
  * @example
  *     import Button from '@material-ui/core/Button';
- *     import { CardActions, EditButton, DeleteButton, Show } from 'react-admin';
+ *     import { CardActions, EditButton, Show } from 'react-admin';
  *
  *     const PostShowActions = ({ basePath, record, resource }) => (
  *         <CardActions>
  *             <EditButton basePath={basePath} record={record} />
- *             <DeleteButton basePath={basePath} record={record} resource={resource} />
  *             // Add your custom actions here //
  *             <Button color="primary" onClick={customAction}>Custom Action</Button>
  *         </CardActions>

--- a/packages/ra-ui-materialui/src/detail/ShowActions.js
+++ b/packages/ra-ui-materialui/src/detail/ShowActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { EditButton, DeleteButton } from '../button';
+import { EditButton } from '../button';
 import CardActions from '../layout/CardActions';
 
 const sanitizeRestProps = ({
@@ -50,13 +50,6 @@ const ShowActions = ({
 }) => (
     <CardActions className={className} {...sanitizeRestProps(rest)}>
         {hasEdit && <EditButton basePath={basePath} record={data} />}
-        {hasEdit && (
-            <DeleteButton
-                basePath={basePath}
-                record={data}
-                resource={resource}
-            />
-        )}
     </CardActions>
 );
 

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.js
@@ -1,18 +1,12 @@
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
-import CardContent from '@material-ui/core/CardContent';
-import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
+import CardContentInner from '../layout/CardContentInner';
 import Labeled from '../input/Labeled';
-
-const styles = {
-    content: { paddingTop: 0 },
-};
 
 const sanitizeRestProps = ({
     children,
-    classes,
     className,
     record,
     resource,
@@ -57,7 +51,6 @@ const sanitizeRestProps = ({
  */
 export const SimpleShowLayout = ({
     basePath,
-    classes,
     className,
     children,
     record,
@@ -65,8 +58,8 @@ export const SimpleShowLayout = ({
     version,
     ...rest
 }) => (
-    <CardContent
-        className={classnames(classes.content, className)}
+    <CardContentInner
+        className={className}
         key={version}
         {...sanitizeRestProps(rest)}
     >
@@ -104,12 +97,11 @@ export const SimpleShowLayout = ({
                     </div>
                 ) : null
         )}
-    </CardContent>
+    </CardContentInner>
 );
 
 SimpleShowLayout.propTypes = {
     basePath: PropTypes.string,
-    classes: PropTypes.object,
     className: PropTypes.string,
     children: PropTypes.node,
     record: PropTypes.object,
@@ -117,4 +109,4 @@ SimpleShowLayout.propTypes = {
     version: PropTypes.number,
 };
 
-export default withStyles(styles)(SimpleShowLayout);
+export default SimpleShowLayout;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -2,19 +2,14 @@ import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Tabs from '@material-ui/core/Tabs';
 import Divider from '@material-ui/core/Divider';
-import CardContent from '@material-ui/core/CardContent';
-import { withStyles } from '@material-ui/core/styles';
 import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const styles = {
-    content: { paddingTop: 0 },
-};
+import CardContentInner from '../layout/CardContentInner';
 
 const sanitizeRestProps = ({
     children,
-    classes,
     className,
     record,
     resource,
@@ -74,7 +69,6 @@ export class TabbedShowLayout extends Component {
         const {
             basePath,
             children,
-            classes,
             className,
             location,
             match,
@@ -94,6 +88,7 @@ export class TabbedShowLayout extends Component {
             >
                 <Tabs
                     scrollable
+                    scrollButtons="off"
                     // The location pathname will contain the page path including the current tab path
                     // so we can use it as a way to determine the current tab
                     value={location.pathname}
@@ -115,7 +110,7 @@ export class TabbedShowLayout extends Component {
                     })}
                 </Tabs>
                 <Divider />
-                <CardContent className={classes.content}>
+                <CardContentInner>
                     {Children.map(
                         children,
                         (tab, index) =>
@@ -134,7 +129,7 @@ export class TabbedShowLayout extends Component {
                                 />
                             )
                     )}
-                </CardContent>
+                </CardContentInner>
             </div>
         );
     }
@@ -142,7 +137,6 @@ export class TabbedShowLayout extends Component {
 
 TabbedShowLayout.propTypes = {
     children: PropTypes.node,
-    classes: PropTypes.object,
     className: PropTypes.string,
     location: PropTypes.object,
     match: PropTypes.object,
@@ -156,8 +150,7 @@ TabbedShowLayout.propTypes = {
 
 const enhance = compose(
     withRouter,
-    translate,
-    withStyles(styles)
+    translate
 );
 
 export default enhance(TabbedShowLayout);

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -3,16 +3,12 @@ import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import CardContent from '@material-ui/core/CardContent';
-import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { getDefaultValues, translate, REDUX_FORM_NAME } from 'ra-core';
+
 import FormInput from './FormInput';
 import Toolbar from './Toolbar';
-
-const styles = {
-    content: { paddingTop: 0 },
-};
+import CardContentInner from '../layout/CardContentInner';
 
 const sanitizeRestProps = ({
     anyTouched,
@@ -23,7 +19,6 @@ const sanitizeRestProps = ({
     autofill,
     blur,
     change,
-    classes,
     clearAsyncError,
     clearFields,
     clearSubmit,
@@ -82,7 +77,7 @@ export class SimpleForm extends Component {
                 className={classnames('simple-form', className)}
                 {...sanitizeRestProps(rest)}
             >
-                <CardContent className={classes.content} key={version}>
+                <CardContentInner key={version}>
                     {Children.map(children, input => (
                         <FormInput
                             basePath={basePath}
@@ -91,9 +86,9 @@ export class SimpleForm extends Component {
                             resource={resource}
                         />
                     ))}
-                </CardContent>
+                </CardContentInner>
                 {toolbar && (
-                    <CardContent>
+                    <CardContentInner>
                         {React.cloneElement(toolbar, {
                             basePath,
                             handleSubmitWithRedirect: this
@@ -107,7 +102,7 @@ export class SimpleForm extends Component {
                             saving,
                             submitOnEnter,
                         })}
-                    </CardContent>
+                    </CardContentInner>
                 )}
             </form>
         );
@@ -117,7 +112,6 @@ export class SimpleForm extends Component {
 SimpleForm.propTypes = {
     basePath: PropTypes.string,
     children: PropTypes.node,
-    classes: PropTypes.object,
     className: PropTypes.string,
     defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     handleSubmit: PropTypes.func, // passed by redux-form
@@ -153,8 +147,7 @@ const enhance = compose(
     reduxForm({
         enableReinitialize: true,
         keepDirtyOnReinitialize: true,
-    }),
-    withStyles(styles)
+    })
 );
 
 export default enhance(SimpleForm);

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -58,7 +58,6 @@ export class SimpleForm extends Component {
         const {
             basePath,
             children,
-            classes = {},
             className,
             invalid,
             pristine,

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -92,17 +92,23 @@ export class SimpleForm extends Component {
                         />
                     ))}
                 </CardContent>
-                {toolbar &&
-                    React.cloneElement(toolbar, {
-                        basePath,
-                        handleSubmitWithRedirect: this.handleSubmitWithRedirect,
-                        handleSubmit: this.props.handleSubmit,
-                        invalid,
-                        pristine,
-                        redirect,
-                        saving,
-                        submitOnEnter,
-                    })}
+                {toolbar && (
+                    <CardContent>
+                        {React.cloneElement(toolbar, {
+                            basePath,
+                            handleSubmitWithRedirect: this
+                                .handleSubmitWithRedirect,
+                            handleSubmit: this.props.handleSubmit,
+                            invalid,
+                            pristine,
+                            record,
+                            redirect,
+                            resource,
+                            saving,
+                            submitOnEnter,
+                        })}
+                    </CardContent>
+                )}
             </form>
         );
     }

--- a/packages/ra-ui-materialui/src/form/SimpleForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.spec.js
@@ -26,7 +26,9 @@ describe('<SimpleForm />', () => {
                 <TextInput source="name" />
             </SimpleForm>
         );
-        const button = wrapper.find('WithStyles(Toolbar)');
+        const button = wrapper.find(
+            'WithTheme(WithWidth(WithStyles(Toolbar)))'
+        );
         assert.equal(button.length, 1);
     });
 
@@ -37,7 +39,9 @@ describe('<SimpleForm />', () => {
                 <TextInput source="name" />
             </SimpleForm>
         );
-        const button1 = wrapper1.find('WithStyles(Toolbar)');
+        const button1 = wrapper1.find(
+            'WithTheme(WithWidth(WithStyles(Toolbar)))'
+        );
         assert.equal(button1.prop('submitOnEnter'), false);
 
         const wrapper2 = shallow(
@@ -45,7 +49,9 @@ describe('<SimpleForm />', () => {
                 <TextInput source="name" />
             </SimpleForm>
         );
-        const button2 = wrapper2.find('WithStyles(Toolbar)');
+        const button2 = wrapper2.find(
+            'WithTheme(WithWidth(WithStyles(Toolbar)))'
+        );
         assert.equal(button2.prop('submitOnEnter'), true);
     });
 });

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -12,14 +12,13 @@ import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import Divider from '@material-ui/core/Divider';
 import Tabs from '@material-ui/core/Tabs';
-import CardContent from '@material-ui/core/CardContent';
 import { withStyles } from '@material-ui/core/styles';
 import { getDefaultValues, translate, REDUX_FORM_NAME } from 'ra-core';
 
 import Toolbar from './Toolbar';
+import CardContentInner from '../layout/CardContentInner';
 
 const styles = theme => ({
-    content: { paddingTop: 0 },
     errorTabButton: { color: theme.palette.error.main },
 });
 
@@ -119,6 +118,7 @@ export class TabbedForm extends Component {
             >
                 <Tabs
                     scrollable
+                    scrollButtons="off"
                     // The location pathname will contain the page path including the current tab path
                     // so we can use it as a way to determine the current tab
                     value={tabsValue}
@@ -145,7 +145,7 @@ export class TabbedForm extends Component {
                     })}
                 </Tabs>
                 <Divider />
-                <CardContent className={classes.content}>
+                <CardContentInner>
                     {/* All tabs are rendered (not only the one in focus), to allow validation
                     on tabs not in focus. The tabs receive a `hidden` property, which they'll
                     use to hide the tab using CSS if it's not the one in focus.
@@ -183,9 +183,9 @@ export class TabbedForm extends Component {
                                 </Route>
                             )
                     )}
-                </CardContent>
+                </CardContentInner>
                 {toolbar && (
-                    <CardContent>
+                    <CardContentInner>
                         {React.cloneElement(toolbar, {
                             basePath,
                             className: 'toolbar',
@@ -200,7 +200,7 @@ export class TabbedForm extends Component {
                             saving,
                             submitOnEnter,
                         })}{' '}
-                    </CardContent>
+                    </CardContentInner>
                 )}
             </form>
         );

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -184,17 +184,24 @@ export class TabbedForm extends Component {
                             )
                     )}
                 </CardContent>
-                {toolbar &&
-                    React.cloneElement(toolbar, {
-                        className: 'toolbar',
-                        handleSubmitWithRedirect: this.handleSubmitWithRedirect,
-                        handleSubmit: this.props.handleSubmit,
-                        invalid,
-                        pristine,
-                        redirect,
-                        saving,
-                        submitOnEnter,
-                    })}
+                {toolbar && (
+                    <CardContent>
+                        {React.cloneElement(toolbar, {
+                            basePath,
+                            className: 'toolbar',
+                            handleSubmitWithRedirect: this
+                                .handleSubmitWithRedirect,
+                            handleSubmit: this.props.handleSubmit,
+                            invalid,
+                            pristine,
+                            record,
+                            redirect,
+                            resource,
+                            saving,
+                            submitOnEnter,
+                        })}{' '}
+                    </CardContent>
+                )}
             </form>
         );
     }

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
@@ -23,7 +23,9 @@ describe('<TabbedForm />', () => {
             </TabbedForm>
         );
 
-        const toolbar = wrapper.find('WithStyles(Toolbar)');
+        const toolbar = wrapper.find(
+            'WithTheme(WithWidth(WithStyles(Toolbar)))'
+        );
         assert.equal(toolbar.length, 1);
     });
 
@@ -40,7 +42,9 @@ describe('<TabbedForm />', () => {
                 tabsWithErrors={[]}
             />
         );
-        const button1 = wrapper1.find('WithStyles(Toolbar)');
+        const button1 = wrapper1.find(
+            'WithTheme(WithWidth(WithStyles(Toolbar)))'
+        );
         assert.equal(button1.prop('submitOnEnter'), false);
 
         const wrapper2 = shallow(
@@ -54,7 +58,9 @@ describe('<TabbedForm />', () => {
                 tabsWithErrors={[]}
             />
         );
-        const button2 = wrapper2.find('WithStyles(Toolbar)');
+        const button2 = wrapper2.find(
+            'WithTheme(WithWidth(WithStyles(Toolbar)))'
+        );
         assert.strictEqual(button2.prop('submitOnEnter'), true);
     });
 

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -1,22 +1,28 @@
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
 import MuiToolbar from '@material-ui/core/Toolbar';
+import withWidth from '@material-ui/core/withWidth';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
-import { SaveButton } from '../button';
-import Responsive from '../layout/Responsive';
+import { SaveButton, DeleteButton } from '../button';
 
 const styles = {
     desktopToolbar: {
-        marginBottom: '0.5em',
+        justifyContent: 'space-between',
     },
     mobileToolbar: {
         position: 'fixed',
         bottom: 0,
+        left: 0,
+        right: 0,
+        padding: '16px',
         width: '100%',
+        boxSizing: 'border-box',
+        flexShrink: 0,
         backgroundColor: 'white',
-        justifyContent: 'flex-end',
+        justifyContent: 'space-between',
         zIndex: 2,
     },
 };
@@ -33,87 +39,61 @@ const Toolbar = ({
     handleSubmitWithRedirect,
     invalid,
     pristine,
+    record,
     redirect,
+    resource,
     saving,
     submitOnEnter,
+    width,
     ...rest
 }) => (
-    <Responsive
-        xsmall={
-            <MuiToolbar
-                className={classnames(classes.mobileToolbar, className)}
-                disableGutters
-                {...rest}
-            >
-                {Children.count(children) === 0 ? (
-                    <SaveButton
-                        handleSubmitWithRedirect={handleSubmitWithRedirect}
-                        invalid={invalid}
-                        variant="flat"
-                        redirect={redirect}
-                        saving={saving}
-                        submitOnEnter={submitOnEnter}
-                    />
-                ) : (
-                    Children.map(
-                        children,
-                        button =>
-                            button
-                                ? React.cloneElement(button, {
-                                      basePath,
-                                      handleSubmit,
-                                      handleSubmitWithRedirect,
-                                      invalid,
-                                      pristine,
-                                      saving,
-                                      submitOnEnter: valueOrDefault(
-                                          button.props.submitOnEnter,
-                                          submitOnEnter
-                                      ),
-                                      variant: 'flat',
-                                  })
-                                : null
-                    )
-                )}
-            </MuiToolbar>
-        }
-        medium={
-            <MuiToolbar
-                className={classnames(classes.desktopToolbar, className)}
-                disableGutters
-                {...rest}
-            >
-                {Children.count(children) === 0 ? (
-                    <SaveButton
-                        handleSubmitWithRedirect={handleSubmitWithRedirect}
-                        invalid={invalid}
-                        redirect={redirect}
-                        saving={saving}
-                        submitOnEnter={submitOnEnter}
-                    />
-                ) : (
-                    Children.map(
-                        children,
-                        button =>
-                            button
-                                ? React.cloneElement(button, {
-                                      basePath,
-                                      handleSubmit,
-                                      handleSubmitWithRedirect,
-                                      invalid,
-                                      pristine,
-                                      saving,
-                                      submitOnEnter: valueOrDefault(
-                                          button.props.submitOnEnter,
-                                          submitOnEnter
-                                      ),
-                                  })
-                                : null
-                    )
-                )}
-            </MuiToolbar>
-        }
-    />
+    <MuiToolbar
+        className={classnames(
+            width === 'xs' ? classes.mobileToolbar : classes.desktopToolbar,
+            className
+        )}
+        disableGutters
+        {...rest}
+    >
+        <span>
+            {Children.count(children) === 0 ? (
+                <SaveButton
+                    handleSubmitWithRedirect={handleSubmitWithRedirect}
+                    invalid={invalid}
+                    redirect={redirect}
+                    saving={saving}
+                    submitOnEnter={submitOnEnter}
+                />
+            ) : (
+                Children.map(
+                    children,
+                    button =>
+                        button
+                            ? React.cloneElement(button, {
+                                  basePath,
+                                  handleSubmit,
+                                  handleSubmitWithRedirect,
+                                  invalid,
+                                  pristine,
+                                  saving,
+                                  submitOnEnter: valueOrDefault(
+                                      button.props.submitOnEnter,
+                                      submitOnEnter
+                                  ),
+                              })
+                            : null
+                )
+            )}
+        </span>
+        {record &&
+            record.id && (
+                <DeleteButton
+                    basePath={basePath}
+                    record={record}
+                    resource={resource}
+                />
+            )}
+    </MuiToolbar>
 );
 
 Toolbar.propTypes = {
@@ -125,17 +105,24 @@ Toolbar.propTypes = {
     handleSubmitWithRedirect: PropTypes.func,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,
+    record: PropTypes.object,
     redirect: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.bool,
         PropTypes.func,
     ]),
+    resource: PropTypes.string,
     saving: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
     submitOnEnter: PropTypes.bool,
+    width: PropTypes.string,
 };
 
 Toolbar.defaultProps = {
     submitOnEnter: true,
 };
 
-export default withStyles(styles)(Toolbar);
+const enhance = compose(
+    withWidth(),
+    withStyles(styles)
+);
+export default enhance(Toolbar);

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -8,6 +8,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
+import withWidth from '@material-ui/core/withWidth';
 import compose from 'recompose/compose';
 import { toggleSidebar as toggleSidebarAction } from 'ra-core';
 
@@ -56,15 +57,20 @@ const AppBar = ({
     open,
     title,
     toggleSidebar,
+    width,
     ...rest
 }) => (
     <MuiAppBar
         className={classNames(classes.appBar, className)}
         color="secondary"
-        position="absolute"
+        position={width === 'xs' ? 'fixed' : 'absolute'}
         {...rest}
     >
-        <Toolbar disableGutters variant="dense" className={classes.toolbar}>
+        <Toolbar
+            disableGutters
+            variant={width === 'xs' ? 'regular' : 'dense'}
+            className={classes.toolbar}
+        >
             <IconButton
                 color="inherit"
                 aria-label="open drawer"
@@ -83,9 +89,8 @@ const AppBar = ({
                 variant="title"
                 color="inherit"
                 className={classes.title}
-            >
-                {typeof title === 'string' ? title : React.cloneElement(title)}
-            </Typography>
+                id="react-admin-title"
+            />
             <LoadingIndicator />
             {logout && <UserMenu logout={logout}>{children}</UserMenu>}
         </Toolbar>
@@ -101,6 +106,7 @@ AppBar.propTypes = {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
         .isRequired,
     toggleSidebar: PropTypes.func.isRequired,
+    width: PropTypes.string,
 };
 
 const enhance = compose(
@@ -112,7 +118,8 @@ const enhance = compose(
             toggleSidebar: toggleSidebarAction,
         }
     ),
-    withStyles(styles)
+    withStyles(styles),
+    withWidth()
 );
 
 export default enhance(AppBar);

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -46,6 +46,9 @@ const styles = theme => ({
     },
     title: {
         flex: 1,
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
     },
 });
 

--- a/packages/ra-ui-materialui/src/layout/AppBarMobile.js
+++ b/packages/ra-ui-materialui/src/layout/AppBarMobile.js
@@ -37,6 +37,7 @@ const styles = {
  * @deprecated
  */
 const AppBarMobile = ({ classes, className, title, toggleSidebar, ...rest }) =>
+    // eslint-disable-next-line no-console
     console.warn(
         '<AppBarMobile> is deprecated, please use <AppBar>, which is now responsive'
     ) || (

--- a/packages/ra-ui-materialui/src/layout/AppBarMobile.js
+++ b/packages/ra-ui-materialui/src/layout/AppBarMobile.js
@@ -33,39 +33,39 @@ const styles = {
     },
 };
 
-const AppBarMobile = ({
-    classes,
-    className,
-    title,
-    toggleSidebar,
-    ...rest
-}) => (
-    <MuiAppBar
-        className={className}
-        color="secondary"
-        position="fixed"
-        {...rest}
-    >
-        <Toolbar>
-            <IconButton
-                color="inherit"
-                aria-label="open drawer"
-                onClick={toggleSidebar}
-                className={classes.icon}
-            >
-                <MenuIcon />
-            </IconButton>
-            <Typography
-                className={classes.title}
-                variant="title"
-                color="inherit"
-            >
-                {title}
-            </Typography>
-            <LoadingIndicator />
-        </Toolbar>
-    </MuiAppBar>
-);
+/**
+ * @deprecated
+ */
+const AppBarMobile = ({ classes, className, title, toggleSidebar, ...rest }) =>
+    console.warn(
+        '<AppBarMobile> is deprecated, please use <AppBar>, which is now responsive'
+    ) || (
+        <MuiAppBar
+            className={className}
+            color="secondary"
+            position="fixed"
+            {...rest}
+        >
+            <Toolbar>
+                <IconButton
+                    color="inherit"
+                    aria-label="open drawer"
+                    onClick={toggleSidebar}
+                    className={classes.icon}
+                >
+                    <MenuIcon />
+                </IconButton>
+                <Typography
+                    className={classes.title}
+                    variant="title"
+                    color="inherit"
+                >
+                    {title}
+                </Typography>
+                <LoadingIndicator />
+            </Toolbar>
+        </MuiAppBar>
+    );
 
 AppBarMobile.propTypes = {
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/layout/CardActions.js
+++ b/packages/ra-ui-materialui/src/layout/CardActions.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import MuiCardActions from '@material-ui/core/CardActions';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
@@ -8,19 +7,17 @@ const styles = {
     cardActions: {
         zIndex: 2,
         display: 'flex',
+        alignItems: 'flex-start',
         justifyContent: 'flex-end',
         flexWrap: 'wrap',
+        padding: 0,
     },
 };
 
 const CardActions = ({ classes, className, children, ...rest }) => (
-    <MuiCardActions
-        disableActionSpacing
-        className={classnames(classes.cardActions, className)}
-        {...rest}
-    >
+    <div className={classnames(classes.cardActions, className)} {...rest}>
         {children}
-    </MuiCardActions>
+    </div>
 );
 
 CardActions.propTypes = {

--- a/packages/ra-ui-materialui/src/layout/CardContentInner.js
+++ b/packages/ra-ui-materialui/src/layout/CardContentInner.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import CardContent from '@material-ui/core/CardContent';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = {
+    root: {
+        paddingTop: 0,
+        paddingBottom: 0,
+        '&:first-child': {
+            paddingTop: 16,
+        },
+        '&:last-child': {
+            paddingBottom: 16,
+        },
+    },
+};
+
+/**
+ * Overrides material-ui CardContent to allow inner content
+ *
+ * When using several CardContent inside the same Card, the top and bottom
+ * padding double the spacing between each CardContent, leading to too much
+ * wasted space. Use this component as a CardContent alternative.
+ */
+const CardContentInner = ({ classes, className, children }) => (
+    <CardContent className={classnames(classes.root, className)}>
+        {children}
+    </CardContent>
+);
+
+CardContentInner.propTypes = {
+    className: PropTypes.string,
+    classes: PropTypes.object.isRequired,
+    children: PropTypes.node,
+};
+
+export default withStyles(styles)(CardContentInner);

--- a/packages/ra-ui-materialui/src/layout/Error.js
+++ b/packages/ra-ui-materialui/src/layout/Error.js
@@ -12,7 +12,7 @@ import ErrorIcon from '@material-ui/icons/Report';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import History from '@material-ui/icons/History';
 
-import AppBarMobile from './AppBarMobile';
+import Title from './Title';
 import { translate } from 'ra-core';
 
 const styles = theme => ({
@@ -56,13 +56,12 @@ const Error = ({
     errorInfo,
     classes,
     className,
+    title,
     translate,
     ...rest
 }) => (
     <Fragment>
-        <Hidden mdUp>
-            <AppBarMobile />
-        </Hidden>
+        <Title defaultTitle={title} />
         <div className={classnames(classes.container, className)} {...rest}>
             <h1 className={classes.title} role="alert">
                 <ErrorIcon className={classes.icon} />
@@ -97,6 +96,7 @@ Error.propTypes = {
     error: PropTypes.object.isRequired,
     errorInfo: PropTypes.object,
     translate: PropTypes.func.isRequired,
+    title: PropTypes.string,
 };
 
 const enhance = compose(

--- a/packages/ra-ui-materialui/src/layout/Error.js
+++ b/packages/ra-ui-materialui/src/layout/Error.js
@@ -6,7 +6,6 @@ import Button from '@material-ui/core/Button';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import Hidden from '@material-ui/core/Hidden';
 import { withStyles } from '@material-ui/core/styles';
 import ErrorIcon from '@material-ui/icons/Report';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';

--- a/packages/ra-ui-materialui/src/layout/Header.js
+++ b/packages/ra-ui-materialui/src/layout/Header.js
@@ -12,6 +12,9 @@ const styles = {
     },
 };
 
+/**
+ * @deprecated
+ */
 export const Header = ({
     classes,
     className,
@@ -19,12 +22,15 @@ export const Header = ({
     actions,
     actionProps,
     ...rest
-}) => (
-    <div className={classnames(classes.root, className)} {...rest}>
-        <ViewTitle title={title} />
-        {actions && React.cloneElement(actions, actionProps)}
-    </div>
-);
+}) =>
+    console.warn(
+        '<Header> is deprecated, please use <Title> directly instead'
+    ) || (
+        <div className={classnames(classes.root, className)} {...rest}>
+            <ViewTitle title={title} />
+            {actions && React.cloneElement(actions, actionProps)}
+        </div>
+    );
 
 Header.propTypes = {
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/layout/Header.js
+++ b/packages/ra-ui-materialui/src/layout/Header.js
@@ -23,6 +23,7 @@ export const Header = ({
     actionProps,
     ...rest
 }) =>
+    // eslint-disable-next-line no-console
     console.warn(
         '<Header> is deprecated, please use <Title> directly instead'
     ) || (

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -8,7 +8,6 @@ import {
     createMuiTheme,
     withStyles,
 } from '@material-ui/core/styles';
-import Hidden from '@material-ui/core/Hidden';
 import compose from 'recompose/compose';
 
 import AppBar from './AppBar';
@@ -106,9 +105,7 @@ class Layout extends Component {
                 {...sanitizeRestProps(props)}
             >
                 <div className={classes.appFrame}>
-                    <Hidden xsDown>
-                        {createElement(appBar, { title, open, logout })}
-                    </Hidden>
+                    {createElement(appBar, { title, open, logout })}
                     <main className={classes.contentWithSidebar}>
                         <Sidebar>
                             {createElement(menu, {

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -118,6 +118,7 @@ class Layout extends Component {
                                 ? createElement(error, {
                                       error: errorMessage,
                                       errorInfo,
+                                      title,
                                   })
                                 : children}
                         </div>

--- a/packages/ra-ui-materialui/src/layout/NotFound.js
+++ b/packages/ra-ui-materialui/src/layout/NotFound.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
-import Hidden from '@material-ui/core/Hidden';
 import HotTub from '@material-ui/icons/HotTub';
 import History from '@material-ui/icons/History';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 
-import AppBarMobile from './AppBarMobile';
 import { translate } from 'ra-core';
+import Title from './Title';
 
 const styles = theme => ({
     container: {
@@ -46,9 +45,7 @@ function goBack() {
 
 const NotFound = ({ classes, className, translate, title, ...rest }) => (
     <div className={classnames(classes.container, className)} {...rest}>
-        <Hidden mdUp>
-            <AppBarMobile title={title} />
-        </Hidden>
+        <Title defaultTitle={title} />
         <div className={classes.message}>
             <HotTub className={classes.icon} />
             <h1>{translate('ra.page.not_found')}</h1>

--- a/packages/ra-ui-materialui/src/layout/RecordTitle.js
+++ b/packages/ra-ui-materialui/src/layout/RecordTitle.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Title from './Title';
+import TitleDeprecated from './TitleDeprecated';
 
+/**
+ * @deprecated Use TitleForRecord instead
+ */
 const RecordTitle = ({ defaultTitle, record, title }) =>
     record ? (
-        <Title title={title} record={record} defaultTitle={defaultTitle} />
+        <TitleDeprecated
+            title={title}
+            record={record}
+            defaultTitle={defaultTitle}
+        />
     ) : (
         ''
     );

--- a/packages/ra-ui-materialui/src/layout/Title.js
+++ b/packages/ra-ui-materialui/src/layout/Title.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { translate } from 'ra-core';
 
@@ -10,21 +11,20 @@ const Title = ({
     translate,
     ...rest
 }) => {
-    if (!title) {
-        return (
-            <span className={className} {...rest}>
-                {defaultTitle}
-            </span>
-        );
-    }
-    if (typeof title === 'string') {
-        return (
-            <span className={className} {...rest}>
-                {translate(title, { _: title })}
-            </span>
-        );
-    }
-    return React.cloneElement(title, { className, record, ...rest });
+    const container = document.getElementById('react-admin-title');
+    if (!container) return null;
+    const titleElement = !title ? (
+        <span className={className} {...rest}>
+            {defaultTitle}
+        </span>
+    ) : typeof title === 'string' ? (
+        <span className={className} {...rest}>
+            {translate(title, { _: title })}
+        </span>
+    ) : (
+        React.cloneElement(title, { className, record, ...rest })
+    );
+    return ReactDOM.createPortal(titleElement, container);
 };
 
 Title.propTypes = {

--- a/packages/ra-ui-materialui/src/layout/Title.js
+++ b/packages/ra-ui-materialui/src/layout/Title.js
@@ -13,6 +13,9 @@ const Title = ({
 }) => {
     const container = document.getElementById('react-admin-title');
     if (!container) return null;
+    if (!defaultTitle && !title) {
+        console.warn('Missing title prop in <Title> element'); //eslint-disable-line no-console
+    }
     const titleElement = !title ? (
         <span className={className} {...rest}>
             {defaultTitle}
@@ -28,7 +31,7 @@ const Title = ({
 };
 
 Title.propTypes = {
-    defaultTitle: PropTypes.string.isRequired,
+    defaultTitle: PropTypes.string,
     className: PropTypes.string,
     record: PropTypes.object,
     translate: PropTypes.func.isRequired,

--- a/packages/ra-ui-materialui/src/layout/TitleDeprecated.js
+++ b/packages/ra-ui-materialui/src/layout/TitleDeprecated.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'ra-core';
+
+/**
+ * @deprecated Use Title instead
+ */
+const Title = ({
+    className,
+    defaultTitle,
+    record,
+    title,
+    translate,
+    ...rest
+}) => {
+    if (!title) {
+        return (
+            <span className={className} {...rest}>
+                {defaultTitle}
+            </span>
+        );
+    }
+    if (typeof title === 'string') {
+        return (
+            <span className={className} {...rest}>
+                {translate(title, { _: title })}
+            </span>
+        );
+    }
+    return React.cloneElement(title, { className, record, ...rest });
+};
+
+Title.propTypes = {
+    defaultTitle: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    record: PropTypes.object,
+    translate: PropTypes.func.isRequired,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+};
+
+export default translate(Title);

--- a/packages/ra-ui-materialui/src/layout/TitleForRecord.js
+++ b/packages/ra-ui-materialui/src/layout/TitleForRecord.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Title from './Title';
+
+const TitleForRecord = ({ defaultTitle, record, title }) =>
+    record ? (
+        <Title title={title} record={record} defaultTitle={defaultTitle} />
+    ) : (
+        ''
+    );
+
+TitleForRecord.propTypes = {
+    defaultTitle: PropTypes.any,
+    record: PropTypes.object,
+    title: PropTypes.any,
+};
+
+export default TitleForRecord;

--- a/packages/ra-ui-materialui/src/layout/ViewTitle.js
+++ b/packages/ra-ui-materialui/src/layout/ViewTitle.js
@@ -11,6 +11,7 @@ import AppBarMobile from './AppBarMobile';
  * @deprecated
  */
 const ViewTitle = ({ className, title, ...rest }) =>
+    // eslint-disable-next-line no-console
     console.warn('<ViewTitle> is deprecated, please use <Title> instead') || (
         <Responsive
             xsmall={

--- a/packages/ra-ui-materialui/src/layout/ViewTitle.js
+++ b/packages/ra-ui-materialui/src/layout/ViewTitle.js
@@ -7,25 +7,32 @@ import classnames from 'classnames';
 import Responsive from './Responsive';
 import AppBarMobile from './AppBarMobile';
 
-const ViewTitle = ({ className, title, ...rest }) => (
-    <Responsive
-        xsmall={
-            <Fragment>
-                <AppBarMobile
+/**
+ * @deprecated
+ */
+const ViewTitle = ({ className, title, ...rest }) =>
+    console.warn('<ViewTitle> is deprecated, please use <Title> instead') || (
+        <Responsive
+            xsmall={
+                <Fragment>
+                    <AppBarMobile
+                        className={classnames('title', className)}
+                        title={title}
+                        {...rest}
+                    />
+                    <span> </span>
+                </Fragment>
+            }
+            medium={
+                <CardContent
                     className={classnames('title', className)}
-                    title={title}
                     {...rest}
-                />
-                <span> </span>
-            </Fragment>
-        }
-        medium={
-            <CardContent className={classnames('title', className)} {...rest}>
-                <Typography variant="title">{title}</Typography>
-            </CardContent>
-        }
-    />
-);
+                >
+                    <Typography variant="title">{title}</Typography>
+                </CardContent>
+            }
+        />
+    );
 
 ViewTitle.propTypes = {
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/layout/index.js
+++ b/packages/ra-ui-materialui/src/layout/index.js
@@ -17,5 +17,6 @@ export RecordTitle from './RecordTitle';
 export Responsive from './Responsive';
 export Sidebar from './Sidebar';
 export Title from './Title';
+export TitleForRecord from './TitleForRecord';
 export UserMenu from './UserMenu';
 export ViewTitle from './ViewTitle';

--- a/packages/ra-ui-materialui/src/layout/index.js
+++ b/packages/ra-ui-materialui/src/layout/index.js
@@ -1,6 +1,7 @@
 export AppBar from './AppBar';
 export AppBarMobile from './AppBarMobile';
 export CardActions from './CardActions';
+export CardContentInner from './CardContentInner';
 export Confirm from './Confirm';
 export DashboardMenuItem from './DashboardMenuItem';
 export Error from './Error';

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -104,17 +104,17 @@ class BulkActions extends Component {
                     <Button
                         buttonRef={this.storeButtonRef}
                         className={classnames('bulk-actions-button', className)}
-                        alignIcon="right"
+                        alignIcon="left"
                         aria-owns={isOpen ? 'bulk-actions-menu' : null}
                         aria-haspopup="true"
                         onClick={this.handleClick}
                         {...sanitizeRestProps(rest)}
-                    >
-                        <FilterNoneIcon className={classes.icon} />
-                        {translate(label, {
+                        label={translate(label, {
                             _: label,
                             smart_count: selectedIds.length,
                         })}
+                    >
+                        <FilterNoneIcon className={classes.icon} />
                     </Button>
                     <Menu
                         id="bulk-actions-menu"

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
-import CardContent from '@material-ui/core/CardContent';
+import classnames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import withProps from 'recompose/withProps';
@@ -10,16 +10,15 @@ import lodashSet from 'lodash/set';
 import FilterFormInput from './FilterFormInput';
 
 const styles = ({ palette: { primary1Color } }) => ({
-    card: {
+    form: {
         marginTop: '-14px',
         paddingTop: 0,
         display: 'flex',
-        justifyContent: 'flex-end',
         alignItems: 'flex-end',
         flexWrap: 'wrap',
     },
     body: { display: 'flex', alignItems: 'flex-end' },
-    spacer: { width: 48 },
+    spacer: { width: '1em' },
     icon: { color: primary1Color || '#00bcd4', paddingBottom: 0 },
     clearFix: { clear: 'right' },
 });
@@ -94,20 +93,19 @@ export class FilterForm extends Component {
         const { classes = {}, className, resource, ...rest } = this.props;
 
         return (
-            <div className={className} {...sanitizeRestProps(rest)}>
-                <CardContent className={classes.card}>
-                    {this.getShownFilters()
-                        .reverse()
-                        .map(filterElement => (
-                            <FilterFormInput
-                                key={filterElement.props.source}
-                                filterElement={filterElement}
-                                handleHide={this.handleHide}
-                                classes={classes}
-                                resource={resource}
-                            />
-                        ))}
-                </CardContent>
+            <div
+                className={classnames(className, classes.form)}
+                {...sanitizeRestProps(rest)}
+            >
+                {this.getShownFilters().map(filterElement => (
+                    <FilterFormInput
+                        key={filterElement.props.source}
+                        filterElement={filterElement}
+                        handleHide={this.handleHide}
+                        classes={classes}
+                        resource={resource}
+                    />
+                ))}
                 <div className={classes.clearFix} />
             </div>
         );

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -21,9 +21,7 @@ const FilterFormInput = ({
         data-source={filterElement.props.source}
         className={classnames('filter-field', classes.body)}
     >
-        {filterElement.props.alwaysOn ? (
-            <div className={classes.spacer}>&nbsp;</div>
-        ) : (
+        {!filterElement.props.alwaysOn && (
             <IconButton
                 className="hide-filter"
                 onClick={handleHide}
@@ -33,16 +31,15 @@ const FilterFormInput = ({
                 <ActionHide />
             </IconButton>
         )}
-        <div>
-            <Field
-                allowEmpty
-                {...sanitizeRestProps(filterElement.props)}
-                name={filterElement.props.source}
-                component={filterElement.type}
-                resource={resource}
-                record={emptyRecord}
-            />
-        </div>
+        <Field
+            allowEmpty
+            {...sanitizeRestProps(filterElement.props)}
+            name={filterElement.props.source}
+            component={filterElement.type}
+            resource={resource}
+            record={emptyRecord}
+        />
+        <div className={classes.spacer}>&nbsp;</div>
     </div>
 );
 

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -2,15 +2,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
+import { ListController, getListControllerProps } from 'ra-core';
 
 import Title from '../layout/Title';
+import CardContentInner from '../layout/CardContentInner';
 import DefaultPagination from './Pagination';
 import DefaultBulkActions from './BulkActions';
 import DefaultActions from './ListActions';
-import { ListController, getListControllerProps } from 'ra-core';
 import defaultTheme from '../defaultTheme';
 
 const styles = {
@@ -113,7 +113,7 @@ export const ListView = ({
             <Title title={title} defaultTitle={defaultTitle} />
             <Card>
                 {(filters || actions) && (
-                    <CardContent className={classes.header}>
+                    <CardContentInner className={classes.header}>
                         <span>
                             {filters &&
                                 React.cloneElement(filters, {
@@ -129,7 +129,7 @@ export const ListView = ({
                                 exporter,
                                 filters,
                             })}
-                    </CardContent>
+                    </CardContentInner>
                 )}
                 <div key={version}>
                     {children &&

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
 import classnames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -20,7 +21,11 @@ const styles = {
         justifyContent: 'flex-end',
         flexWrap: 'wrap',
     },
-    header: {},
+    header: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignSelf: 'flex-start',
+    },
     noResults: { padding: 20 },
 };
 
@@ -107,18 +112,22 @@ export const ListView = ({
         >
             <Title title={title} defaultTitle={defaultTitle} />
             <Card>
-                {React.cloneElement(actions, {
-                    ...controllerProps,
-                    className: classes.actions,
-                    bulkActions,
-                    exporter,
-                    filters,
-                })}
-                {filters &&
-                    React.cloneElement(filters, {
+                <CardContent className={classes.header}>
+                    <span>
+                        {filters &&
+                            React.cloneElement(filters, {
+                                ...controllerProps,
+                                context: 'form',
+                            })}
+                    </span>
+                    {React.cloneElement(actions, {
                         ...controllerProps,
-                        context: 'form',
+                        className: classes.actions,
+                        bulkActions,
+                        exporter,
+                        filters,
                     })}
+                </CardContent>
                 <div key={version}>
                     {children &&
                         React.cloneElement(children, {

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -5,7 +5,6 @@ import Card from '@material-ui/core/Card';
 import classnames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 
-import Header from '../layout/Header';
 import Title from '../layout/Title';
 import DefaultPagination from './Pagination';
 import DefaultBulkActions from './BulkActions';
@@ -100,24 +99,21 @@ export const ListView = ({
 }) => {
     const { defaultTitle, version } = rest;
     const controllerProps = getListControllerProps(rest);
-    const titleElement = <Title title={title} defaultTitle={defaultTitle} />;
+
     return (
         <div
             className={classnames('list-page', classes.root, className)}
             {...sanitizeRestProps(rest)}
         >
+            <Title title={title} defaultTitle={defaultTitle} />
             <Card>
-                <Header
-                    className={classes.header}
-                    title={titleElement}
-                    actions={React.cloneElement(actions, {
-                        ...controllerProps,
-                        className: classes.actions,
-                        bulkActions,
-                        exporter,
-                        filters,
-                    })}
-                />
+                {React.cloneElement(actions, {
+                    ...controllerProps,
+                    className: classes.actions,
+                    bulkActions,
+                    exporter,
+                    filters,
+                })}
                 {filters &&
                     React.cloneElement(filters, {
                         ...controllerProps,

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -112,22 +112,25 @@ export const ListView = ({
         >
             <Title title={title} defaultTitle={defaultTitle} />
             <Card>
-                <CardContent className={classes.header}>
-                    <span>
-                        {filters &&
-                            React.cloneElement(filters, {
+                {(filters || actions) && (
+                    <CardContent className={classes.header}>
+                        <span>
+                            {filters &&
+                                React.cloneElement(filters, {
+                                    ...controllerProps,
+                                    context: 'form',
+                                })}
+                        </span>
+                        {actions &&
+                            React.cloneElement(actions, {
                                 ...controllerProps,
-                                context: 'form',
+                                className: classes.actions,
+                                bulkActions,
+                                exporter,
+                                filters,
                             })}
-                    </span>
-                    {React.cloneElement(actions, {
-                        ...controllerProps,
-                        className: classes.actions,
-                        bulkActions,
-                        exporter,
-                        filters,
-                    })}
-                </CardContent>
+                    </CardContent>
+                )}
                 <div key={version}>
                     {children &&
                         React.cloneElement(children, {

--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -1,9 +1,9 @@
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
-import CardActions from '@material-ui/core/CardActions';
 import { sanitizeListRestProps } from 'ra-core';
 
+import CardActions from '../layout/CardActions';
 import { CreateButton, ExportButton } from '../button';
 
 const Actions = ({
@@ -22,11 +22,7 @@ const Actions = ({
     showFilter,
     ...rest
 }) => (
-    <CardActions
-        className={className}
-        disableActionSpacing
-        {...sanitizeListRestProps(rest)}
-    >
+    <CardActions className={className} {...sanitizeListRestProps(rest)}>
         {bulkActions &&
             cloneElement(bulkActions, {
                 basePath,


### PR DESCRIPTION
## Problem

In List and Edit pages, the content appears very low on the page, mostly because:

1. We write the page title in the *content* (the white paper). In contrast, the App Bar title never changes, and this is wasted space.
2. In the list, the filters are rendered *below* the action buttons, moving the content even further down
3. Action buttons are small but they use large icons

## Solution

1. Display the page title in the AppBar (this requires a [`Portal`](https://reactjs.org/docs/portals.html)).
2. In the list, display the filters where the page title used to be.
3. In buttons, adapt the icon size to the button size

But then the details pages (Edit and show) have only one button, the Delete button, which seems to float there. So:

1. Remove the Delete button from the Show view
2. Move the Delete button in the Toolbar, at the bottom of the form, in the Edit view.

- [x] Rework the `<Title>` component to use a `Portal`
- [x] Display the page title in the `AppBar`
- [x] Display the filters on the top left of the content
- [x] Move the `<Delete>` button down to the `Toolbar` 
- [x] Update `<Button>` to adapt the icon size to the button size
- [x] Make it lint
- [x] Add integration tests for the title
- [x] Make test pass
- [x] Update the doc

Small BC break: custom pages with layout have an empty title. Developers will have to manually define the `<Title>`

|Before|After|
|--|--|
|![2018-08-10_1646](https://user-images.githubusercontent.com/99944/43964333-e85aa006-9cbc-11e8-8259-66f882b02934.png)|![2018-08-10_1645](https://user-images.githubusercontent.com/99944/43964295-c5e661b8-9cbc-11e8-8b66-05c03352110b.png)|

|Before|After|
|--|--|
|![2018-08-10_1646](https://user-images.githubusercontent.com/99944/43964374-03441852-9cbd-11e8-9e5b-d2f5a982e71c.png)|![2018-08-10_1644](https://user-images.githubusercontent.com/99944/43964244-adce7dae-9cbc-11e8-9f38-dfadec20532d.png)|

In Edit and Show views, the Show and Edit buttons still push the content down... only if they exist. That means that if a resource has only a Show or an Edit (and not both), then the form appears right away. IMO, that's the general case.

![2018-08-10_1649](https://user-images.githubusercontent.com/99944/43964574-67e37ca8-9cbd-11e8-82d9-c3946423ab31.png)

One side effect is that the App "title" ('like "My Beautiful Admin") doesn't appear very much. By default, it's only on error pages. Of course, it's injected in the Dashboard, so it's easy to display there.

Another side effect is that it's harder to delete one resource. You can't go to the `Show` page anymore, and in the `Edit` page, it's under the form instead of below it (so sometimes below the fold).

Another side effect is that by default, the UI is pretty bare. It's good for the users, who can focus on their content and custom actions. It's not as good for de Waouh effect of a default admin 🙄 

Another side effect is to get rid of alternative mobile versions for the Title and AppBar (closes #1500), and to make the markup simpler.

Overall I fell that this makes the admins better. The best example is the demo:

![kapture 2018-08-10 at 16 57 11](https://user-images.githubusercontent.com/99944/43965108-b3ee2a2a-9cbe-11e8-95ce-8a6f075cc0ac.gif)

Comments are welcome.
