### PR TITLE
Wrong "data-generator" dependence

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@material-ui/core": "~1.4.0",
         "@material-ui/icons": "~1.1.0",
-        "data-generator": "^2.1.4",
+        "mocker-data-generator": "^2.1.4",
         "fakerest": "~2.1.0",
         "fetch-mock": "~6.3.0",
         "json-graphql-server": "~2.1.1",


### PR DESCRIPTION
Current "data-generator" library version is 0.0.1.
I found out that the right dependence in this project was "mocker-data-generator".