### PR TITLE
Update introspection type check with queryType and mutationType

### DIFF
--- a/packages/ra-data-graphql/src/introspection.js
+++ b/packages/ra-data-graphql/src/introspection.js
@@ -41,13 +41,13 @@ export default async (client, options) => {
               .then(({ data: { __schema } }) => __schema);
 
     const queries = schema.types.reduce((acc, type) => {
-        if (type.name !== 'Query' && type.name !== 'Mutation') return acc;
+        if (type.name !== schema.queryType && type.name !== schema.mutationType) return acc;
 
         return [...acc, ...type.fields];
     }, []);
 
     const types = schema.types.filter(
-        type => type.name !== 'Query' && type.name !== 'Mutation'
+        type => type.name !== schema.queryType && type.name !== schema.mutationType
     );
 
     const isResource = type =>

--- a/packages/ra-data-graphql/src/introspection.js
+++ b/packages/ra-data-graphql/src/introspection.js
@@ -41,13 +41,19 @@ export default async (client, options) => {
               .then(({ data: { __schema } }) => __schema);
 
     const queries = schema.types.reduce((acc, type) => {
-        if (type.name !== schema.queryType && type.name !== schema.mutationType) return acc;
+        if (
+            type.name !== schema.queryType.name &&
+            type.name !== schema.mutationType.name
+        )
+            return acc;
 
         return [...acc, ...type.fields];
     }, []);
 
     const types = schema.types.filter(
-        type => type.name !== schema.queryType && type.name !== schema.mutationType
+        type =>
+            type.name !== schema.queryType.name &&
+            type.name !== schema.mutationType.name
     );
 
     const isResource = type =>

--- a/packages/ra-data-graphql/src/introspection.test.js
+++ b/packages/ra-data-graphql/src/introspection.test.js
@@ -80,6 +80,8 @@ describe('introspection', () => {
                 Promise.resolve({
                     data: {
                         __schema: {
+                            queryType: { name: 'Query' },
+                            mutationType: { name: 'Mutation' },
                             types: [
                                 {
                                     name: 'Query',


### PR DESCRIPTION
Checking for queryType and mutationType instead opens up the possibility for data providers to make use of GraphQL endpoints where the type name for query and mutation types are not 'Query' and 'Mutation'.