### PR TITLE
[AutocompleteArrayInput] wrap chips instead of increasing view width

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -46,6 +46,7 @@ const styles = theme => createStyles({
     },
     chip: {
         marginRight: theme.spacing.unit,
+        marginTop: theme.spacing.unit,
     },
     chipDisabled: {
         pointerEvents: 'none',

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
@@ -12,8 +12,13 @@ const chipInputStyles = createStyles({
     chipContainer: {
         alignItems: 'center',
         display: 'flex',
+        flexWrap: 'wrap',
         minHeight: 50,
+        paddingBottom: 8,
     },
+    inputRoot: {
+        marginTop: 8,
+    }
 });
 
 const AutocompleteArrayInputChip = props => <ChipInput {...props} />;


### PR DESCRIPTION
When using `AutocompleteArrayInput` with lots of chips, view gets wider and wider.
This PR enables chips wrapping to avoid this problem.

Before:
![Screenshot 2019-04-16 at 15 51 39](https://user-images.githubusercontent.com/13808724/56219294-c801c280-6066-11e9-9f0c-989e87176f13.png)

After:
![Screenshot 2019-04-16 at 15 53 50](https://user-images.githubusercontent.com/13808724/56219302-cc2de000-6066-11e9-8a81-3eb957ff686f.png)
