### PR TITLE
[RFR] Allow to extend the buttons onClick handlers

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
@@ -62,16 +62,21 @@ class BulkDeleteButton extends Component {
             selectedIds,
             startUndoable,
             undoable,
+            onClick,
         } = this.props;
         if (undoable) {
             startUndoable(crudDeleteMany(resource, selectedIds, basePath));
         } else {
             dispatchCrudDeleteMany(resource, selectedIds, basePath);
         }
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
     };
 
     render() {
-        const { classes, label, icon, ...rest } = this.props;
+        const { classes, label, icon, onClick, ...rest } = this.props;
         return (
             <Button
                 onClick={this.handleClick}

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -23,6 +23,19 @@ const styles = theme => ({
     },
 });
 
+const sanitizeRestProps = ({
+    basePath,
+    classes,
+    dispatchCrudDeleteMany,
+    filterValues,
+    label,
+    resource,
+    selectedIds,
+    startUndoable,
+    undoable,
+    ...rest
+}) => rest;
+
 class DeleteButton extends Component {
     handleDelete = event => {
         event.stopPropagation();
@@ -34,6 +47,7 @@ class DeleteButton extends Component {
             basePath,
             redirect,
             undoable,
+            onClick,
         } = this.props;
         if (undoable) {
             startUndoable(
@@ -42,6 +56,10 @@ class DeleteButton extends Component {
         } else {
             dispatchCrudDelete(resource, record.id, record, basePath, redirect);
         }
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
     };
 
     render() {
@@ -49,7 +67,9 @@ class DeleteButton extends Component {
             label = 'ra.action.delete',
             classes = {},
             className,
-            icon
+            icon,
+            onClick,
+            ...rest
         } = this.props;
         return (
             <Button
@@ -61,6 +81,7 @@ class DeleteButton extends Component {
                     className
                 )}
                 key="button"
+                {...sanitizeRestProps(rest)}
             >
                 {icon}
             </Button>

--- a/packages/ra-ui-materialui/src/button/ExportButton.js
+++ b/packages/ra-ui-materialui/src/button/ExportButton.js
@@ -118,6 +118,7 @@ class ExportButton extends Component {
             maxResults,
             sort,
             resource,
+            onClick,
         } = this.props;
         dispatch(
             crudGetAll(
@@ -135,6 +136,10 @@ class ExportButton extends Component {
                         : downloadCSV(convertToCSV(data), resource)
             )
         );
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
     };
 
     render() {

--- a/packages/ra-ui-materialui/src/button/RefreshButton.js
+++ b/packages/ra-ui-materialui/src/button/RefreshButton.js
@@ -19,8 +19,13 @@ class RefreshButton extends Component {
     };
 
     handleClick = event => {
+        const { refreshView, onClick } = this.props; 
         event.preventDefault();
-        this.props.refreshView();
+        refreshView();
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
     };
 
     render() {

--- a/packages/ra-ui-materialui/src/button/RefreshIconButton.js
+++ b/packages/ra-ui-materialui/src/button/RefreshIconButton.js
@@ -22,8 +22,13 @@ class RefreshButton extends Component {
     };
 
     handleClick = event => {
+        const { refreshView, onClick } = this.props; 
         event.preventDefault();
-        this.props.refreshView();
+        refreshView();
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
     };
 
     render() {

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -69,6 +69,7 @@ export class SaveButton extends Component {
             redirect,
             saving,
             showNotification,
+            onClick,
         } = this.props;
 
         if (saving) {
@@ -83,6 +84,10 @@ export class SaveButton extends Component {
                 e.preventDefault();
             }
             handleSubmitWithRedirect(redirect)();
+        }
+
+        if (typeof onClick === 'function') {
+            onClick();
         }
     };
 
@@ -99,6 +104,7 @@ export class SaveButton extends Component {
             translate,
             variant = 'raised',
             icon,
+            onClick,
             ...rest
         } = this.props;
 


### PR DESCRIPTION
Allows users to provide their own `onClick` handlers to the buttons which define one without overriding the default