### PR TITLE
Pass dispatch to function that declares resources at runtime

### DIFF
--- a/packages/ra-core/src/CoreAdminRouter.tsx
+++ b/packages/ra-core/src/CoreAdminRouter.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { AnyAction } from 'redux';
 import { Route, Switch } from 'react-router-dom';
 import compose from 'recompose/compose';
 import getContext from 'recompose/getContext';
@@ -47,6 +48,7 @@ interface EnhancedProps {
     authProvider?: AuthProvider;
     isLoggedIn?: boolean;
     userLogout: Dispatch<typeof userLogoutAction>;
+    dispatch: Dispatch<AnyAction>;
 }
 
 interface State {
@@ -81,7 +83,10 @@ export class CoreAdminRouter extends Component<
             const permissions = await authProvider(AUTH_GET_PERMISSIONS);
             const resolveChildren = props.children as RenderResourcesFunction;
 
-            const childrenFuncResult = resolveChildren(permissions);
+            const childrenFuncResult = resolveChildren(
+                permissions,
+                props.dispatch
+            );
             if ((childrenFuncResult as Promise<ResourceElement[]>).then) {
                 (childrenFuncResult as Promise<ResourceElement[]>).then(
                     resolvedChildren => {
@@ -248,12 +253,17 @@ const mapStateToProps = state => ({
     isLoggedIn: isLoggedIn(state),
 });
 
+const mapDispatchToProps = dispatch => ({
+    dispatch,
+    userLogout: userLogoutAction,
+});
+
 export default compose(
     getContext({
         authProvider: PropTypes.func,
     }),
     connect(
         mapStateToProps,
-        { userLogout: userLogoutAction }
+        mapDispatchToProps
     )
 )(CoreAdminRouter) as ComponentType<AdminRouterProps>;

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -1,5 +1,6 @@
 import { ReactNode, ReactElement, ComponentType } from 'react';
 import { RouteProps, RouteComponentProps, match as Match } from 'react-router';
+import { Dispatch, AnyAction } from 'redux';
 
 import { WithPermissionsChildrenParams } from './auth/WithPermissions';
 
@@ -71,7 +72,8 @@ export type Dispatch<T> = T extends (...args: infer A) => any
 
 export type ResourceElement = ReactElement<ResourceProps>;
 export type RenderResourcesFunction = (
-    permissions: any
+    permissions: any,
+    dispatch?: Dispatch<AnyAction>
 ) => ResourceElement[] | Promise<ResourceElement[]>;
 export type AdminChildren = RenderResourcesFunction | ReactNode;
 


### PR DESCRIPTION
When we call a function to dynamically define the resources at app start, it would be convenient if we can dispatch additional actions to redux's store to set some states or show a notification.