### PR TITLE
[RFR] Disable the Export button when there is nothing to export

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -100,7 +100,8 @@ const PostActions = ({
     onUnselectItems,
     resource,
     selectedIds,
-    showFilter
+    showFilter,
+    total
 }) => (
     <CardActions>
         {bulkActions && React.cloneElement(bulkActions, {
@@ -119,6 +120,7 @@ const PostActions = ({
         }) }
         <CreateButton basePath={basePath} />
         <ExportButton
+            disabled={total === 0}
             resource={resource}
             sort={currentSort}
             filter={filterValues}
@@ -149,7 +151,9 @@ export const PostList = ({ permissions, ...props }) => (
 
 ### Exporter
 
-Among the default list actions, react-admin includes an `<ExportButton>`. By default, clicking this button will:
+Among the default list actions, react-admin includes an `<ExportButton>`. This button is disabled when there is no record in the current `<List>`.
+
+By default, clicking this button will:
 
 1. Call the `dataProvider` with the current sort and filter (but without pagination),
 2. Transform the result into a CSV string,

--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -20,6 +20,7 @@ const Actions = ({
     selectedIds,
     onUnselectItems,
     showFilter,
+    total,
     ...rest
 }) => (
     <CardActions className={className} {...sanitizeListRestProps(rest)}>
@@ -41,6 +42,7 @@ const Actions = ({
             })}
         {hasCreate && <CreateButton basePath={basePath} />}
         <ExportButton
+            disabled={total === 0}
             resource={resource}
             sort={currentSort}
             filter={filterValues}

--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -65,6 +65,7 @@ Actions.propTypes = {
     onUnselectItems: PropTypes.func.isRequired,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     showFilter: PropTypes.func,
+    total: PropTypes.number.isRequired,
 };
 
 Actions.defaultProps = {


### PR DESCRIPTION
Related to this issue https://github.com/marmelab/react-admin/issues/2483

## Todo

- [x] Check the total and disable the export button when the total is 0
- [x] Write doc

![selection_137](https://user-images.githubusercontent.com/5584839/49288522-420f2180-f4a1-11e8-8e21-81e1a97c3c74.png)
