### PR TITLE
Updated documentation

### DIFF
--- a/packages/ra-language-english/README.md
+++ b/packages/ra-language-english/README.md
@@ -2,7 +2,7 @@
 
 English messages for [react-admin](https://github.com/marmelab/react-admin), the frontend framework for building admin applications on top of REST/GraphQL services.
 
-![react-admin demo](http://static.marmelab.com/react-admin.gif)
+[![react-admin-demo](https://marmelab.com/react-admin/img/react-admin-demo-still.png)](https://vimeo.com/268958716)
 
 ## Installation
 

--- a/packages/ra-language-english/README.md
+++ b/packages/ra-language-english/README.md
@@ -18,8 +18,9 @@ import englishMessages from 'ra-language-english';
 const messages = {
     'en': englishMessages,
 };
+const i18nProvider = locale => messages[locale];
 
-<Admin locale="en" messages={messages}>
+<Admin locale="en" i18nProvider={i18nProvider}>
   ...
 </Admin>
 ```

--- a/packages/ra-language-french/README.md
+++ b/packages/ra-language-french/README.md
@@ -2,7 +2,7 @@
 
 French messages for [react-admin](https://github.com/marmelab/react-admin), the frontend framework for building admin applications on top of REST/GraphQL services.
 
-![react-admin demo](http://static.marmelab.com/react-admin.gif)
+[![react-admin-demo](https://marmelab.com/react-admin/img/react-admin-demo-still.png)](https://vimeo.com/268958716)
 
 ## Installation
 

--- a/packages/ra-language-french/README.md
+++ b/packages/ra-language-french/README.md
@@ -18,8 +18,9 @@ import frenchMessages from 'ra-language-french';
 const messages = {
     'fr': frenchMessages,
 };
+const i18nProvider = locale => messages[locale];
 
-<Admin locale="fr" messages={messages}>
+<Admin locale="fr" i18nProvider={i18nProvider}>
   ...
 </Admin>
 ```


### PR DESCRIPTION
The examples in the README are misleading because they are outdated since the migration to the i18nProvider. I fixed the examples to avoid future errors. There is still a few more documentation to be updated.