### PR TITLE
[RFR] Fix Autocomplete suggestions positioning is sometimes not recalculated properly

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -334,7 +334,7 @@ export class AutocompleteInput extends React.Component {
         return (
             <Popper
                 className={className}
-                open
+                open={Boolean(children)}
                 anchorEl={this.inputEl}
                 placement="bottom-start"
             >


### PR DESCRIPTION
See the official MUI demo using Popper for autocomplete inputs: https://material-ui.com/demos/autocomplete/

I tried it on a project and it does solve the issue