### PR TITLE
[RFR] Pluralize the confirmation message in BulkDeleteWithConfirmButton

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.js
@@ -106,7 +106,7 @@ class BulkDeleteWithConfirmButton extends Component {
                     translateOptions={{
                         smart_count: selectedIds.length,
                         name: inflection.humanize(
-                            inflection.singularize(resource),
+                            inflection.inflect(resource, selectedIds.length),
                             true
                         ),
                     }}


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/3040
Follows https://github.com/marmelab/react-admin/pull/2955
 
We use to singularize the confirm message in the `BulkDeleteWithConfirmButton` component. But we often select more than one component. The solution is to use [inflect](https://github.com/dreamerslab/node.inflection#inflectioninflect-str-count-singular-plural-) to select wisely between pluralize or singularize.

## Todo

- [x] Use `inflect` instead of `singularize` in the `BulkDeleteWithConfirmButton` component

![Sélection_005](https://user-images.githubusercontent.com/5584839/54991706-cab84d00-4fbd-11e9-9e1c-c5149e1817e0.png)

![Sélection_006](https://user-images.githubusercontent.com/5584839/54991714-cbe97a00-4fbd-11e9-98ef-419ebe8103aa.png)
