### PR TITLE
Add allowDuplicates property to AutocompleteArrayInput and fix #2311

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -159,12 +159,18 @@ export class AutocompleteArrayInput extends React.Component {
     };
 
     handleSuggestionSelected = (event, { suggestion, method }) => {
-        const { input } = this.props;
+        const { allowDuplicates, input } = this.props;
 
-        input.onChange([
-            ...(this.state.inputValue || []),
-            this.getSuggestionValue(suggestion),
-        ]);
+        const values = this.state.inputValue || [];
+        const newValue = this.getSuggestionValue(suggestion);
+
+        if (allowDuplicates || values.indexOf(newValue) < 0) {
+            // Add selected value to the list
+            input.onChange([...values, newValue]);
+
+            // Ensure to reset the filter
+            this.updateFilter('');
+        }
 
         if (method === 'enter') {
             event.preventDefault();
@@ -487,6 +493,7 @@ export class AutocompleteArrayInput extends React.Component {
 }
 
 AutocompleteArrayInput.propTypes = {
+    allowDuplicates: PropTypes.bool,
     allowEmpty: PropTypes.bool,
     alwaysRenderSuggestions: PropTypes.bool, // used only for unit tests
     choices: PropTypes.arrayOf(PropTypes.object),
@@ -513,6 +520,7 @@ AutocompleteArrayInput.propTypes = {
 };
 
 AutocompleteArrayInput.defaultProps = {
+    allowDuplicates: true,
     choices: [],
     options: {},
     optionText: 'name',

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -520,7 +520,7 @@ AutocompleteArrayInput.propTypes = {
 };
 
 AutocompleteArrayInput.defaultProps = {
-    allowDuplicates: true,
+    allowDuplicates: false,
     choices: [],
     options: {},
     optionText: 'name',

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.js
@@ -556,15 +556,37 @@ describe('<AutocompleteArrayInput />', () => {
     });
 
     describe('Add allowDuplicates flag (Fix #2311)', () => {
+        it('should have allowDuplicates disabled by default', () => {
+            const wrapper = mount(
+                <AutocompleteArrayInput {...defaultProps} choices={[]} />
+            );
+
+            expect(wrapper.props().allowDuplicates).toBe(false);
+        });
+
+        it('should enable allowDuplicates when defined', () => {
+            const wrapper = mount(
+                <AutocompleteArrayInput
+                    {...defaultProps}
+                    allowDuplicates
+                    choices={[]}
+                />
+            );
+
+            expect(wrapper.props().allowDuplicates).toBe(true);
+        });
+
         it('should not accept duplicated items by default', () => {
+            const onChange = jest.fn();
+
             const wrapper = mount(
                 <AutocompleteArrayInput
                     {...defaultProps}
                     input={{ value: [], onChange }}
                     choices={[
-                        { id: 1, name: 'a' },
-                        { id: 2, name: 'b' },
-                        { id: 3, name: 'c' },
+                        { id: 1, name: 'Male' },
+                        { id: 2, name: 'Female' },
+                        { id: 3, name: 'Other' },
                     ]}
                 />,
                 { context, childContextTypes }
@@ -573,29 +595,42 @@ describe('<AutocompleteArrayInput />', () => {
             wrapper.find('input').simulate('focus');
             wrapper
                 .find('input')
-                .simulate('change', { target: { value: 'a' } });
+                .simulate('change', { target: { value: 'Other' } });
+            wrapper.find('input').simulate('blur');
 
-            expect(wrapper.state('suggestions')).toHaveLength(1);
-            expect(wrapper.find('ListItem')).toHaveLength(1);
-
+            wrapper.find('input').simulate('focus');
             wrapper
                 .find('input')
-                .simulate('change', { target: { value: 'a' } });
+                .simulate('change', { target: { value: 'Other' } });
+            wrapper.find('input').simulate('blur');
 
-            expect(wrapper.state('suggestions')).toHaveLength(1);
-            expect(wrapper.find('ListItem')).toHaveLength(1);
+            expect.assertions(2);
+
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    try {
+                        expect(onChange).toHaveBeenCalledTimes(2);
+                        expect(onChange).toHaveBeenCalledWith([3]);
+                    } catch (error) {
+                        return reject(error);
+                    }
+                    resolve();
+                }, 250);
+            });
         });
 
         it('should accept duplicated items when allowDuplicates is enabled', () => {
+            const onChange = jest.fn();
+
             const wrapper = mount(
                 <AutocompleteArrayInput
                     {...defaultProps}
                     allowDuplicates
                     input={{ value: [], onChange }}
                     choices={[
-                        { id: 1, name: 'a' },
-                        { id: 2, name: 'b' },
-                        { id: 3, name: 'c' },
+                        { id: 1, name: 'Male' },
+                        { id: 2, name: 'Female' },
+                        { id: 3, name: 'Other' },
                     ]}
                 />,
                 { context, childContextTypes }
@@ -604,17 +639,28 @@ describe('<AutocompleteArrayInput />', () => {
             wrapper.find('input').simulate('focus');
             wrapper
                 .find('input')
-                .simulate('change', { target: { value: 'a' } });
+                .simulate('change', { target: { value: 'Other' } });
+            wrapper.find('input').simulate('blur');
 
-            expect(wrapper.state('suggestions')).toHaveLength(1);
-            expect(wrapper.find('ListItem')).toHaveLength(1);
-
+            wrapper.find('input').simulate('focus');
             wrapper
                 .find('input')
-                .simulate('change', { target: { value: 'a' } });
+                .simulate('change', { target: { value: 'Other' } });
+            wrapper.find('input').simulate('blur');
 
-            expect(wrapper.state('suggestions')).toHaveLength(1);
-            expect(wrapper.find('ListItem')).toHaveLength(2);
+            expect.assertions(2);
+
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    try {
+                        expect(onChange).toHaveBeenCalledTimes(2);
+                        expect(onChange).toHaveBeenCalledWith([3]);
+                    } catch (error) {
+                        return reject(error);
+                    }
+                    resolve();
+                }, 250);
+            });
         });
     });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.js
@@ -554,4 +554,67 @@ describe('<AutocompleteArrayInput />', () => {
             }, 250);
         });
     });
+
+    describe('Add allowDuplicates flag (Fix #2311)', () => {
+        it('should not accept duplicated items by default', () => {
+            const wrapper = mount(
+                <AutocompleteArrayInput
+                    {...defaultProps}
+                    input={{ value: [], onChange }}
+                    choices={[
+                        { id: 1, name: 'a' },
+                        { id: 2, name: 'b' },
+                        { id: 3, name: 'c' },
+                    ]}
+                />,
+                { context, childContextTypes }
+            );
+
+            wrapper.find('input').simulate('focus');
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: 'a' } });
+
+            expect(wrapper.state('suggestions')).toHaveLength(1);
+            expect(wrapper.find('ListItem')).toHaveLength(1);
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: 'a' } });
+
+            expect(wrapper.state('suggestions')).toHaveLength(1);
+            expect(wrapper.find('ListItem')).toHaveLength(1);
+        });
+
+        it('should accept duplicated items when allowDuplicates is enabled', () => {
+            const wrapper = mount(
+                <AutocompleteArrayInput
+                    {...defaultProps}
+                    allowDuplicates
+                    input={{ value: [], onChange }}
+                    choices={[
+                        { id: 1, name: 'a' },
+                        { id: 2, name: 'b' },
+                        { id: 3, name: 'c' },
+                    ]}
+                />,
+                { context, childContextTypes }
+            );
+
+            wrapper.find('input').simulate('focus');
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: 'a' } });
+
+            expect(wrapper.state('suggestions')).toHaveLength(1);
+            expect(wrapper.find('ListItem')).toHaveLength(1);
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: 'a' } });
+
+            expect(wrapper.state('suggestions')).toHaveLength(1);
+            expect(wrapper.find('ListItem')).toHaveLength(2);
+        });
+    });
 });


### PR DESCRIPTION
The method **`handleSuggestionSelected`** is adding the new value directly to the **`input`** through **`onChange`** method. Even when the property **`allowDuplicates`** is enabled in the **`AutocompleteArrayInputChip`** this element will be added.

This merge request adds a new property to **`AutocompleteArrayInput`** component, named **`allowDuplicates`**, that is used to allow or disallow insertion of duplicated elements.

Fixes #2311