### PR TITLE
sticky appbar

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -593,6 +593,18 @@ const MyAppBar = withStyles(styles)(({ classes, ...props }) => (
 export default MyAppBar;
 ```
 
+In addition you can pass `position="sticky"` to prevent AppBar from hiding when you scrolling down
+
+```jsx
+const MyAppBar = (props) => (
+    <AppBar {...props} position="sticky">
+       ...
+    </AppBar>
+);
+
+export default MyAppBar;
+```
+
 To use this custom `MyAppBar` component, pass it as prop to a custom `Layout`, as shown below:
 
 ```jsx

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -57,49 +57,48 @@ const AppBar = ({
     toggleSidebar,
     userMenu,
     width,
+    position,
     ...rest
 }) => (
-    <Headroom>
-        <MuiAppBar
-            className={className}
-            color="secondary"
-            position="static"
-            {...rest}
+    <MuiAppBar
+        className={className}
+        color="secondary"
+        position={position}
+        {...rest}
+    >
+        <Toolbar
+            disableGutters
+            variant={width === 'xs' ? 'regular' : 'dense'}
+            className={classes.toolbar}
         >
-            <Toolbar
-                disableGutters
-                variant={width === 'xs' ? 'regular' : 'dense'}
-                className={classes.toolbar}
+            <IconButton
+                color="inherit"
+                aria-label="open drawer"
+                onClick={toggleSidebar}
+                className={classNames(classes.menuButton)}
             >
-                <IconButton
+                <MenuIcon
+                    classes={{
+                        root: open
+                            ? classes.menuButtonIconOpen
+                            : classes.menuButtonIconClosed,
+                    }}
+                />
+            </IconButton>
+            {Children.count(children) === 0 ? (
+                <Typography
+                    variant="title"
                     color="inherit"
-                    aria-label="open drawer"
-                    onClick={toggleSidebar}
-                    className={classNames(classes.menuButton)}
-                >
-                    <MenuIcon
-                        classes={{
-                            root: open
-                                ? classes.menuButtonIconOpen
-                                : classes.menuButtonIconClosed,
-                        }}
-                    />
-                </IconButton>
-                {Children.count(children) === 0 ? (
-                    <Typography
-                        variant="title"
-                        color="inherit"
-                        className={classes.title}
-                        id="react-admin-title"
-                    />
-                ) : (
-                    children
-                )}
-                <LoadingIndicator />
-                {cloneElement(userMenu, { logout })}
-            </Toolbar>
-        </MuiAppBar>
-    </Headroom>
+                    className={classes.title}
+                    id="react-admin-title"
+                />
+            ) : (
+                children
+            )}
+            <LoadingIndicator />
+            {cloneElement(userMenu, { logout })}
+        </Toolbar>
+    </MuiAppBar>
 );
 
 AppBar.propTypes = {
@@ -113,10 +112,12 @@ AppBar.propTypes = {
     toggleSidebar: PropTypes.func.isRequired,
     userMenu: PropTypes.node,
     width: PropTypes.string,
+    position: PropTypes.string,
 };
 
 AppBar.defaultProps = {
     userMenu: <UserMenu />,
+    poition: 'static',
 };
 
 const enhance = compose(
@@ -132,4 +133,11 @@ const enhance = compose(
     withWidth()
 );
 
-export default enhance(AppBar);
+const EnhancedAppBar = enhance(AppBar);
+
+export default ({ position, ...props }) =>
+    position === 'sticky'
+        ? <EnhancedAppBar {...props} position={position} />
+        : <Headroom>
+            <EnhancedAppBar {...props} />
+          </Headroom>


### PR DESCRIPTION
some times we have lots of content and it requires to scroll down to see them all.
in my case save button is at the end of content. on that position appbar is already hide.
since we have only one loading indicator inside appbar, after user clicking save button there is no way to see something is happening.

so I made this PR to be able to determine custom appbar with `sticky` position.
 