### PR TITLE
[RFR] Support API empty response on DELETE and DELETE_MANY actions

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -679,7 +679,7 @@ export default (type, resource, params) => {
                 case CREATE:
                     return { data: { ...params.data, id: json.id } };
                 case DELETE_MANY:
-                    return { data: json ? json : [] };
+                    return { data: json || [] };
                 default:
                     return { data: json };
             }

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -467,8 +467,8 @@ Request Type         | Response format
 `CREATE`             | `{ data: {Record} }`
 `UPDATE`             | `{ data: {Record} }`
 `UPDATE_MANY`        | `{ data: {mixed[]} }` The ids which have been updated
-`DELETE`             | `{ data: {Record} }` The resource that had been deleted or nothing
-`DELETE_MANY`        | `{ data: {mixed[]} }` The ids which have been deleted or an empty array
+`DELETE`             | `{ data: {Record|null} }` The record that has been deleted (optional)
+`DELETE_MANY`        | `{ data: {mixed[]} }` The ids of the deleted records (optional)
 `GET_MANY`           | `{ data: {Record[]} }`
 `GET_MANY_REFERENCE` | `{ data: {Record[]}, total: {int} }`
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -467,8 +467,8 @@ Request Type         | Response format
 `CREATE`             | `{ data: {Record} }`
 `UPDATE`             | `{ data: {Record} }`
 `UPDATE_MANY`        | `{ data: {mixed[]} }` The ids which have been updated
-`DELETE`             | `{ data: {Record} }`
-`DELETE_MANY`        | `{ data: {mixed[]} }` The ids which have been deleted
+`DELETE`             | `{ data: {Record} }` The resource that had been deleted or nothing
+`DELETE_MANY`        | `{ data: {mixed[]} }` The ids which have been deleted or an empty array
 `GET_MANY`           | `{ data: {Record[]} }`
 `GET_MANY_REFERENCE` | `{ data: {Record[]}, total: {int} }`
 
@@ -678,6 +678,8 @@ export default (type, resource, params) => {
                     };
                 case CREATE:
                     return { data: { ...params.data, id: json.id } };
+                case DELETE_MANY:
+                    return { data: json ? json : [] };
                 default:
                     return { data: json };
             }

--- a/packages/ra-core/src/dataFetchActions.ts
+++ b/packages/ra-core/src/dataFetchActions.ts
@@ -8,7 +8,7 @@ export const UPDATE_MANY = 'UPDATE_MANY';
 export const DELETE = 'DELETE';
 export const DELETE_MANY = 'DELETE_MANY';
 
-export const fetchActionsWithRecordResponse = [GET_ONE, CREATE, UPDATE, DELETE];
+export const fetchActionsWithRecordResponse = [GET_ONE, CREATE, UPDATE];
 export const fetchActionsWithArrayOfIdentifiedRecordsResponse = [
     GET_LIST,
     GET_MANY,

--- a/packages/ra-core/src/sideEffect/fetch.ts
+++ b/packages/ra-core/src/sideEffect/fetch.ts
@@ -44,10 +44,10 @@ function validateResponseFormat(
         fetchActionsWithArrayOfIdentifiedRecordsResponse.includes(type) &&
         Array.isArray(response.data) &&
         response.data.length > 0 &&
-        !response.data[0].hasOwnProperty('id')
+        response.data.some(d => !d.hasOwnProperty('id'))
     ) {
         logger(
-            `The response to '${type}' must be like { data : [{ id: 123, ...}, ...] }, but the received data items do not have an 'id' key. The dataProvider is probably wrong for '${type}'`
+            `The response to '${type}' must be like { data : [{ id: 123, ...}, ...] }, but at least one received data item do not have an 'id' key. The dataProvider is probably wrong for '${type}'`
         );
         throw new Error('ra.notification.data_provider_error');
     }

--- a/packages/ra-data-json-server/src/index.js
+++ b/packages/ra-data-json-server/src/index.js
@@ -122,7 +122,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
             case CREATE:
                 return { data: { ...params.data, id: json.id } };
             case DELETE_MANY:
-                return { data: json ? json : [] };
+                return { data: json || [] };
             default:
                 return { data: json };
         }

--- a/packages/ra-data-json-server/src/index.js
+++ b/packages/ra-data-json-server/src/index.js
@@ -121,6 +121,8 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
                 };
             case CREATE:
                 return { data: { ...params.data, id: json.id } };
+            case DELETE_MANY:
+                return { data: json ? json : [] };
             default:
                 return { data: json };
         }

--- a/packages/ra-data-simple-rest/src/index.js
+++ b/packages/ra-data-simple-rest/src/index.js
@@ -127,7 +127,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
             case CREATE:
                 return { data: { ...params.data, id: json.id } };
             case DELETE_MANY: {
-                return { data: json ? json : [] };
+                return { data: json || [] };
             }
             default:
                 return { data: json };

--- a/packages/ra-data-simple-rest/src/index.js
+++ b/packages/ra-data-simple-rest/src/index.js
@@ -126,6 +126,9 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
                 };
             case CREATE:
                 return { data: { ...params.data, id: json.id } };
+            case DELETE_MANY: {
+                return { data: json ? json : [] };
+            }
             default:
                 return { data: json };
         }


### PR DESCRIPTION
Ok, I checked for both `DELETE` and `DELETE_MANY` actions.

- `DELETE` doesn't require to have an identifier (`{ data: { id: 'id' } }`) but needs to have a data key, which should be returned by the data provider
- `DELETE_MANY` should return a data as a array, but do not require to have something in that array. If the API doesn't return a response, the data provider will return an empty array

Note : It is possible for the data provider to return the ids or resources sent with the request thanks to the `params` argument, but since react admin does nothing with this data, I preferred to remove not require it.