### PR TITLE
fix(EmailField): prevent click bubbling in a datagrid with rowClick

### DIFF
--- a/packages/ra-ui-materialui/src/field/EmailField.tsx
+++ b/packages/ra-ui-materialui/src/field/EmailField.tsx
@@ -5,12 +5,16 @@ import pure from 'recompose/pure';
 import sanitizeRestProps from './sanitizeRestProps';
 import { FieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 
+// useful to prevent click bubbling in a datagrid with rowClick
+const stopPropagation = e => e.stopPropagation();
+
 const EmailField: SFC<
     FieldProps & InjectedFieldProps & HtmlHTMLAttributes<HTMLAnchorElement>
 > = ({ className, source, record = {}, ...rest }) => (
     <a
         className={className}
         href={`mailto:${get(record, source)}`}
+        onClick={stopPropagation}
         {...sanitizeRestProps(rest)}
     >
         {get(record, source)}


### PR DESCRIPTION
Similar to a54acf0152745ebb9bb262ccbec82f2862a3a011.
Let's say we have a user list with an email field.
Without this fix, clicking on the email was redirecting to user/edit
before launching the mailto action.
Now, it just execute the mailto action.