### PR TITLE
[RFR] [Pagination] Add the ability to set the number of rows per page

### DIFF
--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -10,7 +10,7 @@ export default url => ({
         hideFilterButton: source =>
             `.filter-field[data-source="${source}"] .hide-filter`,
         nextPage: '.next-page',
-        pageNumber: n => `.page-number[data-page='${n}']`,
+        pageNumber: n => `.page-number[data-page='${n - 1}']`,
         previousPage: '.previous-page',
         recordRows: '.datagrid-body tr',
         viewsColumn: '.datagrid-body tr td:nth-child(6)',

--- a/docs/List.md
+++ b/docs/List.md
@@ -516,7 +516,24 @@ const filterSentToDataProvider = { ...filterDefaultValues, ...filterChosenByUser
 
 You can replace the default pagination element by your own, using the `pagination` prop. The pagination element receives the current page, the number of records per page, the total number of records, as well as a `setPage()` function that changes the page.
 
-So if you want to replace the default pagination by a "<previous - next>" pagination, create a pagination component like the following:
+For instance, you can modify the default pagination by adjusting the "rows per page" selector. 
+
+```jsx
+// in src/MyPagination.js
+import { Pagination } from 'react-admin';
+
+const PostPagination = props => <Pagination rowsPerPageOptions={[10, 25, 50, 100]} {...props} />
+
+export const PostList = (props) => (
+    <List {...props} pagination={<PostPagination />}>
+        ...
+    </List>
+);
+```
+
+**Tip**: Pass an empty array to `rowsPerPageOptions` to disable the rows per page selection.
+
+Alternately, if you want to replace the default pagination by a "<previous - next>" pagination, create a pagination component like the following:
 
 ```jsx
 import Button from '@material-ui/core/Button';

--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -82,6 +82,7 @@ module.exports = {
             page_out_from_end: 'Cannot go after last page',
             page_out_from_begin: 'Cannot go before page 1',
             page_range_info: '%{offsetBegin}-%{offsetEnd} of %{total}',
+            page_rows_per_page: 'Rows per page:',
             next: 'Next',
             prev: 'Prev',
         },

--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -84,6 +84,7 @@ module.exports = {
             page_out_from_end: 'Fin de la pagination',
             page_out_from_begin: 'La page doit être supérieure à 1',
             page_range_info: '%{offsetBegin}-%{offsetEnd} sur %{total}',
+            page_rows_per_page: 'Lignes par page :',
             next: 'Suivant',
             prev: 'Précédent',
         },

--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -1,308 +1,96 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
-import Button from '@material-ui/core/Button';
-import IconButton from '@material-ui/core/IconButton';
-import Input from '@material-ui/core/Input';
-import MenuItem from '@material-ui/core/MenuItem';
-import Select from '@material-ui/core/Select';
-import Typography from '@material-ui/core/Typography';
-import Toolbar from '@material-ui/core/Toolbar';
-import { withStyles } from '@material-ui/core/styles';
-import ChevronLeft from '@material-ui/icons/ChevronLeft';
-import ChevronRight from '@material-ui/icons/ChevronRight';
+import TablePagination from '@material-ui/core/TablePagination';
 import compose from 'recompose/compose';
-import classnames from 'classnames';
 import { translate, sanitizeListRestProps } from 'ra-core';
 
+import PaginationActions from './PaginationActions';
 import PaginationLimit from './PaginationLimit';
 import Responsive from '../layout/Responsive';
 
-const styles = theme => ({
-    actions: {
-        flexShrink: 0,
-        color: theme.palette.text.secondary,
-        marginLeft: 20,
-    },
-    caption: {
-        flexShrink: 0,
-    },
-    spacer: {
-        flex: '1 1 100%',
-    },
-    /* Styles applied to the Select component `root` class. */
-    selectRoot: {
-        marginRight: 32,
-        marginLeft: 8,
-        color: theme.palette.text.secondary,
-    },
-    /* Styles applied to the Select component `select` class. */
-    select: {
-        paddingLeft: 8,
-        paddingRight: 16,
-    },
-    /* Styles applied to the Select component `icon` class. */
-    selectIcon: {
-        top: 1,
-    },
-    /* Styles applied to the Input component. */
-    input: {
-        fontSize: theme.typography.pxToRem(12),
-        flexShrink: 0,
-    },
-    pageInfo: {
-        padding: '1.2em',
-    },
-    desktopToolbar: {
-        justifyContent: 'flex-end',
-    },
-    mobileToolbar: {
-        justifyContent: 'center',
-    },
-    hellip: { padding: '1.2em' },
-});
+const emptyArray = [];
 
 export class Pagination extends Component {
-    range() {
-        const input = [];
-        const { page, perPage, total } = this.props;
-        if (isNaN(page)) return input;
-        const nbPages = Math.ceil(total / perPage) || 1;
+    getNbPages = () => Math.ceil(this.props.total / this.props.perPage) || 1;
 
-        // display page links around the current page
-        if (page > 2) {
-            input.push('1');
-        }
-        if (page === 4) {
-            input.push('2');
-        }
-        if (page > 4) {
-            input.push('.');
-        }
-        if (page > 1) {
-            input.push(page - 1);
-        }
-        input.push(page);
-        if (page < nbPages) {
-            input.push(page + 1);
-        }
-        if (page === nbPages - 3) {
-            input.push(nbPages - 1);
-        }
-        if (page < nbPages - 3) {
-            input.push('.');
-        }
-        if (page < nbPages - 1) {
-            input.push(nbPages);
-        }
-
-        return input;
-    }
-
-    getNbPages() {
-        return Math.ceil(this.props.total / this.props.perPage) || 1;
-    }
-
-    prevPage = event => {
+    /**
+     * Warning: material-ui's page is 0-based
+     */
+    handlePageChange = (event, page) => {
         event.stopPropagation();
-        if (this.props.page === 1) {
-            throw new Error(
-                this.props.translate('ra.navigation.page_out_from_begin')
-            );
-        }
-        this.props.setPage(this.props.page - 1);
-    };
-
-    nextPage = event => {
-        event.stopPropagation();
-        if (this.props.page > this.getNbPages()) {
-            throw new Error(
-                this.props.translate('ra.navigation.page_out_from_end')
-            );
-        }
-        this.props.setPage(this.props.page + 1);
-    };
-
-    gotoPage = event => {
-        event.stopPropagation();
-        const page = event.currentTarget.dataset.page;
-        if (page < 1 || page > this.getNbPages()) {
+        if (page < 0 || page > this.getNbPages() - 1) {
             throw new Error(
                 this.props.translate('ra.navigation.page_out_of_boundaries', {
-                    page,
+                    page: page + 1,
                 })
             );
         }
-        this.props.setPage(page);
+        this.props.setPage(page + 1);
     };
 
     handlePerPageChange = event => {
         this.props.setPerPage(event.target.value);
     };
 
-    renderPageNums() {
-        const { classes = {} } = this.props;
-
-        return this.range().map(
-            (pageNum, index) =>
-                pageNum === '.' ? (
-                    <span key={`hyphen_${index}`} className={classes.hellip}>
-                        &hellip;
-                    </span>
-                ) : (
-                    <Button
-                        className={classnames('page-number', classes.button)}
-                        color={
-                            pageNum === this.props.page ? 'default' : 'primary'
-                        }
-                        key={pageNum}
-                        data-page={pageNum}
-                        onClick={this.gotoPage}
-                        size="small"
-                    >
-                        {pageNum}
-                    </Button>
-                )
-        );
-    }
+    labelDisplayedRows = ({ from, to, count }) => {
+        const { translate } = this.props;
+        return translate('ra.navigation.page_range_info', {
+            offsetBegin: from,
+            offsetEnd: to,
+            total: count,
+        });
+    };
 
     render() {
         const {
-            classes = {},
-            className,
             ids,
             isLoading,
             page,
             perPage,
             rowsPerPageOptions,
-            setPage,
-            setPerPage,
             total,
             translate,
             ...rest
         } = this.props;
 
-        if (!isLoading && (total === 0 || (ids && !ids.length))) {
+        if (
+            (!isLoading && total === 0) ||
+            page < 1 ||
+            page > this.getNbPages()
+        ) {
             return <PaginationLimit total={total} page={page} ids={ids} />;
         }
-
-        const offsetEnd = Math.min(page * perPage, total);
-        const offsetBegin = Math.min((page - 1) * perPage + 1, offsetEnd);
-        const nbPages = this.getNbPages();
 
         return (
             <Responsive
                 small={
-                    <Toolbar
-                        className={className}
-                        classes={{ root: classes.mobileToolbar }}
+                    <TablePagination
+                        count={total}
+                        rowsPerPage={perPage}
+                        page={page - 1}
+                        onChangePage={this.handlePageChange}
+                        rowsPerPageOptions={emptyArray}
+                        component="span"
+                        labelDisplayedRows={this.labelDisplayedRows}
                         {...sanitizeListRestProps(rest)}
-                    >
-                        {page > 1 && (
-                            <IconButton color="primary" onClick={this.prevPage}>
-                                <ChevronLeft />
-                            </IconButton>
-                        )}
-                        <Typography
-                            variant="body1"
-                            className="displayed-records"
-                        >
-                            {translate('ra.navigation.page_range_info', {
-                                offsetBegin,
-                                offsetEnd,
-                                total,
-                            })}
-                        </Typography>
-                        {page !== nbPages && (
-                            <IconButton color="primary" onClick={this.nextPage}>
-                                <ChevronRight />
-                            </IconButton>
-                        )}
-                    </Toolbar>
+                    />
                 }
                 medium={
-                    <Toolbar
-                        className={classnames(
-                            className,
-                            classes.desktopToolbar
+                    <TablePagination
+                        count={total}
+                        rowsPerPage={perPage}
+                        page={page - 1}
+                        onChangePage={this.handlePageChange}
+                        onChangeRowsPerPage={this.handlePerPageChange}
+                        ActionsComponent={PaginationActions}
+                        component="span"
+                        labelRowsPerPage={translate(
+                            'ra.navigation.page_rows_per_page'
                         )}
+                        labelDisplayedRows={this.labelDisplayedRows}
                         {...sanitizeListRestProps(rest)}
-                    >
-                        <div className={classes.spacer} />
-
-                        <Typography
-                            variant="caption"
-                            className={classes.caption}
-                        >
-                            {translate('ra.navigation.page_rows_per_page')}
-                        </Typography>
-                        <Select
-                            classes={{
-                                root: classes.selectRoot,
-                                select: classes.select,
-                                icon: classes.selectIcon,
-                            }}
-                            input={
-                                <Input
-                                    className={classes.input}
-                                    disableUnderline
-                                />
-                            }
-                            value={perPage}
-                            onChange={this.handlePerPageChange}
-                        >
-                            {rowsPerPageOptions.map(rowsPerPageOption => (
-                                <MenuItem
-                                    key={rowsPerPageOption}
-                                    value={rowsPerPageOption}
-                                >
-                                    {rowsPerPageOption}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                        <Typography
-                            variant="caption"
-                            className={classnames(
-                                classes.caption,
-                                'displayed-records'
-                            )}
-                        >
-                            {translate('ra.navigation.page_range_info', {
-                                offsetBegin,
-                                offsetEnd,
-                                total,
-                            })}
-                        </Typography>
-                        <div className={classes.actions}>
-                            {nbPages > 1 && [
-                                page > 1 && (
-                                    <Button
-                                        color="primary"
-                                        key="prev"
-                                        onClick={this.prevPage}
-                                        className="previous-page"
-                                        size="small"
-                                    >
-                                        <ChevronLeft />
-                                        {translate('ra.navigation.prev')}
-                                    </Button>
-                                ),
-                                this.renderPageNums(),
-                                page !== nbPages && (
-                                    <Button
-                                        color="primary"
-                                        key="next"
-                                        onClick={this.nextPage}
-                                        className="next-page"
-                                        size="small"
-                                    >
-                                        {translate('ra.navigation.next')}
-                                        <ChevronRight />
-                                    </Button>
-                                ),
-                            ]}
-                        </div>
-                    </Toolbar>
+                    />
                 }
             />
         );
@@ -329,8 +117,7 @@ Pagination.defaultProps = {
 
 const enhance = compose(
     pure,
-    translate,
-    withStyles(styles)
+    translate
 );
 
 export default enhance(Pagination);

--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -44,7 +44,6 @@ export class Pagination extends Component {
 
     render() {
         const {
-            ids,
             isLoading,
             page,
             perPage,
@@ -59,7 +58,7 @@ export class Pagination extends Component {
             page < 1 ||
             page > this.getNbPages()
         ) {
-            return <PaginationLimit total={total} page={page} ids={ids} />;
+            return <PaginationLimit total={total} page={page} />;
         }
 
         return (

--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
+import Input from '@material-ui/core/Input';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import Typography from '@material-ui/core/Typography';
 import Toolbar from '@material-ui/core/Toolbar';
 import { withStyles } from '@material-ui/core/styles';
@@ -15,7 +18,38 @@ import { translate, sanitizeListRestProps } from 'ra-core';
 import PaginationLimit from './PaginationLimit';
 import Responsive from '../layout/Responsive';
 
-const styles = {
+const styles = theme => ({
+    actions: {
+        flexShrink: 0,
+        color: theme.palette.text.secondary,
+        marginLeft: 20,
+    },
+    caption: {
+        flexShrink: 0,
+    },
+    spacer: {
+        flex: '1 1 100%',
+    },
+    /* Styles applied to the Select component `root` class. */
+    selectRoot: {
+        marginRight: 32,
+        marginLeft: 8,
+        color: theme.palette.text.secondary,
+    },
+    /* Styles applied to the Select component `select` class. */
+    select: {
+        paddingLeft: 8,
+        paddingRight: 16,
+    },
+    /* Styles applied to the Select component `icon` class. */
+    selectIcon: {
+        top: 1,
+    },
+    /* Styles applied to the Input component. */
+    input: {
+        fontSize: theme.typography.pxToRem(12),
+        flexShrink: 0,
+    },
     pageInfo: {
         padding: '1.2em',
     },
@@ -26,7 +60,7 @@ const styles = {
         justifyContent: 'center',
     },
     hellip: { padding: '1.2em' },
-};
+});
 
 export class Pagination extends Component {
     range() {
@@ -102,6 +136,10 @@ export class Pagination extends Component {
         this.props.setPage(page);
     };
 
+    handlePerPageChange = event => {
+        this.props.setPerPage(event.target.value);
+    };
+
     renderPageNums() {
         const { classes = {} } = this.props;
 
@@ -120,6 +158,7 @@ export class Pagination extends Component {
                         key={pageNum}
                         data-page={pageNum}
                         onClick={this.gotoPage}
+                        size="small"
                     >
                         {pageNum}
                     </Button>
@@ -135,6 +174,7 @@ export class Pagination extends Component {
             isLoading,
             page,
             perPage,
+            rowsPerPageOptions,
             setPage,
             setPerPage,
             total,
@@ -188,9 +228,44 @@ export class Pagination extends Component {
                         )}
                         {...sanitizeListRestProps(rest)}
                     >
+                        <div className={classes.spacer} />
+
                         <Typography
-                            variant="body1"
-                            className="displayed-records"
+                            variant="caption"
+                            className={classes.caption}
+                        >
+                            {translate('ra.navigation.page_rows_per_page')}
+                        </Typography>
+                        <Select
+                            classes={{
+                                root: classes.selectRoot,
+                                select: classes.select,
+                                icon: classes.selectIcon,
+                            }}
+                            input={
+                                <Input
+                                    className={classes.input}
+                                    disableUnderline
+                                />
+                            }
+                            value={perPage}
+                            onChange={this.handlePerPageChange}
+                        >
+                            {rowsPerPageOptions.map(rowsPerPageOption => (
+                                <MenuItem
+                                    key={rowsPerPageOption}
+                                    value={rowsPerPageOption}
+                                >
+                                    {rowsPerPageOption}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                        <Typography
+                            variant="caption"
+                            className={classnames(
+                                classes.caption,
+                                'displayed-records'
+                            )}
                         >
                             {translate('ra.navigation.page_range_info', {
                                 offsetBegin,
@@ -198,31 +273,35 @@ export class Pagination extends Component {
                                 total,
                             })}
                         </Typography>
-                        {nbPages > 1 && [
-                            page > 1 && (
-                                <Button
-                                    color="primary"
-                                    key="prev"
-                                    onClick={this.prevPage}
-                                    className="previous-page"
-                                >
-                                    <ChevronLeft />
-                                    {translate('ra.navigation.prev')}
-                                </Button>
-                            ),
-                            this.renderPageNums(),
-                            page !== nbPages && (
-                                <Button
-                                    color="primary"
-                                    key="next"
-                                    onClick={this.nextPage}
-                                    className="next-page"
-                                >
-                                    {translate('ra.navigation.next')}
-                                    <ChevronRight />
-                                </Button>
-                            ),
-                        ]}
+                        <div className={classes.actions}>
+                            {nbPages > 1 && [
+                                page > 1 && (
+                                    <Button
+                                        color="primary"
+                                        key="prev"
+                                        onClick={this.prevPage}
+                                        className="previous-page"
+                                        size="small"
+                                    >
+                                        <ChevronLeft />
+                                        {translate('ra.navigation.prev')}
+                                    </Button>
+                                ),
+                                this.renderPageNums(),
+                                page !== nbPages && (
+                                    <Button
+                                        color="primary"
+                                        key="next"
+                                        onClick={this.nextPage}
+                                        className="next-page"
+                                        size="small"
+                                    >
+                                        {translate('ra.navigation.next')}
+                                        <ChevronRight />
+                                    </Button>
+                                ),
+                            ]}
+                        </div>
                     </Toolbar>
                 }
             />
@@ -237,10 +316,15 @@ Pagination.propTypes = {
     isLoading: PropTypes.bool,
     page: PropTypes.number,
     perPage: PropTypes.number,
+    rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
     setPage: PropTypes.func,
     setPerPage: PropTypes.func,
     translate: PropTypes.func.isRequired,
     total: PropTypes.number,
+};
+
+Pagination.defaultProps = {
+    rowsPerPageOptions: [5, 10, 25],
 };
 
 const enhance = compose(

--- a/packages/ra-ui-materialui/src/list/Pagination.spec.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import React from 'react';
 import { shallow } from 'enzyme';
 
@@ -52,7 +51,7 @@ describe('<Pagination />', () => {
     });
 
     describe('mobile', () => {
-        it('should render a condensed <Toolbar>', () => {
+        it('should render a <TablePagination> without rowsPerPage choice', () => {
             const wrapper = shallow(
                 <Pagination
                     page={2}
@@ -66,40 +65,12 @@ describe('<Pagination />', () => {
                 .setProps({ width: 'xs' })
                 .shallow()
                 .shallow();
-            const iconButtons = wrapper.find('WithStyles(IconButton)');
-            assert.equal(iconButtons.length, 2);
-            const flatButtons = wrapper.find('WithStyles(Button)');
-            assert.equal(flatButtons.length, 0);
-        });
-        it('should render only the text when no pagination is necessary', () => {
-            const wrapper = shallow(
-                <Pagination
-                    page={1}
-                    perPage={20}
-                    total={15}
-                    translate={x => x}
-                    width={1}
-                />
-            )
-                .shallow()
-                .shallow()
-                .setProps({ width: 'xs' })
-                .shallow()
-                .shallow();
-            const iconButtons = wrapper.find('WithStyles(IconButton)');
-            assert.equal(iconButtons.length, 0);
-            const typography = wrapper.find('WithStyles(Typography)');
-            assert.equal(
-                typography
-                    .shallow()
-                    .shallow()
-                    .text(),
-                'ra.navigation.page_range_info'
-            );
+            const pagination = wrapper.find('WithStyles(TablePagination)');
+            expect(pagination.prop('rowsPerPageOptions')).toEqual([]);
         });
     });
     describe('desktop', () => {
-        it('should render a normal <Toolbar>', () => {
+        it('should render a <TablePagination> with rowsPerPage choice', () => {
             const wrapper = shallow(
                 <Pagination
                     page={2}
@@ -113,35 +84,8 @@ describe('<Pagination />', () => {
                 .shallow()
                 .shallow()
                 .shallow();
-            const iconButtons = wrapper.find('WithStyles(IconButton)');
-            assert.equal(iconButtons.length, 0);
-            const flatButtons = wrapper.find('WithStyles(Button)');
-            assert.equal(flatButtons.length, 5);
-        });
-        it('should render only the text when no pagination is necessary', () => {
-            const wrapper = shallow(
-                <Pagination
-                    page={1}
-                    perPage={20}
-                    total={15}
-                    translate={x => x}
-                    width={2}
-                />
-            )
-                .shallow()
-                .shallow()
-                .shallow()
-                .shallow();
-            const flatButtons = wrapper.find('WithStyles(Button)');
-            assert.equal(flatButtons.length, 0);
-            const typography = wrapper.find('WithStyles(Typography)');
-            assert.equal(
-                typography
-                    .shallow()
-                    .shallow()
-                    .text(),
-                'ra.navigation.page_range_info'
-            );
+            const pagination = wrapper.find('WithStyles(TablePagination)');
+            expect(pagination.prop('rowsPerPageOptions')).toBe(undefined);
         });
     });
 });

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -1,0 +1,167 @@
+import React, { Component } from 'react';
+import pure from 'recompose/pure';
+import Button from '@material-ui/core/Button';
+import TablePaginationActions from '@material-ui/core/TablePaginationActions';
+import { withStyles } from '@material-ui/core/styles';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import compose from 'recompose/compose';
+import { translate } from 'ra-core';
+
+const styles = theme => ({
+    actions: {
+        flexShrink: 0,
+        color: theme.palette.text.secondary,
+        marginLeft: 20,
+    },
+    hellip: { padding: '1.2em' },
+});
+
+class PaginationActions extends Component {
+    /**
+     * Warning: material-ui's page is 0-based
+     */
+    range() {
+        const { page, rowsPerPage, count } = this.props;
+        const nbPages = Math.ceil(count / rowsPerPage) || 1;
+        if (isNaN(page) || nbPages === 1) {
+            return [];
+        }
+        const input = [];
+        // display page links around the current page
+        if (page > 1) {
+            input.push(1);
+        }
+        if (page === 3) {
+            input.push(2);
+        }
+        if (page > 3) {
+            input.push('.');
+        }
+        if (page > 0) {
+            input.push(page);
+        }
+        input.push(page + 1);
+        if (page < nbPages - 1) {
+            input.push(page + 2);
+        }
+        if (page === nbPages - 4) {
+            input.push(nbPages - 1);
+        }
+        if (page < nbPages - 4) {
+            input.push('.');
+        }
+        if (page < nbPages - 2) {
+            input.push(nbPages);
+        }
+
+        return input;
+    }
+
+    getNbPages = () =>
+        Math.ceil(this.props.count / this.props.rowsPerPage) || 1;
+
+    prevPage = event => {
+        if (this.props.page === 0) {
+            throw new Error(
+                this.props.translate('ra.navigation.page_out_from_begin')
+            );
+        }
+        this.props.onChangePage(event, this.props.page - 1);
+    };
+
+    nextPage = event => {
+        if (this.props.page > this.getNbPages() - 1) {
+            throw new Error(
+                this.props.translate('ra.navigation.page_out_from_end')
+            );
+        }
+        this.props.onChangePage(event, this.props.page + 1);
+    };
+
+    gotoPage = event => {
+        const page = parseInt(event.currentTarget.dataset.page, 10);
+        if (page < 0 || page > this.getNbPages() - 1) {
+            throw new Error(
+                this.props.translate('ra.navigation.page_out_of_boundaries', {
+                    page: page + 1,
+                })
+            );
+        }
+        this.props.onChangePage(event, page);
+    };
+
+    renderPageNums() {
+        const { classes = {} } = this.props;
+
+        return this.range().map(
+            (pageNum, index) =>
+                pageNum === '.' ? (
+                    <span key={`hyphen_${index}`} className={classes.hellip}>
+                        &hellip;
+                    </span>
+                ) : (
+                    <Button
+                        className="page-number"
+                        color={
+                            pageNum === this.props.page + 1
+                                ? 'default'
+                                : 'primary'
+                        }
+                        key={pageNum}
+                        data-page={pageNum - 1}
+                        onClick={this.gotoPage}
+                        size="small"
+                    >
+                        {pageNum}
+                    </Button>
+                )
+        );
+    }
+
+    render() {
+        const { classes = {}, page, translate } = this.props;
+
+        const nbPages = this.getNbPages();
+        if (nbPages === 0) return null;
+        return (
+            <div className={classes.actions}>
+                {page > 0 && (
+                    <Button
+                        color="primary"
+                        key="prev"
+                        onClick={this.prevPage}
+                        className="previous-page"
+                        size="small"
+                    >
+                        <ChevronLeft />
+                        {translate('ra.navigation.prev')}
+                    </Button>
+                )}
+                {this.renderPageNums()}
+                {page !== nbPages - 1 && (
+                    <Button
+                        color="primary"
+                        key="next"
+                        onClick={this.nextPage}
+                        className="next-page"
+                        size="small"
+                    >
+                        {translate('ra.navigation.next')}
+                        <ChevronRight />
+                    </Button>
+                )}
+            </div>
+        );
+    }
+}
+
+PaginationActions.propTypes = TablePaginationActions.propTypes;
+
+const enhance = compose(
+    pure,
+    translate,
+    withStyles(styles)
+);
+
+export default enhance(PaginationActions);

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -17,7 +17,7 @@ const styles = theme => ({
     hellip: { padding: '1.2em' },
 });
 
-class PaginationActions extends Component {
+export class PaginationActions extends Component {
     /**
      * Warning: material-ui's page is 0-based
      */
@@ -123,7 +123,7 @@ class PaginationActions extends Component {
         const { classes = {}, page, translate } = this.props;
 
         const nbPages = this.getNbPages();
-        if (nbPages === 0) return null;
+        if (nbPages === 1) return <div className={classes.actions} />;
         return (
             <div className={classes.actions}>
                 {page > 0 && (

--- a/packages/ra-ui-materialui/src/list/PaginationActions.spec.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.spec.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { PaginationActions } from './PaginationActions';
+
+describe('<PaginationActions />', () => {
+    it('should not render any actions when no pagination is necessary', () => {
+        const wrapper = shallow(
+            <PaginationActions
+                page={0}
+                rowsPerPage={20}
+                count={15}
+                translate={x => x}
+                classes={{}}
+            />
+        );
+        expect(wrapper.find('WithStyles(Button)')).toHaveLength(0);
+        expect(wrapper.find('WithStyles(Typography)')).toHaveLength(0);
+    });
+    it('should render action buttons when pagination is necessary', () => {
+        const wrapper = shallow(
+            <PaginationActions
+                page={0}
+                rowsPerPage={5}
+                count={15}
+                translate={x => x}
+                classes={{}}
+            />
+        );
+        // 1 2 3 next
+        expect(wrapper.find('WithStyles(Button)')).toHaveLength(4);
+    });
+
+    it('should skip page action buttons when there are too many', () => {
+        const wrapper = shallow(
+            <PaginationActions
+                page={7}
+                rowsPerPage={1}
+                count={15}
+                translate={x => x}
+                classes={{}}
+            />
+        );
+        // prev 1 ... 7 8 9 ... 15 next
+        expect(wrapper.find('WithStyles(Button)')).toHaveLength(7);
+    });
+});

--- a/packages/ra-ui-materialui/src/list/PaginationLimit.js
+++ b/packages/ra-ui-materialui/src/list/PaginationLimit.js
@@ -6,7 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const PaginationLimit = ({ ids, page, total, translate }) => {
+const PaginationLimit = ({ page, total, translate }) => {
     if (total === 0) {
         return (
             <CardContent>

--- a/packages/ra-ui-materialui/src/list/PaginationLimit.js
+++ b/packages/ra-ui-materialui/src/list/PaginationLimit.js
@@ -16,15 +16,14 @@ const PaginationLimit = ({ ids, page, total, translate }) => {
             </CardContent>
         );
     }
-    if (ids && !ids.length) {
-        return (
-            <CardContent>
-                <Typography variant="body1">
-                    {translate('ra.navigation.no_more_results', { page })}
-                </Typography>
-            </CardContent>
-        );
-    }
+
+    return (
+        <CardContent>
+            <Typography variant="body1">
+                {translate('ra.navigation.no_more_results', { page })}
+            </Typography>
+        </CardContent>
+    );
 };
 
 PaginationLimit.propTypes = {


### PR DESCRIPTION
- [x] Use Material-ui's [`<TablePagination>` component](https://material-ui.com/api/table-pagination/) instead of our own (reduces the code to maintain)
- [x] Hook up the `setPerPage()` handler to support perPage change

![kapture 2018-08-17 at 15 45 10](https://user-images.githubusercontent.com/99944/44269365-97962a00-a234-11e8-9e61-772705b13ffa.gif)

Note that this slightly changes the design of the pagination, to make it more material-design compliant.

Before:

![2018-08-17_1601](https://user-images.githubusercontent.com/99944/44270103-c6150480-a236-11e8-861e-c90a2dbbcf96.png)

After:

![2018-08-17_1559](https://user-images.githubusercontent.com/99944/44270067-a41b8200-a236-11e8-89e9-a5ea19362365.png)
