### PR TITLE
[WIP] On fetch of single record handle invalidation of old records

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/list/ids.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.spec.ts
@@ -65,4 +65,26 @@ describe('data addRecordIdsFactory', () => {
 
         assert.deepEqual(newState, ['record3', 'record1', 'record2']);
     });
+
+    it.only('should preserve old records when "preserveOldIds" param is true ', () => {
+        const newRecords = ['record1'];
+        const oldRecords = ['record2', 'record3'];
+        const getFetchedAt = jest.fn().mockReturnValue({
+            record1: 'date',
+        });
+        Object.defineProperty(oldRecords, 'fetchedAt', {
+            value: {
+                record2: 'date',
+                record3: 'date',
+            },
+        });
+
+        const newState = addRecordIdsFactory(getFetchedAt)(
+            newRecords,
+            oldRecords,
+            true
+        );
+
+        assert.deepEqual(newState, [...oldRecords, ...newRecords]);
+    });
 });

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.spec.ts
@@ -66,7 +66,7 @@ describe('data addRecordIdsFactory', () => {
         assert.deepEqual(newState, ['record3', 'record1', 'record2']);
     });
 
-    it.only('should preserve old records when "preserveOldIds" param is true ', () => {
+    it('should preserve old records when "preserveOldIds" param is true', () => {
         const newRecords = ['record1'];
         const oldRecords = ['record2', 'record3'];
         const getFetchedAt = jest.fn().mockReturnValue({

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.ts
@@ -28,12 +28,18 @@ type State = IdentifierArrayWithDate;
 
 export const addRecordIdsFactory = getFetchedAtCallback => (
     newRecordIds: IdentifierArrayWithDate = [],
-    oldRecordIds: IdentifierArrayWithDate
+    oldRecordIds: IdentifierArrayWithDate,
+    preserveOldIds: boolean = false
 ): IdentifierArrayWithDate => {
-    const newFetchedAt = getFetchedAtCallback(
+    let newFetchedAt = getFetchedAtCallback(
         newRecordIds,
         oldRecordIds.fetchedAt
     );
+
+    if (preserveOldIds) {
+        newFetchedAt = { ...oldRecordIds.fetchedAt, ...newFetchedAt };
+    }
+
     const recordIds = uniq(
         oldRecordIds.filter(id => !!newFetchedAt[id]).concat(newRecordIds)
     );
@@ -108,7 +114,7 @@ const idsReducer: Reducer<State> = (
         case CRUD_GET_ONE_SUCCESS:
         case CRUD_CREATE_SUCCESS:
         case CRUD_UPDATE_SUCCESS:
-            return addRecordIds([action.payload.data.id], previousState);
+            return addRecordIds([action.payload.data.id], previousState, true);
         default:
             return previousState;
     }

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.ts
@@ -31,21 +31,21 @@ export const addRecordIdsFactory = getFetchedAtCallback => (
     oldRecordIds: IdentifierArrayWithDate,
     preserveOldIds: boolean = false
 ): IdentifierArrayWithDate => {
-    let newFetchedAt = getFetchedAtCallback(
+    const newFetchedAt = getFetchedAtCallback(
         newRecordIds,
         oldRecordIds.fetchedAt
     );
 
-    if (preserveOldIds) {
-        newFetchedAt = { ...oldRecordIds.fetchedAt, ...newFetchedAt };
-    }
+    const fetchedAt = preserveOldIds
+        ? { ...oldRecordIds.fetchedAt, ...newFetchedAt }
+        : { ...newFetchedAt };
 
     const recordIds = uniq(
-        oldRecordIds.filter(id => !!newFetchedAt[id]).concat(newRecordIds)
+        oldRecordIds.filter(id => !!fetchedAt[id]).concat(newRecordIds)
     );
 
     Object.defineProperty(recordIds, 'fetchedAt', {
-        value: newFetchedAt,
+        value: fetchedAt,
     }); // non enumerable by default
     return recordIds;
 };


### PR DESCRIPTION
- [x] On CRUD_GET_ONE_SUCCESS action don't invalidate old ids
- [ ] On GET_ONE action don't invalidate old records

Fixes #3227 