### PR TITLE
Fix for list not updating when filter prop is changed

### DIFF
--- a/packages/ra-core/src/controller/ListController.spec.tsx
+++ b/packages/ra-core/src/controller/ListController.spec.tsx
@@ -15,6 +15,7 @@ describe('ListController', () => {
         changeListParams: jest.fn(),
         children: jest.fn(),
         crudGetList: jest.fn(),
+        filter: undefined,
         hasCreate: true,
         hasEdit: true,
         hasList: true,
@@ -42,6 +43,19 @@ describe('ListController', () => {
         total: 100,
         translate: jest.fn(),
     };
+
+    describe('permanentFilter', () => {
+        it('should call change params if the permanent filter changes', () => {
+            const props = {
+                ...defaultProps,
+                changeListParams: jest.fn(),
+            };
+            const changeListParamsCalls = props.changeListParams.mock.calls;
+            const wrapper = shallow(<ListController {...props} />);
+            wrapper.setProps({ filter: { group: 'A' } });
+            expect(changeListParamsCalls.length).toBe(1);
+        });
+    });
 
     describe('setFilters', () => {
         let clock;

--- a/packages/ra-core/src/controller/ListController.tsx
+++ b/packages/ra-core/src/controller/ListController.tsx
@@ -198,7 +198,6 @@ export class UnconnectedListController extends Component<Props> {
         const {
             resource,
             query,
-            params,
             filter,
             sort,
             perPage,
@@ -212,12 +211,11 @@ export class UnconnectedListController extends Component<Props> {
             prevProps.query.page !== query.page ||
             prevProps.query.perPage !== query.perPage ||
             !isEqual(prevProps.query.filter, query.filter) ||
-            !isEqual(prevProps.params, params) ||
             !isEqual(prevProps.filter, filter) ||
             !isEqual(prevProps.sort, sort) ||
             !isEqual(prevProps.perPage, perPage)
         ) {
-            this.updateData(Object.keys(query).length > 0 ? query : params);
+            this.updateData(Object.keys(query).length > 0 && query);
         }
 
         if (prevProps.version !== version) {

--- a/packages/ra-core/src/controller/ListController.tsx
+++ b/packages/ra-core/src/controller/ListController.tsx
@@ -194,25 +194,34 @@ export class UnconnectedListController extends Component<Props> {
         this.setFilters.cancel();
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    componentDidUpdate(prevProps: Props) {
+        const {
+            resource,
+            query,
+            params,
+            filter,
+            sort,
+            perPage,
+            version,
+        } = this.props;
+
         if (
-            nextProps.resource !== this.props.resource ||
-            nextProps.query.sort !== this.props.query.sort ||
-            nextProps.query.order !== this.props.query.order ||
-            nextProps.query.page !== this.props.query.page ||
-            nextProps.query.perPage !== this.props.query.perPage ||
-            !isEqual(nextProps.query.filter, this.props.query.filter) ||
-            !isEqual(nextProps.filter, this.props.filter) ||
-            !isEqual(nextProps.sort, this.props.sort) ||
-            !isEqual(nextProps.perPage, this.props.perPage)
+            prevProps.resource !== resource ||
+            prevProps.query.sort !== query.sort ||
+            prevProps.query.order !== query.order ||
+            prevProps.query.page !== query.page ||
+            prevProps.query.perPage !== query.perPage ||
+            !isEqual(prevProps.query.filter, query.filter) ||
+            !isEqual(prevProps.query.filter, query.filter) ||
+            !isEqual(prevProps.params, params) ||
+            !isEqual(prevProps.filter, filter) ||
+            !isEqual(prevProps.sort, sort) ||
+            !isEqual(prevProps.perPage, perPage)
         ) {
-            this.updateData(
-                Object.keys(nextProps.query).length > 0
-                    ? nextProps.query
-                    : nextProps.params
-            );
+            this.updateData(Object.keys(query).length > 0 && query);
         }
-        if (nextProps.version !== this.props.version) {
+
+        if (prevProps.version !== version) {
             this.updateData();
         }
     }
@@ -222,6 +231,12 @@ export class UnconnectedListController extends Component<Props> {
             nextProps.translate === this.props.translate &&
             nextProps.isLoading === this.props.isLoading &&
             nextProps.version === this.props.version &&
+            nextProps.filter === this.props.filter &&
+            nextProps.params.sort !== this.props.params.sort &&
+            nextProps.params.order !== this.props.params.order &&
+            nextProps.params.page !== this.props.params.page &&
+            nextProps.params.perPage !== this.props.params.perPage &&
+            !isEqual(nextProps.params.filter, this.props.params.filter) &&
             nextState === this.state &&
             nextProps.data === this.props.data &&
             nextProps.selectedIds === this.props.selectedIds &&

--- a/packages/ra-core/src/controller/ListController.tsx
+++ b/packages/ra-core/src/controller/ListController.tsx
@@ -212,13 +212,12 @@ export class UnconnectedListController extends Component<Props> {
             prevProps.query.page !== query.page ||
             prevProps.query.perPage !== query.perPage ||
             !isEqual(prevProps.query.filter, query.filter) ||
-            !isEqual(prevProps.query.filter, query.filter) ||
             !isEqual(prevProps.params, params) ||
             !isEqual(prevProps.filter, filter) ||
             !isEqual(prevProps.sort, sort) ||
             !isEqual(prevProps.perPage, perPage)
         ) {
-            this.updateData(Object.keys(query).length > 0 && query);
+            this.updateData(Object.keys(query).length > 0 ? query : params);
         }
 
         if (prevProps.version !== version) {


### PR DESCRIPTION
fixes #2923

- ListController: update to use `componentDidUpdate` instead of `componentWillReceiveProps`
- ListController:  Add `filter` and `params` to list of props comparison values for `shouldComponentUpdate`