### PR TITLE
[RFR] Check minimum required props are passed to controllers

### DIFF
--- a/packages/ra-core/src/controller/CreateController.js
+++ b/packages/ra-core/src/controller/CreateController.js
@@ -7,6 +7,7 @@ import { parse } from 'query-string';
 
 import translate from '../i18n/translate';
 import { crudCreate as crudCreateAction } from '../actions';
+import checkMinimumRequiredProps from './checkMinimumRequiredProps';
 
 /**
  * Page component for the Create view
@@ -139,9 +140,14 @@ function mapStateToProps(state) {
 }
 
 export default compose(
+    checkMinimumRequiredProps('Create', [
+        'basePath',
+        'location',
+        'resource',
+    ]),
     connect(
         mapStateToProps,
         { crudCreate: crudCreateAction }
     ),
-    translate
+    translate,
 )(CreateController);

--- a/packages/ra-core/src/controller/EditController.js
+++ b/packages/ra-core/src/controller/EditController.js
@@ -7,6 +7,7 @@ import { reset } from 'redux-form';
 import translate from '../i18n/translate';
 import { crudGetOne, crudUpdate, startUndoable } from '../actions';
 import { REDUX_FORM_NAME } from '../form';
+import checkMinimumRequiredProps from './checkMinimumRequiredProps';
 
 /**
  * Page component for the Edit view
@@ -175,6 +176,11 @@ function mapStateToProps(state, props) {
 }
 
 export default compose(
+    checkMinimumRequiredProps('Edit', [
+        'basePath',
+        'location',
+        'resource',
+    ]),
     connect(
         mapStateToProps,
         {

--- a/packages/ra-core/src/controller/ListController.js
+++ b/packages/ra-core/src/controller/ListController.js
@@ -27,6 +27,7 @@ import {
 } from '../actions/listActions';
 import translate from '../i18n/translate';
 import removeKey from '../util/removeKey';
+import checkMinimumRequiredProps from './checkMinimumRequiredProps';
 
 /**
  * List page component
@@ -439,7 +440,14 @@ function mapStateToProps(state, props) {
     };
 }
 
+
+
 export default compose(
+    checkMinimumRequiredProps('List', [
+        'basePath',
+        'location',
+        'resource',
+    ]),
     connect(
         mapStateToProps,
         {

--- a/packages/ra-core/src/controller/ShowController.js
+++ b/packages/ra-core/src/controller/ShowController.js
@@ -5,6 +5,7 @@ import compose from 'recompose/compose';
 import inflection from 'inflection';
 import translate from '../i18n/translate';
 import { crudGetOne as crudGetOneAction } from '../actions';
+import checkMinimumRequiredProps from './checkMinimumRequiredProps';
 
 /**
  * Page component for the Show view
@@ -132,6 +133,11 @@ function mapStateToProps(state, props) {
 }
 
 export default compose(
+    checkMinimumRequiredProps('Show', [
+        'basePath',
+        'location',
+        'resource',
+    ]),
     connect(
         mapStateToProps,
         { crudGetOne: crudGetOneAction }

--- a/packages/ra-core/src/controller/checkMinimumRequiredProps.js
+++ b/packages/ra-core/src/controller/checkMinimumRequiredProps.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const checkMinimumRequiredProps = (displayName, requiredProps) => WrappedComponent => (props) => {
+    const propNames = Object.keys(props);
+    const missingProps = requiredProps.filter(prop => !propNames.includes(prop));
+
+    if (missingProps.length > 0) {
+        throw new Error(
+`<${displayName}> component is not properly configured, some essential props are missing.
+Be sure to pass the props from the parent. Example:
+
+const My${displayName} = props => (
+    <${displayName} {...props}></${displayName}>
+);
+
+The missing props are: ${missingProps.join(', ')}`)
+    }
+
+    return <WrappedComponent {...props} />;
+};
+
+export default checkMinimumRequiredProps;


### PR DESCRIPTION
When we forgot to pass the props from the parent to the controller, the app displays a huge error.

```js
// For example:
const PostShow = () => (
    <Show title={<PostTitle />} />
);

// Instead of:
const PostShow = props => (
    <Show title={<PostTitle />} {...props} />
);
```

## Current Error Message:

![image](https://user-images.githubusercontent.com/1819833/51330377-ae58db00-1a77-11e9-81e7-b40cf2973242.png)

## New Error Message

![image](https://user-images.githubusercontent.com/1819833/51330907-cd0ba180-1a78-11e9-99b8-ed64fe693fd8.png)