### PR TITLE
[RFR] Allow to override datagrid header style

### DIFF
--- a/examples/demo/src/reviews/index.js
+++ b/examples/demo/src/reviews/index.js
@@ -68,6 +68,11 @@ export const ReviewFilter = withStyles(filterStyles)(
 );
 
 const listStyles = {
+    headerRow: {
+        borderLeftColor: 'white',
+        borderLeftWidth: 5,
+        borderLeftStyle: 'solid',
+    },
     comment: {
         maxWidth: '18em',
         overflow: 'hidden',
@@ -95,7 +100,10 @@ export const ReviewList = withStyles(listStyles)(({ classes, ...props }) => (
         <Responsive
             xsmall={<MobileGrid />}
             medium={
-                <Datagrid rowStyle={rowStyle}>
+                <Datagrid
+                    rowStyle={rowStyle}
+                    classes={{ headerRow: classes.headerRow }}
+                >
                     <DateField source="date" />
                     <CustomerReferenceField />
                     <ProductReferenceField />

--- a/examples/demo/src/reviews/rowStyle.js
+++ b/examples/demo/src/reviews/rowStyle.js
@@ -1,10 +1,29 @@
+import green from '@material-ui/core/colors/green';
+import orange from '@material-ui/core/colors/orange';
+import red from '@material-ui/core/colors/red';
+
 const rowStyle = (record, index, defaultStyle = {}) => {
     if (record.status === 'accepted')
-        return { ...defaultStyle, backgroundColor: '#dfd' };
+        return {
+            ...defaultStyle,
+            borderLeftColor: green[500],
+            borderLeftWidth: 5,
+            borderLeftStyle: 'solid',
+        };
     if (record.status === 'pending')
-        return { ...defaultStyle, backgroundColor: '#ffd' };
+        return {
+            ...defaultStyle,
+            borderLeftColor: orange[500],
+            borderLeftWidth: 5,
+            borderLeftStyle: 'solid',
+        };
     if (record.status === 'rejected')
-        return { ...defaultStyle, backgroundColor: '#fdd' };
+        return {
+            ...defaultStyle,
+            borderLeftColor: red[500],
+            borderLeftWidth: 5,
+            borderLeftStyle: 'solid',
+        };
     return defaultStyle;
 };
 

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -17,9 +17,11 @@ const styles = theme => ({
     table: {
         tableLayout: 'auto',
     },
+    thead: {},
     tbody: {
         height: 'inherit',
     },
+    headerRow: {},
     headerCell: {
         padding: '0 12px',
         '&:last-child': {
@@ -146,8 +148,10 @@ class Datagrid extends Component {
                 className={classnames(classes.table, className)}
                 {...sanitizeListRestProps(rest)}
             >
-                <TableHead>
-                    <TableRow className={classes.row}>
+                <TableHead className={classes.thead}>
+                    <TableRow
+                        className={classnames(classes.row, classes.headerRow)}
+                    >
                         {expand && (
                             <TableCell className={classes.expandHeader} />
                         )}
@@ -191,6 +195,7 @@ class Datagrid extends Component {
                     body,
                     {
                         basePath,
+                        className: classes.tbody,
                         classes,
                         expand,
                         rowClick,


### PR DESCRIPTION
I added support for two new keys of the `classes` prop passed to `Datagrid`: `thead` and `headerRow`, which allow to style the datagrid header.

This allowed to make the Reviews list of the demo less ugly (inspired by @djhi's design on another project).

![image](https://user-images.githubusercontent.com/99944/50566344-df77a280-0d38-11e9-945d-59107739cf6a.png)
