### PR TITLE
Prepare ra-ui-materialui Migration to TypeScript

### DIFF
--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -117,7 +117,7 @@ describe('List Page', () => {
             LoginPage.login('admin', 'password');
             ListPageUsers.navigate();
             cy.contains('1-2 of 2');
-            cy.get('button[tooltip="Remove this filter"]').click();
+            cy.get('button[title="Remove this filter"]').click();
             cy.contains('1-3 of 3');
         });
     });

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@material-ui/core": "~1.4.0",
+        "@material-ui/core": "~1.5.1",
         "@material-ui/icons": "~1.1.0",
         "data-generator": "^2.4.0",
         "fakerest": "~2.1.0",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "dependencies": {
         "@material-ui/core": "~1.5.1",
-        "@material-ui/icons": "~1.1.0",
+        "@material-ui/icons": "~1.1.1",
         "data-generator": "^2.4.0",
         "fakerest": "~2.1.0",
         "fetch-mock": "~6.3.0",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -21,7 +21,7 @@
         "@babel/preset-env": "^7.1.0",
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.1.0",
-        "@material-ui/core": "~1.4.0",
+        "@material-ui/core": "~1.5.1",
         "@material-ui/icons": "~1.1.0",
         "babel-loader": "^8.0.4",
         "enzyme": "^3.8.0",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.1.0",
         "@material-ui/core": "~1.5.1",
-        "@material-ui/icons": "~1.1.0",
+        "@material-ui/icons": "~1.1.1",
         "babel-loader": "^8.0.4",
         "enzyme": "^3.8.0",
         "enzyme-adapter-react-16": "^1.7.1",

--- a/examples/tutorial/package.json
+++ b/examples/tutorial/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@material-ui/core": "~1.4.0",
+        "@material-ui/core": "~1.5.1",
         "ra-data-json-server": "^2.0.0",
         "react": "~16.3.1",
         "react-admin": "^2.0.0",

--- a/packages/ra-core/src/inference/types.ts
+++ b/packages/ra-core/src/inference/types.ts
@@ -7,5 +7,5 @@ export interface InferredType {
 }
 
 export interface InferredTypeMap {
-    [key: string]: InferredType;
+    [key: string]: InferredType | undefined;
 }

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -41,7 +41,7 @@
         "react-dom": "^16.3.0"
     },
     "dependencies": {
-        "@material-ui/core": "^1.4.0",
+        "@material-ui/core": "^1.5.1",
         "@material-ui/icons": "^1.0.0",
         "autosuggest-highlight": "^3.1.1",
         "classnames": "~2.2.5",

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -26,6 +26,8 @@
         "watch": "rimraf ./lib && tsc --watch"
     },
     "devDependencies": {
+        "@material-ui/core": "~1.5.1",
+        "@material-ui/icons": "^1.1.1",
         "cross-env": "^5.2.0",
         "enzyme": "~3.7.0",
         "enzyme-adapter-react-16": "~1.6.0",
@@ -41,8 +43,8 @@
         "react-dom": "^16.3.0"
     },
     "dependencies": {
-        "@material-ui/core": "^1.5.1",
-        "@material-ui/icons": "^1.1.1",
+        "@material-ui/core": "^1.4.0",
+        "@material-ui/icons": "^1.0.0",
         "autosuggest-highlight": "^3.1.1",
         "classnames": "~2.2.5",
         "inflection": "~1.12.0",

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@material-ui/core": "^1.5.1",
-        "@material-ui/icons": "^1.0.0",
+        "@material-ui/icons": "^1.1.1",
         "autosuggest-highlight": "^3.1.1",
         "classnames": "~2.2.5",
         "inflection": "~1.12.0",

--- a/packages/ra-ui-materialui/src/Link.js
+++ b/packages/ra-ui-materialui/src/Link.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link as RRLink } from 'react-router-dom';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     link: {
         textDecoration: 'none',
         color: theme.palette.primary.main,

--- a/packages/ra-ui-materialui/src/auth/Login.js
+++ b/packages/ra-ui-materialui/src/auth/Login.js
@@ -7,6 +7,7 @@ import {
     MuiThemeProvider,
     createMuiTheme,
     withStyles,
+    createStyles,
 } from '@material-ui/core/styles';
 import LockIcon from '@material-ui/icons/Lock';
 
@@ -14,7 +15,7 @@ import defaultTheme from '../defaultTheme';
 import Notification from '../layout/Notification';
 import DefaultLoginForm from './LoginForm';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     main: {
         display: 'flex',
         flexDirection: 'column',

--- a/packages/ra-ui-materialui/src/auth/LoginForm.js
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.js
@@ -7,10 +7,10 @@ import CardActions from '@material-ui/core/CardActions';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { translate, userLogin } from 'ra-core';
 
-const styles = () => ({
+const styles = () => createStyles({
     form: {
         padding: '0 1em 1em 1em',
     },

--- a/packages/ra-ui-materialui/src/auth/LoginForm.js
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.js
@@ -24,7 +24,7 @@ const styles = () => createStyles({
 
 // see http://redux-form.com/6.4.3/examples/material-ui/
 const renderInput = ({
-    meta: { touched, error } = {}, // eslint-disable-line react/prop-types
+    meta: { touched, error } = { touched: false, error: '' }, // eslint-disable-line react/prop-types
     input: { ...inputProps }, // eslint-disable-line react/prop-types
     ...props
 }) => (

--- a/packages/ra-ui-materialui/src/auth/Logout.js
+++ b/packages/ra-ui-materialui/src/auth/Logout.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ExitIcon from '@material-ui/icons/PowerSettingsNew';
 import classnames from 'classnames';
 import { translate, userLogout as userLogoutAction } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     menuItem: {
         color: theme.palette.text.secondary,
     },

--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import ActionDelete from '@material-ui/icons/Delete';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import { crudDeleteMany, startUndoable } from 'ra-core';
 
@@ -22,7 +22,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-const styles = theme => ({
+const styles = theme => createStyles({
     deleteButton: {
         color: theme.palette.error.main,
         '&:hover': {

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -4,13 +4,13 @@ import compose from 'recompose/compose';
 import MuiButton from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { translate } from 'ra-core';
 
 import Responsive from '../layout/Responsive';
 
-const styles = {
+const styles = createStyles({
     button: {
         display: 'inline-flex',
         alignItems: 'center',
@@ -30,7 +30,7 @@ const styles = {
     largeIcon: {
         fontSize: 24,
     },
-};
+});
 
 const Button = ({
     alignIcon = 'left',

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -37,10 +37,10 @@ const Button = ({
     children,
     classes = {},
     className,
-    color = 'primary',
+    color,
     disabled,
     label,
-    size = 'small',
+    size,
     translate,
     ...rest
 }) => (
@@ -110,9 +110,14 @@ Button.propTypes = {
     color: PropTypes.string,
     disabled: PropTypes.bool,
     label: PropTypes.string,
-    size: PropTypes.string,
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
     translate: PropTypes.func.isRequired,
 };
+
+Button.defaultProps = {
+    color: 'primary',
+    size: 'small'
+}
 
 const enhance = compose(
     withStyles(styles),

--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import MuiButton from '@material-ui/core/Button';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ContentAdd from '@material-ui/icons/Add';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
@@ -12,7 +12,7 @@ import { translate } from 'ra-core';
 import Button from './Button';
 import Responsive from '../layout/Responsive';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     floating: {
         color: theme.palette.getContrastText(theme.palette.primary.main),
         margin: 0,

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import ActionDelete from '@material-ui/icons/Delete';
 import classnames from 'classnames';
@@ -10,7 +10,7 @@ import { translate, crudDelete, startUndoable } from 'ra-core';
 
 import Button from './Button';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     deleteButton: {
         color: theme.palette.error.main,
         '&:hover': {

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -4,19 +4,19 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ContentSave from '@material-ui/icons/Save';
 import classnames from 'classnames';
 import { showNotification, translate } from 'ra-core';
 
-const styles = {
+const styles = createStyles({
     button: {
         position: 'relative',
     },
     iconPaddingStyle: {
         marginRight: '0.5em',
     },
-};
+});
 
 const sanitizeRestProps = ({
     basePath,

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -1,21 +1,21 @@
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { CreateController } from 'ra-core';
 
 import TitleForRecord from '../layout/TitleForRecord';
 import CardContentInner from '../layout/CardContentInner';
 
-const styles = {
+const styles = createStyles({
     root: {
         display: 'flex',
     },
     card: {
         flex: '1 1 auto',
     },
-};
+});
 
 const sanitizeRestProps = ({
     actions,
@@ -68,14 +68,14 @@ export const CreateView = ({
         <Card className={classes.card}>
             {actions && (
                 <CardContentInner>
-                    {React.cloneElement(actions, {
+                    {cloneElement(actions, {
                         basePath,
                         resource,
                         hasList,
                     })}
                 </CardContentInner>
             )}
-            {React.cloneElement(children, {
+            {cloneElement(Children.only(children), {
                 basePath,
                 record,
                 redirect:
@@ -87,7 +87,7 @@ export const CreateView = ({
             })}
         </Card>
         {aside &&
-            React.cloneElement(aside, {
+            cloneElement(aside, {
                 basePath,
                 record,
                 resource,

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { EditController } from 'ra-core';
 
@@ -10,14 +10,14 @@ import DefaultActions from './EditActions';
 import TitleForRecord from '../layout/TitleForRecord';
 import CardContentInner from '../layout/CardContentInner';
 
-export const styles = {
+export const styles = createStyles({
     root: {
         display: 'flex',
     },
     card: {
         flex: '1 1 auto',
     },
-};
+});
 
 const sanitizeRestProps = ({
     actions,
@@ -85,7 +85,7 @@ export const EditView = ({
             <Card className={classes.card}>
                 {actions && (
                     <CardContentInner>
-                        {React.cloneElement(actions, {
+                        {cloneElement(actions, {
                             basePath,
                             data: record,
                             hasShow,
@@ -95,7 +95,7 @@ export const EditView = ({
                     </CardContentInner>
                 )}
                 {record ? (
-                    React.cloneElement(children, {
+                    cloneElement(Children.only(children), {
                         basePath,
                         record,
                         redirect:

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { cloneElement, Children } from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { ShowController } from 'ra-core';
 
@@ -9,14 +9,14 @@ import DefaultActions from './ShowActions';
 import TitleForRecord from '../layout/TitleForRecord';
 import CardContentInner from '../layout/CardContentInner';
 
-export const styles = {
+export const styles = createStyles({
     root: {
         display: 'flex',
     },
     card: {
         flex: '1 1 auto',
     },
-};
+});
 
 const sanitizeRestProps = ({
     actions,
@@ -80,7 +80,7 @@ export const ShowView = ({
             <Card className={classes.card}>
                 {actions && (
                     <CardContentInner>
-                        {React.cloneElement(actions, {
+                        {cloneElement(actions, {
                             basePath,
                             data: record,
                             hasList,
@@ -90,7 +90,7 @@ export const ShowView = ({
                     </CardContentInner>
                 )}
                 {record &&
-                    React.cloneElement(children, {
+                    cloneElement(Children.only(children), {
                         resource,
                         basePath,
                         record,
@@ -98,7 +98,7 @@ export const ShowView = ({
                     })}
             </Card>
             {aside &&
-                React.cloneElement(aside, {
+                cloneElement(aside, {
                     resource,
                     basePath,
                     record,

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.js
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, isValidElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -64,7 +64,7 @@ export const SimpleShowLayout = ({
         {...sanitizeRestProps(rest)}
     >
         {Children.map(children, field =>
-            field ? (
+            field && isValidElement(field) ? (
                 <div
                     key={field.props.source}
                     className={classnames(
@@ -86,7 +86,7 @@ export const SimpleShowLayout = ({
                     ) : typeof field.type === 'string' ? (
                         field
                     ) : (
-                        React.cloneElement(field, {
+                        cloneElement(field, {
                             record,
                             resource,
                             basePath,

--- a/packages/ra-ui-materialui/src/detail/Tab.js
+++ b/packages/ra-ui-materialui/src/detail/Tab.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import MuiTab from '@material-ui/core/Tab';
@@ -70,7 +70,7 @@ class Tab extends Component {
             {React.Children.map(
                 children,
                 field =>
-                    field && (
+                    field && isValidElement(field) ? (
                         <div
                             key={field.props.source}
                             className={classnames(
@@ -99,7 +99,7 @@ class Tab extends Component {
                                 })
                             )}
                         </div>
-                    )
+                    ) : null
             )}
         </span>
     );

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -1,4 +1,4 @@
-import React, { Component, Children, cloneElement } from 'react';
+import React, { Component, Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Divider from '@material-ui/core/Divider';
 import { withRouter, Route } from 'react-router-dom';
@@ -104,7 +104,7 @@ export class TabbedShowLayout extends Component {
                     {Children.map(
                         children,
                         (tab, index) =>
-                            tab && (
+                            tab && isValidElement(tab) ? (
                                 <Route
                                     exact
                                     path={getTabFullPath(tab, index, match.url)}
@@ -117,7 +117,7 @@ export class TabbedShowLayout extends Component {
                                         })
                                     }
                                 />
-                            )
+                            ) : null
                     )}
                 </CardContentInner>
             </div>

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Tabs from '@material-ui/core/Tabs';
 
@@ -10,7 +10,7 @@ const getTabFullPath = (tab, index, baseUrl) =>
 const TabbedShowLayoutTabs = ({ children, match, ...rest }) => (
     <Tabs indicatorColor="primary" {...rest}>
         {Children.map(children, (tab, index) => {
-            if (!tab) return null;
+            if (!tab || !isValidElement(tab)) return null;
             // Builds the full tab tab which is the concatenation of the last matched route in the
             // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
             // and the tab path.

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -7,8 +7,8 @@ const getTabFullPath = (tab, index, baseUrl) =>
         tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
     }`;
 
-const TabbedShowLayoutTabs = ({ children, match, ...rest }) => (
-    <Tabs indicatorColor="primary" {...rest}>
+const TabbedShowLayoutTabs = ({ children, match, value, ...rest }) => (
+    <Tabs indicatorColor="primary" value={value} {...rest}>
         {Children.map(children, (tab, index) => {
             if (!tab || !isValidElement(tab)) return null;
             // Builds the full tab tab which is the concatenation of the last matched route in the

--- a/packages/ra-ui-materialui/src/field/ArrayField.js
+++ b/packages/ra-ui-materialui/src/field/ArrayField.js
@@ -1,4 +1,4 @@
-import { Component, cloneElement } from 'react';
+import { Component, cloneElement, Children } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import pure from 'recompose/pure';
@@ -111,7 +111,7 @@ export class ArrayField extends Component {
         } = this.props;
         const { ids, data } = this.state;
 
-        return cloneElement(children, {
+        return cloneElement(Children.only(children), {
             ids,
             data,
             isLoading: false,

--- a/packages/ra-ui-materialui/src/field/ChipField.js
+++ b/packages/ra-ui-materialui/src/field/ChipField.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
 import get from 'lodash/get';
 import pure from 'recompose/pure';
 import Chip from '@material-ui/core/Chip';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = {
+const styles = createStyles({
     chip: { margin: 4 },
-};
+});
 
 export const ChipField = ({
     className,
@@ -39,6 +40,9 @@ ChipField.propTypes = {
 // wat? TypeScript looses the displayName if we don't set it explicitly
 ChipField.displayName = 'ChipField';
 
-const PureChipField = withStyles(styles)(pure(ChipField));
+const PureChipField = compose(
+    withStyles(styles),
+    pure
+)(ChipField);
 
 export default PureChipField;

--- a/packages/ra-ui-materialui/src/field/FileField.js
+++ b/packages/ra-ui-materialui/src/field/FileField.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = {
+const styles = createStyles({
     root: { display: 'inline-block' },
-};
+});
 
 export const FileField = ({
     classes = {},

--- a/packages/ra-ui-materialui/src/field/ImageField.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = {
+const styles = createStyles({
     list: {
         display: 'flex',
         listStyleType: 'none',
@@ -14,7 +14,7 @@ const styles = {
         margin: '0.5rem',
         maxHeight: '10rem',
     },
-};
+});
 
 export const ImageField = ({
     className,

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import LinearProgress from '@material-ui/core/LinearProgress';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { ReferenceArrayFieldController } from 'ra-core';
 
-const styles = {
+const styles = createStyles({
     progress: { marginTop: '1em' },
-};
+});
 
 export const ReferenceArrayFieldView = ({
     children,
@@ -22,7 +22,7 @@ export const ReferenceArrayFieldView = ({
         return <LinearProgress className={classes.progress} />;
     }
 
-    return React.cloneElement(children, {
+    return React.cloneElement(Children.only(children), {
         className,
         resource: reference,
         ids,

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { ReferenceFieldController } from 'ra-core';
 
 import LinearProgress from '../layout/LinearProgress';
 import Link from '../Link';
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     link: {
         color: theme.palette.primary.main,
     },
@@ -44,7 +44,7 @@ export const ReferenceFieldView = ({
                 className={className}
                 onClick={stopPropagation}
             >
-                {React.cloneElement(children, {
+                {React.cloneElement(Children.only(children), {
                     className: classnames(
                         children.props.className,
                         classes.link // force color override for Typography components
@@ -60,7 +60,7 @@ export const ReferenceFieldView = ({
         );
     }
 
-    return React.cloneElement(children, {
+    return React.cloneElement(Children.only(children), {
         record: referenceRecord,
         resource: reference,
         allowEmpty,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.js
@@ -1,4 +1,4 @@
-import React, { Fragment, cloneElement } from 'react';
+import React, { Fragment, cloneElement, Children } from 'react';
 import PropTypes from 'prop-types';
 import { ReferenceManyFieldController } from 'ra-core';
 
@@ -20,7 +20,7 @@ export const ReferenceManyFieldView = ({
     total,
 }) => (
     <Fragment>
-        {cloneElement(children, {
+        {cloneElement(Children.only(children), {
             className,
             resource: reference,
             ids,

--- a/packages/ra-ui-materialui/src/form/FormInput.js
+++ b/packages/ra-ui-materialui/src/form/FormInput.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
 import Labeled from '../input/Labeled';
 
 const sanitizeRestProps = ({ basePath, record, ...rest }) => rest;
 
-const styles = theme => ({
+const styles = theme => createStyles({
     input: { width: theme.spacing.unit * 32 },
 });
 

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -6,7 +6,7 @@ import get from 'lodash/get';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/RemoveCircleOutline';
 import AddIcon from '@material-ui/icons/AddCircleOutline';
 import { translate } from 'ra-core';
@@ -14,7 +14,7 @@ import classNames from 'classnames';
 
 import FormInput from '../form/FormInput';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {
         padding: 0,
         marginBottom: 0,

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement, Component } from 'react';
+import React, { Children, cloneElement, Component, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -126,7 +126,7 @@ export class SimpleFormIterator extends Component {
                                     {index + 1}
                                 </Typography>
                                 <section className={classes.form}>
-                                    {Children.map(children, (input, index2) => (
+                                    {Children.map(children, (input, index2) => isValidElement(input) ? (
                                         <FormInput
                                             basePath={
                                                 input.props.basePath || basePath
@@ -150,7 +150,7 @@ export class SimpleFormIterator extends Component {
                                             }
                                             resource={resource}
                                         />
-                                    ))}
+                                    ) : null)}
                                 </section>
                                 {!disableRemove && (
                                     <span className={classes.action}>

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -1,4 +1,4 @@
-import React, { Children, Component } from 'react';
+import React, { Children, Component, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
@@ -12,13 +12,13 @@ import { withRouter, Route } from 'react-router-dom';
 import compose from 'recompose/compose';
 import Divider from '@material-ui/core/Divider';
 import Tabs from '@material-ui/core/Tabs';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { getDefaultValues, translate, REDUX_FORM_NAME } from 'ra-core';
 
 import Toolbar from './Toolbar';
 import CardContentInner from '../layout/CardContentInner';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     errorTabButton: { color: theme.palette.error.main },
 });
 
@@ -157,6 +157,7 @@ export class TabbedForm extends Component {
                                     path={getTabFullPath(tab, index, match.url)}
                                 >
                                     {routeProps =>
+                                        isValidElement(tab) ?
                                         React.cloneElement(tab, {
                                             context: 'content',
                                             resource,
@@ -176,7 +177,7 @@ export class TabbedForm extends Component {
                                              * @ref https://github.com/marmelab/react-admin/issues/1956
                                              */
                                             key: `${index}_${!routeProps.match}`,
-                                        })
+                                        }) : null
                                     }
                                 </Route>
                             )

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -123,7 +123,7 @@ export class TabbedForm extends Component {
                     indicatorColor="primary"
                 >
                     {Children.map(children, (tab, index) => {
-                        if (!tab) return null;
+                        if (!isValidElement(tab)) return null;
 
                         // Builds the full tab tab which is the concatenation of the last matched route in the
                         // TabbedShowLayout hierarchy (ex: '/posts/create', '/posts/12', , '/posts/12/show')
@@ -256,9 +256,13 @@ export const findTabsWithErrors = (
     const errors = collectErrorsImpl(state, props);
 
     return Children.toArray(props.children).reduce((acc, child) => {
+        if (!isValidElement(child)) {
+            return acc;
+        }
+
         const inputs = Children.toArray(child.props.children);
 
-        if (inputs.some(input => errors[input.props.source])) {
+        if (inputs.some(input => isValidElement(input) && errors[input.props.source])) {
             return [...acc, child.props.label];
         }
 
@@ -270,7 +274,7 @@ const enhance = compose(
     withRouter,
     connect((state, props) => {
         const children = Children.toArray(props.children).reduce(
-            (acc, child) => [...acc, ...Children.toArray(child.props.children)],
+            (acc, child) => [...acc, ...(isValidElement(child) ? Children.toArray(child.props.children): [])],
             []
         );
 

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -1,14 +1,14 @@
-import React, { Children, Fragment } from 'react';
+import React, { Children, Fragment, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import MuiToolbar from '@material-ui/core/Toolbar';
 import withWidth from '@material-ui/core/withWidth';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
 import { SaveButton, DeleteButton } from '../button';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     toolbar: {
         backgroundColor:
             theme.palette.type === 'light'
@@ -93,7 +93,7 @@ const Toolbar = ({
                 </div>
             ) : (
                 Children.map(children, button =>
-                    button
+                    button && isValidElement(button)
                         ? React.cloneElement(button, {
                               basePath,
                               handleSubmit: valueOrDefault(

--- a/packages/ra-ui-materialui/src/input/ArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.js
@@ -1,4 +1,4 @@
-import React, { cloneElement, Component } from 'react';
+import React, { cloneElement, Component, Children } from 'react';
 import PropTypes from 'prop-types';
 import { isRequired, FieldTitle, withDefaultValue } from 'ra-core';
 import { FieldArray } from 'redux-form';
@@ -51,7 +51,7 @@ import sanitizeRestProps from './sanitizeRestProps';
 export class ArrayInput extends Component {
     renderFieldArray = fieldProps => {
         const { children, record, resource, source } = this.props;
-        return cloneElement(children, {
+        return cloneElement(Children.only(children), {
             ...fieldProps,
             record,
             resource,

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -7,7 +7,7 @@ import Chip from '@material-ui/core/Chip';
 import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
 import blue from '@material-ui/core/colors/blue';
@@ -18,7 +18,7 @@ import { addField, translate, FieldTitle } from 'ra-core';
 
 import AutocompleteArrayInputChip from './AutocompleteArrayInputChip';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     container: {
         flexGrow: 1,
         position: 'relative',

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -408,9 +408,6 @@ export class AutocompleteArrayInput extends React.Component {
                 component={
                     suggestionComponent || this.renderSuggestionComponent
                 }
-                suggestion={suggestion}
-                query={query}
-                isHighlighted={isHighlighted}
             >
                 <div>
                     {parts.map((part, index) => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -408,6 +408,9 @@ export class AutocompleteArrayInput extends React.Component {
                 component={
                     suggestionComponent || this.renderSuggestionComponent
                 }
+                suggestion={suggestion}
+                query={query}
+                isHighlighted={isHighlighted}
             >
                 <div>
                     {parts.map((part, index) => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ChipInput from 'material-ui-chip-input';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
-const chipInputStyles = {
+const chipInputStyles = createStyles({
     label: {
         top: 18,
     },
@@ -14,7 +14,7 @@ const chipInputStyles = {
         display: 'flex',
         minHeight: 50,
     },
-};
+});
 
 const AutocompleteArrayInputChip = props => <ChipInput {...props} />;
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -7,7 +7,7 @@ import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
 import compose from 'recompose/compose';
@@ -15,7 +15,7 @@ import classnames from 'classnames';
 
 import { addField, translate, FieldTitle } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     container: {
         flexGrow: 1,
         position: 'relative',

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -356,9 +356,6 @@ export class AutocompleteInput extends React.Component {
                 component={
                     suggestionComponent || this.renderSuggestionComponent
                 }
-                suggestion={suggestion}
-                query={query}
-                isHighlighted={isHighlighted}
             >
                 <div>
                     {parts.map((part, index) => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -356,6 +356,9 @@ export class AutocompleteInput extends React.Component {
                 component={
                     suggestionComponent || this.renderSuggestionComponent
                 }
+                suggestion={suggestion}
+                query={query}
+                isHighlighted={isHighlighted}
             >
                 <div>
                     {parts.map((part, index) => {

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.js
@@ -7,7 +7,7 @@ import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Checkbox from '@material-ui/core/Checkbox';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import { addField, translate, FieldTitle } from 'ra-core';
 
@@ -15,7 +15,7 @@ import defaultSanitizeRestProps from './sanitizeRestProps';
 const sanitizeRestProps = ({ setFilter, setPagination, setSort, ...rest }) =>
     defaultSanitizeRestProps(rest);
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {},
     label: {
         transform: 'translate(0, 1.5px) scale(0.75)',

--- a/packages/ra-ui-materialui/src/input/DateInput.js
+++ b/packages/ra-ui-materialui/src/input/DateInput.js
@@ -12,7 +12,7 @@ import sanitizeRestProps from './sanitizeRestProps';
  * @returns {String} A standardized date (yyyy-MM-dd), to be passed to an <input type="date" />
  */
 const dateFormatter = v => {
-    if (!(v instanceof Date) || isNaN(v)) return;
+    if (!(v instanceof Date) || isNaN(v.getDate())) return;
     const pad = '00';
     const yyyy = v.getFullYear().toString();
     const MM = (v.getMonth() + 1).toString();
@@ -28,13 +28,17 @@ const sanitizeValue = value => {
     if (value == null || value === '') {
         return '';
     }
+
+    if (value instanceof Date) {
+        return dateFormatter(value);
+    }
+
     // valid dates should not be converted
     if (dateRegex.test(value)) {
         return value;
     }
 
-    const finalValue = value instanceof Date ? value : new Date(value);
-    return dateFormatter(finalValue);
+    return dateFormatter(new Date(value));
 };
 
 export class DateInput extends Component {

--- a/packages/ra-ui-materialui/src/input/DateInput.js
+++ b/packages/ra-ui-materialui/src/input/DateInput.js
@@ -33,7 +33,7 @@ const sanitizeValue = value => {
         return value;
     }
 
-    const finalValue = typeof value instanceof Date ? value : new Date(value);
+    const finalValue = value instanceof Date ? value : new Date(value);
     return dateFormatter(finalValue);
 };
 

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.js
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.js
@@ -30,8 +30,7 @@ const dateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
  * Converts a date from the Redux store, with timezone, to a date string
  * without timezone for use in an <input type="datetime-local" />.
  *
- * @param {Mixed} value date string or object
- * @param {String} Date string, formatted as yyyy-MM-ddThh:mm
+ * @param {Date | String} value date string or object
  */
 const format = value => {
     // null, undefined and empty string values should not go through convertDateToString
@@ -44,7 +43,7 @@ const format = value => {
         return value;
     }
 
-    const finalValue = typeof value instanceof Date ? value : new Date(value);
+    const finalValue = value instanceof Date ? value : new Date(value);
     return convertDateToString(finalValue);
 };
 

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.js
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.js
@@ -38,13 +38,16 @@ const format = value => {
     if (value == null || value === '') {
         return '';
     }
+
+    if (value instanceof Date) {
+        return convertDateToString(value);
+    }
     // valid dates should not be converted
     if (dateTimeRegex.test(value)) {
         return value;
     }
 
-    const finalValue = value instanceof Date ? value : new Date(value);
-    return convertDateToString(finalValue);
+    return convertDateToString(new Date(value));
 };
 
 /**

--- a/packages/ra-ui-materialui/src/input/FileInput.js
+++ b/packages/ra-ui-materialui/src/input/FileInput.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import Dropzone from 'react-dropzone';
 import compose from 'recompose/compose';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import classnames from 'classnames';
 import { addField, translate } from 'ra-core';
@@ -12,7 +12,7 @@ import Labeled from './Labeled';
 import FileInputPreview from './FileInputPreview';
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = {
+const styles = createStyles({
     dropZone: {
         background: '#efefef',
         cursor: 'pointer',
@@ -23,7 +23,7 @@ const styles = {
     preview: {},
     removeButton: {},
     root: { width: '100%' },
-};
+});
 
 export class FileInput extends Component {
     static propTypes = {
@@ -203,7 +203,7 @@ export class FileInput extends Component {
                                     onRemove={this.onRemove(file)}
                                     className={classes.removeButton}
                                 >
-                                    {React.cloneElement(children, {
+                                    {cloneElement(Children.only(children), {
                                         record: file,
                                         className: classes.preview,
                                     })}

--- a/packages/ra-ui-materialui/src/input/FileInput.js
+++ b/packages/ra-ui-materialui/src/input/FileInput.js
@@ -113,9 +113,7 @@ export class FileInput extends Component {
             return file;
         }
 
-        const { source, title } = React.Children.toArray(
-            this.props.children
-        )[0].props;
+        const { source, title } = Children.only(this.props.children).props;
 
         const transformedFile = {
             rawFile: file,

--- a/packages/ra-ui-materialui/src/input/FileInputPreview.js
+++ b/packages/ra-ui-materialui/src/input/FileInputPreview.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react';
 import compose from 'recompose/compose';
 import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import RemoveCircle from '@material-ui/icons/RemoveCircle';
 import { translate } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     removeButton: {},
     removeIcon: {
         color: theme.palette.accent1Color,

--- a/packages/ra-ui-materialui/src/input/ImageInput.js
+++ b/packages/ra-ui-materialui/src/input/ImageInput.js
@@ -1,10 +1,10 @@
 import compose from 'recompose/compose';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { addField, translate } from 'ra-core';
 
 import { FileInput } from './FileInput';
 
-const styles = {
+const styles = createStyles({
     root: { width: '100%' },
     dropZone: {
         background: '#efefef',
@@ -29,7 +29,7 @@ const styles = {
             opacity: 1,
         },
     },
-};
+});
 
 export class ImageInput extends FileInput {
     static defaultProps = {

--- a/packages/ra-ui-materialui/src/input/Labeled.js
+++ b/packages/ra-ui-materialui/src/input/Labeled.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { FieldTitle } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     label: {
         position: 'relative',
     },

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.js
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 import { addField, translate, FieldTitle } from 'ra-core';
 
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     input: { width: theme.spacing.unit * 16 },
 });
 

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
@@ -7,17 +7,17 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import InputLabel from '@material-ui/core/InputLabel';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import { addField, translate, FieldTitle } from 'ra-core';
 
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = {
+const styles = createStyles({
     label: {
         position: 'relative',
     },
-};
+});
 
 /**
  * An Input component for a radio button group, using an array of objects for the options

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -5,12 +5,12 @@ import classNames from 'classnames';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import IconButton from '@material-ui/core/IconButton';
 import MuiTextField from '@material-ui/core/TextField';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ClearIcon from '@material-ui/icons/Clear';
 
 import { translate } from 'ra-core';
 
-const styles = {
+const styles = createStyles({
     clearIcon: {
         height: 16,
         width: 0,
@@ -25,7 +25,7 @@ const styles = {
     visibleClearButton: {
         width: 24,
     },
-};
+});
 
 /**
  * An override of the default Material-UI TextField which is resettable

--- a/packages/ra-ui-materialui/src/input/SearchInput.js
+++ b/packages/ra-ui-materialui/src/input/SearchInput.js
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import SearchIcon from '@material-ui/icons/Search';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { translate } from 'ra-core';
 
 import TextInput from './TextInput';
 
-const searchFilterStyles = {
+const searchFilterStyles = createStyles({
     input: {
         marginTop: 32,
     },
-};
+});
 
 const SearchInput = ({ classes, translate, ...props }) => (
     <TextInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -8,7 +8,7 @@ import Input from '@material-ui/core/Input';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import FormControl from '@material-ui/core/FormControl';
 import Chip from '@material-ui/core/Chip';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 import { addField, translate, FieldTitle } from 'ra-core';
@@ -53,7 +53,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {},
     chips: {
         display: 'flex',

--- a/packages/ra-ui-materialui/src/input/SelectInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import { addField, translate, FieldTitle } from 'ra-core';
 import ResettableTextField from './ResettableTextField';
@@ -47,7 +47,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-const styles = theme => ({
+const styles = theme => createStyles({
     input: {
         minWidth: theme.spacing.unit * 20,
     },

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -6,7 +6,7 @@ import MuiAppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
 import withWidth from '@material-ui/core/withWidth';
 import compose from 'recompose/compose';
@@ -16,7 +16,7 @@ import LoadingIndicator from './LoadingIndicator';
 import UserMenu from './UserMenu';
 import Headroom from './Headroom';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     toolbar: {
         paddingRight: 24,
     },

--- a/packages/ra-ui-materialui/src/layout/AppBarMobile.js
+++ b/packages/ra-ui-materialui/src/layout/AppBarMobile.js
@@ -5,14 +5,14 @@ import MuiAppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
 import compose from 'recompose/compose';
 import { toggleSidebar } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
 
-const styles = {
+const styles = createStyles({
     title: {
         fontSize: '1.25em',
         lineHeight: '2.5em',
@@ -31,7 +31,7 @@ const styles = {
         color: '#fff',
         textDecoration: 'none',
     },
-};
+});
 
 /**
  * @deprecated

--- a/packages/ra-ui-materialui/src/layout/CardActions.js
+++ b/packages/ra-ui-materialui/src/layout/CardActions.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
-const styles = {
+const styles = createStyles({
     cardActions: {
         zIndex: 2,
         display: 'flex',
@@ -12,7 +12,7 @@ const styles = {
         flexWrap: 'wrap',
         padding: 0,
     },
-};
+});
 
 const CardActions = ({ classes, className, children, ...rest }) => (
     <div className={classnames(classes.cardActions, className)} {...rest}>

--- a/packages/ra-ui-materialui/src/layout/CardContentInner.js
+++ b/packages/ra-ui-materialui/src/layout/CardContentInner.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CardContent from '@material-ui/core/CardContent';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
-var styles = theme => ({
+var styles = theme => createStyles({
     root: {
         paddingTop: 0,
         paddingBottom: 0,

--- a/packages/ra-ui-materialui/src/layout/Confirm.js
+++ b/packages/ra-ui-materialui/src/layout/Confirm.js
@@ -6,7 +6,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import ActionCheck from '@material-ui/icons/CheckCircle';
 import AlertError from '@material-ui/icons/ErrorOutline';
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     confirmPrimary: {
         color: theme.palette.primary.main,
     },

--- a/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
+++ b/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
@@ -5,7 +5,7 @@ import { translate } from 'ra-core';
 
 import MenuItemLink from './MenuItemLink';
 
-const DashboardMenuItem = ({ className, onClick, translate, ...props }) => (
+const DashboardMenuItem = ({ className, locale, onClick, translate, ...props }) => (
     <MenuItemLink
         onClick={onClick}
         to="/"
@@ -19,6 +19,7 @@ const DashboardMenuItem = ({ className, onClick, translate, ...props }) => (
 DashboardMenuItem.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
+    locale: PropTypes.string,
     onClick: PropTypes.func,
     translate: PropTypes.func.isRequired,
 };

--- a/packages/ra-ui-materialui/src/layout/Error.js
+++ b/packages/ra-ui-materialui/src/layout/Error.js
@@ -6,7 +6,7 @@ import Button from '@material-ui/core/Button';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ErrorIcon from '@material-ui/icons/Report';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import History from '@material-ui/icons/History';
@@ -14,7 +14,7 @@ import History from '@material-ui/icons/History';
 import Title from './Title';
 import { translate } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     container: {
         display: 'flex',
         flexDirection: 'column',

--- a/packages/ra-ui-materialui/src/layout/Header.js
+++ b/packages/ra-ui-materialui/src/layout/Header.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
 import ViewTitle from './ViewTitle';
 
-const styles = {
+const styles = createStyles({
     root: {
         display: 'flex',
         justifyContent: 'space-between',
     },
-};
+});
 
 /**
  * @deprecated

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -7,6 +7,7 @@ import {
     MuiThemeProvider,
     createMuiTheme,
     withStyles,
+    createStyles,
 } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 
@@ -17,7 +18,7 @@ import Notification from './Notification';
 import Error from './Error';
 import defaultTheme from '../defaultTheme';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {
         display: 'flex',
         flexDirection: 'column',

--- a/packages/ra-ui-materialui/src/layout/LinearProgress.js
+++ b/packages/ra-ui-materialui/src/layout/LinearProgress.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Progress from '@material-ui/core/LinearProgress';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {
         margin: `${theme.spacing.unit}px 0`,
         width: `${theme.spacing.unit * 20}px`,

--- a/packages/ra-ui-materialui/src/layout/Loading.js
+++ b/packages/ra-ui-materialui/src/layout/Loading.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { translate } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     container: {
         display: 'flex',
         flexDirection: 'column',

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -2,17 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import compose from 'recompose/compose';
 
 import RefreshIconButton from '../button/RefreshIconButton';
 
-const styles = {
+const styles = createStyles({
     loader: {
         margin: 14,
     },
-};
+});
 
 export const LoadingIndicator = ({ classes, className, isLoading, ...rest }) =>
     isLoading ? (

--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import inflection from 'inflection';
 import compose from 'recompose/compose';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import { getResources, translate } from 'ra-core';
 import DefaultIcon from '@material-ui/icons/ViewList';
@@ -12,13 +12,13 @@ import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
 import Responsive from '../layout/Responsive';
 
-const styles = {
+const styles = createStyles({
     main: {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'flex-start',
     },
-};
+});
 
 const translatedResourceName = (resource, translate) =>
     translate(`resources.${resource.name}.name`, {

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.js
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { NavLink } from 'react-router-dom';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {
         color: theme.palette.text.secondary,
         display: 'flex',

--- a/packages/ra-ui-materialui/src/layout/NotFound.js
+++ b/packages/ra-ui-materialui/src/layout/NotFound.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import HotTub from '@material-ui/icons/HotTub';
 import History from '@material-ui/icons/History';
 import compose from 'recompose/compose';
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import { translate } from 'ra-core';
 import Title from './Title';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     container: {
         display: 'flex',
         flexDirection: 'column',

--- a/packages/ra-ui-materialui/src/layout/Notification.js
+++ b/packages/ra-ui-materialui/src/layout/Notification.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Snackbar from '@material-ui/core/Snackbar';
 import Button from '@material-ui/core/Button';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 
@@ -15,7 +15,7 @@ import {
     complete,
 } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     confirm: {
         backgroundColor: theme.palette.background.default,
     },

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
@@ -76,7 +76,7 @@ class Sidebar extends PureComponent {
                         onClose={this.toggleSidebar}
                         {...rest}
                     >
-                        {React.cloneElement(children, {
+                        {cloneElement(Children.only(children), {
                             onMenuClick: this.handleClose,
                         })}
                     </Drawer>
@@ -94,7 +94,7 @@ class Sidebar extends PureComponent {
                         onClose={this.toggleSidebar}
                         {...rest}
                     >
-                        {React.cloneElement(children, {
+                        {cloneElement(Children.only(children), {
                             dense: true,
                             onMenuClick: this.handleClose,
                         })}
@@ -113,7 +113,7 @@ class Sidebar extends PureComponent {
                         onClose={this.toggleSidebar}
                         {...rest}
                     >
-                        {React.cloneElement(children, { dense: true })}
+                        {cloneElement(Children.only(children), { dense: true })}
                     </Drawer>
                 }
             />

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import Drawer from '@material-ui/core/Drawer';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
 import { setSidebarVisibility } from 'ra-core';
 
@@ -12,7 +12,7 @@ import Responsive from './Responsive';
 export const DRAWER_WIDTH = 240;
 export const CLOSED_DRAWER_WIDTH = 55;
 
-const styles = theme => ({
+const styles = theme => createStyles({
     drawerPaper: {
         position: 'relative',
         height: 'auto',

--- a/packages/ra-ui-materialui/src/layout/Title.js
+++ b/packages/ra-ui-materialui/src/layout/Title.js
@@ -6,6 +6,7 @@ import { translate, warning } from 'ra-core';
 const Title = ({
     className,
     defaultTitle,
+    locale,
     record,
     title,
     translate,
@@ -32,6 +33,7 @@ const Title = ({
 Title.propTypes = {
     defaultTitle: PropTypes.string,
     className: PropTypes.string,
+    locale: PropTypes.string,
     record: PropTypes.object,
     translate: PropTypes.func.isRequired,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),

--- a/packages/ra-ui-materialui/src/layout/TitleDeprecated.js
+++ b/packages/ra-ui-materialui/src/layout/TitleDeprecated.js
@@ -11,6 +11,7 @@ const Title = ({
     record,
     title,
     translate,
+    locale,
     ...rest
 }) => {
     if (!title) {
@@ -33,6 +34,7 @@ const Title = ({
 Title.propTypes = {
     defaultTitle: PropTypes.string.isRequired,
     className: PropTypes.string,
+    locale: PropTypes.string,
     record: PropTypes.object,
     translate: PropTypes.func.isRequired,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),

--- a/packages/ra-ui-materialui/src/layout/UserMenu.js
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.js
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
@@ -71,7 +71,8 @@ class UserMenu extends React.Component {
                     onClose={this.handleClose}
                 >
                     {Children.map(children, menuItem =>
-                        cloneElement(menuItem, { onClick: this.handleClose })
+                        isValidElement(menuItem) ?
+                        cloneElement(menuItem, { onClick: this.handleClose }) : null
                     )}
                     {logout}
                 </Menu>

--- a/packages/ra-ui-materialui/src/layout/ViewTitle.js
+++ b/packages/ra-ui-materialui/src/layout/ViewTitle.js
@@ -10,7 +10,7 @@ import AppBarMobile from './AppBarMobile';
 /**
  * @deprecated
  */
-const ViewTitle = ({ className, title, ...rest }) => {
+const ViewTitle = ({ className = undefined, title, ...rest }) => {
     if (process.env.NODE_ENV !== 'production') {
         // eslint-disable-next-line no-console
         console.warn('<ViewTitle> is deprecated, please use <Title> instead');

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import FilterNoneIcon from '@material-ui/icons/FilterNone';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
@@ -12,7 +12,7 @@ import { translate } from 'ra-core';
 import Button from '../button/Button';
 import BulkDeleteAction from './BulkDeleteAction';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     bulkActionsButton: {
         opacity: 1,
         transition: theme.transitions.create('opacity', {

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -1,4 +1,4 @@
-import React, { cloneElement, Children, Component } from 'react';
+import React, { cloneElement, Children, Component, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import Menu from '@material-ui/core/Menu';
@@ -134,7 +134,7 @@ class BulkActions extends Component {
                         onClose={this.handleClose}
                         open={isOpen}
                     >
-                        {Children.map(children, (child, index) => (
+                        {Children.map(children, (child, index) => isValidElement(child) ? (
                             <MenuItem
                                 key={index}
                                 className={classnames(
@@ -146,19 +146,20 @@ class BulkActions extends Component {
                             >
                                 {translate(child.props.label)}
                             </MenuItem>
-                        ))}
+                        ) : null)}
                     </Menu>
                     {Children.map(
                         children,
                         (child, index) =>
-                            this.state.activeAction === index &&
+                            isValidElement(child) &&
+                            this.state.activeAction === index ?
                             cloneElement(child, {
                                 basePath,
                                 filterValues,
                                 onExit: this.handleExitAction,
                                 resource,
                                 selectedIds,
-                            })
+                            }) : null
                     )}
                 </div>
             </CSSTransition>

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -74,7 +74,7 @@ const BulkActionsToolbar = ({
             </div>
             <CardActions>
                 {Children.map(children, child =>
-                    cloneElement(child, {
+                    cloneElement(Children.only(child), {
                         basePath,
                         filterValues,
                         resource,

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
 import { translate, sanitizeListRestProps } from 'ra-core';
 
 import CardActions from '../layout/CardActions';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     toolbar: {
         position: 'absolute',
         top: 0,

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, isValidElement, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { sanitizeListRestProps } from 'ra-core';
 import { withStyles, createStyles } from '@material-ui/core/styles';
@@ -200,8 +200,8 @@ class Datagrid extends Component {
                                 />
                             </TableCell>
                         )}
-                        {React.Children.map(children, (field, index) =>
-                            field ? (
+                        {Children.map(children, (field, index) =>
+                            isValidElement(field) ? (
                                 <DatagridHeaderCell
                                     className={classes.headerCell}
                                     currentSort={currentSort}
@@ -219,7 +219,7 @@ class Datagrid extends Component {
                         )}
                     </TableRow>
                 </TableHead>
-                {React.cloneElement(
+                {cloneElement(
                     body,
                     {
                         basePath,

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { sanitizeListRestProps } from 'ra-core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
@@ -14,7 +14,7 @@ import DatagridHeaderCell from './DatagridHeaderCell';
 import DatagridBody from './DatagridBody';
 import DatagridLoading from './DatagridLoading';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     table: {
         tableLayout: 'auto',
     },

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -97,6 +97,7 @@ const PureDatagridBody = shouldUpdate(
 )(DatagridBody);
 
 // trick material-ui Table into thinking this is one of the child type it supports
+// @ts-ignore
 PureDatagridBody.muiName = 'TableBody';
 
 export default PureDatagridBody;

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -6,11 +6,11 @@ import compose from 'recompose/compose';
 import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Tooltip from '@material-ui/core/Tooltip';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { FieldTitle, translate } from 'ra-core';
 
 // remove the sort icons when not active
-const styles = {
+const styles = createStyles({
     icon: {
         display: 'none',
     },
@@ -19,7 +19,7 @@ const styles = {
             display: 'inline',
         },
     },
-};
+});
 
 export const DatagridHeaderCell = ({
     classes,

--- a/packages/ra-ui-materialui/src/list/DatagridLoading.js
+++ b/packages/ra-ui-materialui/src/list/DatagridLoading.js
@@ -8,13 +8,13 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import IconButton from '@material-ui/core/IconButton';
 import Checkbox from '@material-ui/core/Checkbox';
 import classnames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
 const RawPlaceholder = ({ classes }) => (
     <div className={classes.root}>&nbsp;</div>
 );
 
-const styles = theme => ({
+const styles = theme => createStyles({
     root: {
         backgroundColor: theme.palette.grey[300],
         display: 'flex',

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component, Fragment, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -157,7 +157,7 @@ class DatagridRow extends Component {
                         </TableCell>
                     )}
                     {React.Children.map(children, (field, index) =>
-                        field ? (
+                        isValidElement(field) ? (
                             <DatagridCell
                                 key={`${id}-${field.props.source || index}`}
                                 className={classnames(

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -43,7 +43,7 @@ class DatagridRow extends Component {
     coomponentDidUpdate = (prevProps, prevState) => {
         const colSpan = this.computeColSpan(this.props);
         if (colSpan !== prevState.colSpan) {
-            this.setState({ colspan });
+            this.setState({ colSpan });
         }
     };
 

--- a/packages/ra-ui-materialui/src/list/FilterButton.js
+++ b/packages/ra-ui-materialui/src/list/FilterButton.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import Menu from '@material-ui/core/Menu';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ContentFilter from '@material-ui/icons/FilterList';
 import classnames from 'classnames';
 import compose from 'recompose/compose';
@@ -11,9 +11,9 @@ import { translate } from 'ra-core';
 import FilterButtonMenuItem from './FilterButtonMenuItem';
 import Button from '../button/Button';
 
-const styles = {
+const styles = createStyles({
     root: { display: 'inline-block' },
-};
+});
 
 export class FilterButton extends Component {
     constructor(props) {

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import classnames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import compose from 'recompose/compose';
 import withProps from 'recompose/withProps';
 import lodashSet from 'lodash/set';
 
 import FilterFormInput from './FilterFormInput';
 
-const styles = ({ palette: { primary1Color } }) => ({
+const styles = theme => createStyles({
     form: {
         marginTop: '-10px',
         paddingTop: 0,
@@ -19,7 +19,7 @@ const styles = ({ palette: { primary1Color } }) => ({
     },
     body: { display: 'flex', alignItems: 'flex-end' },
     spacer: { width: '1em' },
-    icon: { color: primary1Color || '#00bcd4', paddingBottom: 0 },
+    icon: { color: theme.palette.primary1Color || '#00bcd4', paddingBottom: 0 },
     clearFix: { clear: 'right' },
 });
 

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -26,7 +26,7 @@ const FilterFormInput = ({
                 className="hide-filter"
                 onClick={handleHide}
                 data-key={filterElement.props.source}
-                tooltip={translate('ra.action.remove_filter')}
+                title={translate('ra.action.remove_filter')}
             >
                 <ActionHide />
             </IconButton>

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -16,6 +16,7 @@ const FilterFormInput = ({
     classes,
     resource,
     translate,
+    locale,
 }) => (
     <div
         data-source={filterElement.props.source}
@@ -48,6 +49,7 @@ FilterFormInput.propTypes = {
     handleHide: PropTypes.func,
     classes: PropTypes.object,
     resource: PropTypes.string,
+    locale: PropTypes.string,
     translate: PropTypes.func,
 };
 

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
 import classnames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { ListController, getListControllerProps } from 'ra-core';
 
 import Title from '../layout/Title';
@@ -14,7 +14,7 @@ import BulkActionsToolbar from './BulkActionsToolbar';
 import DefaultActions from './ListActions';
 import defaultTheme from '../defaultTheme';
 
-export const styles = {
+export const styles = createStyles({
     root: {
         display: 'flex',
     },
@@ -34,7 +34,7 @@ export const styles = {
         alignSelf: 'flex-start',
     },
     noResults: { padding: 20 },
-};
+});
 
 const sanitizeRestProps = ({
     actions,

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -1,5 +1,5 @@
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
-import React from 'react';
+import React, { isValidElement, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
 import classnames from 'classnames';
@@ -98,12 +98,12 @@ const sanitizeRestProps = ({
 
 export const ListView = ({
     // component props
-    actions = <DefaultActions />,
+    actions,
     aside,
     filters,
     bulkActions, // deprecated
-    bulkActionButtons = <DefaultBulkActionButtons />,
-    pagination = <DefaultPagination />,
+    bulkActionButtons,
+    pagination,
     // overridable by user
     children,
     className,
@@ -140,17 +140,17 @@ export const ListView = ({
                 )}
                 <div key={version}>
                     {children &&
-                        React.cloneElement(children, {
+                        cloneElement(Children.only(children), {
                             ...controllerProps,
                             hasBulkActions:
                                 bulkActions !== false &&
                                 bulkActionButtons !== false,
                         })}
                     {pagination &&
-                        React.cloneElement(pagination, controllerProps)}
+                        cloneElement(pagination, controllerProps)}
                 </div>
             </Card>
-            {aside && React.cloneElement(aside, controllerProps)}
+            {aside && cloneElement(aside, controllerProps)}
         </div>
     );
 };
@@ -200,7 +200,10 @@ ListView.propTypes = {
 };
 
 ListView.defaultProps = {
+    actions: <DefaultActions />,
     classes: {},
+    bulkActionButtons: <DefaultBulkActionButtons />,
+    pagination: <DefaultPagination />,
 };
 
 /**

--- a/packages/ra-ui-materialui/src/list/ListToolbar.js
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Toolbar from '@material-ui/core/Toolbar';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
-const styles = {
+const styles = createStyles({
     toolbar: {
         justifyContent: 'space-between',
     },
-};
+});
 
 const ListToolbar = ({
-    classes = {},
+    classes,
     filters,
     actions,
     bulkActions,
@@ -41,6 +41,10 @@ ListToolbar.propTypes = {
     actions: PropTypes.element,
     bulkActions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     exporter: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+};
+
+ListToolbar.defaultProps = {
+    classes: {},
 };
 
 export default withStyles(styles)(ListToolbar);

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
 import Button from '@material-ui/core/Button';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const styles = theme => ({
+const styles = theme => createStyles({
     actions: {
         flexShrink: 0,
         color: theme.palette.text.secondary,

--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -7,17 +7,17 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItemText from '@material-ui/core/ListItemText';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import { linkToRecord, sanitizeListRestProps } from 'ra-core';
 
-const styles = {
+const styles = createStyles({
     link: {
         textDecoration: 'none',
         color: 'inherit',
     },
     tertiary: { float: 'right', opacity: 0.541176 },
-};
+});
 
 const LinkOrNot = withStyles(styles)(
     ({ classes, linkType, basePath, id, children }) =>

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.js
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.js
@@ -1,15 +1,15 @@
-import React, { cloneElement, Component } from 'react';
+import React, { cloneElement, Component, Children } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import LinearProgress from '@material-ui/core/LinearProgress';
-import { withStyles } from '@material-ui/core/styles';
+import { createStyles, withStyles } from '@material-ui/core/styles';
 import { linkToRecord } from 'ra-core';
 
 import Link from '../Link';
 
-const styles = {
+const styles = createStyles({
     root: { display: 'flex', flexWrap: 'wrap' },
-};
+});
 
 // useful to prevent click bubbling in a datagrid with rowClick
 const stopPropagation = e => e.stopPropagation();
@@ -95,7 +95,7 @@ export class SingleFieldList extends Component {
                                 to={resourceLinkPath}
                                 onClick={stopPropagation}
                             >
-                                {cloneElement(children, {
+                                {cloneElement(Children.only(children), {
                                     record: data[id],
                                     resource,
                                     basePath,
@@ -106,7 +106,7 @@ export class SingleFieldList extends Component {
                         );
                     }
 
-                    return cloneElement(children, {
+                    return cloneElement(Children.only(children), {
                         key: id,
                         record: data[id],
                         resource,

--- a/packages/ra-ui-materialui/src/list/listFieldTypes.js
+++ b/packages/ra-ui-materialui/src/list/listFieldTypes.js
@@ -79,7 +79,7 @@ ${children.map(child => `            ${child.getRepresentation()}`).join('\n')}
         component: props => <TextField source="id" {...props} />, // eslint-disable-line react/display-name
         representation: () => `<TextField source="id" />`,
     },
-    richText: false, // never display a rich text field in a datagrid
+    richText: undefined, // never display a rich text field in a datagrid
     string: {
         component: TextField,
         representation: props => `<TextField source="${props.source}" />`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,13 +799,26 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0-beta.42":
-  version "7.0.0-beta.51"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.51.tgz#48b8ed18307034c6620f643514650ca2ccc0165a"
-  integrity sha1-SLjtGDBwNMZiD2Q1FGUMoszAFlo=
+"@babel/runtime@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
+  integrity sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==
   dependencies:
-    core-js "^2.5.7"
-    regenerator-runtime "^0.11.1"
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@7.0.0-rc.1":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-rc.1.tgz#42f36fc5817911c89ea75da2b874054922967616"
+  integrity sha512-Nifv2kwP/nwR39cAOasNxzjYfpeuf/ZbZNtQz5eYxWTC9yHARU9wItFnAwz1GTZ62MU+AtSjzZPMbLK5Q9hmbg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.2.0":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  dependencies:
+    regenerator-runtime "^0.12.0"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -912,12 +925,12 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@material-ui/core@^1.4.0", "@material-ui/core@~1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.4.0.tgz#e535fef84576b096c46e1fb7d6c4c61895155fd3"
-  integrity sha512-Jymq67Hp9XbtzsENkpSl6DeG99wOdNhUCJnnEGcxSlGGBrERRkZxzVRkt4+2v1OyAD8+9NCK3hOOa7DH4Cl4zA==
+"@material-ui/core@^1.5.1", "@material-ui/core@~1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.5.1.tgz#cb00cb934447ae688e08129f1dab55f54d29d87a"
+  integrity sha512-hGT0JelWZGZqgWZzRbON/uqFCgWa4XhmEFG/IEd9SBwCU4sWC99Kv1KpywLhYYWecobqT4Dh7ijO1ZaIAk8HyA==
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.42"
+    "@babel/runtime" "7.0.0-rc.1"
     "@types/jss" "^9.5.3"
     "@types/react-transition-group" "^2.0.8"
     brcast "^3.0.1"
@@ -937,13 +950,12 @@
     jss-vendor-prefixer "^7.0.0"
     keycode "^2.1.9"
     normalize-scroll-left "^0.1.2"
-    popper.js "^1.0.0"
+    popper.js "^1.14.1"
     prop-types "^15.6.0"
-    react-event-listener "^0.6.0"
+    react-event-listener "^0.6.2"
     react-jss "^8.1.0"
     react-transition-group "^2.2.1"
-    recompose "^0.27.0"
-    scroll "^2.0.3"
+    recompose "^0.28.0"
     warning "^4.0.1"
 
 "@material-ui/icons@^1.0.0", "@material-ui/icons@~1.1.0":
@@ -6806,7 +6818,7 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-global@^4.3.0, global@~4.3.0:
+global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
@@ -11068,10 +11080,10 @@ pnp-webpack-plugin@1.1.0:
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.1.0.tgz#947a96d1db94bb5a1fc014d83b581e428699ac8c"
   integrity sha512-CPCdcFxx7fEcDMWTDjXe2Wypt4JuMt4q5Q2UrpTcyBBkLiCIyPEh/mCGmUWIcNkKGyXwQ9Y2wVhlKm6ketiBNQ==
 
-popper.js@^1.0.0:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
-  integrity sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU=
+popper.js@^1.14.1:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.7.tgz#e31ec06cfac6a97a53280c3e55e4e0c860e7738e"
+  integrity sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==
 
 portfinder@^1.0.9:
   version "1.0.13"
@@ -11983,13 +11995,6 @@ raf@3.4.0, raf@^3.3.0, raf@^3.4.0, raf@~3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
-rafl@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/rafl/-/rafl-1.2.2.tgz#fe930f758211020d47e38815f5196a8be4150740"
-  integrity sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=
-  dependencies:
-    global "~4.3.0"
-
 railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
@@ -12167,14 +12172,14 @@ react-error-overlay@^5.0.5:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.5.tgz#716ff1a92fda76bb89a39adf9ce046a5d740e71a"
   integrity sha512-ab0HWBgxdIsngHtMGU8+8gYFdTBXpUGd4AE4lN2VZvOIlBmWx9dtaWEViihuGSIGosCKPeHCnzFoRWB42UtnLg==
 
-react-event-listener@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.0.tgz#f8cf2821f5ca1844e0df1dac1c7b9a3ecb686fd7"
-  integrity sha512-CqewJSQ/0p09oPZ9BABNvoFhGMhUAuLQ4B4skPsZXxxgOBx+2SP3AgM9lP7zc68pRmJXlCQBDjgOAQsp1jnhAQ==
+react-event-listener@^0.6.2:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.6.tgz#758f7b991cad9086dd39fd29fad72127e1d8962a"
+  integrity sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.42"
+    "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
-    warning "^3.0.0"
+    warning "^4.0.1"
 
 react-headroom@^2.2.4:
   version "2.2.4"
@@ -12535,12 +12540,24 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-"recompose@^0.26.0 || ^0.27.0", recompose@^0.27.0, recompose@^0.27.1:
+"recompose@^0.26.0 || ^0.27.0", recompose@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.1.tgz#1a49e931f183634516633bbb4f4edbfd3f38a7ba"
   integrity sha512-p7xsyi/rfNjHfdP7vPU02uSFa+Q1eHhjKrvO+3+kRP4Ortj+MxEmpmd+UQtBGM2D2iNAjzNI5rCyBKp9Ob5McA==
   dependencies:
     babel-runtime "^6.26.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
+recompose@^0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
+  integrity sha512-baVNKQBQAAAuLRnv6Cb/6/j59a1BVj6c6Pags1KXVyRB0yPfQVUZtuAUnqHDBXoR8iXPrLGWE4RNtCQ/AaRP3g==
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.56"
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"
@@ -13190,13 +13207,6 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
   integrity sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=
-
-scroll@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/scroll/-/scroll-2.0.3.tgz#0951b785544205fd17753bc3d294738ba16fc2ab"
-  integrity sha512-3ncZzf8gUW739h3LeS68nSssO60O+GGjT3SxzgofQmT8PIoyHzebql9HHPJopZX8iT6TKOdwaWFMqL6LzUN3DQ==
-  dependencies:
-    rafl "~1.2.1"
 
 section-iterator@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,7 +933,7 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@material-ui/core@^1.5.1", "@material-ui/core@~1.5.1":
+"@material-ui/core@^1.4.0", "@material-ui/core@~1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.5.1.tgz#cb00cb934447ae688e08129f1dab55f54d29d87a"
   integrity sha512-hGT0JelWZGZqgWZzRbON/uqFCgWa4XhmEFG/IEd9SBwCU4sWC99Kv1KpywLhYYWecobqT4Dh7ijO1ZaIAk8HyA==
@@ -966,7 +966,7 @@
     recompose "^0.28.0"
     warning "^4.0.1"
 
-"@material-ui/icons@^1.1.1", "@material-ui/icons@~1.1.1":
+"@material-ui/icons@^1.0.0", "@material-ui/icons@~1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.1.1.tgz#f104d6a1ac4d3ff34a2bed74b066986b2a7054a5"
   integrity sha512-d7I2P1Td4S/1zMAYCIrVQVf+6NUZC5fcIuo0wTrKe/mKxYo9eQ+83lPesI9aBAh+ZTQTjPTqoIvm0WD5e+0uKQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,6 +799,14 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
+  integrity sha512-iOGRzUoONLOtmCvjUsZv3mZzgCT6ljHQY5fr1qG1QIiJQwtM7zbPWGGpa3QWETq+UqwWyJnoi5XZDZRwZDFciQ==
+  dependencies:
+    core-js "^2.5.3"
+    regenerator-runtime "^0.11.1"
+
 "@babel/runtime@7.0.0-beta.56":
   version "7.0.0-beta.56"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
@@ -958,11 +966,12 @@
     recompose "^0.28.0"
     warning "^4.0.1"
 
-"@material-ui/icons@^1.0.0", "@material-ui/icons@~1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.1.0.tgz#4d025df7b0ba6ace8d6710079ed76013a4d26595"
-  integrity sha512-Z4Xo/EYXuVqCIOjLw7AeBJPtJZsgy9dMAdqu6uYr7gxAefFA8L/QukLv/XE5ByxKYvRhzFG/AjA2OKXwKqfXBQ==
+"@material-ui/icons@^1.1.1", "@material-ui/icons@~1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.1.1.tgz#f104d6a1ac4d3ff34a2bed74b066986b2a7054a5"
+  integrity sha512-d7I2P1Td4S/1zMAYCIrVQVf+6NUZC5fcIuo0wTrKe/mKxYo9eQ+83lPesI9aBAh+ZTQTjPTqoIvm0WD5e+0uKQ==
   dependencies:
+    "@babel/runtime" "7.0.0-beta.42"
     recompose "^0.26.0 || ^0.27.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -4390,6 +4399,11 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
+core-js@^2.5.3:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
I locally added the `checkJs` option to the package `tsconfig.json` file (not commited). This gives us the opportunity to fix many issues before starting the migration to TS.

- [x] Use `createStyles`
- [x] Check `isValidElement` before cloning where necessary
- [x] Use `Children.only` before cloning when necessary
- [x] Update `material-ui` to `1.5.1` (which we already use on many projects anyway)
- [x] Fix all other possible errors