### PR TITLE
[RFR] Temporarily use graphql-ast-types-browser instead of graphql-ast-types

### DIFF
--- a/packages/ra-data-graphcool/package.json
+++ b/packages/ra-data-graphcool/package.json
@@ -33,7 +33,7 @@
         "watch": "rimraf ./lib && tsc --watch"
     },
     "dependencies": {
-        "graphql-ast-types": "Kmaschta/graphql-ast-types#master",
+        "graphql-ast-types-browser": "~1.0.2",
         "graphql-tag": "^2.6.1",
         "lodash": "~4.17.5",
         "pluralize": "~7.0.0",

--- a/packages/ra-data-graphcool/src/buildGqlQuery.js
+++ b/packages/ra-data-graphcool/src/buildGqlQuery.js
@@ -1,7 +1,7 @@
 import { GET_LIST, GET_MANY, GET_MANY_REFERENCE, DELETE } from 'react-admin';
 import { QUERY_TYPES } from 'ra-data-graphql';
 import { TypeKind } from 'graphql';
-import * as gqlTypes from 'graphql-ast-types';
+import * as gqlTypes from 'graphql-ast-types-browser';
 
 import getFinalType from './getFinalType';
 import isList from './isList';

--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -32,7 +32,7 @@
         "watch": "rimraf ./lib && tsc --watch"
     },
     "dependencies": {
-        "graphql-ast-types": "Kmaschta/graphql-ast-types#master",
+        "graphql-ast-types-browser": "~1.0.2",
         "graphql-tag": "^2.6.1",
         "lodash": "~4.17.5",
         "pluralize": "~7.0.0",

--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.js
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.js
@@ -1,7 +1,7 @@
 import { GET_LIST, GET_MANY, GET_MANY_REFERENCE, DELETE } from 'react-admin';
 import { QUERY_TYPES } from 'ra-data-graphql';
 import { TypeKind } from 'graphql';
-import * as gqlTypes from 'graphql-ast-types';
+import * as gqlTypes from 'graphql-ast-types-browser';
 
 import getFinalType from './getFinalType';
 import isList from './isList';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,9 +6066,9 @@ graphql-anywhere@^4.1.14:
   dependencies:
     apollo-utilities "^1.0.16"
 
-graphql-ast-types@Kmaschta/graphql-ast-types#master:
+graphql-ast-types-browser@~1.0.2:
   version "1.0.2"
-  resolved "https://codeload.github.com/Kmaschta/graphql-ast-types/tar.gz/412a17d44c4c9e05dc93195263c96e6c96f5db85"
+  resolved "https://registry.yarnpkg.com/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz#474305af7e76f9692df6e50a88fb668ce258c4a4"
 
 graphql-tag@^2.0.0, graphql-tag@^2.4.2, graphql-tag@^2.6.1:
   version "2.9.2"
@@ -10594,15 +10594,15 @@ react-app-polyfill@^0.1.3:
     raf "3.4.0"
     whatwg-fetch "3.0.0"
 
-react-autosuggest@^9.3.2:
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.4.tgz#e47ff800081b2f7c678165bfb7cc84b07f462336"
+react-autosuggest@^9.4.2:
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.2.tgz#18cc0bebeebda3d24328e3da301f061a444ae223"
   dependencies:
     prop-types "^15.5.10"
-    react-autowhatever "^10.1.0"
+    react-autowhatever "^10.1.2"
     shallow-equal "^1.0.0"
 
-react-autowhatever@^10.1.0:
+react-autowhatever@^10.1.2:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.1.2.tgz#200ffc41373b2189e3f6140ac7bdb82363a79fd3"
   dependencies:


### PR DESCRIPTION
Fixes #2398

In order to let the offline users (or those who use a mirror of NPM's registry) install react-admin, I just published a clone of `graphql-ast-types` that is transpiled for browsers.

I'll remove this package as soon as https://github.com/imranolas/graphql-ast-types/issues/7 is fixed.