### PR TITLE
Fix GET_MANY in ra-data-json-server data provider returns too many results

### DIFF
--- a/packages/ra-data-json-server/src/index.js
+++ b/packages/ra-data-json-server/src/index.js
@@ -81,7 +81,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
                 break;
             case GET_MANY: {
                 const query = {
-                    [`id_like`]: params.ids.join('|'),
+                  id: params.ids
                 };
                 url = `${apiUrl}/${resource}?${stringify(query)}`;
                 break;


### PR DESCRIPTION
I think using the [json-server](https://github.com/typicode/json-server) `like` feature is not what we want here, since an `id_like=2|33|444` will match 2, 33, 444 but also 23, 133 and so forth.
We could restrict the match with delimiters (`^` and `$`) but since it supports multiple filters query, it would be simpler to use just that.