### PR TITLE
Add additionalMenuItems prop to Menu

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -43,6 +43,7 @@ const Menu = ({
     resources,
     translate,
     logout,
+    additionalMenuItems,
     ...rest
 }) => (
     <div className={classnames(classes.main, className)} {...rest}>
@@ -56,6 +57,19 @@ const Menu = ({
                     primaryText={translatedResourceName(resource, translate)}
                     leftIcon={
                         resource.icon ? <resource.icon /> : <DefaultIcon />
+                    }
+                    onClick={onMenuClick}
+                    dense={dense}
+                />
+            ))}
+        {!!additionalMenuItems &&
+            additionalMenuItems.map(menuItem => (
+                <MenuItemLink
+                    key={menuItem.key || menuItem.primaryText}
+                    to={menuItem.to}
+                    primaryText={menuItem.primaryText}
+                    leftIcon={
+                        menuItem.icon ? <menuItem.icon /> : <DefaultIcon />
                     }
                     onClick={onMenuClick}
                     dense={dense}


### PR DESCRIPTION
Hello,

Sometimes you only want to add some menu items without overriding the whole `Menu` base component.
This adds an `additionalMenuItems` prop that shows custom menu items.

Another more flexible strategy would be add a `renderAdditionalMenuItems` prop that gives `onMenuClick` as parameter.

Let me know what you think :)