### PR TITLE
Fix unnecessary update of ra-input-rich-text on edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "jest": "^23.6.0",
         "lerna": "~2.9.1",
         "lolex": "~2.3.2",
+        "mutationobserver-shim": "^0.3.3",
         "prettier": "~1.16.4",
         "raf": "~3.4.0",
         "ts-jest": "^23.10.5",

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -10,6 +10,8 @@ import { withStyles } from '@material-ui/core/styles';
 import styles from './styles';
 
 export class RichTextInput extends Component {
+    lastValueChange = null;
+
     static propTypes = {
         addLabel: PropTypes.bool.isRequired,
         classes: PropTypes.object,
@@ -56,6 +58,10 @@ export class RichTextInput extends Component {
         this.quill.on('text-change', debounce(this.onTextChange, 500));
     }
 
+    shouldComponentUpdate(nextProps) {
+        return nextProps.input.value !== this.lastValueChange;
+    }
+
     componentDidUpdate(prevProps) {
         if (prevProps.input.value !== this.props.input.value) {
             const selection = this.quill.getSelection();
@@ -76,6 +82,7 @@ export class RichTextInput extends Component {
     onTextChange = () => {
         const value =
             this.editor.innerHTML == '<p><br></p>' ? '' : this.editor.innerHTML;
+        this.lastValueChange = value;
         this.props.input.onChange(value);
     };
 
@@ -91,7 +98,7 @@ export class RichTextInput extends Component {
                 fullWidth={this.props.fullWidth}
                 className="ra-rich-text-input"
             >
-                <div ref={this.updateDivRef} />
+                <div data-testid="quill" ref={this.updateDivRef} />
                 {error && <FormHelperText error>{error}</FormHelperText>}
                 {helperText && <FormHelperText>{helperText}</FormHelperText>}
             </FormControl>

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import debounce from 'lodash/debounce';
+import {render, fireEvent, waitForElement, cleanup, getByTestId} from 'react-testing-library'
+
+import { RichTextInput } from './index';
+
+let container;
+
+jest.mock('lodash/debounce');
+describe('RichTextInput', () => {
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      document.getSelection = () => {
+          return {
+            removeAllRanges: () => {},
+            getRangeAt: function() {}, 
+          };
+      };
+      jest.mock('lodash.debounce', (fn) => fn);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        container = null;
+    });
+
+    it('should call text-change event only once when editing', async () => {
+        const mockFn = jest.fn();
+        debounce.mockImplementation(fn => fn);
+        const { getByTestId, rerender } = render(
+        <RichTextInput
+            input={{
+              value: '<p>test</p>',
+                onChange: mockFn
+            }}
+            meta={{error: null}} />);
+        const quillNode = await waitForElement(() => {
+            return getByTestId('quill')
+        });
+        quillNode.__quill.setText('test1');
+        rerender(
+          <RichTextInput
+            input={{
+              value: '<p>test1</p>',
+                onChange: mockFn
+            }}
+            meta={{error: null}} />)
+
+        expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+})

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -27,13 +27,13 @@ describe('RichTextInput', () => {
 
     it('should call handleChange only once when editing', async () => {
         jest.useFakeTimers();
-        const mockFn = jest.fn();
+        const handleChange = jest.fn();
         debounce.mockImplementation(fn => fn);
         const { getByTestId, rerender } = render(
         <RichTextInput
             input={{
               value: '<p>test</p>',
-                onChange: mockFn
+                onChange: handleChange
             }}
             meta={{error: null}} />);
         const quillNode = await waitForElement(() => {
@@ -51,10 +51,11 @@ describe('RichTextInput', () => {
           <RichTextInput
             input={{
               value: '<p>test1</p>',
-                onChange: mockFn
+                onChange: handleChange
             }}
             meta={{error: null}} />)
 
-        expect(mockFn).toHaveBeenCalledTimes(1);
+        // jest.runOnlyPendingTimers();
+        expect(handleChange).toHaveBeenCalledTimes(1);
     });
 })

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -44,6 +44,7 @@ describe('RichTextInput', () => {
           target: { innerHTML: '<p>test1</p>' }
         });
 
+        // ensuring the first 'text-change' event had been handled
         jest.runOnlyPendingTimers();
 
         rerender(

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -55,7 +55,6 @@ describe('RichTextInput', () => {
             }}
             meta={{error: null}} />)
 
-        // jest.runOnlyPendingTimers();
         expect(handleChange).toHaveBeenCalledTimes(1);
     });
 })

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -11,13 +11,13 @@ describe('RichTextInput', () => {
     beforeEach(() => {
       container = document.createElement('div');
       document.body.appendChild(container);
+      // required as quilljs uses getSelection api
       document.getSelection = () => {
           return {
             removeAllRanges: () => {},
             getRangeAt: function() {}, 
           };
       };
-      jest.mock('lodash.debounce', (fn) => fn);
     });
 
     afterEach(() => {

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -25,7 +25,7 @@ describe('RichTextInput', () => {
         container = null;
     });
 
-    it('should call text-change event only once when editing', async () => {
+    it('should call handleChange only once when editing', async () => {
         const mockFn = jest.fn();
         debounce.mockImplementation(fn => fn);
         const { getByTestId, rerender } = render(

--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -26,6 +26,7 @@ describe('RichTextInput', () => {
     });
 
     it('should call handleChange only once when editing', async () => {
+        jest.useFakeTimers();
         const mockFn = jest.fn();
         debounce.mockImplementation(fn => fn);
         const { getByTestId, rerender } = render(
@@ -38,7 +39,13 @@ describe('RichTextInput', () => {
         const quillNode = await waitForElement(() => {
             return getByTestId('quill')
         });
-        quillNode.__quill.setText('test1');
+        const node = quillNode.querySelector('.ql-editor');
+        fireEvent.input(node, {
+          target: { innerHTML: '<p>test1</p>' }
+        });
+
+        jest.runOnlyPendingTimers();
+
         rerender(
           <RichTextInput
             input={{

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,4 +1,5 @@
 require('raf/polyfill');
+require('mutationobserver-shim');
 var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,5 +1,9 @@
 require('raf/polyfill');
-require('mutationobserver-shim'); // required due to quilljs
+/**
+ * As jsDom do not support mutationobserver and
+ * quill requires mutationobserver, thus a shim is needed
+ * */
+require('mutationobserver-shim');
 var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,5 +1,5 @@
 require('raf/polyfill');
-require('mutationobserver-shim');
+require('mutationobserver-shim'); // required due to quilljs
 var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10181,6 +10181,11 @@ multimatch@^2.0.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
+mutationobserver-shim@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#65869630bc89d7bf8c9cd9cb82188cd955aacd2b"
+  integrity sha512-gciOLNN8Vsf7YzcqRjKzlAJ6y7e+B86u7i3KXes0xfxx/nfLmozlW1Vn+Sc9x3tPIePFgc1AeIFhtRgkqTjzDQ==
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"


### PR DESCRIPTION
Hi,

in ra-input-rich-text,

whenever the text changes, below is the sequence of events happening.
Original text `<p>test</p>`
1. User change text to `<p>test1</p>`
2. `onTextChange` fired
3. `componentDidUpdate` fired
4. update happens as previous prop value is still `<p>test</p>`, but unecessary
5. `onTextChange` fired again.
6. stops there as the prevProp input value is the same as current prop input value

2nd issue is that, it seems quilljs is always adding additional `<p>` after this method
```
this.quill.setContents(
     this.quill.clipboard.convert(this.props.input.value)
)
```
***ONLY*** for the text that has special characters, i.e ```ARTÍCULO 1.- El presente reglamento es de observancia obligatoria``` after you bold ```ARTÍCULO 1```




fixes https://github.com/marmelab/react-admin/issues/3073
