### PR TITLE
Fix typo in exporter example

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -197,7 +197,7 @@ import { unparse as convertToCSV } from 'papaparse/papaparse.min';
 
 const exporter = (records, fetchRelatedRecords) => {
     fetchRelatedRecords(records, 'post_id', 'posts').then(posts => {
-        const data = posts.map(record => ({
+        const data = records.map(record => ({
                 ...record,
                 post_title: posts[record.post_id].title,
         }));


### PR DESCRIPTION
Updated "posts.map" to "records.map" as this appears produce the intended result.