### PR TITLE
Changed include type from dev to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ React-admin is available from npm. You can install it (and its required dependen
 using:
 
 ```sh
-npm install --save-dev react-admin
+npm install react-admin
+
+#or
+yarn add react-admin
 ```
 
 ## Upgrading From Admin-On-Rest


### PR DESCRIPTION
Previously, the README stated that react-admin should be included as a dev dependency. Now, the README states that react-admin should be included as a production dependency.