### PR TITLE
Fix DeleteWithConfirmButton

### DIFF
--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
@@ -56,8 +56,7 @@ class DeleteWithConfirmButton extends Component {
         this.setState({ isOpen: false });
     };
 
-    handleDelete = event => {
-        event.stopPropagation();
+    handleDelete = () => {
         const { crudDelete, resource, record, basePath, redirect } = this.props;
         crudDelete(resource, record.id, record, basePath, redirect);
     };


### PR DESCRIPTION
A late refactoring in Confirm introduced a bug in the DeleteWithConfirm button: the function called upon confirm doesn't receive any event. So clicking on "confirm" on the dialog raised an error and made the deletion impossible:

> Uncaught TypeError: Cannot read property 'stopPropagation' of undefined

![image](https://user-images.githubusercontent.com/99944/54237488-648bee80-4516-11e9-8bde-9f14f1068223.png)
