### PR TITLE
[RFR] Redux-Saga Error Handling

### DIFF
--- a/packages/ra-core/src/CoreAdmin.tsx
+++ b/packages/ra-core/src/CoreAdmin.tsx
@@ -48,6 +48,7 @@ export interface AdminProps {
     menu?: ComponentType;
     theme?: object;
     title?: TitleComponent;
+    onSagaError?(error: Error): void;
 }
 
 interface AdminContext {
@@ -163,6 +164,7 @@ React-admin requires a valid dataProvider function to work.`);
             i18nProvider,
             initialState,
             locale,
+            onSagaError,
         } = this.props;
 
         return this.reduxIsAlreadyInitialized ? (
@@ -178,6 +180,7 @@ React-admin requires a valid dataProvider function to work.`);
                     initialState,
                     locale,
                     history: this.history,
+                    onSagaError,
                 })}
             >
                 {this.renderCore()}

--- a/packages/ra-core/src/createAdminStore.ts
+++ b/packages/ra-core/src/createAdminStore.ts
@@ -24,6 +24,7 @@ interface Params {
     i18nProvider?: I18nProvider;
     initialState?: object;
     locale?: string;
+    onSagaError?(error: Error): void;
 }
 
 export default ({
@@ -35,6 +36,7 @@ export default ({
     i18nProvider = defaultI18nProvider,
     initialState,
     locale = 'en',
+    onSagaError,
 }: Params) => {
     const messages = i18nProvider(locale);
     const appReducer = createAppReducer(
@@ -54,7 +56,7 @@ export default ({
             ].map(fork)
         );
     };
-    const sagaMiddleware = createSagaMiddleware();
+    const sagaMiddleware = createSagaMiddleware({ onError: onSagaError });
     const typedWindow = window as Window;
 
     const store = createStore(


### PR DESCRIPTION
The goal of this change is better error handling with redux saga.

Currently, if there is an unhandled error thrown in a redux saga, **all saga execution is stopped** without the possibility to catch those errors.

In the proposed change, an `onError` handler for redux saga (see `createSagaMiddleware(options)`
 in https://redux-saga.js.org/docs/api/) can be passed through the `CoreAdmin` component to `createSagaMiddleware`. This provides a convenient error handling solution to all react-admin users.

In the Future, it might also be practical to restart saga execution after an error was handled.