### PR TITLE
Non-undoable delete buttons show confirmation dialog

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -181,7 +181,7 @@ const Aside = ({ record }) => (
 
 By default, the Save and Delete actions are undoable, i.e. react-admin only sends the related request to the data provider after a short delay, during which the user can cancel the action. This is part of the "optimistic rendering" strategy of react-admin ; it makes the user interactions more reactive.
 
-You can disable this behavior by setting `undoable={false}`. Wit hthat setting, clicking on the Delete button displays a confirmation dialog. Both the Save and the Delete actions become blocking, and delay the refresh of the screen until the data provider responds.
+You can disable this behavior by setting `undoable={false}`. With that setting, clicking on the Delete button displays a confirmation dialog. Both the Save and the Delete actions become blocking, and delay the refresh of the screen until the data provider responds.
 
 ```jsx
 const PostEdit = props => (

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -20,6 +20,7 @@ Here are all the props accepted by the `<Create>` and `<Edit>` components:
 * [`title`](#page-title)
 * [`actions`](#actions)
 * [`aside`](#aside-component)
+* [`undoable`](#undoable) (`<Edit>` only)
 
 Here is the minimal code necessary to display a form to create and edit comments:
 
@@ -175,6 +176,53 @@ const Aside = ({ record }) => (
 {% endraw %}
 
 **Tip**: Always test that the `record` is defined before using it, as react-admin starts rendering the UI before the API call is over.
+
+### Undoable
+
+By default, the Save and Delete actions are undoable, i.e. react-admin only sends the related request to the data provider after a short delay, during which the user can cancel the action. This is part of the "optimistic rendering" strategy of react-admin ; it makes the user interactions more reactive.
+
+You can disable this behavior by setting `undoable={false}`. Wit hthat setting, clicking on the Delete button displays a confirmation dialog. Both the Save and the Delete actions become blocking, and delay the refresh of the screen until the data provider responds.
+
+```jsx
+const PostEdit = props => (
+    <Edit undoable={false} {...props}>
+        ...
+    </Edit>
+```
+
+**Tip**: If you want a confirmation dialog for the Delete button but don't mind undoable Edits, then pass a [custom toolbar](#toolbar) to the form, as follows:
+
+```jsx
+import {
+    Toolbar,
+    SaveButton,
+    DeleteWithConfirmButton,
+    Edit,
+    SimpleForm,
+} from 'react-admin';
+import { withStyles } from '@material-ui/core';
+
+const toolbarStyles = {
+    toolbar: {
+        display: 'flex',
+        justifyContent: 'space-between',
+    },
+};
+
+const CustomToolbar = withStyles(toolbarStyles)(props => (
+    <Toolbar {...props}>
+        <SaveButton />
+        <DeleteWithConfirmButton />
+    </Toolbar>
+));
+
+const PostEdit = props => (
+    <Edit {...props}>
+        <SimpleForm toolbar={<CustomToolbar />}>
+            ...
+        </SimpleForm>
+    </Edit>
+```
 
 ## Prefilling a `<Create>` Record
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -196,7 +196,7 @@ const PostEdit = props => (
 import {
     Toolbar,
     SaveButton,
-    DeleteWithConfirmButton,
+    DeleteButton,
     Edit,
     SimpleForm,
 } from 'react-admin';
@@ -212,7 +212,7 @@ const toolbarStyles = {
 const CustomToolbar = withStyles(toolbarStyles)(props => (
     <Toolbar {...props}>
         <SaveButton />
-        <DeleteWithConfirmButton />
+        <DeleteButton undoable={false} />
     </Toolbar>
 ));
 

--- a/examples/simple/src/users/UserEdit.js
+++ b/examples/simple/src/users/UserEdit.js
@@ -2,21 +2,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+    DeleteWithConfirmButton,
     DisabledInput,
     Edit,
     FormTab,
+    SaveButton,
     SelectInput,
     TabbedForm,
     TextInput,
+    Toolbar,
     required,
 } from 'react-admin';
+import { withStyles } from '@material-ui/core';
 
 import UserTitle from './UserTitle';
 import Aside from './Aside';
 
+const toolbarStyles = {
+    toolbar: {
+        display: 'flex',
+        justifyContent: 'space-between',
+    },
+};
+const UserEditToolbar = withStyles(toolbarStyles)(props => (
+    <Toolbar {...props}>
+        <SaveButton />
+        <DeleteWithConfirmButton />
+    </Toolbar>
+));
+
 const UserEdit = ({ permissions, ...props }) => (
     <Edit title={<UserTitle />} aside={<Aside />} {...props}>
-        <TabbedForm defaultValue={{ role: 'user' }}>
+        <TabbedForm
+            defaultValue={{ role: 'user' }}
+            toolbar={<UserEditToolbar />}
+        >
             <FormTab label="user.form.summary" path="">
                 {permissions === 'admin' && <DisabledInput source="id" />}
                 <TextInput

--- a/examples/simple/src/users/UserEdit.js
+++ b/examples/simple/src/users/UserEdit.js
@@ -24,6 +24,12 @@ const toolbarStyles = {
         justifyContent: 'space-between',
     },
 };
+
+/**
+ * Custom Toolbar for the Edit form
+ *
+ * Save with undo, but delete with confirm
+ */
 const UserEditToolbar = withStyles(toolbarStyles)(props => (
     <Toolbar {...props}>
         <SaveButton />

--- a/examples/simple/src/users/UserList.js
+++ b/examples/simple/src/users/UserList.js
@@ -1,18 +1,15 @@
 /* eslint react/jsx-key: off */
 import PeopleIcon from '@material-ui/icons/People';
-import SearchIcon from '@material-ui/icons/Search';
-import InputAdornment from '@material-ui/core/InputAdornment';
 import memoize from 'lodash/memoize';
 
 import React from 'react';
 import {
+    BulkDeleteWithConfirmButton,
     Datagrid,
-    EditButton,
     Filter,
     List,
     Responsive,
     SearchInput,
-    ShowButton,
     SimpleList,
     TextField,
     TextInput,
@@ -30,6 +27,10 @@ const UserFilter = ({ permissions, ...props }) => (
     </Filter>
 );
 
+const UserBulkActionButtons = props => (
+    <BulkDeleteWithConfirmButton {...props} />
+);
+
 const rowClick = memoize(permissions => (id, basePath, record) => {
     return permissions === 'admin'
         ? Promise.resolve('edit')
@@ -43,6 +44,7 @@ const UserList = ({ permissions, ...props }) => (
         filterDefaultValues={{ role: 'user' }}
         sort={{ field: 'name', order: 'ASC' }}
         aside={<Aside />}
+        bulkActionButtons={<UserBulkActionButtons />}
     >
         <Responsive
             small={

--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
@@ -1,104 +1,28 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import compose from 'recompose/compose';
-import ActionDelete from '@material-ui/icons/Delete';
-import { withStyles } from '@material-ui/core/styles';
-import { fade } from '@material-ui/core/styles/colorManipulator';
-import { crudDeleteMany, startUndoable } from 'ra-core';
 
+import BulkDeleteWithConfirmButton from './BulkDeleteWithConfirmButton';
+import BulkDeleteWithUndoButton from './BulkDeleteWithUndoButton';
 import Button from './Button';
 
-const sanitizeRestProps = ({
-    basePath,
-    classes,
-    dispatchCrudDeleteMany,
-    filterValues,
-    label,
-    resource,
-    selectedIds,
-    startUndoable,
-    undoable,
-    ...rest
-}) => rest;
+const BulkDeleteButton = ({ undoable, ...props }) =>
+    undoable ? (
+        <BulkDeleteWithUndoButton {...props} />
+    ) : (
+        <BulkDeleteWithConfirmButton {...props} />
+    );
 
-export const styles = theme => ({
-    deleteButton: {
-        color: theme.palette.error.main,
-        '&:hover': {
-            backgroundColor: fade(theme.palette.error.main, 0.12),
-            // Reset on mouse devices
-            '@media (hover: none)': {
-                backgroundColor: 'transparent',
-            },
-        },
-    },
-});
+BulkDeleteButton.propTypes = {
+    basePath: PropTypes.string,
+    label: PropTypes.string,
+    resource: PropTypes.string.isRequired,
+    selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
+    undoable: PropTypes.bool,
+    icon: PropTypes.element,
+};
 
-class BulkDeleteButton extends Component {
-    static propTypes = {
-        basePath: PropTypes.string,
-        classes: PropTypes.object,
-        dispatchCrudDeleteMany: PropTypes.func.isRequired,
-        label: PropTypes.string,
-        resource: PropTypes.string.isRequired,
-        startUndoable: PropTypes.func,
-        selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
-        undoable: PropTypes.bool,
-        icon: PropTypes.element,
-    };
+BulkDeleteButton.defaultProps = {
+    undoable: true,
+};
 
-    static defaultProps = {
-        label: 'ra.action.delete',
-        undoable: true,
-        icon: <ActionDelete />,
-    };
-
-    handleClick = () => {
-        const {
-            basePath,
-            dispatchCrudDeleteMany,
-            resource,
-            selectedIds,
-            startUndoable,
-            undoable,
-            onClick,
-        } = this.props;
-        if (undoable) {
-            startUndoable(crudDeleteMany(resource, selectedIds, basePath));
-        } else {
-            dispatchCrudDeleteMany(resource, selectedIds, basePath);
-        }
-
-        if (typeof onClick === 'function') {
-            onClick();
-        }
-    };
-
-    render() {
-        const { classes, label, icon, onClick, ...rest } = this.props;
-        return (
-            <Button
-                onClick={this.handleClick}
-                label={label}
-                className={classes.deleteButton}
-                {...sanitizeRestProps(rest)}
-            >
-                {icon}
-            </Button>
-        );
-    }
-}
-
-const EnhancedBulkDeleteButton = compose(
-    connect(
-        undefined,
-        {
-            startUndoable,
-            dispatchCrudDeleteMany: crudDeleteMany,
-        }
-    ),
-    withStyles(styles)
-)(BulkDeleteButton);
-
-export default EnhancedBulkDeleteButton;
+export default BulkDeleteButton;

--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
@@ -22,7 +22,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-const styles = theme => ({
+export const styles = theme => ({
     deleteButton: {
         color: theme.palette.error.main,
         '&:hover': {

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.js
@@ -9,7 +9,6 @@ import { crudDeleteMany } from 'ra-core';
 
 import Confirm from '../layout/Confirm';
 import Button from './Button';
-import { styles } from './BulkDeleteButton';
 
 const sanitizeRestProps = ({
     basePath,
@@ -21,6 +20,19 @@ const sanitizeRestProps = ({
     selectedIds,
     ...rest
 }) => rest;
+
+const styles = theme => ({
+    deleteButton: {
+        color: theme.palette.error.main,
+        '&:hover': {
+            backgroundColor: fade(theme.palette.error.main, 0.12),
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
+});
 
 class BulkDeleteWithConfirmButton extends Component {
     static propTypes = {

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.js
@@ -1,0 +1,115 @@
+import React, { Fragment, Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import ActionDelete from '@material-ui/icons/Delete';
+import { withStyles } from '@material-ui/core/styles';
+import inflection from 'inflection';
+import { crudDeleteMany } from 'ra-core';
+
+import Confirm from '../layout/Confirm';
+import Button from './Button';
+import { styles } from './BulkDeleteButton';
+
+const sanitizeRestProps = ({
+    basePath,
+    classes,
+    crudDeleteMany,
+    filterValues,
+    label,
+    resource,
+    selectedIds,
+    ...rest
+}) => rest;
+
+class BulkDeleteWithConfirmButton extends Component {
+    static propTypes = {
+        basePath: PropTypes.string,
+        classes: PropTypes.object,
+        crudDeleteMany: PropTypes.func.isRequired,
+        label: PropTypes.string,
+        resource: PropTypes.string.isRequired,
+        selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
+        icon: PropTypes.element,
+    };
+
+    static defaultProps = {
+        label: 'ra.action.delete',
+        icon: <ActionDelete />,
+    };
+
+    state = { isOpen: false };
+
+    handleClick = e => {
+        this.setState({ isOpen: true });
+        e.stopPropagation();
+    };
+
+    handleDialogClose = () => {
+        this.setState({ isOpen: false });
+    };
+
+    handleDelete = () => {
+        const {
+            basePath,
+            crudDeleteMany,
+            resource,
+            selectedIds,
+            onClick,
+        } = this.props;
+
+        crudDeleteMany(resource, selectedIds, basePath);
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
+    };
+
+    render() {
+        const {
+            classes,
+            label,
+            icon,
+            onClick,
+            resource,
+            selectedIds,
+            ...rest
+        } = this.props;
+        return (
+            <Fragment>
+                <Button
+                    onClick={this.handleClick}
+                    label={label}
+                    className={classes.deleteButton}
+                    {...sanitizeRestProps(rest)}
+                >
+                    {icon}
+                </Button>
+                <Confirm
+                    isOpen={this.state.isOpen}
+                    title="ra.message.bulk_delete_title"
+                    content="ra.message.bulk_delete_content"
+                    translateOptions={{
+                        smart_count: selectedIds.length,
+                        name: inflection.humanize(
+                            inflection.singularize(resource),
+                            true
+                        ),
+                    }}
+                    onConfirm={this.handleDelete}
+                    onClose={this.handleDialogClose}
+                />
+            </Fragment>
+        );
+    }
+}
+
+const EnhancedBulkDeleteWithConfirmButton = compose(
+    connect(
+        undefined,
+        { crudDeleteMany }
+    ),
+    withStyles(styles)
+)(BulkDeleteWithConfirmButton);
+
+export default EnhancedBulkDeleteWithConfirmButton;

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.js
@@ -1,0 +1,96 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import ActionDelete from '@material-ui/icons/Delete';
+import { withStyles } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
+import { crudDeleteMany, startUndoable } from 'ra-core';
+
+import Button from './Button';
+
+const sanitizeRestProps = ({
+    basePath,
+    classes,
+    dispatchCrudDeleteMany,
+    filterValues,
+    label,
+    resource,
+    selectedIds,
+    startUndoable,
+    undoable,
+    ...rest
+}) => rest;
+
+const styles = theme => ({
+    deleteButton: {
+        color: theme.palette.error.main,
+        '&:hover': {
+            backgroundColor: fade(theme.palette.error.main, 0.12),
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
+});
+
+class BulkDeleteWithUndoButton extends Component {
+    static propTypes = {
+        basePath: PropTypes.string,
+        classes: PropTypes.object,
+        label: PropTypes.string,
+        resource: PropTypes.string.isRequired,
+        startUndoable: PropTypes.func,
+        selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
+        icon: PropTypes.element,
+    };
+
+    static defaultProps = {
+        label: 'ra.action.delete',
+        undoable: true,
+        icon: <ActionDelete />,
+    };
+
+    handleClick = () => {
+        const {
+            basePath,
+            resource,
+            selectedIds,
+            startUndoable,
+            onClick,
+        } = this.props;
+
+        startUndoable(crudDeleteMany(resource, selectedIds, basePath));
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
+    };
+
+    render() {
+        const { classes, label, icon, onClick, ...rest } = this.props;
+        return (
+            <Button
+                onClick={this.handleClick}
+                label={label}
+                className={classes.deleteButton}
+                {...sanitizeRestProps(rest)}
+            >
+                {icon}
+            </Button>
+        );
+    }
+}
+
+const EnhancedBulkDeleteWithUndoButton = compose(
+    connect(
+        undefined,
+        {
+            startUndoable,
+        }
+    ),
+    withStyles(styles)
+)(BulkDeleteWithUndoButton);
+
+export default EnhancedBulkDeleteWithUndoButton;

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -1,105 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import compose from 'recompose/compose';
-import { withStyles } from '@material-ui/core/styles';
-import { fade } from '@material-ui/core/styles/colorManipulator';
-import ActionDelete from '@material-ui/icons/Delete';
-import classnames from 'classnames';
-import { translate, crudDelete, startUndoable } from 'ra-core';
+import DeleteWithUndoButton from './DeleteWithUndoButton';
+import DeleteWithConfirmButton from './DeleteWithConfirmButton';
 
-import Button from './Button';
-
-export const styles = theme => ({
-    deleteButton: {
-        color: theme.palette.error.main,
-        '&:hover': {
-            backgroundColor: fade(theme.palette.error.main, 0.12),
-            // Reset on mouse devices
-            '@media (hover: none)': {
-                backgroundColor: 'transparent',
-            },
-        },
-    },
-});
-
-const sanitizeRestProps = ({
-    basePath,
-    classes,
-    dispatchCrudDelete,
-    filterValues,
-    handleSubmit,
-    handleSubmitWithRedirect,
-    invalid,
-    label,
-    pristine,
-    resource,
-    saving,
-    selectedIds,
-    startUndoable,
-    undoable,
-    redirect,
-    ...rest
-}) => rest;
-
-class DeleteButton extends Component {
-    handleDelete = event => {
-        event.stopPropagation();
-        const {
-            dispatchCrudDelete,
-            startUndoable,
-            resource,
-            record,
-            basePath,
-            redirect,
-            undoable,
-            onClick,
-        } = this.props;
-        if (undoable) {
-            startUndoable(
-                crudDelete(resource, record.id, record, basePath, redirect)
-            );
-        } else {
-            dispatchCrudDelete(resource, record.id, record, basePath, redirect);
-        }
-
-        if (typeof onClick === 'function') {
-            onClick();
-        }
-    };
-
-    render() {
-        const {
-            label = 'ra.action.delete',
-            classes = {},
-            className,
-            icon,
-            onClick,
-            ...rest
-        } = this.props;
-        return (
-            <Button
-                onClick={this.handleDelete}
-                label={label}
-                className={classnames(
-                    'ra-delete-button',
-                    classes.deleteButton,
-                    className
-                )}
-                key="button"
-                {...sanitizeRestProps(rest)}
-            >
-                {icon}
-            </Button>
-        );
-    }
-}
+const DeleteButton = ({ undoable, ...props }) =>
+    undoable ? (
+        <DeleteWithUndoButton {...props} />
+    ) : (
+        <DeleteWithConfirmButton {...props} />
+    );
 
 DeleteButton.propTypes = {
     basePath: PropTypes.string,
-    classes: PropTypes.object,
-    className: PropTypes.string,
-    dispatchCrudDelete: PropTypes.func.isRequired,
     label: PropTypes.string,
     record: PropTypes.object,
     redirect: PropTypes.oneOfType([
@@ -108,23 +20,12 @@ DeleteButton.propTypes = {
         PropTypes.func,
     ]),
     resource: PropTypes.string.isRequired,
-    startUndoable: PropTypes.func,
-    translate: PropTypes.func,
     undoable: PropTypes.bool,
     icon: PropTypes.element,
 };
 
 DeleteButton.defaultProps = {
-    redirect: 'list',
     undoable: true,
-    icon: <ActionDelete />,
 };
 
-export default compose(
-    connect(
-        null,
-        { startUndoable, dispatchCrudDelete: crudDelete }
-    ),
-    translate,
-    withStyles(styles)
-)(DeleteButton);
+export default DeleteButton;

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -10,7 +10,7 @@ import { translate, crudDelete, startUndoable } from 'ra-core';
 
 import Button from './Button';
 
-const styles = theme => ({
+export const styles = theme => ({
     deleteButton: {
         color: theme.palette.error.main,
         '&:hover': {
@@ -28,8 +28,13 @@ const sanitizeRestProps = ({
     classes,
     dispatchCrudDelete,
     filterValues,
+    handleSubmit,
+    handleSubmitWithRedirect,
+    invalid,
     label,
+    pristine,
     resource,
+    saving,
     selectedIds,
     startUndoable,
     undoable,

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -19,7 +19,7 @@ DeleteButton.propTypes = {
         PropTypes.bool,
         PropTypes.func,
     ]),
-    resource: PropTypes.string.isRequired,
+    resource: PropTypes.string,
     undoable: PropTypes.bool,
     icon: PropTypes.element,
 };

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import { withStyles } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import ActionDelete from '@material-ui/icons/Delete';
 import classnames from 'classnames';
 import inflection from 'inflection';
@@ -10,7 +11,6 @@ import { translate, crudDelete } from 'ra-core';
 
 import Confirm from '../layout/Confirm';
 import Button from './Button';
-import { styles } from './DeleteButton';
 
 const sanitizeRestProps = ({
     basePath,
@@ -29,6 +29,19 @@ const sanitizeRestProps = ({
     redirect,
     ...rest
 }) => rest;
+
+const styles = theme => ({
+    deleteButton: {
+        color: theme.palette.error.main,
+        '&:hover': {
+            backgroundColor: fade(theme.palette.error.main, 0.12),
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
+});
 
 class DeleteWithConfirmButton extends Component {
     state = { isOpen: false };

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
@@ -1,0 +1,125 @@
+import React, { Fragment, Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import { withStyles } from '@material-ui/core/styles';
+import ActionDelete from '@material-ui/icons/Delete';
+import classnames from 'classnames';
+import inflection from 'inflection';
+import { translate, crudDelete } from 'ra-core';
+
+import Confirm from '../layout/Confirm';
+import Button from './Button';
+import { styles } from './DeleteButton';
+
+const sanitizeRestProps = ({
+    basePath,
+    classes,
+    crudDelete,
+    filterValues,
+    handleSubmit,
+    handleSubmitWithRedirect,
+    invalid,
+    label,
+    pristine,
+    resource,
+    saving,
+    selectedIds,
+    submitOnEnter,
+    redirect,
+    ...rest
+}) => rest;
+
+class DeleteWithConfirmButton extends Component {
+    state = { isOpen: false };
+
+    handleClick = e => {
+        this.setState({ isOpen: true });
+        e.stopPropagation();
+    };
+
+    handleDialogClose = () => {
+        this.setState({ isOpen: false });
+    };
+
+    handleDelete = event => {
+        event.stopPropagation();
+        const { crudDelete, resource, record, basePath, redirect } = this.props;
+        crudDelete(resource, record.id, record, basePath, redirect);
+    };
+
+    render() {
+        const {
+            classes = {},
+            className,
+            icon,
+            label = 'ra.action.delete',
+            onClick,
+            record,
+            resource,
+            ...rest
+        } = this.props;
+        return (
+            <Fragment>
+                <Button
+                    onClick={this.handleClick}
+                    label={label}
+                    className={classnames(
+                        'ra-delete-button',
+                        classes.deleteButton,
+                        className
+                    )}
+                    key="button"
+                    {...sanitizeRestProps(rest)}
+                >
+                    {icon}
+                </Button>
+                <Confirm
+                    isOpen={this.state.isOpen}
+                    title="ra.message.delete_title"
+                    content="ra.message.delete_content"
+                    translateOptions={{
+                        name: inflection.humanize(
+                            inflection.singularize(resource),
+                            true
+                        ),
+                        id: record.id,
+                    }}
+                    onConfirm={this.handleDelete}
+                    onClose={this.handleDialogClose}
+                />
+            </Fragment>
+        );
+    }
+}
+
+DeleteWithConfirmButton.propTypes = {
+    basePath: PropTypes.string,
+    classes: PropTypes.object,
+    className: PropTypes.string,
+    crudDelete: PropTypes.func.isRequired,
+    label: PropTypes.string,
+    record: PropTypes.object,
+    redirect: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.func,
+    ]),
+    resource: PropTypes.string.isRequired,
+    translate: PropTypes.func,
+    icon: PropTypes.element,
+};
+
+DeleteWithConfirmButton.defaultProps = {
+    redirect: 'list',
+    icon: <ActionDelete />,
+};
+
+export default compose(
+    connect(
+        null,
+        { crudDelete }
+    ),
+    translate,
+    withStyles(styles)
+)(DeleteWithConfirmButton);

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.js
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import { withStyles } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
+import ActionDelete from '@material-ui/icons/Delete';
+import classnames from 'classnames';
+import { translate, crudDelete, startUndoable } from 'ra-core';
+
+import Button from './Button';
+
+export const sanitizeRestProps = ({
+    basePath,
+    classes,
+    dispatchCrudDelete,
+    filterValues,
+    handleSubmit,
+    handleSubmitWithRedirect,
+    invalid,
+    label,
+    pristine,
+    resource,
+    saving,
+    selectedIds,
+    startUndoable,
+    undoable,
+    redirect,
+    ...rest
+}) => rest;
+
+const styles = theme => ({
+    deleteButton: {
+        color: theme.palette.error.main,
+        '&:hover': {
+            backgroundColor: fade(theme.palette.error.main, 0.12),
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
+});
+
+class DeleteWithUndoButton extends Component {
+    handleDelete = event => {
+        event.stopPropagation();
+        const {
+            startUndoable,
+            resource,
+            record,
+            basePath,
+            redirect,
+            onClick,
+        } = this.props;
+
+        startUndoable(
+            crudDelete(resource, record.id, record, basePath, redirect)
+        );
+
+        if (typeof onClick === 'function') {
+            onClick();
+        }
+    };
+
+    render() {
+        const {
+            label = 'ra.action.delete',
+            classes = {},
+            className,
+            icon,
+            onClick,
+            ...rest
+        } = this.props;
+        return (
+            <Button
+                onClick={this.handleDelete}
+                label={label}
+                className={classnames(
+                    'ra-delete-button',
+                    classes.deleteButton,
+                    className
+                )}
+                key="button"
+                {...sanitizeRestProps(rest)}
+            >
+                {icon}
+            </Button>
+        );
+    }
+}
+
+DeleteWithUndoButton.propTypes = {
+    basePath: PropTypes.string,
+    classes: PropTypes.object,
+    className: PropTypes.string,
+    label: PropTypes.string,
+    record: PropTypes.object,
+    redirect: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.func,
+    ]),
+    resource: PropTypes.string.isRequired,
+    startUndoable: PropTypes.func,
+    translate: PropTypes.func,
+    icon: PropTypes.element,
+};
+
+DeleteWithUndoButton.defaultProps = {
+    redirect: 'list',
+    undoable: true,
+    icon: <ActionDelete />,
+};
+
+export default compose(
+    connect(
+        null,
+        { startUndoable }
+    ),
+    translate,
+    withStyles(styles)
+)(DeleteWithUndoButton);

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -30,7 +30,9 @@ const sanitizeRestProps = ({
     handleSubmit,
     handleSubmitWithRedirect,
     submitOnEnter,
+    record,
     redirect,
+    resource,
     locale,
     showNotification,
     ...rest

--- a/packages/ra-ui-materialui/src/button/index.js
+++ b/packages/ra-ui-materialui/src/button/index.js
@@ -5,6 +5,7 @@ import CloneButton from './CloneButton';
 import CreateButton from './CreateButton';
 import DeleteButton from './DeleteButton';
 import DeleteWithConfirmButton from './DeleteWithConfirmButton';
+import DeleteWithUndoButton from './DeleteWithUndoButton';
 import EditButton from './EditButton';
 import ExportButton from './ExportButton';
 import ListButton from './ListButton';
@@ -21,6 +22,7 @@ export {
     CreateButton,
     DeleteButton,
     DeleteWithConfirmButton,
+    DeleteWithUndoButton,
     EditButton,
     ExportButton,
     ListButton,

--- a/packages/ra-ui-materialui/src/button/index.js
+++ b/packages/ra-ui-materialui/src/button/index.js
@@ -1,5 +1,6 @@
 import BulkDeleteButton from './BulkDeleteButton';
 import BulkDeleteWithConfirmButton from './BulkDeleteWithConfirmButton';
+import BulkDeleteWithUndoButton from './BulkDeleteWithUndoButton';
 import Button from './Button';
 import CloneButton from './CloneButton';
 import CreateButton from './CreateButton';
@@ -17,6 +18,7 @@ import RefreshIconButton from './RefreshIconButton';
 export {
     BulkDeleteButton,
     BulkDeleteWithConfirmButton,
+    BulkDeleteWithUndoButton,
     Button,
     CloneButton,
     CreateButton,

--- a/packages/ra-ui-materialui/src/button/index.js
+++ b/packages/ra-ui-materialui/src/button/index.js
@@ -1,8 +1,10 @@
 import BulkDeleteButton from './BulkDeleteButton';
+import BulkDeleteWithConfirmButton from './BulkDeleteWithConfirmButton';
 import Button from './Button';
 import CloneButton from './CloneButton';
 import CreateButton from './CreateButton';
 import DeleteButton from './DeleteButton';
+import DeleteWithConfirmButton from './DeleteWithConfirmButton';
 import EditButton from './EditButton';
 import ExportButton from './ExportButton';
 import ListButton from './ListButton';
@@ -13,10 +15,12 @@ import RefreshIconButton from './RefreshIconButton';
 
 export {
     BulkDeleteButton,
+    BulkDeleteWithConfirmButton,
     Button,
     CloneButton,
     CreateButton,
     DeleteButton,
+    DeleteWithConfirmButton,
     EditButton,
     ExportButton,
     ListButton,

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -63,6 +63,7 @@ export const EditView = ({
     resource,
     save,
     title,
+    undoable,
     version,
     ...rest
 }) => {
@@ -104,6 +105,7 @@ export const EditView = ({
                                 : children.props.redirect,
                         resource,
                         save,
+                        undoable,
                         version,
                     })
                 ) : (

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -44,6 +44,7 @@ const sanitizeRestProps = ({
     touch,
     translate,
     triggerSubmit,
+    undoable,
     untouch,
     valid,
     validate,
@@ -67,6 +68,7 @@ export class SimpleForm extends Component {
             saving,
             submitOnEnter,
             toolbar,
+            undoable,
             version,
             ...rest
         } = this.props;
@@ -98,6 +100,7 @@ export class SimpleForm extends Component {
                         resource,
                         saving,
                         submitOnEnter,
+                        undoable,
                     })}
             </form>
         );
@@ -123,6 +126,7 @@ SimpleForm.propTypes = {
     saving: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
     submitOnEnter: PropTypes.bool,
     toolbar: PropTypes.element,
+    undoable: PropTypes.bool,
     validate: PropTypes.func,
     version: PropTypes.number,
 };

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -57,6 +57,7 @@ const sanitizeRestProps = ({
     touch,
     translate,
     triggerSubmit,
+    undoable,
     untouch,
     valid,
     validate,
@@ -90,6 +91,7 @@ export class TabbedForm extends Component {
             tabsWithErrors,
             toolbar,
             translate,
+            undoable,
             value,
             version,
             ...rest
@@ -195,6 +197,7 @@ export class TabbedForm extends Component {
                         resource,
                         saving,
                         submitOnEnter,
+                        undoable,
                     })}
             </form>
         );
@@ -225,6 +228,7 @@ TabbedForm.propTypes = {
     tabsWithErrors: PropTypes.arrayOf(PropTypes.string),
     toolbar: PropTypes.element,
     translate: PropTypes.func,
+    undoable: PropTypes.bool,
     validate: PropTypes.func,
     value: PropTypes.number,
     version: PropTypes.number,

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -115,7 +115,10 @@ const Toolbar = ({
                                   button.props.submitOnEnter,
                                   submitOnEnter
                               ),
-                              undoable,
+                              undoable: valueOrDefault(
+                                  button.props.undoable,
+                                  undoable
+                              ),
                           })
                         : null
                 )

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -106,6 +106,8 @@ const Toolbar = ({
                               ),
                               invalid,
                               pristine,
+                              record,
+                              resource,
                               saving,
                               submitOnEnter: valueOrDefault(
                                   button.props.submitOnEnter,

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -58,6 +58,7 @@ const Toolbar = ({
     resource,
     saving,
     submitOnEnter,
+    undoable,
     width,
     ...rest
 }) => (
@@ -88,6 +89,7 @@ const Toolbar = ({
                             basePath={basePath}
                             record={record}
                             resource={resource}
+                            undoable={undoable}
                         />
                     )}
                 </div>
@@ -113,6 +115,7 @@ const Toolbar = ({
                                   button.props.submitOnEnter,
                                   submitOnEnter
                               ),
+                              undoable,
                           })
                         : null
                 )
@@ -140,6 +143,7 @@ Toolbar.propTypes = {
     resource: PropTypes.string,
     saving: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
     submitOnEnter: PropTypes.bool,
+    undoable: PropTypes.bool,
     width: PropTypes.string,
 };
 

--- a/packages/ra-ui-materialui/src/layout/Confirm.js
+++ b/packages/ra-ui-materialui/src/layout/Confirm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -51,51 +51,70 @@ const styles = theme => ({
  *     onClose={() => { // do something }}
  * />
  */
-const Confirm = ({
-    isOpen,
-    title,
-    content,
-    confirm,
-    cancel,
-    confirmColor,
-    onConfirm,
-    onClose,
-    classes,
-    translate,
-    translateOptions = {},
-}) => (
-    <Dialog
-        open={isOpen}
-        onClose={onClose}
-        aria-labelledby="alert-dialog-title"
-    >
-        <DialogTitle id="alert-dialog-title">
-            {translate(title, { _: title, ...translateOptions })}
-        </DialogTitle>
-        <DialogContent>
-            <DialogContentText className={classes.contentText}>
-                {translate(content, { _: content, ...translateOptions })}
-            </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-            <Button onClick={onClose}>
-                <AlertError className={classes.iconPaddingStyle} />
-                {translate(cancel, { _: cancel })}
-            </Button>
-            <Button
-                onClick={onConfirm}
-                className={classnames('ra-confirm', {
-                    [classes.confirmWarning]: confirmColor === 'warning',
-                    [classes.confirmPrimary]: confirmColor === 'primary',
-                })}
-                autoFocus
+class Confirm extends Component {
+    state = { loading: false };
+
+    handleConfirm = () => {
+        this.setState({ loading: true });
+        this.props.onConfirm();
+    };
+
+    render() {
+        const {
+            isOpen,
+            title,
+            content,
+            confirm,
+            cancel,
+            confirmColor,
+            onClose,
+            classes,
+            translate,
+            translateOptions = {},
+        } = this.props;
+        const { loading } = this.state;
+
+        return (
+            <Dialog
+                open={isOpen}
+                onClose={onClose}
+                aria-labelledby="alert-dialog-title"
             >
-                <ActionCheck className={classes.iconPaddingStyle} />
-                {translate(confirm, { _: confirm })}
-            </Button>
-        </DialogActions>
-    </Dialog>
-);
+                <DialogTitle id="alert-dialog-title">
+                    {translate(title, { _: title, ...translateOptions })}
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText className={classes.contentText}>
+                        {translate(content, {
+                            _: content,
+                            ...translateOptions,
+                        })}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button disabled={loading} onClick={onClose}>
+                        <AlertError className={classes.iconPaddingStyle} />
+                        {translate(cancel, { _: cancel })}
+                    </Button>
+                    <Button
+                        disabled={loading}
+                        onClick={this.handleConfirm}
+                        className={classnames('ra-confirm', {
+                            [classes.confirmWarning]:
+                                confirmColor === 'warning',
+                            [classes.confirmPrimary]:
+                                confirmColor === 'primary',
+                        })}
+                        autoFocus
+                    >
+                        <ActionCheck className={classes.iconPaddingStyle} />
+                        {translate(confirm, { _: confirm })}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        );
+    }
+}
 
 Confirm.propTypes = {
     cancel: PropTypes.string.isRequired,

--- a/packages/ra-ui-materialui/src/layout/Confirm.js
+++ b/packages/ra-ui-materialui/src/layout/Confirm.js
@@ -15,6 +15,9 @@ import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
 const styles = theme => ({
+    contentText: {
+        minWidth: 400,
+    },
     confirmPrimary: {
         color: theme.palette.primary.main,
     },
@@ -59,6 +62,7 @@ const Confirm = ({
     onClose,
     classes,
     translate,
+    translateOptions = {},
 }) => (
     <Dialog
         open={isOpen}
@@ -66,11 +70,11 @@ const Confirm = ({
         aria-labelledby="alert-dialog-title"
     >
         <DialogTitle id="alert-dialog-title">
-            {translate(title, { _: title })}
+            {translate(title, { _: title, ...translateOptions })}
         </DialogTitle>
         <DialogContent>
-            <DialogContentText>
-                {translate(content, { _: content })}
+            <DialogContentText className={classes.contentText}>
+                {translate(content, { _: content, ...translateOptions })}
             </DialogContentText>
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
Refs #2866 

By default, the Save and Delete actions are undoable, i.e. react-admin only sends the related request to the data provider after a short delay, during which the user can cancel the action. This is part of the "optimistic rendering" strategy of react-admin ; it makes the user interactions more reactive.

You can disable this behavior by setting `undoable={false}`. With that setting, clicking on the Delete button displays a confirmation dialog. Both the Save and the Delete actions become blocking, and delay the refresh of the screen until the data provider responds.

```jsx
const PostEdit = props => (
    <Edit undoable={false} {...props}>
        ...
    </Edit>
```

**Tip**: If you want a confirmation dialog for the Delete button but don't mind undoable Edits, then pass a [custom toolbar](#toolbar) to the form, as follows:

```jsx
import {
    Toolbar,
    SaveButton,
    DeleteButton,
    Edit,
    SimpleForm,
} from 'react-admin';
import { withStyles } from '@material-ui/core';

const toolbarStyles = {
    toolbar: {
        display: 'flex',
        justifyContent: 'space-between',
    },
};

const CustomToolbar = withStyles(toolbarStyles)(props => (
    <Toolbar {...props}>
        <SaveButton />
        <DeleteButton undoable={false} />
    </Toolbar>
));

const PostEdit = props => (
    <Edit {...props}>
        <SimpleForm toolbar={<CustomToolbar />}>
            ...
        </SimpleForm>
    </Edit>
```
