### PR TITLE
Fix RichTextInput toolbar PropsType

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -18,7 +18,14 @@ export class RichTextInput extends Component {
         meta: PropTypes.object,
         options: PropTypes.object,
         source: PropTypes.string,
-        toolbar: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
+        toolbar: PropTypes.oneOfType([
+            PropTypes.array,
+            PropTypes.bool,
+            PropTypes.shape({
+                container: PropTypes.array,
+                handlers: PropTypes.object,
+            }),
+        ]),
         fullWidth: PropTypes.bool,
     };
 


### PR DESCRIPTION
Closes #3022 

Enhancing toolbar Proptypes to accept [quill container and handlers](https://quilljs.com/docs/modules/toolbar/)