### PR TITLE
[RFR] Add ability to paginate ReferenceManyField

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -534,7 +534,7 @@ Then react-admin renders the `<CommentList>` with a loader for the `<ReferenceFi
 
 ## `<ReferenceManyField>`
 
-This component fetches a list of referenced records by reverse lookup of the current `record.id` in other resource (using the `GET_MANY_REFERENCE` REST method). The field name of the current record's id in the other resource is specified by the required `target` field. The result is then passed to an iterator component (like `<SingleFieldList>` or `<Datagrid>`). The iterator component usually has one or more child `<Field>` components.
+This component fetches a list of referenced records by reverse lookup of the current `record.id` in other resource (using the `GET_MANY_REFERENCE` REST method). You can specify the target field name, i.e. the field name of the current record's id in the other resource, using the required `target` field. The result is then passed to an iterator component (like `<SingleFieldList>` or `<Datagrid>`). The iterator component usually has one or more child `<Field>` components.
 
 For instance, here is how to fetch the `comments` related to a `post` record by matching `comment.post_id` to `post.id`, and then display the `author.name` for each, in a `<ChipField>`:
 
@@ -594,10 +594,20 @@ export const PostEdit = (props) => (
 
 ![ReferenceManyFieldDatagrid](./img/reference-many-field-datagrid.png)
 
-By default, react-admin restricts the possible values to 25. You can change this limit by setting the `perPage` prop.
+By default, react-admin restricts the possible values to 25 and displays no pagination control. You can change the limit by setting the `perPage` prop:
 
 ```jsx
 <ReferenceManyField perPage={10} reference="comments" target="post_id">
+   ...
+</ReferenceManyField>
+```
+
+And if you want to allow users to paginate the list, pass a `<Pagination>` component as the `pagination` prop:
+
+```jsx
+import { Pagination } from 'react-admin';
+
+<ReferenceManyField pagination={<Pagination />} reference="comments" target="post_id">
    ...
 </ReferenceManyField>
 ```

--- a/examples/demo/src/products/index.js
+++ b/examples/demo/src/products/index.js
@@ -10,6 +10,7 @@ import {
     FormTab,
     List,
     NumberInput,
+    Pagination,
     ReferenceInput,
     ReferenceManyField,
     SearchInput,
@@ -194,6 +195,7 @@ export const ProductEdit = withStyles(editStyles)(({ classes, ...props }) => (
                     reference="reviews"
                     target="product_id"
                     addLabel={false}
+                    pagination={<Pagination />}
                 >
                     <Datagrid>
                         <DateField source="date" />

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
@@ -64,7 +64,7 @@ import {
 export class ReferenceManyFieldController extends Component {
     constructor(props) {
         super(props);
-        this.state = { sort: props.sort };
+        this.state = { sort: props.sort, page: 1, perPage: props.perPage };
     }
 
     componentDidMount() {
@@ -84,18 +84,21 @@ export class ReferenceManyFieldController extends Component {
     setSort = field => {
         const order =
             this.state.sort.field === field &&
-            this.state.sort.order === SORT_ASC
+                this.state.sort.order === SORT_ASC
                 ? SORT_DESC
                 : SORT_ASC;
         this.setState({ sort: { field, order } }, this.fetchReferences);
     };
 
+    setPage = page => this.setState({ page }, this.fetchReferences);
+
+    setPerPage = perPage => this.setState({ perPage }, this.fetchReferences);
+
     fetchReferences(
-        { reference, record, resource, target, perPage, filter, source } = this
-            .props
+        { reference, record, resource, target, filter, source } = this.props
     ) {
         const { crudGetManyReference } = this.props;
-        const pagination = { page: 1, perPage };
+        const { page, perPage, sort } = this.state;
         const relatedTo = nameRelatedTo(
             reference,
             record[source],
@@ -108,8 +111,8 @@ export class ReferenceManyFieldController extends Component {
             target,
             record[source],
             relatedTo,
-            pagination,
-            this.state.sort,
+            { page, perPage },
+            sort,
             filter
         );
     }
@@ -124,6 +127,7 @@ export class ReferenceManyFieldController extends Component {
             basePath,
             total,
         } = this.props;
+        const { page, perPage } = this.state;
 
         const referenceBasePath = basePath.replace(resource, reference);
 
@@ -132,7 +136,11 @@ export class ReferenceManyFieldController extends Component {
             data,
             ids,
             isLoading: typeof ids === 'undefined',
+            page,
+            perPage,
             referenceBasePath,
+            setPage: this.setPage,
+            setPerPage: this.setPerPage,
             setSort: this.setSort,
             total,
         });
@@ -157,6 +165,7 @@ ReferenceManyFieldController.propTypes = {
     sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     target: PropTypes.string.isRequired,
+    total: PropTypes.number,
     isLoading: PropTypes.bool,
     total: PropTypes.number,
 };

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { withStyles } from '@material-ui/core/styles';
@@ -16,26 +16,35 @@ export const ReferenceManyFieldView = ({
     data,
     ids,
     isLoading,
+    page,
+    pagination,
+    perPage,
     reference,
     referenceBasePath,
+    setPage,
+    setPerPage,
     setSort,
     total,
-}) => {
-    if (isLoading) {
-        return <LinearProgress className={classes.progress} />;
-    }
-
-    return React.cloneElement(children, {
-        className,
-        resource: reference,
-        ids,
-        data,
-        basePath: referenceBasePath,
-        currentSort,
-        setSort,
-        total,
-    });
-};
+}) => isLoading ? <LinearProgress className={classes.progress} /> :
+        <Fragment>
+            {cloneElement(children, {
+                className,
+                resource: reference,
+                ids,
+                data,
+                basePath: referenceBasePath,
+                currentSort,
+                setSort,
+                total,
+            })}
+            {pagination && cloneElement(pagination, {
+                page,
+                perPage,
+                setPage,
+                setPerPage,
+                total,
+            })}
+        </Fragment>;
 
 ReferenceManyFieldView.propTypes = {
     children: PropTypes.element,
@@ -48,6 +57,7 @@ ReferenceManyFieldView.propTypes = {
     data: PropTypes.object,
     ids: PropTypes.array,
     isLoading: PropTypes.bool,
+    pagination: PropTypes.element,
     reference: PropTypes.string,
     referenceBasePath: PropTypes.string,
     setSort: PropTypes.func,


### PR DESCRIPTION
And if you want to allow users to paginate the list, pass a `<Pagination>` component as the `pagination` prop:

```jsx
import { Pagination } from 'react-admin';

<ReferenceManyField pagination={<Pagination />} reference="comments" target="post_id">
   ...
</ReferenceManyField>
```

![peek 27-11-2018 12-42](https://user-images.githubusercontent.com/99944/49080534-47bbfb80-f244-11e8-8f17-26d47c23c67f.gif)
