### PR TITLE
[RFR] [Rework] Datagrid rowclick toggle

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -814,6 +814,7 @@ export const PostList = (props) => (
 * "edit" to redirect to the edition vue
 * "show" to redirect to the show vue
 * "expand" to open the `expand` panel
+* "toggleSelection" to trigger the `onToggleItem` function
 * a function `(id, basePath, record) => path` to redirect to a custom path
 
 **Tip**: If you pass a function, it can return `edit`, `show` or a router path. This allows to redirect to either `edit` or `show` after checking a condition on the record. For example:

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -62,13 +62,12 @@ class DatagridRow extends Component {
 
         if (!rowClick) return;
 
-        if (typeof rowClick === 'function') {
-            const path = await rowClick(id, basePath, record);
-            this.handleRedirection(path, event);
-            return;
-        }
+        const path =
+            typeof rowClick === 'function'
+                ? await rowClick(id, basePath, record)
+                : rowClick;
 
-        this.handleRedirection(rowClick, event);
+        this.handleRedirection(path, event);
     };
 
     handleRedirection = (path, event) => {

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -74,21 +74,22 @@ class DatagridRow extends Component {
     handleRedirection = (path, event) => {
         const { basePath, id, push } = this.props;
 
-        if (path === 'edit') {
-            push(linkToRecord(basePath, id));
-            return;
-        }
-        if (path === 'show') {
-            push(linkToRecord(basePath, id, 'show'));
-            return;
-        }
-        if (path === 'expand') {
-            this.handleToggleExpanded(event);
-            return;
-        }
         if (!path) return;
 
-        push(path);
+        switch (path) {
+            case 'edit':
+                push(linkToRecord(basePath, id));
+                return;
+            case 'show':
+                push(linkToRecord(basePath, id, 'show'));
+                return;
+            case 'expand':
+                this.handleToggleExpanded(event);
+                return;
+            default:
+                push(path);
+                return;
+        }
     };
 
     computeColSpan = props => {

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -31,7 +31,7 @@ const sanitizeRestProps = ({
     ...rest
 }) => rest;
 
-class DatagridRow extends Component {
+export class DatagridRow extends Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -73,8 +73,6 @@ export class DatagridRow extends Component {
     handleRedirection = (path, event) => {
         const { basePath, id, push } = this.props;
 
-        if (!path) return;
-
         switch (path) {
             case 'edit':
                 push(linkToRecord(basePath, id));
@@ -89,7 +87,7 @@ export class DatagridRow extends Component {
                 this.handleToggle(event);
                 return;
             default:
-                push(path);
+                if (path) push(path);
                 return;
         }
     };

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -85,6 +85,9 @@ class DatagridRow extends Component {
             case 'expand':
                 this.handleToggleExpanded(event);
                 return;
+            case 'toggleSelection':
+                this.handleToggle(event);
+                return;
             default:
                 push(path);
                 return;

--- a/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
@@ -1,17 +1,54 @@
-import assert from 'assert';
 import React from 'react';
 import { shallow } from 'enzyme';
+import { linkToRecord } from 'ra-core';
 
 import { DatagridRow } from './DatagridRow';
 
 describe('<DatagridRow />', () => {
-    const defaultProps = {};
+    const defaultProps = {
+        id: 15,
+        basePath: '/blob',
+    };
+
     const event = { preventDefault: () => {}, stopPropagation: () => {} };
 
     describe('on click event, depending on rowClick prop', () => {
+        it("should redirect to edit page if the 'edit' option is selected", () => {
+            const push = jest.fn();
+            const wrapper = shallow(
+                <DatagridRow {...defaultProps} rowClick="edit" push={push} />
+            );
+
+            wrapper.instance().handleClick(event);
+            expect(push.mock.calls).toEqual([
+                [linkToRecord(defaultProps.basePath, defaultProps.id)],
+            ]);
+        });
+
+        it("should redirect to show page if the 'show' option is selected", () => {
+            const push = jest.fn();
+            const wrapper = shallow(
+                <DatagridRow {...defaultProps} rowClick="show" push={push} />
+            );
+
+            wrapper.instance().handleClick(event);
+            expect(push.mock.calls).toEqual([
+                [linkToRecord(defaultProps.basePath, defaultProps.id, 'show')],
+            ]);
+        });
+
+        it("should change the expand state if the 'expand' option is selected", () => {
+            const wrapper = shallow(
+                <DatagridRow {...defaultProps} rowClick="expand" />
+            );
+            expect(wrapper.state('expanded')).toBeFalsy();
+
+            wrapper.instance().handleClick(event);
+            expect(wrapper.state('expanded')).toBeTruthy();
+        });
+
         it("should execute the onToggleItem function if the 'toggleSelection' option is selected", () => {
             const onToggleItem = jest.fn();
-
             const wrapper = shallow(
                 <DatagridRow
                     {...defaultProps}
@@ -23,6 +60,32 @@ describe('<DatagridRow />', () => {
             wrapper.instance().handleClick(event);
 
             expect(onToggleItem.mock.calls.length).toEqual(1);
+        });
+
+        it('should redirect to the custom path if onRowClick is a string', () => {
+            const path = '/foo/bar';
+            const push = jest.fn();
+            const wrapper = shallow(
+                <DatagridRow {...defaultProps} rowClick={path} push={push} />
+            );
+
+            wrapper.instance().handleClick(event);
+            expect(push.mock.calls).toEqual([[path]]);
+        });
+
+        it('should evaluate the function and redirect to the result of that function if onRowClick is a custom function', async () => {
+            const push = jest.fn();
+            const customRowClick = () => '/bar/foo';
+            const wrapper = shallow(
+                <DatagridRow
+                    {...defaultProps}
+                    rowClick={customRowClick}
+                    push={push}
+                />
+            );
+
+            await wrapper.instance().handleClick(event);
+            expect(push.mock.calls).toEqual([['/bar/foo']]);
         });
     });
 });

--- a/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
@@ -10,9 +10,9 @@ describe('<DatagridRow />', () => {
         basePath: '/blob',
     };
 
-    const event = { preventDefault: () => {}, stopPropagation: () => {} };
+    const event = { preventDefault: () => { }, stopPropagation: () => { } };
 
-    describe('on click event, depending on rowClick prop', () => {
+    describe('rowClick', () => {
         it("should redirect to edit page if the 'edit' option is selected", () => {
             const push = jest.fn();
             const wrapper = shallow(
@@ -90,5 +90,19 @@ describe('<DatagridRow />', () => {
             await wrapper.instance().handleClick(event);
             expect(push.mock.calls).toEqual([['/bar/foo']]);
         });
+
+        it('should not call push if onRowClick is falsy', () => {
+            const push = jest.fn();
+            const wrapper = shallow(
+                <DatagridRow
+                    {...defaultProps}
+                    rowClick=""
+                    push={push}
+                />
+            );
+
+            wrapper.instance().handleClick(event);
+            expect(push.mock.calls.length).toEqual(0);
+        })
     });
 });

--- a/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
@@ -1,0 +1,28 @@
+import assert from 'assert';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { DatagridRow } from './DatagridRow';
+
+describe('<DatagridRow />', () => {
+    const defaultProps = {};
+    const event = { preventDefault: () => {}, stopPropagation: () => {} };
+
+    describe('on click event, depending on rowClick prop', () => {
+        it("should execute the onToggleItem function if the 'toggleSelection' option is selected", () => {
+            const onToggleItem = jest.fn();
+
+            const wrapper = shallow(
+                <DatagridRow
+                    {...defaultProps}
+                    onToggleItem={onToggleItem}
+                    rowClick="toggleSelection"
+                />
+            );
+
+            wrapper.instance().handleClick(event);
+
+            expect(onToggleItem.mock.calls.length).toEqual(1);
+        });
+    });
+});

--- a/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.spec.js
@@ -45,6 +45,9 @@ describe('<DatagridRow />', () => {
 
             wrapper.instance().handleClick(event);
             expect(wrapper.state('expanded')).toBeTruthy();
+
+            wrapper.instance().handleClick(event);
+            expect(wrapper.state('expanded')).toBeFalsy();
         });
 
         it("should execute the onToggleItem function if the 'toggleSelection' option is selected", () => {


### PR DESCRIPTION
This is a rework of https://github.com/marmelab/react-admin/pull/3120

* Allow `rowClick="toggleSelection"` option on DatagridRow
* Add corresponding documentation
* Add tests for all the `rowClick` options

Closes https://github.com/marmelab/react-admin/pull/3120