### PR TITLE
[RFR] GraphQL providers enhancements

### DIFF
--- a/examples/graphcool-demo/src/commands/Basket.js
+++ b/examples/graphcool-demo/src/commands/Basket.js
@@ -22,6 +22,7 @@ class Basket extends Component {
     componentDidMount() {
         this.fetchData();
     }
+
     fetchData() {
         const {
             record: { basket },
@@ -32,6 +33,7 @@ class Basket extends Component {
     render() {
         const { classes, record, products, translate } = this.props;
         const { basket } = record;
+
         return (
             <Paper className={classes.container}>
                 <Table>
@@ -62,6 +64,7 @@ class Basket extends Component {
                     <TableBody>
                         {basket.map(
                             item =>
+                                item.product &&
                                 products[item.product.id] && (
                                     <TableRow key={item.product.id}>
                                         <TableCell>
@@ -176,7 +179,9 @@ const mapStateToProps = (state, props) => {
     const {
         record: { basket },
     } = props;
-    const productIds = basket.map(item => item.product.id);
+    const productIds = basket
+        .map(item => item.product && item.product.id)
+        .filter(item => !!item);
     return {
         products: productIds
             .map(productId => state.admin.resources.Product.data[productId])

--- a/packages/ra-data-graphcool/README.md
+++ b/packages/ra-data-graphcool/README.md
@@ -87,6 +87,41 @@ Or supply your client directly with:
 buildGraphcoolProvider({ client: myClient });
 ```
 
+### Overriding a specific query
+
+The default behavior might not be optimized especially when dealing with references. You can override a specific query by wrapping the `buildQuery` function:
+
+```js
+// in src/dataProvider.js
+import buildGraphcoolProvider, { buildQuery } from 'ra-data-graphcool';
+
+const overrideBuildQuery = buildQuery => (fetchType, resource, params) => {
+    const builtQuery = buildQuery(fetchType, resource, params);
+
+    if (resource === 'Command' && fetchType === 'GET_ONE') {
+        return {
+            // Use the default query variables and parseResponse
+            ...buildQuery,
+            // Override the query
+            query: gql`
+                query Command($id: ID!) {
+                    data: Command(id: $id) {
+                        id
+                        reference
+                        customer {
+                            id
+                            firstName
+                            lastName
+                        }
+                    }
+                }`,
+        };
+    }
+
+    return builtQuery;
+}
+```
+
 ### Customize the introspection
 
 These are the default options for introspection:

--- a/packages/ra-data-graphcool/README.md
+++ b/packages/ra-data-graphcool/README.md
@@ -95,13 +95,13 @@ The default behavior might not be optimized especially when dealing with referen
 // in src/dataProvider.js
 import buildGraphcoolProvider, { buildQuery } from 'ra-data-graphcool';
 
-const overrideBuildQuery = buildQuery => (fetchType, resource, params) => {
-    const builtQuery = buildQuery(fetchType, resource, params);
+const myBuildQuery = introspection => (fetchType, resource, params) => {
+    const builtQuery = buildQuery(introspection)(fetchType, resource, params);
 
     if (resource === 'Command' && fetchType === 'GET_ONE') {
         return {
             // Use the default query variables and parseResponse
-            ...buildQuery,
+            ...builtQuery,
             // Override the query
             query: gql`
                 query Command($id: ID!) {
@@ -120,6 +120,8 @@ const overrideBuildQuery = buildQuery => (fetchType, resource, params) => {
 
     return builtQuery;
 }
+
+export default buildGraphcoolProvider({ buildQuery: myBuildQuery })
 ```
 
 ### Customize the introspection

--- a/packages/ra-data-graphcool/src/index.js
+++ b/packages/ra-data-graphcool/src/index.js
@@ -2,11 +2,13 @@ import merge from 'lodash/merge';
 import buildDataProvider from 'ra-data-graphql';
 import { DELETE, DELETE_MANY, UPDATE, UPDATE_MANY } from 'react-admin';
 
-import buildQuery from './buildQuery';
+import defaultBuildQuery from './buildQuery';
 
 const defaultOptions = {
-    buildQuery,
+    buildQuery: defaultBuildQuery,
 };
+
+export const buildQuery = defaultBuildQuery;
 
 export default options => {
     return buildDataProvider(merge({}, defaultOptions, options)).then(

--- a/packages/ra-data-graphql-simple/README.md
+++ b/packages/ra-data-graphql-simple/README.md
@@ -133,6 +133,43 @@ Or supply your client directly with:
 buildGraphQLProvider({ client: myClient });
 ```
 
+### Overriding a specific query
+
+The default behavior might not be optimized especially when dealing with references. You can override a specific query by wrapping the `buildQuery` function:
+
+```js
+// in src/dataProvider.js
+import buildGraphqlProvider, { buildQuery } from 'ra-data-simple';
+
+const myBuildQuery = introspection => (fetchType, resource, params) => {
+    const builtQuery = buildQuery(introspection)(fetchType, resource, params);
+
+    if (resource === 'Command' && fetchType === 'GET_ONE') {
+        return {
+            // Use the default query variables and parseResponse
+            ...builtQuery,
+            // Override the query
+            query: gql`
+                query Command($id: ID!) {
+                    data: Command(id: $id) {
+                        id
+                        reference
+                        customer {
+                            id
+                            firstName
+                            lastName
+                        }
+                    }
+                }`,
+        };
+    }
+
+    return builtQuery;
+}
+
+export default buildGraphqlProvider({ buildQuery: myBuildQuery })
+```
+
 ### Customize the introspection
 
 These are the default options for introspection:

--- a/packages/ra-data-graphql-simple/src/index.js
+++ b/packages/ra-data-graphql-simple/src/index.js
@@ -2,10 +2,12 @@ import merge from 'lodash/merge';
 import buildDataProvider from 'ra-data-graphql';
 import { DELETE, DELETE_MANY, UPDATE, UPDATE_MANY } from 'react-admin';
 
-import buildQuery from './buildQuery';
+import defaultBuildQuery from './buildQuery';
 const defaultOptions = {
-    buildQuery,
+    buildQuery: defaultBuildQuery,
 };
+
+export const buildQuery = defaultBuildQuery;
 
 export default options => {
     return buildDataProvider(merge({}, defaultOptions, options)).then(

--- a/packages/ra-data-graphql/README.md
+++ b/packages/ra-data-graphql/README.md
@@ -16,7 +16,7 @@ It provides the foundations for other GraphQL data provider packages such as `ra
 This library is meant to be used with Apollo on the **client** side but
 you're free to use any graphql **server**.
 
-## How does it work ?
+## How does it work?
 
 In a nutshell, `ra-data-graphql` runs an *introspection query* on your GraphQL API and passes it to your adaptator, along with the *type of query* that is being made (`CREATE`, `UPDATE`, `GET_ONE`, `GET_LIST` etc..) and the *name of the resource* that is being queried.
 
@@ -110,17 +110,13 @@ buildGraphQLProvider({ client: myClient });
 
 ### Introspection Options
 
-Instead of running an IntrospectionQuery you can also provide the IntrospectionQuery result directly. This speeds up the initial rendering of the `Admin` component as it no longer has to wait for the introspection query request to resolve.
+Instead of running an introspection query you can also provide the introspection query result directly. This speeds up the initial rendering of the `Admin` component as it no longer has to wait for the introspection query request to resolve.
 
 ```jsx
 import { __schema as schema } from './schema';
 
-const introspectionOptions = {
-    schema
-};
-
 buildGraphQLProvider({
-    introspection: introspectionOptions
+    introspection: { schema }
 });
 ```
 
@@ -132,11 +128,12 @@ The `./schema` file is a `schema.json` in `./scr` retrieved with [`get-graphql-s
 
 For the provider to know how to map react-admin request to apollo queries and mutations, you must provide a `queryBuilder` option. The `queryBuilder` is a factory function which will be called with the introspection query result.
 
-The introspection result is an object with 3 properties:
+The introspection result is an object with 4 properties:
 
 - `types`: an array of all the GraphQL types discovered on your endpoint
 - `queries`: an array of all the GraphQL queries and mutations discovered on your endpoint
 - `resources`: an array of objects with a `type` property, which is the GraphQL type for this resource, and a property for each react-admin fetch verb for which we found a matching query or mutation
+- `schema`: the full schema
 
 For example:
 
@@ -184,7 +181,8 @@ For example:
             },
             ...
         }
-    ]
+    ],
+    schema: {} // Omitting for brevity
 }
 ```
 
@@ -223,7 +221,7 @@ buildGraphQLProvider({ queryBuilder });
 
 ## Troubleshooting
 
-*When I create or edit a resource, the list or edit page does not refresh its data*
+## When I create or edit a resource, the list or edit page does not refresh its data
 
 `react-admin` maintain its own cache of resources data but, by default, so does the Apollo client. For every queries, we inject a default [`fetchPolicy`](http://dev.apollodata.com/react/api-queries.html#graphql-config-options-fetchPolicy) set to `network-only` so that the Apollo client always refetch the data when requested.
 

--- a/packages/ra-data-graphql/src/index.js
+++ b/packages/ra-data-graphql/src/index.js
@@ -58,6 +58,12 @@ export default async options => {
         ...otherOptions
     } = merge({}, defaultOptions, options);
 
+    if (override && process.env.NODE_ENV === 'production') {
+        console.warn(
+            'The override option is deprecated. You should instead wrap the buildQuery function provided by the dataProvider you use.'
+        );
+    }
+
     const client = clientObject || buildApolloClient(clientOptions);
 
     let introspectionResults;

--- a/packages/ra-data-graphql/src/index.js
+++ b/packages/ra-data-graphql/src/index.js
@@ -59,7 +59,7 @@ export default async options => {
     } = merge({}, defaultOptions, options);
 
     if (override && process.env.NODE_ENV === 'production') {
-        console.warn(
+        console.warn( // eslint-disable-line
             'The override option is deprecated. You should instead wrap the buildQuery function provided by the dataProvider you use.'
         );
     }

--- a/packages/ra-data-graphql/src/introspection.js
+++ b/packages/ra-data-graphql/src/introspection.js
@@ -80,5 +80,6 @@ export default async (client, options) => {
         types,
         queries,
         resources,
+        schema,
     };
 };


### PR DESCRIPTION
Following #2243

- [x] Deprecate the `override` option
- [x] Exports the `buildQuery` function in dialect packages
- [x] Document how to wrap `buildQuery` to override specific queries