### PR TITLE
Fix Datagrid header cell padding

### DIFF
--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -22,6 +22,9 @@ const styles = {
     },
     headerCell: {
         padding: '0 12px',
+        '&:last-child': {
+            padding: '0 12px',
+        },
     },
     checkbox: {},
     row: {},


### PR DESCRIPTION
This fixes the issue I described in #2506. It didn't look like there are any automated tests around this so I checked it in the app built by `make run-simple`. Let me know if there is anything else I can help with around this issue.