### PR TITLE
Add ra-jsonapi-client to third-party Data Providers

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -59,7 +59,6 @@ Due to the breaking changes, the following providers are no longer working with 
 
 * **[DynamoDb](https://github.com/abiglobalhealth/aor-dynamodb-client)**: [abiglobalhealth/aor-dynamodb-client](https://github.com/abiglobalhealth/aor-dynamodb-client)
 * **[Epilogue](https://github.com/dchester/epilogue)**: [dunghuynh/aor-epilogue-client](https://github.com/dunghuynh/aor-epilogue-client)
-* **[JSON API](http://jsonapi.org/)**: [moonlight-labs/aor-jsonapi-client](https://github.com/moonlight-labs/aor-jsonapi-client)
 * **[Loopback](http://loopback.io/)**: [kimkha/aor-loopback](https://github.com/kimkha/aor-loopback)
 * **[Parse Server](https://github.com/ParsePlatform/parse-server)**: [leperone/aor-parseserver-client](https://github.com/leperone/aor-parseserver-client)
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -47,6 +47,7 @@ You can find Data Providers for various backends in third-party repositories:
 * **[Prisma](https://github.com/weakky/ra-data-prisma)**: [weakky/ra-data-prisma](https://github.com/weakky/ra-data-prisma)
 * **[Xmysql](https://github.com/o1lab/xmysql)**: [soaserele/aor-xmysql](https://github.com/soaserele/aor-xmysql)
 * **[Firebase](https://github.com/aymendhaya/ra-data-firebase-client):** [aymendhaya/ra-data-firebase-client](https://github.com/aymendhaya/ra-data-firebase-client).
+* **[JSON API](http://jsonapi.org/)**: [henvo/ra-jsonapi-client](https://github.com/henvo/ra-jsonapi-client)
 
 If you've written a Data Provider for another backend, and open-sourced it, please help complete this list with your package.
 


### PR DESCRIPTION
Hey!

First of all: Awesome project.

I needed a data provider for my JSONAPI backend and first tried this client:
[moonlight-labs/aor-jsonapi-client](https://github.com/moonlight-labs/aor-jsonapi-client)

Unfortunately this project is deprecated and does not seem to be maintained anymore.
It was already marked as deprecated with this pull request a couple of days ago:
https://github.com/marmelab/react-admin/pull/2300

So I've written my own:
[henvo/ra-jsonapi-client](https://github.com/henvo/ra-jsonapi-client)

The client is now in a reasonably stable state and I would like to submit this to the third-party data providers.

Let me know what you think and have a great day.