### PR TITLE
[RFR] Hide the datagrid sort icons when not active

### DIFF
--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -6,9 +6,23 @@ import compose from 'recompose/compose';
 import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Tooltip from '@material-ui/core/Tooltip';
+import { withStyles } from '@material-ui/core/styles';
 import { FieldTitle, translate } from 'ra-core';
 
+// remove the sort icons when not active
+const styles = {
+    icon: {
+        display: 'none',
+    },
+    active: {
+        '& $icon': {
+            display: 'inline',
+        },
+    },
+};
+
 export const DatagridHeaderCell = ({
+    classes,
     className,
     field,
     currentSort,
@@ -43,6 +57,7 @@ export const DatagridHeaderCell = ({
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
                     data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}
+                    classes={classes}
                 >
                     <FieldTitle
                         label={field.props.label}
@@ -62,6 +77,7 @@ export const DatagridHeaderCell = ({
 );
 
 DatagridHeaderCell.propTypes = {
+    classes: PropTypes.object,
     className: PropTypes.string,
     field: PropTypes.element,
     currentSort: PropTypes.shape({
@@ -82,7 +98,8 @@ const enhance = compose(
             (nextProps.isSorting &&
                 props.currentSort.order !== nextProps.currentSort.order)
     ),
-    translate
+    translate,
+    withStyles(styles)
 );
 
 export default enhance(DatagridHeaderCell);


### PR DESCRIPTION
Material-ui table sort labels reserve space for the sort icon even when the column isn't the active sort. This prevents layout changes when clicking on a column for sorting, but this also uses horizontal space. I think the icon should be hidden rather than of 0% opacity (ref https://github.com/mui-org/material-ui/issues/12561).

The effect only appears on columns with a low width content (like `NumberField`), where the header is usually larger than the content, and on tables with many columns.

Before|After
----|-----
![2018-08-17_1208](https://user-images.githubusercontent.com/99944/44260939-568f1d00-a216-11e8-844f-0b65269a576e.png)|![2018-08-17_1207](https://user-images.githubusercontent.com/99944/44260902-37908b00-a216-11e8-8046-f03e4244795f.png)