### PR TITLE
[List, Edit, Create, Show] Wrap view components into styles HOC instead of wrapping main components

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -39,7 +39,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-export const CreateView = ({
+export const CreateView = withStyles(styles)(({
     actions,
     aside,
     basePath,
@@ -95,7 +95,7 @@ export const CreateView = ({
                 save,
             })}
     </div>
-);
+));
 
 CreateView.propTypes = {
     actions: PropTypes.element,
@@ -159,7 +159,7 @@ CreateView.defaultProps = {
  *     );
  *     export default App;
  */
-export const Create = props => (
+const Create = props => (
     <CreateController {...props}>
         {controllerProps => <CreateView {...props} {...controllerProps} />}
     </CreateController>
@@ -180,4 +180,4 @@ Create.propTypes = {
     hasList: PropTypes.bool,
 };
 
-export default withStyles(styles)(Create);
+export default Create;

--- a/packages/ra-ui-materialui/src/detail/Create.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Create.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { TestContext } from 'ra-core';
 
-import { Create } from './Create';
+import Create from './Create';
 
 describe('<Create />', () => {
     const defaultCreateProps = {

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -48,7 +48,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-export const EditView = ({
+export const EditView = withStyles(styles)(({
     actions,
     aside,
     basePath,
@@ -122,7 +122,7 @@ export const EditView = ({
                 })}
         </div>
     );
-};
+});
 
 EditView.propTypes = {
     actions: PropTypes.element,
@@ -188,7 +188,7 @@ EditView.defaultProps = {
  *     );
  *     export default App;
  */
-export const Edit = props => (
+const Edit = props => (
     <EditController {...props}>
         {controllerProps => <EditView {...props} {...controllerProps} />}
     </EditController>
@@ -209,4 +209,4 @@ Edit.propTypes = {
     title: PropTypes.any,
 };
 
-export default withStyles(styles)(Edit);
+export default Edit;

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { TestContext } from 'ra-core';
 
-import { Edit } from './Edit';
+import Edit from './Edit';
 
 describe('<Edit />', () => {
     const defaultEditProps = {

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -172,7 +172,7 @@ ShowView.defaultProps = {
  *     );
  *     export default App;
  */
-export const Show = props => (
+const Show = props => (
     <ShowController {...props}>
         {controllerProps => <ShowView {...props} {...controllerProps} />}
     </ShowController>

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -44,7 +44,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-export const ShowView = ({
+export const ShowView = withStyles(styles)(({
     actions,
     aside,
     basePath,
@@ -107,7 +107,7 @@ export const ShowView = ({
                 })}
         </div>
     );
-};
+});
 
 ShowView.propTypes = {
     actions: PropTypes.element,
@@ -193,4 +193,4 @@ Show.propTypes = {
     title: PropTypes.any,
 };
 
-export default withStyles(styles)(Show);
+export default Show;

--- a/packages/ra-ui-materialui/src/detail/Show.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { TestContext } from 'ra-core';
 
-import { Show } from './Show';
+import Show from './Show';
 
 describe('<Show />', () => {
     const defaultShowProps = {

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -98,7 +98,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-export const ListView = ({
+export const ListView = withStyles(styles)(({
     // component props
     actions,
     aside,
@@ -156,7 +156,7 @@ export const ListView = ({
             {aside && cloneElement(aside, controllerProps)}
         </div>
     );
-};
+});
 
 ListView.propTypes = {
     actions: PropTypes.element,
@@ -250,7 +250,7 @@ ListView.defaultProps = {
  *         </List>
  *     );
  */
-export const List = props => (
+const List = props => (
     <ListController {...props}>
         {controllerProps => <ListView {...props} {...controllerProps} />}
     </ListController>
@@ -294,4 +294,4 @@ List.defaultProps = {
     theme: defaultTheme,
 };
 
-export default withStyles(styles)(List);
+export default List;

--- a/packages/ra-ui-materialui/src/list/List.spec.js
+++ b/packages/ra-ui-materialui/src/list/List.spec.js
@@ -27,7 +27,7 @@ describe('<List />', () => {
             <ListView {...defaultProps}>
                 <Datagrid />
             </ListView>
-        );
+        ).dive();
         assert.equal(wrapper.find('WithStyles(Card)').length, 1);
     });
 
@@ -43,7 +43,7 @@ describe('<List />', () => {
             >
                 <Datagrid />
             </ListView>
-        );
+        ).dive();
         expect(
             wrapper.find('translate(WithStyles(BulkActionsToolbar))')
         ).toHaveLength(1);

--- a/packages/ra-ui-materialui/src/list/List.spec.js
+++ b/packages/ra-ui-materialui/src/list/List.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { shallow, render } from 'enzyme';
 import { TestContext } from 'ra-core';
 
-import { List, ListView } from './List';
+import List, { ListView } from './List';
 
 describe('<List />', () => {
     const defaultProps = {


### PR DESCRIPTION
When using `ShowController` and `ShowView` instead of single `Show` component, `Show` styles aren't used anymore.
This makes `aside` component appear under show view (when using `Show` component, `aside` is on the right).

Wrapping `ShowView` with styles HOC resolves the issue. Also, it makes more sense, since styles are related to *view* component, not `Show` component, which is simply composition of controller and view.