### PR TITLE
[RFR] Fix handling of deleted references

### DIFF
--- a/packages/ra-core/src/reducer/admin/references/oneToMany.spec.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.spec.ts
@@ -40,7 +40,7 @@ describe('oneToMany', () => {
                     total: 3,
                 },
                 'reviews_comments@id_1': {
-                    ids: [1, 2, 3],
+                    ids: [1, 3, 4],
                     total: 3,
                 },
                 'posts_reviews@id_1': {
@@ -67,8 +67,8 @@ describe('oneToMany', () => {
                     total: 2,
                 },
                 'reviews_comments@id_1': {
-                    ids: [1, 3],
-                    total: 2,
+                    ids: [1, 3, 4],
+                    total: 3,
                 },
                 'posts_reviews@id_1': {
                     ids: [1, 2, 3],
@@ -84,7 +84,7 @@ describe('oneToMany', () => {
                     total: 3,
                 },
                 'reviews_comments@id_1': {
-                    ids: [1, 2, 3],
+                    ids: [1, 3, 4],
                     total: 3,
                 },
                 'posts_reviews@id_1': {
@@ -111,8 +111,8 @@ describe('oneToMany', () => {
                     total: 1,
                 },
                 'reviews_comments@id_1': {
-                    ids: [1],
-                    total: 1,
+                    ids: [1, 4],
+                    total: 2,
                 },
                 'posts_reviews@id_1': {
                     ids: [1, 2, 3],

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.spec.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import oneToManyReducer, { nameRelatedTo } from './oneToMany';
-import { DELETE } from '../../../dataFetchActions';
+import { DELETE, DELETE_MANY } from '../../../dataFetchActions';
 import { UNDOABLE } from '../../../actions';
 
 describe('oneToMany', () => {
@@ -33,7 +33,7 @@ describe('oneToMany', () => {
             );
         });
 
-        it('should remove references deleted optimistically', () => {
+        it('should remove reference deleted optimistically', () => {
             const previousState = {
                 'posts_comments@id_1': {
                     ids: [1, 2, 3],
@@ -69,6 +69,50 @@ describe('oneToMany', () => {
                 'reviews_comments@id_1': {
                     ids: [1, 3],
                     total: 2,
+                },
+                'posts_reviews@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+            });
+        });
+
+        it('should remove references deleted optimistically', () => {
+            const previousState = {
+                'posts_comments@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+                'reviews_comments@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+                'posts_reviews@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+            };
+
+            const state = oneToManyReducer(previousState, {
+                type: UNDOABLE,
+                payload: {
+                    ids: [2, 3],
+                },
+                meta: {
+                    resource: 'comments',
+                    optimistic: true,
+                    fetch: DELETE_MANY,
+                },
+            });
+
+            expect(state).toEqual({
+                'posts_comments@id_1': {
+                    ids: [1],
+                    total: 1,
+                },
+                'reviews_comments@id_1': {
+                    ids: [1],
+                    total: 1,
                 },
                 'posts_reviews@id_1': {
                     ids: [1, 2, 3],

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.spec.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 
-import { nameRelatedTo } from './oneToMany';
+import oneToManyReducer, { nameRelatedTo } from './oneToMany';
+import { DELETE } from '../../../dataFetchActions';
+import { UNDOABLE } from '../../../actions';
 
 describe('oneToMany', () => {
     describe('oneToMany', () => {
@@ -29,6 +31,50 @@ describe('oneToMany', () => {
                 }),
                 'posts_comments@id_6?active=true'
             );
+        });
+
+        it('should remove references deleted optimistically', () => {
+            const previousState = {
+                'posts_comments@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+                'reviews_comments@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+                'posts_reviews@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+            };
+
+            const state = oneToManyReducer(previousState, {
+                type: UNDOABLE,
+                payload: {
+                    id: 2,
+                },
+                meta: {
+                    resource: 'comments',
+                    optimistic: true,
+                    fetch: DELETE,
+                },
+            });
+
+            expect(state).toEqual({
+                'posts_comments@id_1': {
+                    ids: [1, 3],
+                    total: 2,
+                },
+                'reviews_comments@id_1': {
+                    ids: [1, 3],
+                    total: 2,
+                },
+                'posts_reviews@id_1': {
+                    ids: [1, 2, 3],
+                    total: 3,
+                },
+            });
         });
     });
 });

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.ts
@@ -141,7 +141,10 @@ export const getReferencesByIds = (
 const getRelatedReferences = (previousState, resource) =>
     Object.keys(previousState).filter(key => key.includes(resource));
 
-const removeDeletedReference = removedId => (previousState, key) => {
+const removeDeletedReference = (removedId: Identifier) => (
+    previousState,
+    key
+) => {
     const hasReferenceToRemovedId = previousState[key].ids.includes(removedId);
 
     if (!hasReferenceToRemovedId) {
@@ -157,7 +160,10 @@ const removeDeletedReference = removedId => (previousState, key) => {
     };
 };
 
-const removeDeletedReferences = removedIds => (previousState, key) => {
+const removeDeletedReferences = (removedIds: Identifier[]) => (
+    previousState,
+    key
+) => {
     const idsToRemove = previousState[key].ids.filter(id =>
         removedIds.includes(id)
     );

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.ts
@@ -164,15 +164,15 @@ const removeDeletedReferences = (removedIds: Identifier[]) => (
     previousState,
     key
 ) => {
-    const idsToRemove = previousState[key].ids.filter(id =>
-        removedIds.includes(id)
+    const idsToKeep = previousState[key].ids.filter(
+        id => !removedIds.includes(id)
     );
 
     return {
         ...previousState,
         [key]: {
-            ids: previousState[key].ids.filter(id => !removedIds.includes(id)),
-            total: previousState[key].total - idsToRemove.length,
+            ids: idsToKeep,
+            total: idsToKeep.length,
         },
     };
 };

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.ts
@@ -5,7 +5,7 @@ import {
     CrudDeleteSuccessAction,
 } from '../../../actions/dataActions';
 import { Identifier, ReduxState } from '../../../types';
-import { DELETE } from '../../../dataFetchActions';
+import { DELETE, DELETE_MANY } from '../../../dataFetchActions';
 
 const initialState = {};
 
@@ -39,6 +39,31 @@ const oneToManyReducer: Reducer<State> = (
             }),
             previousState
         );
+    }
+    if (
+        action.meta &&
+        action.meta.fetch === DELETE_MANY &&
+        action.meta.optimistic
+    ) {
+        const relatedTo = Object.keys(previousState).filter(key =>
+            key.includes(action.meta.resource)
+        );
+
+        return relatedTo.reduce((acc, key) => {
+            const idsToRemove = previousState[key].ids.filter(id =>
+                action.payload.ids.includes(id)
+            );
+
+            return {
+                ...acc,
+                [key]: {
+                    ids: previousState[key].ids.filter(
+                        id => !action.payload.ids.includes(id)
+                    ),
+                    total: previousState[key].total - idsToRemove.length,
+                },
+            };
+        }, previousState);
     }
     switch (action.type) {
         case CRUD_GET_MANY_REFERENCE_SUCCESS:

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.ts
@@ -23,47 +23,15 @@ const oneToManyReducer: Reducer<State> = (
     action: ActionTypes
 ) => {
     if (action.meta && action.meta.fetch === DELETE && action.meta.optimistic) {
-        const relatedTo = Object.keys(previousState).filter(key =>
-            key.includes(action.meta.resource)
-        );
-
-        return relatedTo.reduce(
-            (acc, key) => ({
-                ...acc,
-                [key]: {
-                    ids: previousState[key].ids.filter(
-                        id => id !== action.payload.id
-                    ),
-                    total: previousState[key].total - 1,
-                },
-            }),
-            previousState
-        );
+        return removeDeletedReference(previousState, action);
     }
+
     if (
         action.meta &&
         action.meta.fetch === DELETE_MANY &&
         action.meta.optimistic
     ) {
-        const relatedTo = Object.keys(previousState).filter(key =>
-            key.includes(action.meta.resource)
-        );
-
-        return relatedTo.reduce((acc, key) => {
-            const idsToRemove = previousState[key].ids.filter(id =>
-                action.payload.ids.includes(id)
-            );
-
-            return {
-                ...acc,
-                [key]: {
-                    ids: previousState[key].ids.filter(
-                        id => !action.payload.ids.includes(id)
-                    ),
-                    total: previousState[key].total - idsToRemove.length,
-                },
-            };
-        }, previousState);
+        return removeDeletedReferences(previousState, action);
     }
     switch (action.type) {
         case CRUD_GET_MANY_REFERENCE_SUCCESS:
@@ -159,6 +127,46 @@ export const getReferencesByIds = (
         }, {});
 
     return Object.keys(references).length > 0 ? references : null;
+};
+
+const getRelatedReferences = (previousState, resource) =>
+    Object.keys(previousState).filter(key => key.includes(resource));
+
+const removeDeletedReference = (previousState, action: ActionTypes) => {
+    const relatedTo = getRelatedReferences(previousState, action.meta.resource);
+
+    return relatedTo.reduce(
+        (acc, key) => ({
+            ...acc,
+            [key]: {
+                ids: previousState[key].ids.filter(
+                    id => id !== action.payload.id
+                ),
+                total: previousState[key].total - 1,
+            },
+        }),
+        previousState
+    );
+};
+
+const removeDeletedReferences = (previousState, action: ActionTypes) => {
+    const relatedTo = getRelatedReferences(previousState, action.meta.resource);
+
+    return relatedTo.reduce((acc, key) => {
+        const idsToRemove = previousState[key].ids.filter(id =>
+            action.payload.ids.includes(id)
+        );
+
+        return {
+            ...acc,
+            [key]: {
+                ids: previousState[key].ids.filter(
+                    id => !action.payload.ids.includes(id)
+                ),
+                total: previousState[key].total - idsToRemove.length,
+            },
+        };
+    }, previousState);
 };
 
 export const nameRelatedTo = (reference, id, resource, target, filter = {}) => {

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.ts
@@ -145,17 +145,13 @@ const removeDeletedReferences = (removedIds: Identifier[]) => (
     previousState: State,
     key: string
 ) => {
-    const idsToRemove = previousState[key].ids.filter(id =>
-        removedIds.includes(id)
-    );
-
-    if (idsToRemove.length === 0) {
-        return previousState;
-    }
-
     const idsToKeep = previousState[key].ids.filter(
         id => !removedIds.includes(id)
     );
+
+    if (idsToKeep.length === previousState[key].ids.length) {
+        return previousState;
+    }
 
     return {
         ...previousState,


### PR DESCRIPTION
## Problem

When a `<ReferenceManyField>` displays a `<DataGrid>` with a `DeleteButton` on each row, optimistically deleting a reference will set its row into loading state but won't actually remove it until the action is resolved.

![ra-references-many-delete-bug](https://user-images.githubusercontent.com/1122076/57607517-854edf80-756b-11e9-8fda-122c7023d872.gif)

## Solution

Handle the `DELETE` effects in the `oneToMany` reducer by checking whether we have references related to the deleted item resource and removing the deleted item from them.

![ra-references-many-delete-bug-fix](https://user-images.githubusercontent.com/1122076/57607692-ea0a3a00-756b-11e9-8a21-e983ef074a60.gif)

