### PR TITLE
[RFR] Expose ES modules in order to enable tree shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,26 +1,56 @@
 {
-    "presets": [
-        ["env", {
-            "targets": {
-                "browsers": ["last 2 versions"]
-            }
-        }],
-        "react"
-    ],
-    "plugins": [
-        "transform-react-jsx",
-        "add-module-exports",
-        ["babel-plugin-transform-builtin-extend", {
-            "globals": ["Error"]
-        }],
-        ["transform-runtime", {
-            "polyfill": false,
-            "regenerator": true
-        }],
-        "transform-class-properties",
-        "transform-object-rest-spread",
-        "transform-export-extensions",
-        "transform-async-to-generator",
-        "syntax-trailing-function-commas"
-    ]
+    "env": {
+        "cjs": {
+            "presets": [
+                ["env", {
+                    "targets": {
+                        "browsers": ["last 2 versions"]
+                    }
+                }],
+                "react"
+            ],
+            "plugins": [
+                "transform-react-jsx",
+                "add-module-exports",
+                ["babel-plugin-transform-builtin-extend", {
+                    "globals": ["Error"]
+                }],
+                ["transform-runtime", {
+                    "polyfill": false,
+                    "regenerator": true
+                }],
+                "transform-class-properties",
+                "transform-object-rest-spread",
+                "transform-export-extensions",
+                "transform-async-to-generator",
+                "syntax-trailing-function-commas"
+            ]
+        },
+        "esm": {
+            "presets": [
+                ["env", {
+                    "modules": false,
+                    "targets": {
+                        "browsers": ["last 2 versions"]
+                    }
+                }],
+                "react"
+            ],
+            "plugins": [
+                "transform-react-jsx",
+                ["babel-plugin-transform-builtin-extend", {
+                    "globals": ["Error"]
+                }],
+                ["transform-runtime", {
+                    "polyfill": false,
+                    "regenerator": true
+                }],
+                "transform-class-properties",
+                "transform-object-rest-spread",
+                "transform-export-extensions",
+                "transform-async-to-generator",
+                "syntax-trailing-function-commas"
+            ]
+        },
+    },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ yarn-error.log
 lerna-debug.log
 node_modules
 lib
+esm
 es6
 docs/_site/
 packages/react-admin/docs

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install: package.json ## install dependencies
 run: run-simple
 
 run-simple: ## run the simple example
-	@yarn -s run-simple
+	@BABEL_ENV=cjs yarn -s run-simple
 
 run-tutorial: ## run the tutorial example
 	@yarn -s run-tutorial
@@ -116,7 +116,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
-		cd examples/simple && yarn -s build; \
+		cd examples/simple && BABEL_ENV=cjs yarn -s build; \
 	fi
 
 	@NODE_ENV=test cd cypress && yarn -s test

--- a/Makefile
+++ b/Makefile
@@ -28,50 +28,50 @@ run-graphcool-demo: ## run the demo example
 
 build-ra-core:
 	@echo "Transpiling ra-core files...";
-	@cd ./packages/ra-core && yarn -s build
+	@cd ./packages/ra-core && yarn -s build && yarn -s build-esm
 
 build-ra-ui-materialui:
 	@echo "Transpiling ra-ui-materialui files...";
-	@cd ./packages/ra-ui-materialui && yarn -s build
+	@cd ./packages/ra-ui-materialui && yarn -s build && yarn -s build-esm
 
 build-react-admin:
 	@echo "Transpiling react-admin files...";
 	@rm -rf ./packages/react-admin/docs
-	@cd ./packages/react-admin && yarn -s build
+	@cd ./packages/react-admin && yarn -s build && yarn -s build-esm
 	@mkdir packages/react-admin/docs
 	@cp docs/*.md packages/react-admin/docs
 
 build-ra-data-fakerest:
 	@echo "Transpiling ra-data-fakerest files...";
-	@cd ./packages/ra-data-fakerest && yarn -s build
+	@cd ./packages/ra-data-fakerest && yarn -s build && yarn -s build-esm
 
 build-ra-data-json-server:
 	@echo "Transpiling ra-data-json-server files...";
-	@cd ./packages/ra-data-json-server && yarn -s build
+	@cd ./packages/ra-data-json-server && yarn -s build && yarn -s build-esm
 
 build-ra-data-simple-rest:
 	@echo "Transpiling ra-data-simple-rest files...";
-	@cd ./packages/ra-data-simple-rest && yarn -s build
+	@cd ./packages/ra-data-simple-rest && yarn -s build && yarn -s build-esm
 
 build-ra-data-graphql:
 	@echo "Transpiling ra-data-graphql files...";
-	@cd ./packages/ra-data-graphql && yarn -s build
+	@cd ./packages/ra-data-graphql && yarn -s build && yarn -s build-esm
 
 build-ra-data-graphcool:
 	@echo "Transpiling ra-data-graphcool files...";
-	@cd ./packages/ra-data-graphcool && yarn -s build
+	@cd ./packages/ra-data-graphcool && yarn -s build && yarn -s build-esm
 
 build-ra-data-graphql-simple:
 	@echo "Transpiling ra-data-graphql-simple files...";
-	@cd ./packages/ra-data-graphql-simple && yarn -s build
+	@cd ./packages/ra-data-graphql-simple && yarn -s build && yarn -s build-esm
 
 build-ra-input-rich-text:
 	@echo "Transpiling ra-input-rich-text files...";
-	@cd ./packages/ra-input-rich-text && yarn -s build
+	@cd ./packages/ra-input-rich-text && yarn -s build && yarn -s build-esm
 
 build-ra-realtime:
 	@echo "Transpiling ra-realtime files...";
-	@cd ./packages/ra-realtime && yarn -s build
+	@cd ./packages/ra-realtime && yarn -s build && yarn -s build-esm
 
 build-ra-tree-core:
 	@echo "Transpiling ra-tree-core files...";
@@ -83,7 +83,7 @@ build-ra-tree-ui-materialui:
 
 build-data-generator:
 	@echo "Transpiling data-generator files...";
-	@cd ./examples/data-generator && yarn -s build
+	@cd ./examples/data-generator && yarn -s build && yarn -s build-esm
 
 build: build-ra-core build-ra-ui-materialui build-react-admin build-ra-data-fakerest build-ra-data-json-server build-ra-data-simple-rest build-ra-data-graphql build-ra-data-graphcool build-ra-data-graphql-simple build-ra-input-rich-text build-ra-realtime build-ra-tree-core build-ra-tree-ui-materialui build-data-generator ## compile ES6 files to JS
 
@@ -116,7 +116,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
-		cd examples/simple && yarn -s build; \
+		cd examples/simple && yarn -s build && yarn -s build-esm; \
 	fi
 
 	@NODE_ENV=test cd cypress && yarn -s test

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ build-ra-realtime:
 
 build-ra-tree-core:
 	@echo "Transpiling ra-tree-core files...";
-	@cd ./packages/ra-tree-core && yarn -s build
+	@cd ./packages/ra-tree-core && yarn -s build && yarn -s build-esm
 
 build-ra-tree-ui-materialui:
 	@echo "Transpiling ra-tree-ui-materialui files...";
-	@cd ./packages/ra-tree-ui-materialui && yarn -s build
+	@cd ./packages/ra-tree-ui-materialui && yarn -s build && yarn -s build-esm
 
 build-data-generator:
 	@echo "Transpiling data-generator files...";

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
-		cd examples/simple && yarn -s build && yarn -s build-esm; \
+		cd examples/simple && yarn -s build; \
 	fi
 
 	@NODE_ENV=test cd cypress && yarn -s test

--- a/examples/data-generator/package.json
+++ b/examples/data-generator/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "main": "./lib/index.js",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/examples/simple/webpack.config.js
+++ b/examples/simple/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-core',
-                'src'
+                'lib'
             ),
             'ra-ui-materialui': path.join(
                 __dirname,
@@ -40,7 +40,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-ui-materialui',
-                'src'
+                'lib'
             ),
             'react-admin': path.join(
                 __dirname,
@@ -48,7 +48,7 @@ module.exports = {
                 '..',
                 'packages',
                 'react-admin',
-                'src'
+                'lib'
             ),
             'ra-data-fakerest': path.join(
                 __dirname,
@@ -56,7 +56,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-data-fakerest',
-                'src'
+                'lib'
             ),
             'ra-input-rich-text': path.join(
                 __dirname,
@@ -64,7 +64,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-input-rich-text',
-                'src'
+                'lib'
             ),
             'ra-tree-core': path.join(
                 __dirname,
@@ -72,7 +72,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-tree-core',
-                'src'
+                'lib'
             ),
             'ra-tree-ui-materialui': path.join(
                 __dirname,
@@ -80,7 +80,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-tree-ui-materialui',
-                'src'
+                'lib'
             ),
             'ra-tree-language-english': path.join(
                 __dirname,

--- a/examples/simple/webpack.config.js
+++ b/examples/simple/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-core',
-                'lib'
+                'src'
             ),
             'ra-ui-materialui': path.join(
                 __dirname,
@@ -40,7 +40,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-ui-materialui',
-                'lib'
+                'src'
             ),
             'react-admin': path.join(
                 __dirname,
@@ -48,7 +48,7 @@ module.exports = {
                 '..',
                 'packages',
                 'react-admin',
-                'lib'
+                'src'
             ),
             'ra-data-fakerest': path.join(
                 __dirname,
@@ -56,7 +56,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-data-fakerest',
-                'lib'
+                'src'
             ),
             'ra-input-rich-text': path.join(
                 __dirname,
@@ -64,7 +64,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-input-rich-text',
-                'lib'
+                'src'
             ),
             'ra-tree-core': path.join(
                 __dirname,
@@ -72,7 +72,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-tree-core',
-                'lib'
+                'src'
             ),
             'ra-tree-ui-materialui': path.join(
                 __dirname,
@@ -80,7 +80,7 @@ module.exports = {
                 '..',
                 'packages',
                 'ra-tree-ui-materialui',
-                'lib'
+                'src'
             ),
             'ra-tree-language-english': path.join(
                 __dirname,

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "scripts": {
         "build": "lerna run build",
         "build-demo": "cd examples/demo && cross-env REACT_APP_DATA_PROVIDER=rest yarn -s build",
-        "test-unit": "cross-env NODE_ENV=test cross-env NODE_ICU_DATA=node_modules/full-icu jest",
-        "test-unit-ci": "cross-env NODE_ENV=test cross-env NODE_ICU_DATA=node_modules/full-icu jest --runInBand",
+        "test-unit": "cross-env NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=node_modules/full-icu jest",
+        "test-unit-ci": "cross-env NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=node_modules/full-icu jest --runInBand",
         "test-e2e": "yarn run -s build && cross-env NODE_ENV=test && cd cypress && yarn -s test",
         "test-e2e-local": "cd cypress && yarn -s start",
         "test": "yarn -s test-unit && yarn -s test-e2e",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -5,6 +5,7 @@
     "files": [
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "main": "lib/index",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -8,6 +8,7 @@
         "src"
     ],
     "main": "lib/index",
+    "module": "esm/index.js",
     "authors": [
         "François Zaninotto",
         "Gildas Garcia"
@@ -17,7 +18,8 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "devDependencies": {

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -9,6 +9,7 @@
     ],
     "main": "lib/index",
     "module": "esm/index.js",
+    "sideEffects": false,
     "authors": [
         "François Zaninotto",
         "Gildas Garcia"

--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -9,6 +9,7 @@
         "LICENSE",
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "repository": {

--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -4,6 +4,7 @@
     "description": "JSON Server data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "files": [
         "LICENSE",
         "*.md",

--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -3,6 +3,7 @@
     "version": "2.2.1",
     "description": "JSON Server data provider for react-admin",
     "main": "lib/index.js",
+    "module": "esm/index.js",
     "files": [
         "LICENSE",
         "*.md",
@@ -28,7 +29,8 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphcool/package.json
+++ b/packages/ra-data-graphcool/package.json
@@ -4,6 +4,7 @@
     "description": "A Graphcool data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"

--- a/packages/ra-data-graphcool/package.json
+++ b/packages/ra-data-graphcool/package.json
@@ -2,7 +2,8 @@
     "name": "ra-data-graphcool",
     "version": "2.2.3",
     "description": "A Graphcool data provider for react-admin",
-    "main": "./lib/index.js",
+    "main": "lib/index.js",
+    "module": "esm/index.js",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"
@@ -25,7 +26,8 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -2,7 +2,8 @@
     "name": "ra-data-graphql-simple",
     "version": "2.2.3",
     "description": "A GraphQL simple data provider for react-admin",
-    "main": "./lib/index.js",
+    "main": "lib/index.js",
+    "module": "esm/index.js",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"
@@ -24,7 +25,8 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -4,6 +4,7 @@
     "description": "A GraphQL simple data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"

--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -2,7 +2,8 @@
     "name": "ra-data-graphql",
     "version": "2.2.3",
     "description": "A GraphQL data provider for react-admin",
-    "main": "./lib/index.js",
+    "main": "lib/index.js",
+    "module": "esm/index.js",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"
@@ -24,7 +25,8 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -4,6 +4,7 @@
     "description": "A GraphQL data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -4,6 +4,7 @@
     "description": "JSON Server data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "files": [
         "*.md",
         "lib",

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -8,6 +8,7 @@
     "files": [
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "authors": [

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -3,6 +3,7 @@
     "version": "2.2.3",
     "description": "JSON Server data provider for react-admin",
     "main": "lib/index.js",
+    "module": "esm/index.js",
     "files": [
         "*.md",
         "lib",
@@ -16,7 +17,8 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-simple-rest/package.json
+++ b/packages/ra-data-simple-rest/package.json
@@ -3,6 +3,7 @@
     "version": "2.2.3",
     "description": "Simple REST data provider for react-admin",
     "main": "lib/index.js",
+    "module": "esm/index.js",
     "files": [
         "*.md",
         "lib",
@@ -16,7 +17,8 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-simple-rest/package.json
+++ b/packages/ra-data-simple-rest/package.json
@@ -8,6 +8,7 @@
     "files": [
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "authors": [

--- a/packages/ra-data-simple-rest/package.json
+++ b/packages/ra-data-simple-rest/package.json
@@ -4,6 +4,7 @@
     "description": "Simple REST data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "files": [
         "*.md",
         "lib",

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -3,6 +3,7 @@
     "version": "2.2.1",
     "description": "<RichTextInput> component for react-admin, useful for editing HTML code in admin GUIs.",
     "main": "lib/index.js",
+    "module": "esm/index.js",
     "files": [
         "LICENSE",
         "*.md",
@@ -31,7 +32,8 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -9,6 +9,7 @@
         "LICENSE",
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "repository": {

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -4,6 +4,7 @@
     "description": "<RichTextInput> component for react-admin, useful for editing HTML code in admin GUIs.",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "files": [
         "LICENSE",
         "*.md",

--- a/packages/ra-realtime/package.json
+++ b/packages/ra-realtime/package.json
@@ -4,6 +4,7 @@
     "description": "A saga enabling realtime updates for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"

--- a/packages/ra-realtime/package.json
+++ b/packages/ra-realtime/package.json
@@ -2,7 +2,8 @@
     "name": "ra-realtime",
     "version": "2.2.3",
     "description": "A saga enabling realtime updates for react-admin",
-    "main": "./lib/index.js",
+    "main": "lib/index.js",
+    "module": "esm/index.js",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"
@@ -24,7 +25,8 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-tree-core/package.json
+++ b/packages/ra-tree-core/package.json
@@ -32,7 +32,7 @@
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
         "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-tree-core/package.json
+++ b/packages/ra-tree-core/package.json
@@ -9,6 +9,7 @@
         "LICENSE",
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "repository": {

--- a/packages/ra-tree-core/package.json
+++ b/packages/ra-tree-core/package.json
@@ -3,6 +3,8 @@
     "version": "1.1.2",
     "description": "A treeview component without ui to use with react-admin",
     "main": "lib/index.js",
+    "module": "esm/index.js",
+    "sideEffects": false,
     "files": [
         "LICENSE",
         "*.md",
@@ -28,7 +30,8 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-tree-ui-materialui/package.json
+++ b/packages/ra-tree-ui-materialui/package.json
@@ -32,7 +32,7 @@
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
         "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-tree-ui-materialui/package.json
+++ b/packages/ra-tree-ui-materialui/package.json
@@ -9,6 +9,7 @@
         "LICENSE",
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "repository": {

--- a/packages/ra-tree-ui-materialui/package.json
+++ b/packages/ra-tree-ui-materialui/package.json
@@ -3,6 +3,8 @@
     "version": "1.1.2",
     "description": "A treeview component with material-ui to use with react-admin",
     "main": "lib/index.js",
+    "module": "esm/index.js",
+    "sideEffects": false,
     "files": [
         "LICENSE",
         "*.md",
@@ -28,7 +30,8 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -5,6 +5,7 @@
     "files": [
         "*.md",
         "lib",
+        "esm",
         "src"
     ],
     "main": "lib/index",

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -8,6 +8,7 @@
         "src"
     ],
     "main": "lib/index",
+    "module": "esm/index.js",
     "authors": [
         "François Zaninotto",
         "Gildas Garcia"
@@ -17,7 +18,8 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "devDependencies": {

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -9,6 +9,7 @@
     ],
     "main": "lib/index",
     "module": "esm/index.js",
+    "sideEffects": false,
     "authors": [
         "François Zaninotto",
         "Gildas Garcia"

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -10,6 +10,7 @@
     ],
     "main": "lib/index.js",
     "module": "esm/index.js",
+    "sideEffects": false,
     "authors": [
         "François Zaninotto"
     ],

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -8,7 +8,8 @@
         "src",
         "docs"
     ],
-    "main": "lib/index",
+    "main": "lib/index.js",
+    "module": "esm/index.js",
     "authors": [
         "François Zaninotto"
     ],
@@ -17,7 +18,8 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "devDependencies": {

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -5,6 +5,7 @@
     "files": [
         "*.md",
         "lib",
+        "esm",
         "src",
         "docs"
     ],


### PR DESCRIPTION
Fixes #2204 

## Rationale

As explained in #2204, the goal of this PR is to expose ES modules from the `react-admin` packages in order to enable the usage of Tree Shaking by webpack.

To do so, I take the following measures:

- The assets are now transpiled twice, once in `lib/` for **CommonJS** and once in `esm/` for **ES Modules** (thanks to the `BABEL_ENV` variable and the config in `.babelrc`)
- In all `package.json`, the `esm` folder is now included to the NPM package
- In all `package.json`, a new key `module` tells to consumers that ES modules are available at `esm/index.js`
- In all `package.json` again, the `sideEffects` is set to `false` telling that nothing is done at the import phase (useful to webpack for tree shaking)

## Benchmark

<details>
<summary>Tested codebase and configurations</summary>

- Default webpack configuration in `production` mode

- `index.js`

```jsx
// index.js
import React from 'react';
import ReactDOM from 'react-dom';
import { Admin, Resource, List, Datagrid, TextField } from 'react-admin';
import jsonServerProvider from 'ra-data-json-server';

export const testSomething = () => { console.log('not used'); };

export const PostList = (props) => (
    <List {...props}>
        <Datagrid>
            <TextField source="id" />
            <TextField source="title" />
            <TextField source="body" />
        </Datagrid>
    </List>
);

const dataProvider = jsonServerProvider('http://jsonplaceholder.typicode.com');
const App = () => (
    <Admin dataProvider={dataProvider}>
        <Resource name="posts" list={PostList} />
    </Admin>
);

ReactDOM.render(<App />, document.getElementById('root'))
```

- `.babelrc`

```json
{
    "presets": [
        ["env", { "loose": true, "modules": false }],
        "react"
    ],
    "plugins": [
        "transform-react-jsx",
        "add-module-exports",
        [
            "babel-plugin-transform-builtin-extend",
            {
                "globals": [
                    "Error"
                ]
            }
        ],
        [
            "transform-runtime",
            {
                "polyfill": false,
                "regenerator": true
            }
        ]
    ]
}

```

</details>

### React Admin 2.2.0

Total bundle size: 1.19 MB

![image](https://user-images.githubusercontent.com/1819833/45043896-cbfc4980-b06e-11e8-89ea-6949d501c050.png)

### Current Branch

Total bundle size: 840 KB

![image](https://user-images.githubusercontent.com/1819833/45043969-01a13280-b06f-11e8-8e0c-1207217212cd.png)


## Improvement ideas

- Instead of transpiling twice, we can only have `index.js` files that aren't not transpiled but refers to the common JS files.

## TODO
- [x] Expose ES modules into a separate folders `/esm`
- [x] Link the ES modules with the `module` field of each `package.json`
- [x] Ensure the tree shaking works
- [x] Fix / Add some tests