### PR TITLE
[RFR] Change dependencies of secondary packages to ra-core

### DIFF
--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -44,6 +44,6 @@
         "rimraf": "^2.6.2"
     },
     "peerDependencies": {
-        "react-admin": "^2.0.0"
+        "ra-core": "^2.5.0"
     }
 }

--- a/packages/ra-data-graphcool/package.json
+++ b/packages/ra-data-graphcool/package.json
@@ -41,7 +41,7 @@
     },
     "peerDependencies": {
         "graphql": "^0.13.2",
-        "react-admin": "^2.4.3"
+        "ra-core": "^2.5.0"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "graphql": "^0.13.2",
-        "react-admin": "^2.4.3"
+        "ra-core": "^2.5.0"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "graphql": "^0.13.2",
-        "react-admin": "^2.4.3"
+        "ra-core": "^2.5.0"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "query-string": "~5.1.1",
-        "react-admin": "^2.5.0"
+        "ra-core": "^2.5.0"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-data-simple-rest/package.json
+++ b/packages/ra-data-simple-rest/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "query-string": "~5.1.1",
-        "react-admin": "^2.5.0"
+        "ra-core": "^2.5.0"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-realtime/package.json
+++ b/packages/ra-realtime/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "cross-env": "^5.2.0",
-        "react-admin": "^2.5.0",
+        "ra-core": "^2.5.0",
         "react-router": "~4.2.0",
         "react-router-redux": "~5.0.0-alpha.9",
         "redux-saga": "~0.16.0",


### PR DESCRIPTION
This is to avoid too many reeexports, and a better dependency management in Lerna.