### PR TITLE
Update QuillSnowStylesheet.js

### DIFF
--- a/packages/ra-input-rich-text/src/QuillSnowStylesheet.js
+++ b/packages/ra-input-rich-text/src/QuillSnowStylesheet.js
@@ -53,7 +53,7 @@ export default {
         listStyleType: 'none',
     },
     '.ql-editor ul > li::before': {
-        content: "'2022'",
+        content: "'\2022'",
     },
     '.ql-editor ul[data-checked=true], .ql-editor ul[data-checked=false]': {
         pointerEvents: 'none',
@@ -67,10 +67,10 @@ export default {
         pointerEvents: 'all',
     },
     '.ql-editor ul[data-checked=true] > li::before': {
-        content: "'2611'",
+        content: "'\2611'",
     },
     '.ql-editor ul[data-checked=false] > li::before': {
-        content: "'2610'",
+        content: "'\2610'",
     },
     '.ql-editor li::before': {
         display: 'inline-block',


### PR DESCRIPTION
Missing `\` before Unicode Character

Show [https://github.com/quilljs/quill/blob/develop/assets/core.styl](https://github.com/quilljs/quill/blob/develop/assets/core.styl) ad lines **86**,  **88**,  **90**