### PR TITLE
[RFR] Make UserMenu override more idiomatic

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -386,28 +386,28 @@ const MyLayout = props => <Layout
 export default MyLayout;
 ```
 
-You can add custom menu items to the default `AppBar` user menu by adding children to it:
+You can replace the default user menu by your own by setting the `userMenu` prop of the `<AppBar>` component. For instance, to add custom menu items, just decorate the default `<UserMenu>` by adding children to it:
 
 ```js
-import { AppBar, MenuItemLink } from 'react-admin';
+import { AppBar, UserMenu, MenuItemLink } from 'react-admin';
 import SettingsIcon from '@material-ui/icons/Settings';
 
-const MyAppBar = props => (
-    <AppBar {...props}>
+const MyUserMenu = props => (
+    <UserMenu {...props}>
         <MenuItemLink
             to="/configuration"
             primaryText="Configuration"
             leftIcon={<SettingsIcon />}
         />
-    </AppBar>
+    </UserMenu>
 );
-const MyLayout = props => <Layout
-    {...props}
-    appBar={MyAppBar}
-/>;
+
+const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
+
+const MyLayout = props => <Layout {...props} appBar={MyAppBar} />;
 ```
 
-You can speciy the `Sidebar` size by setting the `size` property:
+You can specify the `Sidebar` size by setting the `size` property:
 
 ```jsx
 import { Sidebar } from 'react-admin';

--- a/examples/demo/src/AppBar.js
+++ b/examples/demo/src/AppBar.js
@@ -1,15 +1,19 @@
 import React from 'react';
-import { AppBar, MenuItemLink, translate } from 'react-admin';
+import { AppBar, UserMenu, MenuItemLink, translate } from 'react-admin';
 import SettingsIcon from '@material-ui/icons/Settings';
 
-const CustomAppBar = ({ translate, ...props }) => (
-    <AppBar {...props}>
+const CustomUserMenu = translate(({ translate, ...props }) => (
+    <UserMenu {...props}>
         <MenuItemLink
             to="/configuration"
             primaryText={translate('pos.configuration')}
             leftIcon={<SettingsIcon />}
         />
-    </AppBar>
+    </UserMenu>
+));
+
+const CustomAppBar = props => (
+    <AppBar {...props} userMenu={<CustomUserMenu />} />
 );
 
-export default translate(CustomAppBar);
+export default CustomAppBar;

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -54,6 +54,7 @@ const AppBar = ({
     open,
     title,
     toggleSidebar,
+    userMenu,
     width,
     ...rest
 }) => (
@@ -90,7 +91,7 @@ const AppBar = ({
                     id="react-admin-title"
                 />
                 <LoadingIndicator />
-                {logout && <UserMenu logout={logout}>{children}</UserMenu>}
+                {cloneElement(userMenu, { logout })}
             </Toolbar>
         </MuiAppBar>
     </Headroom>
@@ -105,7 +106,12 @@ AppBar.propTypes = {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
         .isRequired,
     toggleSidebar: PropTypes.func.isRequired,
+    userMenu: PropTypes.node,
     width: PropTypes.string,
+};
+
+AppBar.defaultProps = {
+    userMenu: <UserMenu />,
 };
 
 const enhance = compose(

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -37,6 +37,7 @@ class UserMenu extends React.Component {
 
     render() {
         const { children, label, logout, translate } = this.props;
+        if (!logout && !children) return null;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
 


### PR DESCRIPTION
The previous way of adding items to the user menu didn't allow to replace the user menu (e.g. to customize the user icon). Now it's possible.

Developers can replace the default user menu by their own by setting the `userMenu` prop of the `<AppBar>` component. For instance, to add custom menu items, just decorate the default `<UserMenu>` by adding children to it:

```js
import { AppBar, UserMenu, MenuItemLink } from 'react-admin';
import SettingsIcon from '@material-ui/icons/Settings';

const MyUserMenu = props => (
    <UserMenu {...props}>
        <MenuItemLink
            to="/configuration"
            primaryText="Configuration"
            leftIcon={<SettingsIcon />}
        />
    </UserMenu>
);

const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;

const MyLayout = props => <Layout {...props} appBar={MyAppBar} />;
```

It's a bit more indirect, but a lot more powerful.