### PR TITLE
fix(ra.navigation): Added missing translation key `no_more_results`

### DIFF
--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -82,6 +82,7 @@ module.exports = {
         },
         navigation: {
             no_results: 'Aucun résultat',
+            no_more_results: 'La page numéro {page} est en dehors des limites. Essayez la page précédente.',
             page_out_of_boundaries: 'La page %{page} est en dehors des limites',
             page_out_from_end: 'Fin de la pagination',
             page_out_from_begin: 'La page doit être supérieure à 1',


### PR DESCRIPTION
As in the https://github.com/marmelab/react-admin/blob/master/packages/ra-language-english/index.js#L81