### PR TITLE
Fix 'handleMenuTap' (onClick) to also pass the event to the 'onClick' prop

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.js
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.js
@@ -28,8 +28,8 @@ export class MenuItemLink extends Component {
         to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
     };
 
-    handleMenuTap = () => {
-        this.props.onClick && this.props.onClick();
+    handleMenuTap = (e) => {
+        this.props.onClick && this.props.onClick(e);
     };
 
     render() {


### PR DESCRIPTION
Much needed, because we could not use `e.preventDefault()` at the header item of an "accordion submenu" in the Menu.