### PR TITLE
[RFR] Add useListController hook

### DIFF
--- a/packages/ra-core/src/controller/ListController.spec.tsx
+++ b/packages/ra-core/src/controller/ListController.spec.tsx
@@ -3,10 +3,11 @@ import { fireEvent, cleanup } from 'react-testing-library';
 import lolex from 'lolex';
 import TextField from '@material-ui/core/TextField/TextField';
 
-import ListController, {
+import ListController from './ListController';
+import {
     getListControllerProps,
     sanitizeListRestProps,
-} from './ListController';
+} from './useListController';
 
 import renderWithRedux from '../util/renderWithRedux';
 import { CRUD_CHANGE_LIST_PARAMS } from '../actions';

--- a/packages/ra-core/src/controller/ListController.tsx
+++ b/packages/ra-core/src/controller/ListController.tsx
@@ -1,16 +1,8 @@
-import { isValidElement, ReactNode, ReactElement, useMemo } from 'react';
-import inflection from 'inflection';
+import { ReactNode } from 'react';
 
-import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
-import { ListParams } from '../actions/listActions';
-import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
-import { Sort, AuthProvider, RecordMap, Identifier, Translate } from '../types';
-import { Location } from 'history';
+import useListController, { Props } from './useListController';
 import { useTranslate } from '../i18n';
-import useListParams from './useListParams';
-import useGetList from './../fetch/useGetList';
-import useRecordSelection from './useRecordSelection';
-import useVersion from './useVersion';
+import { Sort, RecordMap, Identifier, Translate } from '../types';
 
 interface ChildrenFuncParams {
     basePath: string;
@@ -41,230 +33,27 @@ interface ChildrenFuncParams {
     version: number;
 }
 
-interface Props {
-    // the props you can change
+interface ListControllerProps extends Props {
     children: (params: ChildrenFuncParams) => ReactNode;
-    filter?: object;
-    filters?: ReactElement<any>;
-    filterDefaultValues?: object;
-    pagination?: ReactElement<any>;
-    perPage?: number;
-    sort?: Sort;
-    // the props managed by react-admin
-    authProvider?: AuthProvider;
-    basePath: string;
-    debounce?: number;
-    hasCreate?: boolean;
-    hasEdit?: boolean;
-    hasList?: boolean;
-    hasShow?: boolean;
-    location: Location;
-    path?: string;
-    query: ListParams;
-    resource: string;
-    [key: string]: any;
 }
 
-const defaultSort = {
-    field: 'id',
-    order: SORT_ASC,
-};
 /**
- * List page component
+ * Render prop version of the useListController hook.
  *
- * The <List> component renders the list layout (title, buttons, filters, pagination),
- * and fetches the list of records from the REST API.
- * It then delegates the rendering of the list of records to its child component.
- * Usually, it's a <Datagrid>, responsible for displaying a table with one row for each post.
- *
- * In Redux terms, <List> is a connected component, and <Datagrid> is a dumb component.
- *
- * Props:
- *   - title
- *   - perPage
- *   - sort
- *   - filter (the permanent filter to apply to the query)
- *   - actions
- *   - filters (a React component used to display the filter form)
- *   - pagination
- *
+ * @see useListController
  * @example
- *     const PostFilter = (props) => (
- *         <Filter {...props}>
- *             <TextInput label="Search" source="q" alwaysOn />
- *             <TextInput label="Title" source="title" />
- *         </Filter>
- *     );
- *     export const PostList = (props) => (
- *         <List {...props}
- *             title="List of posts"
- *             sort={{ field: 'published_at' }}
- *             filter={{ is_published: true }}
- *             filters={<PostFilter />}
- *         >
- *             <Datagrid>
- *                 <TextField source="id" />
- *                 <TextField source="title" />
- *                 <EditButton />
- *             </Datagrid>
- *         </List>
- *     );
+ *
+ * const ListView = () => <div>...</div>;
+ * const List = props => (
+ *     <ListController {...props}>
+ *        {controllerProps => <ListView {...controllerProps} {...props} />}
+ *     </ListController>
+ * )
  */
-const ListController = (props: Props) => {
-    useCheckMinimumRequiredProps(
-        'List',
-        ['basePath', 'location', 'resource', 'children'],
-        props
-    );
-    if (props.filter && isValidElement(props.filter)) {
-        throw new Error(
-            '<List> received a React element as `filter` props. If you intended to set the list filter elements, use the `filters` (with an s) prop instead. The `filter` prop is internal and should not be set by the developer.'
-        );
-    }
-
-    const {
-        basePath,
-        children,
-        resource,
-        hasCreate,
-        location,
-        filterDefaultValues,
-        sort = defaultSort,
-        perPage = 10,
-        filter,
-        debounce = 500,
-    } = props;
-
+const ListController = ({ children, ...props }: ListControllerProps) => {
+    const controllerProps = useListController(props);
     const translate = useTranslate();
-    const version = useVersion();
-
-    const [query, queryModifiers] = useListParams({
-        resource,
-        location,
-        filterDefaultValues,
-        sort,
-        perPage,
-        debounce,
-    });
-
-    const [selectedIds, selectionModifiers] = useRecordSelection(resource);
-
-    const { data, ids, total, loading, loaded } = useGetList(
-        resource,
-        {
-            page: query.page,
-            perPage: query.perPage,
-        },
-        { field: query.sort, order: query.order },
-        { ...query.filter, ...filter },
-        {
-            version,
-            onFailure: {
-                notification: {
-                    body: 'ra.notification.http_error',
-                    level: 'warning',
-                },
-            },
-        }
-    );
-
-    if (!query.page && !(ids || []).length && query.page > 1 && total > 0) {
-        // query for a page that doesn't exist, check the previous page
-        queryModifiers.setPage(query.page - 1);
-    }
-
-    const currentSort = useMemo(
-        () => ({
-            field: query.sort,
-            order: query.order,
-        }),
-        [query.sort, query.order]
-    );
-
-    const resourceName = translate(`resources.${resource}.name`, {
-        smart_count: 2,
-        _: inflection.humanize(inflection.pluralize(resource)),
-    });
-    const defaultTitle = translate('ra.page.list', {
-        name: resourceName,
-    });
-
-    return children({
-        basePath,
-        currentSort,
-        data,
-        defaultTitle,
-        displayedFilters: query.displayedFilters,
-        filterValues: query.filterValues,
-        hasCreate,
-        ids,
-        isLoading: loading,
-        loadedOnce: loaded,
-        onSelect: selectionModifiers.select,
-        onToggleItem: selectionModifiers.toggle,
-        onUnselectItems: selectionModifiers.clearSelection,
-        page: query.page,
-        perPage: query.perPage,
-        resource,
-        selectedIds,
-        setFilters: queryModifiers.setFilters,
-        hideFilter: queryModifiers.hideFilter,
-        showFilter: queryModifiers.showFilter,
-        setPage: queryModifiers.setPage,
-        setPerPage: queryModifiers.setPerPage,
-        setSort: queryModifiers.setSort,
-        translate,
-        total,
-        version,
-    });
+    return children({ translate, ...controllerProps });
 };
-
-export const injectedProps = [
-    'basePath',
-    'currentSort',
-    'data',
-    'defaultTitle',
-    'displayedFilters',
-    'filterValues',
-    'hasCreate',
-    'hideFilter',
-    'ids',
-    'isLoading',
-    'loadedOnce',
-    'onSelect',
-    'onToggleItem',
-    'onUnselectItems',
-    'page',
-    'perPage',
-    'refresh',
-    'resource',
-    'selectedIds',
-    'setFilters',
-    'setPage',
-    'setPerPage',
-    'setSort',
-    'showFilter',
-    'total',
-    'translate',
-    'version',
-];
-
-/**
- * Select the props injected by the ListController
- * to be passed to the List children need
- * This is an implementation of pick()
- */
-export const getListControllerProps = props =>
-    injectedProps.reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
-
-/**
- * Select the props not injected by the ListController
- * to be used inside the List children to sanitize props injected by List
- * This is an implementation of omit()
- */
-export const sanitizeListRestProps = props =>
-    Object.keys(props)
-        .filter(propName => !injectedProps.includes(propName))
-        .reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
 
 export default ListController;

--- a/packages/ra-core/src/controller/ListController.tsx
+++ b/packages/ra-core/src/controller/ListController.tsx
@@ -1,40 +1,18 @@
 import { ReactNode } from 'react';
 
-import useListController, { Props } from './useListController';
+import useListController, {
+    ListProps,
+    ListControllerProps,
+} from './useListController';
 import { useTranslate } from '../i18n';
-import { Sort, RecordMap, Identifier, Translate } from '../types';
+import { Translate } from '../types';
 
-interface ChildrenFuncParams {
-    basePath: string;
-    currentSort: Sort;
-    data: RecordMap;
-    defaultTitle: string;
-    displayedFilters: any;
-    filterValues: any;
-    hasCreate: boolean;
-    hideFilter: (filterName: string) => void;
-    ids: Identifier[];
-    isLoading: boolean;
-    loadedOnce: boolean;
-    onSelect: (ids: Identifier[]) => void;
-    onToggleItem: (id: Identifier) => void;
-    onUnselectItems: () => void;
-    page: number;
-    perPage: number;
-    resource: string;
-    selectedIds: Identifier[];
-    setFilters: (filters: any) => void;
-    setPage: (page: number) => void;
-    setPerPage: (page: number) => void;
-    setSort: (sort: Sort) => void;
-    showFilter: (filterName: string, defaultValue: any) => void;
+interface ListControllerComponentProps extends ListControllerProps {
     translate: Translate;
-    total: number;
-    version: number;
 }
 
-interface ListControllerProps extends Props {
-    children: (params: ChildrenFuncParams) => ReactNode;
+interface Props extends ListProps {
+    children: (params: ListControllerComponentProps) => ReactNode;
 }
 
 /**
@@ -50,9 +28,9 @@ interface ListControllerProps extends Props {
  *     </ListController>
  * )
  */
-const ListController = ({ children, ...props }: ListControllerProps) => {
+const ListController = ({ children, ...props }: Props) => {
     const controllerProps = useListController(props);
-    const translate = useTranslate();
+    const translate = useTranslate(); // injected for backwards compatibility
     return children({ translate, ...controllerProps });
 };
 

--- a/packages/ra-core/src/controller/index.ts
+++ b/packages/ra-core/src/controller/index.ts
@@ -1,11 +1,11 @@
-import {
-    getListControllerProps,
-    sanitizeListRestProps,
-} from './useListController';
 import CreateController from './CreateController';
 import EditController from './EditController';
 import ListController from './ListController';
 import ShowController from './ShowController';
+import {
+    getListControllerProps,
+    sanitizeListRestProps,
+} from './useListController';
 import useRecordSelection from './useRecordSelection';
 import useVersion from './useVersion';
 import useSortState from './useSortState';

--- a/packages/ra-core/src/controller/index.ts
+++ b/packages/ra-core/src/controller/index.ts
@@ -1,7 +1,7 @@
 import {
     getListControllerProps,
     sanitizeListRestProps,
-} from './ListController';
+} from './useListController';
 import CreateController from './CreateController';
 import EditController from './EditController';
 import ListController from './ListController';
@@ -10,6 +10,8 @@ import useRecordSelection from './useRecordSelection';
 import useVersion from './useVersion';
 import useSortState from './useSortState';
 import usePaginationState from './usePaginationState';
+import useListController from './useListController';
+import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
 export {
     getListControllerProps,
     sanitizeListRestProps,
@@ -17,6 +19,8 @@ export {
     EditController,
     ListController,
     ShowController,
+    useCheckMinimumRequiredProps,
+    useListController,
     useRecordSelection,
     useVersion,
     useSortState,

--- a/packages/ra-core/src/controller/useListController.tsx
+++ b/packages/ra-core/src/controller/useListController.tsx
@@ -1,18 +1,18 @@
 import { isValidElement, ReactElement, useMemo } from 'react';
 import inflection from 'inflection';
-
-import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
-import { ListParams } from '../actions/listActions';
-import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
-import { Sort } from '../types';
 import { Location } from 'history';
-import { useTranslate } from '../i18n';
+
+import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
 import useListParams from './useListParams';
-import useGetList from './../fetch/useGetList';
 import useRecordSelection from './useRecordSelection';
 import useVersion from './useVersion';
+import { useTranslate } from '../i18n';
+import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
+import { ListParams } from '../actions/listActions';
+import { Sort, RecordMap, Identifier } from '../types';
+import useGetList from './../fetch/useGetList';
 
-export interface Props {
+export interface ListProps {
     // the props you can change
     filter?: object;
     filters?: ReactElement<any>;
@@ -39,26 +39,52 @@ const defaultSort = {
     order: SORT_ASC,
 };
 
+export interface ListControllerProps {
+    basePath: string;
+    currentSort: Sort;
+    data: RecordMap;
+    defaultTitle: string;
+    displayedFilters: any;
+    filterValues: any;
+    hasCreate: boolean;
+    hideFilter: (filterName: string) => void;
+    ids: Identifier[];
+    isLoading: boolean;
+    loadedOnce: boolean;
+    onSelect: (ids: Identifier[]) => void;
+    onToggleItem: (id: Identifier) => void;
+    onUnselectItems: () => void;
+    page: number;
+    perPage: number;
+    resource: string;
+    selectedIds: Identifier[];
+    setFilters: (filters: any) => void;
+    setPage: (page: number) => void;
+    setPerPage: (page: number) => void;
+    setSort: (sort: Sort) => void;
+    showFilter: (filterName: string, defaultValue: any) => void;
+    total: number;
+    version: number;
+}
+
 /**
  * Prepare data for the List view
  *
- * @param {Object} props The props passed to the Lsit component.
- *
- * Props should contain:
- *   - title
- *   - perPage
- *   - sort
- *   - filter (the permanent filter to apply to the query)
- *   - actions
- *   - filters (a React component used to display the filter form)
- *   - pagination
+ * @param {Object} props The props passed to the List component.
  *
  * @return {Object} controllerProps Fetched and computed data for the List view
  *
- * controllerProps contain:
+ * @example
  *
+ * import {useListController } from 'react-admin';
+ * import ListView from './ListView';
+ *
+ * const MyList = props => {
+ *     const controllerProps = useListController(props);
+ *     return <ListView {...controllerProps} {...props} />;
+ * }
  */
-const useListController = (props: Props) => {
+const useListController = (props: ListProps): ListControllerProps => {
     useCheckMinimumRequiredProps(
         'List',
         ['basePath', 'location', 'resource'],

--- a/packages/ra-core/src/controller/useListController.tsx
+++ b/packages/ra-core/src/controller/useListController.tsx
@@ -1,0 +1,215 @@
+import { isValidElement, ReactElement, useMemo } from 'react';
+import inflection from 'inflection';
+
+import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
+import { ListParams } from '../actions/listActions';
+import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
+import { Sort } from '../types';
+import { Location } from 'history';
+import { useTranslate } from '../i18n';
+import useListParams from './useListParams';
+import useGetList from './../fetch/useGetList';
+import useRecordSelection from './useRecordSelection';
+import useVersion from './useVersion';
+
+export interface Props {
+    // the props you can change
+    filter?: object;
+    filters?: ReactElement<any>;
+    filterDefaultValues?: object;
+    pagination?: ReactElement<any>;
+    perPage?: number;
+    sort?: Sort;
+    // the props managed by react-admin
+    basePath: string;
+    debounce?: number;
+    hasCreate?: boolean;
+    hasEdit?: boolean;
+    hasList?: boolean;
+    hasShow?: boolean;
+    location: Location;
+    path?: string;
+    query: ListParams;
+    resource: string;
+    [key: string]: any;
+}
+
+const defaultSort = {
+    field: 'id',
+    order: SORT_ASC,
+};
+
+/**
+ * Prepare data for the List view
+ *
+ * @param {Object} props The props passed to the Lsit component.
+ *
+ * Props should contain:
+ *   - title
+ *   - perPage
+ *   - sort
+ *   - filter (the permanent filter to apply to the query)
+ *   - actions
+ *   - filters (a React component used to display the filter form)
+ *   - pagination
+ *
+ * @return {Object} controllerProps Fetched and computed data for the List view
+ *
+ * controllerProps contain:
+ *
+ */
+const useListController = (props: Props) => {
+    useCheckMinimumRequiredProps(
+        'List',
+        ['basePath', 'location', 'resource'],
+        props
+    );
+
+    const {
+        basePath,
+        resource,
+        hasCreate,
+        location,
+        filterDefaultValues,
+        sort = defaultSort,
+        perPage = 10,
+        filter,
+        debounce = 500,
+    } = props;
+
+    if (filter && isValidElement(filter)) {
+        throw new Error(
+            '<List> received a React element as `filter` props. If you intended to set the list filter elements, use the `filters` (with an s) prop instead. The `filter` prop is internal and should not be set by the developer.'
+        );
+    }
+    const translate = useTranslate();
+    const version = useVersion();
+
+    const [query, queryModifiers] = useListParams({
+        resource,
+        location,
+        filterDefaultValues,
+        sort,
+        perPage,
+        debounce,
+    });
+
+    const [selectedIds, selectionModifiers] = useRecordSelection(resource);
+
+    const { data, ids, total, loading, loaded } = useGetList(
+        resource,
+        {
+            page: query.page,
+            perPage: query.perPage,
+        },
+        { field: query.sort, order: query.order },
+        { ...query.filter, ...filter },
+        {
+            version,
+            onFailure: {
+                notification: {
+                    body: 'ra.notification.http_error',
+                    level: 'warning',
+                },
+            },
+        }
+    );
+
+    if (!query.page && !(ids || []).length && query.page > 1 && total > 0) {
+        // query for a page that doesn't exist, check the previous page
+        queryModifiers.setPage(query.page - 1);
+    }
+
+    const currentSort = useMemo(
+        () => ({
+            field: query.sort,
+            order: query.order,
+        }),
+        [query.sort, query.order]
+    );
+
+    const resourceName = translate(`resources.${resource}.name`, {
+        smart_count: 2,
+        _: inflection.humanize(inflection.pluralize(resource)),
+    });
+    const defaultTitle = translate('ra.page.list', {
+        name: resourceName,
+    });
+
+    return {
+        basePath,
+        currentSort,
+        data,
+        defaultTitle,
+        displayedFilters: query.displayedFilters,
+        filterValues: query.filterValues,
+        hasCreate,
+        ids,
+        isLoading: loading,
+        loadedOnce: loaded,
+        onSelect: selectionModifiers.select,
+        onToggleItem: selectionModifiers.toggle,
+        onUnselectItems: selectionModifiers.clearSelection,
+        page: query.page,
+        perPage: query.perPage,
+        resource,
+        selectedIds,
+        setFilters: queryModifiers.setFilters,
+        hideFilter: queryModifiers.hideFilter,
+        showFilter: queryModifiers.showFilter,
+        setPage: queryModifiers.setPage,
+        setPerPage: queryModifiers.setPerPage,
+        setSort: queryModifiers.setSort,
+        total,
+        version,
+    };
+};
+
+export const injectedProps = [
+    'basePath',
+    'currentSort',
+    'data',
+    'defaultTitle',
+    'displayedFilters',
+    'filterValues',
+    'hasCreate',
+    'hideFilter',
+    'ids',
+    'isLoading',
+    'loadedOnce',
+    'onSelect',
+    'onToggleItem',
+    'onUnselectItems',
+    'page',
+    'perPage',
+    'refresh',
+    'resource',
+    'selectedIds',
+    'setFilters',
+    'setPage',
+    'setPerPage',
+    'setSort',
+    'showFilter',
+    'total',
+    'version',
+];
+
+/**
+ * Select the props injected by the useListController hook
+ * to be passed to the List children need
+ * This is an implementation of pick()
+ */
+export const getListControllerProps = props =>
+    injectedProps.reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
+
+/**
+ * Select the props not injected by the useListController hook
+ * to be used inside the List children to sanitize props injected by List
+ * This is an implementation of omit()
+ */
+export const sanitizeListRestProps = props =>
+    Object.keys(props)
+        .filter(propName => !injectedProps.includes(propName))
+        .reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
+
+export default useListController;

--- a/packages/ra-ui-materialui/src/list/ListGuesser.js
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.js
@@ -1,21 +1,18 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import inflection from 'inflection';
-import { withStyles } from '@material-ui/core/styles';
 import {
-    ListController,
+    useListController,
     getElementsFromRecords,
     InferredElement,
 } from 'ra-core';
-import { ListView, styles } from './List';
+import { ListView } from './List';
 import listFieldTypes from './listFieldTypes';
 
-export class ListViewGuesser extends Component {
-    state = {
-        inferredChild: null,
-    };
-    componentDidUpdate() {
-        const { ids, data, resource } = this.props;
-        if (ids.length > 0 && data && !this.state.inferredChild) {
+const ListViewGuesser = props => {
+    const { ids, data, resource } = props;
+    const [inferredChild, setInferredChild] = useState(null);
+    useEffect(() => {
+        if (ids.length > 0 && data && !inferredChild) {
             const inferredElements = getElementsFromRecords(
                 ids.map(id => data[id]),
                 listFieldTypes
@@ -39,21 +36,18 @@ ${inferredChild.getRepresentation()}
     </List>
 );`
                 );
-            this.setState({ inferredChild: inferredChild.getElement() });
+            setInferredChild(inferredChild.getElement());
         }
-    }
+    }, [data, ids, inferredChild, resource]);
 
-    render() {
-        return <ListView {...this.props}>{this.state.inferredChild}</ListView>;
-    }
-}
+    return <ListView {...props}>{inferredChild}</ListView>;
+};
 
 ListViewGuesser.propTypes = ListView.propTypes;
 
-const ListGuesser = props => (
-    <ListController {...props}>
-        {controllerProps => <ListViewGuesser {...props} {...controllerProps} />}
-    </ListController>
-);
+const ListGuesser = props => {
+    const controllerProps = useListController(props);
+    return <ListViewGuesser {...props} {...controllerProps} />;
+};
 
-export default withStyles(styles)(ListGuesser);
+export default ListGuesser;


### PR DESCRIPTION
It helps remove one level in the component tree for lists, and makes the return type explicit. Also, it's easier to understand.

```jsx
import {useListController } from 'react-admin';
import ListView from './ListView';

const MyList = props => {
    const controllerProps = useListController(props);
    return <ListView {...controllerProps} {...props} />;
}
```

The `ListController` component remains for backward compatibility, and to be able to test `useListController`. 

There will be more such controllers (`useEditController`, etc) but Rome wasn't built in one day. 