### PR TITLE
[RFR] Fix CheckboxGroupInput design

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
@@ -18,8 +18,11 @@ const sanitizeRestProps = ({ setFilter, setPagination, setSort, ...rest }) =>
 const styles = theme => ({
     root: {},
     label: {
-        transform: 'translate(0, 5px) scale(0.75)',
+        transform: 'translate(0, 1.5px) scale(0.75)',
         transformOrigin: `top ${theme.direction === 'ltr' ? 'left' : 'right'}`,
+    },
+    checkbox: {
+        height: 32,
     },
 });
 
@@ -114,6 +117,7 @@ export class CheckboxGroupInput extends Component {
             options,
             translate,
             translateChoice,
+            classes,
         } = this.props;
         const choiceName = React.isValidElement(optionText) // eslint-disable-line no-nested-ternary
             ? React.cloneElement(optionText, { record: choice })
@@ -136,6 +140,7 @@ export class CheckboxGroupInput extends Component {
                     <Checkbox
                         id={`${id}_${get(choice, optionValue)}`}
                         color="primary"
+                        className={classes.checkbox}
                         {...options}
                     />
                 }


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/2750

## Todo

In `CheckboxGroupInput.js` file

- [x] Change the label style which is not the same as Material UI Input one
- [x] Pass a new style to the `Checkbox` component which forces the height to 32px

![selection_003](https://user-images.githubusercontent.com/5584839/50966166-6c0e2780-14d4-11e9-9622-23e1db8592e7.png)
