### PR TITLE
[RFR] Improve translation loading

### DIFF
--- a/packages/ra-core/src/i18n/TranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TranslationProvider.tsx
@@ -56,7 +56,7 @@ class TranslationProviderView extends Component<ViewProps, State> {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.locale !== this.props.locale) {
+        if (prevProps.locale !== this.props.locale || prevProps.messages !== this.props.messages) {
             const { locale, messages } = this.props;
 
             const polyglot = new Polyglot({

--- a/packages/ra-core/src/sideEffect/i18n.ts
+++ b/packages/ra-core/src/sideEffect/i18n.ts
@@ -4,6 +4,8 @@ import {
     CHANGE_LOCALE,
     changeLocaleSuccess,
     changeLocaleFailure,
+    fetchStart,
+    fetchEnd,
 } from '../actions';
 
 /**
@@ -15,12 +17,15 @@ export default (i18nProvider: I18nProvider) => {
     function* loadMessages(action) {
         const locale = action.payload;
 
+        yield put(fetchStart())
+
         try {
             const messages = yield call(i18nProvider, locale);
             yield put(changeLocaleSuccess(locale, messages));
         } catch (err) {
             yield put(changeLocaleFailure(action.payload.locale, err));
         }
+        yield put(fetchEnd())
     }
     return function*() {
         yield all([takeLatest(CHANGE_LOCALE, loadMessages)]);

--- a/packages/ra-core/src/sideEffect/i18n.ts
+++ b/packages/ra-core/src/sideEffect/i18n.ts
@@ -17,7 +17,7 @@ export default (i18nProvider: I18nProvider) => {
     function* loadMessages(action) {
         const locale = action.payload;
 
-        yield put(fetchStart())
+        yield put(fetchStart());
 
         try {
             const messages = yield call(i18nProvider, locale);
@@ -25,7 +25,7 @@ export default (i18nProvider: I18nProvider) => {
         } catch (err) {
             yield put(changeLocaleFailure(action.payload.locale, err));
         }
-        yield put(fetchEnd())
+        yield put(fetchEnd());
     }
     return function*() {
         yield all([takeLatest(CHANGE_LOCALE, loadMessages)]);


### PR DESCRIPTION
These changes do two things:

- When receiving a new locale and messages it's not only checked if the locale has changed but also if the messages have changed. This fixes #3139 .
Object comparison might not be the best use here, but I think that the messages object won't be too large for it to still be performant.

- It will start showing the fetch spinner before loading the translations and end it afterwards. This is useful when translations are loaded async. When it takes longer, the user doesn't know that anything is happening and then suddenly the strings switch. 
This might be improved to delay it for a short while, so there is no spinner when the messages are returned immediately.

