### PR TITLE
Fix undefined id in RadioButtonGroupInput

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -700,7 +700,6 @@ Lastly, use the `options` attribute if you want to override any of Material UI's
     labelPosition: 'right'
 }} />
 ```
-**Note**: The `RadioButtonGroupInput` component accepts an optional `id` prop. It is recommended to use this prop if you have more than one `RadioButtonGroupInput` field on one form to avoid interference between the form controls.
 {% endraw %}
 
 Refer to [Material UI RadioGroup documentation](http://www.material-ui.com/#/components/radio-button) for more details.

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -700,6 +700,7 @@ Lastly, use the `options` attribute if you want to override any of Material UI's
     labelPosition: 'right'
 }} />
 ```
+**Note**: The `RadioButtonGroupInput` component accepts an optional `id` prop. It is recommended to use this prop if you have more than one `RadioButtonGroupInput` field on one form to avoid interference between the form controls.
 {% endraw %}
 
 Refer to [Material UI RadioGroup documentation](http://www.material-ui.com/#/components/radio-button) for more details.

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
@@ -94,14 +94,15 @@ export class RadioButtonGroupInput extends Component {
             : typeof optionText === 'function'
             ? optionText(choice)
             : get(choice, optionText);
+        const nodeId = id ? `${id}_${get(choice, optionValue)}` : get(choice, optionValue)
         return (
             <FormControlLabel
-                htmlFor={`${id}_${get(choice, optionValue)}`}
+                htmlFor={nodeId}
                 key={get(choice, optionValue)}
                 value={get(choice, optionValue)}
                 control={
                     <Radio
-                        id={`${id}_${get(choice, optionValue)}`}
+                        id={nodeId}
                         color="primary"
                     />
                 }

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.js
@@ -83,29 +83,26 @@ export class RadioButtonGroupInput extends Component {
 
     renderRadioButton = choice => {
         const {
-            id,
             optionText,
             optionValue,
             translate,
             translateChoice,
+            source,
         } = this.props;
         const choiceName = React.isValidElement(optionText) // eslint-disable-line no-nested-ternary
             ? React.cloneElement(optionText, { record: choice })
             : typeof optionText === 'function'
             ? optionText(choice)
             : get(choice, optionText);
-        const nodeId = id ? `${id}_${get(choice, optionValue)}` : get(choice, optionValue)
+
+        const nodeId = `${source}_${get(choice, optionValue)}`;
+
         return (
             <FormControlLabel
                 htmlFor={nodeId}
                 key={get(choice, optionValue)}
                 value={get(choice, optionValue)}
-                control={
-                    <Radio
-                        id={nodeId}
-                        color="primary"
-                    />
-                }
+                control={<Radio id={nodeId} color="primary" />}
                 label={
                     translateChoice
                         ? translate(choiceName, { _: choiceName })
@@ -174,7 +171,6 @@ RadioButtonGroupInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
     classes: PropTypes.object,
     className: PropTypes.string,
-    id: PropTypes.string,
     input: PropTypes.object,
     isRequired: PropTypes.bool,
     label: PropTypes.string,


### PR DESCRIPTION
If no `id` is passed to `RadioButtonGroupInput` component, the input is given the id `undefined_optionvalue`. Consider the case where two fields have the same choices, but different `source`. They will be given the same id, and the form control labels will interfere, which is not nice.

Updated the component to not put `undefined_optionvalue` into the id of the node, and added a note to the docs.

