### PR TITLE
[RFR] Implement Headroom in AppBar

### DIFF
--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -15,6 +15,18 @@ describe('List Page', () => {
         });
     });
 
+    describe('Headroom', () => {
+        it('should hide/show the appBar when scroll action appears', () => {
+            cy.viewport(1280, 500);
+
+            cy.scrollTo(0, 200);
+            cy.get(ListPagePosts.elements.headroom).should('not.be.visible');
+
+            cy.scrollTo(0, -100);
+            cy.get(ListPagePosts.elements.headroom).should('be.visible');
+        });
+    });
+
     describe('Pagination', () => {
         it('should display paginated list of available posts', () => {
             cy.contains('1-10 of 13');

--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -15,7 +15,7 @@ describe('List Page', () => {
         });
     });
 
-    describe('Headroom', () => {
+    describe('Auto-hide AppBar', () => {
         it('should hide/show the appBar when scroll action appears', () => {
             cy.viewport(1280, 500);
 

--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -26,6 +26,7 @@ export default url => ({
         selectItem: '.select-item input',
         userMenu: 'button[title="Profile"]',
         title: '#react-admin-title',
+        headroom: '.headroom',
     },
 
     navigate() {

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -374,7 +374,7 @@ import MyAppBar from './MyAppBar';
 import MyMenu from './MyMenu';
 import MyNotification from './MyNotification';
 
-const MyLayout = props => <Layout
+const MyLayout = props => <Layout 
     {...props}
     appBar={MyAppBar}
     menu={MyMenu}
@@ -762,9 +762,9 @@ const App = () => (
 
 ## Loading
 
-Display a circular progress component with optional messages. Display the same loading component as `react-admin` on custom pages for consistency.
+Display a circular progress component with optional messages. Display the same loading component as `react-admin` on custom pages for consistency. 
 
-Supported props:
+Supported props: 
 
 Prop | Type | Default | Descriptions
 ---|---|---|---
@@ -773,18 +773,18 @@ Prop | Type | Default | Descriptions
 
 Usage:
 
-```jsx
+```jsx 
 <Loading loadingPrimary="app.page.loading" loadingSecondary="app.message.loading" />
-```
+``` 
 
 ## LinearProgress
 
-Display a linear progress component. Display the same loading component as `react-admin` on custom inputs for consistency.
+Display a linear progress component. Display the same loading component as `react-admin` on custom inputs for consistency. 
 
 Usage:
 
-```jsx
-({ data, ...props }) => !data?
-        <LinearProgress /> :
-        <MyInput data={data} />
-```
+```jsx 
+({ data, ...props }) => !data? 
+        <LinearProgress /> : 
+        <MyInput data={data} />        
+``` 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -501,13 +501,9 @@ export default connect(mapStateToProps, { setSidebarVisibility })(withStyles(sty
 
 ## Using a Custom AppBar
 
-By default, React-admin use [react-headroom](https://github.com/KyleAMathews/react-headroom) with [`<AppBar>`](https://material-ui.com/api/app-bar/#appbar).
+By default, React-admin uses [Material_ui's `<AppBar>` component](https://material-ui.com/api/app-bar/) together with [react-headroom](https://github.com/KyleAMathews/react-headroom) to hide the `AppBar` on scroll.
 
-The `<AppBar>` don't follow [the material design guidelines](https://material.io/design/components/app-bars-top.html#behavior), which specify that the scrollbar should hide on scroll down, and show up (fixed) on scroll up.
-
-A discussion on the same subject in the [material-ui tracker: mui-org/material-ui#12337](https://github.com/mui-org/material-ui/issues/12337).
-
-If you want to remove the `<Headroom>` component, you can create your own appBar component:
+You can create your own `AppBar` component to replace the react-admin one. For instance, to remove the "headroom" effect:
 
 ```jsx
 // in src/MyAppBar.js
@@ -526,7 +522,7 @@ const MyAppBar = props => (
 export default MyAppBar;
 ```
 
-To use this custom appBar component, pass it to a custom Layout, as explained above:
+To use this custom `AppBar` component, pass it as prop to a custom `Layout`, as explained below:
 
 ```jsx
 // in src/MyLayout.js

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -374,7 +374,7 @@ import MyAppBar from './MyAppBar';
 import MyMenu from './MyMenu';
 import MyNotification from './MyNotification';
 
-const MyLayout = props => <Layout 
+const MyLayout = props => <Layout
     {...props}
     appBar={MyAppBar}
     menu={MyMenu}
@@ -534,7 +534,7 @@ const MyLayout = (props) => <Layout {...props} appBar={MyAppBar} />;
 export default MyLayout;
 ```
 
-Then, use this layout in the `<Admin>` `applayout` prop:
+Then, use this layout in the `<Admin>` with the `applayout` prop:
 
 ```jsx
 // in src/App.js
@@ -762,9 +762,9 @@ const App = () => (
 
 ## Loading
 
-Display a circular progress component with optional messages. Display the same loading component as `react-admin` on custom pages for consistency. 
+Display a circular progress component with optional messages. Display the same loading component as `react-admin` on custom pages for consistency.
 
-Supported props: 
+Supported props:
 
 Prop | Type | Default | Descriptions
 ---|---|---|---
@@ -773,18 +773,18 @@ Prop | Type | Default | Descriptions
 
 Usage:
 
-```jsx 
+```jsx
 <Loading loadingPrimary="app.page.loading" loadingSecondary="app.message.loading" />
-``` 
+```
 
 ## LinearProgress
 
-Display a linear progress component. Display the same loading component as `react-admin` on custom inputs for consistency. 
+Display a linear progress component. Display the same loading component as `react-admin` on custom inputs for consistency.
 
 Usage:
 
-```jsx 
-({ data, ...props }) => !data? 
-        <LinearProgress /> : 
-        <MyInput data={data} />        
-``` 
+```jsx
+({ data, ...props }) => !data?
+        <LinearProgress /> :
+        <MyInput data={data} />
+```

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -374,7 +374,7 @@ import MyAppBar from './MyAppBar';
 import MyMenu from './MyMenu';
 import MyNotification from './MyNotification';
 
-const MyLayout = props => <Layout 
+const MyLayout = props => <Layout
     {...props}
     appBar={MyAppBar}
     menu={MyMenu}
@@ -497,6 +497,58 @@ MyLayout.propTypes = {
 
 const mapStateToProps = state => ({ isLoading: state.admin.loading > 0 });
 export default connect(mapStateToProps, { setSidebarVisibility })(withStyles(styles)(MyLayout));
+```
+
+## Using a Custom AppBar
+
+By default, React-admin use [react-headroom](https://github.com/KyleAMathews/react-headroom) with [`<AppBar>`](https://material-ui.com/api/app-bar/#appbar).
+
+The `<AppBar>` don't follow [the material design guidelines](https://material.io/design/components/app-bars-top.html#behavior), which specify that the scrollbar should hide on scroll down, and show up (fixed) on scroll up.
+
+A discussion on the same subject in the [material-ui tracker: mui-org/material-ui#12337](https://github.com/mui-org/material-ui/issues/12337).
+
+If you want to remove the `<Headroom>` component, you can create your own appBar component:
+
+```jsx
+// in src/MyAppBar.js
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+
+const MyAppBar = props => (
+    <AppBar {...props}>
+        <Toolbar>
+            <Typography variant="title" id="react-admin-title" />
+        </Toolbar>
+    </AppBar>
+);
+
+export default MyAppBar;
+```
+
+To use this custom appBar component, pass it to a custom Layout, as explained above:
+
+```jsx
+// in src/MyLayout.js
+import { Layout } from 'react-admin';
+import MyAppBar from './MyAppBar';
+
+const MyLayout = (props) => <Layout {...props} appBar={MyAppBar} />;
+
+export default MyLayout;
+```
+
+Then, use this layout in the `<Admin>` `applayout` prop:
+
+```jsx
+// in src/App.js
+import MyLayout from './MyLayout';
+
+const App = () => (
+    <Admin appLayout={MyLayout} dataProvider={simpleRestProvider('http://path.to.my.api')}>
+        // ...
+    </Admin>
+);
 ```
 
 ## Using a Custom Menu
@@ -714,9 +766,9 @@ const App = () => (
 
 ## Loading
 
-Display a circular progress component with optional messages. Display the same loading component as `react-admin` on custom pages for consistency. 
+Display a circular progress component with optional messages. Display the same loading component as `react-admin` on custom pages for consistency.
 
-Supported props: 
+Supported props:
 
 Prop | Type | Default | Descriptions
 ---|---|---|---
@@ -725,18 +777,18 @@ Prop | Type | Default | Descriptions
 
 Usage:
 
-```jsx 
+```jsx
 <Loading loadingPrimary="app.page.loading" loadingSecondary="app.message.loading" />
-``` 
+```
 
 ## LinearProgress
 
-Display a linear progress component. Display the same loading component as `react-admin` on custom inputs for consistency. 
+Display a linear progress component. Display the same loading component as `react-admin` on custom inputs for consistency.
 
 Usage:
 
-```jsx 
-({ data, ...props }) => !data? 
-        <LinearProgress /> : 
-        <MyInput data={data} />        
-``` 
+```jsx
+({ data, ...props }) => !data?
+        <LinearProgress /> :
+        <MyInput data={data} />
+```

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -635,6 +635,9 @@
                                 <a href="#using-a-custom-layout">Using a Custom Layout</a>
                             </li>
                             <li class="chapter">
+                                <a href="#using-a-custom-appbar">Using a Custom AppBar</a>
+                            </li>
+                            <li class="chapter">
                                 <a href="#using-a-custom-menu">Using a Custom Menu</a>
                             </li>
 

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -48,6 +48,7 @@
         "ra-core": "^2.2.0",
         "react-autosuggest": "^9.3.2",
         "react-dropzone": "~4.0.1",
+        "react-headroom": "^2.2.2",
         "react-redux": "~5.0.7",
         "react-router-dom": "~4.2.2",
         "react-transition-group": "^2.2.1",

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -14,15 +14,9 @@ import { toggleSidebar as toggleSidebarAction } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
 import UserMenu from './UserMenu';
+import Headroom from './Headroom';
 
 const styles = theme => ({
-    appBar: {
-        transition: theme.transitions.create(['margin', 'width'], {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
-        }),
-        zIndex: 1300,
-    },
     toolbar: {
         paddingRight: 24,
     },
@@ -63,41 +57,43 @@ const AppBar = ({
     width,
     ...rest
 }) => (
-    <MuiAppBar
-        className={classNames(classes.appBar, className)}
-        color="secondary"
-        position={width === 'xs' ? 'fixed' : 'absolute'}
-        {...rest}
-    >
-        <Toolbar
-            disableGutters
-            variant={width === 'xs' ? 'regular' : 'dense'}
-            className={classes.toolbar}
+    <Headroom>
+        <MuiAppBar
+            className={className}
+            color="secondary"
+            position="static"
+            {...rest}
         >
-            <IconButton
-                color="inherit"
-                aria-label="open drawer"
-                onClick={toggleSidebar}
-                className={classNames(classes.menuButton)}
+            <Toolbar
+                disableGutters
+                variant={width === 'xs' ? 'regular' : 'dense'}
+                className={classes.toolbar}
             >
-                <MenuIcon
-                    classes={{
-                        root: open
-                            ? classes.menuButtonIconOpen
-                            : classes.menuButtonIconClosed,
-                    }}
+                <IconButton
+                    color="inherit"
+                    aria-label="open drawer"
+                    onClick={toggleSidebar}
+                    className={classNames(classes.menuButton)}
+                >
+                    <MenuIcon
+                        classes={{
+                            root: open
+                                ? classes.menuButtonIconOpen
+                                : classes.menuButtonIconClosed,
+                        }}
+                    />
+                </IconButton>
+                <Typography
+                    variant="title"
+                    color="inherit"
+                    className={classes.title}
+                    id="react-admin-title"
                 />
-            </IconButton>
-            <Typography
-                variant="title"
-                color="inherit"
-                className={classes.title}
-                id="react-admin-title"
-            />
-            <LoadingIndicator />
-            {logout && <UserMenu logout={logout}>{children}</UserMenu>}
-        </Toolbar>
-    </MuiAppBar>
+                <LoadingIndicator />
+                {logout && <UserMenu logout={logout}>{children}</UserMenu>}
+            </Toolbar>
+        </MuiAppBar>
+    </Headroom>
 );
 
 AppBar.propTypes = {

--- a/packages/ra-ui-materialui/src/layout/Headroom.js
+++ b/packages/ra-ui-materialui/src/layout/Headroom.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Headroom from 'react-headroom';
+
+const defaultStyle = {
+    position: 'fixed',
+    zIndex: 1300,
+};
+
+const HeadroomCustom = ({ children }) => (
+    <Headroom style={defaultStyle}>{children}</Headroom>
+);
+
+HeadroomCustom.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default HeadroomCustom;

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -29,7 +29,6 @@ const styles = theme => ({
     appFrame: {
         display: 'flex',
         flexDirection: 'column',
-        overflowX: 'auto',
     },
     contentWithSidebar: {
         display: 'flex',
@@ -41,14 +40,10 @@ const styles = theme => ({
         flexGrow: 2,
         padding: theme.spacing.unit * 3,
         [theme.breakpoints.up('xs')]: {
-            marginTop: '3em',
             paddingLeft: 5,
         },
         [theme.breakpoints.down('sm')]: {
             padding: 0,
-        },
-        [theme.breakpoints.down('xs')]: {
-            marginTop: '3.5em',
         },
     },
 });

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -23,8 +23,8 @@ const styles = theme => ({
             duration: theme.transitions.duration.leavingScreen,
         }),
         backgroundColor: 'transparent',
+        marginTop: '0.5em',
         borderRight: 'none',
-        marginTop: '3.5em',
         [theme.breakpoints.only('xs')]: {
             marginTop: 0,
             height: '100vh',
@@ -33,7 +33,7 @@ const styles = theme => ({
         },
         [theme.breakpoints.up('md')]: {
             border: 'none',
-            marginTop: '4.5em',
+            marginTop: '1.5em',
         },
     },
     drawerPaperClose: {

--- a/packages/ra-ui-materialui/src/layout/index.js
+++ b/packages/ra-ui-materialui/src/layout/index.js
@@ -6,6 +6,7 @@ export Confirm from './Confirm';
 export DashboardMenuItem from './DashboardMenuItem';
 export Error from './Error';
 export Header from './Header';
+export Headroom from './Headroom';
 export Layout from './Layout';
 export Loading from './Loading';
 export LinearProgress from './LinearProgress';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5332,7 +5332,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -5678,7 +5678,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -6950,9 +6950,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.17.10, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._objecttypes@~2.4.1:
   version "2.4.1"
@@ -6986,11 +6990,27 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
 lodash.isobject@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
   dependencies:
     lodash._objecttypes "~2.4.1"
+
+lodash.keys@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -8850,7 +8870,7 @@ ra-data-simple-rest@~2.0.0:
     query-string "~5.1.1"
     react-admin "^2.0.4"
 
-raf@3.4.0, raf@^3.4.0, raf@~3.4.0:
+raf@3.4.0, raf@^3.3.0, raf@^3.4.0, raf@~3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -9004,6 +9024,14 @@ react-event-listener@^0.6.0:
     prop-types "^15.6.0"
     warning "^3.0.0"
 
+react-headroom@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-headroom/-/react-headroom-2.2.2.tgz#5ddea3bc87cd54be38f6f98c3fde4527e2a5fb0f"
+  dependencies:
+    prop-types "^15.5.8"
+    raf "^3.3.0"
+    shallowequal "^0.2.2"
+
 react-is@^16.3.2, react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
@@ -9018,7 +9046,7 @@ react-jss@^8.1.0:
     prop-types "^15.6.0"
     theming "^1.3.0"
 
-react-lifecycles-compat@^3.0.2:
+react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -9351,14 +9379,14 @@ redux-form@~7.4.0:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.4.2.tgz#d6061088fb682eb9fc5fb9749bd8b102f03154b0"
   dependencies:
-    deep-equal "^1.0.1"
     es6-error "^4.1.1"
-    hoist-non-react-statics "^2.5.0"
-    invariant "^2.2.3"
+    hoist-non-react-statics "^2.5.4"
+    invariant "^2.2.4"
     is-promise "^2.1.0"
-    lodash "^4.17.5"
-    lodash-es "^4.17.5"
+    lodash "^4.17.10"
+    lodash-es "^4.17.10"
     prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
 
 redux-saga@~0.16.0:
   version "0.16.0"
@@ -9927,6 +9955,12 @@ sha.js@^2.4.0, sha.js@^2.4.8:
 shallow-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.0.0.tgz#508d1838b3de590ab8757b011b25e430900945f7"
+
+shallowequal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
+  dependencies:
+    lodash.keys "^3.1.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description

We have some issue on AppBar component like #1819. 

In fact, we don't follow [ the material design guidelines](https://material.io/design/components/app-bars-top.html#behavior), which specify that the scrollbar should hide on scroll down, and show up (fixed) on scroll up (see https://material-components.github.io/material-components-web-catalog/#/component/top-app-bar/standard for an example).

A discussion on the same subject in the [material-ui tracker: mui-org/material-ui#12337](https://github.com/mui-org/material-ui/issues/12337).

## Solution

I implement [react-headroom](https://github.com/KyleAMathews/react-headroom) container in AppBar component. I export `<Headroom />` component which is already configure for react-admin.

- [x] Clean example
- [x] Documentation
- [x] Add test E2E
- [x] Test Chrome
- [x] Test Firefox
- [x] Test Edge
- [x] Test IE

## Result

![peek 2018-08-24 12-11](https://user-images.githubusercontent.com/2212144/44579485-d7aa5f00-a796-11e8-991a-77ed5c792d13.gif)
![peek 2018-08-24 12-10](https://user-images.githubusercontent.com/2212144/44579486-d842f580-a796-11e8-9b7a-f1d1755712b1.gif)


fix #1819 