### PR TITLE
GraphQL-simple: Update building metaArgs

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.js
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.js
@@ -139,10 +139,9 @@ export default introspectionResults => (
     queryType,
     variables
 ) => {
-    const { sortField, sortOrder, ...metaVariables } = variables;
     const apolloArgs = buildApolloArgs(queryType, variables);
     const args = buildArgs(queryType, variables);
-    const metaArgs = buildArgs(queryType, metaVariables);
+    const metaArgs = buildArgs(queryType, { filter: variables.filter });
     const fields = buildFields(introspectionResults)(resource.type.fields);
     if (
         aorFetchType === GET_LIST ||


### PR DESCRIPTION
Only the filter variable is required by the graphql server, to calculate the total count. Additional variables add no value, however if left out of the schema, an error is produced as the client attempts to pass variables for `page` and `perPage`.