### PR TITLE
[RFR] Allow changing the sidebar width using a Layout prop

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -365,19 +365,20 @@ const App = () => (
 );
 ```
 
-Your custom layout can extend the default `<Layout>` component if you only want to override the sidebar width, the appBar, the menu, the notification component, or the error page. For instance:
+Your custom layout can extend the default `<Layout>` component if you only want to override the sidebar, the appBar, the menu, the notification component, or the error page. For instance:
 
 ```jsx
 // in src/MyLayout.js
 import { Layout } from 'react-admin';
 import MyAppBar from './MyAppBar';
+import MySidebar from './MySidebar';
 import MyMenu from './MyMenu';
 import MyNotification from './MyNotification';
 
 const MyLayout = props => <Layout
     {...props}
-    sidebarWidth={200}
     appBar={MyAppBar}
+    sidebar={MySidebar}
     menu={MyMenu}
     notification={MyNotification}
 />;
@@ -404,6 +405,19 @@ const MyLayout = props => <Layout
     {...props}
     appBar={MyAppBar}
 />;
+```
+
+You can speciy the `Sidebar` size by setting the `size` property:
+
+```jsx
+import { Sidebar } from 'react-admin';
+
+const MySidebar = props => <Sidebar {...props} size={200} />;
+const MyLayout = props => <Layout
+    {...props}
+    sidebar={MySidebar}
+/>;
+
 ```
 
 For more custom layouts, write a component from scratch. It must contain a `{children}` placeholder, where react-admin will render the resources. Use the [default layout](https://github.com/marmelab/react-admin/blob/master/src/mui/layout/Layout.js) as a starting point. Here is a simplified version (with no responsive support):

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -365,7 +365,7 @@ const App = () => (
 );
 ```
 
-Your custom layout can extend the default `<Layout>` component if you only want to override the appBar, the menu, the notification component, or the error page. For instance:
+Your custom layout can extend the default `<Layout>` component if you only want to override the sidebar width, the appBar, the menu, the notification component, or the error page. For instance:
 
 ```jsx
 // in src/MyLayout.js
@@ -376,6 +376,7 @@ import MyNotification from './MyNotification';
 
 const MyLayout = props => <Layout
     {...props}
+    sidebarWidth={200}
     appBar={MyAppBar}
     menu={MyMenu}
     notification={MyNotification}

--- a/examples/demo/src/Layout.js
+++ b/examples/demo/src/Layout.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Layout } from 'react-admin';
+import { Layout, Sidebar } from 'react-admin';
 import AppBar from './AppBar';
 
+const CustomSidebar = props => <Sidebar size={200} {...props} />;
 const CustomLayout = props => (
-    <Layout appBar={AppBar} sidebarWidth={200} {...props} />
+    <Layout appBar={AppBar} sidebar={CustomSidebar} {...props} />
 );
 
 const darkTheme = {

--- a/examples/demo/src/Layout.js
+++ b/examples/demo/src/Layout.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import { Layout } from 'react-admin';
 import AppBar from './AppBar';
 
-const CustomLayout = props => <Layout appBar={AppBar} {...props} />;
+const CustomLayout = props => (
+    <Layout appBar={AppBar} sidebarWidth={200} {...props} />
+);
 
 const darkTheme = {
     palette: {

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -90,6 +90,7 @@ class Layout extends Component {
             menu,
             notification,
             open,
+            sidebarWidth,
             title,
             ...props
         } = this.props;
@@ -102,7 +103,7 @@ class Layout extends Component {
                 <div className={classes.appFrame}>
                     {createElement(appBar, { title, open, logout })}
                     <main className={classes.contentWithSidebar}>
-                        <Sidebar>
+                        <Sidebar size={sidebarWidth}>
                             {createElement(menu, {
                                 logout,
                                 hasDashboard: !!dashboard,
@@ -147,6 +148,7 @@ Layout.propTypes = {
     menu: componentPropType,
     notification: componentPropType,
     open: PropTypes.bool,
+    sidebarWidth: PropTypes.number,
     title: PropTypes.node.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -90,7 +90,7 @@ class Layout extends Component {
             menu,
             notification,
             open,
-            sidebarWidth,
+            sidebar,
             title,
             ...props
         } = this.props;
@@ -103,12 +103,12 @@ class Layout extends Component {
                 <div className={classes.appFrame}>
                     {createElement(appBar, { title, open, logout })}
                     <main className={classes.contentWithSidebar}>
-                        <Sidebar size={sidebarWidth}>
-                            {createElement(menu, {
+                        {createElement(sidebar, {
+                            children: createElement(menu, {
                                 logout,
                                 hasDashboard: !!dashboard,
-                            })}
-                        </Sidebar>
+                            }),
+                        })}
                         <div className={classes.content}>
                             {hasError
                                 ? createElement(error, {
@@ -148,7 +148,7 @@ Layout.propTypes = {
     menu: componentPropType,
     notification: componentPropType,
     open: PropTypes.bool,
-    sidebarWidth: PropTypes.number,
+    sidebar: componentPropType,
     title: PropTypes.node.isRequired,
 };
 
@@ -157,6 +157,7 @@ Layout.defaultProps = {
     error: Error,
     menu: Menu,
     notification: Notification,
+    sidebar: Sidebar,
 };
 
 const mapStateToProps = state => ({

--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -11,14 +11,12 @@ import DefaultIcon from '@material-ui/icons/ViewList';
 import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
 import Responsive from '../layout/Responsive';
-import { DRAWER_WIDTH } from './Sidebar';
 
 const styles = {
     main: {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'flex-start',
-        width: DRAWER_WIDTH,
     },
 };
 

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -26,7 +26,6 @@ const styles = theme => ({
         borderRight: 'none',
         [theme.breakpoints.only('xs')]: {
             marginTop: 0,
-            width: 240,
             height: '100vh',
             position: 'inherit',
             backgroundColor: theme.palette.background.default,

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -55,6 +55,7 @@ class Sidebar extends PureComponent {
         const {
             children,
             classes,
+            closedSize,
             open,
             setSidebarVisibility,
             size,
@@ -87,7 +88,7 @@ class Sidebar extends PureComponent {
                         PaperProps={{
                             className: classes.drawerPaper,
                             style: {
-                                width: open ? size : CLOSED_DRAWER_WIDTH,
+                                width: open ? size : closedSize,
                             },
                         }}
                         onClose={this.toggleSidebar}
@@ -106,7 +107,7 @@ class Sidebar extends PureComponent {
                         PaperProps={{
                             className: classes.drawerPaper,
                             style: {
-                                width: open ? size : CLOSED_DRAWER_WIDTH,
+                                width: open ? size : closedSize,
                             },
                         }}
                         onClose={this.toggleSidebar}
@@ -123,6 +124,7 @@ class Sidebar extends PureComponent {
 Sidebar.propTypes = {
     children: PropTypes.node.isRequired,
     classes: PropTypes.object,
+    closedSize: PropTypes.number,
     open: PropTypes.bool.isRequired,
     setSidebarVisibility: PropTypes.func.isRequired,
     size: PropTypes.number,
@@ -131,6 +133,7 @@ Sidebar.propTypes = {
 
 Sidebar.defaultProps = {
     size: DRAWER_WIDTH,
+    closedSize: CLOSED_DRAWER_WIDTH,
 };
 
 const mapStateToProps = state => ({

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -5,18 +5,17 @@ import compose from 'recompose/compose';
 import Drawer from '@material-ui/core/Drawer';
 import { withStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
-import classnames from 'classnames';
 import { setSidebarVisibility } from 'ra-core';
 
 import Responsive from './Responsive';
 
 export const DRAWER_WIDTH = 240;
+export const CLOSED_DRAWER_WIDTH = 55;
 
 const styles = theme => ({
     drawerPaper: {
         position: 'relative',
         height: 'auto',
-        width: DRAWER_WIDTH,
         overflowX: 'hidden',
         transition: theme.transitions.create('width', {
             easing: theme.transitions.easing.sharp,
@@ -27,6 +26,7 @@ const styles = theme => ({
         borderRight: 'none',
         [theme.breakpoints.only('xs')]: {
             marginTop: 0,
+            width: 240,
             height: '100vh',
             position: 'inherit',
             backgroundColor: theme.palette.background.default,
@@ -35,9 +35,6 @@ const styles = theme => ({
             border: 'none',
             marginTop: '1.5em',
         },
-    },
-    drawerPaperClose: {
-        width: 55,
     },
 });
 
@@ -61,6 +58,7 @@ class Sidebar extends PureComponent {
             classes,
             open,
             setSidebarVisibility,
+            size,
             width,
             ...rest
         } = this.props;
@@ -71,8 +69,9 @@ class Sidebar extends PureComponent {
                     <Drawer
                         variant="temporary"
                         open={open}
-                        classes={{
-                            paper: classes.drawerPaper,
+                        PaperProps={{
+                            className: classes.drawerPaper,
+                            style: { width: size },
                         }}
                         onClose={this.toggleSidebar}
                         {...rest}
@@ -86,11 +85,11 @@ class Sidebar extends PureComponent {
                     <Drawer
                         variant="permanent"
                         open={open}
-                        classes={{
-                            paper: classnames(
-                                classes.drawerPaper,
-                                !open && classes.drawerPaperClose
-                            ),
+                        PaperProps={{
+                            className: classes.drawerPaper,
+                            style: {
+                                width: open ? size : CLOSED_DRAWER_WIDTH,
+                            },
                         }}
                         onClose={this.toggleSidebar}
                         {...rest}
@@ -105,11 +104,11 @@ class Sidebar extends PureComponent {
                     <Drawer
                         variant="permanent"
                         open={open}
-                        classes={{
-                            paper: classnames(
-                                classes.drawerPaper,
-                                !open && classes.drawerPaperClose
-                            ),
+                        PaperProps={{
+                            className: classes.drawerPaper,
+                            style: {
+                                width: open ? size : CLOSED_DRAWER_WIDTH,
+                            },
                         }}
                         onClose={this.toggleSidebar}
                         {...rest}
@@ -127,7 +126,12 @@ Sidebar.propTypes = {
     classes: PropTypes.object,
     open: PropTypes.bool.isRequired,
     setSidebarVisibility: PropTypes.func.isRequired,
+    size: PropTypes.number,
     width: PropTypes.string,
+};
+
+Sidebar.defaultProps = {
+    size: DRAWER_WIDTH,
 };
 
 const mapStateToProps = state => ({
@@ -141,5 +145,5 @@ export default compose(
         { setSidebarVisibility }
     ),
     withStyles(styles),
-    withWidth()
+    withWidth({ resizeInterval: Infinity }) // used to initialize the visibility on first render
 )(Sidebar);


### PR DESCRIPTION
Until now, changing the sidebar width (to accommodate shorter or longer resource names) used to require a lot of boilerplate. No more!

```jsx
const MyLayout = props => <Layout {...props} sidebarWidth={200} />;
```