### PR TITLE
[RFR] Prevents passing the sidebarIsOpen prop to the MenuItem

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.js
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.js
@@ -45,6 +45,7 @@ export class MenuItemLink extends Component {
             primaryText,
             leftIcon,
             staticContext,
+            sidebarIsOpen,
             ...props
         } = this.props;
 


### PR DESCRIPTION
This PR is related to #3390. I forgot to add the `sidebarIsOpen` to the sanitized props before passing them to `@material-ui/core/MenuItem`. Without the fix the prop is passed to a HTML element which causes an unknown-prop warning on the console.