### PR TITLE
fix(List.js): add children style

### DIFF
--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -33,6 +33,7 @@ export const styles = {
         justifyContent: 'space-between',
         alignSelf: 'flex-start',
     },
+    children: { display: 'flex' },
     noResults: { padding: 20 },
 };
 
@@ -138,7 +139,7 @@ export const ListView = ({
                         exporter={exporter}
                     />
                 )}
-                <div key={version}>
+                <div className={classes.children} key={version}>
                     {children &&
                         React.cloneElement(children, {
                             ...controllerProps,


### PR DESCRIPTION
We do not have access to holders of `children` for personalization. And this holder has been blocking our layout. This `div` should be deleted or added to that `CSS class`.
That's why I added this `class` through which we can personalize.