### PR TITLE
Fixed wrong scalar types into variables for ra-data-graphql-simple

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -210,7 +210,7 @@ export default introspectionResults => (
     params,
     queryType
 ) => {
-    const preparedParams = prepareParams(params, queryType);
+    const preparedParams = prepareParams(params, queryType, introspectionResults);
 
     switch (aorFetchType) {
         case GET_LIST: {

--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -24,49 +24,59 @@ const sanitizeValue = (type, value) => {
 };
 
 const castType = (value, type) => {
-  switch (`${type.kind}:${type.name}`) {
-    case 'SCALAR:Int':
-      return Number(value);
-    case 'SCALAR:String':
-      return String(value);
-    case 'SCALAR:Boolean':
-      return Boolean(value);
-    default:
-      return value;
-  }
+    switch (`${type.kind}:${type.name}`) {
+        case "SCALAR:Int":
+            return Number(value);
+
+        case "SCALAR:String":
+            return String(value);
+
+        case "SCALAR:Boolean":
+            return Boolean(value);
+
+        default:
+            return value;
+    }
 };
 
 const prepareParams = (params, queryType, introspectionResults) => {
-  const result = {};
-
-  Object.keys(params).forEach(key => {
-    const param = params[key];
-    let arg = null;
-
-    if (queryType && Array.isArray(queryType.args)) {
-      arg = queryType.args.find(item => item.name === key)
-    }
-
-    if (param instanceof Object && !Array.isArray(param) && arg && arg.type.kind === 'INPUT_OBJECT') {
-      const args = introspectionResults.types.find(i => i.kind === arg.type.kind && i.name === arg.type.name).inputFields;
-      result[key] = prepareParams(param, { args }, introspectionResults);
-      return;
-    }
-
-    if (param instanceof Object && !Array.isArray(param)) {
-      result[key] = prepareParams(param, queryType, introspectionResults);
-      return;
-    }
-
-    if (!arg) {
-      result[key] = param;
-      return;
-    }
-
-    result[key] = castType(param, arg.type, introspectionResults.types);
-  });
-
-  return result;
+    const result = {};
+  
+    Object.keys(params).forEach(key => {
+        const param = params[key];
+        let arg = null;
+    
+        if (queryType && Array.isArray(queryType.args)) {
+            arg = queryType.args.find(item => item.name === key);
+        }
+    
+        if (
+            param instanceof Object &&
+            !Array.isArray(param) &&
+            arg &&
+            arg.type.kind === "INPUT_OBJECT"
+        ) {
+            const args = introspectionResults.types.find(
+                item => item.kind === arg.type.kind && item.name === arg.type.name
+            ).inputFields;
+            result[key] = prepareParams(param, { args }, introspectionResults);
+            return;
+        }
+    
+        if (param instanceof Object && !Array.isArray(param)) {
+            result[key] = prepareParams(param, queryType, introspectionResults);
+            return;
+        }
+    
+        if (!arg) {
+            result[key] = param;
+            return;
+        }
+    
+        result[key] = castType(param, arg.type, introspectionResults.types);
+    });
+  
+    return result;
 };
 
 const buildGetListVariables = introspectionResults => (

--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -42,9 +42,18 @@ const castType = (value, type) => {
 const prepareParams = (params, queryType, introspectionResults) => {
     const result = {};
 
+    if (!params) {
+        return params;
+    }
+
     Object.keys(params).forEach(key => {
         const param = params[key];
         let arg = null;
+
+        if (!param) {
+            result[key] = param;
+            return;
+        }
 
         if (queryType && Array.isArray(queryType.args)) {
             arg = queryType.args.find(item => item.name === key);

--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -41,15 +41,20 @@ const castType = (value, type) => {
 
 const prepareParams = (params, queryType, introspectionResults) => {
     const result = {};
-  
+
     Object.keys(params).forEach(key => {
         const param = params[key];
         let arg = null;
-    
+
         if (queryType && Array.isArray(queryType.args)) {
             arg = queryType.args.find(item => item.name === key);
         }
-    
+
+        if (param instanceof File) {
+            result[key] = param;
+            return;
+        }
+
         if (
             param instanceof Object &&
             !Array.isArray(param) &&
@@ -62,20 +67,20 @@ const prepareParams = (params, queryType, introspectionResults) => {
             result[key] = prepareParams(param, { args }, introspectionResults);
             return;
         }
-    
+
         if (param instanceof Object && !Array.isArray(param)) {
             result[key] = prepareParams(param, queryType, introspectionResults);
             return;
         }
-    
+
         if (!arg) {
             result[key] = param;
             return;
         }
-    
+
         result[key] = castType(param, arg.type, introspectionResults.types);
     });
-  
+
     return result;
 };
 

--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -24,42 +24,45 @@ const sanitizeValue = (type, value) => {
 };
 
 const castType = (value, type) => {
-    if (type.kind !== 'SCALAR') {
-        return value;
-    }
-
-    switch (type.name) {
-        case 'Int':
-            return Number(value);
-        case 'String':
-            return String(value);
-        case 'Boolean':
-            return Boolean(value);
-        default:
-            return value;
-    }
+  switch (`${type.kind}:${type.name}`) {
+    case 'SCALAR:Int':
+      return Number(value);
+    case 'SCALAR:String':
+      return String(value);
+    case 'SCALAR:Boolean':
+      return Boolean(value);
+    default:
+      return value;
+  }
 };
 
-const prepareParams = (params, queryType) => {
-    const result = {};
+const prepareParams = (params, queryType, introspectionResults) => {
+  const result = {};
 
-    Object.keys(params).forEach(key => {
-        const param = params[key];
-        if (param instanceof Object) {
-            result[key] = prepareParams(param, queryType);
-            return;
-        }
+  Object.keys(params).forEach(key => {
+    const param = params[key];
+    const arg = queryType.args.find(item => item.name === key);
 
-        const arg = queryType.args.find(item => item.name === key);
-        if (!arg) {
-            result[key] = param;
-            return;
-        }
+    if (param instanceof Object && !Array.isArray(param) && arg && arg.type.kind === 'INPUT_OBJECT') {
+      const args = introspectionResults.types.find(i => i.kind === arg.type.kind && i.name === arg.type.name).inputFields;
+      result[key] = prepareParams(param, { args }, introspectionResults);
+      return;
+    }
 
-        result[key] = castType(param, arg.type);
-    });
+    if (param instanceof Object && !Array.isArray(param)) {
+      result[key] = prepareParams(param, queryType, introspectionResults);
+      return;
+    }
 
-    return result;
+    if (!arg) {
+      result[key] = param;
+      return;
+    }
+
+    result[key] = castType(param, arg.type, introspectionResults.types);
+  });
+
+  return result;
 };
 
 const buildGetListVariables = introspectionResults => (

--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -41,7 +41,11 @@ const prepareParams = (params, queryType, introspectionResults) => {
 
   Object.keys(params).forEach(key => {
     const param = params[key];
-    const arg = queryType.args.find(item => item.name === key);
+    let arg = null;
+
+    if (queryType && Array.isArray(queryType.args)) {
+      arg = queryType.args.find(item => item.name === key)
+    }
 
     if (param instanceof Object && !Array.isArray(param) && arg && arg.type.kind === 'INPUT_OBJECT') {
       const args = introspectionResults.types.find(i => i.kind === arg.type.kind && i.name === arg.type.name).inputFields;


### PR DESCRIPTION
The fix for GraphQL version 14.0.0+ related scalar value coercion. The current version doesn't work correctly. GraphQL changes: https://www.libupdate.com/libs/1c88bd1e-024d-41aa-9241-c29cd6d5f0c5