### PR TITLE
fix Flex Layout to allow subcomponents to shrink

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -36,12 +36,14 @@ const styles = theme => createStyles({
     contentWithSidebar: {
         display: 'flex',
         flexGrow: 1,
+        minWidth: 0,
     },
     content: {
         display: 'flex',
         flexDirection: 'column',
         flexGrow: 1,
         flexBasis: 0,
+        minWidth: 0,
         padding: theme.spacing.unit * 3,
         [theme.breakpoints.up('xs')]: {
             paddingLeft: 5,


### PR DESCRIPTION
Please refer to : 
https://dfmcphee.com/flex-items-and-min-width-0/
By default, flex items won’t shrink below their minimum content size, you need to force it with a min-width:0
https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored