### PR TITLE
Support nested records in source property of ReferenceManyField

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.tsx
@@ -1,5 +1,6 @@
 import { Component, ReactNode } from 'react';
 import { connect } from 'react-redux';
+import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 
 import { crudGetManyReference as crudGetManyReferenceAction } from '../../actions';
@@ -154,7 +155,7 @@ export class UnconnectedReferenceManyFieldController extends Component<
         const { page, perPage, sort } = this.state;
         const relatedTo = nameRelatedTo(
             reference,
-            record[source],
+            get(record, source),
             resource,
             target,
             filter
@@ -163,7 +164,7 @@ export class UnconnectedReferenceManyFieldController extends Component<
         crudGetManyReference(
             reference,
             target,
-            record[source],
+            get(record, source),
             relatedTo,
             { page, perPage },
             sort,
@@ -205,7 +206,7 @@ export class UnconnectedReferenceManyFieldController extends Component<
 function mapStateToProps(state, props) {
     const relatedTo = nameRelatedTo(
         props.reference,
-        props.record[props.source],
+        get(props.record, props.source),
         props.resource,
         props.target,
         props.filter


### PR DESCRIPTION
All the `...Field` components can accept a compound source property to enable the display of nested record properties, with the exception of `ReferenceManyField`. This PR fixes that.

Unfortunately I haven't been able to get tests working so far and can't spend any more time on it right now, so I'm hoping someone else can add the one extra test to test this specific capability of the source property.

I don't think any extra documentation is required, as this is merely bringing the behaviour of this field in line with all the other field components.