### PR TITLE
Fixes error when using ReferenceInput in SimpleFormIterator

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -136,7 +136,7 @@ export class SimpleFormIterator extends Component {
                                                     input.props.label ||
                                                     input.props.source,
                                             })}
-                                            record={records && records[index]}
+                                            record={(records && records[index]) || {}}
                                             resource={resource}
                                         />
                                     ))}

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -136,7 +136,10 @@ export class SimpleFormIterator extends Component {
                                                     input.props.label ||
                                                     input.props.source,
                                             })}
-                                            record={(records && records[index]) || {}}
+                                            record={
+                                                (records && records[index]) ||
+                                                {}
+                                            }
                                             resource={resource}
                                         />
                                     ))}


### PR DESCRIPTION
An error was  thrown when using ReferenceInput insite ArrayInput. 
When adding new records, prop "record" was indefined. This change initiaizes new record to an empty object.