### PR TITLE
Fix absence of 'modifiers' and 'disablePortal' for material-ui Popper

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -215,6 +215,7 @@ import { AutocompleteInput, ReferenceInput } from 'react-admin'
 | `setFilter` | Optional | `Function` | null | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |
 | `suggestionComponent` | Optional | Function | `({ suggestion, query, isHighlighted, props }) => <div {...props} />` | Allows to override how the item is rendered.  |
 | `shouldRenderSuggestions` | Optional | Function | `() => true` | A function that returns a `boolean` to determine whether or not suggestions are rendered. Use this when working with large collections of data to improve performance and user experience. This function is passed into the underlying react-autosuggest component. Ex.`(value) => value.trim() > 2` |
+| `disablePortal` | Optional | `boolean` | `false` | `disablePortal` prop of the material-ui `Popper` (more info: https://material-ui.com/api/popper/) |
 | `modifiers` | Optional | `Object[]` | - | Modifiers for the material-ui `Popper` (more info: https://material-ui.com/api/popper/) |
 
 ## `<AutocompleteArrayInput>`
@@ -316,6 +317,7 @@ import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin'
 | `optionText` | Optional | <code>string &#124; Function</code> | `name` | Fieldname of record to display in the suggestion item or function which accepts the current record as argument (`(record)=> {string}`) |
 | `setFilter` | Optional | `Function` | null | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |
 | `suggestionComponent` | Optional | Function | `({ suggestion, query, isHighlighted, props }) => <div {...props} />` | Allows to override how the item is rendered.  |
+| `disablePortal` | Optional | `boolean` | `false` | `disablePortal` prop of the material-ui `Popper` (more info: https://material-ui.com/api/popper/) |
 | `modifiers` | Optional | `Object[]` | - | Modifiers for the material-ui `Popper` (more info: https://material-ui.com/api/popper/) |
 
 ## `<BooleanInput>` and `<NullableBooleanInput>`

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -215,6 +215,7 @@ import { AutocompleteInput, ReferenceInput } from 'react-admin'
 | `setFilter` | Optional | `Function` | null | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |
 | `suggestionComponent` | Optional | Function | `({ suggestion, query, isHighlighted, props }) => <div {...props} />` | Allows to override how the item is rendered.  |
 | `shouldRenderSuggestions` | Optional | Function | `() => true` | A function that returns a `boolean` to determine whether or not suggestions are rendered. Use this when working with large collections of data to improve performance and user experience. This function is passed into the underlying react-autosuggest component. Ex.`(value) => value.trim() > 2` |
+| `modifiers` | Optional | `Object[]` | - | Modifiers for the material-ui `Popper` (more info: https://material-ui.com/api/popper/) |
 
 ## `<AutocompleteArrayInput>`
 
@@ -315,6 +316,7 @@ import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin'
 | `optionText` | Optional | <code>string &#124; Function</code> | `name` | Fieldname of record to display in the suggestion item or function which accepts the current record as argument (`(record)=> {string}`) |
 | `setFilter` | Optional | `Function` | null | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |
 | `suggestionComponent` | Optional | Function | `({ suggestion, query, isHighlighted, props }) => <div {...props} />` | Allows to override how the item is rendered.  |
+| `modifiers` | Optional | `Object[]` | - | Modifiers for the material-ui `Popper` (more info: https://material-ui.com/api/popper/) |
 
 ## `<BooleanInput>` and `<NullableBooleanInput>`
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -334,6 +334,7 @@ export class AutocompleteArrayInput extends React.Component {
             containerProps: { className, ...containerProps },
             children,
         } = options;
+        const { modifiers } = this.props;
 
         return (
             <Popper
@@ -341,6 +342,7 @@ export class AutocompleteArrayInput extends React.Component {
                 open
                 anchorEl={this.inputEl}
                 placement="bottom-start"
+                modifiers={modifiers}
             >
                 <Paper square {...containerProps}>
                     {children}

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -334,7 +334,7 @@ export class AutocompleteArrayInput extends React.Component {
             containerProps: { className, ...containerProps },
             children,
         } = options;
-        const { modifiers } = this.props;
+        const { modifiers, disablePortal = false } = this.props;
 
         return (
             <Popper
@@ -343,6 +343,7 @@ export class AutocompleteArrayInput extends React.Component {
                 anchorEl={this.inputEl}
                 placement="bottom-start"
                 modifiers={modifiers}
+                disablePortal={disablePortal}
             >
                 <Paper square {...containerProps}>
                     {children}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -329,7 +329,7 @@ export class AutocompleteInput extends React.Component {
             containerProps: { className, ...containerProps },
             children,
         } = options;
-        const { classes = {} } = this.props;
+        const { classes = {}, modifiers } = this.props;
 
         return (
             <Popper
@@ -337,6 +337,7 @@ export class AutocompleteInput extends React.Component {
                 open={Boolean(children)}
                 anchorEl={this.inputEl}
                 placement="bottom-start"
+                modifiers={modifiers}
             >
                 <Paper
                     square

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -329,7 +329,7 @@ export class AutocompleteInput extends React.Component {
             containerProps: { className, ...containerProps },
             children,
         } = options;
-        const { classes = {}, modifiers } = this.props;
+        const { classes = {}, modifiers, disablePortal = false } = this.props;
 
         return (
             <Popper
@@ -338,6 +338,7 @@ export class AutocompleteInput extends React.Component {
                 anchorEl={this.inputEl}
                 placement="bottom-start"
                 modifiers={modifiers}
+                disablePortal={disablePortal}
             >
                 <Paper
                     square


### PR DESCRIPTION
Related issue: https://github.com/marmelab/react-admin/issues/2370