### PR TITLE
[RFR] Warn About Outdated Material-UI version

### DIFF
--- a/packages/ra-ui-materialui/src/index.js
+++ b/packages/ra-ui-materialui/src/index.js
@@ -8,3 +8,7 @@ export * from './layout';
 export * from './list';
 export Link from './Link';
 export defaultTheme from './defaultTheme';
+
+import { warnForUnsupportedMuiVersion } from './warnings';
+
+warnForUnsupportedMuiVersion();

--- a/packages/ra-ui-materialui/src/warnings.js
+++ b/packages/ra-ui-materialui/src/warnings.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-console */
+import { ToggleButtons } from '@material-ui/core';
+
+// ToogleButtons was introduced on Material-UI 1.4.0
+// which is the minimum supported version of React Admin
+// https://github.com/mui-org/material-ui/releases/tag/v1.4.0
+const muiVersionIsSupported = !!ToggleButtons;
+
+export const warnForUnsupportedMuiVersion = () => {
+    if (process.env.NODE_ENV !== 'production' && !muiVersionIsSupported) {
+        console.error(
+            `Your version of @material-ui/core is not supported by ra-ui-materialui!
+            Please install @material-ui/core@^1.4.0 in order to avoid uncertain UI behaviors on production.
+            More infos at https://github.com/marmelab/react-admin/issues/1782`
+        );
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5332,7 +5332,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -5678,7 +5678,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -6950,7 +6950,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.17.10, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
@@ -9018,7 +9018,7 @@ react-jss@^8.1.0:
     prop-types "^15.6.0"
     theming "^1.3.0"
 
-react-lifecycles-compat@^3.0.2:
+react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -9351,14 +9351,14 @@ redux-form@~7.4.0:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.4.2.tgz#d6061088fb682eb9fc5fb9749bd8b102f03154b0"
   dependencies:
-    deep-equal "^1.0.1"
     es6-error "^4.1.1"
-    hoist-non-react-statics "^2.5.0"
-    invariant "^2.2.3"
+    hoist-non-react-statics "^2.5.4"
+    invariant "^2.2.4"
     is-promise "^2.1.0"
-    lodash "^4.17.5"
-    lodash-es "^4.17.5"
+    lodash "^4.17.10"
+    lodash-es "^4.17.10"
     prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
 
 redux-saga@~0.16.0:
   version "0.16.0"


### PR DESCRIPTION
Here is a small idea that I found to warn developers about the outdated Material-UI issue on production (#1782).

It can be added in addition to #2215. I've considered other alternatives like throwing an error at the build phase or read the `@material-ui/core/package.json` but it's the less intrusive method I found.

Here is the result on the console:

![image](https://user-images.githubusercontent.com/1819833/44682702-6394e300-aa44-11e8-9bc0-0a5526d1a3ec.png)
