### PR TITLE
trigger refresh after crudUpdate. this is to fix a similar issue to #2425…

### DIFF
--- a/packages/ra-core/src/actions/dataActions.js
+++ b/packages/ra-core/src/actions/dataActions.js
@@ -119,7 +119,8 @@ export const crudUpdate = (
     data,
     previousData,
     basePath,
-    redirectTo = 'show'
+    redirectTo = 'show',
+    refresh = true
 ) => ({
     type: CRUD_UPDATE,
     payload: { id, data, previousData },
@@ -134,6 +135,7 @@ export const crudUpdate = (
                     smart_count: 1,
                 },
             },
+            refresh,
             redirectTo,
             basePath,
         },


### PR DESCRIPTION
I have a custom edit view allowing user to do in-place editing.
Once field editing is done, the user stay on the same edit view so they can work on the other fields.
When undoable={false} is set on the edit view, the edit view does not get refreshed after editing.
But when undoable={true} is set, the edit view does get refreshed.