### PR TITLE
Fix AutoCompleteArrayInput not showing error message

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -260,8 +260,8 @@ export class AutocompleteArrayInput extends React.Component {
                 onDelete={this.handleDelete}
                 value={this.getInputValue(input.value)}
                 inputRef={storeInputRef}
-                error={touched && error}
-                helperText={touched && error && helperText}
+                error={!!(touched && error)}
+                helperText={(touched && error) || helperText}
                 chipRenderer={this.renderChip}
                 label={
                     <FieldTitle


### PR DESCRIPTION
AutoCompleteArrayInput was not showing up error message when there is a validation error. It shows up the input in red color but the error message is not shown. 
Fixing the code to follow the same patten as SelectInput and AutocompleteInput.