### PR TITLE
Fix ra-data-graphql-simple handling of UPDATE mutations

### DIFF
--- a/examples/demo/src/dataProvider/graphql.js
+++ b/examples/demo/src/dataProvider/graphql.js
@@ -1,35 +1,67 @@
-import buildApolloClient from 'ra-data-graphql-simple';
+import buildApolloClient, { buildQuery as buildQueryFactory } from 'ra-data-graphql-simple';
+import { DELETE } from 'ra-core';
+import gql from 'graphql-tag';
+const getGqlResource = resource => {
+    switch (resource) {
+        case 'customers':
+            return 'Customer';
+
+        case 'categories':
+            return 'Category';
+
+        case 'commands':
+            return 'Command';
+
+        case 'products':
+            return 'Product';
+
+        case 'reviews':
+            return 'Review';
+
+        case 'invoices':
+            return 'Invoice';
+
+        default:
+            throw new Error(`Unknown resource ${resource}`);
+    }
+};
+
+const customBuildQuery = introspectionResults => {
+    const buildQuery = buildQueryFactory(introspectionResults);
+
+    return (type, resource, params) => {
+        if (type === DELETE) {
+            return {
+                query: gql`mutation remove${resource}($id: ID!) {
+                    remove${resource}(id: $id)
+                }`,
+                variables: { id: params.id },
+                parseResponse: ({ data }) => {
+                    if (data[`remove${resource}`]) {
+                        return { data: { id: params.id } };
+                    }
+
+                    throw new Error(`Could not delete ${resource}`);
+                }
+            }
+        }
+
+        return buildQuery(type, resource, params);
+    }
+}
 
 export default () => {
-    const getGqlResource = resource => {
-        switch (resource) {
-            case 'customers':
-                return 'Customer';
-
-            case 'categories':
-                return 'Category';
-
-            case 'commands':
-                return 'Command';
-
-            case 'products':
-                return 'Product';
-
-            case 'reviews':
-                return 'Review';
-
-            case 'invoices':
-                return 'Invoice';
-
-            default:
-                throw new Error(`Unknown resource ${resource}`);
-        }
-    };
 
     return buildApolloClient({
         clientOptions: {
             uri: 'http://localhost:4000/graphql',
         },
+        introspection: {
+            operationNames: {
+                [DELETE]: resource => `remove${resource.name}`
+            }
+        },
+        buildQuery: customBuildQuery
     }).then(dataProvider => (type, resource, params) =>
         dataProvider(type, getGqlResource(resource), params)
     );

--- a/packages/ra-data-graphcool/src/buildQuery.js
+++ b/packages/ra-data-graphcool/src/buildQuery.js
@@ -26,7 +26,7 @@ export const buildQueryFactory = (
 
         if (!queryType) {
             throw new Error(
-                `No query or mutation matching aor fetch type ${aorFetchType} could be found for resource ${
+                `No query or mutation matching fetch type ${aorFetchType} could be found for resource ${
                     resource.type.name
                 }`
             );

--- a/packages/ra-data-graphcool/src/buildQuery.test.js
+++ b/packages/ra-data-graphcool/src/buildQuery.test.js
@@ -24,7 +24,7 @@ describe('buildQuery', () => {
         expect(() =>
             buildQueryFactory()(introspectionResults)('CREATE', 'Post')
         ).toThrow(
-            'No query or mutation matching aor fetch type CREATE could be found for resource Post'
+            'No query or mutation matching fetch type CREATE could be found for resource Post'
         );
     });
 

--- a/packages/ra-data-graphql-simple/src/buildQuery.js
+++ b/packages/ra-data-graphql-simple/src/buildQuery.js
@@ -26,7 +26,7 @@ export const buildQueryFactory = (
 
         if (!queryType) {
             throw new Error(
-                `No query or mutation matching aor fetch type ${aorFetchType} could be found for resource ${
+                `No query or mutation matching fetch type ${aorFetchType} could be found for resource ${
                     resource.type.name
                 }`
             );

--- a/packages/ra-data-graphql-simple/src/buildQuery.test.js
+++ b/packages/ra-data-graphql-simple/src/buildQuery.test.js
@@ -24,7 +24,7 @@ describe('buildQuery', () => {
         expect(() =>
             buildQueryFactory()(introspectionResults)('CREATE', 'Post')
         ).toThrow(
-            'No query or mutation matching aor fetch type CREATE could be found for resource Post'
+            'No query or mutation matching fetch type CREATE could be found for resource Post'
         );
     });
 

--- a/packages/ra-data-graphql-simple/src/index.js
+++ b/packages/ra-data-graphql-simple/src/index.js
@@ -18,7 +18,7 @@ export default options => {
                 if (fetchType === DELETE_MANY) {
                     const { ids, ...otherParams } = params;
                     return Promise.all(
-                        params.ids.map(id =>
+                        ids.map(id =>
                             defaultDataProvider(DELETE, resource, {
                                 id,
                                 ...otherParams,
@@ -36,11 +36,14 @@ export default options => {
                 // This provider does not support multiple deletions so instead we send multiple UPDATE requests
                 // This can be optimized using the apollo-link-batch-http link
                 if (fetchType === UPDATE_MANY) {
-                    const { ids, ...otherParams } = params;
+                    const { ids, data, ...otherParams } = params;
                     return Promise.all(
-                        params.ids.map(id =>
+                        ids.map(id =>
                             defaultDataProvider(UPDATE, resource, {
-                                id,
+                                data: {
+                                    id,
+                                    ...data,
+                                },
                                 ...otherParams,
                             })
                         )

--- a/packages/ra-data-graphql/src/index.js
+++ b/packages/ra-data-graphql/src/index.js
@@ -78,15 +78,15 @@ export default async options => {
     const buildQuery = buildQueryFactory(introspectionResults, otherOptions);
 
     const raDataProvider = (aorFetchType, resource, params) => {
-        const overridedbuildQuery = get(
+        const overriddenBuildQuery = get(
             override,
             `${resource}.${aorFetchType}`
         );
 
-        const { parseResponse, ...query } = overridedbuildQuery
+        const { parseResponse, ...query } = overriddenBuildQuery
             ? {
                   ...buildQuery(aorFetchType, resource, params),
-                  ...overridedbuildQuery(params),
+                  ...overriddenBuildQuery(params),
               }
             : buildQuery(aorFetchType, resource, params);
 


### PR DESCRIPTION
- [x] Fix `ra-data-graphql-simple` handling of `UPDATE` mutations
- [x] Fix error messages still referring to aor
- [x] Fix type in `ra-data-graphql` variable name
- [x] Fix graphql demo as it needs to override `DELETE` requests

Fixes #2776 