### PR TITLE
[RFR] Improve form look and feel

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -799,3 +799,38 @@ const OrderEdit = (props) => (
 
 Some components (such as `<SelectArrayInput />`) accepted the `helperText` in their `meta` prop. They now receive it directly in their props.
 Besides, all components now display their error or their helperText, but not both at the same time.
+
+## Form Inputs are now filled and dense by default
+
+To better match the [Material Design](https://material.io/components/text-fields/) specification, react-admin defaults to the 'filled' variant for form inputs, and uses a *dense* margin to allow more compact forms. This will change the look and fill of existing forms built with `<SimpleForm>`, `<TabbedForm>`, and `<Filter>`. If you want your forms to look just like before, you need to set the `variant` and `margin` props as follows: 
+
+```diff
+// for SimpleForm
+const PostEdit = props =>
+    <Edit {...props}>
+        <SimpleForm
++           variant="standard"
++           margin="normal"
+        >
+            // ...
+        </SimpleForm>
+    </Edit>;
+// for TabbedForm
+const PostEdit = props =>
+    <Edit {...props}>
+        <TabbedForm
++           variant="standard"
++           margin="normal"
+        >
+            <FormTab label="Identity>
+                // ...
+            </FormTab>
+        </TabbedForm>
+    </Edit>;
+// for Filter
+const PostFilter = props => 
+-   <Filter>
++   <Filter variant="standard">
+        // ...
+    </Filter>;
+```

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -363,6 +363,8 @@ Here are all the props accepted by the `<SimpleForm>` component:
 * [`submitOnEnter`](#submit-on-enter)
 * [`redirect`](#redirection-after-submission)
 * [`toolbar`](#toolbar)
+* [`variant`](#variant)
+* [`margin`](#margin)
 * `save`: The function invoked when the form is submitted. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * `saving`: A boolean indicating whether a save operation is ongoing. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 
@@ -394,6 +396,8 @@ Here are all the props accepted by the `<TabbedForm>` component:
 * [`submitOnEnter`](#submit-on-enter)
 * [`redirect`](#redirection-after-submission)
 * [`toolbar`](#toolbar)
+* [`variant`](#variant)
+* [`margin`](#margin)
 * `save`: The function invoked when the form is submitted. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * `saving`: A boolean indicating whether a save operation is ongoing. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 
@@ -440,6 +444,7 @@ To style the tabs, the `<FormTab>` component accepts two props:
 - `contentClassName` is passed to the tab *content*
 
 ### TabbedFormTabs
+
 By default `<TabbedForm>` uses `<TabbedFormTabs>`, an internal react-admin component to renders tabs. You can pass a custom component as the `tabs` prop to override the default component. Besides, props from `<TabbedFormTabs>` are passed to material-ui's `<Tabs>` component inside `<TabbedFormTabs>`.
 
 The following example shows how to make use of scrollable `<Tabs>`. Pass the `scrollable` prop to `<TabbedFormTabs>` and pass that as the `tabs` prop to `<TabbedForm>`
@@ -826,6 +831,34 @@ Here are the props received by the `Toolbar` component when passed as the `toolb
 **Tip**: Don't forget to also set the `redirect` prop of the Form component to handle submission by the `ENTER` key.
 
 **Tip**: To alter the form values before submitting, you should use the `handleSubmit` prop. See [Altering the Form Values before Submitting](./Actions.md#altering-the-form-values-before-submitting) for more information and examples.
+
+## Variant
+
+By default, react-admin input components use the Material Design "filled" variant. If you want to use the "standard" or "outlined" variants, you can either set the `variant` prop on each Input component individually, or set the `variant` prop directly on the Form component. In that case, the Form component will transmit the `variant` to each Input.
+
+```jsx
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm variant="standard">
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+
+## Margin
+
+By default, react-admin input components use the Material Design "dense" mrgin. If you want to use the "normal" or "none" margins, you can either set the `margin` prop on each Input component individually, or set the `margin` prop directly on the Form component. In that case, the Form component will transmit the `margin` to each Input.
+
+```jsx
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm margin="normal">
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
 
 ## Customizing Input Container Styles
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -848,7 +848,7 @@ export const PostEdit = (props) => (
 
 ## Margin
 
-By default, react-admin input components use the Material Design "dense" mrgin. If you want to use the "normal" or "none" margins, you can either set the `margin` prop on each Input component individually, or set the `margin` prop directly on the Form component. In that case, the Form component will transmit the `margin` to each Input.
+By default, react-admin input components use the Material Design "dense" margin. If you want to use the "normal" or "none" margins, you can either set the `margin` prop on each Input component individually, or set the `margin` prop directly on the Form component. In that case, the Form component will transmit the `margin` to each Input.
 
 ```jsx
 export const PostEdit = (props) => (

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@material-ui/core": "^4.2.1",
+        "@material-ui/core": "^4.3.3",
         "@material-ui/icons": "^4.2.1",
         "data-generator-retail": "^2.7.0",
         "fakerest": "~2.1.0",

--- a/examples/demo/src/layout/Menu.js
+++ b/examples/demo/src/layout/Menu.js
@@ -119,6 +119,7 @@ const Menu = ({ onMenuClick, open, logout }) => {
                 leftIcon={<reviews.icon />}
                 onClick={onMenuClick}
                 sidebarIsOpen={open}
+                dense
             />
             {isXsmall && (
                 <MenuItemLink
@@ -127,6 +128,7 @@ const Menu = ({ onMenuClick, open, logout }) => {
                     leftIcon={<SettingsIcon />}
                     onClick={onMenuClick}
                     sidebarIsOpen={open}
+                    dense
                 />
             )}
             {isXsmall && logout}

--- a/examples/demo/src/layout/themes.js
+++ b/examples/demo/src/layout/themes.js
@@ -13,4 +13,11 @@ export const lightTheme = {
             contrastText: '#fff',
         },
     },
+    overrides: {
+        MuiFilledInput: {
+            root: {
+                backgroundColor: 'rgba(0, 0, 0, 0.04)',
+            },
+        },
+    },
 };

--- a/examples/demo/src/layout/themes.js
+++ b/examples/demo/src/layout/themes.js
@@ -17,6 +17,9 @@ export const lightTheme = {
         MuiFilledInput: {
             root: {
                 backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                '&$disabled': {
+                    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                },
             },
         },
     },

--- a/examples/demo/src/products/ProductCreate.js
+++ b/examples/demo/src/products/ProductCreate.js
@@ -9,15 +9,16 @@ import {
     TextInput,
     required,
 } from 'react-admin';
+import { InputAdornment } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import RichTextInput from 'ra-input-rich-text';
 
 export const styles = {
-    stock: { width: '5em' },
-    price: { width: '5em' },
-    width: { width: '5em' },
+    price: { width: '7em' },
+    width: { width: '7em' },
+    height: { width: '7em' },
+    stock: { width: '7em' },
     widthFormGroup: { display: 'inline-block' },
-    height: { width: '5em' },
     heightFormGroup: { display: 'inline-block', marginLeft: 32 },
 };
 
@@ -32,12 +33,12 @@ const ProductCreate = props => {
                     <TextInput
                         autoFocus
                         source="image"
-                        options={{ fullWidth: true }}
+                        fullWidth
                         validate={required()}
                     />
                     <TextInput
                         source="thumbnail"
-                        options={{ fullWidth: true }}
+                        fullWidth
                         validate={required()}
                     />
                 </FormTab>
@@ -47,18 +48,39 @@ const ProductCreate = props => {
                         source="price"
                         validate={required()}
                         className={classes.price}
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    €
+                                </InputAdornment>
+                            ),
+                        }}
                     />
                     <NumberInput
                         source="width"
                         validate={required()}
                         className={classes.width}
                         formClassName={classes.widthFormGroup}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="start">
+                                    cm
+                                </InputAdornment>
+                            ),
+                        }}
                     />
                     <NumberInput
                         source="height"
                         validate={required()}
                         className={classes.height}
                         formClassName={classes.heightFormGroup}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="start">
+                                    cm
+                                </InputAdornment>
+                            ),
+                        }}
                     />
                     <ReferenceInput
                         source="category_id"
@@ -77,7 +99,7 @@ const ProductCreate = props => {
                     label="resources.products.tabs.description"
                     path="description"
                 >
-                    <RichTextInput source="description" addLabel={false} />
+                    <RichTextInput source="description" label="" />
                 </FormTab>
             </TabbedForm>
         </Create>

--- a/examples/demo/src/products/ProductEdit.js
+++ b/examples/demo/src/products/ProductEdit.js
@@ -14,6 +14,7 @@ import {
     TextField,
     TextInput,
 } from 'react-admin';
+import { InputAdornment } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import RichTextInput from 'ra-input-rich-text';
 
@@ -43,24 +44,45 @@ const ProductEdit = props => {
             <TabbedForm>
                 <FormTab label="resources.products.tabs.image">
                     <Poster />
-                    <TextInput source="image" options={{ fullWidth: true }} />
-                    <TextInput
-                        source="thumbnail"
-                        options={{ fullWidth: true }}
-                    />
+                    <TextInput source="image" fullWidth />
+                    <TextInput source="thumbnail" fullWidth />
                 </FormTab>
                 <FormTab label="resources.products.tabs.details" path="details">
                     <TextInput source="reference" />
-                    <NumberInput source="price" className={classes.price} />
+                    <NumberInput
+                        source="price"
+                        className={classes.price}
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    €
+                                </InputAdornment>
+                            ),
+                        }}
+                    />
                     <NumberInput
                         source="width"
                         className={classes.width}
                         formClassName={classes.widthFormGroup}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="start">
+                                    cm
+                                </InputAdornment>
+                            ),
+                        }}
                     />
                     <NumberInput
                         source="height"
                         className={classes.height}
                         formClassName={classes.heightFormGroup}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="start">
+                                    cm
+                                </InputAdornment>
+                            ),
+                        }}
                     />
                     <ReferenceInput source="category_id" reference="categories">
                         <SelectInput source="name" />
@@ -71,7 +93,7 @@ const ProductEdit = props => {
                     label="resources.products.tabs.description"
                     path="description"
                 >
-                    <RichTextInput source="description" addLabel={false} />
+                    <RichTextInput source="description" label="" />
                 </FormTab>
                 <FormTab label="resources.products.tabs.reviews" path="reviews">
                     <ReferenceManyField
@@ -79,6 +101,7 @@ const ProductEdit = props => {
                         target="product_id"
                         addLabel={false}
                         pagination={<Pagination />}
+                        fullWidth
                     >
                         <Datagrid>
                             <DateField source="date" />

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@babel/polyfill": "^7.0.0",
-        "@material-ui/core": "^4.2.1",
+        "@material-ui/core": "^4.3.3",
         "@material-ui/icons": "^4.2.1",
         "ra-data-fakerest": "^3.0.0-alpha.0",
         "ra-input-rich-text": "^3.0.0-alpha.0",

--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -30,7 +30,7 @@ export const PostIcon = BookIcon;
 
 const useQuickFilterStyles = makeStyles(theme => ({
     chip: {
-        marginBottom: theme.spacing(3),
+        marginBottom: theme.spacing(1),
     },
 }));
 const QuickFilter = ({ label }) => {

--- a/examples/tutorial/package.json
+++ b/examples/tutorial/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@material-ui/core": "^4.2.1",
+        "@material-ui/core": "^4.3.3",
         "ra-data-json-server": "^3.0.0-alpha.0",
         "react": "~16.8.0",
         "react-admin": "^3.0.0-alpha.0",

--- a/packages/ra-input-rich-text/src/QuillBubbleStylesheet.js
+++ b/packages/ra-input-rich-text/src/QuillBubbleStylesheet.js
@@ -1,0 +1,811 @@
+// converted from vendor (node_modules/quill/dist/quill.bubble.css) using the jss cli
+export default {
+    '@global': {
+        '.ql-container': {
+            boxSizing: 'border-box',
+            fontFamily: 'Helvetica, Arial, sans-serif',
+            fontSize: 13,
+            height: '100%',
+            margin: 0,
+            position: 'relative',
+        },
+        '.ql-container.ql-disabled .ql-tooltip': {
+            visibility: 'hidden',
+        },
+        '.ql-container.ql-disabled .ql-editor ul[data-checked] > li::before': {
+            pointerEvents: 'none',
+        },
+        '.ql-clipboard': {
+            left: -100000,
+            height: 1,
+            overflowY: 'hidden',
+            position: 'absolute',
+            top: '50%',
+        },
+        '.ql-clipboard p': {
+            margin: '0',
+            padding: '0',
+        },
+        '.ql-editor': {
+            boxSizing: 'border-box',
+            lineHeight: '1.42',
+            height: '100%',
+            outline: 'none',
+            overflowY: 'auto',
+            padding: '12px 15px',
+            tabSize: '4',
+            M: '4',
+            textAlign: 'left',
+            whiteSpace: 'pre-wrap',
+            wordWrap: 'break-word',
+        },
+        '.ql-editor > *': {
+            cursor: 'text',
+        },
+        '.ql-editor p, .ql-editor ol, .ql-editor ul, .ql-editor pre, .ql-editor blockquote, .ql-editor h1, .ql-editor h2, .ql-editor h3, .ql-editor h4, .ql-editor h5, .ql-editor h6': {
+            margin: '0',
+            padding: '0',
+            counterReset:
+                'list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+        },
+        '.ql-editor ol, .ql-editor ul': {
+            paddingLeft: '1.5em',
+        },
+        '.ql-editor ol > li, .ql-editor ul > li': {
+            listStyleType: 'none',
+        },
+        '.ql-editor ul > li::before': {
+            content: "'\\2022'",
+        },
+        '.ql-editor ul[data-checked=true], .ql-editor ul[data-checked=false]': {
+            pointerEvents: 'none',
+        },
+        '.ql-editor ul[data-checked=true] > li *, .ql-editor ul[data-checked=false] > li *': {
+            pointerEvents: 'all',
+        },
+        '.ql-editor ul[data-checked=true] > li::before, .ql-editor ul[data-checked=false] > li::before': {
+            color: '#777',
+            cursor: 'pointer',
+            pointerEvents: 'all',
+        },
+        '.ql-editor ul[data-checked=true] > li::before': {
+            content: "'\\2611'",
+        },
+        '.ql-editor ul[data-checked=false] > li::before': {
+            content: "'\\2610'",
+        },
+        '.ql-editor li::before': {
+            display: 'inline-block',
+            whiteSpace: 'nowrap',
+            width: '1.2em',
+        },
+        '.ql-editor li:not(.ql-direction-rtl)::before': {
+            marginLeft: '-1.5em',
+            marginRight: '0.3em',
+            textAlign: 'right',
+        },
+        '.ql-editor li.ql-direction-rtl::before': {
+            marginLeft: '0.3em',
+            marginRight: '-1.5em',
+        },
+        '.ql-editor ol li:not(.ql-direction-rtl), .ql-editor ul li:not(.ql-direction-rtl)': {
+            paddingLeft: '1.5em',
+        },
+        '.ql-editor ol li.ql-direction-rtl, .ql-editor ul li.ql-direction-rtl': {
+            paddingRight: '1.5em',
+        },
+        '.ql-editor ol li': {
+            counterReset:
+                'list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+            counterIncrement: 'list-0',
+        },
+        '.ql-editor ol li:before': {
+            content: "counter(list-0, decimal) '. '",
+        },
+        '.ql-editor ol li.ql-indent-1': {
+            counterIncrement: 'list-1',
+            counterReset:
+                'list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-1:before': {
+            content: "counter(list-1, lower-alpha) '. '",
+        },
+        '.ql-editor ol li.ql-indent-2': {
+            counterIncrement: 'list-2',
+            counterReset: 'list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-2:before': {
+            content: "counter(list-2, lower-roman) '. '",
+        },
+        '.ql-editor ol li.ql-indent-3': {
+            counterIncrement: 'list-3',
+            counterReset: 'list-4 list-5 list-6 list-7 list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-3:before': {
+            content: "counter(list-3, decimal) '. '",
+        },
+        '.ql-editor ol li.ql-indent-4': {
+            counterIncrement: 'list-4',
+            counterReset: 'list-5 list-6 list-7 list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-4:before': {
+            content: "counter(list-4, lower-alpha) '. '",
+        },
+        '.ql-editor ol li.ql-indent-5': {
+            counterIncrement: 'list-5',
+            counterReset: 'list-6 list-7 list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-5:before': {
+            content: "counter(list-5, lower-roman) '. '",
+        },
+        '.ql-editor ol li.ql-indent-6': {
+            counterIncrement: 'list-6',
+            counterReset: 'list-7 list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-6:before': {
+            content: "counter(list-6, decimal) '. '",
+        },
+        '.ql-editor ol li.ql-indent-7': {
+            counterIncrement: 'list-7',
+            counterReset: 'list-8 list-9',
+        },
+        '.ql-editor ol li.ql-indent-7:before': {
+            content: "counter(list-7, lower-alpha) '. '",
+        },
+        '.ql-editor ol li.ql-indent-8': {
+            counterIncrement: 'list-8',
+            counterReset: 'list-9',
+        },
+        '.ql-editor ol li.ql-indent-8:before': {
+            content: "counter(list-8, lower-roman) '. '",
+        },
+        '.ql-editor ol li.ql-indent-9': {
+            counterIncrement: 'list-9',
+        },
+        '.ql-editor ol li.ql-indent-9:before': {
+            content: "counter(list-9, decimal) '. '",
+        },
+        '.ql-editor .ql-indent-1:not(.ql-direction-rtl)': {
+            paddingLeft: '3em',
+        },
+        '.ql-editor li.ql-indent-1:not(.ql-direction-rtl)': {
+            paddingLeft: '4.5em',
+        },
+        '.ql-editor .ql-indent-1.ql-direction-rtl.ql-align-right': {
+            paddingRight: '3em',
+        },
+        '.ql-editor li.ql-indent-1.ql-direction-rtl.ql-align-right': {
+            paddingRight: '4.5em',
+        },
+        '.ql-editor .ql-indent-2:not(.ql-direction-rtl)': {
+            paddingLeft: '6em',
+        },
+        '.ql-editor li.ql-indent-2:not(.ql-direction-rtl)': {
+            paddingLeft: '7.5em',
+        },
+        '.ql-editor .ql-indent-2.ql-direction-rtl.ql-align-right': {
+            paddingRight: '6em',
+        },
+        '.ql-editor li.ql-indent-2.ql-direction-rtl.ql-align-right': {
+            paddingRight: '7.5em',
+        },
+        '.ql-editor .ql-indent-3:not(.ql-direction-rtl)': {
+            paddingLeft: '9em',
+        },
+        '.ql-editor li.ql-indent-3:not(.ql-direction-rtl)': {
+            paddingLeft: '10.5em',
+        },
+        '.ql-editor .ql-indent-3.ql-direction-rtl.ql-align-right': {
+            paddingRight: '9em',
+        },
+        '.ql-editor li.ql-indent-3.ql-direction-rtl.ql-align-right': {
+            paddingRight: '10.5em',
+        },
+        '.ql-editor .ql-indent-4:not(.ql-direction-rtl)': {
+            paddingLeft: '12em',
+        },
+        '.ql-editor li.ql-indent-4:not(.ql-direction-rtl)': {
+            paddingLeft: '13.5em',
+        },
+        '.ql-editor .ql-indent-4.ql-direction-rtl.ql-align-right': {
+            paddingRight: '12em',
+        },
+        '.ql-editor li.ql-indent-4.ql-direction-rtl.ql-align-right': {
+            paddingRight: '13.5em',
+        },
+        '.ql-editor .ql-indent-5:not(.ql-direction-rtl)': {
+            paddingLeft: '15em',
+        },
+        '.ql-editor li.ql-indent-5:not(.ql-direction-rtl)': {
+            paddingLeft: '16.5em',
+        },
+        '.ql-editor .ql-indent-5.ql-direction-rtl.ql-align-right': {
+            paddingRight: '15em',
+        },
+        '.ql-editor li.ql-indent-5.ql-direction-rtl.ql-align-right': {
+            paddingRight: '16.5em',
+        },
+        '.ql-editor .ql-indent-6:not(.ql-direction-rtl)': {
+            paddingLeft: '18em',
+        },
+        '.ql-editor li.ql-indent-6:not(.ql-direction-rtl)': {
+            paddingLeft: '19.5em',
+        },
+        '.ql-editor .ql-indent-6.ql-direction-rtl.ql-align-right': {
+            paddingRight: '18em',
+        },
+        '.ql-editor li.ql-indent-6.ql-direction-rtl.ql-align-right': {
+            paddingRight: '19.5em',
+        },
+        '.ql-editor .ql-indent-7:not(.ql-direction-rtl)': {
+            paddingLeft: '21em',
+        },
+        '.ql-editor li.ql-indent-7:not(.ql-direction-rtl)': {
+            paddingLeft: '22.5em',
+        },
+        '.ql-editor .ql-indent-7.ql-direction-rtl.ql-align-right': {
+            paddingRight: '21em',
+        },
+        '.ql-editor li.ql-indent-7.ql-direction-rtl.ql-align-right': {
+            paddingRight: '22.5em',
+        },
+        '.ql-editor .ql-indent-8:not(.ql-direction-rtl)': {
+            paddingLeft: '24em',
+        },
+        '.ql-editor li.ql-indent-8:not(.ql-direction-rtl)': {
+            paddingLeft: '25.5em',
+        },
+        '.ql-editor .ql-indent-8.ql-direction-rtl.ql-align-right': {
+            paddingRight: '24em',
+        },
+        '.ql-editor li.ql-indent-8.ql-direction-rtl.ql-align-right': {
+            paddingRight: '25.5em',
+        },
+        '.ql-editor .ql-indent-9:not(.ql-direction-rtl)': {
+            paddingLeft: '27em',
+        },
+        '.ql-editor li.ql-indent-9:not(.ql-direction-rtl)': {
+            paddingLeft: '28.5em',
+        },
+        '.ql-editor .ql-indent-9.ql-direction-rtl.ql-align-right': {
+            paddingRight: '27em',
+        },
+        '.ql-editor li.ql-indent-9.ql-direction-rtl.ql-align-right': {
+            paddingRight: '28.5em',
+        },
+        '.ql-editor .ql-video': {
+            display: 'block',
+            maxWidth: '100%',
+        },
+        '.ql-editor .ql-video.ql-align-center': {
+            margin: '0 auto',
+        },
+        '.ql-editor .ql-video.ql-align-right': {
+            margin: '0 0 0 auto',
+        },
+        '.ql-editor .ql-bg-black': {
+            backgroundColor: '#000',
+        },
+        '.ql-editor .ql-bg-red': {
+            backgroundColor: '#e60000',
+        },
+        '.ql-editor .ql-bg-orange': {
+            backgroundColor: '#f90',
+        },
+        '.ql-editor .ql-bg-yellow': {
+            backgroundColor: '#ff0',
+        },
+        '.ql-editor .ql-bg-green': {
+            backgroundColor: '#008a00',
+        },
+        '.ql-editor .ql-bg-blue': {
+            backgroundColor: '#06c',
+        },
+        '.ql-editor .ql-bg-purple': {
+            backgroundColor: '#93f',
+        },
+        '.ql-editor .ql-color-white': {
+            color: '#fff',
+        },
+        '.ql-editor .ql-color-red': {
+            color: '#e60000',
+        },
+        '.ql-editor .ql-color-orange': {
+            color: '#f90',
+        },
+        '.ql-editor .ql-color-yellow': {
+            color: '#ff0',
+        },
+        '.ql-editor .ql-color-green': {
+            color: '#008a00',
+        },
+        '.ql-editor .ql-color-blue': {
+            color: '#06c',
+        },
+        '.ql-editor .ql-color-purple': {
+            color: '#93f',
+        },
+        '.ql-editor .ql-font-serif': {
+            fontFamily: 'Georgia, Times New Roman, serif',
+        },
+        '.ql-editor .ql-font-monospace': {
+            fontFamily: 'Monaco, Courier New, monospace',
+        },
+        '.ql-editor .ql-size-small': {
+            fontSize: '0.75em',
+        },
+        '.ql-editor .ql-size-large': {
+            fontSize: '1.5em',
+        },
+        '.ql-editor .ql-size-huge': {
+            fontSize: '2.5em',
+        },
+        '.ql-editor .ql-direction-rtl': {
+            direction: 'rtl',
+            textAlign: 'inherit',
+        },
+        '.ql-editor .ql-align-center': {
+            textAlign: 'center',
+        },
+        '.ql-editor .ql-align-justify': {
+            textAlign: 'justify',
+        },
+        '.ql-editor .ql-align-right': {
+            textAlign: 'right',
+        },
+        '.ql-editor.ql-blank::before': {
+            color: 'rgba(0,0,0,0.6)',
+            content: 'attr(data-placeholder)',
+            fontStyle: 'italic',
+            left: 15,
+            pointerEvents: 'none',
+            position: 'absolute',
+            right: 15,
+        },
+        '.ql-bubble.ql-toolbar:after, .ql-bubble .ql-toolbar:after': {
+            clear: 'both',
+            content: "''",
+            display: 'table',
+        },
+        '.ql-bubble.ql-toolbar button, .ql-bubble .ql-toolbar button': {
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            display: 'inline-block',
+            float: 'left',
+            height: 24,
+            padding: '3px 5px',
+            width: 28,
+        },
+        '.ql-bubble.ql-toolbar button svg, .ql-bubble .ql-toolbar button svg': {
+            float: 'left',
+            height: '100%',
+        },
+        '.ql-bubble.ql-toolbar button:active:hover, .ql-bubble .ql-toolbar button:active:hover': {
+            outline: 'none',
+        },
+        '.ql-bubble.ql-toolbar input.ql-image[type=file], .ql-bubble .ql-toolbar input.ql-image[type=file]': {
+            display: 'none',
+        },
+        '.ql-bubble.ql-toolbar button:hover, .ql-bubble .ql-toolbar button:hover, .ql-bubble.ql-toolbar button:focus, .ql-bubble .ql-toolbar button:focus, .ql-bubble.ql-toolbar button.ql-active, .ql-bubble .ql-toolbar button.ql-active, .ql-bubble.ql-toolbar .ql-picker-label:hover, .ql-bubble .ql-toolbar .ql-picker-label:hover, .ql-bubble.ql-toolbar .ql-picker-label.ql-active, .ql-bubble .ql-toolbar .ql-picker-label.ql-active, .ql-bubble.ql-toolbar .ql-picker-item:hover, .ql-bubble .ql-toolbar .ql-picker-item:hover, .ql-bubble.ql-toolbar .ql-picker-item.ql-selected, .ql-bubble .ql-toolbar .ql-picker-item.ql-selected': {
+            color: '#fff',
+        },
+        '.ql-bubble.ql-toolbar button:hover .ql-fill, .ql-bubble .ql-toolbar button:hover .ql-fill, .ql-bubble.ql-toolbar button:focus .ql-fill, .ql-bubble .ql-toolbar button:focus .ql-fill, .ql-bubble.ql-toolbar button.ql-active .ql-fill, .ql-bubble .ql-toolbar button.ql-active .ql-fill, .ql-bubble.ql-toolbar .ql-picker-label:hover .ql-fill, .ql-bubble .ql-toolbar .ql-picker-label:hover .ql-fill, .ql-bubble.ql-toolbar .ql-picker-label.ql-active .ql-fill, .ql-bubble .ql-toolbar .ql-picker-label.ql-active .ql-fill, .ql-bubble.ql-toolbar .ql-picker-item:hover .ql-fill, .ql-bubble .ql-toolbar .ql-picker-item:hover .ql-fill, .ql-bubble.ql-toolbar .ql-picker-item.ql-selected .ql-fill, .ql-bubble .ql-toolbar .ql-picker-item.ql-selected .ql-fill, .ql-bubble.ql-toolbar button:hover .ql-stroke.ql-fill, .ql-bubble .ql-toolbar button:hover .ql-stroke.ql-fill, .ql-bubble.ql-toolbar button:focus .ql-stroke.ql-fill, .ql-bubble .ql-toolbar button:focus .ql-stroke.ql-fill, .ql-bubble.ql-toolbar button.ql-active .ql-stroke.ql-fill, .ql-bubble .ql-toolbar button.ql-active .ql-stroke.ql-fill, .ql-bubble.ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill, .ql-bubble .ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill, .ql-bubble.ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill, .ql-bubble .ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill, .ql-bubble.ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill, .ql-bubble .ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill, .ql-bubble.ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill, .ql-bubble .ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill': {
+            fill: '#fff',
+        },
+        '.ql-bubble.ql-toolbar button:hover .ql-stroke, .ql-bubble .ql-toolbar button:hover .ql-stroke, .ql-bubble.ql-toolbar button:focus .ql-stroke, .ql-bubble .ql-toolbar button:focus .ql-stroke, .ql-bubble.ql-toolbar button.ql-active .ql-stroke, .ql-bubble .ql-toolbar button.ql-active .ql-stroke, .ql-bubble.ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-bubble .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-bubble.ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-bubble .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-bubble.ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-bubble .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-bubble.ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-bubble .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-bubble.ql-toolbar button:hover .ql-stroke-miter, .ql-bubble .ql-toolbar button:hover .ql-stroke-miter, .ql-bubble.ql-toolbar button:focus .ql-stroke-miter, .ql-bubble .ql-toolbar button:focus .ql-stroke-miter, .ql-bubble.ql-toolbar button.ql-active .ql-stroke-miter, .ql-bubble .ql-toolbar button.ql-active .ql-stroke-miter, .ql-bubble.ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-bubble .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-bubble.ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-bubble .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-bubble.ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-bubble .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-bubble.ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-bubble .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter': {
+            stroke: '#fff',
+        },
+        '@media (pointer: coarse)': {
+            '.ql-bubble.ql-toolbar button:hover:not(.ql-active), .ql-bubble .ql-toolbar button:hover:not(.ql-active)': {
+                color: '#ccc',
+            },
+            '.ql-bubble.ql-toolbar button:hover:not(.ql-active) .ql-fill, .ql-bubble .ql-toolbar button:hover:not(.ql-active) .ql-fill, .ql-bubble.ql-toolbar button:hover:not(.ql-active) .ql-stroke.ql-fill, .ql-bubble .ql-toolbar button:hover:not(.ql-active) .ql-stroke.ql-fill': {
+                fill: '#ccc',
+            },
+            '.ql-bubble.ql-toolbar button:hover:not(.ql-active) .ql-stroke, .ql-bubble .ql-toolbar button:hover:not(.ql-active) .ql-stroke, .ql-bubble.ql-toolbar button:hover:not(.ql-active) .ql-stroke-miter, .ql-bubble .ql-toolbar button:hover:not(.ql-active) .ql-stroke-miter': {
+                stroke: '#ccc',
+            },
+        },
+        '.ql-bubble': {
+            boxSizing: 'border-box',
+        },
+        '.ql-bubble *': {
+            boxSizing: 'border-box',
+        },
+        '.ql-bubble .ql-hidden': {
+            display: 'none',
+        },
+        '.ql-bubble .ql-out-bottom, .ql-bubble .ql-out-top': {
+            visibility: 'hidden',
+        },
+        '.ql-bubble .ql-tooltip': {
+            position: 'absolute',
+            transform: 'translateY(10px)',
+            backgroundColor: '#444',
+            borderRadius: 25,
+            color: '#fff',
+        },
+        '.ql-bubble .ql-tooltip a': {
+            cursor: 'pointer',
+            textDecoration: 'none',
+        },
+        '.ql-bubble .ql-tooltip.ql-flip': {
+            transform: 'translateY(-10px)',
+        },
+        '.ql-bubble .ql-formats': {
+            display: 'inline-block',
+            verticalAlign: 'middle',
+        },
+        '.ql-bubble .ql-formats:after': {
+            clear: 'both',
+            content: "''",
+            display: 'table',
+        },
+        '.ql-bubble .ql-stroke': {
+            fill: 'none',
+            stroke: '#ccc',
+            strokeLinecap: 'round',
+            strokeLinejoin: 'round',
+            strokeWidth: '2',
+        },
+        '.ql-bubble .ql-stroke-miter': {
+            fill: 'none',
+            stroke: '#ccc',
+            strokeMiterlimit: '10',
+            strokeWidth: '2',
+        },
+        '.ql-bubble .ql-fill, .ql-bubble .ql-stroke.ql-fill': {
+            fill: '#ccc',
+        },
+        '.ql-bubble .ql-empty': {
+            fill: 'none',
+        },
+        '.ql-bubble .ql-even': {
+            fillRule: 'evenodd',
+        },
+        '.ql-bubble .ql-thin, .ql-bubble .ql-stroke.ql-thin': {
+            strokeWidth: '1',
+        },
+        '.ql-bubble .ql-transparent': {
+            opacity: '0.4',
+        },
+        '.ql-bubble .ql-direction svg:last-child': {
+            display: 'none',
+        },
+        '.ql-bubble .ql-direction.ql-active svg:last-child': {
+            display: 'inline',
+        },
+        '.ql-bubble .ql-direction.ql-active svg:first-child': {
+            display: 'none',
+        },
+        '.ql-bubble .ql-editor h1': {
+            fontSize: '2em',
+        },
+        '.ql-bubble .ql-editor h2': {
+            fontSize: '1.5em',
+        },
+        '.ql-bubble .ql-editor h3': {
+            fontSize: '1.17em',
+        },
+        '.ql-bubble .ql-editor h4': {
+            fontSize: '1em',
+        },
+        '.ql-bubble .ql-editor h5': {
+            fontSize: '0.83em',
+        },
+        '.ql-bubble .ql-editor h6': {
+            fontSize: '0.67em',
+        },
+        '.ql-bubble .ql-editor a': {
+            textDecoration: 'underline',
+        },
+        '.ql-bubble .ql-editor blockquote': {
+            borderLeft: '4px solid #ccc',
+            marginBottom: 5,
+            marginTop: 5,
+            paddingLeft: 16,
+        },
+        '.ql-bubble .ql-editor code, .ql-bubble .ql-editor pre': {
+            backgroundColor: '#f0f0f0',
+            borderRadius: 3,
+        },
+        '.ql-bubble .ql-editor pre': {
+            whiteSpace: 'pre-wrap',
+            marginBottom: 5,
+            marginTop: 5,
+            padding: '5px 10px',
+        },
+        '.ql-bubble .ql-editor code': {
+            fontSize: '85%',
+            padding: '2px 4px',
+        },
+        '.ql-bubble .ql-editor pre.ql-syntax': {
+            backgroundColor: '#23241f',
+            color: '#f8f8f2',
+            overflow: 'visible',
+        },
+        '.ql-bubble .ql-editor img': {
+            maxWidth: '100%',
+        },
+        '.ql-bubble .ql-picker': {
+            color: '#ccc',
+            display: 'inline-block',
+            float: 'left',
+            fontSize: 14,
+            fontWeight: '500',
+            height: 24,
+            position: 'relative',
+            verticalAlign: 'middle',
+        },
+        '.ql-bubble .ql-picker-label': {
+            cursor: 'pointer',
+            display: 'inline-block',
+            height: '100%',
+            paddingLeft: 8,
+            paddingRight: 2,
+            position: 'relative',
+            width: '100%',
+        },
+        '.ql-bubble .ql-picker-label::before': {
+            display: 'inline-block',
+            lineHeight: 22,
+        },
+        '.ql-bubble .ql-picker-options': {
+            backgroundColor: '#444',
+            display: 'none',
+            minWidth: '100%',
+            padding: '4px 8px',
+            position: 'absolute',
+            whiteSpace: 'nowrap',
+        },
+        '.ql-bubble .ql-picker-options .ql-picker-item': {
+            cursor: 'pointer',
+            display: 'block',
+            paddingBottom: 5,
+            paddingTop: 5,
+        },
+        '.ql-bubble .ql-picker.ql-expanded .ql-picker-label': {
+            color: '#777',
+            zIndex: '2',
+        },
+        '.ql-bubble .ql-picker.ql-expanded .ql-picker-label .ql-fill': {
+            fill: '#777',
+        },
+        '.ql-bubble .ql-picker.ql-expanded .ql-picker-label .ql-stroke': {
+            stroke: '#777',
+        },
+        '.ql-bubble .ql-picker.ql-expanded .ql-picker-options': {
+            display: 'block',
+            marginTop: -1,
+            top: '100%',
+            zIndex: '1',
+        },
+        '.ql-bubble .ql-color-picker, .ql-bubble .ql-icon-picker': {
+            width: 28,
+        },
+        '.ql-bubble .ql-color-picker .ql-picker-label, .ql-bubble .ql-icon-picker .ql-picker-label': {
+            padding: '2px 4px',
+        },
+        '.ql-bubble .ql-color-picker .ql-picker-label svg, .ql-bubble .ql-icon-picker .ql-picker-label svg': {
+            right: 4,
+        },
+        '.ql-bubble .ql-icon-picker .ql-picker-options': {
+            padding: '4px 0px',
+        },
+        '.ql-bubble .ql-icon-picker .ql-picker-item': {
+            height: 24,
+            width: 24,
+            padding: '2px 4px',
+        },
+        '.ql-bubble .ql-color-picker .ql-picker-options': {
+            padding: '3px 5px',
+            width: 152,
+        },
+        '.ql-bubble .ql-color-picker .ql-picker-item': {
+            border: '1px solid transparent',
+            float: 'left',
+            height: 16,
+            margin: 2,
+            padding: 0,
+            width: 16,
+        },
+        '.ql-bubble .ql-picker:not(.ql-color-picker):not(.ql-icon-picker) svg': {
+            position: 'absolute',
+            marginTop: -9,
+            right: '0',
+            top: '50%',
+            width: 18,
+        },
+        ".ql-bubble .ql-picker.ql-header .ql-picker-label[data-label]:not([data-label=''])::before, .ql-bubble .ql-picker.ql-font .ql-picker-label[data-label]:not([data-label=''])::before, .ql-bubble .ql-picker.ql-size .ql-picker-label[data-label]:not([data-label=''])::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-label]:not([data-label=''])::before, .ql-bubble .ql-picker.ql-font .ql-picker-item[data-label]:not([data-label=''])::before, .ql-bubble .ql-picker.ql-size .ql-picker-item[data-label]:not([data-label=''])::before": {
+            content: 'attr(data-label)',
+        },
+        '.ql-bubble .ql-picker.ql-header': {
+            width: 98,
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label::before, .ql-bubble .ql-picker.ql-header .ql-picker-item::before': {
+            content: "'Normal'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label[data-value="1"]::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="1"]::before': {
+            content: "'Heading 1'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label[data-value="2"]::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="2"]::before': {
+            content: "'Heading 2'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label[data-value="3"]::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="3"]::before': {
+            content: "'Heading 3'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label[data-value="4"]::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="4"]::before': {
+            content: "'Heading 4'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label[data-value="5"]::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="5"]::before': {
+            content: "'Heading 5'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-label[data-value="6"]::before, .ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="6"]::before': {
+            content: "'Heading 6'",
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="1"]::before': {
+            fontSize: '2em',
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="2"]::before': {
+            fontSize: '1.5em',
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="3"]::before': {
+            fontSize: '1.17em',
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="4"]::before': {
+            fontSize: '1em',
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="5"]::before': {
+            fontSize: '0.83em',
+        },
+        '.ql-bubble .ql-picker.ql-header .ql-picker-item[data-value="6"]::before': {
+            fontSize: '0.67em',
+        },
+        '.ql-bubble .ql-picker.ql-font': {
+            width: 108,
+        },
+        '.ql-bubble .ql-picker.ql-font .ql-picker-label::before, .ql-bubble .ql-picker.ql-font .ql-picker-item::before': {
+            content: "'Sans Serif'",
+        },
+        '.ql-bubble .ql-picker.ql-font .ql-picker-label[data-value=serif]::before, .ql-bubble .ql-picker.ql-font .ql-picker-item[data-value=serif]::before': {
+            content: "'Serif'",
+        },
+        '.ql-bubble .ql-picker.ql-font .ql-picker-label[data-value=monospace]::before, .ql-bubble .ql-picker.ql-font .ql-picker-item[data-value=monospace]::before': {
+            content: "'Monospace'",
+        },
+        '.ql-bubble .ql-picker.ql-font .ql-picker-item[data-value=serif]::before': {
+            fontFamily: 'Georgia, Times New Roman, serif',
+        },
+        '.ql-bubble .ql-picker.ql-font .ql-picker-item[data-value=monospace]::before': {
+            fontFamily: 'Monaco, Courier New, monospace',
+        },
+        '.ql-bubble .ql-picker.ql-size': {
+            width: 98,
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-label::before, .ql-bubble .ql-picker.ql-size .ql-picker-item::before': {
+            content: "'Normal'",
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-label[data-value=small]::before, .ql-bubble .ql-picker.ql-size .ql-picker-item[data-value=small]::before': {
+            content: "'Small'",
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-label[data-value=large]::before, .ql-bubble .ql-picker.ql-size .ql-picker-item[data-value=large]::before': {
+            content: "'Large'",
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-label[data-value=huge]::before, .ql-bubble .ql-picker.ql-size .ql-picker-item[data-value=huge]::before': {
+            content: "'Huge'",
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-item[data-value=small]::before': {
+            fontSize: 10,
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-item[data-value=large]::before': {
+            fontSize: 18,
+        },
+        '.ql-bubble .ql-picker.ql-size .ql-picker-item[data-value=huge]::before': {
+            fontSize: 32,
+        },
+        '.ql-bubble .ql-color-picker.ql-background .ql-picker-item': {
+            backgroundColor: '#fff',
+        },
+        '.ql-bubble .ql-color-picker.ql-color .ql-picker-item': {
+            backgroundColor: '#000',
+        },
+        '.ql-bubble .ql-toolbar .ql-formats': {
+            margin: '8px 12px 8px 0px',
+        },
+        '.ql-bubble .ql-toolbar .ql-formats:first-child': {
+            marginLeft: 12,
+        },
+        '.ql-bubble .ql-color-picker svg': {
+            margin: 1,
+        },
+        '.ql-bubble .ql-color-picker .ql-picker-item.ql-selected, .ql-bubble .ql-color-picker .ql-picker-item:hover': {
+            borderColor: '#fff',
+        },
+        '.ql-bubble .ql-tooltip-arrow': {
+            borderLeft: '6px solid transparent',
+            borderRight: '6px solid transparent',
+            content: '" "',
+            display: 'block',
+            left: '50%',
+            marginLeft: -6,
+            position: 'absolute',
+        },
+        '.ql-bubble .ql-tooltip:not(.ql-flip) .ql-tooltip-arrow': {
+            borderBottom: '6px solid #444',
+            top: -6,
+        },
+        '.ql-bubble .ql-tooltip.ql-flip .ql-tooltip-arrow': {
+            borderTop: '6px solid #444',
+            bottom: -6,
+        },
+        '.ql-bubble .ql-tooltip.ql-editing .ql-tooltip-editor': {
+            display: 'block',
+        },
+        '.ql-bubble .ql-tooltip.ql-editing .ql-formats': {
+            visibility: 'hidden',
+        },
+        '.ql-bubble .ql-tooltip-editor': {
+            display: 'none',
+        },
+        '.ql-bubble .ql-tooltip-editor input[type=text]': {
+            background: 'transparent',
+            border: 'none',
+            color: '#fff',
+            fontSize: 13,
+            height: '100%',
+            outline: 'none',
+            padding: '10px 20px',
+            position: 'absolute',
+            width: '100%',
+        },
+        '.ql-bubble .ql-tooltip-editor a': {
+            top: 10,
+            position: 'absolute',
+            right: 20,
+        },
+        '.ql-bubble .ql-tooltip-editor a:before': {
+            color: '#ccc',
+            content: '"D7"',
+            fontSize: 16,
+            fontWeight: 'bold',
+        },
+        '.ql-container.ql-bubble:not(.ql-disabled) a': {
+            position: 'relative',
+            whiteSpace: 'nowrap',
+        },
+        '.ql-container.ql-bubble:not(.ql-disabled) a::before': {
+            backgroundColor: '#444',
+            borderRadius: 15,
+            top: -5,
+            fontSize: 12,
+            color: '#fff',
+            content: 'attr(href)',
+            fontWeight: 'normal',
+            overflow: 'hidden',
+            padding: '5px 15px',
+            textDecoration: 'none',
+            zIndex: '1',
+        },
+        '.ql-container.ql-bubble:not(.ql-disabled) a::after': {
+            borderTop: '6px solid #444',
+            borderLeft: '6px solid transparent',
+            borderRight: '6px solid transparent',
+            top: '0',
+            content: '" "',
+            height: '0',
+            width: '0',
+        },
+        '.ql-container.ql-bubble:not(.ql-disabled) a::before, .ql-container.ql-bubble:not(.ql-disabled) a::after': {
+            left: '0',
+            marginLeft: '50%',
+            position: 'absolute',
+            transform: 'translate(-50%, -100%)',
+            transition: 'visibility 0s ease 200ms',
+            visibility: 'hidden',
+        },
+        '.ql-container.ql-bubble:not(.ql-disabled) a:hover::before, .ql-container.ql-bubble:not(.ql-disabled) a:hover::after': {
+            visibility: 'visible',
+        },
+    },
+};

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -2,10 +2,9 @@ import debounce from 'lodash/debounce';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Quill from 'quill';
-import { addField } from 'ra-core';
+import { addField, FieldTitle } from 'ra-core';
 import { InputHelperText } from 'ra-ui-materialui';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import FormControl from '@material-ui/core/FormControl';
+import { FormHelperText, FormControl, InputLabel } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
 import styles from './styles';
@@ -91,26 +90,36 @@ export class RichTextInput extends Component {
     };
 
     render() {
+        const { label, source, resource, isRequired, id, classes } = this.props;
         const { touched, error, helperText = false } = this.props.meta;
         return (
             <FormControl
                 error={!!(touched && error)}
                 fullWidth={this.props.fullWidth}
                 className="ra-rich-text-input"
+                margin="dense"
             >
+                <InputLabel shrink htmlFor={id} className={classes.label}>
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                </InputLabel>
                 <div data-testid="quill" ref={this.updateDivRef} />
-                {helperText || (touched && error) ? (
-                    <FormHelperText
-                        error={!!error}
-                        className={!!error ? 'ra-rich-text-input-error' : ''}
-                    >
+                <FormHelperText
+                    error={!!error}
+                    className={!!error ? 'ra-rich-text-input-error' : ''}
+                >
+                    {helperText || (touched && error) ? (
                         <InputHelperText
                             error={error}
                             helperText={helperText}
                             touched={touched}
                         />
-                    </FormHelperText>
-                ) : null}
+                    ) : null}
+                </FormHelperText>
             </FormControl>
         );
     }
@@ -119,7 +128,6 @@ export class RichTextInput extends Component {
 const RichTextInputWithField = addField(withStyles(styles)(RichTextInput));
 
 RichTextInputWithField.defaultProps = {
-    addLabel: true,
     fullWidth: true,
 };
 export default RichTextInputWithField;

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -90,14 +90,23 @@ export class RichTextInput extends Component {
     };
 
     render() {
-        const { label, source, resource, isRequired, id, classes } = this.props;
+        const {
+            label,
+            source,
+            resource,
+            isRequired,
+            id,
+            classes,
+            margin = 'dense',
+            variant,
+        } = this.props;
         const { touched, error, helperText = false } = this.props.meta;
         return (
             <FormControl
                 error={!!(touched && error)}
                 fullWidth={this.props.fullWidth}
                 className="ra-rich-text-input"
-                margin="dense"
+                margin={margin}
             >
                 {label !== '' && label !== false && (
                     <InputLabel shrink htmlFor={id} className={classes.label}>
@@ -109,7 +118,11 @@ export class RichTextInput extends Component {
                         />
                     </InputLabel>
                 )}
-                <div data-testid="quill" ref={this.updateDivRef} />
+                <div
+                    data-testid="quill"
+                    ref={this.updateDivRef}
+                    className={variant}
+                />
                 <FormHelperText
                     error={!!error}
                     className={!!error ? 'ra-rich-text-input-error' : ''}

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -96,7 +96,7 @@ export class RichTextInput extends Component {
             resource,
             isRequired,
             id,
-            classes,
+            classes = {},
             margin = 'dense',
             variant,
         } = this.props;

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -123,18 +123,18 @@ export class RichTextInput extends Component {
                     ref={this.updateDivRef}
                     className={variant}
                 />
-                <FormHelperText
-                    error={!!error}
-                    className={!!error ? 'ra-rich-text-input-error' : ''}
-                >
-                    {helperText || (touched && error) ? (
+                {helperText || (touched && error) ? (
+                    <FormHelperText
+                        error={!!error}
+                        className={!!error ? 'ra-rich-text-input-error' : ''}
+                    >
                         <InputHelperText
                             error={error}
                             helperText={helperText}
                             touched={touched}
                         />
-                    ) : null}
-                </FormHelperText>
+                    </FormHelperText>
+                ) : null}
             </FormControl>
         );
     }

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -99,14 +99,16 @@ export class RichTextInput extends Component {
                 className="ra-rich-text-input"
                 margin="dense"
             >
-                <InputLabel shrink htmlFor={id} className={classes.label}>
-                    <FieldTitle
-                        label={label}
-                        source={source}
-                        resource={resource}
-                        isRequired={isRequired}
-                    />
-                </InputLabel>
+                {label !== '' && label !== false && (
+                    <InputLabel shrink htmlFor={id} className={classes.label}>
+                        <FieldTitle
+                            label={label}
+                            source={source}
+                            resource={resource}
+                            isRequired={isRequired}
+                        />
+                    </InputLabel>
+                )}
                 <div data-testid="quill" ref={this.updateDivRef} />
                 <FormHelperText
                     error={!!error}

--- a/packages/ra-input-rich-text/src/styles.js
+++ b/packages/ra-input-rich-text/src/styles.js
@@ -1,12 +1,16 @@
 import QuillSnowStylesheet from './QuillSnowStylesheet';
 
 export default theme => ({
+    label: {
+        position: 'relative',
+    },
     '@global': Object.assign({}, QuillSnowStylesheet, {
         '.ra-rich-text-input': {
             '& .ql-editor': {
                 fontSize: '1rem',
                 fontFamily: 'Roboto, sans-serif',
-                padding: 0,
+                padding: '6px 12px',
+                backgroundColor: 'rgba(0, 0, 0, 0.04)',
 
                 '&:hover::before': {
                     backgroundColor: 'rgba(0, 0, 0, 1)',

--- a/packages/ra-input-rich-text/src/styles.js
+++ b/packages/ra-input-rich-text/src/styles.js
@@ -11,7 +11,6 @@ export default theme => ({
                 fontFamily: 'Roboto, sans-serif',
                 padding: '6px 12px',
                 backgroundColor: 'rgba(0, 0, 0, 0.04)',
-
                 '&:hover::before': {
                     backgroundColor: 'rgba(0, 0, 0, 1)',
                     height: 2,
@@ -79,7 +78,9 @@ export default theme => ({
                     transform: 'scaleX(1)',
                 },
             },
-
+            '& .standard .ql-editor': {
+                backgroundColor: 'white',
+            },
             '& .ql-toolbar.ql-snow': {
                 margin: '0.5rem 0',
                 border: 0,

--- a/packages/ra-input-rich-text/src/styles.js
+++ b/packages/ra-input-rich-text/src/styles.js
@@ -81,6 +81,9 @@ export default theme => ({
             '& .standard .ql-editor': {
                 backgroundColor: 'white',
             },
+            '& .outlined .ql-editor': {
+                backgroundColor: 'white',
+            },
             '& .ql-toolbar.ql-snow': {
                 margin: '0.5rem 0',
                 border: 0,

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -42,9 +42,9 @@
         "react-dom": "^16.8.0"
     },
     "dependencies": {
-        "@material-ui/core": "^4.2.1",
+        "@material-ui/core": "^4.3.3",
         "@material-ui/icons": "^4.2.1",
-        "@material-ui/styles": "^4.2.1",
+        "@material-ui/styles": "^4.3.3",
         "autosuggest-highlight": "^3.1.1",
         "classnames": "~2.2.5",
         "connected-react-router": "^6.4.0",

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -54,7 +54,7 @@
         "inflection": "~1.12.0",
         "jsonexport": "^2.4.1",
         "lodash": "~4.17.5",
-        "material-ui-chip-input": "1.0.0-beta.6 - 1.0.0-beta.8",
+        "material-ui-chip-input": "1.0.0",
         "prop-types": "^15.6.1",
         "ra-core": "^3.0.0-alpha.3",
         "react-autosuggest": "^9.4.2",

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.js
@@ -37,7 +37,7 @@ describe('<SaveButton />', () => {
             />
         );
 
-        fireEvent.click(getByLabelText('ra.action.save'));
+        fireEvent.mouseDown(getByLabelText('ra.action.save'));
         expect(onSubmit).toHaveBeenCalled();
     });
 
@@ -52,7 +52,7 @@ describe('<SaveButton />', () => {
             />
         );
 
-        fireEvent.click(getByLabelText('ra.action.save'));
+        fireEvent.mouseDown(getByLabelText('ra.action.save'));
         expect(onSubmit).not.toHaveBeenCalled();
     });
     it('should show a notification if the form is not valid', () => {
@@ -68,7 +68,7 @@ describe('<SaveButton />', () => {
             />
         );
 
-        fireEvent.click(getByLabelText('ra.action.save'));
+        fireEvent.mouseDown(getByLabelText('ra.action.save'));
         expect(showNotification).toHaveBeenCalled();
         expect(onSubmit).toHaveBeenCalled();
     });

--- a/packages/ra-ui-materialui/src/defaultTheme.ts
+++ b/packages/ra-ui-materialui/src/defaultTheme.ts
@@ -16,4 +16,11 @@ export default {
         width: 240,
         closedWidth: 55,
     },
+    overrides: {
+        MuiFilledInput: {
+            root: {
+                backgroundColor: 'rgba(0, 0, 0, 0.04)',
+            },
+        },
+    },
 };

--- a/packages/ra-ui-materialui/src/defaultTheme.ts
+++ b/packages/ra-ui-materialui/src/defaultTheme.ts
@@ -20,6 +20,9 @@ export default {
         MuiFilledInput: {
             root: {
                 backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                '&$disabled': {
+                    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                },
             },
         },
     },

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -68,18 +68,20 @@ Create.propTypes = {
     successMessage: PropTypes.string,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
     root: {},
     main: {
         display: 'flex',
     },
     noActions: {
-        marginTop: '1em',
+        [theme.breakpoints.up('sm')]: {
+            marginTop: '1em',
+        },
     },
     card: {
         flex: '1 1 auto',
     },
-});
+}));
 
 const sanitizeRestProps = ({
     actions,

--- a/packages/ra-ui-materialui/src/form/FormTab.js
+++ b/packages/ra-ui-materialui/src/form/FormTab.js
@@ -43,6 +43,8 @@ class FormTab extends Component {
         basePath,
         record,
         resource,
+        variant,
+        margin,
     }) => (
         <span style={hidden ? hiddenStyle : null} className={contentClassName}>
             {React.Children.map(
@@ -54,6 +56,8 @@ class FormTab extends Component {
                             input={input}
                             record={record}
                             resource={resource}
+                            variant={variant}
+                            margin={margin}
                         />
                     )
             )}

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -82,6 +82,8 @@ const SimpleFormView = ({
     undoable,
     version,
     handleSubmit,
+    variant,
+    margin,
     ...rest
 }) => {
     useInitializeFormWithRecord(form, record);
@@ -106,6 +108,8 @@ const SimpleFormView = ({
                         input={input}
                         record={record}
                         resource={resource}
+                        variant={variant}
+                        margin={margin}
                     />
                 ))}
             </CardContentInner>

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -43,9 +43,9 @@ const SimpleForm = ({ initialValues, ...props }) => {
             destroyOnUnregister
             subscription={defaultSubscription}
             {...props}
-            render={({ submitting, ...formProps }) => (
+            render={formProps => (
                 <SimpleFormView
-                    saving={submitting || saving}
+                    saving={formProps.submitting || saving}
                     translate={translate}
                     setRedirect={setRedirect}
                     {...props}

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -121,6 +121,8 @@ export class SimpleFormIterator extends Component {
             translate,
             disableAdd,
             disableRemove,
+            variant,
+            margin,
         } = this.props;
         const records = get(record, source);
         return fields ? (
@@ -169,6 +171,8 @@ export class SimpleFormIterator extends Component {
                                                     {}
                                                 }
                                                 resource={resource}
+                                                variant={variant}
+                                                margin={margin}
                                             />
                                         ) : null
                                     )}

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -97,6 +97,8 @@ export const TabbedFormView = ({
     undoable,
     value,
     version,
+    variant,
+    margin,
     ...rest
 }) => {
     useInitializeFormWithRecord(form, record);
@@ -147,6 +149,8 @@ export const TabbedFormView = ({
                                               record,
                                               basePath,
                                               hidden: !routeProps.match,
+                                              variant,
+                                              margin,
                                           })
                                         : null
                                 }

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -10,12 +10,16 @@ import { makeStyles } from '@material-ui/core/styles';
 import { useTranslate } from 'ra-core';
 
 import Toolbar from './Toolbar';
-import CardContentInner from '../layout/CardContentInner';
 import TabbedFormTabs from './TabbedFormTabs';
 import useInitializeFormWithRecord from './useInitializeFormWithRecord';
 
 const useStyles = makeStyles(theme => ({
     errorTabButton: { color: theme.palette.error.main },
+    content: {
+        paddingTop: theme.spacing(1),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+    },
 }));
 
 const TabbedForm = ({ initialValues, ...props }) => {
@@ -131,7 +135,7 @@ export const TabbedFormView = ({
                 children
             )}
             <Divider />
-            <CardContentInner>
+            <div className={classes.content}>
                 {/* All tabs are rendered (not only the one in focus), to allow validation
                 on tabs not in focus. The tabs receive a `hidden` property, which they'll
                 use to hide the tab using CSS if it's not the one in focus.
@@ -157,7 +161,7 @@ export const TabbedFormView = ({
                             </Route>
                         )
                 )}
-            </CardContentInner>
+            </div>
             {toolbar &&
                 React.cloneElement(toolbar, {
                     basePath,

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -56,10 +56,10 @@ const TabbedForm = ({ initialValues, ...props }) => {
             destroyOnUnregister
             subscription={defaultSubscription}
             {...props}
-            render={({ submitting, ...formProps }) => (
+            render={formProps => (
                 <TabbedFormView
                     classes={classes}
-                    saving={submitting || saving}
+                    saving={formProps.submitting || saving}
                     translate={translate}
                     {...props}
                     {...formProps}

--- a/packages/ra-ui-materialui/src/input/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.tsx
@@ -56,6 +56,8 @@ export const ArrayInput = ({
     resource,
     source,
     validate,
+    variant,
+    margin = 'dense',
     ...rest
 }) => {
     const fieldProps = useFieldArray(source, {
@@ -84,6 +86,8 @@ export const ArrayInput = ({
                 record,
                 resource,
                 source,
+                variant,
+                margin,
             })}
         </FormControl>
     );

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -48,7 +48,6 @@ const styles = theme =>
         },
         chip: {
             marginRight: theme.spacing(1),
-            marginTop: theme.spacing(1),
         },
         chipDisabled: {
             pointerEvents: 'none',

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -48,6 +48,9 @@ const styles = theme =>
         },
         chip: {
             marginRight: theme.spacing(1),
+            '&.standard': {
+                marginTop: theme.spacing(1),
+            },
         },
         chipDisabled: {
             pointerEvents: 'none',
@@ -230,6 +233,7 @@ export class AutocompleteArrayInput extends React.Component {
             helperText,
             fullWidth,
             options: { InputProps, suggestionsContainerProps, ...options },
+            variant,
         } = this.props;
 
         const {
@@ -294,6 +298,7 @@ export class AutocompleteArrayInput extends React.Component {
                         isRequired={isRequired}
                     />
                 }
+                variant={variant}
                 {...other}
                 {...finalOptions}
             />
@@ -304,7 +309,7 @@ export class AutocompleteArrayInput extends React.Component {
         { value, isFocused, isDisabled, handleClick, handleDelete },
         key
     ) => {
-        const { classes = {}, choices } = this.props;
+        const { classes = {}, choices, variant } = this.props;
 
         const suggestion = choices.find(
             choice => this.getSuggestionValue(choice) === value
@@ -313,7 +318,7 @@ export class AutocompleteArrayInput extends React.Component {
         return (
             <Chip
                 key={key}
-                className={classNames(classes.chip, {
+                className={classNames(classes.chip, variant, {
                     [classes.chipDisabled]: isDisabled,
                     [classes.chipFocused]: isFocused,
                 })}

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.js
@@ -277,11 +277,13 @@ export class AutocompleteArrayInput extends React.Component {
                 inputRef={storeInputRef}
                 error={touched && !!error}
                 helperText={
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
+                    (touched && error) || helperText ? (
+                        <InputHelperText
+                            touched={touched}
+                            error={error}
+                            helperText={helperText}
+                        />
+                    ) : null
                 }
                 chipRenderer={this.renderChip}
                 label={

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.js
@@ -257,7 +257,7 @@ describe('<AutocompleteArrayInput />', () => {
             expect(queryAllByRole('option')).toHaveLength(1);
         });
 
-        it('should revert the searchText when allowEmpty is false', async () => {
+        it('should revert the searchText when allowEmpty is false', () => {
             const { getByLabelText, queryAllByRole } = render(
                 <AutocompleteArrayInput
                     {...defaultProps}
@@ -272,7 +272,6 @@ describe('<AutocompleteArrayInput />', () => {
             fireEvent.change(input, { target: { value: 'foo' } });
             expect(queryAllByRole('option')).toHaveLength(0);
             fireEvent.blur(input);
-            await waitForDomChange();
             expect(getByLabelText('resources.bar.fields.foo').value).toEqual(
                 ''
             );
@@ -300,7 +299,7 @@ describe('<AutocompleteArrayInput />', () => {
             expect(queryAllByRole('option')).toHaveLength(2);
         });
 
-        it('should resolve value from input value', async () => {
+        it('should resolve value from input value', () => {
             const onChange = jest.fn();
             const { getByLabelText } = render(
                 <AutocompleteArrayInput
@@ -316,7 +315,6 @@ describe('<AutocompleteArrayInput />', () => {
             fireEvent.change(input, { target: { value: 'male' } });
             fireEvent.blur(input);
 
-            await waitForDomChange();
             expect(onChange).toHaveBeenCalledTimes(1);
             expect(onChange).toHaveBeenCalledWith(['M']);
         });
@@ -409,7 +407,7 @@ describe('<AutocompleteArrayInput />', () => {
     });
 
     describe('Fix issue #2121', () => {
-        it('updates suggestions when input is blurred and refocused', async () => {
+        it('updates suggestions when input is blurred and refocused', () => {
             const { getByLabelText, queryAllByRole } = render(
                 <AutocompleteArrayInput
                     {...defaultProps}
@@ -427,7 +425,6 @@ describe('<AutocompleteArrayInput />', () => {
             fireEvent.change(input, { target: { value: 'ab' } });
             expect(queryAllByRole('option')).toHaveLength(2);
             fireEvent.blur(input);
-            await waitForDomChange();
 
             fireEvent.focus(input);
             fireEvent.change(input, { target: { value: 'ab' } });
@@ -476,7 +473,7 @@ describe('<AutocompleteArrayInput />', () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
-    it('automatically selects a matched choice on blur if there is only one', async () => {
+    it('automatically selects a matched choice on blur if there is only one', () => {
         const onChange = jest.fn();
 
         const { getByLabelText } = render(
@@ -494,7 +491,6 @@ describe('<AutocompleteArrayInput />', () => {
         fireEvent.focus(input);
         fireEvent.change(input, { target: { value: 'abc' } });
         fireEvent.blur(input);
-        await waitForDomChange();
 
         expect(onChange).toHaveBeenCalled();
     });

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
@@ -21,6 +21,8 @@ const chipInputStyles = createStyles({
     },
 });
 
-const AutocompleteArrayInputChip = props => <ChipInput {...props} />;
+const AutocompleteArrayInputChip = props => (
+    <ChipInput variant="filled" {...props} />
+);
 
 export default withStyles(chipInputStyles)(AutocompleteArrayInputChip);

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInputChip.js
@@ -21,8 +21,8 @@ const chipInputStyles = createStyles({
     },
 });
 
-const AutocompleteArrayInputChip = props => (
-    <ChipInput variant="filled" {...props} />
+const AutocompleteArrayInputChip = ({ variant = 'filled', ...props }) => (
+    <ChipInput variant={variant} {...props} />
 );
 
 export default withStyles(chipInputStyles)(AutocompleteArrayInputChip);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -249,12 +249,14 @@ export class AutocompleteInput extends React.Component {
             classes = {},
             isRequired,
             label,
+            margin = 'dense',
             meta,
             onChange,
             resource,
             source,
             value,
             ref,
+            variant = 'filled',
             options: { InputProps, suggestionsContainerProps, ...options },
             ...other
         } = inputProps;
@@ -286,7 +288,8 @@ export class AutocompleteInput extends React.Component {
                 value={value}
                 onChange={onChange}
                 autoFocus={autoFocus}
-                margin="normal"
+                margin={margin}
+                variant={variant}
                 className={classnames(classes.root, className)}
                 inputRef={storeInputRef}
                 error={!!(touched && error)}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -294,11 +294,13 @@ export class AutocompleteInput extends React.Component {
                 inputRef={storeInputRef}
                 error={!!(touched && error)}
                 helperText={
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
+                    (touched && error) || helperText ? (
+                        <InputHelperText
+                            touched={touched}
+                            error={error}
+                            helperText={helperText}
+                        />
+                    ) : null
                 }
                 name={input.name}
                 {...options}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -242,21 +242,24 @@ export class AutocompleteInput extends React.Component {
     };
 
     renderInput = inputProps => {
-        const { helperText, input } = this.props;
+        const {
+            helperText,
+            input,
+            variant = 'filled',
+            margin = 'dense',
+        } = this.props;
         const {
             autoFocus,
             className,
             classes = {},
             isRequired,
             label,
-            margin = 'dense',
             meta,
             onChange,
             resource,
             source,
             value,
             ref,
-            variant = 'filled',
             options: { InputProps, suggestionsContainerProps, ...options },
             ...other
         } = inputProps;

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -72,7 +72,7 @@ const BooleanInput: FunctionComponent<
                     />
                 }
             />
-            {helperText || (touched && !!error) ? (
+            {(touched && error) || helperText ? (
                 <FormHelperText error={!!error}>
                     <InputHelperText
                         touched={touched}

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -54,6 +54,7 @@ export const DateInput: FunctionComponent<
     onChange,
     onFocus,
     validate,
+    variant = 'filled',
     ...rest
 }) => {
     const {
@@ -76,8 +77,8 @@ export const DateInput: FunctionComponent<
         <TextField
             id={id}
             {...input}
+            variant={variant}
             type="date"
-            margin="normal"
             error={!!(touched && error)}
             helperText={
                 <InputHelperText

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -50,6 +50,7 @@ export const DateInput: FunctionComponent<
     source,
     resource,
     helperText,
+    margin = 'dense',
     onBlur,
     onChange,
     onFocus,
@@ -78,6 +79,7 @@ export const DateInput: FunctionComponent<
             id={id}
             {...input}
             variant={variant}
+            margin={margin}
             type="date"
             error={!!(touched && error)}
             helperText={

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -83,11 +83,13 @@ export const DateInput: FunctionComponent<
             type="date"
             error={!!(touched && error)}
             helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error}
-                    helperText={helperText}
-                />
+                (touched && error) || helperText ? (
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                ) : null
             }
             label={
                 <FieldTitle

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -102,11 +102,13 @@ export const DateTimeInput: FunctionComponent<
             margin="normal"
             error={!!(touched && error)}
             helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error}
-                    helperText={helperText}
-                />
+                (touched && error) || helperText ? (
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                ) : null
             }
             label={
                 <FieldTitle

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -200,7 +200,7 @@ const FileInput: FunctionComponent<
                         ))}
                     </div>
                 )}
-                {helperText || (touched && error) ? (
+                {(touched && error) || helperText ? (
                     <FormHelperText>
                         <InputHelperText
                             touched={touched}

--- a/packages/ra-ui-materialui/src/input/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/input/Labeled.tsx
@@ -66,7 +66,6 @@ export const Labeled = ({
     return (
         <FormControl
             className={className}
-            margin="normal"
             fullWidth={fullWidth}
             error={meta && meta.touched && !!meta.error}
         >

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -31,6 +31,7 @@ const NullableBooleanInput: FunctionComponent<
     className,
     helperText,
     label,
+    margin = 'dense',
     onBlur,
     onChange,
     onFocus,
@@ -38,6 +39,7 @@ const NullableBooleanInput: FunctionComponent<
     resource,
     source,
     validate,
+    variant = 'filled',
     ...rest
 }) => {
     const classes = useStyles({});
@@ -64,7 +66,7 @@ const NullableBooleanInput: FunctionComponent<
             id={id}
             {...input}
             select
-            margin="normal"
+            margin={margin}
             label={
                 <FieldTitle
                     label={label}
@@ -82,6 +84,7 @@ const NullableBooleanInput: FunctionComponent<
                 />
             }
             className={classnames(classes.input, className)}
+            variant={variant}
             {...options}
             {...sanitizeRestProps(rest)}
         >

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -77,11 +77,13 @@ const NullableBooleanInput: FunctionComponent<
             }
             error={!!(touched && error)}
             helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error}
-                    helperText={helperText}
-                />
+                (touched && error) || helperText ? (
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                ) : null
             }
             className={classnames(classes.input, className)}
             variant={variant}

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -43,6 +43,7 @@ const NumberInput: FunctionComponent<
     onFocus,
     onChange,
     validate,
+    variant = 'filled',
     ...rest
 }) => {
     const {
@@ -66,7 +67,7 @@ const NumberInput: FunctionComponent<
         <TextField
             id={id}
             {...input}
-            margin="normal"
+            variant={variant}
             error={!!(touched && error)}
             helperText={
                 <InputHelperText

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -35,6 +35,7 @@ const NumberInput: FunctionComponent<
 > = ({
     helperText,
     label,
+    margin = 'dense',
     options,
     source,
     step,
@@ -70,11 +71,13 @@ const NumberInput: FunctionComponent<
             variant={variant}
             error={!!(touched && error)}
             helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error}
-                    helperText={helperText}
-                />
+                (touched && error) || helperText ? (
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                ) : null
             }
             step={step}
             label={
@@ -85,6 +88,7 @@ const NumberInput: FunctionComponent<
                     isRequired={isRequired}
                 />
             }
+            margin={margin}
             {...options}
             {...sanitizeRestProps(rest)}
         />

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -143,7 +143,7 @@ export const RadioButtonGroupInput: FunctionComponent<
                     />
                 ))}
             </RadioGroup>
-            {helperText || (touched && error) ? (
+            {(touched && error) || helperText ? (
                 <FormHelperText>
                     <InputHelperText
                         touched={touched}

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -74,6 +74,8 @@ class ResettableTextField extends Component {
             value,
             resettable,
             disabled,
+            variant = 'filled',
+            margin = 'dense',
             ...props
         } = this.props;
         const { showClear } = this.state;
@@ -118,6 +120,8 @@ class ResettableTextField extends Component {
                     ...InputProps,
                 }}
                 disabled={disabled}
+                variant={variant}
+                margin={margin}
                 {...props}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -21,7 +21,8 @@ const SearchInput: FunctionComponent<
 
     return (
         <TextInput
-            label={false}
+            hiddenLabel
+            label=""
             placeholder={translate('ra.action.search')}
             InputProps={{
                 endAdornment: (

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -209,7 +209,7 @@ const SelectArrayInput: FunctionComponent<
             variant={variant}
             {...sanitizeRestProps(rest)}
         >
-            <InputLabel htmlFor={id} margin={margin} shrink variant={variant}>
+            <InputLabel htmlFor={id} shrink variant={variant}>
                 <FieldTitle
                     label={label}
                     source={source}
@@ -246,7 +246,6 @@ const SelectArrayInput: FunctionComponent<
                     </div>
                 )}
                 data-testid="selectArray"
-                margin={margin}
                 variant={variant}
                 {...input}
                 value={input.value || []}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -7,6 +7,7 @@ import {
     MenuItem,
     InputLabel,
     Input,
+    FilledInput,
     FormHelperText,
     FormControl,
     Chip,
@@ -132,6 +133,7 @@ const SelectArrayInput: FunctionComponent<
     classes: classesOverride,
     className,
     label,
+    margin = 'dense',
     helperText,
     onBlur,
     onChange,
@@ -143,6 +145,7 @@ const SelectArrayInput: FunctionComponent<
     source,
     translateChoice,
     validate,
+    variant = 'filled',
     ...rest
 }) => {
     const classes = useStyles({ classes: classesOverride });
@@ -200,12 +203,13 @@ const SelectArrayInput: FunctionComponent<
 
     return (
         <FormControl
-            margin="normal"
+            margin={margin}
             className={classnames(classes.root, className)}
             error={touched && !!error}
+            variant={variant}
             {...sanitizeRestProps(rest)}
         >
-            <InputLabel htmlFor={id}>
+            <InputLabel htmlFor={id} margin={margin} shrink variant={variant}>
                 <FieldTitle
                     label={label}
                     source={source}
@@ -216,7 +220,13 @@ const SelectArrayInput: FunctionComponent<
             <Select
                 autoWidth
                 multiple
-                input={<Input id={id} />}
+                input={
+                    variant === 'standard' ? (
+                        <Input id={id} />
+                    ) : (
+                        <FilledInput id={id} />
+                    )
+                }
                 error={!!(touched && error)}
                 renderValue={(selected: any[]) => (
                     <div className={classes.chips}>
@@ -236,13 +246,15 @@ const SelectArrayInput: FunctionComponent<
                     </div>
                 )}
                 data-testid="selectArray"
+                margin={margin}
+                variant={variant}
                 {...input}
                 value={input.value || []}
                 {...options}
             >
                 {choices.map(renderMenuItem)}
             </Select>
-            {helperText || (touched && error) ? (
+            {(touched && error) || helperText ? (
                 <FormHelperText>
                     <InputHelperText
                         touched={touched}

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -202,7 +202,6 @@ const SelectInput: FunctionComponent<
             id={id}
             {...input}
             select
-            margin="normal"
             label={
                 <FieldTitle
                     label={label}

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -214,11 +214,13 @@ const SelectInput: FunctionComponent<
             clearAlwaysVisible
             error={!!(touched && error)}
             helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error}
-                    helperText={helperText}
-                />
+                (touched && error) || helperText ? (
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                ) : null
             }
             {...options}
             {...sanitizeRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -55,7 +55,6 @@ export const TextInput: FunctionComponent<
         <ResettableTextField
             id={id}
             {...input}
-            margin="normal"
             label={
                 <FieldTitle
                     label={label}

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -65,11 +65,13 @@ export const TextInput: FunctionComponent<
             }
             error={!!(touched && error)}
             helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error}
-                    helperText={helperText}
-                />
+                (touched && error) || helperText ? (
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                ) : null
             }
             {...options}
             {...sanitizeRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -56,12 +56,15 @@ export const TextInput: FunctionComponent<
             id={id}
             {...input}
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label !== '' &&
+                label !== false && (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                )
             }
             error={!!(touched && error)}
             helperText={

--- a/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
+++ b/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
@@ -14,6 +14,7 @@ const DashboardMenuItem = ({ locale, onClick, ...props }) => {
             primaryText={translate('ra.page.dashboard')}
             leftIcon={<DashboardIcon />}
             exact
+            dense
             {...props}
         />
     );

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -21,11 +21,15 @@ const useStyles = makeStyles(theme => ({
             theme.palette.type === 'light'
                 ? lighten(theme.palette.primary.light, 0.85)
                 : theme.palette.primary.dark,
-        minHeight: theme.spacing(8),
-        height: theme.spacing(8),
+        minHeight: theme.spacing(9),
+        height: theme.spacing(9),
         transition: `${theme.transitions.create(
             'height'
         )}, ${theme.transitions.create('min-height')}`,
+    },
+    buttons: {
+        paddingTop: theme.spacing(1),
+        paddingBottom: 0,
     },
     collapsed: {
         minHeight: 0,

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -21,16 +21,13 @@ const useStyles = makeStyles(theme => ({
             theme.palette.type === 'light'
                 ? lighten(theme.palette.primary.light, 0.85)
                 : theme.palette.primary.dark,
-        minHeight: theme.spacing(9),
-        height: theme.spacing(9),
+        minHeight: theme.spacing(8),
+        height: theme.spacing(8),
         transition: `${theme.transitions.create(
             'height'
         )}, ${theme.transitions.create('min-height')}`,
     },
-    buttons: {
-        paddingTop: theme.spacing(1),
-        paddingBottom: 0,
-    },
+    buttons: {},
     collapsed: {
         minHeight: 0,
         height: 0,

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -6,12 +6,10 @@ import { sanitizeListRestProps } from 'ra-core';
 import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
 
-const styles = theme => ({
+const styles = {
     button: {},
-    form: {
-        marginBottom: theme.spacing(1),
-    },
-});
+    form: {},
+};
 
 export class Filter extends Component {
     renderButton() {

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -22,6 +22,7 @@ export class Filter extends Component {
             hideFilter,
             displayedFilters,
             filterValues,
+            variant,
             ...rest
         } = this.props;
 

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -8,16 +8,16 @@ import lodashGet from 'lodash/get';
 
 import FilterFormInput from './FilterFormInput';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
     form: {
-        marginTop: '-10px',
+        marginTop: -theme.spacing(2),
         paddingTop: 0,
         display: 'flex',
         alignItems: 'flex-end',
         flexWrap: 'wrap',
     },
     clearFix: { clear: 'right' },
-});
+}));
 
 const sanitizeRestProps = ({
     anyTouched,
@@ -96,7 +96,14 @@ export class FilterForm extends Component {
         this.props.hideFilter(event.currentTarget.dataset.key);
 
     render() {
-        const { classes = {}, className, resource, ...rest } = this.props;
+        const {
+            classes = {},
+            className,
+            resource,
+            margin,
+            variant,
+            ...rest
+        } = this.props;
 
         return (
             <form
@@ -109,6 +116,8 @@ export class FilterForm extends Component {
                         filterElement={filterElement}
                         handleHide={this.handleHide}
                         resource={resource}
+                        margin={margin}
+                        variant={variant}
                     />
                 ))}
                 <div className={classes.clearFix} />

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -15,6 +15,7 @@ const useStyles = makeStyles(theme => ({
         display: 'flex',
         alignItems: 'flex-end',
         flexWrap: 'wrap',
+        minHeight: theme.spacing(9.5),
     },
     clearFix: { clear: 'right' },
 }));

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -22,6 +22,8 @@ const FilterFormInput = ({
     handleHide,
     classes: classesOverride,
     resource,
+    variant,
+    margin,
 }) => {
     const translate = useTranslate();
     const classes = useStyles({ classes: classesOverride });
@@ -47,6 +49,8 @@ const FilterFormInput = ({
                 component={filterElement.type}
                 resource={resource}
                 record={emptyRecord}
+                variant={variant}
+                margin={margin}
             />
             <div className={classes.spacer}>&nbsp;</div>
         </div>

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -14,9 +14,7 @@ const sanitizeRestProps = ({ alwaysOn, ...props }) => props;
 const useStyles = makeStyles(theme => ({
     body: { display: 'flex', alignItems: 'flex-end' },
     spacer: { width: theme.spacing(2) },
-    hideButton: {
-        marginBottom: theme.spacing(2),
-    },
+    hideButton: {},
 }));
 
 const FilterFormInput = ({

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -35,7 +35,7 @@ export const useStyles = makeStyles(theme => ({
         },
     },
     bulkActionsDisplayed: {
-        marginTop: -theme.spacing(8),
+        marginTop: -theme.spacing(9),
         transition: theme.transitions.create('margin-top'),
     },
     actions: {

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -35,7 +35,7 @@ export const useStyles = makeStyles(theme => ({
         },
     },
     bulkActionsDisplayed: {
-        marginTop: -theme.spacing(9),
+        marginTop: -theme.spacing(8),
         transition: theme.transitions.create('margin-top'),
     },
     actions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10125,10 +10125,10 @@ matcher@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.4"
 
-"material-ui-chip-input@1.0.0-beta.6 - 1.0.0-beta.8":
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/material-ui-chip-input/-/material-ui-chip-input-1.0.0-beta.8.tgz#1752aea40a0de723d39b3255d8df6622c61456a0"
-  integrity sha512-Yqljgimr+AfLO2WPoErbU/YwYSB5N1IN4yjUQb6qEUyZcM5W+499JN+6lmNYJdr/oG9gUxRKHX7q0J2yH7NtTQ==
+material-ui-chip-input@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/material-ui-chip-input/-/material-ui-chip-input-1.0.0.tgz#96df9d655d2c16c63afd73828aa3f98c778016b1"
+  integrity sha512-GJ9xkGB+n1SODvflOca4YanHaV8hWkKKBIMrM0YVjo5Jnm+gIom2915CwT86FiDWyoIS6BQOMIof48/l85hZxQ==
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,7 +914,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -1195,17 +1195,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@material-ui/core@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.2.1.tgz#18255c01d039ff856bfdb2f955fec6c9ae64a464"
-  integrity sha512-hasPQUFAb9OxKng7UX2+SjUWtVZbnkVJ/jHZWXTivVcU+UzvNIpA9AyRRQvZ8SPV6swP/HD2VzUBzoMEeRR6wg==
+"@material-ui/core@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.3.3.tgz#38a02331da7916c18e65c3dc56f3f6a67ba60c07"
+  integrity sha512-wUQjoJEbtVWYi+R9gBWCPGy0O+c0oY8cAp2TugyB70f89ahq/cnfnTbMZl6O2arKe2xQlfAMzY8rOOy8UMzJoQ==
   dependencies:
-    "@babel/runtime" "^7.2.0"
-    "@material-ui/styles" "^4.2.0"
-    "@material-ui/system" "^4.3.0"
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.3.3"
+    "@material-ui/system" "^4.3.3"
     "@material-ui/types" "^4.1.1"
-    "@material-ui/utils" "^4.1.0"
-    "@types/react-transition-group" "^2.0.16"
+    "@material-ui/utils" "^4.3.0"
+    "@types/react-transition-group" "^4.2.0"
     clsx "^1.0.2"
     convert-css-length "^2.0.1"
     deepmerge "^4.0.0"
@@ -1224,12 +1224,12 @@
   dependencies:
     "@babel/runtime" "^7.2.0"
 
-"@material-ui/styles@^4.2.0", "@material-ui/styles@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.2.1.tgz#b07383ffeaa840bcb6969eb17c5f0e3b734e8e5b"
-  integrity sha512-1KSOZ17LBWBqIyPRsEpyb4snT/wRIfQTPi0x66UvSzznVK9MPAfJx3/s5lVT4vrGFObs/nj6Pet6Nhrdl2WCrg==
+"@material-ui/styles@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.3.3.tgz#39867dd6f3779a8326075e097d72208d3c5b4977"
+  integrity sha512-quupQ6RYXbtKBJxhLkF3RQx6LSfrfuh2lYpILvk7p9XNkfqOQq36fuNVgrJ/A+NNn03uqDFfQYIWh4CByKr4hA==
   dependencies:
-    "@babel/runtime" "^7.2.0"
+    "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.7.1"
     "@material-ui/types" "^4.1.1"
     "@material-ui/utils" "^4.1.0"
@@ -1237,23 +1237,23 @@
     csstype "^2.5.2"
     deepmerge "^4.0.0"
     hoist-non-react-statics "^3.2.1"
-    jss "10.0.0-alpha.17"
-    jss-plugin-camel-case "10.0.0-alpha.17"
-    jss-plugin-default-unit "10.0.0-alpha.17"
-    jss-plugin-global "10.0.0-alpha.17"
-    jss-plugin-nested "10.0.0-alpha.17"
-    jss-plugin-props-sort "10.0.0-alpha.17"
-    jss-plugin-rule-value-function "10.0.0-alpha.17"
-    jss-plugin-vendor-prefixer "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
+    jss-plugin-camel-case "10.0.0-alpha.24"
+    jss-plugin-default-unit "10.0.0-alpha.24"
+    jss-plugin-global "10.0.0-alpha.24"
+    jss-plugin-nested "10.0.0-alpha.24"
+    jss-plugin-props-sort "10.0.0-alpha.24"
+    jss-plugin-rule-value-function "10.0.0-alpha.24"
+    jss-plugin-vendor-prefixer "10.0.0-alpha.24"
     prop-types "^15.7.2"
     warning "^4.0.1"
 
-"@material-ui/system@^4.3.0":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.3.1.tgz#5fe508d4ca94cdf1d76f7fe535413fcc949b23d9"
-  integrity sha512-Krrc/p/A3rod4M3FYcsWSqE5KxpoyMzYuUHhs0Pns3KH+5kcFyBU+aYbIzMfUz58rhbHkqrShf1fjj7EKcgY0g==
+"@material-ui/system@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.3.3.tgz#8534fe76adbd3938a8dea833e69d84a7a143ecff"
+  integrity sha512-j7JyvlhcTdc1wV6HzrDTU7XXlarxYXEUyzyHawOA0kCGmYVN2uFHENQRARLUdl+mEmuXO4TsAhNAiqiKakkFMg==
   dependencies:
-    "@babel/runtime" "^7.2.0"
+    "@babel/runtime" "^7.4.4"
     deepmerge "^4.0.0"
     prop-types "^15.7.2"
     warning "^4.0.1"
@@ -1273,6 +1273,15 @@
     "@babel/runtime" "^7.2.0"
     prop-types "^15.7.2"
     react-is "^16.8.0"
+
+"@material-ui/utils@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.3.0.tgz#ea7f09815c792e80f270ef8b916517c3f9caba13"
+  integrity sha512-tK3Z/ap5ifPQwIryuGQ+AHLh2hEyBLRPj4NCMcqVrQfD+0KH2IP5BXR4A+wGVsyamKfLaOc8tz1fzxZblsztpw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1633,10 +1642,10 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-transition-group@^2.0.16":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.9.2.tgz#c48cf2a11977c8b4ff539a1c91d259eaa627028d"
-  integrity sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==
+"@types/react-transition-group@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.2.tgz#8c851c4598a23a3a34173069fb4c5c9e41c02e3f"
+  integrity sha512-YfoaTNqBwbIqpiJ5NNfxfgg5kyFP1Hqf/jqBtSWNv0E+EkkxmN+3VD6U2fu86tlQvdAc1o0SdWhnWFwcRMTn9A==
   dependencies:
     "@types/react" "*"
 
@@ -4912,12 +4921,12 @@ css-unit-converter@^1.1.1:
   resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
   integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
 
-css-vendor@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.5.tgz#949c58fd5307e79a9417daa0939506f0e5d0a187"
-  integrity sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==
+css-vendor@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.6.tgz#a205f73d7562e8728c86ef6ce5ee7c7e5eefd71b"
+  integrity sha512-buv8FoZh84iMrtPHYGYll00/qSNV0gYO6E/GUCjUPTsSPj7uf/wot/QZwig+7qdFGxJ7HjOSJoclbhag09TVUQ==
   dependencies:
-    "@babel/runtime" "^7.3.1"
+    "@babel/runtime" "^7.5.5"
     is-in-browser "^1.0.2"
 
 css-what@2.1, css-what@^2.1.2:
@@ -5027,7 +5036,7 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.2:
+csstype@^2.2.0, csstype@^2.5.2, csstype@^2.6.5:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
@@ -9407,71 +9416,72 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jss-plugin-camel-case@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz#6f7c9d9742e349bb061e53cd9b1c3cb006169a67"
-  integrity sha512-aPY4kr6MwliH7KToLRzeSk1NxXUo9n7MQsAa0Hghwj01x9UnMkDkGAKENMKUtPjGkQZfiJpB9tTLFrSJ/6VrIQ==
+jss-plugin-camel-case@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.24.tgz#579a48989d2628ee8baaa006449b1b82d32ee27e"
+  integrity sha512-cRYLbGl6oO9wdGXp3hn+xqc8pw8bjaui25dDYuEeEsRZMh5/OKl3ByYxDT3PLKgFqouy5Xo+YmLGVH8l+nnEdQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
     hyphenate-style-name "^1.0.3"
-    jss "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
 
-jss-plugin-default-unit@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.17.tgz#4e3bf6d8e9691a8e05d50b5abf300515eb0f67ee"
-  integrity sha512-KQgiXczvzJ9AlFdD8NS7FZLub0NSctSrCA9Yi/GqdsfJg4ZCriU4DzIybCZBHCi/INFGJmLIESYWSxnuhAzgSQ==
+jss-plugin-default-unit@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.24.tgz#3e6e24e8ec7aaa950c8975f1645ea861b8aa338e"
+  integrity sha512-1E1XlJqJ/9I1lR5EO/tA75U1LIIicKvW6xZEKLxAP8NC/rUjI+yBQBTBJn61LOpua51e7fgW8me46Z+iuXiC4A==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
 
-jss-plugin-global@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.17.tgz#13005f6b963aee3c1498fe2bad767967ad2eb838"
-  integrity sha512-WYxiwwI+CLk0ozW8loeceqXBAZXBMsLBEZeRwVf9WX+FljdJkGwVZpRCk6LBX4aXnqAGyKqCxIAIJ3KP2yBdEg==
+jss-plugin-global@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.24.tgz#a53e2028d0cb073661e8213f2e622fef9ef4b1fa"
+  integrity sha512-3LoxrZloF4tvXrS5S7enV9OhtaxXsEP3BQdiE76vI/ecCmgNDZNpnPd8MG20ptn2iAOsoMGfoMX20Ea1IKl/Mg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
 
-jss-plugin-nested@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.17.tgz#cb1c20cdc81558c164eaa333bbb24c88bef12202"
-  integrity sha512-onpFqv904KCujryf2t6IIV1/QoB7cSF7ojrd4UujcN5TPvYOvXF5bchi7jnHG5U0SLlRSDGMLJ9fhtoCknhEbw==
+jss-plugin-nested@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.24.tgz#f1b4a0bd1050e29d627c9bc2dc0f424c35f0aa44"
+  integrity sha512-BWU6NaRZTVSJc7N+3FeHacdkFOjCMThouoRQPCWVxeT0nmAVlVGwgYzChcI+vzncx+UaRQC0x+01FYhVQ2xAFA==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
     tiny-warning "^1.0.2"
 
-jss-plugin-props-sort@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.17.tgz#a49be72b8dc8e2861f8136661c53d130abb07ccd"
-  integrity sha512-KnbyrxCbtQTqpDx2mSZU/r/E5QnDPIVfIxRi8K+W/q4gZpomBvqWC+xgvAk9hbpmA6QBoQaOilV8o12w2IZ6fg==
+jss-plugin-props-sort@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.24.tgz#e309e286004b6e059c373efaa308b8742e22ec16"
+  integrity sha512-TB4RpXwnGSEE58rN2RRzcWqhIaz0oAS1UBg10mk1fuLpkKyHEJWuuZXzgGih23Ivl/8LDVzTF+QRY5JagMUUGg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
 
-jss-plugin-rule-value-function@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.17.tgz#45617ccc2d695d77287554e7dbe3b9c37f5f5af4"
-  integrity sha512-8AuJB44Q+ehfkWVRi2XlRbUf6SrLmrHTa5EXd6dgQRCCRuvGmqX8Dl4fZvNeKRFjTLPZgzg9+31rqeOMhKa2vA==
+jss-plugin-rule-value-function@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.24.tgz#85bfd5f994647cb4bf2237d18232421ea362665c"
+  integrity sha512-uFw4tf8PN48bdv4ZcDjG3OzKPIFZ4gpCC1cWO/dyexYfFIubX3bnQUbK4B0wPNe9LJU4KQo8s4F42B8B1ADTrA==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.0.0-alpha.17"
+    jss "10.0.0-alpha.24"
 
-jss-plugin-vendor-prefixer@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.17.tgz#7bb05076d1a14d20b567231c36e57ebf6cb6625f"
-  integrity sha512-wDq9EL0QaoMGSGifPEBb+/SA9LBcqPEW0jpL9ht+Z2t+lV7NNz0j7uCEOuE6FvNWqHzUKTsiATs1rTHPkzNBEQ==
+jss-plugin-vendor-prefixer@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.24.tgz#c4c2c28667d3c7c0d9a01ca1f7a2f74367d1ceef"
+  integrity sha512-hffKj0kSSvZsXs6RYEylpBlEGjryMzU1lsWqC5vQAT/Xb3tDe60BbEarEOFLBGv7EfyajXkuRwlXAQocV5ejCg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    css-vendor "^2.0.1"
-    jss "10.0.0-alpha.17"
+    css-vendor "^2.0.5"
+    jss "10.0.0-alpha.24"
 
-jss@10.0.0-alpha.17:
-  version "10.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0-alpha.17.tgz#3057c85a846c3bd207c04aafd91c8277955d9c57"
-  integrity sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==
+jss@10.0.0-alpha.24:
+  version "10.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0-alpha.24.tgz#f8e2044b6b2f034db05a685d99c599095baf8b61"
+  integrity sha512-kfuSitcj7MTrDtSPLkrWcZppgZlTE3A+cqrkC+Z10WYROt0RXIWINAaK8tE2ohwkDfUlaM1YcRYvV3iT6YNFTA==
   dependencies:
     "@babel/runtime" "^7.3.1"
+    csstype "^2.6.5"
     is-in-browser "^1.1.3"
     tiny-warning "^1.0.2"
 


### PR DESCRIPTION
Material design no longer advocates the usage of fields denoted by a simple underline. Only the "filled" and "outline" variants are documented in [the material design guide](https://material.io/components/text-fields/).

The major bump in react-admin v3 is the right occasion to reflect that change. But we should let an escape hatch for users who absolutely don't want filled inputs. That is possible with the material ui theme, and we should make it possible to override the variant at the form level.

Also, I want to make forms more compact, so we use a `dense` margin by default.

| Before | After |
|----------|---------|
| ![image](https://user-images.githubusercontent.com/99944/63599187-637ce400-c5c1-11e9-8611-87bb149d6d93.png) | ![image](https://user-images.githubusercontent.com/99944/63599127-39c3bd00-c5c1-11e9-8463-6b97a96013f7.png) |

- [x] Provide a default theme with less ugly filled variant than mui default light
- [x] Provide a default theme with less ugly filled variant than mui default dark
- [x] Allow users to override `margin` and `variant` at the form level
- [x] Make common inputs dense and filled by default
- [x] Make other inputs dense and filled by default
- [x] Update Form documentation to mention the new props 
- [x] Add upgrade guide