### PR TITLE
Fix ShowButton in Datagrids using rowClick

### DIFF
--- a/packages/ra-ui-materialui/src/button/ShowButton.js
+++ b/packages/ra-ui-materialui/src/button/ShowButton.js
@@ -7,6 +7,9 @@ import { linkToRecord } from 'ra-core';
 
 import Button from './Button';
 
+// useful to prevent click bubbling in a datagrid with rowClick
+const stopPropagation = e => e.stopPropagation();
+
 const ShowButton = ({
     basePath = '',
     label = 'ra.action.show',
@@ -18,6 +21,7 @@ const ShowButton = ({
         component={Link}
         to={`${linkToRecord(basePath, record.id)}/show`}
         label={label}
+        onClick={stopPropagation}
         {...rest}
     >
         {icon}


### PR DESCRIPTION
Fixes a similar issue to #2457 and #2686 where clicking on a Show Button inside of a Datagrid with rowClick doesn't handle the button event properly.

Requested by @fzaninotto 