### PR TITLE
Corrected prop types for ArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.js
@@ -107,7 +107,10 @@ ArrayInput.propTypes = {
     source: PropTypes.string,
     record: PropTypes.object,
     options: PropTypes.object,
-    validate: PropTypes.func,
+    validate: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.arrayOf(PropTypes.func),
+    ]),
 };
 
 ArrayInput.defaultProps = {


### PR DESCRIPTION
It wasn't letting arrays through, even though they work absolutely fine.