### PR TITLE
[RFR] Correctly parse array values from query-string in Create

### DIFF
--- a/packages/ra-core/src/controller/CreateController.js
+++ b/packages/ra-core/src/controller/CreateController.js
@@ -60,7 +60,7 @@ export class CreateController extends Component {
             state && state.record
                 ? state.record
                 : search
-                    ? parse(search)
+                    ? parse(search, { arrayFormat: 'bracket' })
                     : record;
     }
 

--- a/packages/ra-core/src/controller/CreateController.spec.js
+++ b/packages/ra-core/src/controller/CreateController.spec.js
@@ -47,12 +47,14 @@ describe('CreateController', () => {
             const props = {
                 ...defaultProps,
                 children: childrenMock,
-                location: { search: '?foo=baz' },
+                location: { search: '?foo=baz&array[]=1&array[]=2' },
             };
 
             shallow(<CreateController {...props} />);
             expect(childrenMock).toHaveBeenCalledWith(
-                expect.objectContaining({ record: { foo: 'baz' } })
+                expect.objectContaining({
+                    record: { foo: 'baz', array: ['1', '2'] },
+                })
             );
         });
 


### PR DESCRIPTION
The current behavior ([default](https://github.com/sindresorhus/query-string#arrayformat) of `query-string`) prevent passing an array with a single value as it will be considered as a field of the value's type instead of an array of that type.

This prevents passing array of references containing a single reference.