### PR TITLE
[RFR] Fix sanitization of DeleteButton props

### DIFF
--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -33,6 +33,7 @@ const sanitizeRestProps = ({
     selectedIds,
     startUndoable,
     undoable,
+    redirect,
     ...rest
 }) => rest;
 


### PR DESCRIPTION
Sepecifying the `redirect` prop as a boolean was trigerring a warning in console