### PR TITLE
[RFR] Add options prop to TabbedShowLayout

### DIFF
--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -31,6 +31,7 @@ const getTabFullPath = (tab, index, baseUrl) =>
  *
  * Receives the current `record` from the parent `<Show>` component,
  * and passes it to its childen. Children should be Tab components.
+ * The object passed as `options` props is passed to the material-ui <Tabs> component
  *
  * @example
  *     // in src/posts.js
@@ -77,6 +78,7 @@ export class TabbedShowLayout extends Component {
             translate,
             version,
             value,
+            options,
             ...rest
         } = this.props;
 
@@ -91,6 +93,7 @@ export class TabbedShowLayout extends Component {
                     // so we can use it as a way to determine the current tab
                     value={location.pathname}
                     indicatorColor="primary"
+                    {...options}
                 >
                     {Children.map(children, (tab, index) => {
                         if (!tab) return null;
@@ -144,6 +147,7 @@ TabbedShowLayout.propTypes = {
     value: PropTypes.number,
     version: PropTypes.number,
     translate: PropTypes.func,
+    options: PropTypes.object,
 };
 
 const enhance = compose(

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -7,6 +7,7 @@ import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
 import CardContentInner from '../layout/CardContentInner';
+import TabbedShowLayoutTabs from './TabbedShowLayoutTabs';
 
 const sanitizeRestProps = ({
     children,
@@ -18,6 +19,7 @@ const sanitizeRestProps = ({
     initialValues,
     staticContext,
     translate,
+    tabs,
     ...rest
 }) => rest;
 
@@ -31,7 +33,7 @@ const getTabFullPath = (tab, index, baseUrl) =>
  *
  * Receives the current `record` from the parent `<Show>` component,
  * and passes it to its childen. Children should be Tab components.
- * The object passed as `options` props is passed to the material-ui <Tabs> component
+ * The component passed as `tabs` props replaces the default material-ui's <Tabs> component.
  *
  * @example
  *     // in src/posts.js
@@ -78,7 +80,7 @@ export class TabbedShowLayout extends Component {
             translate,
             version,
             value,
-            options,
+            tabs,
             ...rest
         } = this.props;
 
@@ -88,14 +90,15 @@ export class TabbedShowLayout extends Component {
                 key={version}
                 {...sanitizeRestProps(rest)}
             >
-                <Tabs
-                    // The location pathname will contain the page path including the current tab path
-                    // so we can use it as a way to determine the current tab
-                    value={location.pathname}
-                    indicatorColor="primary"
-                    {...options}
-                >
-                    {Children.map(children, (tab, index) => {
+                {React.cloneElement(
+                    tabs,
+                    {
+                      // The location pathname will contain the page path including the current tab path
+                      // so we can use it as a way to determine the current tab
+                      value: location.pathname,
+                      match
+                    },
+                    Children.map(children, (tab, index) => {
                         if (!tab) return null;
 
                         // Builds the full tab tab which is the concatenation of the last matched route in the
@@ -108,8 +111,8 @@ export class TabbedShowLayout extends Component {
                             context: 'header',
                             value: tabPath,
                         });
-                    })}
-                </Tabs>
+                    })
+                )}
                 <Divider />
                 <CardContentInner>
                     {Children.map(
@@ -147,7 +150,11 @@ TabbedShowLayout.propTypes = {
     value: PropTypes.number,
     version: PropTypes.number,
     translate: PropTypes.func,
-    options: PropTypes.object,
+  tabs: PropTypes.element.required
+};
+
+TabbedShowLayout.defaultProps = {
+    tabs: <TabbedShowLayoutTabs />
 };
 
 const enhance = compose(

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -1,6 +1,5 @@
 import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import Tabs from '@material-ui/core/Tabs';
 import Divider from '@material-ui/core/Divider';
 import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
@@ -85,33 +84,16 @@ export class TabbedShowLayout extends Component {
         } = this.props;
 
         return (
-            <div
-                className={className}
-                key={version}
-                {...sanitizeRestProps(rest)}
-            >
-                {React.cloneElement(
+            <div className={className} key={version} {...sanitizeRestProps(rest)}>
+                {cloneElement(
                     tabs,
                     {
-                      // The location pathname will contain the page path including the current tab path
-                      // so we can use it as a way to determine the current tab
-                      value: location.pathname,
-                      match
+                        // The location pathname will contain the page path including the current tab path
+                        // so we can use it as a way to determine the current tab
+                        value: location.pathname,
+                        match,
                     },
-                    Children.map(children, (tab, index) => {
-                        if (!tab) return null;
-
-                        // Builds the full tab tab which is the concatenation of the last matched route in the
-                        // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
-                        // and the tab path.
-                        // This will be used as the Tab's value
-                        const tabPath = getTabFullPath(tab, index, match.url);
-
-                        return cloneElement(tab, {
-                            context: 'header',
-                            value: tabPath,
-                        });
-                    })
+                    [...children],
                 )}
                 <Divider />
                 <CardContentInner>
@@ -150,7 +132,7 @@ TabbedShowLayout.propTypes = {
     value: PropTypes.number,
     version: PropTypes.number,
     translate: PropTypes.func,
-  tabs: PropTypes.element.required
+    tabs: PropTypes.element.required
 };
 
 TabbedShowLayout.defaultProps = {

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -93,7 +93,7 @@ export class TabbedShowLayout extends Component {
                         value: location.pathname,
                         match,
                     },
-                    [...children],
+                    children,
                 )}
                 <Divider />
                 <CardContentInner>

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -132,7 +132,7 @@ TabbedShowLayout.propTypes = {
     value: PropTypes.number,
     version: PropTypes.number,
     translate: PropTypes.func,
-    tabs: PropTypes.element.required
+    tabs: PropTypes.element.isRequired,
 };
 
 TabbedShowLayout.defaultProps = {

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -7,7 +7,7 @@ const getTabFullPath = (tab, index, baseUrl) =>
       tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
     }`;
 
-const TabbedShowLayoutTabs = ({ value, children, match }) => (
+const TabbedShowLayoutTabs = ({ value, children, match, ...rest }) => (
     <Tabs value={value} indicatorColor='primary'>
         {Children.map(children, (tab, index) => {
             if (!tab) return null;
@@ -21,6 +21,7 @@ const TabbedShowLayoutTabs = ({ value, children, match }) => (
             return cloneElement(tab, {
                 context: 'header',
                 value: tabPath,
+                ...rest,
             });
         })}
     </Tabs>

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -11,7 +11,6 @@ const TabbedShowLayoutTabs = ({ children, match, ...rest }) => (
     <Tabs indicatorColor='primary' {...rest} >
         {Children.map(children, (tab, index) => {
             if (!tab) return null;
-
             // Builds the full tab tab which is the concatenation of the last matched route in the
             // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
             // and the tab path.
@@ -28,7 +27,8 @@ const TabbedShowLayoutTabs = ({ children, match, ...rest }) => (
 
 TabbedShowLayoutTabs.propTypes = {
     children: PropTypes.node,
-    value: PropTypes.number,
+    match: PropTypes.object,
+    value: PropTypes.string,
 };
 
 export default TabbedShowLayoutTabs;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -1,0 +1,25 @@
+import React, { Component, Children, cloneElement } from "react";
+import PropTypes from "prop-types";
+import Tabs from "@material-ui/core/Tabs";
+import Divider from "@material-ui/core/Divider";
+import { withRouter, Route } from "react-router-dom";
+import compose from "recompose/compose";
+import { translate } from "ra-core";
+
+import CardContentInner from "../layout/CardContentInner";
+
+const TabbedShowLayoutTabs = ({ value, children, ...rest }) => (
+    <Tabs
+        value={value}
+        indicatorColor="primary"
+    >
+        {children}
+    </Tabs>
+);
+
+TabbedShowLayoutTabs.propTypes = {
+    children: PropTypes.node,
+    value: PropTypes.number
+};
+
+export default TabbedShowLayoutTabs;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -7,7 +7,7 @@ const getTabFullPath = (tab, index, baseUrl) =>
       tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
     }`;
 
-const TabbedShowLayoutTabs = ({ value, children, match, ...rest }) => (
+const TabbedShowLayoutTabs = ({ value, children, match }) => (
     <Tabs value={value} indicatorColor='primary'>
         {Children.map(children, (tab, index) => {
             if (!tab) return null;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -7,8 +7,8 @@ const getTabFullPath = (tab, index, baseUrl) =>
       tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
     }`;
 
-const TabbedShowLayoutTabs = ({ value, children, match, ...rest }) => (
-    <Tabs value={value} indicatorColor='primary'>
+const TabbedShowLayoutTabs = ({ children, match, ...rest }) => (
+    <Tabs indicatorColor='primary' {...rest} >
         {Children.map(children, (tab, index) => {
             if (!tab) return null;
 
@@ -21,7 +21,6 @@ const TabbedShowLayoutTabs = ({ value, children, match, ...rest }) => (
             return cloneElement(tab, {
                 context: 'header',
                 value: tabPath,
-                ...rest,
             });
         })}
     </Tabs>

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -1,25 +1,34 @@
-import React, { Component, Children, cloneElement } from "react";
-import PropTypes from "prop-types";
-import Tabs from "@material-ui/core/Tabs";
-import Divider from "@material-ui/core/Divider";
-import { withRouter, Route } from "react-router-dom";
-import compose from "recompose/compose";
-import { translate } from "ra-core";
+import React, { Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import Tabs from '@material-ui/core/Tabs';
 
-import CardContentInner from "../layout/CardContentInner";
+const getTabFullPath = (tab, index, baseUrl) =>
+    `${baseUrl}${
+      tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
+    }`;
 
-const TabbedShowLayoutTabs = ({ value, children, ...rest }) => (
-    <Tabs
-        value={value}
-        indicatorColor="primary"
-    >
-        {children}
+const TabbedShowLayoutTabs = ({ value, children, match, ...rest }) => (
+    <Tabs value={value} indicatorColor='primary'>
+        {Children.map(children, (tab, index) => {
+            if (!tab) return null;
+
+            // Builds the full tab tab which is the concatenation of the last matched route in the
+            // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
+            // and the tab path.
+            // This will be used as the Tab's value
+            const tabPath = getTabFullPath(tab, index, match.url);
+
+            return cloneElement(tab, {
+                context: 'header',
+                value: tabPath,
+            });
+        })}
     </Tabs>
 );
 
 TabbedShowLayoutTabs.propTypes = {
     children: PropTypes.node,
-    value: PropTypes.number
+    value: PropTypes.number,
 };
 
 export default TabbedShowLayoutTabs;


### PR DESCRIPTION
After facing the same problems as #2317, this PR allows to pass props through `<TabbedShowLayout>` to material-ui's `<Tabs>`. This way the user can enable all the different Tabs modes (such as `scrollable`, `centered`), and pass other props that might be useful. This is done through the `options` prop in `<TabbedShowLayout>`.