### PR TITLE
[RFR] Allow <Query> to pass all results from dataProvider

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -349,6 +349,34 @@ const UserProfile = ({ record }) => (
 ```
 {% endraw %}
 
+Or a user list on the dashboard:
+
+{% raw %}
+```jsx
+const payload = {
+   pagination: { page: 1, perPage: 10 },
+   sort: { field: 'username', order: 'ASC' },
+};
+
+const UserList = () => (
+    <Query type="GET_LIST" resource="users" payload={payload}>
+        {({ data, total, loading, error }) => {
+            if (loading) { return <Loading />; }
+            if (error) { return <p>ERROR</p>; }
+            return (
+                <div>
+                    <p>Total users: {total}</p>
+                    <ul>
+                        {data.map(user => <li key={user.username}>{user.username}</li>)}
+                    </ul>
+                </div>
+            );
+        }}
+    </Query>
+);
+```
+{% endraw %}
+
 Just like the `dataProvider` injected prop, the `<Query>` component expects three parameters: `type`, `resource`, and `payload`. It fetches the data provider on mount, and passes the data to its child component once the response from the API arrives.
 
 The `<Query>` component is designed to read data from the API. When calling the API to update ("mutate") data, use the `<Mutation>` component instead. It passes a callback to trigger the API call to its child function. And the `<ApproveButton>` component from previous sections is a great use case for demonstrating `<Mutation>`:

--- a/packages/ra-core/src/util/Query.tsx
+++ b/packages/ra-core/src/util/Query.tsx
@@ -1,15 +1,11 @@
 import { Component, ReactNode } from 'react';
 import withDataProvider from './withDataProvider';
 
-type DataProviderCallback = (
-    type: string,
-    resource: string,
-    payload?: any,
-    options?: any
-) => Promise<any>;
+type DataProviderCallback = (type: string, resource: string, payload?: any, options?: any) => Promise<any>;
 
 interface ChildrenFuncParams {
     data?: any;
+    total?: number;
     loading: boolean;
     error?: any;
 }
@@ -28,6 +24,7 @@ interface Props extends RawProps {
 
 interface State {
     data?: any;
+    total?: number;
     loading: boolean;
     error?: any;
 }
@@ -46,27 +43,52 @@ interface State {
  *         }}
  *     </Query>
  * );
+ *
+ * @example
+ *
+ * const payload = {
+ *    pagination: { page: 1, perPage: 10 },
+ *    sort: { field: 'username', order: 'ASC' },
+ * };
+ * const UserList = () => (
+ *     <Query type="GET_LIST" resource="users" payload={payload}>
+ *         {({ data, total, loading, error }) => {
+ *             if (loading) { return <Loading />; }
+ *             if (error) { return <p>ERROR</p>; }
+ *             return (
+ *                 <div>
+ *                     <p>Total users: {total}</p>
+ *                     <ul>
+ *                         {data.map(user => <li key={user.username}>{user.username}</li>)}
+ *                     </ul>
+ *                 </div>
+ *             );
+ *         }}
+ *     </Query>
+ * );
  */
 class Query extends Component<Props, State> {
     state = {
         data: null,
+        total: null,
         loading: true,
-        error: null,
+        error: null
     };
 
     componentDidMount = () => {
         const { dataProvider, type, resource, payload, options } = this.props;
         dataProvider(type, resource, payload, options)
-            .then(({ data }) => {
+            .then(({ data, total }) => {
                 this.setState({
                     data,
-                    loading: false,
+                    total,
+                    loading: false
                 });
             })
             .catch(error => {
                 this.setState({
                     error,
-                    loading: false,
+                    loading: false
                 });
             });
     };


### PR DESCRIPTION
As explained on [the documentation](https://marmelab.com/react-admin/DataProviders.html#response-format), the dataProvider can return two keys `data` and `total`:

![image](https://user-images.githubusercontent.com/1819833/54866611-5fc90500-4d76-11e9-9005-090d6a126a5f.png)

As of now, `<Query>` can only return `data`, and this is very restrictive, especially when dealing with lists or references.

This PR aims to pass the prop `total` with the data, but also test and document the usage of <Query> with lists.