### PR TITLE
Fix IE11 layout problem caused by missing `flex-basis: 0`

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -40,6 +40,7 @@ const styles = theme => ({
         display: 'flex',
         flexDirection: 'column',
         flexGrow: 1,
+        flexBasis: 0,
         padding: theme.spacing.unit * 3,
         [theme.breakpoints.up('xs')]: {
             paddingLeft: 5,


### PR DESCRIPTION
Following up from Pull Request #2763 

I work with @phacks and I found another solution to fix the layout problem.

@fzaninotto we can't see the additional scrollbar at the bottom anymore.

<details>
<summary>Internet Explorer 11 (Windows)</summary>
<img src="https://user-images.githubusercontent.com/13064661/53894918-3cd9e980-4031-11e9-9abf-390fef10e207.png"/>
</details>
<details>
<summary>Mozilla Firefox (Windows)</summary>
<img src="https://user-images.githubusercontent.com/13064661/53895191-bf62a900-4031-11e9-935e-43422c10586f.png"/>
</details>
<details>
<summary>Safari 12 (MacOS)</summary>
<img src="https://user-images.githubusercontent.com/13064661/53895225-d4d7d300-4031-11e9-8062-337eedfa9289.png"/>
</details>
<details>
<summary>Edge (Windows)</summary>
<img src="https://user-images.githubusercontent.com/13064661/53895288-fd5fcd00-4031-11e9-8b02-b7b10454859a.png"/>
</details>
<details>
<summary>Opera (Windows)</summary>
<img src="https://user-images.githubusercontent.com/13064661/53895328-1a949b80-4032-11e9-936d-46886486e615.png"/>
</details>

<details>
<summary>Comment List in chrome (MacOS)</summary>
<img src="https://user-images.githubusercontent.com/13064661/53895427-56c7fc00-4032-11e9-95df-c385a6db7eea.png"/>
</details>
