### PR TITLE
Revert "[RFR] Fix Autocomplete list is cut off by content area"

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -4,7 +4,6 @@ import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import Autosuggest from 'react-autosuggest';
 import Paper from '@material-ui/core/Paper';
-import Popper from '@material-ui/core/Popper';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import { withStyles } from '@material-ui/core/styles';
@@ -97,8 +96,6 @@ export class AutocompleteInput extends React.Component {
         selectedItem: null,
         suggestions: [],
     };
-
-    inputEl = null;
 
     componentWillMount() {
         const selectedItem = this.getSelectedItem(
@@ -275,13 +272,6 @@ export class AutocompleteInput extends React.Component {
 
         const { touched, error, helperText = false } = meta;
 
-        // We need to store the input reference for our Popper element containg the suggestions
-        // but Autosuggest also needs this reference (it provides the ref prop)
-        const storeInputRef = input => {
-            this.inputEl = input;
-            ref(input);
-        };
-
         return (
             <TextField
                 label={
@@ -297,7 +287,7 @@ export class AutocompleteInput extends React.Component {
                 autoFocus={autoFocus}
                 margin="normal"
                 className={classnames(classes.root, className)}
-                inputRef={storeInputRef}
+                inputRef={ref}
                 error={!!(touched && error)}
                 helperText={(touched && error) || helperText}
                 name={input.name}
@@ -317,11 +307,9 @@ export class AutocompleteInput extends React.Component {
         const { containerProps, children } = options;
 
         return (
-            <Popper open anchorEl={this.inputEl} placement="bottom-start">
-                <Paper square {...containerProps}>
-                    {children}
-                </Paper>
-            </Popper>
+            <Paper {...containerProps} square>
+                {children}
+            </Paper>
         );
     };
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.js
@@ -90,26 +90,21 @@ describe('<AutocompleteInput />', () => {
     };
 
     it('should use optionText with a string value as text identifier', () => {
-        const wrapper = shallow(
-            <AutocompleteInput {...defaultProps} optionText="foobar" />,
+        const wrapper = render(
+            <AutocompleteInput
+                {...defaultProps}
+                optionText="foobar"
+                choices={[{ id: 'M', foobar: 'Male' }]}
+                alwaysRenderSuggestions={true}
+            />,
             { context, childContextTypes }
         );
-
-        // This is necesary because we use the material-ui Popper element which does not includes
-        // its children in the AutocompleteInput dom hierarchy
-        const menuItem = wrapper
-            .instance()
-            .renderSuggestion(
-                { id: 'M', foobar: 'Male' },
-                { query: '', highlighted: false }
-            );
-
-        const MenuItem = render(menuItem);
+        const MenuItem = wrapper.find('div[role="menuitem"]').first();
         assert.equal(MenuItem.text(), 'Male');
     });
 
     it('should use optionText with a string value including "." as text identifier', () => {
-        const wrapper = shallow(
+        const wrapper = render(
             <AutocompleteInput
                 {...defaultProps}
                 optionText="foobar.name"
@@ -118,22 +113,12 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-
-        // This is necesary because we use the material-ui Popper element which does not includes
-        // its children in the AutocompleteInput dom hierarchy
-        const menuItem = wrapper
-            .instance()
-            .renderSuggestion(
-                { id: 'M', foobar: { name: 'Male' } },
-                { query: '', highlighted: false }
-            );
-
-        const MenuItem = render(menuItem);
+        const MenuItem = wrapper.find('div[role="menuitem"]').first();
         assert.equal(MenuItem.text(), 'Male');
     });
 
     it('should use optionText with a function value as text identifier', () => {
-        const wrapper = shallow(
+        const wrapper = render(
             <AutocompleteInput
                 {...defaultProps}
                 optionText={choice => choice.foobar}
@@ -142,22 +127,12 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-
-        // This is necesary because we use the material-ui Popper element which does not includes
-        // its children in the AutocompleteInput dom hierarchy
-        const menuItem = wrapper
-            .instance()
-            .renderSuggestion(
-                { id: 'M', foobar: 'Male' },
-                { query: '', highlighted: false }
-            );
-
-        const MenuItem = render(menuItem);
+        const MenuItem = wrapper.find('div[role="menuitem"]').first();
         assert.equal(MenuItem.text(), 'Male');
     });
 
     it('should translate the choices by default', () => {
-        const wrapper = shallow(
+        const wrapper = render(
             <AutocompleteInput
                 {...defaultProps}
                 choices={[{ id: 'M', name: 'Male' }]}
@@ -166,21 +141,12 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-        // This is necesary because we use the material-ui Popper element which does not includes
-        // its children in the AutocompleteInput dom hierarchy
-        const menuItem = wrapper
-            .instance()
-            .renderSuggestion(
-                { id: 'M', name: 'Male' },
-                { query: '', highlighted: false }
-            );
-
-        const MenuItem = render(menuItem);
+        const MenuItem = wrapper.find('div[role="menuitem"]').first();
         assert.equal(MenuItem.text(), '**Male**');
     });
 
     it('should not translate the choices if translateChoice is false', () => {
-        const wrapper = shallow(
+        const wrapper = render(
             <AutocompleteInput
                 {...defaultProps}
                 choices={[{ id: 'M', name: 'Male' }]}
@@ -190,16 +156,7 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-        // This is necesary because we use the material-ui Popper element which does not includes
-        // its children in the AutocompleteInput dom hierarchy
-        const menuItem = wrapper
-            .instance()
-            .renderSuggestion(
-                { id: 'M', name: 'Male' },
-                { query: '', highlighted: false }
-            );
-
-        const MenuItem = render(menuItem);
+        const MenuItem = wrapper.find('div[role="menuitem"]').first();
         assert.equal(MenuItem.text(), 'Male');
     });
 


### PR DESCRIPTION
The suggestions simply don't appear anymore on my machine... There must be something more to do. In the meantime, I revert.

Reverts marmelab/react-admin#2123