### PR TITLE
[RFR] Upgrade react-redux to version 7.1

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -19,7 +19,7 @@
         "react-admin": "^2.0.0",
         "react-app-polyfill": "^0.1.3",
         "react-dom": "~16.8.0",
-        "react-redux": "^7.1.0-rc.1",
+        "react-redux": "^7.1.0",
         "react-router": "^5.0.1",
         "react-router-dom": "^5.0.1",
         "react-scripts": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "devDependencies": {
         "@types/jest": "^24.0.13",
         "@types/react": "^16.8.0",
-        "@types/react-redux": "^7.0.9",
+        "@types/react-redux": "^7.1.0",
         "@types/recompose": "^0.27.0",
         "@typescript-eslint/eslint-plugin": "^1.9.0",
         "@typescript-eslint/parser": "^1.9.0",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -59,7 +59,7 @@
         "prop-types": "^15.6.1",
         "query-string": "~5.1.1",
         "ra-language-english": "^2.9.3",
-        "react-redux": "^7.1.0-rc.1",
+        "react-redux": "^7.1.0",
         "react-router": "^5.0.1",
         "react-router-dom": "^5.0.1",
         "recompose": "~0.26.0",

--- a/packages/ra-core/src/controller/field/useReferenceArray.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArray.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 // @ts-ignore
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import get from 'lodash/get';
 
 import { crudGetManyAccumulate } from '../../actions';
@@ -66,7 +66,7 @@ const useReferenceArray = ({
     const dispatch = useDispatch();
     const { data, ids } = useSelector(
         getReferenceArray({ record, source, reference }),
-        [record, source, reference]
+        shallowEqual
     );
     useEffect(() => {
         dispatch(crudGetManyAccumulate(reference, ids));

--- a/packages/ra-core/src/controller/field/useReferenceMany.ts
+++ b/packages/ra-core/src/controller/field/useReferenceMany.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 // @ts-ignore
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import get from 'lodash/get';
 
 import { crudGetManyReference } from '../../actions';
@@ -100,12 +100,9 @@ const useReferenceMany = ({
         () => nameRelatedTo(reference, referenceId, resource, target, filter),
         [filter, reference, referenceId, resource, target]
     );
-    const ids = useSelector(selectIds(relatedTo), [relatedTo]);
-    const data = useSelector(selectData(reference, relatedTo), [
-        reference,
-        relatedTo,
-    ]);
-    const total = useSelector(selectTotal(relatedTo), [relatedTo]);
+    const ids = useSelector(selectIds(relatedTo), shallowEqual);
+    const data = useSelector(selectData(reference, relatedTo), shallowEqual);
+    const total = useSelector(selectTotal(relatedTo));
 
     const dispatch = useDispatch();
 

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState, useMemo } from 'react';
 // @ts-ignore
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { parse, stringify } from 'query-string';
 import { push } from 'connected-react-router';
 import lodashDebounce from 'lodash/debounce';
@@ -116,7 +116,7 @@ const useListParams = ({
 
     const { params } = useSelector(
         (reduxState: ReduxState) => reduxState.admin.resources[resource].list,
-        [resource]
+        shallowEqual
     );
 
     const requestSignature = [

--- a/packages/ra-core/src/controller/useRecordSelection.ts
+++ b/packages/ra-core/src/controller/useRecordSelection.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 // @ts-ignore
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { setListSelectedIds, toggleListItem } from '../actions/listActions';
 import { Identifier, ReduxState } from '../types';
 
@@ -16,7 +16,7 @@ const useSelectItems = (resource: string) => {
     const selectedIds = useSelector(
         (reduxState: ReduxState) =>
             reduxState.admin.resources[resource].list.selectedIds,
-        [resource]
+        shallowEqual
     );
     const selectionModifiers = {
         select: useCallback(

--- a/packages/ra-core/src/fetch/useGetList.ts
+++ b/packages/ra-core/src/fetch/useGetList.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 import { CRUD_GET_LIST } from '../actions/dataActions/crudGetList';
 import { GET_LIST } from '../dataFetchActions';
 import { Pagination, Sort, ReduxState } from '../types';
@@ -66,7 +66,7 @@ const useGetList = (
             state.admin.resources[resource]
                 ? state.admin.resources[resource].data
                 : null,
-        [resource]
+        shallowEqual
     );
     return { data, ids, total, error, loading, loaded };
 };

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -58,7 +58,7 @@
         "ra-core": "^2.9.3",
         "react-autosuggest": "^9.4.2",
         "react-dropzone": "~4.0.1",
-        "react-redux": "^7.1.0-rc.1",
+        "react-redux": "^7.1.0",
         "react-router": "^5.0.1",
         "react-router-dom": "^5.0.1",
         "react-transition-group": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,10 +2021,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/react-redux@^7.0.9":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.9.tgz#4825ee2872c44768916304b6bb8df5b46d443b88"
-  integrity sha512-fMVX9SneWWw68d/JoeNUh6hj42kx2G30YhPdCYJTOv3xqbJ1xzIz6tEM/xzi7nBvpNbwZkSa9TMsV06kWOFIIg==
+"@types/react-redux@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.0.tgz#ed2c90ff192433251bd8a264195529f3613d53e2"
+  integrity sha512-SBJd6oNACDU/taMcDzFfj0mbVa+OI42L8WNvgPsCWiWUNIavPLeX5oA22V64tYIDUc7cGmJjDyLlWeCrqpZu1w==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
@@ -14405,10 +14405,10 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@^7.1.0-rc.1:
-  version "7.1.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.0-rc.1.tgz#af42e20901e443191ace09392b1c8b85721a5de6"
-  integrity sha512-ULeRoensr1LZqs1f7HiWYWN67ppRuoBbB5NfSKn3Py92G7qNSnNb+GC2quMgOXXrMBmcq0C9hvPn3xwhQmUXKw==
+react-redux@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.0.tgz#72af7cf490a74acdc516ea9c1dd80e25af9ea0b2"
+  integrity sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
Requires changes in useSelector due to breaking change in react-redux 7.1.0-alpha.5 (see https://github.com/reduxjs/react-redux/releases/tag/v7.1.0-alpha.5).

Without this upgrade, TypeScript will fail to build after a yarn fresh install, because the new DefinitelyTyped types for react-redux enforce the `useSelector` signature of 7.1.0 final. 