### PR TITLE
Fix example simple GraphQL schema for delete

### DIFF
--- a/packages/ra-data-graphql-simple/README.md
+++ b/packages/ra-data-graphql-simple/README.md
@@ -84,7 +84,7 @@ type Mutation {
     views: Int!
     user_id: ID!
   ): Post
-  deletePost(id: ID!): Boolean
+  deletePost(id: ID!): Post
 }
 
 type Post {


### PR DESCRIPTION
Update the documented return type of the example `deletePost` mutation
to match what `ra-core` expects.

Fixes #2338