### PR TITLE
Prevent ra-data-graphql-simple from circular dependencies issue

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.js
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.js
@@ -7,7 +7,7 @@ import getFinalType from './getFinalType';
 import isList from './isList';
 import isRequired from './isRequired';
 
-export const buildFields = introspectionResults => fields =>
+export const buildFields = (introspectionResults, path = []) => fields =>
     fields.reduce((acc, field) => {
         const type = getFinalType(field.type);
 
@@ -40,7 +40,9 @@ export const buildFields = introspectionResults => fields =>
             t => t.name === type.name
         );
 
-        if (linkedType) {
+        if (linkedType && !path.includes(linkedType.name)) {
+            path.push(linkedType.name);
+
             return [
                 ...acc,
                 gqlTypes.field(
@@ -49,7 +51,7 @@ export const buildFields = introspectionResults => fields =>
                     null,
                     null,
                     gqlTypes.selectionSet(
-                        buildFields(introspectionResults)(linkedType.fields)
+                        buildFields(introspectionResults, path)(linkedType.fields)
                     )
                 ),
             ];

--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.test.js
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.test.js
@@ -175,6 +175,55 @@ describe('buildFields', () => {
     });
 });
 
+describe('buildFieldsWithCircularDependency', () => {
+    it('returns an object with the fields to retrieve', () => {
+        const introspectionResults = {
+            resources: [{ type: { name: 'resourceType' } }],
+            types: [
+                {
+                    name: 'linkedType',
+                    fields: [
+                        {
+                            name: 'id',
+                            type: { kind: TypeKind.SCALAR, name: 'ID' },
+                        },
+                        {
+                            name: 'child',
+                            type: { kind: TypeKind.OBJECT, name: 'linkedType' },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const fields = [
+            { type: { kind: TypeKind.SCALAR, name: 'ID' }, name: 'id' },
+            {
+                type: { kind: TypeKind.SCALAR, name: '_internalField' },
+                name: 'foo1',
+            },
+            {
+                type: { kind: TypeKind.OBJECT, name: 'linkedType' },
+                name: 'linked',
+            },
+            {
+                type: { kind: TypeKind.OBJECT, name: 'resourceType' },
+                name: 'resource',
+            },
+        ];
+
+        expect(print(buildFields(introspectionResults)(fields))).toEqual([
+            'id',
+            `linked {
+  id
+}`,
+            `resource {
+  id
+}`,
+        ]);
+    });
+});
+
 describe('buildGqlQuery', () => {
     const introspectionResults = {
         resources: [{ type: { name: 'resourceType' } }],


### PR DESCRIPTION
The path prevents the `buildFields` method from circular dependencies, so that `linkedTypes` are only processed if they aren't  analyzed before.