### PR TITLE
fix: delete-many keep selected items 

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/list/selectedIds.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/selectedIds.ts
@@ -56,10 +56,6 @@ const selectedIdsReducer: Reducer<State> = (
             ];
         }
         if (action.meta.fetch === DELETE_MANY) {
-            const index = previousState.indexOf(action.payload.ids);
-            if (index === -1) {
-                return previousState;
-            }
             return previousState.filter(id => !action.payload.ids.includes(id));
         }
     }


### PR DESCRIPTION
Hi and happy new year to you 😄 

I'm opening this pull request as I encountered a bug.
When I'm selecting rows in `<List>` and using the default "bulk delete" button, the rows disappear but the "header" still show "X item selected", until I refresh the page.

![kapture 2019-01-16 at 12 28 19](https://user-images.githubusercontent.com/11151445/51252347-db37c000-199b-11e9-9f7b-e34818e37322.gif)

I investigated and found the issue. 
It seems this code is not working as we are passing an `array` to `indexOf`.
```js
const index = previousState.indexOf(action.payload.ids);	
if (index === -1) {	
  return previousState;	
}
```
I deleted it as this test seems useless in DELETE_MANY case.

Hope this is good ! 👌 
Don't hesitate to tell me if I can do something more with this PR.