### PR TITLE
[RFR] Custom User Menu icon

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -386,9 +386,11 @@ const MyLayout = props => <Layout
 export default MyLayout;
 ```
 
+### UserMenu Customization
+
 You can replace the default user menu by your own by setting the `userMenu` prop of the `<AppBar>` component. For instance, to add custom menu items, just decorate the default `<UserMenu>` by adding children to it:
 
-```js
+```jsx
 import { AppBar, UserMenu, MenuItemLink } from 'react-admin';
 import SettingsIcon from '@material-ui/icons/Settings';
 
@@ -407,6 +409,53 @@ const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
 const MyLayout = props => <Layout {...props} appBar={MyAppBar} />;
 ```
 
+You can also customize the default icon by setting the `icon` prop to the `<UserMenu />` component.
+
+``` jsx
+import AccountBox from '@material-ui/icons/AccountBox';
+
+const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu icon={<AccountBox />}/>} />;
+```
+
+Event better, there is a way to write your own component using the `customIcon` prop.
+
+{% raw %}
+``` jsx
+import { AppBar, UserMenu } from 'react-admin';
+import { withStyles } from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import Avatar from '@material-ui/core/Avatar';
+
+const myCustomIconStyle = {
+    avatar: {
+        height: 30,
+        width: 30,
+    },
+};
+
+const MyCustomIcon = withStyles(myCustomIconStyle)(
+    ({ classes, ...props }) => (
+        <IconButton {...props}>
+            <Avatar
+                className={classes.avatar}
+                src="https://marmelab.com/images/avatars/adrien.jpg"
+            />
+        </IconButton>
+    )
+);
+
+const MyUserMenu = props => (<UserMenu {...props} customIcon={<MyCustomIcon />} />);
+
+const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
+```
+{% endraw %}
+
+**Be careful**: You can't have `icon` and `customIcon` props at the same time. The `icon` prop will be ignored if both are defined.
+
+**Tip**: Don't forget to make your `customIcon` component clickable and to pass down props.
+
+### Sidebar Customization
+
 You can specify the `Sidebar` size by setting the `size` property:
 
 ```jsx
@@ -419,6 +468,8 @@ const MyLayout = props => <Layout
 />;
 
 ```
+
+### Layout From Scratch
 
 For more custom layouts, write a component from scratch. It must contain a `{children}` placeholder, where react-admin will render the resources. Use the [default layout](https://github.com/marmelab/react-admin/blob/master/src/mui/layout/Layout.js) as a starting point. Here is a simplified version (with no responsive support):
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -411,19 +411,10 @@ const MyLayout = props => <Layout {...props} appBar={MyAppBar} />;
 
 You can also customize the default icon by setting the `icon` prop to the `<UserMenu />` component.
 
-``` jsx
-import AccountBox from '@material-ui/icons/AccountBox';
-
-const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu icon={<AccountBox />}/>} />;
-```
-
-Event better, there is a way to write your own component using the `customIcon` prop.
-
 {% raw %}
 ``` jsx
 import { AppBar, UserMenu } from 'react-admin';
 import { withStyles } from '@material-ui/core/styles';
-import IconButton from '@material-ui/core/IconButton';
 import Avatar from '@material-ui/core/Avatar';
 
 const myCustomIconStyle = {
@@ -434,25 +425,19 @@ const myCustomIconStyle = {
 };
 
 const MyCustomIcon = withStyles(myCustomIconStyle)(
-    ({ classes, ...props }) => (
-        <IconButton {...props}>
-            <Avatar
-                className={classes.avatar}
-                src="https://marmelab.com/images/avatars/adrien.jpg"
-            />
-        </IconButton>
+    ({ classes }) => (
+        <Avatar
+            className={classes.avatar}
+            src="https://marmelab.com/images/avatars/adrien.jpg"
+        />
     )
 );
 
-const MyUserMenu = props => (<UserMenu {...props} customIcon={<MyCustomIcon />} />);
+const MyUserMenu = props => (<UserMenu {...props} icon={<MyCustomIcon />} />);
 
 const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
 ```
 {% endraw %}
-
-**Be careful**: You can't have `icon` and `customIcon` props at the same time. The `icon` prop will be ignored if both are defined.
-
-**Tip**: Don't forget to make your `customIcon` component clickable and to pass down props.
 
 ### Sidebar Customization
 

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -53,7 +53,7 @@ class UserMenu extends React.Component {
                         color="inherit"
                         onClick={this.handleMenu}
                     >
-                        {icon && cloneElement(icon)}
+                        {icon}
                     </IconButton>
                 </Tooltip>
                 <Menu

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -11,7 +11,6 @@ class UserMenu extends React.Component {
         children: PropTypes.node,
         label: PropTypes.string.isRequired,
         logout: PropTypes.node,
-        customIcon: PropTypes.node,
         icon: PropTypes.node,
         translate: PropTypes.func.isRequired,
     };
@@ -39,14 +38,7 @@ class UserMenu extends React.Component {
     };
 
     render() {
-        const {
-            children,
-            label,
-            customIcon,
-            icon,
-            logout,
-            translate,
-        } = this.props;
+        const { children, label, icon, logout, translate } = this.props;
         if (!logout && !children) return null;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
@@ -57,17 +49,13 @@ class UserMenu extends React.Component {
             'aria-haspopup': true,
             color: 'inherit',
             onClick: this.handleMenu,
-            children: !customIcon ? cloneElement(icon) : '',
+            children: cloneElement(icon),
         };
 
         return (
             <div>
                 <Tooltip title={label && translate(label, { _: label })}>
-                    {customIcon ? (
-                        cloneElement(customIcon, menuIconProps)
-                    ) : (
-                        <IconButton {...menuIconProps} />
-                    )}
+                    <IconButton {...menuIconProps} />
                 </Tooltip>
                 <Menu
                     id="menu-appbar"

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -43,19 +43,18 @@ class UserMenu extends React.Component {
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
 
-        const menuIconProps = {
-            'arial-label': label && translate(label, { _: label }),
-            'aria-owns': open ? 'menu-appbar' : null,
-            'aria-haspopup': true,
-            color: 'inherit',
-            onClick: this.handleMenu,
-            children: cloneElement(icon),
-        };
-
         return (
             <div>
                 <Tooltip title={label && translate(label, { _: label })}>
-                    <IconButton {...menuIconProps} />
+                    <IconButton
+                        arial-label={label && translate(label, { _: label })}
+                        aria-owns={open ? 'menu-appbar' : null}
+                        aria-haspopup={true}
+                        color="inherit"
+                        onClick={this.handleMenu}
+                    >
+                        {icon && cloneElement(icon)}
+                    </IconButton>
                 </Tooltip>
                 <Menu
                     id="menu-appbar"

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -11,11 +11,13 @@ class UserMenu extends React.Component {
         children: PropTypes.node,
         label: PropTypes.string.isRequired,
         logout: PropTypes.node,
+        icon: PropTypes.node,
         translate: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
         label: 'ra.auth.user_menu',
+        icon: <AccountCircle />,
     };
 
     state = {
@@ -36,7 +38,7 @@ class UserMenu extends React.Component {
     };
 
     render() {
-        const { children, label, logout, translate } = this.props;
+        const { children, label, icon, logout, translate } = this.props;
         if (!logout && !children) return null;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
@@ -44,15 +46,19 @@ class UserMenu extends React.Component {
         return (
             <div>
                 <Tooltip title={label && translate(label, { _: label })}>
-                    <IconButton
-                        arial-label={label && translate(label, { _: label })}
-                        aria-owns={open ? 'menu-appbar' : null}
-                        aria-haspopup="true"
-                        onClick={this.handleMenu}
-                        color="inherit"
-                    >
-                        <AccountCircle />
-                    </IconButton>
+                    {icon && (
+                        <IconButton
+                            arial-label={
+                                label && translate(label, { _: label })
+                            }
+                            aria-owns={open ? 'menu-appbar' : null}
+                            aria-haspopup="true"
+                            onClick={this.handleMenu}
+                            color="inherit"
+                        >
+                            {cloneElement(icon)}
+                        </IconButton>
+                    )}
                 </Tooltip>
                 <Menu
                     id="menu-appbar"

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -11,6 +11,7 @@ class UserMenu extends React.Component {
         children: PropTypes.node,
         label: PropTypes.string.isRequired,
         logout: PropTypes.node,
+        customIcon: PropTypes.node,
         icon: PropTypes.node,
         translate: PropTypes.func.isRequired,
     };
@@ -38,26 +39,34 @@ class UserMenu extends React.Component {
     };
 
     render() {
-        const { children, label, icon, logout, translate } = this.props;
+        const {
+            children,
+            label,
+            customIcon,
+            icon,
+            logout,
+            translate,
+        } = this.props;
         if (!logout && !children) return null;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
 
+        const menuIconProps = {
+            'arial-label': label && translate(label, { _: label }),
+            'aria-owns': open ? 'menu-appbar' : null,
+            'aria-haspopup': true,
+            color: 'inherit',
+            onClick: this.handleMenu,
+            children: !customIcon ? cloneElement(icon) : '',
+        };
+
         return (
             <div>
                 <Tooltip title={label && translate(label, { _: label })}>
-                    {icon && (
-                        <IconButton
-                            arial-label={
-                                label && translate(label, { _: label })
-                            }
-                            aria-owns={open ? 'menu-appbar' : null}
-                            aria-haspopup="true"
-                            onClick={this.handleMenu}
-                            color="inherit"
-                        >
-                            {cloneElement(icon)}
-                        </IconButton>
+                    {customIcon ? (
+                        cloneElement(customIcon, menuIconProps)
+                    ) : (
+                        <IconButton {...menuIconProps} />
                     )}
                 </Tooltip>
                 <Menu


### PR DESCRIPTION
The idea is to let the user choosing the Icon but also the Component without rewriting the whole UserMenu.

## Todo

- [x] Make possible the change of the UserMenu icon
- [x] Make possible the change of the UserMenu icon component
- [x] Take Screenshots
- [x] Write docs

## Screenshots

**Changing UserMenu icon**

![selection_107](https://user-images.githubusercontent.com/5584839/46520376-13e3db80-c87c-11e8-9212-964e3453c270.png)

**Changing UserMenu component**

![selection_113](https://user-images.githubusercontent.com/5584839/46520379-17776280-c87c-11e8-9de9-b00950e617fa.png)
