### PR TITLE
Fix EditButton in Datagrids using rowClick

### DIFF
--- a/packages/ra-ui-materialui/src/button/EditButton.js
+++ b/packages/ra-ui-materialui/src/button/EditButton.js
@@ -7,6 +7,9 @@ import { linkToRecord } from 'ra-core';
 
 import Button from './Button';
 
+// useful to prevent click bubbling in a datagrid with rowClick
+const stopPropagation = e => e.stopPropagation();
+
 const EditButton = ({
     basePath = '',
     label = 'ra.action.edit',
@@ -18,6 +21,7 @@ const EditButton = ({
         component={Link}
         to={linkToRecord(basePath, record.id)}
         label={label}
+        onClick={stopPropagation}
         {...rest}
     >
         {icon}


### PR DESCRIPTION
Fixes a similar issue to #2457 where clicking on an Edit Button inside of a Datagrid with rowClick set to "show" doesn't handle the button event properly. 