### PR TITLE
[RFR] Prevent Event propagation after Delete Confirm modal close

### DIFF
--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
@@ -52,8 +52,8 @@ class DeleteWithConfirmButton extends Component {
         this.setState({ isOpen: true });
     };
 
-    handleDialogClose = evt => {
-        evt.stopPropagation();
+    handleDialogClose = e => {
+        e.stopPropagation();
         this.setState({ isOpen: false });
     };
 

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.js
@@ -48,11 +48,12 @@ class DeleteWithConfirmButton extends Component {
     state = { isOpen: false };
 
     handleClick = e => {
-        this.setState({ isOpen: true });
         e.stopPropagation();
+        this.setState({ isOpen: true });
     };
 
-    handleDialogClose = () => {
+    handleDialogClose = evt => {
+        evt.stopPropagation();
         this.setState({ isOpen: false });
     };
 


### PR DESCRIPTION
Fixes #3359

When the DeleteWithConfirm modal was closed, it behaved like we clicked
on the Datagrid row (triggering the `rowClick` handler of Datagrid)