### PR TITLE
[RFR] Change routing state key from routing to router

### DIFF
--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -13,7 +13,7 @@ Fortunately, the `<Admin>` component detects when it's used inside an existing R
 
 Beware that you need to know about [redux](http://redux.js.org/), [react-router](https://github.com/reactjs/react-router), and [redux-saga](https://github.com/yelouafi/redux-saga) to go further.
 
-React-admin requires that the redux state contains at least 4 reducers: `admin`, `i18n`, `form`, and `routing`. You can add more, or replace some of them with your own, but you can't remove or rename them. As it relies on redux-form, react-router, and redux-saga, react-admin also expects the store to use their middlewares.
+React-admin requires that the redux state contains at least 4 reducers: `admin`, `i18n`, `form`, and `router`. You can add more, or replace some of them with your own, but you can't remove or rename them. As it relies on redux-form, react-router, and redux-saga, react-admin also expects the store to use their middlewares.
 
 Here is the default store creation for react-admin:
 
@@ -44,7 +44,7 @@ export default ({
         admin: adminReducer,
         i18n: i18nReducer(locale, i18nProvider(locale)),
         form: formReducer,
-        routing: routerReducer,
+        router: routerReducer,
         { /* add your own reducers here */ },
     });
     const resettableAppReducer = (state, action) =>

--- a/packages/ra-core/src/reducer/index.js
+++ b/packages/ra-core/src/reducer/index.js
@@ -14,7 +14,7 @@ export default (customReducers, locale, messages) =>
         admin,
         i18n: i18nReducer(locale, messages),
         form: formReducer,
-        routing: routerReducer,
+        router: routerReducer,
         ...customReducers,
     });
 

--- a/packages/ra-core/src/sideEffect/auth.js
+++ b/packages/ra-core/src/sideEffect/auth.js
@@ -16,11 +16,11 @@ import {
 import { FETCH_ERROR } from '../actions/fetchActions';
 import { AUTH_LOGIN, AUTH_CHECK, AUTH_ERROR, AUTH_LOGOUT } from '../auth';
 const nextPathnameSelector = state => {
-    const locationState = state.routing.location.state;
+    const locationState = state.router.location.state;
     return locationState && locationState.nextPathname;
 };
 
-const currentPathnameSelector = state => state.routing.location;
+const currentPathnameSelector = state => state.router.location;
 
 export default authProvider => {
     if (!authProvider) return () => null;

--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -85,7 +85,7 @@ Menu.defaultProps = {
 const mapStateToProps = state => ({
     open: state.admin.ui.sidebarOpen,
     resources: getResources(state),
-    pathname: state.routing.location.pathname, // used to force redraw on navigation
+    pathname: state.router.location.pathname, // used to force redraw on navigation
 });
 
 const enhance = compose(


### PR DESCRIPTION
This change enables react-admin to be included in an app that uses connected-react-router