### PR TITLE
Remove const client = new ApolloClient();

### DIFF
--- a/packages/ra-data-graphql-simple/README.md
+++ b/packages/ra-data-graphql-simple/README.md
@@ -33,8 +33,6 @@ import { Admin, Resource, Delete } from 'react-admin';
 
 import { PostCreate, PostEdit, PostList } from './posts';
 
-const client = new ApolloClient();
-
 class App extends Component {
     constructor() {
         super();


### PR DESCRIPTION
Hi!

"client" is not used in example, so const client = new ApolloClient() can be removed