### PR TITLE
[RFR] [Rework] Display errors on mui BooleanInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.js
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import Switch from '@material-ui/core/Switch';
 import { addField, FieldTitle } from 'ra-core';
 
@@ -23,6 +24,7 @@ export class BooleanInput extends Component {
             resource,
             options,
             fullWidth,
+            meta,
             ...rest
         } = this.props;
 
@@ -51,6 +53,9 @@ export class BooleanInput extends Component {
                         />
                     }
                 />
+                {meta.error && (
+                    <FormHelperText error>{meta.error}</FormHelperText>
+                )}
             </FormGroup>
         );
     }

--- a/packages/ra-ui-materialui/src/input/BooleanInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.spec.js
@@ -1,15 +1,20 @@
 import React from 'react';
-import expect from 'expect';
 import { render, cleanup } from 'react-testing-library';
+import { shallow } from 'enzyme';
 
 import { BooleanInput } from './BooleanInput';
 
 describe('<BooleanInput />', () => {
     afterEach(cleanup);
 
+    const defaultProps = {
+        resource: 'foo',
+        meta: {},
+    };
+
     it('should render as a checkbox', () => {
         const { getByLabelText } = render(
-            <BooleanInput resource="foo" source="bar" input={{}} />
+            <BooleanInput {...defaultProps} source="bar" input={{}} />
         );
         expect(getByLabelText('resources.foo.fields.bar').type).toBe(
             'checkbox'
@@ -18,7 +23,11 @@ describe('<BooleanInput />', () => {
 
     it('should be checked if the value is true', () => {
         const { getByLabelText } = render(
-            <BooleanInput resource="foo" source="bar" input={{ value: true }} />
+            <BooleanInput
+                {...defaultProps}
+                source="bar"
+                input={{ value: true }}
+            />
         );
         expect(getByLabelText('resources.foo.fields.bar').checked).toBe(true);
     });
@@ -26,7 +35,7 @@ describe('<BooleanInput />', () => {
     it('should not be checked if the value is false', () => {
         const { getByLabelText } = render(
             <BooleanInput
-                resource="foo"
+                {...defaultProps}
                 source="bar"
                 input={{ value: false }}
             />
@@ -36,8 +45,30 @@ describe('<BooleanInput />', () => {
 
     it('should not be checked if the value is undefined', () => {
         const { getByLabelText } = render(
-            <BooleanInput resource="foo" source="bar" input={{}} />
+            <BooleanInput {...defaultProps} source="bar" input={{}} />
         );
         expect(getByLabelText('resources.foo.fields.bar').checked).toBe(false);
+    });
+
+    it('should displays errors', () => {
+        const wrapper = shallow(
+            <BooleanInput
+                {...defaultProps}
+                source="foo"
+                input={{}}
+                meta={{ error: 'foobar' }}
+            />
+        )
+            .find('WithStyles(FormGroup)')
+            .shallow()
+            .dive();
+        expect(wrapper.find('WithStyles(FormHelperText)').length).toBe(1);
+        expect(
+            wrapper
+                .find('WithStyles(FormHelperText)')
+                .at(0)
+                .children()
+                .text()
+        ).toBe('foobar');
     });
 });


### PR DESCRIPTION
This is a rework of https://github.com/marmelab/react-admin/pull/3115

* display error on MUI BootstrapInput
* adapt tests (defaultProps)

Closes https://github.com/marmelab/react-admin/pull/3115