### PR TITLE
[RFR] Add useEditController hook

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -164,6 +164,40 @@ export const CommentList = (props) =>
     </List>;
 ```
 
+**Tip**: For simple mutations, you can use a specialised hook like `useUpdate` instead of the more generic `useMutation`. The main benefit is that `useUpdate` will update the recod in Redux store first, allowing optimistic rendering of the UI:
+
+```jsx
+import { useUpdate } from 'react-admin';
+
+const ApproveButton = ({ record }) => {
+    const [approve, { loading }] = useUpdate('comments', record.id, { isApproved: true }, record);
+    return <FlatButton label="Approve" onClick={approve} disabled={loading} />;
+};
+```
+
+**Tip**: The mutation data can also be passed at call time, using the second parameter of the `mutate` callback:
+
+```jsx
+import { useMutation, UPDATE } from 'react-admin';
+
+const MarkDateButton = ({ record }) => {
+    const [approve, { loading }] = useMutation({
+        type: UPDATE,
+        resource: 'posts',
+        payload: { id: record.id } // no data
+    });
+    // the mutation callback expects call time payload as second parameter
+    // and merges it with the initial payload when called
+    return <FlatButton
+        label="Mark Date"
+        onClick={() => approve(null, {
+            data: { updatedAt: new Date() } // data defined here
+        })}
+        disabled={loading}
+    />;
+};
+```
+
 ## Handling Side Effects
 
 Fetching data is called a *side effect*, since it calls the outside world, and is asynchronous. Usual actions may have other side effects, like showing a notification, or redirecting the user to another page. Both `useQuery` and `useMutation` hooks accept a second parameter in addition to the query, which lets you describe the options of the query, including success and failure side effects. 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -570,7 +570,7 @@ The side effects accepted in the `meta` field of the action are the same as in t
 
 ## Making An Action Undoable
 
-when using the `useMutation` hook, you could trigger optimistic rendering and get an undo button for free. The same feature is possible using custom actions. You need to decorate the action with the `startUndoable` action creator:
+When using the `useMutation` hook, you could trigger optimistic rendering and get an undo button for free. The same feature is possible using custom actions. You need to decorate the action with the `startUndoable` action creator:
 
 ```diff
 // in src/comments/ApproveButton.js

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -53,6 +53,7 @@
         "classnames": "~2.2.5",
         "connected-react-router": "^6.4.0",
         "date-fns": "^1.29.0",
+        "deepmerge": "^3.0.0",
         "inflection": "~1.12.0",
         "lodash": "~4.17.5",
         "node-polyglot": "^2.2.2",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -53,7 +53,6 @@
         "classnames": "~2.2.5",
         "connected-react-router": "^6.4.0",
         "date-fns": "^1.29.0",
-        "deepmerge": "^3.0.0",
         "inflection": "~1.12.0",
         "lodash": "~4.17.5",
         "node-polyglot": "^2.2.2",

--- a/packages/ra-core/src/controller/EditController.tsx
+++ b/packages/ra-core/src/controller/EditController.tsx
@@ -1,155 +1,36 @@
-import { ReactNode, useEffect, useCallback } from 'react';
-// @ts-ignore
-import { useDispatch } from 'react-redux';
-import { reset as resetForm } from 'redux-form';
-import inflection from 'inflection';
-import { crudUpdate, startUndoable } from '../actions';
-import { REDUX_FORM_NAME } from '../form';
-import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
-import { Translate, Record, Identifier } from '../types';
-import { RedirectionSideEffect } from '../sideEffect';
-import useGetOne from './../fetch/useGetOne';
+import { ReactNode } from 'react';
+import { Translate } from '../types';
 import { useTranslate } from '../i18n';
-import useVersion from './useVersion';
+import useEditController, {
+    EditProps,
+    EditControllerProps,
+} from './useEditController';
 
-interface ChildrenFuncParams {
-    isLoading: boolean;
-    defaultTitle: string;
-    save: (data: Record, redirect: RedirectionSideEffect) => void;
-    resource: string;
-    basePath: string;
-    record?: Record;
-    redirect: RedirectionSideEffect;
+interface EditControllerComponentProps extends EditControllerProps {
     translate: Translate;
-    version: number;
 }
 
-interface Props {
-    basePath: string;
-    children: (params: ChildrenFuncParams) => ReactNode;
-    hasCreate?: boolean;
-    hasEdit?: boolean;
-    hasShow?: boolean;
-    hasList?: boolean;
-    id: Identifier;
-    isLoading: boolean;
-    resource: string;
-    undoable?: boolean;
-    record?: Record;
+interface Props extends EditProps {
+    children: (params: EditControllerComponentProps) => ReactNode;
 }
 
 /**
- * Page component for the Edit view
+ * Render prop version of the useEditController hook
  *
- * The `<Edit>` component renders the page title and actions,
- * fetches the record from the data provider.
- * It is not responsible for rendering the actual form -
- * that's the job of its child component (usually `<SimpleForm>`),
- * to which it passes pass the `record` as prop.
- *
- * The `<Edit>` component accepts the following props:
- *
- * - title
- * - actions
- *
- * Both expect an element for value.
- *
+ * @see useEditController
  * @example
- *     // in src/posts.js
- *     import React from 'react';
- *     import { Edit, SimpleForm, TextInput } from 'react-admin';
  *
- *     export const PostEdit = (props) => (
- *         <Edit {...props}>
- *             <SimpleForm>
- *                 <TextInput source="title" />
- *             </SimpleForm>
- *         </Edit>
- *     );
- *
- *     // in src/App.js
- *     import React from 'react';
- *     import { Admin, Resource } from 'react-admin';
- *
- *     import { PostEdit } from './posts';
- *
- *     const App = () => (
- *         <Admin dataProvider={...}>
- *             <Resource name="posts" edit={PostEdit} />
- *         </Admin>
- *     );
- *     export default App;
+ * const EditView = () => <div>...</div>
+ * const MyEdit = props => (
+ *     <EditController {...props}>
+ *         {controllerProps => <EditView {...controllerProps} {...props} />}
+ *     </EditController>
+ * );
  */
-const EditController = (props: Props) => {
-    useCheckMinimumRequiredProps(
-        'Edit',
-        ['basePath', 'resource', 'children'],
-        props
-    );
-    const { basePath, children, id, resource, undoable } = props;
-    const translate = useTranslate();
-    const dispatch = useDispatch();
-    const version = useVersion();
-    const { data: record, loading } = useGetOne(resource, id, {
-        basePath,
-        version, // used to force reload
-        onFailure: {
-            notification: {
-                body: 'ra.notification.item_doesnt_exist',
-                level: 'warning',
-            },
-            redirectTo: 'list',
-            refresh: true,
-        },
-    });
-
-    useEffect(() => {
-        dispatch(resetForm(REDUX_FORM_NAME));
-    }, [resource, id, version]); // eslint-disable-line react-hooks/exhaustive-deps
-
-    const resourceName = translate(`resources.${resource}.name`, {
-        smart_count: 1,
-        _: inflection.humanize(inflection.singularize(resource)),
-    });
-    const defaultTitle = translate('ra.page.edit', {
-        name: `${resourceName}`,
-        id,
-        record,
-    });
-
-    const save = useCallback(
-        (data: Partial<Record>, redirect: RedirectionSideEffect) => {
-            const updateAction = crudUpdate(
-                resource,
-                id,
-                data,
-                record,
-                basePath,
-                redirect
-            );
-
-            if (undoable) {
-                dispatch(startUndoable(updateAction));
-            } else {
-                dispatch(updateAction);
-            }
-        },
-        [resource, id, record, basePath, undoable] // eslint-disable-line react-hooks/exhaustive-deps
-    );
-
-    return children({
-        isLoading: loading,
-        defaultTitle,
-        save,
-        resource,
-        basePath,
-        record,
-        redirect: getDefaultRedirectRoute(),
-        translate,
-        version,
-    });
+const EditController = ({ children, ...props }: Props) => {
+    const controllerProps = useEditController(props);
+    const translate = useTranslate(); // injected for backwards compatibility
+    return children({ translate, ...controllerProps });
 };
-
-const getDefaultRedirectRoute = () => 'list';
 
 export default EditController;

--- a/packages/ra-core/src/controller/EditController.tsx
+++ b/packages/ra-core/src/controller/EditController.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import { Translate } from '../types';
 import { useTranslate } from '../i18n';
 import useEditController, {
@@ -11,7 +10,7 @@ interface EditControllerComponentProps extends EditControllerProps {
 }
 
 interface Props extends EditProps {
-    children: (params: EditControllerComponentProps) => ReactNode;
+    children: (params: EditControllerComponentProps) => JSX.Element;
 }
 
 /**

--- a/packages/ra-core/src/controller/ListController.tsx
+++ b/packages/ra-core/src/controller/ListController.tsx
@@ -1,5 +1,3 @@
-import { ReactNode } from 'react';
-
 import useListController, {
     ListProps,
     ListControllerProps,
@@ -12,7 +10,7 @@ interface ListControllerComponentProps extends ListControllerProps {
 }
 
 interface Props extends ListProps {
-    children: (params: ListControllerComponentProps) => ReactNode;
+    children: (params: ListControllerComponentProps) => JSX.Element;
 }
 
 /**

--- a/packages/ra-core/src/controller/index.ts
+++ b/packages/ra-core/src/controller/index.ts
@@ -11,6 +11,7 @@ import useVersion from './useVersion';
 import useSortState from './useSortState';
 import usePaginationState from './usePaginationState';
 import useListController from './useListController';
+import useEditController from './useEditController';
 import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
 export {
     getListControllerProps,
@@ -21,6 +22,7 @@ export {
     ShowController,
     useCheckMinimumRequiredProps,
     useListController,
+    useEditController,
     useRecordSelection,
     useVersion,
     useSortState,

--- a/packages/ra-core/src/controller/useEditController.ts
+++ b/packages/ra-core/src/controller/useEditController.ts
@@ -1,0 +1,124 @@
+import { useEffect, useCallback } from 'react';
+// @ts-ignore
+import { useDispatch } from 'react-redux';
+import { reset as resetForm } from 'redux-form';
+import inflection from 'inflection';
+
+import useVersion from './useVersion';
+import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
+import { crudUpdate, startUndoable } from '../actions';
+import { REDUX_FORM_NAME } from '../form';
+import { Record, Identifier } from '../types';
+import { RedirectionSideEffect } from '../sideEffect';
+import useGetOne from '../fetch/useGetOne';
+import { useTranslate } from '../i18n';
+
+export interface EditProps {
+    basePath: string;
+    hasCreate?: boolean;
+    hasEdit?: boolean;
+    hasShow?: boolean;
+    hasList?: boolean;
+    id: Identifier;
+    isLoading: boolean;
+    resource: string;
+    undoable?: boolean;
+    record?: Record;
+}
+
+export interface EditControllerProps {
+    isLoading: boolean;
+    defaultTitle: string;
+    save: (data: Record, redirect: RedirectionSideEffect) => void;
+    resource: string;
+    basePath: string;
+    record?: Record;
+    redirect: RedirectionSideEffect;
+    version: number;
+}
+
+/**
+ * Prepare data for the Edit view
+ *
+ * @param {Object} props The props passed to the Edit component.
+ *
+ * @return {Object} controllerProps Fetched data and callbacks for the Edit view
+ *
+ * @example
+ *
+ * import { useEditController } from 'react-admin';
+ * import EditView from './EditView';
+ *
+ * const MyEdit = props => {
+ *     const controllerProps = useEditController(props);
+ *     return <EditView {...controllerProps} {...props} />;
+ * }
+ */
+const useEditController = (props: EditProps): EditControllerProps => {
+    useCheckMinimumRequiredProps('Edit', ['basePath', 'resource'], props);
+    const { basePath, id, resource, undoable } = props;
+    const translate = useTranslate();
+    const dispatch = useDispatch();
+    const version = useVersion();
+    const { data: record, loading } = useGetOne(resource, id, {
+        basePath,
+        version, // used to force reload
+        onFailure: {
+            notification: {
+                body: 'ra.notification.item_doesnt_exist',
+                level: 'warning',
+            },
+            redirectTo: 'list',
+            refresh: true,
+        },
+    });
+
+    useEffect(() => {
+        dispatch(resetForm(REDUX_FORM_NAME));
+    }, [resource, id, version]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const resourceName = translate(`resources.${resource}.name`, {
+        smart_count: 1,
+        _: inflection.humanize(inflection.singularize(resource)),
+    });
+    const defaultTitle = translate('ra.page.edit', {
+        name: `${resourceName}`,
+        id,
+        record,
+    });
+
+    const save = useCallback(
+        (data: Partial<Record>, redirect: RedirectionSideEffect) => {
+            const updateAction = crudUpdate(
+                resource,
+                id,
+                data,
+                record,
+                basePath,
+                redirect
+            );
+
+            if (undoable) {
+                dispatch(startUndoable(updateAction));
+            } else {
+                dispatch(updateAction);
+            }
+        },
+        [resource, id, record, basePath, undoable] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    return {
+        isLoading: loading,
+        defaultTitle,
+        save,
+        resource,
+        basePath,
+        record,
+        redirect: getDefaultRedirectRoute(),
+        version,
+    };
+};
+
+const getDefaultRedirectRoute = () => 'list';
+
+export default useEditController;

--- a/packages/ra-core/src/controller/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/useListController.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import expect from 'expect';
 import { fireEvent, cleanup } from 'react-testing-library';
 import lolex from 'lolex';
 import TextField from '@material-ui/core/TextField/TextField';

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -76,7 +76,7 @@ export interface ListControllerProps {
  *
  * @example
  *
- * import {useListController } from 'react-admin';
+ * import { useListController } from 'react-admin';
  * import ListView from './ListView';
  *
  * const MyList = props => {

--- a/packages/ra-core/src/fetch/Mutation.spec.tsx
+++ b/packages/ra-core/src/fetch/Mutation.spec.tsx
@@ -1,20 +1,13 @@
 import React from 'react';
-import {
-    render,
-    cleanup,
-    fireEvent,
-    waitForDomChange,
-} from 'react-testing-library';
+import { cleanup } from 'react-testing-library';
 import expect from 'expect';
 import Mutation from './Mutation';
-import CoreAdmin from '../CoreAdmin';
-import Resource from '../Resource';
 import renderWithRedux from '../util/renderWithRedux';
 
 describe('Mutation', () => {
     afterEach(cleanup);
 
-    it('should render its child', () => {
+    it('should render its child function', () => {
         const { getByTestId } = renderWithRedux(
             <Mutation type="foo" resource="bar">
                 {() => <div data-testid="test">Hello</div>}
@@ -23,102 +16,25 @@ describe('Mutation', () => {
         expect(getByTestId('test').textContent).toBe('Hello');
     });
 
-    it('should pass a callback to trigger the mutation', () => {
+    it('should pass useEditController return value to child', () => {
         let callback = null;
+        let state = null;
         renderWithRedux(
             <Mutation type="foo" resource="bar">
-                {mutate => {
+                {(mutate, controllerState) => {
                     callback = mutate;
+                    state = controllerState;
                     return <div data-testid="test">Hello</div>;
                 }}
             </Mutation>
         );
         expect(callback).toBeInstanceOf(Function);
-    });
-
-    it('should dispatch a fetch action when the mutation callback is triggered', () => {
-        const myPayload = {};
-        const { getByText, dispatch } = renderWithRedux(
-            <Mutation type="mytype" resource="myresource" payload={myPayload}>
-                {mutate => <button onClick={mutate}>Hello</button>}
-            </Mutation>
-        );
-        fireEvent.click(getByText('Hello'));
-        const action = dispatch.mock.calls[0][0];
-        expect(action.type).toEqual('CUSTOM_FETCH');
-        expect(action.payload).toEqual(myPayload);
-        expect(action.meta.fetch).toEqual('mytype');
-        expect(action.meta.resource).toEqual('myresource');
-    });
-
-    it('should update the loading state when the mutation callback is triggered', () => {
-        const myPayload = {};
-        const { getByText } = renderWithRedux(
-            <Mutation type="mytype" resource="myresource" payload={myPayload}>
-                {(mutate, { loading }) => (
-                    <button
-                        className={loading ? 'loading' : 'idle'}
-                        onClick={mutate}
-                    >
-                        Hello
-                    </button>
-                )}
-            </Mutation>
-        );
-        expect(getByText('Hello').className).toEqual('idle');
-        fireEvent.click(getByText('Hello'));
-        expect(getByText('Hello').className).toEqual('loading');
-    });
-
-    it('should update the data state after a success response', async () => {
-        const dataProvider = jest.fn();
-        dataProvider.mockImplementationOnce(() =>
-            Promise.resolve({ data: { foo: 'bar' } })
-        );
-        const Foo = () => (
-            <Mutation type="mytype" resource="foo">
-                {(mutate, { data }) => (
-                    <button data-testid="test" onClick={mutate}>
-                        {data ? data.foo : 'no data'}
-                    </button>
-                )}
-            </Mutation>
-        );
-        const { getByTestId } = render(
-            <CoreAdmin dataProvider={dataProvider}>
-                <Resource name="foo" list={Foo} />
-            </CoreAdmin>
-        );
-        const testElement = getByTestId('test');
-        expect(testElement.textContent).toBe('no data');
-        fireEvent.click(testElement);
-        await waitForDomChange({ container: testElement });
-        expect(testElement.textContent).toEqual('bar');
-    });
-
-    it('should update the error state after an error response', async () => {
-        const dataProvider = jest.fn();
-        dataProvider.mockImplementationOnce(() =>
-            Promise.reject({ message: 'provider error' })
-        );
-        const Foo = () => (
-            <Mutation type="mytype" resource="foo">
-                {(mutate, { error }) => (
-                    <button data-testid="test" onClick={mutate}>
-                        {error ? error.message : 'no data'}
-                    </button>
-                )}
-            </Mutation>
-        );
-        const { getByTestId } = render(
-            <CoreAdmin dataProvider={dataProvider}>
-                <Resource name="foo" list={Foo} />
-            </CoreAdmin>
-        );
-        const testElement = getByTestId('test');
-        expect(testElement.textContent).toBe('no data');
-        fireEvent.click(testElement);
-        await waitForDomChange({ container: testElement });
-        expect(testElement.textContent).toEqual('provider error');
+        expect(state).toEqual({
+            data: null,
+            error: null,
+            total: null,
+            loaded: false,
+            loading: false,
+        });
     });
 });

--- a/packages/ra-core/src/fetch/Mutation.tsx
+++ b/packages/ra-core/src/fetch/Mutation.tsx
@@ -1,24 +1,23 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import useMutation from './useMutation';
-
-type DataProviderCallback = (
-    type: string,
-    resource: string,
-    payload?: any,
-    options?: any
-) => Promise<any>;
 
 interface ChildrenFuncParams {
     data?: any;
-    loading: boolean;
+    total?: number;
     error?: any;
+    loading: boolean;
+    loaded: boolean;
 }
 
 interface Props {
     children: (
-        mutate: () => void,
+        mutate: (
+            event?: any,
+            callTimePayload?: any,
+            callTimeOptions?: any
+        ) => void,
         params: ChildrenFuncParams
-    ) => ReactElement<any, any>;
+    ) => JSX.Element;
     type: string;
     resource: string;
     payload?: any;

--- a/packages/ra-core/src/fetch/Query.tsx
+++ b/packages/ra-core/src/fetch/Query.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import useQuery from './useQuery';
 
 interface ChildrenFuncParams {
@@ -10,7 +10,7 @@ interface ChildrenFuncParams {
 }
 
 interface Props {
-    children: (params: ChildrenFuncParams) => ReactElement<any, any>;
+    children: (params: ChildrenFuncParams) => JSX.Element;
     type: string;
     resource: string;
     payload?: any;

--- a/packages/ra-core/src/fetch/index.ts
+++ b/packages/ra-core/src/fetch/index.ts
@@ -9,6 +9,7 @@ import useQueryWithStore from './useQueryWithStore';
 import withDataProvider from './withDataProvider';
 import useGetOne from './useGetOne';
 import useGetList from './useGetList';
+import useUpdate from './useUpdate';
 
 export {
     fetchUtils,
@@ -20,6 +21,7 @@ export {
     useQuery,
     useGetOne,
     useGetList,
+    useUpdate,
     useQueryWithStore,
     withDataProvider,
 };

--- a/packages/ra-core/src/fetch/useMutation.spec.tsx
+++ b/packages/ra-core/src/fetch/useMutation.spec.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import {
+    render,
+    cleanup,
+    fireEvent,
+    waitForDomChange,
+} from 'react-testing-library';
+import expect from 'expect';
+import Mutation from './Mutation';
+import CoreAdmin from '../CoreAdmin';
+import Resource from '../Resource';
+import renderWithRedux from '../util/renderWithRedux';
+
+describe('useMutation', () => {
+    afterEach(cleanup);
+
+    it('should pass a callback to trigger the mutation', () => {
+        let callback = null;
+        renderWithRedux(
+            <Mutation type="foo" resource="bar">
+                {mutate => {
+                    callback = mutate;
+                    return <div data-testid="test">Hello</div>;
+                }}
+            </Mutation>
+        );
+        expect(callback).toBeInstanceOf(Function);
+    });
+
+    it('should dispatch a fetch action when the mutation callback is triggered', () => {
+        const myPayload = {};
+        const { getByText, dispatch } = renderWithRedux(
+            <Mutation type="mytype" resource="myresource" payload={myPayload}>
+                {mutate => <button onClick={mutate}>Hello</button>}
+            </Mutation>
+        );
+        fireEvent.click(getByText('Hello'));
+        const action = dispatch.mock.calls[0][0];
+        expect(action.type).toEqual('CUSTOM_FETCH');
+        expect(action.payload).toEqual(myPayload);
+        expect(action.meta.fetch).toEqual('mytype');
+        expect(action.meta.resource).toEqual('myresource');
+    });
+
+    it('should use callTimePayload and callTimeOptions', () => {
+        const myPayload = { foo: 1 };
+        const { getByText, dispatch } = renderWithRedux(
+            <Mutation type="mytype" resource="myresource" payload={myPayload}>
+                {mutate => (
+                    <button onClick={e => mutate(e, { bar: 2 }, { baz: 1 })}>
+                        Hello
+                    </button>
+                )}
+            </Mutation>
+        );
+        fireEvent.click(getByText('Hello'));
+        const action = dispatch.mock.calls[0][0];
+        expect(action.payload).toEqual({ foo: 1, bar: 2 });
+        expect(action.meta.baz).toEqual(1);
+    });
+
+    it('should update the loading state when the mutation callback is triggered', () => {
+        const myPayload = {};
+        const { getByText } = renderWithRedux(
+            <Mutation type="mytype" resource="myresource" payload={myPayload}>
+                {(mutate, { loading }) => (
+                    <button
+                        className={loading ? 'loading' : 'idle'}
+                        onClick={mutate}
+                    >
+                        Hello
+                    </button>
+                )}
+            </Mutation>
+        );
+        expect(getByText('Hello').className).toEqual('idle');
+        fireEvent.click(getByText('Hello'));
+        expect(getByText('Hello').className).toEqual('loading');
+    });
+
+    it('should update the data state after a success response', async () => {
+        const dataProvider = jest.fn();
+        dataProvider.mockImplementationOnce(() =>
+            Promise.resolve({ data: { foo: 'bar' } })
+        );
+        const Foo = () => (
+            <Mutation type="mytype" resource="foo">
+                {(mutate, { data }) => (
+                    <button data-testid="test" onClick={mutate}>
+                        {data ? data.foo : 'no data'}
+                    </button>
+                )}
+            </Mutation>
+        );
+        const { getByTestId } = render(
+            <CoreAdmin dataProvider={dataProvider}>
+                <Resource name="foo" list={Foo} />
+            </CoreAdmin>
+        );
+        const testElement = getByTestId('test');
+        expect(testElement.textContent).toBe('no data');
+        fireEvent.click(testElement);
+        await waitForDomChange({ container: testElement });
+        expect(testElement.textContent).toEqual('bar');
+    });
+
+    it('should update the error state after an error response', async () => {
+        const dataProvider = jest.fn();
+        dataProvider.mockImplementationOnce(() =>
+            Promise.reject({ message: 'provider error' })
+        );
+        const Foo = () => (
+            <Mutation type="mytype" resource="foo">
+                {(mutate, { error }) => (
+                    <button data-testid="test" onClick={mutate}>
+                        {error ? error.message : 'no data'}
+                    </button>
+                )}
+            </Mutation>
+        );
+        const { getByTestId } = render(
+            <CoreAdmin dataProvider={dataProvider}>
+                <Resource name="foo" list={Foo} />
+            </CoreAdmin>
+        );
+        const testElement = getByTestId('test');
+        expect(testElement.textContent).toBe('no data');
+        fireEvent.click(testElement);
+        await waitForDomChange({ container: testElement });
+        expect(testElement.textContent).toEqual('provider error');
+    });
+});

--- a/packages/ra-core/src/fetch/useMutation.ts
+++ b/packages/ra-core/src/fetch/useMutation.ts
@@ -40,15 +40,37 @@ export interface QueryOptions {
  *
  * @example
  *
- * import { useMutation } from 'react-admin';
+ * import { useMutation, UPDATE } from 'react-admin';
  *
  * const ApproveButton = ({ record }) => {
  *     const [approve, { loading }] = useMutation({
- *         type: 'UPDATE',
+ *         type: UPDATE,
  *         resource: 'comments',
  *         payload: { id: record.id, data: { isApproved: true } }
  *     });
  *     return <FlatButton label="Approve" onClick={approve} disabled={loading} />;
+ * };
+ *
+ * @example
+ *
+ * import { useMutation, UPDATE } from 'react-admin';
+ *
+ * const MarkDateButton = ({ record }) => {
+ *     // the mutation data can be passed at call time
+ *     const [approve, { loading }] = useMutation({
+ *         type: UPDATE,
+ *         resource: 'posts',
+ *         payload: { id: record.id } // no data
+ *     });
+ *     // the mutation callback expects call time payload as second parameter
+ *     // and merges it with the initial payload when called
+ *     return <FlatButton
+ *          label="Mark Date"
+ *          onClick={() => approve(null, {
+ *              data: { updatedAt: new Date() } // data defined here
+ *          })}
+ *          disabled={loading}
+ *     />;
  * };
  */
 const useMutation = (

--- a/packages/ra-core/src/fetch/useMutation.ts
+++ b/packages/ra-core/src/fetch/useMutation.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import deepmerge from 'deepmerge';
+import merge from 'lodash/merge';
 
 import { useSafeSetState } from '../util/hooks';
 import useDataProvider from './useDataProvider';
@@ -101,8 +101,8 @@ const useMutation = (
             dataProvider(
                 type,
                 resource,
-                deepmerge(payload, callTimePayload),
-                deepmerge(options, callTimeOptions)
+                merge({}, payload, callTimePayload),
+                merge({}, options, callTimeOptions)
             )
                 .then(({ data, total }) => {
                     setState({

--- a/packages/ra-core/src/fetch/useUpdate.ts
+++ b/packages/ra-core/src/fetch/useUpdate.ts
@@ -18,16 +18,17 @@ import useMutation from './useMutation';
  * @param previousData The record before the update is applied
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [updateOne, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [update, { data, error, loading, loaded }].
  *
  * @example
  *
- * import { useUpdateOne } from 'react-admin';
+ * import { useUpdate } from 'react-admin';
  *
  * const IncreaseLikeButton = ({ record }) => {
- *     const [updateOne, { loading, error }] = useUpdateOne('posts', record.id, { likes: record.likes + 1 }, record);
+ *     const diff = { likes: record.likes + 1 };
+ *     const [update, { loading, error }] = useUpdate('posts', record.id, diff, record);
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={{loading}} onClick={updateOne}>Like</div>;
+ *     return <button disabled={loading} onClick={update}>Like</div>;
  * };
  */
 const useUpdate = (

--- a/packages/ra-core/src/fetch/useUpdate.ts
+++ b/packages/ra-core/src/fetch/useUpdate.ts
@@ -1,0 +1,45 @@
+import { CRUD_UPDATE } from '../actions/dataActions/crudUpdate';
+import { UPDATE } from '../dataFetchActions';
+import { Identifier } from '../types';
+import useMutation from './useMutation';
+
+/**
+ * Get a callback to call the dataProvider with an UPDATE verb, the result and the loading state.
+ *
+ * The return value updates according to the request state:
+ *
+ * - start: [callback, { loading: true, loaded: false }]
+ * - success: [callback, { data: [data from response], loading: false, loaded: true }]
+ * - error: [callback, { error: [error from response], loading: false, loaded: true }]
+ *
+ * @param resource The resource name, e.g. 'posts'
+ * @param id The resource identifier, e.g. 123
+ * @param data The updates to merge into the record, e.g. { views: 10 }
+ * @param previousData The record before the update is applied
+ * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
+ *
+ * @returns The current request state. Destructure as [updateOne, { data, error, loading, loaded }].
+ *
+ * @example
+ *
+ * import { useUpdateOne } from 'react-admin';
+ *
+ * const IncreaseLikeButton = ({ record }) => {
+ *     const [updateOne, { loading, error }] = useUpdateOne('posts', record.id, { likes: record.likes + 1 }, record);
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <button disabled={{loading}} onClick={updateOne}>Like</div>;
+ * };
+ */
+const useUpdate = (
+    resource: string,
+    id: Identifier,
+    data?: any,
+    previousData?: any,
+    options?: any
+) =>
+    useMutation(
+        { type: UPDATE, resource, payload: { id, data, previousData } },
+        { ...options, action: CRUD_UPDATE }
+    );
+
+export default useUpdate;

--- a/packages/ra-core/src/util/TestContext.tsx
+++ b/packages/ra-core/src/util/TestContext.tsx
@@ -57,12 +57,12 @@ class TestContext extends Component<Props> {
         const { initialState = {}, enableReducers = false } = props;
         this.storeWithDefault = enableReducers
             ? createAdminStore({
-                  initialState: merge(defaultStore, initialState),
+                  initialState: merge({}, defaultStore, initialState),
                   dataProvider: () =>
                       Promise.resolve(dataProviderDefaultResponse),
                   history: createMemoryHistory(),
               })
-            : createStore(() => merge(defaultStore, initialState));
+            : createStore(() => merge({}, defaultStore, initialState));
     }
 
     renderChildren = () => {

--- a/packages/ra-core/src/util/TestContext.tsx
+++ b/packages/ra-core/src/util/TestContext.tsx
@@ -23,6 +23,8 @@ interface Props {
     enableReducers?: boolean;
 }
 
+const dataProviderDefaultResponse = { data: null };
+
 /**
  * Simulate a react-admin context in unit tests
  *
@@ -56,7 +58,8 @@ class TestContext extends Component<Props> {
         this.storeWithDefault = enableReducers
             ? createAdminStore({
                   initialState: merge(defaultStore, initialState),
-                  dataProvider: () => Promise.resolve({}),
+                  dataProvider: () =>
+                      Promise.resolve(dataProviderDefaultResponse),
                   history: createMemoryHistory(),
               })
             : createStore(() => merge(defaultStore, initialState));

--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -15,7 +15,7 @@ const styles = theme =>
             position: 'relative',
         },
         leftIcon: {
-            marginRight: theme.spacing(),
+            marginRight: theme.spacing(1),
         },
         icon: {
             fontSize: 18,

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -9,6 +9,66 @@ import { useEditController } from 'ra-core';
 import DefaultActions from './EditActions';
 import TitleForRecord from '../layout/TitleForRecord';
 
+/**
+ * Page component for the Edit view
+ *
+ * The `<Edit>` component renders the page title and actions,
+ * fetches the record from the data provider.
+ * It is not responsible for rendering the actual form -
+ * that's the job of its child component (usually `<SimpleForm>`),
+ * to which it passes pass the `record` as prop.
+ *
+ * The `<Edit>` component accepts the following props:
+ *
+ * - aside
+ * - title
+ * - actions
+ *
+ * They all expect an element for value.
+ *
+ * @example
+ *     // in src/posts.js
+ *     import React from 'react';
+ *     import { Edit, SimpleForm, TextInput } from 'react-admin';
+ *
+ *     export const PostEdit = (props) => (
+ *         <Edit {...props}>
+ *             <SimpleForm>
+ *                 <TextInput source="title" />
+ *             </SimpleForm>
+ *         </Edit>
+ *     );
+ *
+ *     // in src/App.js
+ *     import React from 'react';
+ *     import { Admin, Resource } from 'react-admin';
+ *
+ *     import { PostEdit } from './posts';
+ *
+ *     const App = () => (
+ *         <Admin dataProvider={...}>
+ *             <Resource name="posts" edit={PostEdit} />
+ *         </Admin>
+ *     );
+ *     export default App;
+ */
+const Edit = props => <EditView {...props} {...useEditController(props)} />;
+
+Edit.propTypes = {
+    actions: PropTypes.element,
+    aside: PropTypes.element,
+    children: PropTypes.node,
+    classes: PropTypes.object,
+    className: PropTypes.string,
+    hasCreate: PropTypes.bool,
+    hasEdit: PropTypes.bool,
+    hasShow: PropTypes.bool,
+    hasList: PropTypes.bool,
+    id: PropTypes.any.isRequired,
+    resource: PropTypes.string.isRequired,
+    title: PropTypes.node,
+};
+
 export const useStyles = makeStyles({
     root: {},
     main: {
@@ -23,12 +83,6 @@ export const useStyles = makeStyles({
 });
 
 const sanitizeRestProps = ({
-    actions,
-    aside,
-    children,
-    className,
-    crudGetOne,
-    crudUpdate,
     data,
     hasCreate,
     hasEdit,
@@ -37,7 +91,6 @@ const sanitizeRestProps = ({
     id,
     isLoading,
     isSaving,
-    resetForm,
     resource,
     title,
     version,
@@ -153,65 +206,6 @@ EditView.propTypes = {
 
 EditView.defaultProps = {
     classes: {},
-};
-
-/**
- * Page component for the Edit view
- *
- * The `<Edit>` component renders the page title and actions,
- * fetches the record from the data provider.
- * It is not responsible for rendering the actual form -
- * that's the job of its child component (usually `<SimpleForm>`),
- * to which it passes pass the `record` as prop.
- *
- * The `<Edit>` component accepts the following props:
- *
- * - title
- * - actions
- *
- * Both expect an element for value.
- *
- * @example
- *     // in src/posts.js
- *     import React from 'react';
- *     import { Edit, SimpleForm, TextInput } from 'react-admin';
- *
- *     export const PostEdit = (props) => (
- *         <Edit {...props}>
- *             <SimpleForm>
- *                 <TextInput source="title" />
- *             </SimpleForm>
- *         </Edit>
- *     );
- *
- *     // in src/App.js
- *     import React from 'react';
- *     import { Admin, Resource } from 'react-admin';
- *
- *     import { PostEdit } from './posts';
- *
- *     const App = () => (
- *         <Admin dataProvider={...}>
- *             <Resource name="posts" edit={PostEdit} />
- *         </Admin>
- *     );
- *     export default App;
- */
-const Edit = props => <EditView {...props} {...useEditController(props)} />;
-
-Edit.propTypes = {
-    actions: PropTypes.element,
-    aside: PropTypes.element,
-    children: PropTypes.node,
-    classes: PropTypes.object,
-    className: PropTypes.string,
-    hasCreate: PropTypes.bool,
-    hasEdit: PropTypes.bool,
-    hasShow: PropTypes.bool,
-    hasList: PropTypes.bool,
-    id: PropTypes.any.isRequired,
-    resource: PropTypes.string.isRequired,
-    title: PropTypes.node,
 };
 
 export default Edit;

--- a/packages/ra-ui-materialui/src/detail/EditGuesser.js
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.js
@@ -1,21 +1,19 @@
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import inflection from 'inflection';
-import { withStyles } from '@material-ui/core/styles';
 import {
-    EditController,
+    useEditController,
     InferredElement,
     getElementsFromRecords,
 } from 'ra-core';
-import { EditView, styles } from './Edit';
+
+import { EditView } from './Edit';
 import editFieldTypes from './editFieldTypes';
 
-export class EditViewGuesser extends Component {
-    state = {
-        inferredChild: null,
-    };
-    componentDidUpdate() {
-        const { record, resource } = this.props;
-        if (record && !this.state.inferredChild) {
+const EditViewGuesser = props => {
+    const { record, resource } = props;
+    const [inferredChild, setInferredChild] = useState(null);
+    useEffect(() => {
+        if (record && !inferredChild) {
             const inferredElements = getElementsFromRecords(
                 [record],
                 editFieldTypes
@@ -39,21 +37,17 @@ ${inferredChild.getRepresentation()}
     </Edit>
 );`
                 );
-            this.setState({ inferredChild: inferredChild.getElement() });
+            setInferredChild(inferredChild.getElement());
         }
-    }
+    }, [record, inferredChild, resource]);
 
-    render() {
-        return <EditView {...this.props}>{this.state.inferredChild}</EditView>;
-    }
-}
+    return <EditView {...props}>{inferredChild}</EditView>;
+};
 
 EditViewGuesser.propTypes = EditView.propTypes;
 
 const EditGuesser = props => (
-    <EditController {...props}>
-        {controllerProps => <EditViewGuesser {...props} {...controllerProps} />}
-    </EditController>
+    <EditViewGuesser {...props} {...useEditController(props)} />
 );
 
-export default withStyles(styles)(EditGuesser);
+export default EditGuesser;

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -269,10 +269,7 @@ ListView.defaultProps = {
  *         </List>
  *     );
  */
-const List = props => {
-    const controllerProps = useListController(props);
-    return <ListView {...props} {...controllerProps} />;
-};
+const List = props => <ListView {...props} {...useListController(props)} />;
 
 List.propTypes = {
     // the props you can change

--- a/packages/ra-ui-materialui/src/list/ListGuesser.js
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.js
@@ -5,6 +5,7 @@ import {
     getElementsFromRecords,
     InferredElement,
 } from 'ra-core';
+
 import { ListView } from './List';
 import listFieldTypes from './listFieldTypes';
 
@@ -45,9 +46,8 @@ ${inferredChild.getRepresentation()}
 
 ListViewGuesser.propTypes = ListView.propTypes;
 
-const ListGuesser = props => {
-    const controllerProps = useListController(props);
-    return <ListViewGuesser {...props} {...controllerProps} />;
-};
+const ListGuesser = props => (
+    <ListViewGuesser {...props} {...useListController(props)} />
+);
 
 export default ListGuesser;


### PR DESCRIPTION
Removes one level of indentation in the React tree for Edit views.

I also introduced a new specialized mutation hook, `useUpdate`. This addresses #2952 for the `crudUpdate` action.

```jsx
import { useEditController } from 'react-admin';
import EditView from './EditView';

const MyEdit = props => {
     const controllerProps = useEditController(props);
     return <EditView {...controllerProps} {...props} />;
}
```

The only difference between `useEditController` and `EditController` is that the former doesn't inject `translate` (just like for `useListController`).