### PR TITLE
Minor Menu Item Style Fixes

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.js
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.js
@@ -10,11 +10,14 @@ const styles = theme => ({
         color: theme.palette.text.secondary,
         display: 'flex',
         alignItems: 'flex-start',
+        flexShrink: 0,
+        whiteSpace: 'normal',
+        height: "auto"
     },
     active: {
         color: theme.palette.text.primary,
     },
-    icon: { paddingRight: '1.2em' },
+    icon: { paddingRight: '1.2em', height: "24px" },
 });
 
 export class MenuItemLink extends Component {


### PR DESCRIPTION
- Fixes issue of scrunched elements when you there
  are a lot of resources
- Fixes cut off name of resource when it's too long to
  fit in the window

Before:

<img width="399" alt="screen shot 2018-08-15 at 3 40 26 pm" src="https://user-images.githubusercontent.com/1975857/44177223-c5973500-a0a1-11e8-8805-45347a8c61fe.png">

<img width="285" alt="screen shot 2018-08-15 at 3 41 27 pm" src="https://user-images.githubusercontent.com/1975857/44177225-c6c86200-a0a1-11e8-8634-220881333af1.png">

After:

<img width="271" alt="screen shot 2018-08-15 at 3 41 43 pm" src="https://user-images.githubusercontent.com/1975857/44177228-cd56d980-a0a1-11e8-8c77-6601886fee93.png">
