### PR TITLE
Fix extra FormTab/Tab props are passed to two different components

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -65,7 +65,7 @@ class Tab extends Component {
         />
     );
 
-    renderContent = ({ className, children, ...rest }) => (
+    renderContent = ({ className, children, basePath, record, resource }) => (
         <span className={className}>
             {React.Children.map(
                 children,
@@ -89,7 +89,11 @@ class Tab extends Component {
                             ) : typeof field.type === 'string' ? (
                                 field
                             ) : (
-                                React.cloneElement(field)
+                                React.cloneElement(field, {
+                                    basePath,
+                                    record,
+                                    resource,
+                                })
                             )}
                         </div>
                     )

--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -83,6 +83,9 @@ class Tab extends Component {
                                 <Labeled
                                     label={field.props.label}
                                     source={field.props.source}
+                                    basePath={basePath}
+                                    record={record}
+                                    resource={resource}
                                 >
                                     {field}
                                 </Labeled>

--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -83,17 +83,13 @@ class Tab extends Component {
                                 <Labeled
                                     label={field.props.label}
                                     source={field.props.source}
-                                    {...sanitizeRestProps(rest)}
                                 >
                                     {field}
                                 </Labeled>
                             ) : typeof field.type === 'string' ? (
                                 field
                             ) : (
-                                React.cloneElement(
-                                    field,
-                                    sanitizeRestProps(rest)
-                                )
+                                React.cloneElement(field)
                             )}
                         </div>
                     )

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -35,7 +35,7 @@ class FormTab extends Component {
                 children,
                 input =>
                     input && (
-                        <FormInput input={input} {...sanitizeRestProps(rest)} />
+                        <FormInput input={input} />
                     )
             )}
         </span>

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -29,13 +29,24 @@ class FormTab extends Component {
         );
     };
 
-    renderContent = ({ children, hidden, ...rest }) => (
+    renderContent = ({
+        children,
+        hidden,
+        basePath,
+        record,
+        resource,
+    }) => (
         <span style={hidden ? hiddenStyle : null}>
             {React.Children.map(
                 children,
                 input =>
                     input && (
-                        <FormInput input={input} />
+                        <FormInput
+                            basePath={basePath}
+                            input={input}
+                            record={record}
+                            resource={resource}
+                        />
                     )
             )}
         </span>


### PR DESCRIPTION
For issue #2651.

I looked at every component that used `Link` and decided that `Tab` and `FormTab` were the only components where this ability really made sense.

I briefly considered adding docs for this prop, but `Tab` and `FormTab` are not documented and neither are their properties, so I thought it best to leave that for a different pull request.

Thank you.