### PR TITLE
[RFR] createAdminStore - set initialState on logout

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -502,6 +502,35 @@ const App = () => (
 
 The `initialState` prop lets you pass preloaded state to Redux. See the [Redux Documentation](http://redux.js.org/docs/api/createStore.html#createstorereducer-preloadedstate-enhancer) for more details.
 
+It accepts either a function or an object:
+
+```jsx
+const initialState = {
+    theme: 'dark',
+    grid: 5,
+};
+
+const App = () => (
+    <Admin initialState={initialState} dataProvider={simpleRestProvider('http://path.to.my.api')}>
+        // ...
+    </Admin>
+);
+```
+
+```jsx
+const initialState = () => ({
+    theme: localStorage.getItem('theme'),
+    grid: localStorage.getItem('grid'),
+});
+
+const App = () => (
+    <Admin initialState={initialState} dataProvider={simpleRestProvider('http://path.to.my.api')}>
+        // ...
+    </Admin>
+);
+```
+
+
 ## `history`
 
 By default, react-admin creates URLs using a hash sign (e.g. "myadmin.acme.com/#/posts/123"). The hash portion of the URL (i.e. `#/posts/123` in the example) contains the main application route. This strategy has the benefit of working without a server, and with legacy web browsers. But you may want to use another routing strategy, e.g. to allow server-side rendering.

--- a/packages/ra-core/src/CoreAdmin.tsx
+++ b/packages/ra-core/src/CoreAdmin.tsx
@@ -12,7 +12,7 @@ import { ConnectedRouter } from 'connected-react-router';
 
 import AuthContext from './auth/AuthContext';
 import DataProviderContext from './dataProvider/DataProviderContext';
-import createAdminStore from './createAdminStore';
+import createAdminStore, { InitialState } from './createAdminStore';
 import TranslationProvider from './i18n/TranslationProvider';
 import CoreAdminRouter from './CoreAdminRouter';
 import {
@@ -48,7 +48,7 @@ export interface AdminProps {
     dataProvider: DataProvider;
     history: History;
     i18nProvider?: I18nProvider;
-    initialState?: object;
+    initialState?: InitialState;
     loading: ComponentType;
     locale?: string;
     loginPage: LoginComponent | boolean;


### PR DESCRIPTION
to prevent undefined behaviour

fixes having undefined state instead of new state

ie. if you have some inital data from localStorage, then you dont wanna forget them on logout

and if initialState is function, call it to get the state