### PR TITLE
[RFR] Pass total to ReferenceManyField

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
@@ -11,6 +11,7 @@ import {
 import {
     getIds,
     getReferences,
+    getTotal,
     nameRelatedTo,
 } from '../../reducer/admin/references/oneToMany';
 
@@ -121,6 +122,7 @@ export class ReferenceManyFieldController extends Component {
             ids,
             children,
             basePath,
+            total,
         } = this.props;
 
         const referenceBasePath = basePath.replace(resource, reference);
@@ -132,6 +134,7 @@ export class ReferenceManyFieldController extends Component {
             isLoading: typeof ids === 'undefined',
             referenceBasePath,
             setSort: this.setSort,
+            total,
         });
     }
 }
@@ -155,6 +158,7 @@ ReferenceManyFieldController.propTypes = {
     source: PropTypes.string.isRequired,
     target: PropTypes.string.isRequired,
     isLoading: PropTypes.bool,
+    total: PropTypes.number,
 };
 
 ReferenceManyFieldController.defaultProps = {
@@ -175,6 +179,7 @@ function mapStateToProps(state, props) {
     return {
         data: getReferences(state, props.reference, relatedTo),
         ids: getIds(state, relatedTo),
+        total: getTotal(state, relatedTo),
     };
 }
 

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.js
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.js
@@ -7,7 +7,10 @@ export default (previousState = initialState, { type, payload, meta }) => {
         case CRUD_GET_MANY_REFERENCE_SUCCESS:
             return {
                 ...previousState,
-                [meta.relatedTo]: payload.data.map(record => record.id),
+                [meta.relatedTo]: {
+                    ids: payload.data.map(record => record.id),
+                    total: payload.total,
+                },
             };
         default:
             return previousState;
@@ -15,7 +18,12 @@ export default (previousState = initialState, { type, payload, meta }) => {
 };
 
 export const getIds = (state, relatedTo) =>
-    state.admin.references.oneToMany[relatedTo];
+    state.admin.references.oneToMany[relatedTo] &&
+    state.admin.references.oneToMany[relatedTo].ids;
+
+export const getTotal = (state, relatedTo) =>
+    state.admin.references.oneToMany[relatedTo] &&
+    state.admin.references.oneToMany[relatedTo].total;
 
 export const getReferences = (state, reference, relatedTo) => {
     const ids = getIds(state, relatedTo);

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.js
@@ -19,6 +19,7 @@ export const ReferenceManyFieldView = ({
     reference,
     referenceBasePath,
     setSort,
+    total,
 }) => {
     if (isLoading) {
         return <LinearProgress className={classes.progress} />;
@@ -32,6 +33,7 @@ export const ReferenceManyFieldView = ({
         basePath: referenceBasePath,
         currentSort,
         setSort,
+        total,
     });
 };
 

--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -122,7 +122,7 @@ SimpleList.propTypes = {
     leftIcon: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
         .isRequired,
-    onToggleItem: PropTypes.func.isRequired,
+    onToggleItem: PropTypes.func,
     primaryText: PropTypes.func,
     rightAvatar: PropTypes.func,
     rightIcon: PropTypes.func,


### PR DESCRIPTION
Since we refactored the `List` component, its children expect a `total` prop to be passed to them. But the same children can also be used as children of the `<ReferenceManyField>` component, which didn't pass the `total` prop. this caused a regression in 2.4.0.

This PR lets the `<ReferenceManyField>` grab the `total` of the references from the store, and pass it to its children - so it solves the issue when `<ReferenceManyField>` is used with `<SimpleList>` as child.

Closes #2462 
Supersedes #2467 