### PR TITLE
[#2632] Fix deprecated Redux Dev Tools extension warning

### DIFF
--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -70,8 +70,8 @@ export default ({
                 routerMiddleware(history),
                 // add your own middlewares here
             ),
-            typeof window !== 'undefined' && window.devToolsExtension
-                ? window.devToolsExtension()
+            typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__
+                ? window.__REDUX_DEVTOOLS_EXTENSION__()
                 : f => f
             // add your own enhancers here
         )

--- a/packages/ra-core/src/createAdminStore.ts
+++ b/packages/ra-core/src/createAdminStore.ts
@@ -10,7 +10,7 @@ import { defaultI18nProvider } from './i18n';
 import formMiddleware from './form/formMiddleware';
 
 interface Window {
-    devToolsExtension?: () => () => void;
+    __REDUX_DEVTOOLS_EXTENSION__?: () => () => void;
 }
 
 export default ({
@@ -48,8 +48,9 @@ export default ({
                 formMiddleware,
                 routerMiddleware(history)
             ),
-            typeof typedWindow !== 'undefined' && typedWindow.devToolsExtension
-                ? typedWindow.devToolsExtension()
+            typeof typedWindow !== 'undefined' &&
+            typedWindow.__REDUX_DEVTOOLS_EXTENSION__
+                ? typedWindow.__REDUX_DEVTOOLS_EXTENSION__()
                 : f => f
         )
     );


### PR DESCRIPTION
Closes #2632

This Pull Request removes the deprecation warning visible in latest versions of React Admin.

![image](https://user-images.githubusercontent.com/2587348/49802198-8675a980-fd4c-11e8-8d53-6fa40e557a59.png)

(The links points to https://github.com/zalmoxisus/redux-devtools-extension#usage)