### PR TITLE
Fix demo application for IE 11

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -17,6 +17,7 @@
         "ra-language-french": "^2.0.0",
         "react": "~16.3.1",
         "react-admin": "^2.0.0",
+        "react-app-polyfill": "^0.1.3",
         "react-dom": "~16.3.1",
         "react-redux": "~5.0.7",
         "react-router-dom": "~4.2.2",
@@ -34,7 +35,7 @@
     "browserslist": [
         ">0.2%",
         "not dead",
-        "not ie <= 11",
+        "not ie <= 10",
         "not op_mini all"
     ]
 }

--- a/examples/demo/src/index.js
+++ b/examples/demo/src/index.js
@@ -1,3 +1,4 @@
+import 'react-app-polyfill/ie11';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';


### PR DESCRIPTION
Fixes #2653

CRA 2.0 needs polyfills to work with IE11, so I followed [this doc](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md) and everything seems to be back up for IE11.