### PR TITLE
Fix custom actions cannot override basePath

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -72,6 +72,7 @@ export const CreateView = ({
                         basePath,
                         resource,
                         hasList,
+                        ...actions.props,
                     })}
                 </CardContentInner>
             )}

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -92,6 +92,7 @@ export const EditView = ({
                             hasShow,
                             hasList,
                             resource,
+                            ...actions.props
                         })}
                     </CardContentInner>
                 )}

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -86,6 +86,7 @@ export const ShowView = ({
                             hasList,
                             hasEdit,
                             resource,
+                            ...actions.props
                         })}
                     </CardContentInner>
                 )}

--- a/packages/ra-ui-materialui/src/list/ListToolbar.js
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.js
@@ -31,6 +31,7 @@ const ListToolbar = ({
                 bulkActions,
                 exporter,
                 filters,
+                ...actions.props
             })}
     </Toolbar>
 );


### PR DESCRIPTION
Previously, it was impossible to write: `<Show basePath="/foo" actions={<ShowActions basePath="/foo/bar" />} />` because we were not tolerating `props` on `DefaultActions`, making the API/props useless/broken.