### PR TITLE
[RFC] Add formatLabel prop to ChipField

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -185,6 +185,12 @@ import { ChipField, SingleFieldList, ReferenceManyField } from 'react-admin';
 </ReferenceManyField>
 ```
 
+**Tip**: If you need to override `ChipField` label, there's `formatLabel` prop, which receives `record` as argument:
+
+```jsx
+<ChipField formatLabel={record => `${record.firstName} ${record.lastName}`} />
+```
+
 ## `<DateField>`
 
 Displays a date or datetime using the browser locale (thanks to `Date.toLocaleDateString()` and `Date.toLocaleString()`).

--- a/packages/ra-ui-materialui/src/field/ChipField.spec.js
+++ b/packages/ra-ui-materialui/src/field/ChipField.spec.js
@@ -30,4 +30,18 @@ describe('<ChipField />', () => {
             ).prop('label'),
             'foo'
         ));
+    
+    it('should display label returned by formatLabel prop', () =>
+        assert.equal(
+            shallow(
+                <ChipField
+                    className="className"
+                    classes={{}}
+                    source="firstName"
+                    record={{ firstName: 'foo', lastName: 'bar' }}
+                    formatLabel={record => `${record.firstName} ${record.lastName}`}
+                />
+            ).prop('label'),
+            'foo bar'
+        ));
 });

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -15,10 +15,10 @@ const styles = createStyles({
 
 export const ChipField: SFC<
     FieldProps & InjectedFieldProps & WithStyles<typeof styles> & ChipProps
-> = ({ className, classes, source, record = {}, ...rest }) => (
+> = ({ className, classes, source, record = {}, formatLabel, ...rest }) => (
     <Chip
         className={classnames(classes.chip, className)}
-        label={get(record, source)}
+        label={formatLabel ? formatLabel(record) : get(record, source)}
         {...sanitizeRestProps(rest)}
     />
 );

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -7,6 +7,7 @@ export interface FieldProps {
     sortBy?: string;
     source?: string;
     label?: string;
+    formatLabel?: (record: any) => string,
     sortable?: boolean;
     className?: string;
     cellClassName?: string;
@@ -25,6 +26,7 @@ export const fieldPropTypes = {
     sortBy: PropTypes.string,
     source: PropTypes.string,
     label: PropTypes.string,
+    formatLabel: PropTypes.func,
     sortable: PropTypes.bool,
     className: PropTypes.string,
     cellClassName: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -7,7 +7,7 @@ export interface FieldProps {
     sortBy?: string;
     source?: string;
     label?: string;
-    formatLabel?: (record: any) => string,
+    formatLabel?: (record: any) => string;
     sortable?: boolean;
     className?: string;
     cellClassName?: string;


### PR DESCRIPTION
Closes #3162

I've implemented `formatLabel` prop only for ChipField for now.

@Kmaschta suggested, that this may be useful for other fields too. But I'm not sure, if I should handle that in each component separately or not. Let me know what is the right direction for implementing this in other fields.

Also, feel free to suggest better naming for this prop.