### PR TITLE
[RichTextInput] Fix debouncing

### DIFF
--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -55,7 +55,7 @@ export class RichTextInput extends Component {
         this.quill.setContents(this.quill.clipboard.convert(value));
 
         this.editor = this.divRef.querySelector('.ql-editor');
-        this.quill.on('text-change', debounce(this.onTextChange, 500));
+        this.quill.on('text-change', this.onTextChange);
     }
 
     shouldComponentUpdate(nextProps) {
@@ -76,15 +76,16 @@ export class RichTextInput extends Component {
 
     componentWillUnmount() {
         this.quill.off('text-change', this.onTextChange);
+        this.onTextChange.cancel();
         this.quill = null;
     }
 
-    onTextChange = () => {
+    onTextChange = debounce(() => {
         const value =
             this.editor.innerHTML == '<p><br></p>' ? '' : this.editor.innerHTML;
         this.lastValueChange = value;
         this.props.input.onChange(value);
-    };
+    }, 500);
 
     updateDivRef = ref => {
         this.divRef = ref;


### PR DESCRIPTION
Fixes issue, described by @fzaninotto in https://github.com/marmelab/react-admin/pull/3209#issuecomment-492246926

This PR makes sure, that `onTextInput` is the same function used for adding and removing event listener.

Also, it partially resolves #3220, I'll describe it better in issue comment