### PR TITLE
[RFR] Fix SaveButton misaligned CircularProgress

### DIFF
--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -15,7 +15,7 @@ const styles = {
         position: 'relative',
     },
     iconPaddingStyle: {
-        marginRight: '0.5em', // use margin instead of padding because rotating padding is bad, issue #2279
+        marginRight: '0.5em',
     },
 };
 

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -15,7 +15,7 @@ const styles = {
         position: 'relative',
     },
     iconPaddingStyle: {
-        paddingRight: '0.5em',
+        marginRight: '0.5em', // use margin instead of padding because rotating padding is bad, issue #2279
     },
 };
 


### PR DESCRIPTION
Fix SaveButton misaligned CircularProgress on saving (because of the icon's paddingRight)

before:
![before](https://user-images.githubusercontent.com/488136/45095066-61561700-b11d-11e8-84d9-b2555d053da4.gif)

after fix:
![after](https://user-images.githubusercontent.com/488136/45095945-a2e7c180-b11f-11e8-9ce8-c71c45156a58.gif)

