### PR TITLE
Fix AutocompleteInput crashes when a choice doesn't have a string value

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -180,7 +180,7 @@ export class AutocompleteInput extends React.Component {
         const suggestionLabel =
             typeof optionText === 'function'
                 ? optionText(suggestion)
-                : get(suggestion, optionText);
+                : get(suggestion, optionText, '');
 
         // We explicitly call toString here because AutoSuggest expect a string
         return translateChoice


### PR DESCRIPTION
Closes #2991