### PR TITLE
[RFR] Fix DashboardMenuItem className prop

### DIFF
--- a/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
+++ b/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
@@ -5,13 +5,7 @@ import { translate } from 'ra-core';
 
 import MenuItemLink from './MenuItemLink';
 
-const DashboardMenuItem = ({
-    className,
-    locale,
-    onClick,
-    translate,
-    ...props
-}) => (
+const DashboardMenuItem = ({ locale, onClick, translate, ...props }) => (
     <MenuItemLink
         onClick={onClick}
         to="/"
@@ -24,7 +18,6 @@ const DashboardMenuItem = ({
 
 DashboardMenuItem.propTypes = {
     classes: PropTypes.object,
-    className: PropTypes.string,
     locale: PropTypes.string,
     onClick: PropTypes.func,
     translate: PropTypes.func.isRequired,


### PR DESCRIPTION
## Problem

When (re)using the component `<DashboardMenuItem>`, if pass it a `className` prop it is supressed by the component and not passed to its children `MenuItem`.

## Solution

1. Pass the `className` prop to its children
2. or, let this one in the default props passed in the children

I choose the second one, because this prop isn't used anyway.