### PR TITLE
[RFR] fix ReferenceArrayInputController error on undefined record

### DIFF
--- a/packages/ra-core/src/controller/input/ReferenceArrayInputController.js
+++ b/packages/ra-core/src/controller/input/ReferenceArrayInputController.js
@@ -114,7 +114,7 @@ export class ReferenceArrayInputController extends Component {
     componentWillReceiveProps(nextProps) {
         let shouldFetchOptions = false;
 
-        if (this.props.record.id !== nextProps.record.id) {
+        if ((this.props.record || {}).id !== (nextProps.record || {}).id) {
             this.fetchReferencesAndOptions(nextProps);
         } else if (this.props.input.value !== nextProps.input.value) {
             this.fetchReferences(nextProps);


### PR DESCRIPTION
ReferenceArrayInputController will make error in componentWillReceiveProps if record does not exist's

happens sometimes on initial render

fixed same way as in ReferenceInputController