### PR TITLE
Add 'to' prop to 'CreateButton', to be able to pass related data to the Create form

### DIFF
--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -35,6 +35,7 @@ const CreateButton = ({
     translate,
     label = 'ra.action.create',
     icon = <ContentAdd />,
+    to,
     ...rest
 }) => (
     <Responsive
@@ -44,7 +45,7 @@ const CreateButton = ({
                 variant="fab"
                 color="primary"
                 className={classnames(classes.floating, className)}
-                to={`${basePath}/create`}
+                to={to || `${basePath}/create`}
                 aria-label={label && translate(label)}
                 {...rest}
             >
@@ -54,7 +55,7 @@ const CreateButton = ({
         medium={
             <Button
                 component={Link}
-                to={`${basePath}/create`}
+                to={to || `${basePath}/create`}
                 className={className}
                 label={label && translate(label)}
                 {...rest}


### PR DESCRIPTION
With that addition, we can now just use the react-admin `<CreateButton>` to achieve this:

```
to={{
            pathname: '/comments/create',
            state: { record: { post_id: ourId } },
        }}
```
OR

```
        to={{
            pathname: '/comments/create',
            search: '?post_id=' + ourId,
        }}
```
