### PR TITLE
[RFR] Add link to news in Readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A frontend Framework for building admin applications running in the browser on top of REST/GraphQL APIs, using ES6, [React](https://facebook.github.io/react/) and [Material Design](https://material.io/). Previously named [admin-on-rest](https://github.com/marmelab/admin-on-rest). Open sourced and maintained by [marmelab](https://marmelab.com/).
 
-[Demo](https://marmelab.com/react-admin-demo/) - [Documentation](https://marmelab.com/react-admin/) - [Releases](https://github.com/marmelab/react-admin/releases) - [Support](http://stackoverflow.com/questions/tagged/react-admin)
+[Demo](https://marmelab.com/react-admin-demo/) - [Documentation](https://marmelab.com/react-admin/) - [News](https://https://marmelab.com/en/blog/#react-admin) - [Releases](https://github.com/marmelab/react-admin/releases) - [Support](http://stackoverflow.com/questions/tagged/react-admin)
 
 [![react-admin-demo](https://marmelab.com/react-admin/img/react-admin-demo-still.png)](https://vimeo.com/268958716)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@ A frontend Framework for building admin applications running in the browser on t
 <div style="text-align: center" markdown="1">
 <i class="octicon octicon-device-desktop"></i> [Demo](https://marmelab.com/react-admin-demo/) -
 <i class="octicon octicon-mark-github"></i> [Source](https://github.com/marmelab/react-admin) -
-<i class="octicon octicon-megaphone"></i> [Releases](https://github.com/marmelab/react-admin/releases) -
+<i class="octicon octicon-megaphone"></i> [News](https://https://marmelab.com/en/blog/#react-admin) -
+<i class="octicon octicon-clock"></i> [Releases](https://github.com/marmelab/react-admin/releases) -
 <i class="octicon octicon-comment-discussion"></i> [Support](http://stackoverflow.com/questions/tagged/react-admin)
 </div>
 


### PR DESCRIPTION
Because we publish a lot of articles about react-admin, but people aren't aware of them