### PR TITLE
[RFR] Rely on meta to handle optimistic actions

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -1,18 +1,15 @@
 import { FETCH_END } from '../../../actions/fetchActions';
 import {
+    CREATE,
+    DELETE,
+    DELETE_MANY,
     GET_LIST,
-    GET_ONE,
     GET_MANY,
     GET_MANY_REFERENCE,
-    CREATE,
+    GET_ONE,
     UPDATE,
+    UPDATE_MANY,
 } from '../../../dataFetchActions';
-import {
-    CRUD_DELETE_OPTIMISTIC,
-    CRUD_DELETE_MANY_OPTIMISTIC,
-    CRUD_UPDATE_OPTIMISTIC,
-    CRUD_UPDATE_MANY_OPTIMISTIC,
-} from '../../../actions/dataActions';
 
 import getFetchedAt from '../../../util/getFetchedAt';
 
@@ -60,40 +57,43 @@ const addRecords = addRecordsFactory(getFetchedAt);
 const initialState = {};
 Object.defineProperty(initialState, 'fetchedAt', { value: {} }); // non enumerable by default
 
-export default (previousState = initialState, { type, payload, meta }) => {
-    if (type === CRUD_UPDATE_OPTIMISTIC) {
-        const updatedRecord = { ...previousState[payload.id], ...payload.data };
-        return addRecords([updatedRecord], previousState);
-    }
-    if (type === CRUD_UPDATE_MANY_OPTIMISTIC) {
-        const updatedRecords = payload.ids
-            .reduce((records, id) => records.concat(previousState[id]), [])
-            .map(record => ({ ...record, ...payload.data }));
-        return addRecords(updatedRecords, previousState);
-    }
-    if (type === CRUD_DELETE_OPTIMISTIC) {
-        const { [payload.id]: removed, ...newState } = previousState;
+export default (previousState = initialState, { payload, meta }) => {
+    if (meta && meta.optimistic) {
+        if (meta.fetch === UPDATE) {
+            const updatedRecord = { ...previousState[payload.id], ...payload.data };
+            return addRecords([updatedRecord], previousState);
+        }
+        if (meta.fetch === UPDATE_MANY) {
+            const updatedRecords = payload.ids
+                .reduce((records, id) => records.concat(previousState[id]), [])
+                .map(record => ({ ...record, ...payload.data }));
+            return addRecords(updatedRecords, previousState);
+        }
+        if (meta.fetch === DELETE) {
+            const { [payload.id]: removed, ...newState } = previousState;
 
-        Object.defineProperty(newState, 'fetchedAt', {
-            value: previousState.fetchedAt,
-        });
+            Object.defineProperty(newState, 'fetchedAt', {
+                value: previousState.fetchedAt,
+            });
 
-        return newState;
-    }
-    if (type === CRUD_DELETE_MANY_OPTIMISTIC) {
-        const newState = Object.entries(previousState)
-            .filter(([key]) => !payload.ids.includes(key))
-            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+            return newState;
+        }
+        if (meta.fetch === DELETE_MANY) {
+            const newState = Object.entries(previousState)
+                .filter(([key]) => !payload.ids.includes(key))
+                .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
 
-        Object.defineProperty(newState, 'fetchedAt', {
-            value: previousState.fetchedAt,
-        });
+            Object.defineProperty(newState, 'fetchedAt', {
+                value: previousState.fetchedAt,
+            });
 
-        return newState;
+            return newState;
+        }
     }
     if (!meta || !meta.fetchResponse || meta.fetchStatus !== FETCH_END) {
         return previousState;
     }
+
     switch (meta.fetchResponse) {
         case GET_LIST:
         case GET_MANY:

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -54,8 +54,16 @@ export const addRecordsFactory = getFetchedAt => (
 
 const addRecords = addRecordsFactory(getFetchedAt);
 
+// We track the last time data was fetched by adding a property on the data which is an array
+// (Hence using defineProperty)
+const updateDataFetchedTime = (data, fetchedAt) => {
+    Object.defineProperty(data, 'fetchedAt', {
+        value: fetchedAt,
+    });
+}
+
 const initialState = {};
-Object.defineProperty(initialState, 'fetchedAt', { value: {} }); // non enumerable by default
+updateDataFetchedTime(initialState, {}); // non enumerable by default
 
 export default (previousState = initialState, { payload, meta }) => {
     if (meta && meta.optimistic) {
@@ -72,9 +80,7 @@ export default (previousState = initialState, { payload, meta }) => {
         if (meta.fetch === DELETE) {
             const { [payload.id]: removed, ...newState } = previousState;
 
-            Object.defineProperty(newState, 'fetchedAt', {
-                value: previousState.fetchedAt,
-            });
+            updateDataFetchedTime(newState, previousState.fetchedAt);
 
             return newState;
         }
@@ -83,9 +89,7 @@ export default (previousState = initialState, { payload, meta }) => {
                 .filter(([key]) => !payload.ids.includes(key))
                 .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
 
-            Object.defineProperty(newState, 'fetchedAt', {
-                value: previousState.fetchedAt,
-            });
+            updateDataFetchedTime(newState, previousState.fetchedAt);
 
             return newState;
         }

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -73,8 +73,11 @@ export default (previousState = initialState, { payload, meta }) => {
         }
         if (meta.fetch === UPDATE_MANY) {
             const updatedRecords = payload.ids
-                .reduce((records, id) => records.concat(previousState[id]), [])
-                .map(record => ({ ...record, ...payload.data }));
+                .map(id => ({
+                    ...previousState[id],
+                    ...payload.data,
+                }));
+
             return addRecords(updatedRecords, previousState);
         }
         if (meta.fetch === DELETE) {

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.js
@@ -96,7 +96,7 @@ describe('data addRecordsFactory', () => {
     });
 });
 
-describe.only('Resources data reducer', () => {
+describe('Resources data reducer', () => {
     describe('optimistic DELETE', () => {
         it('removes the deleted record', () => {
             const state = {
@@ -105,7 +105,6 @@ describe.only('Resources data reducer', () => {
                 record3: { id: 'record3', prop: 'value' },
             };
 
-            console.log('test');
             assert.deepEqual(
                 dataReducer(state, {
                     type: 'FOO',

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.js
@@ -1,9 +1,6 @@
 import assert from 'assert';
 
-import {
-    CRUD_DELETE_OPTIMISTIC,
-    CRUD_DELETE_MANY_OPTIMISTIC,
-} from '../../../actions/dataActions';
+import { DELETE, DELETE_MANY } from '../../../dataFetchActions';
 
 import dataReducer, { addRecordsFactory } from './data';
 
@@ -99,8 +96,8 @@ describe('data addRecordsFactory', () => {
     });
 });
 
-describe('Resources data reducer', () => {
-    describe('CRUD_DELETE_OPTIMISTIC', () => {
+describe.only('Resources data reducer', () => {
+    describe('optimistic DELETE', () => {
         it('removes the deleted record', () => {
             const state = {
                 record1: { id: 'record1', prop: 'value' },
@@ -108,10 +105,15 @@ describe('Resources data reducer', () => {
                 record3: { id: 'record3', prop: 'value' },
             };
 
+            console.log('test');
             assert.deepEqual(
                 dataReducer(state, {
-                    type: CRUD_DELETE_OPTIMISTIC,
+                    type: 'FOO',
                     payload: { id: 'record2' },
+                    meta: {
+                        fetch: DELETE,
+                        optimistic: true,
+                    }
                 }),
                 {
                     record1: { id: 'record1', prop: 'value' },
@@ -120,7 +122,7 @@ describe('Resources data reducer', () => {
             );
         });
     });
-    describe('CRUD_DELETE_MANY_OPTIMISTIC', () => {
+    describe('optimistic DELETE_MANY', () => {
         it('removes the deleted records', () => {
             const state = {
                 record1: { id: 'record1', prop: 'value' },
@@ -130,8 +132,12 @@ describe('Resources data reducer', () => {
 
             assert.deepEqual(
                 dataReducer(state, {
-                    type: CRUD_DELETE_MANY_OPTIMISTIC,
+                    type: 'FOO',
                     payload: { ids: ['record3', 'record2'] },
+                    meta: {
+                        fetch: DELETE_MANY,
+                        optimistic: true,
+                    }
                 }),
                 {
                     record1: { id: 'record1', prop: 'value' },


### PR DESCRIPTION
Context: https://marmelab.com/react-admin/Actions.html#using-a-custom-action-creator

We were relying on the action type to handle optimistic effects. This prevent custom actions to be handled optimistically too. 

Consider the following case: I have an `ACCEPT_CHANGE` and `REJECT_CHANGE` actions. Both will remove their targeted item from the `change` resource but will be caught by a custom saga to be applied on another resource. From the `change` resource perspective, they should be removed after being either accepted or rejected.

```js
export const acceptChange = (
    id: string,
    previousData: any,
    basePath: string
) => ({
    type: ACCEPT_CHANGE,
    payload: { id, previousData },
    meta: {
        resource: 'changes',
        fetch: DELETE,
        onSuccess: {
            notification: {
                body: 'myapp.notification.accepted',
                level: 'info',
                messageArgs: {
                    smart_count: 1,
                },
            },
            redirectTo: 'list',
            basePath,
        },
        onFailure: {
            notification: {
                body: 'ra.notification.http_error',
                level: 'warning',
            },
        },
    },
});
```