### PR TITLE
[RFR] Fix missing styles in rendered documentation

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -139,6 +139,7 @@ export const PostEdit = (props) => (
 
 You may want to display additional information on the side of the form. Use the `aside` prop for that, passing the component of your choice:
 
+{% raw %}
 ```jsx
 const Aside = () => (
     <div style={{ width: 200, margin: '1em' }}>
@@ -154,9 +155,11 @@ const PostEdit = props => (
         ...
     </Edit>
 ```
+{% endraw %}
 
 The `aside` component receives the same props as the `Edit` or `Create` child component: `basePath`, `record`, `resource`, and `version`. That means you can display non-editable details of the current record in the aside component:
 
+{% raw %}
 ```jsx
 const Aside = ({ record }) => (
     <div style={{ width: 200, margin: '1em' }}>
@@ -167,6 +170,7 @@ const Aside = ({ record }) => (
     </div>
 );
 ```
+{% endraw %}
 
 ## Prefilling a `<Create>` Record
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -586,6 +586,7 @@ export const PostList = (props) => (
 
 You may want to display additional information on the side of the list. Use the `aside` prop for that, passing the component of your choice:
 
+{% raw %}
 ```jsx
 const Aside = () => (
     <div style={{ width: 200, margin: '1em' }}>
@@ -601,6 +602,7 @@ const PostList = props => (
         ...
     </List>
 ```
+{% endraw %}
 
 The `aside` component receives the same props as the `List` child component, including the following:
 
@@ -619,6 +621,7 @@ The `aside` component receives the same props as the `List` child component, inc
 
 That means you can display additional details of the current list in the aside component:
 
+{% raw %}
 ```jsx
 const Aside = ({ data, ids }) => (
     <div style={{ width: 200, margin: '1em' }}>
@@ -629,6 +632,7 @@ const Aside = ({ data, ids }) => (
     </div>
 );
 ```
+{% endraw %}
 
 ### CSS API
 

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -120,6 +120,7 @@ export const PostShow = (props) => (
 
 You may want to display additional information on the side of the resource detail. Use the `aside` prop for that, passing the component of your choice:
 
+{% raw %}
 ```jsx
 const Aside = () => (
     <div style={{ width: 200, margin: '1em' }}>
@@ -135,9 +136,11 @@ const PostShow = props => (
         ...
     </Show>
 ```
+{% endraw %}
 
 The `aside` component receives the same props as the `Show` child component: `basePath`, `record`, `resource`, and `version`. That means you can display secondary details of the current record in the aside component:
 
+{% raw %}
 ```jsx
 const Aside = ({ record }) => (
     <div style={{ width: 200, margin: '1em' }}>
@@ -148,6 +151,7 @@ const Aside = ({ record }) => (
     </div>
 );
 ```
+{% endraw %}
 
 ## The `<ShowGuesser>` component
 


### PR DESCRIPTION
Double brackets (`{{`) declare an instruction in Liquid. We must use `{% raw %}` around code snippets using them, or the conent isn't rendered in the gh-pages docs.