### PR TITLE
[RFR] Login Background Image: handle empty ref

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -471,7 +471,9 @@ const App = () => (
 );
 ```
 
-See The [Authentication documentation](./Authentication.md#customizing-the-login-and-logout-components) for more details.
+Before considering to write your own login page component, please take a look at how to change the default [background image](./Theming.md#using-a-custom-login-page) or the [Material UI theme](#theme).
+
+See the [Authentication documentation](./Authentication.md#customizing-the-login-and-logout-components) for more details.
 
 ## `logoutButton`
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -704,6 +704,24 @@ const mapStateToProps = state => ({
 export default withRouter(connect(mapStateToProps)(withStyles(styles)(Menu)));
 ```
 
+## Using a Custom Login Page
+
+### Changing the Background Image
+
+By default, the login page displays a random background image changing every day. If you want to change that background image, you can use the default Login page component and pass an image URL as the `backgroundImage` prop.
+
+```jsx
+import { Admin, Login } from 'react-admin';
+
+const MyLoginPage = () => <Login backgroundImage="/background.jpg" />;
+
+const App = () => (
+    <Admin loginPage={MyLoginPage}>
+        // ...
+    </Admin>
+);
+```
+
 ## Notifications
 
 You can override the notification component, for instance to change the notification duration. It defaults to 4000, i.e. 4 seconds, and you can override it using the `autoHideDuration` prop. For instance, to create a custom Notification component with a 5 seconds default:


### PR DESCRIPTION
Even though the React doc ensure the ref creation is done before the
componentDidMount, it can happen that the ref is set to null until the
next render.

So, to handle this case the component will now try to load the image on
the componentDidMount, but if the ref doesn't exist, it will try again
on the following componentDidUpdate. The try will be done only once.

Refs:
- https://reactjs.org/docs/refs-and-the-dom.html