### PR TITLE
Add 'redirect' prop to 'DeleteButton' in 'Toolbar'

### DIFF
--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -79,6 +79,7 @@ const Toolbar = ({
                                 basePath={basePath}
                                 record={record}
                                 resource={resource}
+                                redirect={redirect}
                             />
                         )}
                 </div>


### PR DESCRIPTION
I could not redirect to a custom list page after pressing Delete in the default toolbar.

This fixes it.