### PR TITLE
Fix Validation issues on RichTextInput [2371]

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -66,7 +66,7 @@ export class RichTextInput extends Component {
         const { error, helperText = false } = this.props.meta;
         return (
             <FormControl
-                error={error}
+                error={error !== null && error != undefined}
                 fullWidth={this.props.fullWidth}
                 className="ra-rich-text-input"
             >


### PR DESCRIPTION
Error property expects a boolean but receives a string.
Changed to a null and undefined check.