### PR TITLE
fix: expand icon overlaps actions in tree view

### DIFF
--- a/packages/ra-tree-ui-materialui/src/TreeNode.js
+++ b/packages/ra-tree-ui-materialui/src/TreeNode.js
@@ -8,6 +8,7 @@ const styles = theme => ({
     expandIcon: {
         margin: 0,
         left: -theme.spacing.unit * 6,
+        right: "auto" /* fix for material-ui 3 */
     },
     root: {
         alignItems: 'baseline',


### PR DESCRIPTION
On certain material-ui versions, the expand icon stretches the whole TreeNode width, because we set it to `left: ...` but material-ui sets it to `right: ...`.

I am force to use 3.9.2, but this was already the case in the used version 1.4.0.

This is fixed in material-ui 4 in this commit: https://github.com/mui-org/material-ui/commit/7b0f7d5afae78303c43545573bd1433094921e7e

until then, setting `right: auto` on the expandIcon in the TreeNode will fix it for every version