### PR TITLE
[RFR] Use Lock instead of LockOutline icon to be compatible with material-ui v1 and v3

### DIFF
--- a/examples/demo/src/Login.js
+++ b/examples/demo/src/Login.js
@@ -11,7 +11,7 @@ import CardActions from '@material-ui/core/CardActions';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import TextField from '@material-ui/core/TextField';
 import { withStyles } from '@material-ui/core/styles';
-import LockIcon from '@material-ui/icons/LockOutline';
+import LockIcon from '@material-ui/icons/Lock';
 
 import { Notification, translate, userLogin } from 'react-admin';
 

--- a/packages/ra-ui-materialui/src/auth/Login.js
+++ b/packages/ra-ui-materialui/src/auth/Login.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import Card from '@material-ui/core/Card';
 import Avatar from '@material-ui/core/Avatar';
 import { withStyles } from '@material-ui/core/styles';
-import LockIcon from '@material-ui/icons/LockOutline';
+import LockIcon from '@material-ui/icons/Lock';
 
 import defaultTheme from '../defaultTheme';
 import Notification from '../layout/Notification';


### PR DESCRIPTION
![screen](http://pix.toile-libre.org/upload/original/1535462426.png)