### PR TITLE
Fix ReferenceManyField doesn't rerender when the filter props changes

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
@@ -72,7 +72,10 @@ export class ReferenceManyFieldController extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (this.props.record.id !== nextProps.record.id) {
+        if (
+          this.props.record.id !== nextProps.record.id ||
+          !isEqual(this.props.filter, nextProps.filter)
+        ) {
             this.fetchReferences(nextProps);
         }
 


### PR DESCRIPTION
Component ReferenceManyField takes filter prop but now it doesn't call fetching new data if filter changed. This PR can fix it.