### PR TITLE
[RFR] Doc update of <CheckboxGroupInput>

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -456,13 +456,16 @@ Lastly, use the `options` attribute if you want to override any of Material UI's
 
 {% raw %}
 ```jsx
+import { FavoriteBorder, Favorite } from '@material-ui/icons';
+
 <CheckboxGroupInput source="category" options={{
-    labelPosition: 'right'
+    icon: <FavoriteBorder />,
+    checkedIcon: <Favorite />
 }} />
 ```
 {% endraw %}
 
-Refer to [Material UI Checkbox documentation](http://www.material-ui.com/#/components/checkbox) for more details.
+Refer to [Material UI Checkbox documentation](https://v1-5-0.material-ui.com/api/checkbox/) for more details.
 
 ## `<DateInput>`
 


### PR DESCRIPTION
Example in the doc was using prop from the latest version of `<Checkbox>` component from Material Ui and also a link of `<Checkbox>` documentation was pointing to the latest Material Ui version, and Material Ui version used by `ra-ui-materialui` does not support many props from the latest version, so the confusion for users.

Changed both prop example and link to version (1.5.1) used by `ra-ui-materialui`.

Resolves #2883 