### PR TITLE
Fix error thrown by ChipInput component generated by AutocompleteArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -104,25 +104,27 @@ const styles = theme => ({
 export class AutocompleteArrayInput extends React.Component {
     state = {
         dirty: false,
-        inputValue: null,
+        inputValue: [],
         searchText: '',
         suggestions: [],
     };
 
     inputEl = null;
 
+    getInputValue = inputValue => (inputValue === '' ? [] : inputValue);
+
     componentWillMount() {
         this.setState({
-            inputValue: this.props.input.value,
+            inputValue: this.getInputValue(this.props.input.value),
             suggestions: this.props.choices,
         });
     }
 
     componentWillReceiveProps(nextProps) {
         const { choices, input, inputValueMatcher } = nextProps;
-        if (!isEqual(input.value, this.state.inputValue)) {
+        if (!isEqual(this.getInputValue(input.value), this.state.inputValue)) {
             this.setState({
-                inputValue: input.value,
+                inputValue: this.getInputValue(input.value),
                 dirty: false,
                 suggestions: this.props.choices,
             });
@@ -245,7 +247,7 @@ export class AutocompleteArrayInput extends React.Component {
                 onUpdateInput={onChange}
                 onAdd={this.handleAdd}
                 onDelete={this.handleDelete}
-                value={input.value}
+                value={this.getInputValue(input.value)}
                 inputRef={storeInputRef}
                 error={touched && error}
                 helperText={touched && error && helperText}

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -102,16 +102,19 @@ const styles = theme => ({
  * <AutocompleteInput source="author_id" options={{ fullWidth: true }} />
  */
 export class AutocompleteArrayInput extends React.Component {
+    initialInputValue = [];
+
     state = {
         dirty: false,
-        inputValue: [],
+        inputValue: this.initialInputValue,
         searchText: '',
         suggestions: [],
     };
 
     inputEl = null;
 
-    getInputValue = inputValue => (inputValue === '' ? [] : inputValue);
+    getInputValue = inputValue =>
+        inputValue === '' ? this.initialInputValue : inputValue;
 
     componentWillMount() {
         this.setState({


### PR DESCRIPTION
The problem described in issue #2361 happens because, sometimes, the **input** component has an **empty string** as a default value, but the **`AutocompleteArrayInputChip`** component only accepts an **`Array`** as a value.

Enforcing **`state.inputValue`** to be an **`Array`** solves the issue.

Fixes #2361.