### PR TITLE
Fix IE11 layout problem caused by `flex-basis: auto`

### DIFF
--- a/examples/demo/src/visitors/SegmentsField.js
+++ b/examples/demo/src/visitors/SegmentsField.js
@@ -4,7 +4,6 @@ import { translate } from 'react-admin';
 import segments from '../segments/data';
 
 const styles = {
-    main: { display: 'flex', flexWrap: 'wrap' },
     chip: { margin: 4 },
 };
 

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -13,7 +13,8 @@ const styles = {
         display: 'flex',
     },
     card: {
-        flex: '1 1 auto',
+        flex: '1 1 0px',
+        overflowX: 'auto',
     },
 };
 

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -15,7 +15,8 @@ export const styles = {
         display: 'flex',
     },
     card: {
-        flex: '1 1 auto',
+        flex: '1 1 0px',
+        overflowX: 'auto',
     },
 };
 

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -14,7 +14,8 @@ export const styles = {
         display: 'flex',
     },
     card: {
-        flex: '1 1 auto',
+        flex: '1 1 0px',
+        overflowX: 'auto',
     },
 };
 

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -20,7 +20,8 @@ export const styles = {
     },
     card: {
         position: 'relative',
-        flex: '1 1 auto',
+        flex: '1 1 0px',
+        overflowX: 'auto',
     },
     actions: {
         zIndex: 2,


### PR DESCRIPTION
As mentioned in #2676, IE11 suffers from several layout problems where the user would have to horizontally scroll to see all content and/or images would get absurdly distorted.

https://github.com/philipwalton/flexbugs/issues/170 seems to show that IE11 shows inconsistency when using `flex-basis: auto` (or the shorthand version: `flex: X Y auto`).

I tried changing `auto` by `0px` in such statements, and it looks like it fixed many of those layout problems in the demo app:

| 🙁Before (IE11) | 🙂After (IE11) |
|---|---|
| ![image](https://user-images.githubusercontent.com/2587348/51079199-46934080-16c3-11e9-874d-5b3bb269bc7a.png) | ![image](https://user-images.githubusercontent.com/2587348/51079252-45164800-16c4-11e9-980d-1697f58048b3.png) |
| ![image](https://user-images.githubusercontent.com/2587348/51079220-abe73180-16c3-11e9-8059-ed2dc4e89c0c.png) | ![image](https://user-images.githubusercontent.com/2587348/51079214-8fe39000-16c3-11e9-820b-49fcfb35a3a8.png) |
| ![image](https://user-images.githubusercontent.com/2587348/51079638-a8a37400-16ca-11e9-8512-5cea6b3c2a38.png) | ![image](https://user-images.githubusercontent.com/2587348/51079635-9de8df00-16ca-11e9-9e4f-a441695dae5f.png) |

I also had to remove the `display: flex` and `flex-wrap: wrap` on `SegmentsField` because IE11 [has](https://stackoverflow.com/questions/31022747/flexbox-ie11-flex-wrap-wrap-does-not-wrap-images-codepen-inside) [many](https://stackoverflow.com/questions/35111090/text-in-a-flex-container-doesnt-wrap-in-ie11/35113633) [problems](https://github.com/philipwalton/flexbugs/issues/179) with `flex-wrap: wrap`. The wrapping still works (Chrome + IE11) though.

Navigating the demo app on Chrome showed me no visual regression, and `<Aside />` components (for which the `flex-basis: auto` were introduced) still work as expected:

![image](https://user-images.githubusercontent.com/2587348/51079243-0bddd800-16c4-11e9-924d-1ce1725670f0.png)
![image](https://user-images.githubusercontent.com/2587348/51079245-22842f00-16c4-11e9-89d6-31a09c1e70ea.png)
