### PR TITLE
Change LongTextInput to TextInput in examples/demo app

### DIFF
--- a/examples/demo/src/visitors/VisitorCreate.js
+++ b/examples/demo/src/visitors/VisitorCreate.js
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-    Create,
-    DateInput,
-    FormTab,
-    LongTextInput,
-    TabbedForm,
-    TextInput,
-} from 'react-admin';
+import { Create, DateInput, FormTab, TabbedForm, TextInput } from 'react-admin';
 import { makeStyles } from '@material-ui/core/styles';
 
 export const styles = {
@@ -54,9 +47,11 @@ const VisitorCreate = props => {
                     label="resources.customers.tabs.address"
                     path="address"
                 >
-                    <LongTextInput
+                    <TextInput
                         source="address"
                         formClassName={classes.address}
+                        multiline={true}
+                        fullWidth={true}
                     />
                     <TextInput
                         source="zipcode"

--- a/examples/demo/src/visitors/VisitorEdit.js
+++ b/examples/demo/src/visitors/VisitorEdit.js
@@ -6,7 +6,6 @@ import {
     Edit,
     EditButton,
     FormTab,
-    LongTextInput,
     NullableBooleanInput,
     NumberField,
     ReferenceManyField,
@@ -55,9 +54,11 @@ const VisitorEdit = props => {
                     label="resources.customers.tabs.address"
                     path="address"
                 >
-                    <LongTextInput
+                    <TextInput
                         source="address"
                         formClassName={classes.address}
+                        multiline={true}
+                        fullWidth={true}
                     />
                     <TextInput
                         source="zipcode"


### PR DESCRIPTION
Changed the two uses of `LongTextInput` in the examples/demo app to `TextInput`.