### PR TITLE
[RFR] Use default colors for most buttons

### DIFF
--- a/examples/simple/src/tags/TagList.js
+++ b/examples/simple/src/tags/TagList.js
@@ -23,7 +23,7 @@ const TagDragPreview = props => (
 
 const CustomNodeActions = props => (
     <NodeActions {...props}>
-        <SaveButton variant="flat" />
+        <SaveButton color="default" variant="flat" />
         <IgnoreFormProps>
             <EditButton />
             <ShowButton />

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -37,7 +37,7 @@ const Button = ({
     children,
     classes = {},
     className,
-    color = 'primary',
+    color = 'default',
     disabled,
     label,
     size = 'small',

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -69,15 +69,19 @@ class DeleteButton extends Component {
             className,
             icon,
             onClick,
+            color = 'danger',
             ...rest
         } = this.props;
         return (
             <Button
                 onClick={this.handleDelete}
                 label={label}
+                // danger is not supported by material-ui so we pass default as we will use a custom class anyway
+                color={color === 'danger' ? 'default' : color}
                 className={classnames(
                     'ra-delete-button',
-                    classes.deleteButton,
+                    // Most of the time, the delete button shouldn't stand out so we only apply the danger class if explicitly required
+                    color === 'danger' ? classes.deleteButton : undefined,
                     className
                 )}
                 key="button"
@@ -92,6 +96,7 @@ class DeleteButton extends Component {
 DeleteButton.propTypes = {
     basePath: PropTypes.string,
     classes: PropTypes.object,
+    color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary', 'danger']),
     className: PropTypes.string,
     dispatchCrudDelete: PropTypes.func.isRequired,
     label: PropTypes.string,
@@ -109,6 +114,7 @@ DeleteButton.propTypes = {
 };
 
 DeleteButton.defaultProps = {
+    color: 'default',
     redirect: 'list',
     undoable: true,
     icon: <ActionDelete />,

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -103,11 +103,7 @@ export class PaginationActions extends Component {
                 ) : (
                     <Button
                         className="page-number"
-                        color={
-                            pageNum === this.props.page + 1
-                                ? 'default'
-                                : 'primary'
-                        }
+                        color="default"
                         key={pageNum}
                         data-page={pageNum - 1}
                         onClick={this.gotoPage}
@@ -128,7 +124,6 @@ export class PaginationActions extends Component {
             <div className={classes.actions}>
                 {page > 0 && (
                     <Button
-                        color="primary"
                         key="prev"
                         onClick={this.prevPage}
                         className="previous-page"
@@ -141,7 +136,6 @@ export class PaginationActions extends Component {
                 {this.renderPageNums()}
                 {page !== nbPages - 1 && (
                     <Button
-                        color="primary"
                         key="next"
                         onClick={this.nextPage}
                         className="next-page"


### PR DESCRIPTION
We currently set the color prop of all buttons to `primary` which defeat the purpose of having a primary button.

This PR sets the default color of all buttons to `default`. However, it keeps the `primary` color for some cases when it makes sense such as the `CreateButton` in fab mode (on mobile devices) or the `SaveButton` used in forms. It can still be overriden by supplying the `color` prop.

Same logic is applied to the `DeleteButton` which should not stand out by default (it is currently always red). However, a new `danger` value is supported by its `color` prop in addition of the material-ui values for when it is needed (such as in a confirmation modal)

Before: ![before](https://i.imgur.com/elszlGJ.png)
After: ![after](https://i.imgur.com/2vw7aK0.png)

Before: ![before](https://i.imgur.com/ZzEooOm.png)
After: ![after](https://i.imgur.com/LqmZ3Xf.png)