### PR TITLE
[RichTextInput] Use color from theme

### DIFF
--- a/packages/ra-input-rich-text/src/styles.js
+++ b/packages/ra-input-rich-text/src/styles.js
@@ -1,6 +1,6 @@
 import QuillSnowStylesheet from './QuillSnowStylesheet';
 
-export default {
+export default theme => ({
     '@global': Object.assign({}, QuillSnowStylesheet, {
         '.ra-rich-text-input': {
             '& .ql-editor': {
@@ -35,7 +35,7 @@ export default {
                     transform: 'scaleX(0)',
                     transition:
                         'transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms',
-                    backgroundColor: '#304ffe',
+                    backgroundColor: theme.palette.primary.main,
                 },
 
                 '& p:not(:last-child)': {
@@ -131,4 +131,4 @@ export default {
             },
         },
     }),
-};
+});


### PR DESCRIPTION
`RichTextInput` has hardcoded color, which doesn't look good when using non-default theme colors.