### PR TITLE
[RFR] Fix out of boundaries pagination does not allow pagination

### DIFF
--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -14,11 +14,17 @@ const emptyArray = [];
 export class Pagination extends Component {
     getNbPages = () => Math.ceil(this.props.total / this.props.perPage) || 1;
 
+    componentDidUpdate() {
+        if (this.props.page < 1 || isNaN(this.props.page)) {
+            this.props.setPage(1);
+        }
+    }
+
     /**
      * Warning: material-ui's page is 0-based
      */
     handlePageChange = (event, page) => {
-        event.stopPropagation();
+        event && event.stopPropagation();
         if (page < 0 || page > this.getNbPages() - 1) {
             throw new Error(
                 this.props.translate('ra.navigation.page_out_of_boundaries', {
@@ -53,12 +59,8 @@ export class Pagination extends Component {
             ...rest
         } = this.props;
 
-        if (
-            (!isLoading && total === 0) ||
-            page < 1 ||
-            page > this.getNbPages()
-        ) {
-            return <PaginationLimit total={total} page={page} />;
+        if (!isLoading && total === 0) {
+            return <PaginationLimit />;
         }
 
         return (

--- a/packages/ra-ui-materialui/src/list/Pagination.spec.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.spec.js
@@ -33,7 +33,7 @@ describe('<Pagination />', () => {
         );
     });
 
-    it('should display a pagination limit on an empty paginated page', () => {
+    it('should not display a pagination limit on an out of bounds page', () => {
         const wrapper = shallow(
             <Pagination
                 translate={x => x}
@@ -46,7 +46,7 @@ describe('<Pagination />', () => {
             />
         );
         expect(wrapper.find('pure(translate(PaginationLimit))')).toHaveLength(
-            1
+            0
         );
     });
 

--- a/packages/ra-ui-materialui/src/list/PaginationLimit.js
+++ b/packages/ra-ui-materialui/src/list/PaginationLimit.js
@@ -6,30 +6,15 @@ import Typography from '@material-ui/core/Typography';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const PaginationLimit = ({ page, total, translate }) => {
-    if (total === 0) {
-        return (
-            <CardContent>
-                <Typography variant="body1">
-                    {translate('ra.navigation.no_results')}
-                </Typography>
-            </CardContent>
-        );
-    }
-
-    return (
-        <CardContent>
-            <Typography variant="body1">
-                {translate('ra.navigation.no_more_results', { page })}
-            </Typography>
-        </CardContent>
-    );
-};
+const PaginationLimit = ({ translate }) => (
+    <CardContent>
+        <Typography variant="body1">
+            {translate('ra.navigation.no_results')}
+        </Typography>
+    </CardContent>
+);
 
 PaginationLimit.propTypes = {
-    ids: PropTypes.array,
-    page: PropTypes.number,
-    total: PropTypes.number,
     translate: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
We don't display the "out of boundaries" message anymore. Instead, we get back to page 1 (when page < 1) or to the last page (when page > last Page) without showing any notice.

![kapture 2018-09-28 at 8 34 14](https://user-images.githubusercontent.com/99944/46191860-5dbb4780-c2f9-11e8-8453-7aef0eb0c068.gif)

The first check is done in our `Pagination`'s `componentDidUpdate`, the second check is done in material-ui's `<TablePagination>`.

The `ra.navigation.page_out_of_boundaries` message is still required by `Pagination.handlePageChange`, so I didn't remove it from translation files.

Closes #2350