### PR TITLE
[RFR] Button - don't display empty label and center icon if no label

### DIFF
--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -45,23 +45,29 @@ const Button = ({
 }) => (
     <Responsive
         small={
-            <Tooltip title={label && translate(label, { _: label })}>
-                <IconButton
-                    arial-label={label && translate(label, { _: label })}
-                    className={className}
-                    color={color}
-                    {...rest}
-                >
+            label ? (
+                <Tooltip title={translate(label, { _: label })}>
+                    <IconButton
+                        arial-label={translate(label, { _: label })}
+                        className={className}
+                        color={color}
+                        {...rest}
+                    >
+                        {children}
+                    </IconButton>
+                </Tooltip>
+            ) : (
+                <IconButton className={className} color={color} {...rest}>
                     {children}
                 </IconButton>
-            </Tooltip>
+            )
         }
         medium={
             <MuiButton
                 className={classnames(classes.button, className)}
                 color={color}
                 size={size}
-                aria-label={label && translate(label, { _: label })}
+                aria-label={label ? translate(label, { _: label }) : undefined}
                 {...rest}
             >
                 {alignIcon === 'left' &&
@@ -69,14 +75,16 @@ const Button = ({
                     React.cloneElement(children, {
                         className: classes[`${size}Icon`],
                     })}
-                <span
-                    className={classnames({
-                        [classes.label]: alignIcon === 'left',
-                        [classes.labelRightIcon]: alignIcon !== 'left',
-                    })}
-                >
-                    {label && translate(label, { _: label })}
-                </span>
+                {label && (
+                    <span
+                        className={classnames({
+                            [classes.label]: alignIcon === 'left',
+                            [classes.labelRightIcon]: alignIcon !== 'left',
+                        })}
+                    >
+                        {translate(label, { _: label })}
+                    </span>
+                )}
                 {alignIcon === 'right' &&
                     children &&
                     React.cloneElement(children, {


### PR DESCRIPTION
If you provide no label to Button, then on mobile mode there is empty tooltip visible
![snimek obrazovky 2018-10-10 v 9 40 52](https://user-images.githubusercontent.com/488136/46720355-a0bdd900-cc70-11e8-8e35-37e1af977898.png)

and on desktop mode the icon is not center due to empty span with padding
![snimek obrazovky 2018-10-10 v 9 41 01](https://user-images.githubusercontent.com/488136/46720357-a1566f80-cc70-11e8-828f-c959c597d535.png)

this PR fixes that

btw. no idea if this should go to next or master, so made it for next first
