### PR TITLE
Switch jsonapi data provider in ecosystem chapter

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -28,7 +28,7 @@ See the [translation](./Translation.md#available-locales) page.
 * **[GraphQL](http://graphql.org/)**: [marmelab/ra-data-graphql](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql) (uses [Apollo](http://www.apollodata.com/))
 * **[GraphCool](http://www.graph.cool/)**: [marmelab/ra-data-graphcool](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql) (uses [Apollo](http://www.apollodata.com/))
 * **[Hydra](http://www.hydra-cg.com/) / [JSON-LD](https://json-ld.org/)**: [api-platform/admin/hydra](https://github.com/api-platform/admin/blob/master/src/hydra/hydraClient.js)
-* **[JSON API](http://jsonapi.org/)**: [moonlight-labs/aor-jsonapi-client](https://github.com/moonlight-labs/aor-jsonapi-client)
+* **[JSON API](http://jsonapi.org/)**: [henvo/ra-jsonapi-client](https://github.com/henvo/ra-jsonapi-client)
 * **[JSON server](https://github.com/typicode/json-server)**: [marmelab/ra-data-json-server](https://github.com/marmelab/ra-data-json-server).
 * Local JSON: [marmelab/ra-data-fakerest](https://github.com/marmelab/ra-data-fakerest)
 * **[Loopback](http://loopback.io/)**: [kimkha/aor-loopback](https://github.com/kimkha/aor-loopback)

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -115,7 +115,7 @@
                                 <a href="#error-format">Error Format</a>
                             </li>
                             <li class="chapter">
-                                <a href="#example-implementation">Example Implmentation</a>
+                                <a href="#example-implementation">Example Implementation</a>
                             </li>
                         </ul>
                     </li>


### PR DESCRIPTION
This is a follow up PR for https://github.com/marmelab/react-admin/pull/2386 where we switched the data provider for JSONAPI and forgot to change this also in the 'Ecosystem' chapter.

Also a small typo fix.