### PR TITLE
[RFR] Change LongTextInput to TextInput in examples/simple

### DIFF
--- a/examples/simple/src/comments/CommentCreate.js
+++ b/examples/simple/src/comments/CommentCreate.js
@@ -4,7 +4,6 @@ import {
     Create,
     DateInput,
     TextInput,
-    LongTextInput,
     SimpleForm,
     required,
     minLength,
@@ -28,7 +27,7 @@ const CommentCreate = props => (
                 fullWidth
             />
             <DateInput source="created_at" />
-            <LongTextInput source="body" />
+            <TextInput source="body" fullWidth={true} multiline={true} />
         </SimpleForm>
     </Create>
 );

--- a/examples/simple/src/comments/CommentEdit.js
+++ b/examples/simple/src/comments/CommentEdit.js
@@ -9,7 +9,6 @@ import {
     EditActions,
     useEditController,
     Link,
-    LongTextInput,
     ReferenceInput,
     SimpleForm,
     TextInput,
@@ -87,10 +86,11 @@ const CommentEdit = props => {
                             fullWidth
                         />
                         <DateInput source="created_at" fullWidth />
-                        <LongTextInput
+                        <TextInput
                             source="body"
                             validate={minLength(10)}
-                            fullWidth
+                            fullWidth={true}
+                            multiline={true}
                         />
                     </SimpleForm>
                 )}

--- a/examples/simple/src/comments/PostQuickCreate.js
+++ b/examples/simple/src/comments/PostQuickCreate.js
@@ -4,7 +4,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import {
     CREATE,
-    LongTextInput,
     SaveButton,
     SimpleForm,
     TextInput,
@@ -75,7 +74,12 @@ const PostQuickCreate = ({ onCancel, onSave, ...props }) => {
             {...props}
         >
             <TextInput source="title" validate={required()} />
-            <LongTextInput source="teaser" validate={required()} />
+            <TextInput
+                source="teaser"
+                validate={required()}
+                fullWidth={true}
+                multiline={true}
+            />
         </SimpleForm>
     );
 };

--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -7,7 +7,6 @@ import {
     Create,
     DateInput,
     FormDataConsumer,
-    LongTextInput,
     NumberInput,
     ReferenceInput,
     SaveButton,
@@ -127,7 +126,7 @@ const PostCreate = ({ permissions, ...props }) => {
                 }}
             >
                 <TextInput autoFocus source="title" />
-                <LongTextInput source="teaser" />
+                <TextInput source="teaser" fullWidth={true} multiline={true} />
                 <RichTextInput source="body" validate={required()} />
                 <FormDataConsumer>
                     {({ formData, ...rest }) =>

--- a/examples/simple/src/posts/PostEdit.js
+++ b/examples/simple/src/posts/PostEdit.js
@@ -17,7 +17,6 @@ import {
     FormTab,
     ImageField,
     ImageInput,
-    LongTextInput,
     NumberInput,
     ReferenceArrayInput,
     ReferenceManyField,
@@ -49,7 +48,9 @@ const PostEdit = props => (
             <FormTab label="post.form.summary">
                 <DisabledInput source="id" />
                 <TextInput source="title" validate={required()} resettable />
-                <LongTextInput
+                <TextInput
+                    multiline={true}
+                    fullWidth={true}
                     source="teaser"
                     validate={required()}
                     resettable


### PR DESCRIPTION
This is to fix console.warns of `LongTextInput` being deprecated and to use `TextInput` instead in the `examples/simple` app.

To see these error message:

```
make run-simple
// Navigate to http://localhost:8080
// Open the JavaScript console and try to Add a Post
```

![image](https://user-images.githubusercontent.com/75389/63293097-0b21ab80-c27c-11e9-80dd-e0199f92d2fa.png)
