### PR TITLE
Fix custom app snippet leads to warnings for missing props

### DIFF
--- a/packages/ra-core/src/controller/ListController.js
+++ b/packages/ra-core/src/controller/ListController.js
@@ -318,10 +318,10 @@ ListController.propTypes = {
     data: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     debounce: PropTypes.number,
     filterValues: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    hasCreate: PropTypes.bool.isRequired,
-    hasEdit: PropTypes.bool.isRequired,
-    hasList: PropTypes.bool.isRequired,
-    hasShow: PropTypes.bool.isRequired,
+    hasCreate: PropTypes.bool,
+    hasEdit: PropTypes.bool,
+    hasList: PropTypes.bool,
+    hasShow: PropTypes.bool,
     ids: PropTypes.array,
     selectedIds: PropTypes.array,
     isLoading: PropTypes.bool.isRequired,


### PR DESCRIPTION
The `has*` props aren't really required anyway, because the `ListController` treats an empty value as falsy. And since all the other controllers consider these props as non-required, the change is also about making the controllers consistent.

Refs #2485