### PR TITLE
[RFR] Fix Dead Link to Bulk Action Buttons in Docs

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -791,7 +791,7 @@ Almost everything we saw before about custom actions is true for custom `List` b
 * Bulk action button components receive the following props: `resource`, `selectedIds` and `filterValues`
 * They do not receive the current record in the `record` prop as there are many of them.
 
-You can find a complete example of a custom Bulk Action button in the `List` documentation, in the [Bulk Action Buttons](/List.html#bulk-action-buttons) section.
+You can find a complete example of a custom Bulk Action button in the `List` documentation, in the [Bulk Action Buttons](./List.md#bulk-action-buttons) section.
 
 ## Conclusion
 


### PR DESCRIPTION
Fixes #3355

#### What Does This PR Do?
This PR fixes the dead link to the `Bulk Action Buttons` implementation example in https://marmelab.com/react-admin/Actions.html#list-bulk-actions
```

"You can find a complete example of a custom Bulk Action button in the List documentation, 
in the Bulk Action Buttons section." <--- Here
```

#### Description Of Task To Be Completed
- Clicking on the link should navigate the user to the `Bulk Action Buttons` implementation example in `List markdown` instead of displaying a `Not Found` page

#### Any Background Context You Want To Provide?
- N/A

#### How can this be manually tested?
- Navigate to [here](https://marmelab.com/react-admin/Actions.html#list-bulk-actions)
- Click on `Bulk Action Buttons`
- The page should navigate to [here](https://marmelab.com/react-admin/List.html#bulk-action-buttons) instead of displaying a `Not Found` page 

References [#3355](https://github.com/marmelab/react-admin/issues/3355)