### PR TITLE
Booleaninput helpertext

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.js
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.js
@@ -29,6 +29,7 @@ export class BooleanInput extends Component {
         } = this.props;
 
         const { value, ...inputProps } = input;
+        const { error, helperText = false } = meta;
 
         return (
             <FormGroup className={className} {...sanitizeRestProps(rest)}>
@@ -53,9 +54,10 @@ export class BooleanInput extends Component {
                         />
                     }
                 />
-                {meta.error && (
-                    <FormHelperText error>{meta.error}</FormHelperText>
+                {error && (
+                    <FormHelperText error>{error}</FormHelperText>
                 )}
+                {helperText && <FormHelperText>{helperText}</FormHelperText>}
             </FormGroup>
         );
     }

--- a/packages/ra-ui-materialui/src/input/BooleanInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.spec.js
@@ -71,4 +71,16 @@ describe('<BooleanInput />', () => {
                 .text()
         ).toBe('foobar');
     });
+
+    it('should display helperText if prop is present in meta', () => {
+        const { queryByText } = render(
+            <BooleanInput
+                {...defaultProps}
+                source="bar"
+                input={{ value: true }}
+                meta={{ helperText: 'Can I help you?' }}
+            />
+        );
+        expect(queryByText('Can I help you?')).not.toBeNull();
+    });
 });


### PR DESCRIPTION
This is to support passing a helperText into a BooleanInput, following the same convention as other inputs that use the meta tag, such as RadioButtonGroupInput. 

An issue was created here prior to making this PR:  https://github.com/marmelab/react-admin/issues/3127