### PR TITLE
[RFR] Replace withDataProvider by Query on demo dashboard

### DIFF
--- a/examples/demo/src/dashboard/CustomerAvatar.js
+++ b/examples/demo/src/dashboard/CustomerAvatar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Query, GET_ONE } from 'react-admin';
+
+import Avatar from '@material-ui/core/Avatar';
+
+const CustomerAvatar = ({ record, classes }) => {
+    if (!record.customer_id) {
+        return <Avatar />;
+    }
+
+    return (
+        <Query type={GET_ONE} resource="customers" payload={{ id: record.customer_id }}>
+            {({ data }) => <Avatar src={data ? `${data.avatar}?size=32x32` : null} className={classes.avatar} />}
+        </Query>
+    );
+};
+
+export default CustomerAvatar;

--- a/examples/demo/src/dashboard/Dashboard.js
+++ b/examples/demo/src/dashboard/Dashboard.js
@@ -1,7 +1,5 @@
-import React, { Component } from 'react';
-import { GET_LIST, GET_MANY, Responsive, withDataProvider } from 'react-admin';
-import compose from 'recompose/compose';
-import { connect } from 'react-redux';
+import React from 'react';
+import { Responsive } from 'react-admin';
 
 import Welcome from './Welcome';
 import MonthlyRevenue from './MonthlyRevenue';
@@ -15,217 +13,64 @@ const styles = {
     flexColumn: { display: 'flex', flexDirection: 'column' },
     leftCol: { flex: 1, marginRight: '1em' },
     rightCol: { flex: 1, marginLeft: '1em' },
-    singleCol: { marginTop: '2em', marginBottom: '2em' },
+    singleCol: { marginTop: '2em', marginBottom: '2em' }
 };
 
-class Dashboard extends Component {
-    state = {};
-
-    componentDidMount() {
-        this.fetchData();
-    }
-
-    componentDidUpdate(prevProps) {
-        // handle refresh
-        if (this.props.version !== prevProps.version) {
-            this.fetchData();
-        }
-    }
-
-    fetchData() {
-        this.fetchOrders();
-        this.fetchReviews();
-        this.fetchCustomers();
-    }
-
-    async fetchOrders() {
-        const { dataProvider } = this.props;
-        const aMonthAgo = new Date();
-        aMonthAgo.setDate(aMonthAgo.getDate() - 30);
-        const { data: recentOrders } = await dataProvider(
-            GET_LIST,
-            'commands',
-            {
-                filter: { date_gte: aMonthAgo.toISOString() },
-                sort: { field: 'date', order: 'DESC' },
-                pagination: { page: 1, perPage: 50 },
-            }
-        );
-        const aggregations = recentOrders
-            .filter(order => order.status !== 'cancelled')
-            .reduce(
-                (stats, order) => {
-                    if (order.status !== 'cancelled') {
-                        stats.revenue += order.total;
-                        stats.nbNewOrders++;
-                    }
-                    if (order.status === 'ordered') {
-                        stats.pendingOrders.push(order);
-                    }
-                    return stats;
-                },
-                {
-                    revenue: 0,
-                    nbNewOrders: 0,
-                    pendingOrders: [],
-                }
-            );
-        this.setState({
-            revenue: aggregations.revenue.toLocaleString(undefined, {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0,
-            }),
-            nbNewOrders: aggregations.nbNewOrders,
-            pendingOrders: aggregations.pendingOrders,
-        });
-        const { data: customers } = await dataProvider(GET_MANY, 'customers', {
-            ids: aggregations.pendingOrders.map(order => order.customer_id),
-        });
-        this.setState({
-            pendingOrdersCustomers: customers.reduce((prev, customer) => {
-                prev[customer.id] = customer; // eslint-disable-line no-param-reassign
-                return prev;
-            }, {}),
-        });
-    }
-
-    async fetchReviews() {
-        const { dataProvider } = this.props;
-        const { data: reviews } = await dataProvider(GET_LIST, 'reviews', {
-            filter: { status: 'pending' },
-            sort: { field: 'date', order: 'DESC' },
-            pagination: { page: 1, perPage: 100 },
-        });
-        const nbPendingReviews = reviews.reduce(nb => ++nb, 0);
-        const pendingReviews = reviews.slice(0, Math.min(10, reviews.length));
-        this.setState({ pendingReviews, nbPendingReviews });
-        const { data: customers } = await dataProvider(GET_MANY, 'customers', {
-            ids: pendingReviews.map(review => review.customer_id),
-        });
-        this.setState({
-            pendingReviewsCustomers: customers.reduce((prev, customer) => {
-                prev[customer.id] = customer; // eslint-disable-line no-param-reassign
-                return prev;
-            }, {}),
-        });
-    }
-
-    async fetchCustomers() {
-        const { dataProvider } = this.props;
-        const aMonthAgo = new Date();
-        aMonthAgo.setDate(aMonthAgo.getDate() - 30);
-        const { data: newCustomers } = await dataProvider(
-            GET_LIST,
-            'customers',
-            {
-                filter: {
-                    has_ordered: true,
-                    first_seen_gte: aMonthAgo.toISOString(),
-                },
-                sort: { field: 'first_seen', order: 'DESC' },
-                pagination: { page: 1, perPage: 100 },
-            }
-        );
-        this.setState({
-            newCustomers,
-            nbNewCustomers: newCustomers.reduce(nb => ++nb, 0),
-        });
-    }
-
-    render() {
-        const {
-            nbNewCustomers,
-            nbNewOrders,
-            nbPendingReviews,
-            newCustomers,
-            pendingOrders,
-            pendingOrdersCustomers,
-            pendingReviews,
-            pendingReviewsCustomers,
-            revenue,
-        } = this.state;
-        return (
-            <Responsive
-                xsmall={
-                    <div>
-                        <div style={styles.flexColumn}>
-                            <div style={{ marginBottom: '2em' }}>
-                                <Welcome />
-                            </div>
-                            <div style={styles.flex}>
-                                <MonthlyRevenue value={revenue} />
-                                <NbNewOrders value={nbNewOrders} />
-                            </div>
-                            <div style={styles.singleCol}>
-                                <PendingOrders
-                                    orders={pendingOrders}
-                                    customers={pendingOrdersCustomers}
-                                />
-                            </div>
-                        </div>
+const Dashboard = () => (
+    <Responsive
+        xsmall={
+            <div>
+                <div style={styles.flexColumn}>
+                    <div style={{ marginBottom: '2em' }}>
+                        <Welcome />
                     </div>
-                }
-                small={
-                    <div style={styles.flexColumn}>
-                        <div style={styles.singleCol}>
-                            <Welcome />
-                        </div>
-                        <div style={styles.flex}>
-                            <MonthlyRevenue value={revenue} />
-                            <NbNewOrders value={nbNewOrders} />
-                        </div>
-                        <div style={styles.singleCol}>
-                            <PendingOrders
-                                orders={pendingOrders}
-                                customers={pendingOrdersCustomers}
-                            />
-                        </div>
-                    </div>
-                }
-                medium={
                     <div style={styles.flex}>
-                        <div style={styles.leftCol}>
-                            <div style={styles.flex}>
-                                <MonthlyRevenue value={revenue} />
-                                <NbNewOrders value={nbNewOrders} />
-                            </div>
-                            <div style={styles.singleCol}>
-                                <Welcome />
-                            </div>
-                            <div style={styles.singleCol}>
-                                <PendingOrders
-                                    orders={pendingOrders}
-                                    customers={pendingOrdersCustomers}
-                                />
-                            </div>
-                        </div>
-                        <div style={styles.rightCol}>
-                            <div style={styles.flex}>
-                                <PendingReviews
-                                    nb={nbPendingReviews}
-                                    reviews={pendingReviews}
-                                    customers={pendingReviewsCustomers}
-                                />
-                                <NewCustomers
-                                    nb={nbNewCustomers}
-                                    visitors={newCustomers}
-                                />
-                            </div>
-                        </div>
+                        <MonthlyRevenue />
+                        <NbNewOrders />
                     </div>
-                }
-            />
-        );
-    }
-}
+                    <div style={styles.singleCol}>
+                        <PendingOrders />
+                    </div>
+                </div>
+            </div>
+        }
+        small={
+            <div style={styles.flexColumn}>
+                <div style={styles.singleCol}>
+                    <Welcome />
+                </div>
+                <div style={styles.flex}>
+                    <MonthlyRevenue />
+                    <NbNewOrders />
+                </div>
+                <div style={styles.singleCol}>
+                    <PendingOrders />
+                </div>
+            </div>
+        }
+        medium={
+            <div style={styles.flex}>
+                <div style={styles.leftCol}>
+                    <div style={styles.flex}>
+                        <MonthlyRevenue />
+                        <NbNewOrders />
+                    </div>
+                    <div style={styles.singleCol}>
+                        <Welcome />
+                    </div>
+                    <div style={styles.singleCol}>
+                        <PendingOrders />
+                    </div>
+                </div>
+                <div style={styles.rightCol}>
+                    <div style={styles.flex}>
+                        <PendingReviews />
+                        <NewCustomers />
+                    </div>
+                </div>
+            </div>
+        }
+    />
+);
 
-const mapStateToProps = state => ({
-    version: state.admin.ui.viewVersion,
-});
-
-export default compose(
-    connect(mapStateToProps),
-    withDataProvider
-)(Dashboard);
+export default Dashboard;

--- a/examples/demo/src/dashboard/MonthlyRevenue.js
+++ b/examples/demo/src/dashboard/MonthlyRevenue.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import compose from 'recompose/compose';
+import { translate, Query, GET_LIST } from 'react-admin';
+
 import Card from '@material-ui/core/Card';
 import DollarIcon from '@material-ui/icons/AttachMoney';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import { translate } from 'react-admin';
 
 import CardIcon from './CardIcon';
 
@@ -12,15 +13,26 @@ const styles = {
     main: {
         flex: '1',
         marginRight: '1em',
-        marginTop: 20,
+        marginTop: 20
     },
     card: {
         overflow: 'inherit',
         textAlign: 'right',
         padding: 16,
-        minHeight: 52,
-    },
+        minHeight: 52
+    }
 };
+
+const aMonthAgo = new Date();
+aMonthAgo.setDate(aMonthAgo.getDate() - 30);
+const payload = {
+    filter: { date_gte: aMonthAgo.toISOString() },
+    sort: { field: 'date', order: 'DESC' },
+    pagination: { page: 1, perPage: 50 }
+};
+
+const recentOrdersToMonthlyRevenue = orders =>
+    orders.filter(order => order.status !== 'cancelled').reduce((revenue, order) => revenue + order.total, 0);
 
 const MonthlyRevenue = ({ value, translate, classes }) => (
     <div className={classes.main}>
@@ -29,9 +41,19 @@ const MonthlyRevenue = ({ value, translate, classes }) => (
             <Typography className={classes.title} color="textSecondary">
                 {translate('pos.dashboard.monthly_revenue')}
             </Typography>
-            <Typography variant="headline" component="h2">
-                {value}
-            </Typography>
+            <Query type={GET_LIST} resource="commands" payload={payload}>
+                {({ data }) => (
+                    <Typography variant="headline" component="h2">
+                        {data &&
+                            recentOrdersToMonthlyRevenue(data).toLocaleString(undefined, {
+                                style: 'currency',
+                                currency: 'USD',
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 0
+                            })}
+                    </Typography>
+                )}
+            </Query>
         </Card>
     </div>
 );

--- a/examples/demo/src/dashboard/NbNewOrders.js
+++ b/examples/demo/src/dashboard/NbNewOrders.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import compose from 'recompose/compose';
+import { translate, Query, GET_LIST } from 'react-admin';
+
 import Card from '@material-ui/core/Card';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import { translate } from 'react-admin';
 
 import CardIcon from './CardIcon';
 
@@ -12,26 +13,38 @@ const styles = {
     main: {
         flex: '1',
         marginLeft: '1em',
-        marginTop: 20,
+        marginTop: 20
     },
     card: {
         overflow: 'inherit',
         textAlign: 'right',
         padding: 16,
-        minHeight: 52,
-    },
+        minHeight: 52
+    }
 };
 
-const NbNewOrders = ({ value, translate, classes }) => (
+const aMonthAgo = new Date();
+aMonthAgo.setDate(aMonthAgo.getDate() - 30);
+const payload = {
+    filter: { date_gte: aMonthAgo.toISOString() },
+    sort: { field: 'date', order: 'DESC' },
+    pagination: { page: 1, perPage: 50 }
+};
+
+const NbNewOrders = ({ translate, classes }) => (
     <div className={classes.main}>
         <CardIcon Icon={ShoppingCartIcon} bgColor="#ff9800" />
         <Card className={classes.card}>
             <Typography className={classes.title} color="textSecondary">
                 {translate('pos.dashboard.new_orders')}
             </Typography>
-            <Typography variant="headline" component="h2">
-                {value}
-            </Typography>
+            <Query type={GET_LIST} resource="commands" payload={payload}>
+                {({ data: orders }) => (
+                    <Typography variant="headline" component="h2">
+                        {orders && orders.filter(order => order.status !== 'cancelled').length}
+                    </Typography>
+                )}
+            </Query>
         </Card>
     </div>
 );

--- a/examples/demo/src/dashboard/NewCustomers.js
+++ b/examples/demo/src/dashboard/NewCustomers.js
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import compose from 'recompose/compose';
+import { Link } from 'react-router-dom';
+import { translate, Query, GET_LIST } from 'react-admin';
+
 import Card from '@material-ui/core/Card';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -9,8 +12,6 @@ import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import CustomerIcon from '@material-ui/icons/PersonAdd';
 import Divider from '@material-ui/core/Divider';
-import { Link } from 'react-router-dom';
-import { translate } from 'react-admin';
 
 import CardIcon from './CardIcon';
 
@@ -18,62 +19,68 @@ const styles = theme => ({
     main: {
         flex: '1',
         marginLeft: '1em',
-        marginTop: 20,
+        marginTop: 20
     },
     card: {
         padding: '16px 0',
         overflow: 'inherit',
-        textAlign: 'right',
+        textAlign: 'right'
     },
     title: {
-        padding: '0 16px',
+        padding: '0 16px'
     },
     value: {
         padding: '0 16px',
-        minHeight: 48,
+        minHeight: 48
     },
     avatar: {
-        background: theme.palette.background.avatar,
+        background: theme.palette.background.avatar
     },
     listItemText: {
-        paddingRight: 0,
-    },
+        paddingRight: 0
+    }
 });
 
-const NewCustomers = ({ visitors = [], nb, translate, classes }) => (
+const aMonthAgo = new Date();
+aMonthAgo.setDate(aMonthAgo.getDate() - 30);
+const payload = {
+    filter: {
+        has_ordered: true,
+        first_seen_gte: aMonthAgo.toISOString()
+    },
+    sort: { field: 'first_seen', order: 'DESC' },
+    pagination: { page: 1, perPage: 100 }
+};
+
+const NewCustomers = ({ translate, classes }) => (
     <div className={classes.main}>
         <CardIcon Icon={CustomerIcon} bgColor="#4caf50" />
         <Card className={classes.card}>
             <Typography className={classes.title} color="textSecondary">
                 {translate('pos.dashboard.new_customers')}
             </Typography>
-            <Typography
-                variant="headline"
-                component="h2"
-                className={classes.value}
-            >
-                {nb}
-            </Typography>
-            <Divider />
-            <List>
-                {visitors.map(record => (
-                    <ListItem
-                        button
-                        to={`/customers/${record.id}`}
-                        component={Link}
-                        key={record.id}
-                    >
-                        <Avatar
-                            src={`${record.avatar}?size=32x32`}
-                            className={classes.avatar}
-                        />
-                        <ListItemText
-                            primary={`${record.first_name} ${record.last_name}`}
-                            className={classes.listItemText}
-                        />
-                    </ListItem>
-                ))}
-            </List>
+            <Query type={GET_LIST} resource="customers" payload={payload}>
+                {({ total, data: customers }) => (
+                    <Fragment>
+                        <Typography variant="headline" component="h2" className={classes.value}>
+                            {total}
+                        </Typography>
+                        <Divider />
+                        <List>
+                            {customers &&
+                                customers.map(record => (
+                                    <ListItem button to={`/customers/${record.id}`} component={Link} key={record.id}>
+                                        <Avatar src={`${record.avatar}?size=32x32`} className={classes.avatar} />
+                                        <ListItemText
+                                            primary={`${record.first_name} ${record.last_name}`}
+                                            className={classes.listItemText}
+                                        />
+                                    </ListItem>
+                                ))}
+                        </List>
+                    </Fragment>
+                )}
+            </Query>
         </Card>
     </div>
 );

--- a/examples/demo/src/dashboard/PendingOrders.js
+++ b/examples/demo/src/dashboard/PendingOrders.js
@@ -1,68 +1,71 @@
 import React from 'react';
 import compose from 'recompose/compose';
+import { Link } from 'react-router-dom';
+import { translate, Query, GET_LIST, GET_ONE } from 'react-admin';
+
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItemText from '@material-ui/core/ListItemText';
-import Avatar from '@material-ui/core/Avatar';
 import { withStyles } from '@material-ui/core/styles';
-import { Link } from 'react-router-dom';
-import { translate } from 'react-admin';
+
+import CustomerAvatar from './CustomerAvatar';
 
 const style = theme => ({
     root: {
-        flex: 1,
+        flex: 1
     },
     avatar: {
-        background: theme.palette.background.avatar,
+        background: theme.palette.background.avatar
     },
     cost: {
         marginRight: '1em',
-        color: theme.palette.text.primary,
-    },
+        color: theme.palette.text.primary
+    }
 });
 
-const PendingOrders = ({ orders = [], customers = {}, translate, classes }) => (
+const aMonthAgo = new Date();
+aMonthAgo.setDate(aMonthAgo.getDate() - 30);
+const payload = {
+    filter: { status: 'ordered', date_gte: aMonthAgo.toISOString() },
+    sort: { field: 'date', order: 'DESC' },
+    pagination: { page: 1, perPage: 50 }
+};
+
+const PendingOrders = ({ translate, classes }) => (
     <Card className={classes.root}>
         <CardHeader title={translate('pos.dashboard.pending_orders')} />
-        <List dense={true}>
-            {orders.map(record => (
-                <ListItem
-                    key={record.id}
-                    button
-                    component={Link}
-                    to={`/commands/${record.id}`}
-                >
-                    {customers[record.customer_id] ? (
-                        <Avatar
-                            className={classes.avatar}
-                            src={`${
-                                customers[record.customer_id].avatar
-                            }?size=32x32`}
-                        />
-                    ) : (
-                        <Avatar />
-                    )}
-                    <ListItemText
-                        primary={new Date(record.date).toLocaleString('en-GB')}
-                        secondary={translate('pos.dashboard.order.items', {
-                            smart_count: record.basket.length,
-                            nb_items: record.basket.length,
-                            customer_name: customers[record.customer_id]
-                                ? `${
-                                      customers[record.customer_id].first_name
-                                  } ${customers[record.customer_id].last_name}`
-                                : '',
-                        })}
-                    />
-                    <ListItemSecondaryAction>
-                        <span className={classes.cost}>{record.total}$</span>
-                    </ListItemSecondaryAction>
-                </ListItem>
-            ))}
-        </List>
+        <Query type={GET_LIST} resource="commands" payload={payload}>
+            {({ data: orders }) => (
+                <List dense={true}>
+                    {orders &&
+                        orders.map(record => (
+                            <ListItem key={record.id} button component={Link} to={`/commands/${record.id}`}>
+                                <CustomerAvatar record={record} classes={classes} />
+                                <Query type={GET_ONE} resource="customers" payload={{ id: record.customer_id }}>
+                                    {({ data: customer }) => (
+                                        <ListItemText
+                                            primary={new Date(record.date).toLocaleString('en-GB')}
+                                            secondary={translate('pos.dashboard.order.items', {
+                                                smart_count: record.basket.length,
+                                                nb_items: record.basket.length,
+                                                customer_name: customer
+                                                    ? `${customer.first_name} ${customer.last_name}`
+                                                    : ''
+                                            })}
+                                        />
+                                    )}
+                                </Query>
+                                <ListItemSecondaryAction>
+                                    <span className={classes.cost}>{record.total}$</span>
+                                </ListItemSecondaryAction>
+                            </ListItem>
+                        ))}
+                </List>
+            )}
+        </Query>
     </Card>
 );
 

--- a/examples/demo/src/dashboard/PendingReviews.js
+++ b/examples/demo/src/dashboard/PendingReviews.js
@@ -1,18 +1,19 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import compose from 'recompose/compose';
+import { Link } from 'react-router-dom';
+import { translate, Query, GET_LIST } from 'react-admin';
+
 import Card from '@material-ui/core/Card';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import Avatar from '@material-ui/core/Avatar';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import CommentIcon from '@material-ui/icons/Comment';
 import Divider from '@material-ui/core/Divider';
-import { Link } from 'react-router-dom';
-import { translate } from 'react-admin';
 
 import CardIcon from './CardIcon';
+import CustomerAvatar from './CustomerAvatar';
 
 import StarRatingField from '../reviews/StarRatingField';
 
@@ -20,89 +21,77 @@ const styles = theme => ({
     main: {
         flex: '1',
         marginRight: '1em',
-        marginTop: 20,
+        marginTop: 20
     },
     titleLink: { textDecoration: 'none', color: 'inherit' },
     card: {
         padding: '16px 0',
         overflow: 'inherit',
-        textAlign: 'right',
+        textAlign: 'right'
     },
     title: {
-        padding: '0 16px',
+        padding: '0 16px'
     },
     value: {
         padding: '0 16px',
-        minHeight: 48,
+        minHeight: 48
     },
     avatar: {
-        background: theme.palette.background.avatar,
+        background: theme.palette.background.avatar
     },
     listItemText: {
         overflowY: 'hidden',
         height: '4em',
         display: '-webkit-box',
         WebkitLineClamp: 2,
-        WebkitBoxOrient: 'vertical',
-    },
+        WebkitBoxOrient: 'vertical'
+    }
 });
 
 const location = {
     pathname: 'reviews',
-    query: { filter: JSON.stringify({ status: 'pending' }) },
+    query: { filter: JSON.stringify({ status: 'pending' }) }
 };
 
-const PendingReviews = ({
-    reviews = [],
-    customers = {},
-    nb,
-    translate,
-    classes,
-}) => (
+const payload = {
+    filter: { status: 'pending' },
+    sort: { field: 'date', order: 'DESC' },
+    pagination: { page: 1, perPage: 100 }
+};
+
+const PendingReviews = ({ translate, classes }) => (
     <div className={classes.main}>
         <CardIcon Icon={CommentIcon} bgColor="#f44336" />
         <Card className={classes.card}>
             <Typography className={classes.title} color="textSecondary">
                 {translate('pos.dashboard.pending_reviews')}
             </Typography>
-            <Typography
-                variant="headline"
-                component="h2"
-                className={classes.value}
-            >
-                <Link to={location} className={classes.titleLink}>
-                    {nb}
-                </Link>
-            </Typography>
-            <Divider />
-            <List>
-                {reviews.map(record => (
-                    <ListItem
-                        key={record.id}
-                        button
-                        component={Link}
-                        to={`/reviews/${record.id}`}
-                    >
-                        {customers[record.customer_id] ? (
-                            <Avatar
-                                src={`${
-                                    customers[record.customer_id].avatar
-                                }?size=32x32`}
-                                className={classes.avatar}
-                            />
-                        ) : (
-                            <Avatar />
-                        )}
-
-                        <ListItemText
-                            primary={<StarRatingField record={record} />}
-                            secondary={record.comment}
-                            className={classes.listItemText}
-                            style={{ paddingRight: 0 }}
-                        />
-                    </ListItem>
-                ))}
-            </List>
+            <Query type={GET_LIST} resource="reviews" payload={payload}>
+                {({ data: reviews, total }) => (
+                    <Fragment>
+                        <Typography variant="headline" component="h2" className={classes.value}>
+                            <Link to={location} className={classes.titleLink}>
+                                {total}
+                            </Link>
+                        </Typography>
+                        <Divider />
+                        <List>
+                            {reviews &&
+                                reviews.map(record => (
+                                    <ListItem key={record.id} button component={Link} to={`/reviews/${record.id}`}>
+                                        <CustomerAvatar record={record} classes={classes} />
+                                        <ListItemText
+                                            primary={<StarRatingField record={record} />}
+                                            secondary={record.comment}
+                                            className={classes.listItemText}
+                                            style={{ paddingRight: 0 }}
+                                        />
+                                    </ListItem>
+                                ))}
+                        </List>
+                    </Fragment>
+                )}
+            </Query>
         </Card>
     </div>
 );


### PR DESCRIPTION
Replace all the dataprovider usage on the demo dashboard by the `<Query>` component.

**Pros**
- Make the code more readable
- Suggests a better pattern to new users
- Test the `<Query>` component on a "real" usage

**Cons**
- Do a lot more requests (but can be memoized)
- No longer suggest how to use the `withDataProvider` HOC