### PR TITLE
Fix <RichTextInput> not working on IE11

### DIFF
--- a/packages/ra-input-rich-text/src/styles.js
+++ b/packages/ra-input-rich-text/src/styles.js
@@ -18,7 +18,7 @@ export default {
                     right: 0,
                     bottom: 0,
                     height: 1,
-                    content: '',
+                    content: '""',
                     position: 'absolute',
                     transition:
                         'background-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
@@ -30,7 +30,7 @@ export default {
                     right: 0,
                     bottom: 0,
                     height: 2,
-                    content: '',
+                    content: '""',
                     position: 'absolute',
                     transform: 'scaleX(0)',
                     transition:


### PR DESCRIPTION
Fixes #2675

The underlying problem is in the [css-vendor](https://github.com/cssinjs/css-vendor) library, specifically in the cssVendor.supportedValue method that breaks on IE11 with content and '' as parameters.

the `content: ''` attribute is currently not working on Chrome either.