### PR TITLE
[RFR] Turn data generator for demo into a public repository

### DIFF
--- a/examples/data-generator/LICENSE.md
+++ b/examples/data-generator/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019-present, Francois Zaninotto, Marmelab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/data-generator/README.md
+++ b/examples/data-generator/README.md
@@ -1,0 +1,96 @@
+# Fake Data Generator for Retail
+
+Generates a large JSON object full of fake data for simulating the backend of a poster shop. 
+
+Used to simulate a REST / GraphQL backend in [react-admin](https://github.com/marmelab/react-admin). To get a glimpse of the test data, browse the [react-admin demo](https://marmelab.com/react-admin-demo/#/).
+
+[![react-admin-demo](https://marmelab.com/react-admin/img/react-admin-demo-still.png)](https://vimeo.com/268958716)
+
+## Usage
+
+```js
+import generator from 'data-generator-retail';
+
+const data = generateData();
+// now do whatever you want with the data...
+console.log(data);
+{
+    customers: [ /* ...900 customers */],
+    categories: [ /* ...12 categories */],
+    products: [ /* ...120 products */],
+    commands: [ /* ...600 orders */],
+    invoices: [ /* ...about 500 invoices */],
+    reviews: [ /* ... */],
+}
+```
+
+## Data schema
+
+- customers
+  - id: integer
+  - first_name: string
+  - last_name: string
+  - email: string
+  - address: string
+  - zipcode: string
+  - city: string
+  - avatar: string
+  - birthday: date
+  - first_seen: date
+  - last_seen: date
+  - has_ordered: boolean
+  - latest_purchase
+  - has_newsletter: boolean
+  - groups: array
+  - nb_commands: integer
+  - total_spent: integer
+- categories
+  - id: number
+  - name: string
+- products
+  - id: integer
+  - category_id: integer
+  - reference: string
+  - width: float
+  - height: float
+  - price: float
+  - thumbnail: string
+  - image: string
+  - description: string
+  - stock: integer
+- commands
+  - id: integer
+  - reference: string
+  - date: date
+  - customer_id: integer
+  - basket: [{ product_id: integer, quantity: integer }]
+  - total_ex_taxes: float
+  - delivery_fees: float
+  - tax_rate: float
+  - taxes: float
+  - total: float
+  - status: 'ordered' | 'delivered' | 'canceled'
+  - returned: boolean
+- invoices
+  - id: integer
+  - date: date
+  - command_id: integer
+  - customer_id: integer
+  - total_ex_taxes: float
+  - delivery_fees: float
+  - tax_rate: float
+  - taxes: float
+  - total: float
+- reviews
+  - id: integer
+  - date: date
+  - status: 'pending' | 'accepted' | 'rejected'
+  - command_id: integer
+  - product_id: integer
+  - customer_id: integer
+  - rating: integer
+  - comment: string
+
+## Licence
+
+Data Generator for Retail is licensed under the [MIT License](https://github.com/marmelab/react-admin/blob/master/LICENSE.md), sponsored and supported by [marmelab](http://marmelab.com).

--- a/examples/data-generator/package.json
+++ b/examples/data-generator/package.json
@@ -1,7 +1,9 @@
 {
-    "name": "data-generator",
+    "name": "data-generator-retail",
     "version": "2.7.1",
-    "private": true,
+    "homepage": "https://github.com/marmelab/react-admin/tree/master/examples/data-generator",
+    "bugs": "https://github.com/marmelab/react-admin/issues",
+    "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@material-ui/core": "~1.5.1",
         "@material-ui/icons": "~1.1.1",
-        "data-generator": "^2.4.0",
+        "data-generator-retail": "^2.7.0",
         "fakerest": "~2.1.0",
         "fetch-mock": "~6.3.0",
         "json-graphql-server": "~2.1.3",

--- a/examples/demo/src/fakeServer/graphql.js
+++ b/examples/demo/src/fakeServer/graphql.js
@@ -1,5 +1,5 @@
 import JsonGraphqlServer from 'json-graphql-server';
-import generateData from 'data-generator';
+import generateData from 'data-generator-retail';
 import fetchMock from 'fetch-mock';
 
 export default () => {

--- a/examples/demo/src/fakeServer/rest.js
+++ b/examples/demo/src/fakeServer/rest.js
@@ -1,6 +1,6 @@
 import FakeRest from 'fakerest';
 import fetchMock from 'fetch-mock';
-import generateData from 'data-generator';
+import generateData from 'data-generator-retail';
 
 export default () => {
     const data = generateData({ serializeDate: true });


### PR DESCRIPTION
## Rationale

- When learning react-admin, developers often need a fake API. jsonplaceholder isn't perfect (it doesn't accept mutations), so developers use JSONServer or json-graphql-server, but they need data.
- The demo doesn't run on CodeSandbox as is because of the dependency to an internal package. Having the demo run in CodeSandbox would ease bug reports
- Who doesn't need fake data?  