### PR TITLE
[RFR] Fix warning about missing translation for empty key

### DIFF
--- a/packages/ra-core/src/i18n/TranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TranslationProvider.tsx
@@ -44,7 +44,7 @@ class TranslationProviderView extends Component<ViewProps, State> {
         const { locale, messages } = props;
         const polyglot = new Polyglot({
             locale,
-            phrases: defaultsDeep({}, messages, defaultMessages),
+            phrases: defaultsDeep({ '': '' }, messages, defaultMessages),
         });
 
         this.state = {
@@ -61,7 +61,7 @@ class TranslationProviderView extends Component<ViewProps, State> {
 
             const polyglot = new Polyglot({
                 locale,
-                phrases: defaultsDeep({}, messages, defaultMessages),
+                phrases: defaultsDeep({ '': '' }, messages, defaultMessages),
             });
 
             this.setState({

--- a/packages/ra-core/src/i18n/translate.tsx
+++ b/packages/ra-core/src/i18n/translate.tsx
@@ -9,7 +9,7 @@ import {
 /**
  * Higher-Order Component for getting access to the `translate` function in props.
  *
- * Requires that the app is decorated by the <TranslationPRovider> to inject
+ * Requires that the app is decorated by the <TranslationProvider> to inject
  * the translation dictionaries and function in the context.
  *
  * @example


### PR DESCRIPTION
The following warning occurs when the translate method tries to translate an empty string. This is possible for example for the empty default choice in autocomplete inputs.

> Warning: Missing translation for key: ""

The solution is to declare an empty translation for empty string `'' => ''` in `TranslationProvider`.

## Todo

- [x] Set an empty translation in `TranslationProvider`