### PR TITLE
[RFR] Change links from .md to .html

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -76,7 +76,7 @@ export const CommentList = (props) =>
     </List>;
 ```
 
-Or, in the `<Edit>` page, as a [custom action](./CreateEdit.md#actions):
+Or, in the `<Edit>` page, as a [custom action](./CreateEdit.html#actions):
 
 ```jsx
 // in src/comments/CommentEditActions.js
@@ -112,7 +112,7 @@ export const CommentEdit = (props) =>
 
 ## Using a Data Provider Instead of Fetch
 
-The previous code uses `fetch()`, which means it has to make raw HTTP requests. The REST logic often requires a bit of HTTP plumbing to deal with authentication, query parameters, encoding, headers, etc. It turns out you probably already have a function that maps from a REST request to an HTTP request: the [Data Provider](./DataProviders.md). So it's a good idea to use this function instead of `fetch` - provided you have exported it:
+The previous code uses `fetch()`, which means it has to make raw HTTP requests. The REST logic often requires a bit of HTTP plumbing to deal with authentication, query parameters, encoding, headers, etc. It turns out you probably already have a function that maps from a REST request to an HTTP request: the [Data Provider](./DataProviders.html). So it's a good idea to use this function instead of `fetch` - provided you have exported it:
 
 ```jsx
 // in src/dataProvider.js
@@ -174,7 +174,7 @@ There you go: no more `fetch`. Just like `fetch`, the `dataProvider` returns a `
 const dataProvider = (type, resource, params) => new Promise();
 ```
 
-As for the syntax of the various request types (`GET_LIST`, `GET_ONE`, `UPDATE`, etc.), head to the [Data Provider documentation](./DataProviders.md#request-format) for more details.
+As for the syntax of the various request types (`GET_LIST`, `GET_ONE`, `UPDATE`, etc.), head to the [Data Provider documentation](./DataProviders.html#request-format) for more details.
 
 ## Triggering The Loading Indicator
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -67,7 +67,7 @@ Upon receiving a 403 response, the admin app shows the Login page. `authProvider
 
 ## Sending Credentials to the API
 
-To use the credentials when calling a data provider, you have to tweak, this time, the `dataProvider` function. As explained in the [Data providers documentation](DataProviders.md#adding-custom-headers), `simpleRestProvider` and `jsonServerProvider` take an `httpClient` as second parameter. That's the place where you can change request headers, cookies, etc.
+To use the credentials when calling a data provider, you have to tweak, this time, the `dataProvider` function. As explained in the [Data providers documentation](DataProviders.html#adding-custom-headers), `simpleRestProvider` and `jsonServerProvider` take an `httpClient` as second parameter. That's the place where you can change request headers, cookies, etc.
 
 For instance, to pass the token obtained during login as an `Authorization` header, configure the Data Provider as follows:
 
@@ -315,7 +315,7 @@ const App = () => (
 
 ## Restricting Access To A Custom Page
 
-If you add [custom pages](./Actions.md), of if you [create an admin app from scratch](./CustomApp.md), you may need to secure access to pages manually. That's the purpose of the `<Authenticated>` component, that you can use as a decorator for your own components.
+If you add [custom pages](./Actions.html), of if you [create an admin app from scratch](./CustomApp.html), you may need to secure access to pages manually. That's the purpose of the `<Authenticated>` component, that you can use as a decorator for your own components.
 
 {% raw %}
 ```jsx

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -202,7 +202,7 @@ export const UserList = ({ permissions, ...props }) =>
 
 ## Restricting Access to Content Inside a Dashboard
 
-The component provided as a [`dashboard`]('./Admin.md#dashboard) will receive the permissions in its props too:
+The component provided as a [`dashboard`]('./Admin.html#dashboard) will receive the permissions in its props too:
 
 {% raw %}
 ```jsx
@@ -227,7 +227,7 @@ export default ({ permissions }) => (
 
 ## Restricting Access to Content Inside Custom Pages
 
-You might want to check user permissions inside a [custom pages](./Admin.md#customroutes). You'll have to use the `WithPermissions` component for that. It will ensure the user is authenticated then call the `authProvider` with the `AUTH_GET_PERMISSIONS` type and the `authParams` you specify:
+You might want to check user permissions inside a [custom pages](./Admin.html#customroutes). You'll have to use the `WithPermissions` component for that. It will ensure the user is authenticated then call the `authProvider` with the `AUTH_GET_PERMISSIONS` type and the `authParams` you specify:
 
 {% raw %}
 ```jsx

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -5,7 +5,7 @@ title: "The Create and Edit Views"
 
 # The Create and Edit Views
 
-The Create and Edit views both display a form, initialized with an empty record (for the Create view) or with a record fetched from the API (for the Edit view). The `<Create>` and `<Edit>` components then delegate the actual rendering of the form to a form component - usually `<SimpleForm>`. This form component uses its children ([`<Input>`](./Inputs.md) components) to render each form input.
+The Create and Edit views both display a form, initialized with an empty record (for the Create view) or with a record fetched from the API (for the Edit view). The `<Create>` and `<Edit>` components then delegate the actual rendering of the form to a form component - usually `<SimpleForm>`. This form component uses its children ([`<Input>`](./Inputs.html) components) to render each form input.
 
 ![post creation form](./img/create-view.png)
 
@@ -628,7 +628,7 @@ Here are the props received by the `Toolbar` component when passed as the `toolb
 
 **Tip**: Don't forget to also set the `redirect` prop of the Form component to handle submission by the `ENTER` key.
 
-**Tip**: To alter the form values before submitting, you should use the `handleSubmit` prop. See [Altering the Form Values before Submitting](./Actions.md#altering-the-form-values-before-submitting) for more informations and example.
+**Tip**: To alter the form values before submitting, you should use the `handleSubmit` prop. See [Altering the Form Values before Submitting](./Actions.html#altering-the-form-values-before-submitting) for more informations and example.
 
 ## Customizing Input Container Styles
 

--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -9,7 +9,7 @@ The `<Admin>` tag is a great shortcut got be up and running with react-admin in 
 
 Beware that you need to know about [redux](http://redux.js.org/), [react-router](https://github.com/reactjs/react-router), and [redux-saga](https://github.com/yelouafi/redux-saga) to go further.
 
-**Tip**: Before going for the Custom App route, explore all the options of [the `<Admin>` component](./Admin.md). They allow you to add custom routes, custom reducers, custom sagas, and customize the layout.
+**Tip**: Before going for the Custom App route, explore all the options of [the `<Admin>` component](./Admin.html). They allow you to add custom routes, custom reducers, custom sagas, and customize the layout.
 
 Here is the main code for bootstrapping a barebones react-admin application with 3 resources: `posts`, `comments`, and `users`:
 
@@ -109,4 +109,4 @@ const App = () => (
 );
 ```
 
-This application has no sidebar, no theming, no [auth control](./Authentication.md#restricting-access-to-a-custom-page) - it's up to you to add these. From there on, you can customize pretty much anything you want.
+This application has no sidebar, no theming, no [auth control](./Authentication.html#restricting-access-to-a-custom-page) - it's up to you to add these. From there on, you can customize pretty much anything you want.

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -659,7 +659,7 @@ export default (type, resource, params) => {
 
 ### Error Format
 
-When the API backend returns an error, the Data Provider should `throw` an `Error` object. This object should contain a `status` property with the HTTP response code (404, 500, etc.). React-admin inspects this error code, and uses it for [authentication](./Authentication.md) (in case of 401 or 403 errors). Besides, react-admin displays the error `message` on screen in a temporary notification.
+When the API backend returns an error, the Data Provider should `throw` an `Error` object. This object should contain a `status` property with the HTTP response code (404, 500, etc.). React-admin inspects this error code, and uses it for [authentication](./Authentication.html) (in case of 401 or 403 errors). Besides, react-admin displays the error `message` on screen in a temporary notification.
 
 ### Example implementation
 

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -18,7 +18,7 @@ title: "Ecosystem"
 
 ## Translations
 
-See the [translation](./Translation.md#available-locales) page.
+See the [translation](./Translation.html#available-locales) page.
 
 ## Data Providers
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,7 @@ title: "FAQ"
 
 ## Can I have custom identifiers/primary keys for my resources?
 
-React-admin requires that each resource has an `id` field to identify it. If your API uses a different name for the primary key, you have to map that name to `id` in a custom [dataProvider](./DataProviders.md). For instance, to use a field named `_id` as identifier:
+React-admin requires that each resource has an `id` field to identify it. If your API uses a different name for the primary key, you have to map that name to `id` in a custom [dataProvider](./DataProviders.html). For instance, to use a field named `_id` as identifier:
 
 ```js
 const convertHTTPResponse = (response, type, resource, params) => {

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -71,9 +71,9 @@ Then you can display the author first name as follows:
 <TextField source="author.firstName" />
 ```
 
-**Tip**: If you want to format a field according to the value, use a higher-order component to do conditional formatting, as described in the [Theming documentation](./Theming.md#conditional-formatting).
+**Tip**: If you want to format a field according to the value, use a higher-order component to do conditional formatting, as described in the [Theming documentation](./Theming.html#conditional-formatting).
 
-**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.md#translating-resource-and-field-names) for details.
+**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.html#translating-resource-and-field-names) for details.
 
 ## `<ArrayField>`
 
@@ -245,7 +245,7 @@ import { ImageField } from 'react-admin';
 <ImageField source="url" title="title" />
 ```
 
-This field is also generally used within an [<ImageInput />](http://marmelab.com/react-admin/Inputs.md#imageinput) component to display preview.
+This field is also generally used within an [<ImageInput />](./Inputs.html#imageinput) component to display preview.
 
 The optional `title` prop points to the picture title property, used for both `alt` and `title` attributes. It can either be an hard-written string, or a path within your JSON object:
 
@@ -286,7 +286,7 @@ import { FileField } from 'react-admin';
 <FileField source="url" title="title" />
 ```
 
-This field is also generally used within an [<FileInput />](http://marmelab.com/react-admin/Inputs.md#fileinput) component to display preview.
+This field is also generally used within an [<FileInput />](./Inputs.html#fileinput) component to display preview.
 
 The optional `title` prop points to the file title property, used for `title` attributes. It can either be an hard-written string, or a path within your JSON object:
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -60,7 +60,7 @@ Then you can display a text input to edit the author first name as follows:
 <TextInput source="author.firstName" />
 ```
 
-**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.md#translating-resource-and-field-names) for details.
+**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.html#translating-resource-and-field-names) for details.
 
 ## `<ArrayInput>`
 
@@ -411,7 +411,7 @@ Previews are enabled using `<ImageInput>` children, as following:
 </ImageInput>
 ```
 
-Writing a custom field component for displaying the current value(s) is easy:  it's a standard [field](./Fields.md#writing_your_own_field_component).
+Writing a custom field component for displaying the current value(s) is easy:  it's a standard [field](./Fields.html#writing_your_own_field_component).
 
 When receiving **new** files, `ImageInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display informations about size or mimetype inside a custom field.
 
@@ -425,7 +425,7 @@ If the default Dropzone label doesn't fit with your need, you can pass a `placeh
 </ImageInput>
 ```
 
-Note that the image upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#decorating-your-rest-client-example-of-file-upload) for base64 encoding data by extending the REST Client.
+Note that the image upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.html#decorating-your-rest-client-example-of-file-upload) for base64 encoding data by extending the REST Client.
 
 ## `<FileInput>`
 
@@ -441,11 +441,11 @@ Previews (actually a simple list of files names) are enabled using `<FileInput>`
 </FileInput>
 ```
 
-Writing a custom field component for displaying the current value(s) is easy:  it's a standard [field](./Fields.md#writing_your_own_field_component).
+Writing a custom field component for displaying the current value(s) is easy:  it's a standard [field](./Fields.html#writing_your_own_field_component).
 
 When receiving **new** files, `FileInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display informations about size or mimetype inside a custom field.
 
-The `FileInput` component accepts an `options` prop into which you can pass all the [react-dropzone properties](https://github.com/okonet/react-dropzone#features). For instance, if you need to upload several files at once, just add the `options={{ multiple: true }}` DropZone attribute to your `<FileInput />` field.
+The `FileInput` component accepts an `options` prop into which you can pass all the [react-dropzone properties](https://github.com/okonet/react-dropzone#features). For instance, if you need to upload several files at once, just add the {% raw %}`options={{ multiple: true }}`{% endraw %} DropZone attribute to your `<FileInput />` field.
 
 If the default Dropzone label doesn't fit with your need, you can pass a `placeholder` attribute to overwrite it. The attribute can be anything React can render (`PropTypes.node`):
 
@@ -455,7 +455,7 @@ If the default Dropzone label doesn't fit with your need, you can pass a `placeh
 </FileInput>
 ```
 
-Note that the file upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#decorating-your-rest-client-example-of-file-upload) for base64 encoding data by extending the REST Client.
+Note that the file upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.html#decorating-your-rest-client-example-of-file-upload) for base64 encoding data by extending the REST Client.
 
 ## `<LongTextInput>`
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -585,7 +585,7 @@ export withStyles(styles)(PostList);
 
 ## The `<Datagrid>` component
 
-The datagrid component renders a list of records as a table. It is usually used as a child of the [`<List>`](#the-list-component) and [`<ReferenceManyField>`](./Fields.md#referencemanyfield) components.
+The datagrid component renders a list of records as a table. It is usually used as a child of the [`<List>`](#the-list-component) and [`<ReferenceManyField>`](./Fields.html#referencemanyfield) components.
 
 Here are all the props accepted by the component:
 

--- a/docs/Resource.md
+++ b/docs/Resource.md
@@ -84,7 +84,7 @@ The routing will map the component as follows:
 * `/posts/:id` maps to `PostEdit`
 * `/posts/:id/show` maps to `PostShow`
 
-**Tip**: If you want to use a special API endpoint (e.g. 'http://jsonplaceholder.typicode.com/my-custom-posts-endpoint') without altering the URL in the react-admin application (so still use `/posts`), write the mapping from the resource `name` (`posts`) to the API endpoint (`my-custom-posts-endpoint`) in your own [`dataProvider`](./Admin.md#dataprovider)
+**Tip**: If you want to use a special API endpoint (e.g. 'http://jsonplaceholder.typicode.com/my-custom-posts-endpoint') without altering the URL in the react-admin application (so still use `/posts`), write the mapping from the resource `name` (`posts`) to the API endpoint (`my-custom-posts-endpoint`) in your own [`dataProvider`](./Admin.html#dataprovider)
 
 ## `icon`
 

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -5,7 +5,7 @@ title: "The Show View"
 
 # The Show View
 
-The Show view displays a record fetched from the API in a read-only fashion. It delegates the actual rendering of the record to a layout component - usually `<SimpleShowLayout>`. This layout component uses its children ([`<Fields>`](./Fields.md) components) to render each record field.
+The Show view displays a record fetched from the API in a read-only fashion. It delegates the actual rendering of the record to a layout component - usually `<SimpleShowLayout>`. This layout component uses its children ([`<Fields>`](./Fields.html) components) to render each record field.
 
 ![post show view](./img/show-view.png)
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -131,9 +131,9 @@ This example results in:
 
 ![Visitor List with customized CSS classes](./img/list_with_customized_css.png)
 
-Take a look at a component documentation and source code to know which classes are available for styling. For instance, you can have a look at the [Datagrid CSS documentation](./List.md#the-datagrid-component).
+Take a look at a component documentation and source code to know which classes are available for styling. For instance, you can have a look at the [Datagrid CSS documentation](./List.html#the-datagrid-component).
 
-If you need more control over the HTML code, you can also create your own [Field](./Fields.md#writing-your-own-field-component) and [Input](./Inputs.md#writing-your-own-input-component) components.
+If you need more control over the HTML code, you can also create your own [Field](./Fields.html#writing-your-own-field-component) and [Input](./Inputs.html#writing-your-own-input-component) components.
 
 ## Conditional Formatting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ npm install react-admin
 
 ## Usage
 
-Read the [Tutorial](./Tutorial.md) for a 15 minutes introduction. After that, head to the [Documentation](./index.md), or checkout the [source code of the demo](https://github.com/marmelab/react-admin/tree/master/examples/demo) for an example usage.
+Read the [Tutorial](./Tutorial.html) for a 15 minutes introduction. After that, head to the [Documentation](./index.html), or checkout the [source code of the demo](https://github.com/marmelab/react-admin/tree/master/examples/demo) for an example usage.
 
 ## At a Glance
 
@@ -136,7 +136,7 @@ React-admin uses an adapter approach, with a concept called *Data Providers*. Ex
 
 ![Data Provider architecture](./img/data-provider.png)
 
-See the [Data Providers documentation](./DataProviders.md) for details.
+See the [Data Providers documentation](./DataProviders.html) for details.
 
 ## Batteries Included But Removable
 


### PR DESCRIPTION
.md links only work when browsing the doc via the GitHub file explorer, .html links only work when browsing the Jekyll-generated documentation online. We choose the latter.