### PR TITLE
Accept object as valid parameter for toolbar

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -18,7 +18,7 @@ export class RichTextInput extends Component {
         meta: PropTypes.object,
         options: PropTypes.object,
         source: PropTypes.string,
-        toolbar: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
+        toolbar: PropTypes.oneOfType([PropTypes.array, PropTypes.bool, PropTypes.object]),
         fullWidth: PropTypes.bool,
     };
 


### PR DESCRIPTION
This input should accept object as valid parameter for toolbar for advance custom.