### PR TITLE
[RFR] Fix double asterix on required RadioButtonGroupInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
@@ -132,17 +132,11 @@ export class RadioButtonGroupInput extends Component {
         return (
             <FormControl
                 component="fieldset"
-                required={isRequired}
                 className={className}
                 margin="normal"
                 {...sanitizeRestProps(rest)}
             >
-                <InputLabel
-                    component="legend"
-                    shrink
-                    required={isRequired}
-                    className={classes.label}
-                >
+                <InputLabel component="legend" shrink className={classes.label}>
                     <FieldTitle
                         label={label}
                         source={source}


### PR DESCRIPTION
Closes #2395

Incidentally, this bug teaught me that material-ui now handles the required label at the `FormControl` level. We'll have to use that in the future.