### PR TITLE
[RFR] Fix optimistic actions never get sent when changing tabs

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.js
+++ b/packages/ra-ui-materialui/src/layout/Notification.js
@@ -89,6 +89,9 @@ class Notification extends React.Component {
                     (notification && notification.autoHideDuration) ||
                     autoHideDuration
                 }
+                disableWindowBlurListener={
+                    notification && notification.undoable
+                }
                 onExited={this.handleExited}
                 onClose={this.handleRequestClose}
                 ContentProps={{


### PR DESCRIPTION
Closes #2721 

See [Material-ui's documentation of the `disableWindowBlurListener` Snackbar prop](https://v1-5-0.material-ui.com/api/snackbar/).
