### PR TITLE
[RFR] Display selected choices in their selection order in SelectArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -141,6 +141,7 @@ export class SelectArrayInput extends Component {
         this.props.input.onBlur(event.target.value);
         this.setState({ value: event.target.value });
     };
+
     renderMenuItemOption = choice => {
         const { optionText, translate, translateChoice } = this.props;
         if (React.isValidElement(optionText))
@@ -213,16 +214,16 @@ export class SelectArrayInput extends Component {
                     error={!!(touched && error)}
                     renderValue={selected => (
                         <div className={classes.chips}>
-                            {choices
-                                .filter(choice =>
-                                    selected.includes(get(choice, optionValue))
+                            {selected
+                                .map(item =>
+                                    choices.find(
+                                        choice => choice[optionValue] === item
+                                    )
                                 )
-                                .map(choice => (
+                                .map(item => (
                                     <Chip
-                                        key={get(choice, optionValue)}
-                                        label={this.renderMenuItemOption(
-                                            choice
-                                        )}
+                                        key={get(item, optionValue)}
+                                        label={this.renderMenuItemOption(item)}
                                         className={classes.chip}
                                     />
                                 ))}


### PR DESCRIPTION
The behavior of the `SelectArrayInput` doesn't follow the way they are stored. I've changed the render method in the `SelectArrayInput` component in order to fix this.

In addition, this change respects the [Multiple Select demo](https://material-ui.com/demos/selects/#multiple-select) in Material-UI.

## Scenario

In the following screenshot, we can find *on the left the new version**, and **on the right the old version**.

Selection order:
- (1) Compulsive
- (2) Reviewer
- (3) Regular

Choices order:
- **(1) Compulsive**
- Collector
- Ordered once
- **(3) Regular**
- Returns
- **(2) Reviewer**

We notice that without this PR, the `SelectArrayInput` displays the items in the choices order instead of the selection order. However, in the storage, the items are ordered following the user selection order.

![selection_001](https://user-images.githubusercontent.com/5584839/51668427-7d6e2e00-1fc2-11e9-956f-2a243689ee42.png)

## Todo

- [x] Change the `renderValue` method in `SelectArrayInput` to display selected choices in their selection order