### PR TITLE
Add componentWillReceiveProps for RichTextInput

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -47,6 +47,12 @@ export class RichTextInput extends Component {
         this.quill.on('text-change', debounce(this.onTextChange, 500));
     }
 
+    componentWillReceiveProps(nextProps) {
+       if (nextProps.input.value !== this.props.input.value) {
+          this.quill.pasteHTML(nextProps.input.value);
+       }
+    }
+
     componentWillUnmount() {
         this.quill.off('text-change', this.onTextChange);
         this.quill = null;


### PR DESCRIPTION
Today i found bug with ```RichTextInput``` component. On first load it will be empty.
Proposed solution: call ```quill.pasteHTML``` in ```componentWillReceiveProps```.