### PR TITLE
[RFR] Fix wrong warning on FormDataConsumer

### DIFF
--- a/packages/ra-core/src/form/FormDataConsumer.js
+++ b/packages/ra-core/src/form/FormDataConsumer.js
@@ -75,18 +75,22 @@ const FormDataConsumer = ({ children, formData, source, index, ...rest }) => {
     let scopedFormData = formData;
     let getSource;
     let getSourceHasBeenCalled = false;
+    let ret;
 
     // If we have an index, we are in an iterator like component (such as the SimpleFormIterator)
-    if (index) {
+    if (typeof index !== 'undefined') {
         scopedFormData = get(formData, source);
         getSource = scopedSource => {
             getSourceHasBeenCalled = true;
             return `${source}.${scopedSource}`;
         };
+        ret = children({ formData, scopedFormData, getSource, ...rest });
+    } else {
+        ret = children({ formData, ...rest });
     }
-    const ret = children({ formData, scopedFormData, getSource, ...rest });
 
     if (
+        typeof index !== 'undefined' &&
         ret &&
         !getSourceHasBeenCalled &&
         process.env.NODE_ENV !== 'production'

--- a/packages/ra-core/src/form/FormDataConsumer.js
+++ b/packages/ra-core/src/form/FormDataConsumer.js
@@ -71,7 +71,13 @@ const warnAboutArrayInput = () =>
  *     </Edit>
  * );
  */
-const FormDataConsumer = ({ children, formData, source, index, ...rest }) => {
+export const FormDataConsumer = ({
+    children,
+    formData,
+    source,
+    index,
+    ...rest
+}) => {
     let scopedFormData = formData;
     let getSource;
     let getSourceHasBeenCalled = false;

--- a/packages/ra-core/src/form/FormDataConsumer.spec.js
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { FormDataConsumer } from './FormDataConsumer';
+
+describe('FormDataConsumer', () => {
+    it('does not call its children function with scopedFormData and getSource if it did not receive an index prop', () => {
+        const children = jest.fn();
+        const formData = { id: 123, title: 'A title' };
+
+        shallow(
+            <FormDataConsumer formData={formData}>{children}</FormDataConsumer>
+        );
+
+        expect(children).toHaveBeenCalledWith({
+            formData,
+        });
+    });
+
+    it('calls its children function with scopedFormData and getSource if it received an index prop', () => {
+        const children = jest.fn(({ getSource }) => {
+            getSource('id');
+        });
+        const formData = { id: 123, title: 'A title', authors: [{ id: 0 }] };
+
+        shallow(
+            <FormDataConsumer source="authors[0]" index={0} formData={formData}>
+                {children}
+            </FormDataConsumer>
+        );
+
+        expect(children.mock.calls[0][0].formData).toEqual(formData);
+        expect(children.mock.calls[0][0].scopedFormData).toEqual({ id: 0 });
+        expect(children.mock.calls[0][0].getSource('id')).toEqual(
+            'authors[0].id'
+        );
+    });
+});


### PR DESCRIPTION
It should only be displayed when the `FormDataConsumer` is used inside an `ArrayInput`.

Also do not pass `ArrayInput` related props if not needed