### PR TITLE
[RFR] Improve form performance

### DIFF
--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -20,7 +20,7 @@ import {
     useRedirect,
     useNotify,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
-import { useFormState } from 'react-final-form';
+import { useFormState, FormSpy } from 'react-final-form';
 
 const SaveWithNoteButton = props => {
     const [create] = useCreate('posts');
@@ -128,17 +128,17 @@ const PostCreate = ({ permissions, ...props }) => {
                 <TextInput autoFocus source="title" />
                 <TextInput source="teaser" fullWidth={true} multiline={true} />
                 <RichTextInput source="body" validate={required()} />
-                <FormDataConsumer>
-                    {({ formData, ...rest }) =>
-                        formData.title && (
+                <FormSpy subscription={{ values: true }}>
+                    {({ values }) =>
+                        values.title ? (
                             <NumberInput
                                 source="average_note"
                                 defaultValue={5}
-                                {...rest}
                             />
-                        )
+                        ) : null
                     }
-                </FormDataConsumer>
+                </FormSpy>
+
                 <DateInput
                     source="published_at"
                     defaultValue={dateDefaultValue}

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -41,6 +41,7 @@ const SimpleForm = ({ initialValues, ...props }) => {
             mutators={{ ...arrayMutators }}
             keepDirtyOnReinitialize
             destroyOnUnregister
+            subscription={defaultSubscription}
             {...props}
             render={({ submitting, ...formProps }) => (
                 <SimpleFormView
@@ -53,6 +54,11 @@ const SimpleForm = ({ initialValues, ...props }) => {
             )}
         />
     );
+};
+
+const defaultSubscription = {
+    submitting: true,
+    pristine: true,
 };
 
 export default SimpleForm;

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -59,6 +59,8 @@ const SimpleForm = ({ initialValues, ...props }) => {
 const defaultSubscription = {
     submitting: true,
     pristine: true,
+    valid: true,
+    invalid: true,
 };
 
 export default SimpleForm;

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -50,6 +50,7 @@ const TabbedForm = ({ initialValues, ...props }) => {
             setRedirect={setRedirect}
             keepDirtyOnReinitialize
             destroyOnUnregister
+            subscription={defaultSubscription}
             {...props}
             render={({ submitting, ...formProps }) => (
                 <TabbedFormView
@@ -62,6 +63,11 @@ const TabbedForm = ({ initialValues, ...props }) => {
             )}
         />
     );
+};
+
+const defaultSubscription = {
+    submitting: true,
+    pristine: true,
 };
 
 export default withRouter(TabbedForm);

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -68,6 +68,8 @@ const TabbedForm = ({ initialValues, ...props }) => {
 const defaultSubscription = {
     submitting: true,
     pristine: true,
+    valid: true,
+    invalid: true,
 };
 
 export default withRouter(TabbedForm);


### PR DESCRIPTION
Our forms rerender all fields each time one of the values change - this is not good. I'm proposing a better default - having SimpleForm and TabbedForm subscribe only to submissions. 

- [x] improve perf
- [x] look for side effects