### PR TITLE
Support URI for ImageField source

### DIFF
--- a/packages/ra-ui-materialui/src/field/ImageField.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.js
@@ -1,8 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import get from 'lodash/get';
-import { withStyles, createStyles } from '@material-ui/core/styles';
+import { createStyles, withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
+import get from 'lodash/get';
+import PropTypes from 'prop-types';
+import React from 'react';
+
 import sanitizeRestProps from './sanitizeRestProps';
 
 const styles = createStyles({
@@ -25,7 +26,9 @@ export const ImageField = ({
     title,
     ...rest
 }) => {
-    const sourceValue = get(record, source) || source;
+    const looksLikeUri = /^https?:\/\//i.test(source);
+    const sourceDefault = looksLikeUri && source;
+    const sourceValue = get(record, source) || sourceDefault;
     if (!sourceValue) {
         return <div className={className} {...sanitizeRestProps(rest)} />;
     }

--- a/packages/ra-ui-materialui/src/field/ImageField.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.js
@@ -38,7 +38,7 @@ export const ImageField = ({
             >
                 {sourceValue.map((file, index) => {
                     const titleValue = get(file, title) || title;
-                    const srcValue = get(file, src) || title;
+                    const srcValue = get(file, src) || src;
 
                     return (
                         <li key={index}>

--- a/packages/ra-ui-materialui/src/field/ImageField.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.js
@@ -38,7 +38,7 @@ export const ImageField = ({
             >
                 {sourceValue.map((file, index) => {
                     const titleValue = get(file, title) || title;
-                    const srcValue = get(file, src) || src;
+                    const srcValue = get(file, src) || title;
 
                     return (
                         <li key={index}>

--- a/packages/ra-ui-materialui/src/field/ImageField.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.js
@@ -25,7 +25,7 @@ export const ImageField = ({
     title,
     ...rest
 }) => {
-    const sourceValue = get(record, source);
+    const sourceValue = get(record, source) || source;
     if (!sourceValue) {
         return <div className={className} {...sanitizeRestProps(rest)} />;
     }

--- a/packages/ra-ui-materialui/src/field/ImageField.spec.js
+++ b/packages/ra-ui-materialui/src/field/ImageField.spec.js
@@ -65,6 +65,21 @@ describe('<ImageField />', () => {
         assert.equal(img.prop('title'), 'Hello world!');
     });
 
+    it('should allow setting static URI as source', () => {
+        const wrapper = shallow(
+            <ImageField
+                record={{}}
+                source="http://foo.com/bar.jpg"
+                title="Hello world!"
+            />
+        );
+
+        const img = wrapper.find('img');
+        assert.equal(img.prop('src'), 'http://foo.com/bar.jpg');
+        assert.equal(img.prop('alt'), 'Hello world!');
+        assert.equal(img.prop('title'), 'Hello world!');
+    });
+
     it('should render a list of images with correct attributes based on `src` and `title`', () => {
         const wrapper = shallow(
             <ImageField


### PR DESCRIPTION
I was trying to use `<ImageField>` with a full URI, but was unable to.  ~After looking at the source it looks like this should be possible with lists, but there is a bug.~  For single images, it looks like it's not possible.  So two commits here:

- ~Fix src default for lists~
- Try to default src for non-lists

**Update:**

Looks like my understanding of the list logic was wrong so I revered that commit. I also updated the full URI option to be more backwards compatible and added a test.

**Side Note:** The docs on contributing might need to be updated. I'm having a hard time getting all of the tests to pass locally. Getting a handful of `ra-data-graphql` failures.