### PR TITLE
[RFR] Add aside support in List, Edit, and Show views

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -157,7 +157,7 @@ const PostEdit = props => (
     </Edit>
 ```
 
-The `aside` component receives the same props as the `Edit` child component: `basePath`, `record`, `resource`, and `version`. That means you can display non-editable details of the current record in the aside component:
+The `aside` component receives the same props as the `Edit` of `Create` child component: `basePath`, `record`, `resource`, and `version`. That means you can display non-editable details of the current record in the aside component:
 
 ```jsx
 const Aside = ({ record }) => (

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -19,6 +19,7 @@ Here are all the props accepted by the `<Create>` and `<Edit>` components:
 
 * [`title`](#page-title)
 * [`actions`](#actions)
+* [`aside`](#aside-component)
 
 Here is the minimal code necessary to display a form to create and edit comments:
 
@@ -135,6 +136,39 @@ export const PostEdit = (props) => (
 ```
 
 Using a custom `EditActions` component also allow to remove the `<DeleteButton>` if you want to prevent deletions from the admin.
+
+### Aside component
+
+You may want to display additional information on the side of the form. Use the `aside` prop for that, passing the component of your choice:
+
+```jsx
+const Aside = () => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">Post details</Typography>
+        <Typography variant="body1">
+            Posts will only be published one an editor approves them
+        </Typography>
+    </div>
+);
+
+const PostEdit = props => (
+    <Edit aside={<Aside />} {...props}>
+        ...
+    </Edit>
+```
+
+The `aside` component receives the same props as the `Edit` child component: `basePath`, `record`, `resource`, and `version`. That means you can display non-editable details of the current record in the aside component:
+
+```jsx
+const Aside = ({ record }) => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">Post details</Typography>
+        <Typography variant="body1">
+            Creation date: {record.createdAt}
+        </Typography>
+    </div>
+);
+```
 
 ## Prefilling a `<Create>` Record
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -157,7 +157,7 @@ const PostEdit = props => (
     </Edit>
 ```
 
-The `aside` component receives the same props as the `Edit` of `Create` child component: `basePath`, `record`, `resource`, and `version`. That means you can display non-editable details of the current record in the aside component:
+The `aside` component receives the same props as the `Edit` or `Create` child component: `basePath`, `record`, `resource`, and `version`. That means you can display non-editable details of the current record in the aside component:
 
 ```jsx
 const Aside = ({ record }) => (

--- a/docs/List.md
+++ b/docs/List.md
@@ -27,6 +27,7 @@ Here are all the props accepted by the `<List>` component:
 * [`filter`](#permanent-filter) (the permanent filter used in the REST request)
 * [`filterDefaultValues`](#filter-default-values) (the default values for `alwaysOn` filters)
 * [`pagination`](#pagination)
+* [`aside`](#aside-component)
 
 Here is the minimal code necessary to display a list of posts:
 
@@ -577,6 +578,54 @@ export const PostList = (props) => (
     <List {...props} pagination={<PostPagination />}>
         ...
     </List>
+);
+```
+
+### Aside component
+
+You may want to display additional information on the side of the list. Use the `aside` prop for that, passing the component of your choice:
+
+```jsx
+const Aside = () => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">Post details</Typography>
+        <Typography variant="body1">
+            Posts will only be published one an editor approves them
+        </Typography>
+    </div>
+);
+
+const PostList = props => (
+    <List aside={<Aside />} {...props}>
+        ...
+    </List>
+```
+
+The `aside` component receives the same props as the `List` child component, including the following:
+
+* `basePath`,
+* `currentSort`,
+* `data`,
+* `defaultTitle`,
+* `filterValues`,
+* `ids`,
+* `page`,
+* `perPage`,
+* `resource`,
+* `selectedIds`,
+* `total`,
+* `version`,
+
+That means you can display additional details of the current list in the aside component:
+
+```jsx
+const Aside = ({ data, ids }) => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">Posts stats</Typography>
+        <Typography variant="body1">
+            Total views: {ids.map(id => data[id]).reduce((sum, post) => sum + post.views)}
+        </Typography>
+    </div>
 );
 ```
 

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -17,6 +17,7 @@ Here are all the props accepted by the `<Show>` component:
 
 * [`title`](#page-title)
 * [`actions`](#actions)
+* [`aside`](#aside-component)
 
 Here is the minimal code necessary to display a view to show a post:
 
@@ -112,6 +113,39 @@ export const PostShow = (props) => (
     <Show actions={<PostShowActions />} {...props}>
         ...
     </Show>
+);
+```
+
+### Aside component
+
+You may want to display additional information on the side of the resource detail. Use the `aside` prop for that, passing the component of your choice:
+
+```jsx
+const Aside = () => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">Post details</Typography>
+        <Typography variant="body1">
+            Posts will only be published one an editor approves them
+        </Typography>
+    </div>
+);
+
+const PostShow = props => (
+    <Show aside={<Aside />} {...props}>
+        ...
+    </Show>
+```
+
+The `aside` component receives the same props as the `Show` child component: `basePath`, `record`, `resource`, and `version`. That means you can display secondary details of the current record in the aside component:
+
+```jsx
+const Aside = ({ record }) => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">Post details</Typography>
+        <Typography variant="body1">
+            Creation date: {record.createdAt}
+        </Typography>
+    </div>
 );
 ```
 

--- a/examples/simple/src/users/Aside.js
+++ b/examples/simple/src/users/Aside.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+const Aside = () => (
+    <div style={{ width: 200, margin: '1em' }}>
+        <Typography variant="title">App Users</Typography>
+        <Typography variant="body1">
+            Eiusmod adipisicing tempor duis qui. Ullamco aliqua tempor incididunt aliquip aliquip qui ad minim aliqua. Aute et magna quis pariatur irure sunt. Aliquip velit consequat dolore ullamco laborum voluptate cupidatat. Proident minim reprehenderit id dolore elit sit occaecat ad amet tempor esse occaecat enim. Laborum aliqua excepteur qui ipsum in dolor et cillum est.
+        </Typography>
+    </div>
+);
+
+export default Aside;

--- a/examples/simple/src/users/UserCreate.js
+++ b/examples/simple/src/users/UserCreate.js
@@ -11,6 +11,8 @@ import {
     required,
 } from 'react-admin';
 
+import Aside from './Aside';
+
 const UserEditToolbar = ({ permissions, ...props }) => (
     <Toolbar {...props}>
         <SaveButton
@@ -30,7 +32,7 @@ const UserEditToolbar = ({ permissions, ...props }) => (
 );
 
 const UserCreate = ({ permissions, ...props }) => (
-    <Create {...props}>
+    <Create {...props} aside={<Aside />}>
         <TabbedForm toolbar={<UserEditToolbar permissions={permissions} />}>
             <FormTab label="user.form.summary" path="">
                 <TextInput

--- a/examples/simple/src/users/UserEdit.js
+++ b/examples/simple/src/users/UserEdit.js
@@ -10,10 +10,12 @@ import {
     TextInput,
     required,
 } from 'react-admin';
+
 import UserTitle from './UserTitle';
+import Aside from './Aside';
 
 const UserEdit = ({ permissions, ...props }) => (
-    <Edit title={<UserTitle />} {...props}>
+    <Edit title={<UserTitle />} aside={<Aside />} {...props}>
         <TabbedForm defaultValue={{ role: 'user' }}>
             <FormTab label="user.form.summary" path="">
                 {permissions === 'admin' && <DisabledInput source="id" />}

--- a/examples/simple/src/users/UserList.js
+++ b/examples/simple/src/users/UserList.js
@@ -17,6 +17,8 @@ import {
 } from 'react-admin';
 export const UserIcon = PeopleIcon;
 
+import Aside from './Aside';
+
 const UserFilter = ({ permissions, ...props }) => (
     <Filter {...props}>
         <SearchInput source="q" alwaysOn />
@@ -31,6 +33,7 @@ const UserList = ({ permissions, ...props }) => (
         filters={<UserFilter permissions={permissions} />}
         filterDefaultValues={{ role: 'user' }}
         sort={{ field: 'name', order: 'ASC' }}
+        aside={<Aside />}
     >
         <Responsive
             small={

--- a/examples/simple/src/users/UserShow.js
+++ b/examples/simple/src/users/UserShow.js
@@ -2,10 +2,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Show, Tab, TabbedShowLayout, TextField } from 'react-admin'; // eslint-disable-line import/no-unresolved
+
 import UserTitle from './UserTitle';
+import Aside from './Aside';
 
 const UserShow = ({ permissions, ...props }) => (
-    <Show title={<UserTitle />} {...props}>
+    <Show title={<UserTitle />} aside={<Aside />} {...props}>
         <TabbedShowLayout>
             <Tab label="user.form.summary">
                 <TextField source="id" />

--- a/packages/ra-core/src/util/TestContext.js
+++ b/packages/ra-core/src/util/TestContext.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { reducer as formReducer } from 'redux-form';
+import { TranslationProvider } from 'ra-core';
+import merge from 'lodash/merge';
+
+const defaultStore = {
+    admin: {
+        resources: {},
+        references: { possibleValues: {} },
+        ui: { viewVersion: 1 },
+    },
+    form: formReducer(),
+    i18n: { locale: 'en', messages: {} },
+};
+
+/**
+ * Simulate a react-admin context in unit tests
+ *
+ * Pass custom store values as store prop
+ *
+ * @example
+ * // in an enzyme test
+ * const wrapper = render(
+ *     <AdminContext store={{ admin: { resources: { post: { data: { 1: {id: 1, title: 'foo' } } } } } }}>
+ *         <Show {...defaultShowProps} />
+ *     </AdminContext>
+ * );
+ */
+const TestContext = ({ store, children }) => {
+    const storeWithDefault = createStore(() => merge(store, defaultStore));
+    return (
+        <Provider store={storeWithDefault}>
+            <TranslationProvider>{children}</TranslationProvider>
+        </Provider>
+    );
+};
+
+TestContext.propTypes = {
+    store: PropTypes.object,
+    children: PropTypes.node,
+};
+
+TestContext.defaultProps = {
+    store: {},
+};
+
+export default TestContext;

--- a/packages/ra-core/src/util/index.js
+++ b/packages/ra-core/src/util/index.js
@@ -7,3 +7,4 @@ export linkToRecord from './linkToRecord';
 export removeEmpty from './removeEmpty';
 export removeKey from './removeKey';
 export resolveRedirectTo from './resolveRedirectTo';
+export TestContext from './TestContext';

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -1,11 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
+import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { CreateController } from 'ra-core';
 
 import TitleForRecord from '../layout/TitleForRecord';
 import CardContentInner from '../layout/CardContentInner';
+
+const styles = {
+    root: {
+        display: 'flex',
+    },
+    card: {
+        flex: '1 1 auto',
+    },
+};
 
 const sanitizeRestProps = ({
     actions,
@@ -31,8 +41,10 @@ const sanitizeRestProps = ({
 
 export const CreateView = ({
     actions,
+    aside,
     basePath,
     children,
+    classes,
     className,
     defaultTitle,
     hasList,
@@ -45,7 +57,7 @@ export const CreateView = ({
     ...rest
 }) => (
     <div
-        className={classnames('create-page', className)}
+        className={classnames('create-page', classes.root, className)}
         {...sanitizeRestProps(rest)}
     >
         <TitleForRecord
@@ -53,7 +65,7 @@ export const CreateView = ({
             record={record}
             defaultTitle={defaultTitle}
         />
-        <Card>
+        <Card className={classes.card}>
             {actions && (
                 <CardContentInner>
                     {React.cloneElement(actions, {
@@ -74,13 +86,22 @@ export const CreateView = ({
                 save,
             })}
         </Card>
+        {aside &&
+            React.cloneElement(aside, {
+                basePath,
+                record,
+                resource,
+                save,
+            })}
     </div>
 );
 
 CreateView.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     basePath: PropTypes.string,
     children: PropTypes.element,
+    classes: PropTypes.object,
     className: PropTypes.string,
     defaultTitle: PropTypes.any,
     hasList: PropTypes.bool,
@@ -90,6 +111,10 @@ CreateView.propTypes = {
     resource: PropTypes.string,
     save: PropTypes.func,
     title: PropTypes.any,
+};
+
+CreateView.defaultProps = {
+    classes: {},
 };
 
 /**
@@ -141,7 +166,9 @@ const Create = props => (
 
 Create.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     children: PropTypes.element,
+    classes: PropTypes.object,
     className: PropTypes.string,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
@@ -152,4 +179,4 @@ Create.propTypes = {
     hasList: PropTypes.bool,
 };
 
-export default Create;
+export default withStyles(styles)(Create);

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -158,7 +158,7 @@ CreateView.defaultProps = {
  *     );
  *     export default App;
  */
-const Create = props => (
+export const Create = props => (
     <CreateController {...props}>
         {controllerProps => <CreateView {...props} {...controllerProps} />}
     </CreateController>

--- a/packages/ra-ui-materialui/src/detail/Create.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Create.spec.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { TestContext } from 'ra-core';
+
+import { Create } from './Create';
+
+describe('<Create />', () => {
+    const defaultCreateProps = {
+        basePath: '/foo',
+        id: '123',
+        resource: 'foo',
+        location: {},
+        match: {},
+    };
+
+    it('should display aside component', () => {
+        const Dummy = () => <div />;
+        const Aside = () => <div id="aside">Hello</div>;
+        const wrapper = render(
+            <TestContext>
+                <Create {...defaultCreateProps} aside={<Aside />}>
+                    <Dummy />
+                </Create>
+            </TestContext>
+        );
+        const aside = wrapper.find('#aside');
+        expect(aside.text()).toEqual('Hello');
+    });
+});

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -182,7 +182,7 @@ EditView.defaultProps = {
  *     );
  *     export default App;
  */
-const Edit = props => (
+export const Edit = props => (
     <EditController {...props}>
         {controllerProps => <EditView {...props} {...controllerProps} />}
     </EditController>

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
+import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { EditController } from 'ra-core';
 
@@ -9,8 +10,18 @@ import DefaultActions from './EditActions';
 import TitleForRecord from '../layout/TitleForRecord';
 import CardContentInner from '../layout/CardContentInner';
 
+const styles = {
+    root: {
+        display: 'flex',
+    },
+    card: {
+        flex: '1 1 auto',
+    },
+};
+
 const sanitizeRestProps = ({
     actions,
+    aside,
     children,
     className,
     crudGetOne,
@@ -39,8 +50,10 @@ const sanitizeRestProps = ({
 
 export const EditView = ({
     actions,
+    aside,
     basePath,
     children,
+    classes = {},
     className,
     defaultTitle,
     hasList,
@@ -58,7 +71,7 @@ export const EditView = ({
     }
     return (
         <div
-            className={classnames('edit-page', className)}
+            className={classnames('edit-page', classes.root, className)}
             {...sanitizeRestProps(rest)}
         >
             <TitleForRecord
@@ -66,7 +79,7 @@ export const EditView = ({
                 record={record}
                 defaultTitle={defaultTitle}
             />
-            <Card>
+            <Card className={classes.card}>
                 {actions && (
                     <CardContentInner>
                         {React.cloneElement(actions, {
@@ -94,14 +107,23 @@ export const EditView = ({
                     <CardContent>&nbsp;</CardContent>
                 )}
             </Card>
+            {aside &&
+                React.cloneElement(aside, {
+                    basePath,
+                    record,
+                    resource,
+                    version,
+                })}
         </div>
     );
 };
 
 EditView.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     basePath: PropTypes.string,
     children: PropTypes.element,
+    classes: PropTypes.object,
     className: PropTypes.string,
     defaultTitle: PropTypes.any,
     hasList: PropTypes.bool,
@@ -165,6 +187,7 @@ const Edit = props => (
 Edit.propTypes = {
     actions: PropTypes.element,
     children: PropTypes.node,
+    classes: PropTypes.object,
     className: PropTypes.string,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
@@ -175,4 +198,4 @@ Edit.propTypes = {
     title: PropTypes.any,
 };
 
-export default Edit;
+export default withStyles(styles)(Edit);

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -53,7 +53,7 @@ export const EditView = ({
     aside,
     basePath,
     children,
-    classes = {},
+    classes,
     className,
     defaultTitle,
     hasList,
@@ -136,6 +136,10 @@ EditView.propTypes = {
     version: PropTypes.number,
 };
 
+EditView.defaultProps = {
+    classes: {},
+};
+
 /**
  * Page component for the Edit view
  *
@@ -186,6 +190,7 @@ const Edit = props => (
 
 Edit.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { TestContext } from 'ra-core';
+
+import { Edit } from './Edit';
+
+describe('<Edit />', () => {
+    const defaultEditProps = {
+        basePath: '/',
+        id: '123',
+        resource: 'foo',
+        location: {},
+        match: {},
+    };
+
+    it('should display aside component', () => {
+        const Aside = () => <div id="aside">Hello</div>;
+        const wrapper = render(
+            <TestContext>
+                <Edit {...defaultEditProps} aside={<Aside />}>
+                    <div />
+                </Edit>
+            </TestContext>
+        );
+        const aside = wrapper.find('#aside');
+        expect(aside.text()).toEqual('Hello');
+    });
+});

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
+import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { ShowController } from 'ra-core';
 
@@ -8,8 +9,18 @@ import DefaultActions from './ShowActions';
 import TitleForRecord from '../layout/TitleForRecord';
 import CardContentInner from '../layout/CardContentInner';
 
+const styles = {
+    root: {
+        display: 'flex',
+    },
+    card: {
+        flex: '1 1 auto',
+    },
+};
+
 const sanitizeRestProps = ({
     actions,
+    aside,
     title,
     children,
     className,
@@ -35,8 +46,10 @@ const sanitizeRestProps = ({
 
 export const ShowView = ({
     actions,
+    aside,
     basePath,
     children,
+    classes,
     className,
     defaultTitle,
     hasEdit,
@@ -53,7 +66,7 @@ export const ShowView = ({
     }
     return (
         <div
-            className={classnames('show-page', className)}
+            className={classnames('show-page', classes.root, className)}
             {...sanitizeRestProps(rest)}
         >
             <TitleForRecord
@@ -61,7 +74,7 @@ export const ShowView = ({
                 record={record}
                 defaultTitle={defaultTitle}
             />
-            <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
+            <Card className={classes.card}>
                 {actions && (
                     <CardContentInner>
                         {React.cloneElement(actions, {
@@ -81,14 +94,23 @@ export const ShowView = ({
                         version,
                     })}
             </Card>
+            {aside &&
+                React.cloneElement(aside, {
+                    resource,
+                    basePath,
+                    record,
+                    version,
+                })}
         </div>
     );
 };
 
 ShowView.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     basePath: PropTypes.string,
     children: PropTypes.element,
+    classes: PropTypes.object,
     className: PropTypes.string,
     defaultTitle: PropTypes.any,
     hasEdit: PropTypes.bool,
@@ -151,6 +173,7 @@ const Show = props => (
 Show.propTypes = {
     actions: PropTypes.element,
     children: PropTypes.element,
+    classes: PropTypes.node,
     className: PropTypes.string,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
@@ -161,4 +184,4 @@ Show.propTypes = {
     title: PropTypes.any,
 };
 
-export default Show;
+export default withStyles(styles)(Show);

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -168,7 +168,7 @@ ShowView.defaultProps = {
  *     );
  *     export default App;
  */
-const Show = props => (
+export const Show = props => (
     <ShowController {...props}>
         {controllerProps => <ShowView {...props} {...controllerProps} />}
     </ShowController>

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -122,6 +122,10 @@ ShowView.propTypes = {
     version: PropTypes.number,
 };
 
+ShowView.defaultProps = {
+    classes: {},
+};
+
 /**
  * Page component for the Show view
  *
@@ -172,6 +176,7 @@ const Show = props => (
 
 Show.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     children: PropTypes.element,
     classes: PropTypes.node,
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/detail/Show.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { TestContext } from 'ra-core';
+
+import { Show } from './Show';
+
+describe('<Show />', () => {
+    const defaultShowProps = {
+        basePath: '/',
+        id: '123',
+        resource: 'foo',
+        location: {},
+        match: {},
+    };
+
+    it('should display aside component', () => {
+        const Aside = () => <div id="aside">Hello</div>;
+        const wrapper = render(
+            <TestContext>
+                <Show {...defaultShowProps} aside={<Aside />}>
+                    <div />
+                </Show>
+            </TestContext>
+        );
+        const aside = wrapper.find('#aside');
+        expect(aside.text()).toEqual('Hello');
+    });
+});

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -106,7 +106,7 @@ export const ListView = ({
     // overridable by user
     children,
     className,
-    classes = {},
+    classes,
     exporter,
     title,
     ...rest
@@ -197,6 +197,10 @@ ListView.propTypes = {
     total: PropTypes.number,
     translate: PropTypes.func,
     version: PropTypes.number,
+};
+
+ListView.defaultProps = {
+    classes: {},
 };
 
 /**

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -244,7 +244,7 @@ ListView.defaultProps = {
  *         </List>
  *     );
  */
-const List = props => (
+export const List = props => (
     <ListController {...props}>
         {controllerProps => <ListView {...props} {...controllerProps} />}
     </ListController>

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -15,9 +15,12 @@ import DefaultActions from './ListActions';
 import defaultTheme from '../defaultTheme';
 
 const styles = {
-    root: {},
+    root: {
+        display: 'flex',
+    },
     card: {
         position: 'relative',
+        flex: '1 1 auto',
     },
     actions: {
         zIndex: 2,
@@ -95,6 +98,7 @@ const sanitizeRestProps = ({
 export const ListView = ({
     // component props
     actions = <DefaultActions />,
+    aside,
     filters,
     bulkActions, // deprecated
     bulkActionButtons = <DefaultBulkActionButtons />,
@@ -146,12 +150,14 @@ export const ListView = ({
                         React.cloneElement(pagination, controllerProps)}
                 </div>
             </Card>
+            {aside && React.cloneElement(aside, controllerProps)}
         </div>
     );
 };
 
 ListView.propTypes = {
     actions: PropTypes.element,
+    aside: PropTypes.node,
     basePath: PropTypes.string,
     bulkActions: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
     bulkActionButtons: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
@@ -243,6 +249,7 @@ const List = props => (
 List.propTypes = {
     // the props you can change
     actions: PropTypes.element,
+    aside: PropTypes.node,
     bulkActions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     children: PropTypes.node,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/list/List.spec.js
+++ b/packages/ra-ui-materialui/src/list/List.spec.js
@@ -1,8 +1,9 @@
 import assert from 'assert';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, render } from 'enzyme';
+import { TestContext } from 'ra-core';
 
-import { ListView } from './List';
+import { List, ListView } from './List';
 
 describe('<List />', () => {
     const defaultProps = {
@@ -48,5 +49,47 @@ describe('<List />', () => {
         ).toHaveLength(1);
         expect(wrapper.find('Datagrid')).toHaveLength(1);
         expect(wrapper.find('Pagination')).toHaveLength(1);
+    });
+
+    const defaultListProps = {
+        basePath: '/foo',
+        ids: [],
+        data: {},
+        hasCreate: false,
+        hasEdit: false,
+        hasList: false,
+        hasShow: false,
+        location: {},
+        match: {},
+        resource: 'foo',
+        total: 0,
+    };
+    const defaultStoreForList = {
+        admin: {
+            resources: {
+                foo: {
+                    list: {
+                        ids: [],
+                        params: {},
+                        selectedIds: [],
+                        total: 0,
+                    },
+                },
+            },
+        },
+    };
+
+    it('should display aside component', () => {
+        const Dummy = () => <div />;
+        const Aside = () => <div id="aside">Hello</div>;
+        const wrapper = render(
+            <TestContext store={defaultStoreForList}>
+                <List {...defaultListProps} aside={<Aside />}>
+                    <Dummy />
+                </List>
+            </TestContext>
+        );
+        const aside = wrapper.find('#aside');
+        expect(aside.text()).toEqual('Hello');
     });
 });

--- a/test-setup.js
+++ b/test-setup.js
@@ -6,39 +6,37 @@ enzyme.configure({ adapter: new Adapter() });
 
 /**
  * Mock PopperJS
- * 
+ *
  * When using mount(), material-ui calls Popper.js, which is not compatible with JSDom
  * And causes UnhandledPromiseRejectionWarning: TypeError: document.createRange is not a function
- * 
+ *
  * @see https://github.com/FezVrasta/popper.js/issues/478
  * */
-jest.mock(
-    'popper.js',
-    () =>
-        class Popper {
-            static placements = [
-                'auto',
-                'auto-end',
-                'auto-start',
-                'bottom',
-                'bottom-end',
-                'bottom-start',
-                'left',
-                'left-end',
-                'left-start',
-                'right',
-                'right-end',
-                'right-start',
-                'top',
-                'top-end',
-                'top-start',
-            ];
-
-            constructor() {
-                return {
-                    destroy: () => {},
-                    scheduleUpdate: () => {},
-                };
-            }
+jest.mock('popper.js', () => {
+    class Popper {
+        constructor() {
+            return {
+                destroy: () => {},
+                scheduleUpdate: () => {},
+            };
         }
-);
+    }
+    Popper.placements = [
+        'auto',
+        'auto-end',
+        'auto-start',
+        'bottom',
+        'bottom-end',
+        'bottom-start',
+        'left',
+        'left-end',
+        'left-start',
+        'right',
+        'right-end',
+        'right-start',
+        'top',
+        'top-end',
+        'top-start',
+    ];
+    return Popper;
+});


### PR DESCRIPTION
- [x] Add `aside` support in Create view
- [x] Add `aside` support in Edit view
- [x] Add `aside` support in Show view
- [x] Add `aside` support in List view
- [x] Document it
- [x] Add integration tests

Users may need to see info related to the current content, but secondary. Using tabs for that has one drawback: it is contained in the form, and the presence of the "save" button  makes the content not secondary.

Besides, adding a second column requires overriding the View, which is advanced customization. 

The `aside` prop is style agnostic, and allows for all sorts of customizations thanks to flexbox.

```jsx
const Aside = () => (
    <div style={{ width: 200, margin: '1em' }}>
        <Typography variant="title">App Users</Typography>
        <Typography variant="body1">
            Eiusmod adipisicing tempor duis qui. Ullamco aliqua tempor incididunt aliquip aliquip qui ad minim aliqua. Aute et magna quis pariatur irure sunt. Aliquip velit consequat dolore ullamco laborum voluptate cupidatat. Proident minim reprehenderit id dolore elit sit occaecat ad amet tempor esse occaecat enim. Laborum aliqua excepteur qui ipsum in dolor et cillum est.
        </Typography>
    </div>
);

const UserShow = ({ permissions, ...props }) => (
    <Show aside={<Aside />} {...props}>
        ...
    </Show>
```

![2018-09-11_1214](https://user-images.githubusercontent.com/99944/45353836-4a4f7300-b5bc-11e8-9aae-b8ea0d3017d9.png)
