### PR TITLE
[RFR] Fix theme.spacing warning

### DIFF
--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -54,7 +54,7 @@ const styles = theme =>
             width: theme.spacing(6),
         },
         expandButton: {
-            padding: theme.spacing.unit,
+            padding: theme.spacing(1),
         },
         expandIconCell: {
             width: theme.spacing(6),


### PR DESCRIPTION
Fix the remaining warning with the material UI v4 migration.

> Warning: Material-UI: theme.spacing.unit usage has been deprecated.
> It will be removed in v5.
> You can replace `theme.spacing.unit * y` with `theme.spacing(y)`.

## Todo

- [x] Fix warning in Datagrid