### PR TITLE
[WIP] Avoid warning when receiving a 204 HTTP response after delete

### DIFF
--- a/packages/ra-core/src/sideEffect/fetch.ts
+++ b/packages/ra-core/src/sideEffect/fetch.ts
@@ -25,6 +25,10 @@ function validateResponseFormat(
     type,
     logger = console.error // eslint-disable-line no-console
 ) {
+    if (type === 'DELETE' && !response) {
+        // Some API return a 204 HTTP error with empty response when a delete has been successful
+        return;
+    }
     if (!response.hasOwnProperty('data')) {
         logger(
             `The response to '${type}' must be like { data: ... }, but the received response does not have a 'data' key. The dataProvider is probably wrong for '${type}'.`


### PR DESCRIPTION
Some API return a 204 HTTP response after successfuly deleted a resource.

In development only, we have an inopportune warning each time we delete a resource and the API return an empty 204 HTTP response.

Note : In development, this cause an error and a `RA/HIDE_NOTIFICATION` action is dispatched.
In production, some other code might break later in the process, I'll check that further.


![image](https://user-images.githubusercontent.com/1819833/61595438-8b121280-abf7-11e9-9844-4dce2883ce65.png)
