### PR TITLE
[RFR] Add error prop to FormHelperText, to mark it as error on error meta

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -71,7 +71,7 @@ export class RichTextInput extends Component {
                 className="ra-rich-text-input"
             >
                 <div ref={this.updateDivRef} />
-                {error && <FormHelperText>{error}</FormHelperText>}
+                {error && <FormHelperText error>{error}</FormHelperText>}
                 {helperText && <FormHelperText>{helperText}</FormHelperText>}
             </FormControl>
         );

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
@@ -177,7 +177,8 @@ export class CheckboxGroupInput extends Component {
                     />
                 </FormLabel>
                 <FormGroup row>{choices.map(this.renderCheckbox)}</FormGroup>
-                {touched && error && <FormHelperText>{error}</FormHelperText>}
+                {touched &&
+                    error && <FormHelperText error>{error}</FormHelperText>}
                 {helperText && <FormHelperText>{helperText}</FormHelperText>}
             </FormControl>
         );

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
@@ -159,7 +159,8 @@ export class RadioButtonGroupInput extends Component {
                 >
                     {choices.map(this.renderRadioButton)}
                 </RadioGroup>
-                {touched && error && <FormHelperText>{error}</FormHelperText>}
+                {touched &&
+                    error && <FormHelperText error>{error}</FormHelperText>}
                 {helperText && <FormHelperText>{helperText}</FormHelperText>}
             </FormControl>
         );

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -232,7 +232,8 @@ export class SelectArrayInput extends Component {
                 >
                     {choices.map(this.renderMenuItem)}
                 </Select>
-                {touched && error && <FormHelperText>{error}</FormHelperText>}
+                {touched &&
+                    error && <FormHelperText error>{error}</FormHelperText>}
                 {helperText && <FormHelperText>{helperText}</FormHelperText>}
             </FormControl>
         );


### PR DESCRIPTION
Add's error prop to FormHelperText, to mark it as error on error meta

Makes the error text red (well, the error color defined by theme) like other errors in TextInput's

changes RichTextInput, RadioButtonGroupInput, CheckboxGroupInput and SelectArrayInput

note: added as pull to master instead of next as i consider it a bug that these components have inconsistent way to display error with other input's

**edit: maybe i should add some borderBottom to make it even more consistent?
edit2: added images**

before:
![old](https://user-images.githubusercontent.com/488136/45755030-89657000-bc1d-11e8-9217-bda0287d1fa6.png)

![old](https://user-images.githubusercontent.com/488136/45757420-9ab17b00-bc23-11e8-83d9-013f8e30d5fa.png)

after (in this PR):
![new](https://user-images.githubusercontent.com/488136/45755041-8ff3e780-bc1d-11e8-80b7-8f01d27a0182.png)

![new](https://user-images.githubusercontent.com/488136/45757426-a00ec580-bc23-11e8-9d51-4418cb191ecb.png)


with borderBottom (not in this PR, shpuld i add it?):
![withborder](https://user-images.githubusercontent.com/488136/45755077-b31e9700-bc1d-11e8-9926-2d970660c3d4.png)

![withborder](https://user-images.githubusercontent.com/488136/45757435-a3a24c80-bc23-11e8-8c45-b313b57cce70.png)




