### PR TITLE
[RFR] Update documentation with German translation package

### DIFF
--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -82,7 +82,7 @@ You can find translation packages for the following languages:
 - Farsi (`fa`): [hamidfzm/ra-language-farsi](https://github.com/hamidfzm/ra-language-farsi)
 - Finnish (`fi`): [aikain/ra-language-finnish](https://github.com/aikain/ra-language-finnish)
 - French (`fr`): [marmelab/ra-language-french](https://github.com/marmelab/react-admin/tree/master/packages/ra-language-french)
-- German (`de`): [greenbananaCH/ra-language-german](https://github.com/greenbananaCH/ra-language-german)
+- German (`de`): [greenbananaCH/ra-language-german](https://github.com/greenbananaCH/ra-language-german) (tree translation: [straurob/ra-tree-language-german](https://github.com/straurob/ra-tree-language-german))
 - Hungarian (`hu`): [phelion/ra-language-hungarian](https://github.com/phelion/ra-language-hungarian)
 - Indonesian (`id`): [ronadi/ra-language-indonesian](https://github.com/ronadi/ra-language-indonesian)
 - Italian (`it`): [stefsava/ra-italian](https://github.com/stefsava/ra-italian)


### PR DESCRIPTION
This PR adds a link to the translation section. It refers to a new standalone package for the German translations of the ra-tree-ui-materialui package as propsed in PR #2998.

Due to problems with my local repo I had to recreate the fork. Thus, PR #3011 is obsolete and can be continued here.