### PR TITLE
Use 'network-only' apollo option for graphql introspection.

### DIFF
--- a/packages/ra-data-graphql/src/introspection.js
+++ b/packages/ra-data-graphql/src/introspection.js
@@ -33,6 +33,7 @@ export default async (client, options) => {
         ? options.schema
         : await client
               .query({
+                  fetchPolicy: 'network-only',
                   query: gql`
                       ${introspectionQuery}
                   `,


### PR DESCRIPTION
Fixes #2397 

Not very trivial to test with jest, as it's a browser-only issue. The change mimics the behaviour already already in place for regular graphql queries (See issue).