### PR TITLE
Change node polyglot dependency tag

### DIFF
--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -49,7 +49,7 @@
         "date-fns": "^1.29.0",
         "inflection": "~1.12.0",
         "lodash": "~4.17.5",
-        "node-polyglot": "2.2.2",
+        "node-polyglot": "^2.2.2",
         "prop-types": "~15.6.1",
         "query-string": "~5.1.1",
         "ra-language-english": "^2.3.0",


### PR DESCRIPTION
Node polyglot has some issues with Farsi locale in version 2.2.0 and it is fixed in 2.3.0. But as I looked tag version in ra-core is 2.2.0 and creates conflicts with 2.3.0. I suggest using ^2.2.0 to fix this issue.