### PR TITLE
[RFR] [BC break] Easier custom toolbar

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -612,7 +612,7 @@ The most common use case is to display two submit buttons in the `<Create>` view
 For that use case, use the `<SaveButton>` component with a custom `redirect` prop:
 
 ```jsx
-import { Edit, SimpleForm, SaveButton, Toolbar } from 'react-admin';
+import { Create, SimpleForm, SaveButton, Toolbar } from 'react-admin';
 
 const PostCreateToolbar = props => (
     <Toolbar {...props} >
@@ -630,9 +630,29 @@ const PostCreateToolbar = props => (
     </Toolbar>
 );
 
+export const PostCreate = (props) => (
+    <Create {...props}>
+        <SimpleForm toolbar={<PostCreateToolbar />} redirect="show">
+            ...
+        </SimpleForm>
+    </Create>
+);
+```
+
+Another use case is to remove the `<DeleteButton>` from the toolbar in an edit view. In that case, create a custom toolbar containing only the `<SaveButton>` as child;
+
+```jsx
+import { Edit, SimpleForm, SaveButton, Toolbar } from 'react-admin';
+
+const PostEditToolbar = props => (
+    <Toolbar {...props} >
+        <SaveButton />
+    </Toolbar>
+);
+
 export const PostEdit = (props) => (
     <Edit {...props}>
-        <SimpleForm toolbar={<PostCreateToolbar />} redirect="show">
+        <SimpleForm toolbar={<PostEditToolbar />}>
             ...
         </SimpleForm>
     </Edit>

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -1,4 +1,4 @@
-import React, { Children, Fragment } from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import MuiToolbar from '@material-ui/core/Toolbar';

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import MuiToolbar from '@material-ui/core/Toolbar';
@@ -9,9 +9,6 @@ import classnames from 'classnames';
 import { SaveButton, DeleteButton } from '../button';
 
 const styles = {
-    desktopToolbar: {
-        justifyContent: 'space-between',
-    },
     mobileToolbar: {
         position: 'fixed',
         bottom: 0,
@@ -22,8 +19,12 @@ const styles = {
         boxSizing: 'border-box',
         flexShrink: 0,
         backgroundColor: 'white',
-        justifyContent: 'space-between',
         zIndex: 2,
+    },
+    defaultToolbar: {
+        flex: 1,
+        display: 'flex',
+        justifyContent: 'space-between',
     },
 };
 
@@ -49,14 +50,14 @@ const Toolbar = ({
 }) => (
     <MuiToolbar
         className={classnames(
-            width === 'xs' ? classes.mobileToolbar : classes.desktopToolbar,
+            { [classes.mobileToolbar]: width === 'xs' },
             className
         )}
         disableGutters
         {...rest}
     >
-        <span>
-            {Children.count(children) === 0 ? (
+        {Children.count(children) === 0 ? (
+            <div className={classes.defaultToolbar}>
                 <SaveButton
                     handleSubmitWithRedirect={handleSubmitWithRedirect}
                     invalid={invalid}
@@ -64,41 +65,41 @@ const Toolbar = ({
                     saving={saving}
                     submitOnEnter={submitOnEnter}
                 />
-            ) : (
-                Children.map(
-                    children,
-                    button =>
-                        button
-                            ? React.cloneElement(button, {
-                                  basePath,
-                                  handleSubmit: valueOrDefault(
-                                      button.props.handleSubmit,
-                                      handleSubmit
-                                  ),
-                                  handleSubmitWithRedirect: valueOrDefault(
-                                      button.props.handleSubmitWithRedirect,
-                                      handleSubmitWithRedirect
-                                  ),
-                                  invalid,
-                                  pristine,
-                                  saving,
-                                  submitOnEnter: valueOrDefault(
-                                      button.props.submitOnEnter,
-                                      submitOnEnter
-                                  ),
-                              })
-                            : null
-                )
-            )}
-        </span>
-        {record &&
-            record.id && (
-                <DeleteButton
-                    basePath={basePath}
-                    record={record}
-                    resource={resource}
-                />
-            )}
+                {record &&
+                    record.id && (
+                        <DeleteButton
+                            basePath={basePath}
+                            record={record}
+                            resource={resource}
+                        />
+                    )}
+            </div>
+        ) : (
+            Children.map(
+                children,
+                button =>
+                    button
+                        ? React.cloneElement(button, {
+                              basePath,
+                              handleSubmit: valueOrDefault(
+                                  button.props.handleSubmit,
+                                  handleSubmit
+                              ),
+                              handleSubmitWithRedirect: valueOrDefault(
+                                  button.props.handleSubmitWithRedirect,
+                                  handleSubmitWithRedirect
+                              ),
+                              invalid,
+                              pristine,
+                              saving,
+                              submitOnEnter: valueOrDefault(
+                                  button.props.submitOnEnter,
+                                  submitOnEnter
+                              ),
+                          })
+                        : null
+            )
+        )}
     </MuiToolbar>
 );
 


### PR DESCRIPTION
## Problem

Removing the delete button from the Edit toolbar used to require to create a Toolbar component from scratch. 

Refs #2319

## Solution

With this PR, it's as easy as passing just the `<SaveButton>` as only child of a custom `<Toolbar>`:

```jsx
const PostEditToolbar = props => (
    <Toolbar {...props} >
        <SaveButton />
    </Toolbar>
);

export const PostEdit = (props) => (
    <Edit {...props}>
        <SimpleForm toolbar={<PostEditToolbar />}>
            ...
        </SimpleForm>
    </Edit>
```

There is a slight BC break here: people with custom Toolbar for Edit views used to have the Delete button displayed even though it wasn't in their custom toolbar. With that change, the Edit button will disappear. I think, with proper warning in the release notes, we can assume this BC break (on a feature that is very young and probably not very widely used to date).

