### PR TITLE
[RFR] Fix ReferenceField does not respect its child's className

### DIFF
--- a/examples/simple/src/comments/CommentList.js
+++ b/examples/simple/src/comments/CommentList.js
@@ -103,6 +103,9 @@ const listStyles = theme => ({
         ...theme.typography.body1,
         flexGrow: 1,
     },
+    cardLinkLink: {
+        display: 'inline',
+    },
     cardActions: {
         justifyContent: 'flex-end',
     },
@@ -146,7 +149,10 @@ const CommentGrid = withStyles(listStyles)(
                                 reference="posts"
                                 basePath={basePath}
                             >
-                                <TextField source="title" />
+                                <TextField
+                                    source="title"
+                                    className={classes.cardLinkLink}
+                                />
                             </ReferenceField>
                         </CardContent>
                         <CardActions className={classes.cardActions}>

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import { ReferenceFieldController } from 'ra-core';
 
@@ -37,7 +38,10 @@ export const ReferenceFieldView = ({
         return (
             <Link to={resourceLinkPath} className={className}>
                 {React.cloneElement(children, {
-                    className: classes.link, // force color override for Typography components
+                    className: classnames(
+                        children.props.className,
+                        classes.link // force color override for Typography components
+                    ),
                     record: referenceRecord,
                     resource: reference,
                     allowEmpty,


### PR DESCRIPTION
The `className` specified on the child of a `ReferenceField` used to be overridden, which prevented a custom style.

```jsx
<ReferenceField source="post_id" reference="posts">
    <TextField source="title" className={classes.title} />
</ReferenceField>
```