### PR TITLE
[RFR] Change to useStyles for LinearProgress component

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.js
@@ -29,9 +29,7 @@ describe('<ReferenceArrayInput />', () => {
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
-        const LinearProgressElement = wrapper.find(
-            'WithStyles(LinearProgress)'
-        );
+        const LinearProgressElement = wrapper.find('LinearProgress');
         assert.equal(LinearProgressElement.length, 1);
     });
 

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.spec.js
@@ -29,9 +29,7 @@ describe('<ReferenceInput />', () => {
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
-        const LinearProgressElement = wrapper.find(
-            'WithStyles(LinearProgress)'
-        );
+        const LinearProgressElement = wrapper.find('LinearProgress');
         assert.equal(LinearProgressElement.length, 1);
     });
 
@@ -47,9 +45,7 @@ describe('<ReferenceInput />', () => {
                 <MyComponent />
             </ReferenceInputView>
         );
-        const LinearProgressElement = wrapper.find(
-            'WithStyles(LinearProgress)'
-        );
+        const LinearProgressElement = wrapper.find('LinearProgress');
         assert.equal(LinearProgressElement.length, 0);
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 1);

--- a/packages/ra-ui-materialui/src/layout/LinearProgress.js
+++ b/packages/ra-ui-materialui/src/layout/LinearProgress.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import Progress from '@material-ui/core/LinearProgress';
 import PropTypes from 'prop-types';
-import { withStyles, createStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
-const styles = theme =>
-    createStyles({
-        root: {
-            margin: `${theme.spacing(1)}px 0`,
-            width: `${theme.spacing(20)}px`,
-        },
-    });
+const useStyles = makeStyles(theme => ({
+    root: {
+        margin: `${theme.spacing(1)}px 0`,
+        width: `${theme.spacing(20)}px`,
+    },
+}));
 
 /**
  * Progress bar formatted to replace an input or a field in a form layout
@@ -22,9 +21,12 @@ const styles = theme =>
  *
  * @param {object} classes CSS class names injected by withStyles
  */
-export const LinearProgress = ({ classes, className, ...rest }) => (
-    <Progress className={classnames(classes.root, className)} {...rest} />
-);
+const LinearProgress = ({ classes: classesOverride, className, ...rest }) => {
+    const classes = useStyles({ classes: classesOverride });
+    return (
+        <Progress className={classnames(classes.root, className)} {...rest} />
+    );
+};
 LinearProgress.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
@@ -32,4 +34,4 @@ LinearProgress.propTypes = {
 // wat? TypeScript looses the displayName if we don't set it explicitly
 LinearProgress.displayName = 'LinearProgress';
 
-export default withStyles(styles)(LinearProgress);
+export default LinearProgress;


### PR DESCRIPTION
Change from withStyles to useStyles  for ra-ui-materialui's `LinearProgress` component.
Also fixed two tests in `ReferenceInput.spec.js` and `ReferenceArrayInput.spec` by removing the HOC wrap `WithStyles` of `LinearProgress`