### PR TITLE
feat(form-tab): add className to tab content

### DIFF
--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -29,8 +29,8 @@ class FormTab extends Component {
         );
     };
 
-    renderContent = ({ children, hidden, ...rest }) => (
-        <span style={hidden ? hiddenStyle : null}>
+    renderContent = ({ children, className, hidden, ...rest }) => (
+        <span className={className} style={hidden ? hiddenStyle : null}>
             {React.Children.map(
                 children,
                 input =>


### PR DESCRIPTION
As it's already done on Tab, apply className to both FormTab tab and content elements.