### PR TITLE
[RFR] Fix design of icon loaders

### DIFF
--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -31,7 +31,7 @@ interface EnhancedProps
     isLoading: boolean;
 }
 
-const styles = ({ spacing }: Theme) =>  =>
+const styles = ({ spacing }: Theme) =>
     createStyles({
         form: {
             padding: '0 1em 1em 1em',
@@ -46,7 +46,7 @@ const styles = ({ spacing }: Theme) =>  =>
             height: 20,
             width: 20,
             marginRight: spacing.unit / 2,
-        }
+        },
     });
 
 // see http://redux-form.com/6.4.3/examples/material-ui/
@@ -103,7 +103,13 @@ const LoginForm: SFC<Props & EnhancedProps> = ({
                 disabled={isLoading}
                 className={classes.button}
             >
-                {isLoading && <CircularProgress className={classes.icon} size={18} thickness={2} />}
+                {isLoading && (
+                    <CircularProgress
+                        className={classes.icon}
+                        size={18}
+                        thickness={2}
+                    />
+                )}
                 {translate('ra.auth.sign_in')}
             </Button>
         </CardActions>

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -45,7 +45,7 @@ const styles = ({ spacing }: Theme) =>
         icon: {
             height: 20,
             width: 20,
-            marginRight: spacing.unit / 2,
+            marginRight: spacing.unit,
         },
     });
 

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -48,8 +48,6 @@ const styles = ({ spacing }: Theme) =>
             width: '100%',
         },
         icon: {
-            height: 20,
-            width: 20,
             marginRight: spacing.unit,
         },
     });

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -7,7 +7,12 @@ import CardActions from '@material-ui/core/CardActions';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
+import {
+    withStyles,
+    createStyles,
+    WithStyles,
+    Theme,
+} from '@material-ui/core/styles';
 import {
     withTranslate,
     userLogin,

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -31,7 +31,7 @@ interface EnhancedProps
     isLoading: boolean;
 }
 
-const styles = () =>
+const styles = ({ spacing }: Theme) =>  =>
     createStyles({
         form: {
             padding: '0 1em 1em 1em',
@@ -42,6 +42,11 @@ const styles = () =>
         button: {
             width: '100%',
         },
+        icon: {
+            height: 20,
+            width: 20,
+            marginRight: spacing.unit / 2,
+        }
     });
 
 // see http://redux-form.com/6.4.3/examples/material-ui/
@@ -98,7 +103,7 @@ const LoginForm: SFC<Props & EnhancedProps> = ({
                 disabled={isLoading}
                 className={classes.button}
             >
-                {isLoading && <CircularProgress size={25} thickness={2} />}
+                {isLoading && <CircularProgress className={classes.icon} size={18} thickness={2} />}
                 {translate('ra.auth.sign_in')}
             </Button>
         </CardActions>

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -14,10 +14,11 @@ const styles = ({ spacing }) =>
         button: {
             position: 'relative',
         },
-        icon: {
-            height: 20,
-            width: 20,
+        leftIcon: {
             marginRight: spacing.unit,
+        },
+        icon: {
+            fontSize: 18,
         },
     });
 
@@ -128,11 +129,11 @@ export class SaveButton extends Component {
                     <CircularProgress
                         size={18}
                         thickness={2}
-                        className={classes.icon}
+                        className={classes.leftIcon}
                     />
                 ) : (
                     React.cloneElement(icon, {
-                        className: classes.icon,
+                        className: classnames(classes.leftIcon, classes.icon),
                     })
                 )}
                 {label && translate(label, { _: label })}

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -17,7 +17,7 @@ const styles = ({ spacing }) =>
         icon: {
             height: 20,
             width: 20,
-            marginRight: spacing.unit / 2,
+            marginRight: spacing.unit,
         },
     });
 

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -9,14 +9,17 @@ import ContentSave from '@material-ui/icons/Save';
 import classnames from 'classnames';
 import { showNotification, translate } from 'ra-core';
 
-const styles = createStyles({
-    button: {
-        position: 'relative',
-    },
-    iconPaddingStyle: {
-        marginRight: '0.5em',
-    },
-});
+const styles = ({ spacing }) =>
+    createStyles({
+        button: {
+            position: 'relative',
+        },
+        icon: {
+            height: 20,
+            width: 20,
+            marginRight: spacing.unit / 2,
+        },
+    });
 
 const sanitizeRestProps = ({
     basePath,
@@ -123,13 +126,13 @@ export class SaveButton extends Component {
             >
                 {saving && saving.redirect === redirect ? (
                     <CircularProgress
-                        size={25}
+                        size={18}
                         thickness={2}
-                        className={classes.iconPaddingStyle}
+                        className={classes.icon}
                     />
                 ) : (
                     React.cloneElement(icon, {
-                        className: classes.iconPaddingStyle,
+                        className: classes.icon,
                     })
                 )}
                 {label && translate(label, { _: label })}


### PR DESCRIPTION
The `<CircularProgress />` icon in Login Form is too close to the text and too big.  The solution is to add a margin and reduce its size.

## Todo

- [x] Change icon design in `LoginForm`
- [x] Change icon design in `SaveButton`

## Screenshots

**Before**

![Peek 24-05-2019 15-20-2](https://user-images.githubusercontent.com/5584839/58330612-8cad9d00-7e37-11e9-8682-254e45a14425.gif)

**After**

![Peek 24-05-2019 15-11](https://user-images.githubusercontent.com/5584839/58330286-de095c80-7e36-11e9-8bf9-cc97cee8ef92.gif)
