### PR TITLE
[RFR] Fix Autocomplete list is cut off by content area

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -325,7 +325,6 @@ export class AutocompleteInput extends React.Component {
                 open
                 anchorEl={this.inputEl}
                 placement="bottom-start"
-                popperOptions={{ positionFixed: true }}
             >
                 <Paper square {...containerProps}>
                     {children}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import Autosuggest from 'react-autosuggest';
 import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import { withStyles } from '@material-ui/core/styles';
@@ -96,6 +97,8 @@ export class AutocompleteInput extends React.Component {
         selectedItem: null,
         suggestions: [],
     };
+
+    inputEl = null;
 
     componentWillMount() {
         const selectedItem = this.getSelectedItem(
@@ -272,6 +275,13 @@ export class AutocompleteInput extends React.Component {
 
         const { touched, error, helperText = false } = meta;
 
+        // We need to store the input reference for our Popper element containg the suggestions
+        // but Autosuggest also needs this reference (it provides the ref prop)
+        const storeInputRef = input => {
+            this.inputEl = input;
+            ref(input);
+        };
+
         return (
             <TextField
                 label={
@@ -287,7 +297,7 @@ export class AutocompleteInput extends React.Component {
                 autoFocus={autoFocus}
                 margin="normal"
                 className={classnames(classes.root, className)}
-                inputRef={ref}
+                inputRef={storeInputRef}
                 error={!!(touched && error)}
                 helperText={(touched && error) || helperText}
                 name={input.name}
@@ -304,12 +314,23 @@ export class AutocompleteInput extends React.Component {
     };
 
     renderSuggestionsContainer = options => {
-        const { containerProps, children } = options;
+        const {
+            containerProps: { className, ...containerProps },
+            children,
+        } = options;
 
         return (
-            <Paper {...containerProps} square>
-                {children}
-            </Paper>
+            <Popper
+                className={className}
+                open
+                anchorEl={this.inputEl}
+                placement="bottom-start"
+                popperOptions={{ positionFixed: true }}
+            >
+                <Paper square {...containerProps}>
+                    {children}
+                </Paper>
+            </Popper>
         );
     };
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.js
@@ -90,21 +90,26 @@ describe('<AutocompleteInput />', () => {
     };
 
     it('should use optionText with a string value as text identifier', () => {
-        const wrapper = render(
-            <AutocompleteInput
-                {...defaultProps}
-                optionText="foobar"
-                choices={[{ id: 'M', foobar: 'Male' }]}
-                alwaysRenderSuggestions={true}
-            />,
+        const wrapper = shallow(
+            <AutocompleteInput {...defaultProps} optionText="foobar" />,
             { context, childContextTypes }
         );
-        const MenuItem = wrapper.find('div[role="menuitem"]').first();
+
+        // This is necesary because we use the material-ui Popper element which does not includes
+        // its children in the AutocompleteInput dom hierarchy
+        const menuItem = wrapper
+            .instance()
+            .renderSuggestion(
+                { id: 'M', foobar: 'Male' },
+                { query: '', highlighted: false }
+            );
+
+        const MenuItem = render(menuItem);
         assert.equal(MenuItem.text(), 'Male');
     });
 
     it('should use optionText with a string value including "." as text identifier', () => {
-        const wrapper = render(
+        const wrapper = shallow(
             <AutocompleteInput
                 {...defaultProps}
                 optionText="foobar.name"
@@ -113,12 +118,22 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-        const MenuItem = wrapper.find('div[role="menuitem"]').first();
+
+        // This is necesary because we use the material-ui Popper element which does not includes
+        // its children in the AutocompleteInput dom hierarchy
+        const menuItem = wrapper
+            .instance()
+            .renderSuggestion(
+                { id: 'M', foobar: { name: 'Male' } },
+                { query: '', highlighted: false }
+            );
+
+        const MenuItem = render(menuItem);
         assert.equal(MenuItem.text(), 'Male');
     });
 
     it('should use optionText with a function value as text identifier', () => {
-        const wrapper = render(
+        const wrapper = shallow(
             <AutocompleteInput
                 {...defaultProps}
                 optionText={choice => choice.foobar}
@@ -127,12 +142,22 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-        const MenuItem = wrapper.find('div[role="menuitem"]').first();
+
+        // This is necesary because we use the material-ui Popper element which does not includes
+        // its children in the AutocompleteInput dom hierarchy
+        const menuItem = wrapper
+            .instance()
+            .renderSuggestion(
+                { id: 'M', foobar: 'Male' },
+                { query: '', highlighted: false }
+            );
+
+        const MenuItem = render(menuItem);
         assert.equal(MenuItem.text(), 'Male');
     });
 
     it('should translate the choices by default', () => {
-        const wrapper = render(
+        const wrapper = shallow(
             <AutocompleteInput
                 {...defaultProps}
                 choices={[{ id: 'M', name: 'Male' }]}
@@ -141,12 +166,21 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-        const MenuItem = wrapper.find('div[role="menuitem"]').first();
+        // This is necesary because we use the material-ui Popper element which does not includes
+        // its children in the AutocompleteInput dom hierarchy
+        const menuItem = wrapper
+            .instance()
+            .renderSuggestion(
+                { id: 'M', name: 'Male' },
+                { query: '', highlighted: false }
+            );
+
+        const MenuItem = render(menuItem);
         assert.equal(MenuItem.text(), '**Male**');
     });
 
     it('should not translate the choices if translateChoice is false', () => {
-        const wrapper = render(
+        const wrapper = shallow(
             <AutocompleteInput
                 {...defaultProps}
                 choices={[{ id: 'M', name: 'Male' }]}
@@ -156,7 +190,16 @@ describe('<AutocompleteInput />', () => {
             />,
             { context, childContextTypes }
         );
-        const MenuItem = wrapper.find('div[role="menuitem"]').first();
+        // This is necesary because we use the material-ui Popper element which does not includes
+        // its children in the AutocompleteInput dom hierarchy
+        const menuItem = wrapper
+            .instance()
+            .renderSuggestion(
+                { id: 'M', name: 'Male' },
+                { query: '', highlighted: false }
+            );
+
+        const MenuItem = render(menuItem);
         assert.equal(MenuItem.text(), 'Male');
     });
 


### PR DESCRIPTION
The fix introduced by #2123 has been reverted by #2159. This PR apply the fix again, correctly setting the z-index this time.

Fixes #2097

Before:
![Before](http://pix.toile-libre.org/upload/original/1533200458.png)

After:
![After](http://pix.toile-libre.org/upload/original/1533200521.png)