### PR TITLE
[RFR] Introduce Datagrid rowClick

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -669,6 +669,7 @@ The datagrid component renders a list of records as a table. It is usually used 
 Here are all the props accepted by the component:
 
 * [`rowStyle`](#row-style-function)
+* [`rowClick`](#rowclick)
 
 It renders as many columns as it receives `<Field>` children.
 
@@ -709,6 +710,26 @@ export const PostList = (props) => (
     </List>
 );
 ```
+
+### `rowClick`
+
+You can catch clicks on rows to redirect to the show or edit view by setting the `rowClick` prop:
+
+```jsx
+export const PostList = (props) => (
+    <List {...props}>
+        <Datagrid rowClick="edit">
+            ...
+        </Datagrid>
+    </List>
+);
+```
+
+`rowClick` accepts the following values:
+
+* "edit" to redirect to the edition vue
+* "show" to redirect to the show vue
+* a function `(id, basePath) => path` to redirect to a custom path
 
 ### CSS API
 

--- a/examples/simple/src/users/UserList.js
+++ b/examples/simple/src/users/UserList.js
@@ -45,12 +45,10 @@ const UserList = ({ permissions, ...props }) => (
                 />
             }
             medium={
-                <Datagrid hover={false}>
+                <Datagrid rowClick="show">
                     <TextField source="id" />
                     <TextField source="name" />
                     {permissions === 'admin' && <TextField source="role" />}
-                    <EditButton />
-                    <ShowButton />
                 </Datagrid>
             }
         />

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -25,6 +25,9 @@ const styles = {
     },
     checkbox: {},
     row: {},
+    clickableRow: {
+        cursor: 'pointer',
+    },
     rowEven: {},
     rowOdd: {},
     rowCell: {
@@ -112,6 +115,7 @@ class Datagrid extends Component {
             setSort,
             onSelect,
             onToggleItem,
+            rowClick,
             total,
             version,
             ...rest
@@ -167,6 +171,7 @@ class Datagrid extends Component {
                 <DatagridBody
                     basePath={basePath}
                     classes={classes}
+                    rowClick={rowClick}
                     data={data}
                     hasBulkActions={hasBulkActions}
                     hover={hover}
@@ -202,6 +207,7 @@ Datagrid.propTypes = {
     onSelect: PropTypes.func,
     onToggleItem: PropTypes.func,
     resource: PropTypes.string,
+    rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
     setSort: PropTypes.func,

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -8,19 +8,20 @@ import DatagridRow from './DatagridRow';
 
 const DatagridBody = ({
     basePath,
+    children,
     classes,
     className,
-    resource,
-    children,
+    data,
     hasBulkActions,
     hover,
     ids,
     isLoading,
-    data,
+    onToggleItem,
+    resource,
+    rowClick,
+    rowStyle,
     selectedIds,
     styles,
-    rowStyle,
-    onToggleItem,
     version,
     ...rest
 }) => (
@@ -32,7 +33,9 @@ const DatagridBody = ({
                 className={classnames(classes.row, {
                     [classes.rowEven]: rowIndex % 2 === 0,
                     [classes.rowOdd]: rowIndex % 2 !== 0,
+                    [classes.clickableRow]: rowClick,
                 })}
+                rowClick={rowClick}
                 hasBulkActions={hasBulkActions}
                 id={id}
                 key={id}
@@ -61,6 +64,7 @@ DatagridBody.propTypes = {
     isLoading: PropTypes.bool,
     onToggleItem: PropTypes.func,
     resource: PropTypes.string,
+    rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
     styles: PropTypes.object,

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -1,31 +1,51 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Checkbox from '@material-ui/core/Checkbox';
 import classnames from 'classnames';
+import { linkToRecord } from 'ra-core';
 
 import DatagridCell from './DatagridCell';
 
 const sanitizeRestProps = ({
+    basePath,
+    children,
     classes,
     className,
-    resource,
-    children,
+    rowClick,
     id,
     isLoading,
-    record,
-    basePath,
-    selected,
-    styles,
-    style,
     onToggleItem,
+    push,
+    record,
+    resource,
+    selected,
+    style,
+    styles,
     ...rest
 }) => rest;
 
 class DatagridRow extends Component {
-    handleToggle = () => {
+    handleToggle = event => {
         this.props.onToggleItem(this.props.id);
+        event.stopPropagation();
+    };
+
+    handleClick = () => {
+        const { basePath, rowClick, id, push } = this.props;
+        if (!rowClick) return;
+        if (rowClick === 'edit') {
+            push(linkToRecord(basePath, id));
+        }
+        if (rowClick === 'show') {
+            push(linkToRecord(basePath, id, 'show'));
+        }
+        if (typeof rowClick === 'function') {
+            push(rowClick(id, basePath));
+        }
     };
 
     render() {
@@ -50,6 +70,7 @@ class DatagridRow extends Component {
                 key={id}
                 style={style}
                 hover={hover}
+                onClick={this.handleClick}
                 {...sanitizeRestProps(rest)}
             >
                 {hasBulkActions && (
@@ -92,8 +113,10 @@ DatagridRow.propTypes = {
     hover: PropTypes.bool,
     id: PropTypes.any,
     onToggleItem: PropTypes.func,
+    push: PropTypes.func,
     record: PropTypes.object.isRequired,
     resource: PropTypes.string,
+    rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     selected: PropTypes.bool,
     style: PropTypes.object,
     styles: PropTypes.object,
@@ -106,4 +129,7 @@ DatagridRow.defaultProps = {
     selected: false,
 };
 
-export default DatagridRow;
+export default connect(
+    null,
+    { push }
+)(DatagridRow);


### PR DESCRIPTION
Some users require datagrids with many columns. The Edit or Show button takes a significant share of the horizontal space. As an alternative to adding an `<EditButton>`, developers can now enable the `rowClick` option on the `<Datagrid>` component:

```jsx
const UserList = props => (
    <List {...props}>
        <Datagrid rowClick="show">
            <TextField source="id" />
            <TextField source="name" />
            <TextField source="role" />
        </Datagrid>
    </List>
);
```

![kapture 2018-09-19 at 22 36 27](https://user-images.githubusercontent.com/99944/45779862-7faf2d00-bc5c-11e8-872c-dff8748dfedc.gif)
