### PR TITLE
[WIP] Avoid to build twice in order to expose ESM

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,56 +1,39 @@
 {
-    "env": {
-        "cjs": {
-            "presets": [
-                ["env", {
-                    "targets": {
-                        "browsers": ["last 2 versions"]
-                    }
-                }],
-                "react"
-            ],
-            "plugins": [
-                "transform-react-jsx",
-                "add-module-exports",
-                ["babel-plugin-transform-builtin-extend", {
-                    "globals": ["Error"]
-                }],
-                ["transform-runtime", {
-                    "polyfill": false,
-                    "regenerator": true
-                }],
-                "transform-class-properties",
-                "transform-object-rest-spread",
-                "transform-export-extensions",
-                "transform-async-to-generator",
-                "syntax-trailing-function-commas"
-            ]
-        },
-        "esm": {
-            "presets": [
-                ["env", {
-                    "modules": false,
-                    "targets": {
-                        "browsers": ["last 2 versions"]
-                    }
-                }],
-                "react"
-            ],
-            "plugins": [
-                "transform-react-jsx",
-                ["babel-plugin-transform-builtin-extend", {
-                    "globals": ["Error"]
-                }],
-                ["transform-runtime", {
-                    "polyfill": false,
-                    "regenerator": true
-                }],
-                "transform-class-properties",
-                "transform-object-rest-spread",
-                "transform-export-extensions",
-                "transform-async-to-generator",
-                "syntax-trailing-function-commas"
-            ]
-        },
-    },
+    "presets": [
+        [
+            "env",
+            {
+                "targets": {
+                    "browsers": [
+                        "last 2 versions"
+                    ]
+                }
+            }
+        ],
+        "react"
+    ],
+    "plugins": [
+        "transform-react-jsx",
+        "add-module-exports",
+        [
+            "babel-plugin-transform-builtin-extend",
+            {
+                "globals": [
+                    "Error"
+                ]
+            }
+        ],
+        [
+            "transform-runtime",
+            {
+                "polyfill": false,
+                "regenerator": true
+            }
+        ],
+        "transform-class-properties",
+        "transform-object-rest-spread",
+        "transform-export-extensions",
+        "transform-async-to-generator",
+        "syntax-trailing-function-commas"
+    ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ yarn-error.log
 lerna-debug.log
 node_modules
 lib
-esm
 es6
 docs/_site/
 packages/react-admin/docs

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install: package.json ## install dependencies
 run: run-simple
 
 run-simple: ## run the simple example
-	@BABEL_ENV=cjs yarn -s run-simple
+	@yarn -s run-simple
 
 run-tutorial: ## run the tutorial example
 	@yarn -s run-tutorial
@@ -28,62 +28,62 @@ run-graphcool-demo: ## run the demo example
 
 build-ra-core:
 	@echo "Transpiling ra-core files...";
-	@cd ./packages/ra-core && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-core && yarn -s build
 
 build-ra-ui-materialui:
 	@echo "Transpiling ra-ui-materialui files...";
-	@cd ./packages/ra-ui-materialui && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-ui-materialui && yarn -s build
 
 build-react-admin:
 	@echo "Transpiling react-admin files...";
 	@rm -rf ./packages/react-admin/docs
-	@cd ./packages/react-admin && yarn -s build && yarn -s build-esm
+	@cd ./packages/react-admin && yarn -s build
 	@mkdir packages/react-admin/docs
 	@cp docs/*.md packages/react-admin/docs
 
 build-ra-data-fakerest:
 	@echo "Transpiling ra-data-fakerest files...";
-	@cd ./packages/ra-data-fakerest && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-data-fakerest && yarn -s build
 
 build-ra-data-json-server:
 	@echo "Transpiling ra-data-json-server files...";
-	@cd ./packages/ra-data-json-server && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-data-json-server && yarn -s build
 
 build-ra-data-simple-rest:
 	@echo "Transpiling ra-data-simple-rest files...";
-	@cd ./packages/ra-data-simple-rest && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-data-simple-rest && yarn -s build
 
 build-ra-data-graphql:
 	@echo "Transpiling ra-data-graphql files...";
-	@cd ./packages/ra-data-graphql && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-data-graphql && yarn -s build
 
 build-ra-data-graphcool:
 	@echo "Transpiling ra-data-graphcool files...";
-	@cd ./packages/ra-data-graphcool && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-data-graphcool && yarn -s build
 
 build-ra-data-graphql-simple:
 	@echo "Transpiling ra-data-graphql-simple files...";
-	@cd ./packages/ra-data-graphql-simple && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-data-graphql-simple && yarn -s build
 
 build-ra-input-rich-text:
 	@echo "Transpiling ra-input-rich-text files...";
-	@cd ./packages/ra-input-rich-text && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-input-rich-text && yarn -s build
 
 build-ra-realtime:
 	@echo "Transpiling ra-realtime files...";
-	@cd ./packages/ra-realtime && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-realtime && yarn -s build
 
 build-ra-tree-core:
 	@echo "Transpiling ra-tree-core files...";
-	@cd ./packages/ra-tree-core && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-tree-core && yarn -s build
 
 build-ra-tree-ui-materialui:
 	@echo "Transpiling ra-tree-ui-materialui files...";
-	@cd ./packages/ra-tree-ui-materialui && yarn -s build && yarn -s build-esm
+	@cd ./packages/ra-tree-ui-materialui && yarn -s build
 
 build-data-generator:
 	@echo "Transpiling data-generator files...";
-	@cd ./examples/data-generator && yarn -s build && yarn -s build-esm
+	@cd ./examples/data-generator && yarn -s build
 
 build: build-ra-core build-ra-ui-materialui build-react-admin build-ra-data-fakerest build-ra-data-json-server build-ra-data-simple-rest build-ra-data-graphql build-ra-data-graphcool build-ra-data-graphql-simple build-ra-input-rich-text build-ra-realtime build-ra-tree-core build-ra-tree-ui-materialui build-data-generator ## compile ES6 files to JS
 
@@ -116,7 +116,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
-		cd examples/simple && BABEL_ENV=cjs yarn -s build; \
+		cd examples/simple && yarn -s build; \
 	fi
 
 	@NODE_ENV=test cd cypress && yarn -s test

--- a/examples/data-generator/package.json
+++ b/examples/data-generator/package.json
@@ -4,8 +4,8 @@
     "private": true,
     "main": "./lib/index.js",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+    
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "scripts": {
         "build": "lerna run build",
         "build-demo": "cd examples/demo && cross-env REACT_APP_DATA_PROVIDER=rest yarn -s build",
-        "test-unit": "cross-env NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=node_modules/full-icu jest",
-        "test-unit-ci": "cross-env NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=node_modules/full-icu jest --runInBand",
+        "test-unit": "cross-env NODE_ENV=test cross-env NODE_ICU_DATA=node_modules/full-icu jest",
+        "test-unit-ci": "cross-env NODE_ENV=test cross-env NODE_ICU_DATA=node_modules/full-icu jest --runInBand",
         "test-e2e": "yarn run -s build && cross-env NODE_ENV=test && cd cypress && yarn -s test",
         "test-e2e-local": "cd cypress && yarn -s start",
         "test": "yarn -s test-unit && yarn -s test-e2e",

--- a/packages/ra-core/esm/index.js
+++ b/packages/ra-core/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-core/esm/index.js
+++ b/packages/ra-core/esm/index.js
@@ -1,1 +1,95 @@
-export * from '../lib';
+export * from '../lib/dataFetchActions';
+
+export * from '../lib/actions/accumulateActions';
+export * from '../lib/actions/authActions';
+export * from '../lib/actions/dataActions';
+export * from '../lib/actions/fetchActions';
+export * from '../lib/actions/filterActions';
+export * from '../lib/actions/formActions';
+export * from '../lib/actions/listActions';
+export * from '../lib/actions/localeActions';
+export * from '../lib/actions/notificationActions';
+export * from '../lib/actions/resourcesActions';
+export * from '../lib/actions/uiActions';
+export * from '../lib/actions/undoActions';
+
+export * from '../lib/auth/types';
+export Authenticated from '../lib/auth/Authenticated';
+export WithPermissions from '../lib/auth/WithPermissions';
+
+import {
+    getListControllerProps,
+    sanitizeListRestProps,
+} from '../lib/controller/ListController';
+export CreateController from '../lib/controller/CreateController';
+export EditController from '../lib/controller/EditController';
+export ListController from '../lib/controller/ListController';
+export ShowController from '../lib/controller/ShowController';
+export { getListControllerProps, sanitizeListRestProps };
+export ReferenceArrayFieldController from '../lib/controller/field/ReferenceArrayFieldController';
+export ReferenceFieldController from '../lib/controller/field/ReferenceFieldController';
+export ReferenceManyFieldController from '../lib/controller/field/ReferenceManyFieldController';
+export ReferenceArrayInputController from '../lib/controller/input/ReferenceArrayInputController';
+export ReferenceInputController from '../lib/controller/input/ReferenceInputController';
+
+export addField from '../lib/form/addField';
+export FormDataConsumer from '../lib/form/FormDataConsumer';
+export FormField, { isRequired } from '../lib/form/FormField';
+export getDefaultValues from '../lib/form/getDefaultValues';
+export withDefaultValue from '../lib/form/withDefaultValue';
+export * from '../lib/form/validate';
+export * from '../lib/form/constants';
+
+export { DEFAULT_LOCALE } from '../lib/i18n';
+export * from '../lib/i18n/TranslationUtils';
+export defaultI18nProvider from '../lib/i18n/defaultI18nProvider';
+export translate from '../lib/i18n/translate';
+export TranslationProvider from '../lib/i18n/TranslationProvider';
+
+export createAppReducer, {
+    getResources,
+    getReferenceResource,
+    getLocale,
+    getNotification,
+    getPossibleReferences,
+    getPossibleReferenceValues,
+} from '../lib/reducer';
+export adminReducer from '../lib/reducer/admin';
+export i18nReducer from '../lib/reducer/i18n';
+export queryReducer from '../lib/reducer/admin/resource/list/queryReducer';
+
+export adminSaga from '../lib/sideEffect/admin';
+export authSaga from '../lib/sideEffect/auth';
+export callbackSaga from '../lib/sideEffect/callback';
+export fetchSaga from '../lib/sideEffect/fetch';
+export errorSaga from '../lib/sideEffect/error';
+export notificationSaga from '../lib/sideEffect/notification';
+export redirectionSaga from '../lib/sideEffect/redirection';
+export accumulateSaga from '../lib/sideEffect/accumulate';
+export refreshSaga from '../lib/sideEffect/refresh';
+export i18nSaga from '../lib/sideEffect/i18n';
+export undoSaga from '../lib/sideEffect/undo';
+export recordForm from '../lib/sideEffect/recordForm';
+
+export * as fetchUtils from '../lib/util/fetch';
+export downloadCSV from '../lib/util/downloadCSV';
+export FieldTitle from '../lib/util/FieldTitle';
+export getFetchedAt from '../lib/util/getFetchedAt';
+export HttpError from '../lib/util/HttpError';
+export linkToRecord from '../lib/util/linkToRecord';
+export removeEmpty from '../lib/util/removeEmpty';
+export removeKey from '../lib/util/removeKey';
+export resolveRedirectTo from '../lib/util/resolveRedirectTo';
+
+export {
+    getIds,
+    getReferences,
+    getReferencesByIds,
+    nameRelatedTo,
+} from '../lib/reducer/admin/references/oneToMany';
+
+export CoreAdmin from '../lib/CoreAdmin';
+export CoreAdminRouter from '../lib/CoreAdminRouter';
+export createAdminStore from '../lib/createAdminStore';
+export RoutesWithLayout from '../lib/RoutesWithLayout';
+export Resource from '../lib/Resource';

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -20,8 +20,7 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "devDependencies": {

--- a/packages/ra-data-fakerest/esm/index.js
+++ b/packages/ra-data-fakerest/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -31,8 +31,7 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphcool/esm/index.js
+++ b/packages/ra-data-graphcool/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-data-graphcool/package.json
+++ b/packages/ra-data-graphcool/package.json
@@ -27,8 +27,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphql-simple/esm/index.js
+++ b/packages/ra-data-graphql-simple/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -26,8 +26,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-graphql/esm/index.js
+++ b/packages/ra-data-graphql/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -26,8 +26,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-json-server/esm/index.js
+++ b/packages/ra-data-json-server/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -19,8 +19,7 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-data-simple-rest/esm/index.js
+++ b/packages/ra-data-simple-rest/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-data-simple-rest/package.json
+++ b/packages/ra-data-simple-rest/package.json
@@ -19,8 +19,7 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-input-rich-text/esm/index.js
+++ b/packages/ra-input-rich-text/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -34,8 +34,7 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-realtime/esm/index.js
+++ b/packages/ra-realtime/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-realtime/package.json
+++ b/packages/ra-realtime/package.json
@@ -26,8 +26,8 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
+    
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "dependencies": {

--- a/packages/ra-tree-core/esm/index.js
+++ b/packages/ra-tree-core/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-tree-core/package.json
+++ b/packages/ra-tree-core/package.json
@@ -31,8 +31,7 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-tree-ui-materialui/esm/index.js
+++ b/packages/ra-tree-ui-materialui/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-tree-ui-materialui/package.json
+++ b/packages/ra-tree-ui-materialui/package.json
@@ -31,8 +31,7 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "peerDependencies": {

--- a/packages/ra-ui-materialui/esm/index.js
+++ b/packages/ra-ui-materialui/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -20,8 +20,7 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "devDependencies": {

--- a/packages/react-admin/esm/index.js
+++ b/packages/react-admin/esm/index.js
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -20,8 +20,7 @@
     "bugs": "https://github.com/marmelab/react-admin/issues",
     "license": "MIT",
     "scripts": {
-        "build": "rimraf ./lib && cross-env NODE_ENV=production BABEL_ENV=cjs babel --quiet ./src -d ./lib --ignore spec.js,test.js",
-        "build-esm": "rimraf ./esm && cross-env NODE_ENV=production BABEL_ENV=esm babel --quiet ./src -d ./esm --ignore spec.js,test.js",
+        "build": "rimraf ./lib && cross-env NODE_ENV=production babel --quiet ./src -d ./lib --ignore spec.js,test.js",
         "watch": "rimraf ./lib && cross-env NODE_ENV=production babel --watch ./src -d ./lib --ignore spec.js,test.js"
     },
     "devDependencies": {


### PR DESCRIPTION
Exposing ESM is good for library consumers and performance.
But building twice the entire libary and multiplying the codebase in the node module is not the best solution to do so.

The goal of this PR is to manually importing the right modules in order to have only imports and exports in the `esm` folder for the same result.

## TODO
- [x] Remove the dedicated process for building ESM packages
- [ ] For each package, fill the `esm` folder with proper imports
- [ ] Find a way to test these ESM folder