### PR TITLE
Rename improperly named RejectButton class name

### DIFF
--- a/examples/demo/src/reviews/RejectButton.js
+++ b/examples/demo/src/reviews/RejectButton.js
@@ -11,8 +11,8 @@ import { reviewReject as reviewRejectAction } from './reviewActions';
 /**
  * This custom button demonstrate using a custom action to update data
  */
-class AcceptButton extends Component {
-    handleApprove = () => {
+class RejectButton extends Component {
+    handleReject = () => {
         const { reviewReject, record, comment } = this.props;
         reviewReject(record.id, { ...record, comment });
     };
@@ -24,7 +24,7 @@ class AcceptButton extends Component {
                 variant="outlined"
                 color="primary"
                 size="small"
-                onClick={this.handleApprove}
+                onClick={this.handleReject}
             >
                 <ThumbDown
                     color="primary"
@@ -38,7 +38,7 @@ class AcceptButton extends Component {
     }
 }
 
-AcceptButton.propTypes = {
+RejectButton.propTypes = {
     comment: PropTypes.string,
     record: PropTypes.object,
     reviewReject: PropTypes.func,
@@ -59,4 +59,4 @@ const enhance = compose(
     )
 );
 
-export default enhance(AcceptButton);
+export default enhance(RejectButton);


### PR DESCRIPTION
Looks like there was some copy-and-paste error, so RejectButton
was defined as AcceptButton. This commit renames references to
properly to "Reject..."

Fixes Issue #3178

Signed-off-by: Eric Brown <browne@vmware.com>