### PR TITLE
[RFR] Add link function to ReferenceField

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -78,6 +78,16 @@ If you're using a Custom App, you had to render Resource components with the reg
 +               <Resource name="users" intent="registration" />
 ```
 
+## ReferenceField prop `linkType` renamed to `link`
+
+When using the ReferenceField component, you should rename your `linkType` props to `link`. This prop now also accepts custom functions to return a link, see the Fields documentation.
+
+```diff
+- <ReferenceField resource="comments" record={data[id]} source="post_id" reference="posts" basePath={basePath} linkType="show">
++ <ReferenceField resource="comments" record={data[id]} source="post_id" reference="posts" basePath={basePath} link="show">
+```
+
+
 ## `withDataProvider` no longer injects `dispatch`
 
 The `withDataProvider` HOC used to inject two props: `dataProvider`, and redux' `dispatch`. This last prop is now easy to get via the `useDispatch` hook from Redux, so `withDataProvider` no longer injects it.

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -520,6 +520,15 @@ You can also prevent `<ReferenceField>` from adding link to children by setting 
 </ReferenceField>
 ```
 
+You can also use a custom `linkType` function to get a custom path for the children.
+
+```jsx
+// Custom path
+<ReferenceField label="User" source="userId" reference="users" linkType={() => '/my/path'}>
+    <TextField source="name" />
+</ReferenceField>
+```
+
 **Tip**: React-admin uses `CRUD_GET_ONE_REFERENCE` action to accumulate and deduplicate the ids of the referenced records to make *one* `GET_MANY` call for the entire list, instead of n `GET_ONE` calls. So for instance, if the API returns the following list of comments:
 
 ```jsx

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -495,10 +495,10 @@ With this configuration, `<ReferenceField>` wraps the user's name in a link to t
 </Admin>
 ```
 
-To change the link from the `<Edit>` page to the `<Show>` page, set the `linkTo` prop to "show".
+To change the link from the `<Edit>` page to the `<Show>` page, set the `link` prop to "show".
 
 ```jsx
-<ReferenceField label="User" source="userId" reference="users" linkTo="show">
+<ReferenceField label="User" source="userId" reference="users" link="show">
     <TextField source="name" />
 </ReferenceField>
 ```
@@ -511,20 +511,20 @@ By default, `<ReferenceField>` is sorted by its `source`. To specify another att
 </ReferenceField>
 ```
 
-You can also prevent `<ReferenceField>` from adding link to children by setting `linkTo` to `false`.
+You can also prevent `<ReferenceField>` from adding link to children by setting `link` to `false`.
 
 ```jsx
 // No link
-<ReferenceField label="User" source="userId" reference="users" linkTo={false}>
+<ReferenceField label="User" source="userId" reference="users" link={false}>
     <TextField source="name" />
 </ReferenceField>
 ```
 
-You can also use a custom `linkTo` function to get a custom path for the children. This function must accept `record` and `reference` as arguments. On previous versions of React-Admin, this prop was named `LinkType`, however you should migrate it to `linkTo`.
+You can also use a custom `link` function to get a custom path for the children. This function must accept `record` and `reference` as arguments.
 
 ```jsx
 // Custom path
-<ReferenceField label="User" source="userId" reference="users" linkTo={(record, reference) => `/my/path/to/${reference}/${record.id}`}>
+<ReferenceField label="User" source="userId" reference="users" link={(record, reference) => `/my/path/to/${reference}/${record.id}`}>
     <TextField source="name" />
 </ReferenceField>
 ```

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -520,11 +520,11 @@ You can also prevent `<ReferenceField>` from adding link to children by setting 
 </ReferenceField>
 ```
 
-You can also use a custom `linkType` function to get a custom path for the children.
+You can also use a custom `linkType` function to get a custom path for the children. This function must accept sourceId and reference as arguments.
 
 ```jsx
 // Custom path
-<ReferenceField label="User" source="userId" reference="users" linkType={() => '/my/path'}>
+<ReferenceField label="User" source="userId" reference="users" linkType={(sourceId, reference) => `/my/path/to/${reference}/${sourceId}`}>
     <TextField source="name" />
 </ReferenceField>
 ```

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -495,10 +495,10 @@ With this configuration, `<ReferenceField>` wraps the user's name in a link to t
 </Admin>
 ```
 
-To change the link from the `<Edit>` page to the `<Show>` page, set the `linkType` prop to "show".
+To change the link from the `<Edit>` page to the `<Show>` page, set the `linkTo` prop to "show".
 
 ```jsx
-<ReferenceField label="User" source="userId" reference="users" linkType="show">
+<ReferenceField label="User" source="userId" reference="users" linkTo="show">
     <TextField source="name" />
 </ReferenceField>
 ```
@@ -511,20 +511,20 @@ By default, `<ReferenceField>` is sorted by its `source`. To specify another att
 </ReferenceField>
 ```
 
-You can also prevent `<ReferenceField>` from adding link to children by setting `linkType` to `false`.
+You can also prevent `<ReferenceField>` from adding link to children by setting `linkTo` to `false`.
 
 ```jsx
 // No link
-<ReferenceField label="User" source="userId" reference="users" linkType={false}>
+<ReferenceField label="User" source="userId" reference="users" linkTo={false}>
     <TextField source="name" />
 </ReferenceField>
 ```
 
-You can also use a custom `linkType` function to get a custom path for the children. This function must accept sourceId and reference as arguments.
+You can also use a custom `linkTo` function to get a custom path for the children. This function must accept `record` and `reference` as arguments. On previous versions of React-Admin, this prop was named `LinkType`, however you should migrate it to `linkTo`.
 
 ```jsx
 // Custom path
-<ReferenceField label="User" source="userId" reference="users" linkType={(sourceId, reference) => `/my/path/to/${reference}/${sourceId}`}>
+<ReferenceField label="User" source="userId" reference="users" linkTo={(record, reference) => `/my/path/to/${reference}/${record.id}`}>
     <TextField source="name" />
 </ReferenceField>
 ```

--- a/packages/ra-core/src/controller/field/ReferenceFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldController.spec.tsx
@@ -156,7 +156,7 @@ describe('<ReferenceFieldController />', () => {
         });
     });
 
-    it('should render a link to the Show page of the related record when the linkType is show', () => {
+    it('should render a link to the Show page of the related record when the link is show', () => {
         const children = jest.fn().mockReturnValue(<span>children</span>);
         renderWithRedux(
             <ReferenceFieldController
@@ -165,7 +165,7 @@ describe('<ReferenceFieldController />', () => {
                 resource="comments"
                 reference="posts"
                 basePath="/comments"
-                linkType="show"
+                link="show"
             >
                 {children}
             </ReferenceFieldController>,
@@ -179,7 +179,7 @@ describe('<ReferenceFieldController />', () => {
         });
     });
 
-    it('should accept edit as resource name when linkType is show', () => {
+    it('should accept edit as resource name when link is show', () => {
         const children = jest.fn().mockReturnValue(<span>children</span>);
         renderWithRedux(
             <ReferenceFieldController
@@ -188,7 +188,7 @@ describe('<ReferenceFieldController />', () => {
                 reference="edit"
                 resource="show"
                 basePath="/show"
-                linkType="show"
+                link="show"
             >
                 {children}
             </ReferenceFieldController>,
@@ -210,7 +210,7 @@ describe('<ReferenceFieldController />', () => {
         });
     });
 
-    it('should accept show as resource name when linkType is show', () => {
+    it('should accept show as resource name when link is show', () => {
         const children = jest.fn().mockReturnValue(<span>children</span>);
         renderWithRedux(
             <ReferenceFieldController
@@ -220,7 +220,7 @@ describe('<ReferenceFieldController />', () => {
                 resource="edit"
                 basePath="/edit"
                 crudGetManyAccumulate={crudGetManyAccumulate}
-                linkType="show"
+                link="show"
             >
                 {children}
             </ReferenceFieldController>,
@@ -242,7 +242,7 @@ describe('<ReferenceFieldController />', () => {
         });
     });
 
-    it('should set resourceLinkPath to false when the linkType is false', () => {
+    it('should set resourceLinkPath to false when the link is false', () => {
         const children = jest.fn().mockReturnValue(<span>children</span>);
         renderWithRedux(
             <ReferenceFieldController
@@ -250,7 +250,7 @@ describe('<ReferenceFieldController />', () => {
                 source="postId"
                 reference="posts"
                 basePath="/foo"
-                linkType={false}
+                link={false}
             >
                 {children}
             </ReferenceFieldController>,

--- a/packages/ra-core/src/controller/field/ReferenceFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldController.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, ReactNode, ReactElement } from 'react';
 import { Record } from '../../types';
-import useReference, { UseReferenceProps } from './useReference';
+import useReference, { UseReferenceProps, LinkToFunctionType } from './useReference';
 
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
     reference: string;
     resource: string;
     source: string;
-    linkType: string | boolean;
+    link: string | boolean | LinkToFunctionType;
 }
 
 /**
@@ -28,18 +28,18 @@ interface Props {
  * By default, includes a link to the <Edit> page of the related record
  * (`/users/:userId` in the previous example).
  *
- * Set the linkType prop to "show" to link to the <Show> page instead.
+ * Set the link prop to "show" to link to the <Show> page instead.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkType="show">
+ * <ReferenceField label="User" source="userId" reference="users" link="show">
  *     <TextField source="name" />
  * </ReferenceField>
  *
  * You can also prevent `<ReferenceField>` from adding link to children by setting
- * `linkType` to false.
+ * `link` to false.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkType={false}>
+ * <ReferenceField label="User" source="userId" reference="users" link={false}>
  *     <TextField source="name" />
  * </ReferenceField>
  */

--- a/packages/ra-core/src/controller/field/useReference.ts
+++ b/packages/ra-core/src/controller/field/useReference.ts
@@ -7,7 +7,7 @@ import { crudGetManyAccumulate } from '../../actions';
 import { linkToRecord } from '../../util';
 import { Record, ReduxState } from '../../types';
 
-type linkTypeFunction = () => string;
+type linkTypeFunction = (record: Record, reference: string) => string;
 
 interface Option {
     allowEmpty?: boolean;
@@ -52,8 +52,7 @@ export interface UseReferenceProps {
  * @param {Object} option
  * @param {boolean} option.allowEmpty do we allow for no referenced record (default to false)
  * @param {string} option.basePath basepath to current resource
- * @param {string | false | linkTypeFunction} option.linkType The type of the link toward the referenced record. 'edit', 'show' or
- * false for no link (default to edit). Alternatively a function that returns a string
+ * @param {string | false | linkTypeFunction} option.linkType The type of the link toward the referenced record. 'edit', 'show' or false for no link (default to edit). Alternatively a function that returns a string
  * @param {Object} option.record The The current resource record
  * @param {string} option.reference The linked resource name
  * @param {string} option.resource The current resource name
@@ -84,7 +83,7 @@ export const useReference = ({
     const resourceLinkPath = !linkType
         ? false
         : typeof linkType === 'function'
-        ? linkType()
+        ? linkType(record, reference)
         : linkToRecord(rootPath, sourceId, linkType as string);
 
     return {

--- a/packages/ra-core/src/controller/field/useReference.ts
+++ b/packages/ra-core/src/controller/field/useReference.ts
@@ -7,6 +7,8 @@ import { crudGetManyAccumulate } from '../../actions';
 import { linkToRecord } from '../../util';
 import { Record, ReduxState } from '../../types';
 
+type linkTypeFunction = () => string;
+
 interface Option {
     allowEmpty?: boolean;
     basePath: string;
@@ -14,7 +16,7 @@ interface Option {
     reference: string;
     resource: string;
     source: string;
-    linkType: string | boolean;
+    linkType: string | boolean | linkTypeFunction;
 }
 
 export interface UseReferenceProps {
@@ -50,7 +52,8 @@ export interface UseReferenceProps {
  * @param {Object} option
  * @param {boolean} option.allowEmpty do we allow for no referenced record (default to false)
  * @param {string} option.basePath basepath to current resource
- * @param {string | false} option.linkType The type of the link toward the referenced record. edit, show of false for no link (default to edit)
+ * @param {string | false | linkTypeFunction} option.linkType The type of the link toward the referenced record. 'edit', 'show' or
+ * false for no link (default to edit). Alternatively a function that returns a string
  * @param {Object} option.record The The current resource record
  * @param {string} option.reference The linked resource name
  * @param {string} option.resource The current resource name
@@ -80,6 +83,8 @@ export const useReference = ({
     const rootPath = basePath.replace(resource, reference);
     const resourceLinkPath = !linkType
         ? false
+        : typeof linkType === 'function'
+        ? linkType()
         : linkToRecord(rootPath, sourceId, linkType as string);
 
     return {

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -101,33 +101,33 @@ ReferenceFieldView.propTypes = {
  * By default, includes a link to the <Edit> page of the related record
  * (`/users/:userId` in the previous example).
  *
- * Set the `linkTo` prop to "show" to link to the <Show> page instead.
+ * Set the `link` prop to "show" to link to the <Show> page instead.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkTo="show">
+ * <ReferenceField label="User" source="userId" reference="users" link="show">
  *     <TextField source="name" />
  * </ReferenceField>
  *
  * @default
  * You can also prevent `<ReferenceField>` from adding link to children by setting
- * `linkTo` to false.
+ * `link` to false.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkTo={false}>
+ * <ReferenceField label="User" source="userId" reference="users" link={false}>
  *     <TextField source="name" />
  * </ReferenceField>
  * 
  * @default
- * Alternatively, you can also pass a custom function to `LinkTo`. It must take reference and record
+ * Alternatively, you can also pass a custom function to `link`. It must take reference and record
  * as arguments and return a string
  * 
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkTo={(reference, record) => "/path/to/${reference}/${record}"}>
+ * <ReferenceField label="User" source="userId" reference="users" link={(reference, record) => "/path/to/${reference}/${record}"}>
  *     <TextField source="name" />
  * </ReferenceField>
  * 
  * @default
- * In previous versions of React-Admin, the prop `linkType` was used. It is now deprecated and replaced with `linkTo`. However
+ * In previous versions of React-Admin, the prop `linkType` was used. It is now deprecated and replaced with `link`. However
  * backward-compatibility is still kept
  */
 
@@ -166,13 +166,13 @@ ReferenceField.propTypes = {
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func]),
-    linkTo: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func]).isRequired,
+    link: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func]).isRequired,
 };
 
 ReferenceField.defaultProps = {
     allowEmpty: false,
     classes: {},
-    linkTo: 'edit',
+    link: 'edit',
     record: {},
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -149,7 +149,7 @@ ReferenceField.propTypes = {
     sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
-    linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
+    linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func])
         .isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -97,24 +97,40 @@ ReferenceFieldView.propTypes = {
  *     <TextField source="name" />
  * </ReferenceField>
  *
+ * @default
  * By default, includes a link to the <Edit> page of the related record
  * (`/users/:userId` in the previous example).
  *
- * Set the linkType prop to "show" to link to the <Show> page instead.
+ * Set the `linkTo` prop to "show" to link to the <Show> page instead.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkType="show">
+ * <ReferenceField label="User" source="userId" reference="users" linkTo="show">
  *     <TextField source="name" />
  * </ReferenceField>
  *
+ * @default
  * You can also prevent `<ReferenceField>` from adding link to children by setting
- * `linkType` to false.
+ * `linkTo` to false.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkType={false}>
+ * <ReferenceField label="User" source="userId" reference="users" linkTo={false}>
  *     <TextField source="name" />
  * </ReferenceField>
+ * 
+ * @default
+ * Alternatively, you can also pass a custom function to `LinkTo`. It must take reference and record
+ * as arguments and return a string
+ * 
+ * @example
+ * <ReferenceField label="User" source="userId" reference="users" linkTo={(reference, record) => "/path/to/${reference}/${record}"}>
+ *     <TextField source="name" />
+ * </ReferenceField>
+ * 
+ * @default
+ * In previous versions of React-Admin, the prop `linkType` was used. It is now deprecated and replaced with `linkTo`. However
+ * backward-compatibility is still kept
  */
+
 const ReferenceField = ({ children, ...props }) => {
     if (React.Children.count(children) !== 1) {
         throw new Error('<ReferenceField> only accepts a single child');
@@ -149,14 +165,14 @@ ReferenceField.propTypes = {
     sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
-    linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func])
-        .isRequired,
+    linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func]),
+    linkTo: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func]).isRequired,
 };
 
 ReferenceField.defaultProps = {
     allowEmpty: false,
     classes: {},
-    linkType: 'edit',
+    linkTo: 'edit',
     record: {},
 };
 

--- a/packages/ra-ui-materialui/src/field/sanitizeRestProps.ts
+++ b/packages/ra-ui-materialui/src/field/sanitizeRestProps.ts
@@ -11,6 +11,7 @@ export default (props: object): object =>
         'headerClassName',
         'label',
         'linkType',
+        'linkTo',
         'locale',
         'record',
         'resource',

--- a/packages/ra-ui-materialui/src/field/sanitizeRestProps.ts
+++ b/packages/ra-ui-materialui/src/field/sanitizeRestProps.ts
@@ -11,7 +11,7 @@ export default (props: object): object =>
         'headerClassName',
         'label',
         'linkType',
-        'linkTo',
+        'link',
         'locale',
         'record',
         'resource',


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/2288

* enable linkType function for ReferenceField
* update docs

PR to `next` as it is a new feature