### PR TITLE
[RFR] [Rework] Fix sending request by Query with deep props on every update

### DIFF
--- a/packages/ra-core/src/util/Query.spec.tsx
+++ b/packages/ra-core/src/util/Query.spec.tsx
@@ -213,11 +213,15 @@ describe('Query', () => {
 
     it('should not dispatch a new fetch action when updating with the same query props', () => {
         let dispatchSpy;
-        const myPayload = {};
         const { rerender } = render(
             <TestContext>
                 {({ store }) => {
                     dispatchSpy = jest.spyOn(store, 'dispatch');
+                    const myPayload = {
+                        foo: {
+                            bar: 1,
+                        },
+                    };
                     return (
                         <Query
                             type="mytype"
@@ -232,15 +236,22 @@ describe('Query', () => {
         );
         rerender(
             <TestContext>
-                {() => (
-                    <Query
-                        type="mytype"
-                        resource="myresource"
-                        payload={myPayload}
-                    >
-                        {() => <div>Hello</div>}
-                    </Query>
-                )}
+                {() => {
+                    const myPayload = {
+                        foo: {
+                            bar: 1,
+                        },
+                    };
+                    return (
+                        <Query
+                            type="mytype"
+                            resource="myresource"
+                            payload={myPayload}
+                        >
+                            {() => <div>Hello</div>}
+                        </Query>
+                    );
+                }}
             </TestContext>
         );
         expect(dispatchSpy.mock.calls.length).toEqual(1);

--- a/packages/ra-core/src/util/Query.tsx
+++ b/packages/ra-core/src/util/Query.tsx
@@ -1,5 +1,5 @@
 import { Component, ReactNode } from 'react';
-import { shallowEqual } from 'recompose';
+import isEqual from 'lodash/isEqual';
 import withDataProvider from './withDataProvider';
 
 type DataProviderCallback = (
@@ -107,8 +107,8 @@ class Query extends Component<Props, State> {
         if (
             prevProps.type !== this.props.type ||
             prevProps.resource !== this.props.resource ||
-            !shallowEqual(prevProps.payload, this.props.payload) ||
-            !shallowEqual(prevProps.options, this.props.options)
+            !isEqual(prevProps.payload, this.props.payload) ||
+            !isEqual(prevProps.options, this.props.options)
         ) {
             this.callDataProvider();
         }


### PR DESCRIPTION
This is a rework of https://github.com/marmelab/react-admin/pull/3176

- Changed shallowEqual to deepEqual in Query to accommodate for possible deep props.

- Changed the placement of myPayload variable.
When myPayload is global the objects are indeed identical and the script worked did pass. However, this assumes independency from props, which is not desired. This can easily lead to endless loops.

Fixes #3174

Closes https://github.com/marmelab/react-admin/pull/3176