### PR TITLE
[RFR] Remove AOR Data Providers From The Doc

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -42,14 +42,6 @@ The react-admin project includes 4 Data Providers:
 
 You can find Data Providers for various backends in third-party repositories:
 
-* **[DynamoDb](https://github.com/abiglobalhealth/aor-dynamodb-client)**: [abiglobalhealth/aor-dynamodb-client](https://github.com/abiglobalhealth/aor-dynamodb-client)
-* **[Epilogue](https://github.com/dchester/epilogue)**: [dunghuynh/aor-epilogue-client](https://github.com/dunghuynh/aor-epilogue-client)
-* **[Feathersjs](http://www.feathersjs.com/)**: [josx/aor-feathers-client](https://github.com/josx/aor-feathers-client)
-* **[Firebase](https://firebase.google.com/)**: [sidferreira/aor-firebase-client](https://github.com/sidferreira/aor-firebase-client)
-* **[JSON API](http://jsonapi.org/)**: [moonlight-labs/aor-jsonapi-client](https://github.com/moonlight-labs/aor-jsonapi-client)
-* **[Loopback](http://loopback.io/)**: [kimkha/aor-loopback](https://github.com/kimkha/aor-loopback)
-* **[Parse Server](https://github.com/ParsePlatform/parse-server)**: [leperone/aor-parseserver-client](https://github.com/leperone/aor-parseserver-client)
-* **[PostgREST](http://postgrest.com/en/v0.4/)**: [tomberek/aor-postgrest-client](https://github.com/tomberek/aor-postgrest-client)
 * **[Prisma](https://github.com/weakky/ra-data-prisma)**: [weakky/ra-data-prisma](https://github.com/weakky/ra-data-prisma)
 * **[Xmysql](https://github.com/o1lab/xmysql)**: [soaserele/aor-xmysql](https://github.com/soaserele/aor-xmysql)
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -51,7 +51,7 @@ If you've written a Data Provider for another backend, and open-sourced it, plea
 
 ### Legacy Data Providers
 
-Before the version 2, react-admin was called [admin-on-rest](/admin-on-rest) (AOR), the community was as active as it is now, and several Data Providers was published yet.
+Before the version 2, react-admin was called [admin-on-rest](/admin-on-rest) (AOR), the community was as active as it is now, and several Data Providers were published then.
 
 Due to the breaking changes, the following providers are no longer working with the current react-admin implementation:
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -49,6 +49,21 @@ You can find Data Providers for various backends in third-party repositories:
 
 If you've written a Data Provider for another backend, and open-sourced it, please help complete this list with your package.
 
+### Legacy Data Providers
+
+Before the version 2, react-admin was called [admin-on-rest](/admin-on-rest) (AOR) and the community was as active as it is now and several Data Providers was published yet.
+
+Due to the breaking changes, the following providers are no longer works with the current react-admin implementation:
+
+* **[DynamoDb](https://github.com/abiglobalhealth/aor-dynamodb-client)**: [abiglobalhealth/aor-dynamodb-client](https://github.com/abiglobalhealth/aor-dynamodb-client)		
+* **[Epilogue](https://github.com/dchester/epilogue)**: [dunghuynh/aor-epilogue-client](https://github.com/dunghuynh/aor-epilogue-client)
+* **[Firebase](https://firebase.google.com/)**: [sidferreira/aor-firebase-client](https://github.com/sidferreira/aor-firebase-client)		
+* **[JSON API](http://jsonapi.org/)**: [moonlight-labs/aor-jsonapi-client](https://github.com/moonlight-labs/aor-jsonapi-client)		
+* **[Loopback](http://loopback.io/)**: [kimkha/aor-loopback](https://github.com/kimkha/aor-loopback)		
+* **[Parse Server](https://github.com/ParsePlatform/parse-server)**: [leperone/aor-parseserver-client](https://github.com/leperone/aor-parseserver-client)
+ 
+Hopefully, Data Providers aren't complex pieces of code. If you are a maintainer of one of these projects we would warmly welcome an upgrade to support the new react-admin version.
+
 ## Usage
 
 As an example, let's focus on the Simple REST data provider. It fits REST APIs using simple GET parameters for filters and sorting.

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -62,7 +62,7 @@ Due to the breaking changes, the following providers are no longer working with 
 * **[Loopback](http://loopback.io/)**: [kimkha/aor-loopback](https://github.com/kimkha/aor-loopback)		
 * **[Parse Server](https://github.com/ParsePlatform/parse-server)**: [leperone/aor-parseserver-client](https://github.com/leperone/aor-parseserver-client)
  
-Hopefully, Data Providers aren't complex pieces of code and supporting the new version of react-admin should not be too harsh. If you are a maintainer of one of these projects we would warmly welcome an upgrade.
+Fortunately, Data Providers aren't complex pieces of code and supporting the new version of react-admin should not be too harsh. If you are a maintainer of one of these projects we would warmly welcome an upgrade.
 
 ## Usage
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -51,9 +51,9 @@ If you've written a Data Provider for another backend, and open-sourced it, plea
 
 ### Legacy Data Providers
 
-Before the version 2, react-admin was called [admin-on-rest](/admin-on-rest) (AOR) and the community was as active as it is now and several Data Providers was published yet.
+Before the version 2, react-admin was called [admin-on-rest](/admin-on-rest) (AOR), the community was as active as it is now, and several Data Providers was published yet.
 
-Due to the breaking changes, the following providers are no longer works with the current react-admin implementation:
+Due to the breaking changes, the following providers are no longer working with the current react-admin implementation:
 
 * **[DynamoDb](https://github.com/abiglobalhealth/aor-dynamodb-client)**: [abiglobalhealth/aor-dynamodb-client](https://github.com/abiglobalhealth/aor-dynamodb-client)		
 * **[Epilogue](https://github.com/dchester/epilogue)**: [dunghuynh/aor-epilogue-client](https://github.com/dunghuynh/aor-epilogue-client)
@@ -62,7 +62,7 @@ Due to the breaking changes, the following providers are no longer works with th
 * **[Loopback](http://loopback.io/)**: [kimkha/aor-loopback](https://github.com/kimkha/aor-loopback)		
 * **[Parse Server](https://github.com/ParsePlatform/parse-server)**: [leperone/aor-parseserver-client](https://github.com/leperone/aor-parseserver-client)
  
-Hopefully, Data Providers aren't complex pieces of code. If you are a maintainer of one of these projects we would warmly welcome an upgrade to support the new react-admin version.
+Hopefully, Data Providers aren't complex pieces of code and supporting the new version of react-admin should not be too harsh. If you are a maintainer of one of these projects we would warmly welcome an upgrade.
 
 ## Usage
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -42,6 +42,8 @@ The react-admin project includes 4 Data Providers:
 
 You can find Data Providers for various backends in third-party repositories:
 
+* **[Feathersjs](http://www.feathersjs.com/)**: [josx/aor-feathers-client](https://github.com/josx/aor-feathers-client)
+* **[PostgREST](http://postgrest.com/en/v0.4/)**: [tomberek/aor-postgrest-client](https://github.com/tomberek/aor-postgrest-client)
 * **[Prisma](https://github.com/weakky/ra-data-prisma)**: [weakky/ra-data-prisma](https://github.com/weakky/ra-data-prisma)
 * **[Xmysql](https://github.com/o1lab/xmysql)**: [soaserele/aor-xmysql](https://github.com/soaserele/aor-xmysql)
 


### PR DESCRIPTION
As you can see in [this SO question](https://stackoverflow.com/questions/52247855/react-admin-edit-form-not-prefilled-with-existing-attributes/52253320), the AOR Data Providers are no longer supported by the React Admin core but are still documented.

Another solution would be to mark them as deprecated. As you want!