### PR TITLE
Fix SimpleList showing ListItem as button even though linkType is false

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -67,7 +67,7 @@ const SimpleList = ({
                     id={id}
                     key={id}
                 >
-                    <ListItem button>
+                    <ListItem button={!!linkType}>
                         {leftIcon && (
                             <ListItemIcon>
                                 {leftIcon(data[id], id)}


### PR DESCRIPTION
When `linkType` is set to false, the `ListItems` are still styled as buttons. This seems like undesired behavior for a non-interactive item. Instead, do not style as buttons if linkType is false (or null).

Another solution would be to add a new prop to List to explicitly declare whether ListItems were styled as buttons if there was concern about altering existing behavior.