### PR TITLE
Corrects package name in readme

### DIFF
--- a/packages/ra-data-fakerest/README.md
+++ b/packages/ra-data-fakerest/README.md
@@ -11,7 +11,7 @@ All operations carried out in react-admin are local to the browser, and last onl
 ## Installation
 
 ```sh
-npm install --save ra-data-json-fakerest
+npm install --save ra-data-fakerest
 ```
 
 ## Usage


### PR DESCRIPTION
The current install snippet for the `ra-data-fakerest` package is wrong.
This corrects the misnaming.