### PR TITLE
Allow 'object' propType in 'to' prop of 'MenuItemLink'

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.js
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.js
@@ -25,7 +25,7 @@ export class MenuItemLink extends Component {
         onClick: PropTypes.func,
         primaryText: PropTypes.string,
         staticContext: PropTypes.object,
-        to: PropTypes.string.isRequired,
+        to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
     };
 
     handleMenuTap = () => {


### PR DESCRIPTION
As documented in `react-router`, the `<NavLink>` component can have either `string` or `object` type for its `to' property:

https://reacttraining.com/react-router/web/api/Link

Some developers use it as such:

```
              <MenuItemLink
                to={{
                  pathname: '/departments',
                }}
                primaryText="departments"
                title="departments"
                onClick={onMenuClick}
                leftIcon={<BusinessIcon />}
              />
```