### PR TITLE
Set key prop on CheckboxGroupInputItem

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -161,7 +161,8 @@ const CheckboxGroupInput: FunctionComponent<
             <FormGroup row>
                 {choices.map(choice => (
                     <CheckboxGroupInputItem
-                        choice={choice}
+                        key={choice.id}
+                        choice={choice.id}
                         id={id}
                         onChange={handleCheck}
                         options={options}

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -163,7 +163,7 @@ const CheckboxGroupInput: FunctionComponent<
                 {choices.map(choice => (
                     <CheckboxGroupInputItem
                         key={get(choice, optionValue)}
-                        choice={choice.id}
+                        choice={choice}
                         id={id}
                         onChange={handleCheck}
                         options={options}

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash/get';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl, { FormControlProps } from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -161,7 +162,7 @@ const CheckboxGroupInput: FunctionComponent<
             <FormGroup row>
                 {choices.map(choice => (
                     <CheckboxGroupInputItem
-                        key={choice.id}
+                        key={get(choice, optionValue)}
                         choice={choice.id}
                         id={id}
                         onChange={handleCheck}


### PR DESCRIPTION
The key prop is missing in the mapping to `CheckboxGroupInputItem` in `choices.map`.  This results in console.warn.  This can be seen in the JavaScript console of simple example app after clicking the Edit on any of the Posts.

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `CheckboxGroupInput`. See https://fb.me/react-warning-keys for more information.
    in CheckboxGroupInputItem (created by CheckboxGroupInput)
    in CheckboxGroupInput (created by PostEdit)
    in div (created by FormInput)
    in FormInput (created by WithStyles(FormInput))
    in WithStyles(FormInput) (created by FormTab)
    in span (created by FormTab)
```
