### PR TITLE
[RFR] Fix typos in DataProvider's documentation

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -120,7 +120,7 @@ Here is how this provider maps request types to API calls:
 | `UPDATE_MANY`        | Multiple calls to `PUT http://my.api.url/posts/123`
 | `DELETE`             | `DELETE http://my.api.url/posts/123`
 | `DELETE_MANY`        | Multiple calls to `DELETE http://my.api.url/posts/123`
-| `GET_MANY`           | `GET http://my.api.url/posts?filter={ids:[123,456,789]}`
+| `GET_MANY`           | `GET http://my.api.url/posts?filter={id:[123,456,789]}`
 | `GET_MANY_REFERENCE` | `GET http://my.api.url/posts?filter={author_id:345}`
 
 **Note**: The simple REST client expects the API to include a `Content-Range` header in the response to `GET_LIST` calls. The value must be the total number of resources in the collection. This allows react-admin to know how many pages of resources there are in total, and build the pagination controls.
@@ -400,7 +400,7 @@ export default (type, resource, params) => {
             options.method = 'PUT';
             options.body = JSON.stringify(params.data);
             break;
-        case UPDATE_MANY:
+        case UPDATE_MANY: {
             const query = {
                 filter: JSON.stringify({ id: params.ids }),
             };
@@ -408,17 +408,19 @@ export default (type, resource, params) => {
             options.method = 'PATCH';
             options.body = JSON.stringify(params.data);
             break;
+        }
         case DELETE:
             url = `${apiUrl}/${resource}/${params.id}`;
             options.method = 'DELETE';
             break;
-        case DELETE_MANY:
+        case DELETE_MANY: {
             const query = {
                 filter: JSON.stringify({ id: params.ids }),
             };
             url = `${apiUrl}/${resource}?${stringify(query)}`;
             options.method = 'DELETE';
             break;
+        }
         case GET_MANY: {
             const query = {
                 filter: JSON.stringify({ id: params.ids }),
@@ -449,9 +451,10 @@ export default (type, resource, params) => {
 
     return fetch(url, options)
         .then(res => res.json())
-        .then(response =>
+        .then(response => {
             /* Convert HTTP Response to Data Provider Response */
             /* Covered in the next section */
+        }
         );
 };
 ```
@@ -589,16 +592,16 @@ POST http://path.to.my.api/posts
 PUT http://path.to.my.api/posts/123
 { "id": 123, "title": "hello, world", "author_id": 12 }
 
-PUT http://path.to.my.api/posts?filter={ids:[123,124,125]}
+PUT http://path.to.my.api/posts?filter={id:[123,124,125]}
 [123, 124, 125]
 
 DELETE http://path.to.my.api/posts/123
 { "id": 123, "title": "hello, world", "author_id": 12 }
 
-DELETE http://path.to.my.api/posts?filter={ids:[123,124,125]}
+DELETE http://path.to.my.api/posts?filter={id:[123,124,125]}
 [123, 124, 125]
 
-GET http://path.to.my.api/posts?filter={ids:[123,124,125]}
+GET http://path.to.my.api/posts?filter={id:[123,124,125]}
 [
     { "id": 123, "title": "hello, world", "author_id": 12 },
     { "id": 124, "title": "good day sunshine", "author_id": 12 },

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -791,7 +791,7 @@ For instance, let's imagine you have to use the `my.api.url` REST API, which exp
 |---------------------|---------------------- |
 | Get list            | `GET http://my.api.url/posts?sort=['title','ASC']&range=[0, 24]&filter={title:'bar'}` |
 | Get one record      | `GET http://my.api.url/posts/123` |
-| Get several records | `GET http://my.api.url/posts?filter={ids:[123,456,789]}` |
+| Get several records | `GET http://my.api.url/posts?filter={id:[123,456,789]}` |
 | Update a record     | `PUT http://my.api.url/posts/123` |
 | Create a record     | `POST http://my.api.url/posts/123` |
 | Delete a record     | `DELETE http://my.api.url/posts/123` |


### PR DESCRIPTION
- [x] replaced `ids` by `id` in url
- [x] block constructs added in switch/case when a local variable is defined 