### PR TITLE
Add an optional emptyValue to SelectInput

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -989,10 +989,10 @@ const FullNameField = ({ record }) => <span>{record.first_name} {record.last_nam
 <SelectInput source="gender" choices={choices} optionText={<FullNameField />}/>
 ```
 
-Enabling the `allowEmpty` props adds an empty choice (with `null` value) on top of the options, and makes the value nullable:
+Enabling the `allowEmpty` props adds an empty choice (with a default `null` value, which you can overwrite with the `emptyValue` prop) on top of the options, and makes the value nullable:
 
 ```jsx
-<SelectInput source="category" allowEmpty choices={[
+<SelectInput source="category" allowEmpty emptyValue="" choices={[
     { id: 'programming', name: 'Programming' },
     { id: 'lifestyle', name: 'Lifestyle' },
     { id: 'photography', name: 'Photography' },

--- a/packages/ra-ui-materialui/src/input/SelectInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.js
@@ -10,6 +10,7 @@ import ResettableTextField from './ResettableTextField';
 const sanitizeRestProps = ({
     addLabel,
     allowEmpty,
+    emptyValue,
     basePath,
     choices,
     className,
@@ -155,7 +156,10 @@ export class SelectInput extends Component {
 
     addAllowEmpty = choices => {
         if (this.props.allowEmpty) {
-            return [<MenuItem value="" key="null" />, ...choices];
+            const value = this.props.hasOwnProperty('emptyValue')
+                ? this.props.emptyValue
+                : '';
+            return [<MenuItem value={value} key="null" />, ...choices];
         }
 
         return choices;

--- a/packages/ra-ui-materialui/src/input/SelectInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.js
@@ -156,10 +156,7 @@ export class SelectInput extends Component {
 
     addAllowEmpty = choices => {
         if (this.props.allowEmpty) {
-            const value = this.props.hasOwnProperty('emptyValue')
-                ? this.props.emptyValue
-                : '';
-            return [<MenuItem value={value} key="null" />, ...choices];
+            return [<MenuItem value={this.props.emptyValue} key="null" />, ...choices];
         }
 
         return choices;
@@ -244,6 +241,7 @@ export class SelectInput extends Component {
 
 SelectInput.propTypes = {
     allowEmpty: PropTypes.bool.isRequired,
+    emptyValue: PropTypes.any,
     choices: PropTypes.arrayOf(PropTypes.object),
     classes: PropTypes.object,
     className: PropTypes.string,
@@ -267,6 +265,7 @@ SelectInput.propTypes = {
 
 SelectInput.defaultProps = {
     allowEmpty: false,
+    emptyValue: '',
     classes: {},
     choices: [],
     options: {},

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.js
@@ -94,6 +94,26 @@ describe('<SelectInput />', () => {
         assert.equal(MenuItemElement1.children().length, 0);
     });
 
+    it('should add an empty menu with custom value when allowEmpty is true', () => {
+        const emptyValue = 'test';
+        const wrapper = shallow(
+            <SelectInput
+                allowEmpty
+                emptyValue={emptyValue}
+                {...defaultProps}
+                choices={[
+                    { id: 'M', name: 'Male' },
+                    { id: 'F', name: 'Female' },
+                ]}
+            />
+        );
+        const MenuItemElements = wrapper.find('WithStyles(MenuItem)');
+        assert.equal(MenuItemElements.length, 3);
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), emptyValue);
+        assert.equal(MenuItemElement1.children().length, 0);
+    });
+
     it('should not add a falsy (null or false) element when allowEmpty is false', () => {
         const wrapper = shallow(
             <SelectInput


### PR DESCRIPTION
#2234 introduced a breaking change for our application. This change adds an optional custom value which is used when allowEmpty is set.

Previously `null` was set as an empty value, now you can set null again.