### PR TITLE
[RFR] Fix AutocompleteInput by removing auto selection

### DIFF
--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -55,9 +55,10 @@ describe('Create Page', () => {
             {
                 type: 'input',
                 name: 'authors[0].user_id',
-                value: 'Annamarie Mayer{enter}',
+                value: 'Annamarie Mayer',
             },
         ]);
+        cy.contains('Annamarie Mayer').click();
         cy.get(CreatePage.elements.input('authors[0].role')).should(
             el => expect(el).to.exist
         );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -211,43 +211,11 @@ export class AutocompleteInput extends React.Component {
     };
 
     handleMatchSuggestionOrFilter = inputValue => {
-        const { choices, inputValueMatcher, input } = this.props;
-
-        const matches =
-            inputValue &&
-            choices.filter(it =>
-                inputValueMatcher(inputValue, it, this.getSuggestionText)
-            );
-
-        if (matches.length === 1) {
-            const match = matches[0];
-            const nextId = this.getSuggestionValue(match);
-            const suggestionText = this.getSuggestionText(match);
-
-            if (this.state.inputValue !== nextId) {
-                this.setState(
-                    {
-                        inputValue: nextId,
-                        searchText: suggestionText, // The searchText could be whatever the inputvalue matcher likes, so sanitize it
-                        selectedItem: match,
-                        suggestions: [match],
-                    },
-                    () => input.onChange(nextId)
-                );
-            } else {
-                this.setState({
-                    dirty: false,
-                    suggestions: [match],
-                    searchText: suggestionText,
-                });
-            }
-        } else {
-            this.setState({
-                dirty: true,
-                searchText: inputValue,
-            });
-            this.updateFilter(inputValue);
-        }
+        this.setState({
+            dirty: true,
+            searchText: inputValue,
+        });
+        this.updateFilter(inputValue);
     };
 
     handleChange = (event, { newValue, method }) => {
@@ -533,7 +501,6 @@ AutocompleteInput.propTypes = {
     suggestionComponent: PropTypes.func,
     translate: PropTypes.func.isRequired,
     translateChoice: PropTypes.bool.isRequired,
-    inputValueMatcher: PropTypes.func,
 };
 
 AutocompleteInput.defaultProps = {
@@ -543,11 +510,6 @@ AutocompleteInput.defaultProps = {
     optionValue: 'id',
     limitChoicesToValue: false,
     translateChoice: true,
-    inputValueMatcher: (input, suggestion, getOptionText) =>
-        getOptionText(suggestion)
-            .toLowerCase()
-            .trim()
-            .includes(input.toLowerCase().trim()),
 };
 
 export default compose(

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.js
@@ -363,26 +363,6 @@ describe('<AutocompleteInput />', () => {
             expect(wrapper.find('ListItem')).toHaveLength(2);
         });
 
-        it('should resolve value from input value', () => {
-            const onChange = jest.fn();
-            const wrapper = mount(
-                <AutocompleteInput
-                    {...defaultProps}
-                    input={{ value: '', onChange }}
-                />,
-                { context, childContextTypes }
-            );
-            wrapper.setProps({
-                choices: [{ id: 'M', name: 'Male' }],
-            });
-            wrapper
-                .find('input')
-                .simulate('change', { target: { value: 'male' } });
-            expect(wrapper.state('searchText')).toBe('Male');
-            expect(onChange).toHaveBeenCalledTimes(1);
-            expect(onChange).toHaveBeenCalledWith('M');
-        });
-
         it('should reset filter when input value changed', () => {
             const setFilter = jest.fn();
             const wrapper = mount(
@@ -530,7 +510,7 @@ describe('<AutocompleteInput />', () => {
         expect(wrapper.state('suggestions')).toHaveLength(2);
     });
 
-    it('automatically selects a matched choice if there is only one', () => {
+    it('does not automatically select a matched choice if there is only one', () => {
         const onChange = jest.fn();
 
         const wrapper = mount(
@@ -548,7 +528,6 @@ describe('<AutocompleteInput />', () => {
         wrapper.find('input').simulate('focus');
         wrapper.find('input').simulate('change', { target: { value: 'abc' } });
         expect(wrapper.state('suggestions')).toHaveLength(1);
-        expect(onChange).toHaveBeenCalledWith(2);
     });
 
     it('passes options.suggestionsContainerProps to the suggestions container', () => {


### PR DESCRIPTION
The main issue was that when used in a `ReferenceInput`, whenever the filter changed,  the `AutocompleteInput` first checked if one of the already available choices matched and if only one was found, it would not even try to fetch others from the `dataProvider`.

As we also had numerous complaints about the auto-selection feature, we decided to remove it completely.

Fixes #2688, #2346