### PR TITLE
[RFR] Fix GraphQL demo

### DIFF
--- a/examples/data-generator/src/commands.js
+++ b/examples/data-generator/src/commands.js
@@ -9,7 +9,7 @@ import {
     weightedBoolean,
 } from './utils';
 
-export default db => {
+export default (db, { serializeDate }) => {
     const today = new Date();
     const aMonthAgo = subDays(today, 30);
 
@@ -47,7 +47,7 @@ export default db => {
         return {
             id,
             reference: random.alphaNumeric(6).toUpperCase(),
-            date: date,
+            date: serializeDate ? date.toISOString() : date,
             customer_id: customer.id,
             basket: basket,
             total_ex_taxes: total_ex_taxes,

--- a/examples/data-generator/src/customers.js
+++ b/examples/data-generator/src/customers.js
@@ -2,7 +2,7 @@ import { date, name, internet, address } from 'faker/locale/en';
 
 import { randomDate, weightedBoolean } from './utils';
 
-export default () =>
+export default (db, { serializeDate }) =>
     Array.from(Array(900).keys()).map(id => {
         const first_seen = randomDate();
         const last_seen = randomDate(first_seen);
@@ -10,6 +10,7 @@ export default () =>
         const first_name = name.firstName();
         const last_name = name.lastName();
         const email = internet.email(first_name, last_name);
+        const birthday = has_ordered ? date.past(60) : null;
         return {
             id,
             first_name,
@@ -19,11 +20,10 @@ export default () =>
             zipcode: has_ordered ? address.zipCode() : null,
             city: has_ordered ? address.city() : null,
             avatar: internet.avatar(),
-            birthday: has_ordered
-                ? date.past(60) - 15 * 365 * 24 * 3600 * 1000
-                : null,
-            first_seen: first_seen,
-            last_seen: last_seen,
+            birthday:
+                serializeDate && birthday ? birthday.toISOString() : birthday,
+            first_seen: serializeDate ? first_seen.toISOString() : first_seen,
+            last_seen: serializeDate ? last_seen.toISOString() : last_seen,
             has_ordered: has_ordered,
             latest_purchase: null, // finalize
             has_newsletter: has_ordered ? weightedBoolean(30) : true,

--- a/examples/data-generator/src/index.js
+++ b/examples/data-generator/src/index.js
@@ -5,13 +5,13 @@ import generateCommands from './commands';
 import generateReviews from './reviews';
 import finalize from './finalize';
 
-export default () => {
+export default (options = { serializeDate: true }) => {
     const db = {};
-    db.customers = generateCustomers(db);
-    db.categories = generateCategories(db);
-    db.products = generateProducts(db);
-    db.commands = generateCommands(db);
-    db.reviews = generateReviews(db);
+    db.customers = generateCustomers(db, options);
+    db.categories = generateCategories(db, options);
+    db.products = generateProducts(db, options);
+    db.commands = generateCommands(db, options);
+    db.reviews = generateReviews(db, options);
     finalize(db);
 
     return db;

--- a/examples/data-generator/src/reviews.js
+++ b/examples/data-generator/src/reviews.js
@@ -4,7 +4,7 @@ import isAfter from 'date-fns/is_after';
 
 import { randomDate, weightedArrayElement, weightedBoolean } from './utils';
 
-export default db => {
+export default (db, { serializeDate }) => {
     const today = new Date();
     const aMonthAgo = subDays(today, 30);
 
@@ -35,7 +35,7 @@ export default db => {
 
                         return {
                             id: id++,
-                            date: date,
+                            date: serializeDate ? date.toISOString() : date,
                             status: status,
                             command_id: command.id,
                             product_id: product.product_id,

--- a/examples/data-generator/src/utils.js
+++ b/examples/data-generator/src/utils.js
@@ -22,7 +22,7 @@ export const randomDate = (minDate, maxDate) => {
     const randomRange = faker.random.number({ max: range });
     // move it more towards today to account for traffic increase
     const ts = Math.sqrt(randomRange / range) * range;
-    return new Date(minTs + ts).toISOString();
+    return new Date(minTs + ts);
 };
 
 export const randomFloat = (min, max) =>

--- a/examples/demo/src/fakeServer/graphql.js
+++ b/examples/demo/src/fakeServer/graphql.js
@@ -3,7 +3,7 @@ import generateData from 'data-generator';
 import fetchMock from 'fetch-mock';
 
 export default () => {
-    const data = generateData();
+    const data = generateData({ serializeDate: false });
     const restServer = JsonGraphqlServer({ data });
     const handler = restServer.getHandler();
 


### PR DESCRIPTION
When we moved from `chance` to `faker`, the option used to specify whether to serialize dates was ignored and the GraphQL demo did not work anymore.