### PR TITLE
[RFR] List perf improvements

### DIFF
--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -134,7 +134,7 @@ const PostList = props => {
                     }
                 />
             ) : (
-                <Datagrid rowClick={rowClick} expand={<PostPanel />}>
+                <Datagrid rowClick={rowClick} expand={PostPanel}>
                     <TextField source="id" />
                     <TextField source="title" cellClassName={classes.title} />
                     <DateField

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -81,8 +81,10 @@ const useGetMany = (resource: string, ids: Identifier[], options: any = {}) => {
     const [state, setState] = useSafeSetState({
         data,
         error: null,
-        loading: true,
-        loaded: data.length !== 0 && !data.includes(undefined),
+        loading: ids.length !== 0,
+        loaded:
+            ids.length === 0 ||
+            (data.length !== 0 && !data.includes(undefined)),
     });
     if (!isEqual(state.data, data)) {
         setState({

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import ReactDOM from 'react-dom';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import debounce from 'lodash/debounce';
@@ -175,27 +176,32 @@ const callQueries = debounce(() => {
             { ids: accumulatedIds },
             { action: CRUD_GET_MANY }
         )
-            .then(response => {
-                queries.forEach(({ ids, setState, onSuccess }) => {
-                    setState(prevState => ({
-                        ...prevState,
-                        loading: false,
-                        loaded: true,
-                    }));
-                    if (onSuccess) {
-                        const subData = ids.map(id =>
-                            response.data.find(datum => datum.id == id)
-                        );
-                        onSuccess({ data: subData });
-                    }
-                });
-            })
-            .catch(error => {
-                queries.forEach(({ setState, onFailure }) => {
-                    setState({ error, loading: false, loaded: false });
-                    onFailure && onFailure(error);
-                });
-            });
+            .then(response =>
+                // Forces batching, see https://stackoverflow.com/questions/48563650/does-react-keep-the-order-for-state-updates/48610973#48610973
+                ReactDOM.unstable_batchedUpdates(() =>
+                    queries.forEach(({ ids, setState, onSuccess }) => {
+                        setState(prevState => ({
+                            ...prevState,
+                            loading: false,
+                            loaded: true,
+                        }));
+                        if (onSuccess) {
+                            const subData = ids.map(id =>
+                                response.data.find(datum => datum.id == id)
+                            );
+                            onSuccess({ data: subData });
+                        }
+                    })
+                )
+            )
+            .catch(error =>
+                ReactDOM.unstable_batchedUpdates(() =>
+                    queries.forEach(({ setState, onFailure }) => {
+                        setState({ error, loading: false, loaded: false });
+                        onFailure && onFailure(error);
+                    })
+                )
+            );
         delete queriesToCall[resource];
     });
 });

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -1,4 +1,5 @@
 import { Reducer } from 'redux';
+import isEqual from 'lodash/isEqual';
 import { FETCH_END } from '../../../actions/fetchActions';
 import {
     CREATE,
@@ -75,7 +76,12 @@ export const addRecords = (
 
     const records = { fetchedAt: newFetchedAt };
     Object.keys(newFetchedAt).forEach(
-        id => (records[id] = newRecordsById[id] || oldRecords[id])
+        id =>
+            (records[id] = newRecordsById[id]
+                ? isEqual(newRecordsById[id], oldRecords[id])
+                    ? oldRecords[id] // do not change the record to avoid a redraw
+                    : newRecordsById[id]
+                : oldRecords[id])
     );
 
     return hideFetchedAt(records);

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -53,13 +53,11 @@ const styles = theme =>
             padding: 0,
             width: theme.spacing(6),
         },
-        expandButton: {
-            padding: theme.spacing(1),
-        },
         expandIconCell: {
             width: theme.spacing(6),
         },
         expandIcon: {
+            padding: theme.spacing(1),
             transform: 'rotate(-90deg)',
             transition: theme.transitions.create('transform', {
                 duration: theme.transitions.duration.shortest,
@@ -173,7 +171,7 @@ class Datagrid extends Component {
          * displaying the table header with zero data rows,
          * the datagrid displays nothing in this case.
          */
-        if (!isLoading && (ids.length === 0 || total === 0)) {
+        if (loaded && (ids.length === 0 || total === 0)) {
             return null;
         }
 
@@ -245,7 +243,6 @@ class Datagrid extends Component {
                         hasBulkActions,
                         hover,
                         ids,
-                        isLoading,
                         onToggleItem,
                         resource,
                         rowStyle,
@@ -270,7 +267,7 @@ Datagrid.propTypes = {
         order: PropTypes.string,
     }),
     data: PropTypes.object.isRequired,
-    expand: PropTypes.element,
+    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
     hasBulkActions: PropTypes.bool.isRequired,
     hover: PropTypes.bool,
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -15,7 +15,6 @@ const DatagridBody = ({
     hasBulkActions,
     hover,
     ids,
-    isLoading,
     onToggleItem,
     resource,
     row,
@@ -62,7 +61,7 @@ const DatagridBody = ({
                 )}
             </TableBody>
         ),
-        [version, isLoading, data, selectedIds, JSON.stringify(ids)] // eslint-disable-line
+        [version, data, selectedIds, JSON.stringify(ids)] // eslint-disable-line
     );
 
 DatagridBody.propTypes = {
@@ -71,11 +70,10 @@ DatagridBody.propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
     data: PropTypes.object.isRequired,
-    expand: PropTypes.element,
+    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
     hasBulkActions: PropTypes.bool.isRequired,
     hover: PropTypes.bool,
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,
-    isLoading: PropTypes.bool,
     onToggleItem: PropTypes.func,
     resource: PropTypes.string,
     row: PropTypes.element,

--- a/packages/ra-ui-materialui/src/list/DatagridLoading.js
+++ b/packages/ra-ui-materialui/src/list/DatagridLoading.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import Table from '@material-ui/core/Table';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
@@ -25,7 +25,7 @@ const Placeholder = ({ classes: classesOverride }) => {
 const times = (nbChildren, fn) =>
     Array.from({ length: nbChildren }, (_, key) => fn(key));
 
-export default ({
+const DatagridLoading = ({
     classes,
     className,
     expand,
@@ -113,3 +113,5 @@ export default ({
         </TableBody>
     </Table>
 );
+
+export default memo(DatagridLoading);

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -207,7 +207,13 @@ DatagridRow.defaultProps = {
     selected: false,
 };
 
-const PureDatagridRow = memo(DatagridRow, isEqual);
+const areEqual = (prevProps, nextProps) => {
+    const { children: _, ...prevPropsWithoutChildren } = prevProps;
+    const { children: __, ...nextPropsWithoutChildren } = nextProps;
+    return isEqual(prevPropsWithoutChildren, nextPropsWithoutChildren);
+};
+
+const PureDatagridRow = memo(DatagridRow, areEqual);
 
 PureDatagridRow.displayName = 'PureDatagridRow';
 

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -2,16 +2,18 @@ import React, {
     Fragment,
     isValidElement,
     cloneElement,
+    createElement,
     useState,
     useEffect,
+    useCallback,
+    memo,
 } from 'react';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
-import Checkbox from '@material-ui/core/Checkbox';
+import { TableCell, TableRow, Checkbox } from '@material-ui/core';
 import { linkToRecord } from 'ra-core';
 
 import DatagridCell from './DatagridCell';
@@ -58,38 +60,55 @@ const DatagridRow = ({
     }, [expand, nbColumns, children, hasBulkActions]);
     const dispatch = useDispatch();
 
-    const handleToggleExpand = event => {
-        setExpanded(!expanded);
-        event.stopPropagation();
-    };
-    const handleToggleSelection = event => {
-        onToggleItem(id);
-        event.stopPropagation();
-    };
-    const handleClick = async event => {
-        if (!rowClick) return;
-        const effect =
-            typeof rowClick === 'function'
-                ? await rowClick(id, basePath, record)
-                : rowClick;
-        switch (effect) {
-            case 'edit':
-                dispatch(push(linkToRecord(basePath, id)));
-                return;
-            case 'show':
-                dispatch(push(linkToRecord(basePath, id, 'show')));
-                return;
-            case 'expand':
-                handleToggleExpand(event);
-                return;
-            case 'toggleSelection':
-                handleToggleSelection(event);
-                return;
-            default:
-                if (effect) dispatch(push(effect));
-                return;
-        }
-    };
+    const handleToggleExpand = useCallback(
+        event => {
+            setExpanded(!expanded);
+            event.stopPropagation();
+        },
+        [expanded]
+    );
+    const handleToggleSelection = useCallback(
+        event => {
+            onToggleItem(id);
+            event.stopPropagation();
+        },
+        [id, onToggleItem]
+    );
+    const handleClick = useCallback(
+        async event => {
+            if (!rowClick) return;
+            const effect =
+                typeof rowClick === 'function'
+                    ? await rowClick(id, basePath, record)
+                    : rowClick;
+            switch (effect) {
+                case 'edit':
+                    dispatch(push(linkToRecord(basePath, id)));
+                    return;
+                case 'show':
+                    dispatch(push(linkToRecord(basePath, id, 'show')));
+                    return;
+                case 'expand':
+                    handleToggleExpand(event);
+                    return;
+                case 'toggleSelection':
+                    handleToggleSelection(event);
+                    return;
+                default:
+                    if (effect) dispatch(push(effect));
+                    return;
+            }
+        },
+        [
+            basePath,
+            dispatch,
+            handleToggleExpand,
+            handleToggleSelection,
+            id,
+            record,
+            rowClick,
+        ]
+    );
 
     return (
         <Fragment>
@@ -107,7 +126,6 @@ const DatagridRow = ({
                         className={classes.expandIconCell}
                     >
                         <ExpandRowButton
-                            className={classes.expandButton}
                             classes={classes}
                             expanded={expanded}
                             onClick={handleToggleExpand}
@@ -145,12 +163,19 @@ const DatagridRow = ({
             {expand && expanded && (
                 <TableRow key={`${id}-expand`} id={`${id}-expand`}>
                     <TableCell colSpan={nbColumns}>
-                        {cloneElement(expand, {
-                            record,
-                            basePath,
-                            resource,
-                            id: String(id),
-                        })}
+                        {isValidElement(expand)
+                            ? cloneElement(expand, {
+                                  record,
+                                  basePath,
+                                  resource,
+                                  id: String(id),
+                              })
+                            : createElement(expand, {
+                                  record,
+                                  basePath,
+                                  resource,
+                                  id: String(id),
+                              })}
                     </TableCell>
                 </TableRow>
             )}
@@ -163,7 +188,7 @@ DatagridRow.propTypes = {
     children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
-    expand: PropTypes.element,
+    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
     hasBulkActions: PropTypes.bool.isRequired,
     hover: PropTypes.bool,
     id: PropTypes.any,
@@ -182,7 +207,8 @@ DatagridRow.defaultProps = {
     selected: false,
 };
 
-// wat? TypeScript looses the displayName if we don't set it explicitly
-DatagridRow.displayName = 'DatagridRow';
+const PureDatagridRow = memo(DatagridRow, isEqual);
 
-export default DatagridRow;
+PureDatagridRow.displayName = 'PureDatagridRow';
+
+export default PureDatagridRow;

--- a/packages/ra-ui-materialui/src/list/ExpandRowButton.tsx
+++ b/packages/ra-ui-materialui/src/list/ExpandRowButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import classNames from 'classnames';
@@ -26,4 +26,4 @@ const ExpandRowButton = ({ classes, expanded, expandContentId, ...props }) => {
     );
 };
 
-export default ExpandRowButton;
+export default memo(ExpandRowButton);


### PR DESCRIPTION
Various list perf improvements following a profiling sessions.

After an initial render of the datagrid from store, avoids a rerendering of each datagrid row once an unchanged response comes from the dataprovider.

Also, I believe we'll have to support Component injection in some places to avoid forced renders due to the fact that *elements* are always different.