### PR TITLE
[RFR] Add disabled prop to clear IconButton in <ResettableTextField>

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -34,6 +34,7 @@ class ResettableTextField extends Component {
     static propTypes = {
         classes: PropTypes.object.isRequired,
         clearAlwaysVisible: PropTypes.bool,
+        disabled: PropTypes.bool,
         InputProps: PropTypes.object,
         onBlur: PropTypes.func,
         onChange: PropTypes.func.isRequired,
@@ -72,6 +73,7 @@ class ResettableTextField extends Component {
             InputProps,
             value,
             resettable,
+            disabled,
             ...props
         } = this.props;
         const { showClear } = this.state;
@@ -102,6 +104,7 @@ class ResettableTextField extends Component {
                                 disableRipple
                                 onClick={this.handleClickClearButton}
                                 onMouseDown={this.handleMouseDownClearButton}
+                                disabled={disabled}
                             >
                                 <ClearIcon
                                     className={classNames(clearIcon, {
@@ -114,6 +117,7 @@ class ResettableTextField extends Component {
                     ),
                     ...InputProps,
                 }}
+                disabled={disabled}
                 {...props}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}


### PR DESCRIPTION
Disable both `MuTextField` and `IconButton` when `disabled` prop is passed to `<ResettableTextField>`

Fixes #2619 