### PR TITLE
Fix position of choices container when input element moves to another location

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -110,6 +110,7 @@ export class AutocompleteArrayInput extends React.Component {
     };
 
     inputEl = null;
+    anchorEl = null;
 
     componentWillMount() {
         this.setState({
@@ -236,6 +237,7 @@ export class AutocompleteArrayInput extends React.Component {
         // but Autosuggest also needs this reference (it provides the ref prop)
         const storeInputRef = input => {
             this.inputEl = input;
+            this.updateAnchorEl();
             ref(input);
         };
 
@@ -329,25 +331,42 @@ export class AutocompleteArrayInput extends React.Component {
         input.onChange(this.state.inputValue.filter(value => value !== chip));
     };
 
+    updateAnchorEl() {
+        if (!this.inputEl) {
+            return;
+        }
+
+        if (!this.anchorEl) {
+            const inputPosition = this.inputEl.getBoundingClientRect();
+
+            this.anchorEl = { getBoundingClientRect: () => inputPosition };
+        } else {
+            const anchorPosition = this.anchorEl.getBoundingClientRect();
+            const inputPosition = this.inputEl.getBoundingClientRect();
+
+            if (
+                anchorPosition.x !== inputPosition.x ||
+                anchorPosition.y !== inputPosition.y
+            ) {
+                this.anchorEl = { getBoundingClientRect: () => inputPosition };
+            }
+        }
+    }
+
     renderSuggestionsContainer = options => {
         const {
             containerProps: { className, ...containerProps },
             children,
         } = options;
 
-        // Force the Popper component to reposition the popup when this.inputEl is moved to another location
-        const anchorEl = !this.inputEl
-            ? null
-            : {
-                  getBoundingClientRect: () =>
-                      this.inputEl.getBoundingClientRect(),
-              };
+        // Force the Popper component to reposition the popup only when this.inputEl is moved to another location
+        this.updateAnchorEl();
 
         return (
             <Popper
                 className={className}
                 open
-                anchorEl={anchorEl}
+                anchorEl={this.anchorEl}
                 placement="bottom-start"
             >
                 <Paper square {...containerProps}>

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -335,11 +335,19 @@ export class AutocompleteArrayInput extends React.Component {
             children,
         } = options;
 
+        // Force the Popper component to reposition the popup when this.inputEl is moved to another location
+        const anchorEl = !this.inputEl
+            ? null
+            : {
+                  getBoundingClientRect: () =>
+                      this.inputEl.getBoundingClientRect(),
+              };
+
         return (
             <Popper
                 className={className}
                 open
-                anchorEl={this.inputEl}
+                anchorEl={anchorEl}
                 placement="bottom-start"
             >
                 <Paper square {...containerProps}>

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -336,13 +336,12 @@ export class AutocompleteArrayInput extends React.Component {
             return;
         }
 
-        if (!this.anchorEl) {
-            const inputPosition = this.inputEl.getBoundingClientRect();
+        const inputPosition = this.inputEl.getBoundingClientRect();
 
+        if (!this.anchorEl) {
             this.anchorEl = { getBoundingClientRect: () => inputPosition };
         } else {
             const anchorPosition = this.anchorEl.getBoundingClientRect();
-            const inputPosition = this.inputEl.getBoundingClientRect();
 
             if (
                 anchorPosition.x !== inputPosition.x ||


### PR DESCRIPTION
This merge request solves the problem reported in issue #2259.

The problem happens because the **`Popper`** component used to render the **`choices`** is a stateless component. Since the **`Popper`** component receives a reference to the **`inputEl`** component, the render method is unable to detect when the original **`inputEl`** moved to another place.

I noticed that when the original **input** element moves, React is keeping the old **`Popper`** component without forcing it to redraw.

My solution is based on this example from **`Material-UI`** docs:
https://v1-5-0.material-ui.com/utils/popper/#faked-reference-object

I'm keeping an object that has a reference to the last position of the **`inputEl`** and updating this object only when the **`inputEl`** moves. Doing this we only force the redraw of the **`Popper`** container only when needed.

Fixes #2259.