### PR TITLE
[RFR] Convert AppBar to use useDispatch, useSelector, useWidth

### DIFF
--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -8,12 +8,30 @@ import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
-import withWidth from '@material-ui/core/withWidth';
+import { useTheme } from '@material-ui/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { toggleSidebar } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
 import DefaultUserMenu from './UserMenu';
 import HideOnScroll from './HideOnScroll';
+
+/**
+ * Be careful using this hook. It only works because the number of
+ * breakpoints in theme is static. It will break once you change the number of
+ * breakpoints. See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+ */
+function useWidth() {
+    const theme = useTheme();
+    const keys = [...theme.breakpoints.keys].reverse();
+    return (
+        keys.reduce((output, key) => {
+            // eslint-disable-next-line react-hooks/rules-of-hooks
+            const matches = useMediaQuery(theme.breakpoints.up(key));
+            return !output && matches ? key : output;
+        }, null) || 'xs'
+    );
+}
 
 const useStyles = makeStyles(theme => ({
     toolbar: {
@@ -54,12 +72,12 @@ const AppBar = ({
     open,
     title,
     userMenu,
-    width,
     ...rest
 }) => {
     const classes = useStyles({ classes: classesOverride });
     const dispatch = useDispatch();
     const locale = useSelector(state => state.i18n.locale);
+    const width = useWidth();
 
     return (
         <HideOnScroll>
@@ -113,11 +131,10 @@ AppBar.propTypes = {
     logout: PropTypes.element,
     open: PropTypes.bool,
     userMenu: PropTypes.element,
-    width: PropTypes.string,
 };
 
 AppBar.defaultProps = {
     userMenu: <DefaultUserMenu />,
 };
 
-export default withWidth()(AppBar);
+export default AppBar;

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -8,30 +8,12 @@ import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
-import { useTheme } from '@material-ui/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { toggleSidebar } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
 import DefaultUserMenu from './UserMenu';
 import HideOnScroll from './HideOnScroll';
-
-/**
- * Be careful using this hook. It only works because the number of
- * breakpoints in theme is static. It will break once you change the number of
- * breakpoints. See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
- */
-function useWidth() {
-    const theme = useTheme();
-    const keys = [...theme.breakpoints.keys].reverse();
-    return (
-        keys.reduce((output, key) => {
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            const matches = useMediaQuery(theme.breakpoints.up(key));
-            return !output && matches ? key : output;
-        }, null) || 'xs'
-    );
-}
 
 const useStyles = makeStyles(theme => ({
     toolbar: {
@@ -77,7 +59,7 @@ const AppBar = ({
     const classes = useStyles({ classes: classesOverride });
     const dispatch = useDispatch();
     const locale = useSelector(state => state.i18n.locale);
-    const width = useWidth();
+    const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
 
     return (
         <HideOnScroll>
@@ -89,7 +71,7 @@ const AppBar = ({
             >
                 <Toolbar
                     disableGutters
-                    variant={width === 'xs' ? 'regular' : 'dense'}
+                    variant={isXSmall ? 'regular' : 'dense'}
                     className={classes.toolbar}
                 >
                     <IconButton

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -1,6 +1,6 @@
 import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import classNames from 'classnames';
 import MuiAppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -9,8 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
 import withWidth from '@material-ui/core/withWidth';
-import compose from 'recompose/compose';
-import { toggleSidebar as toggleSidebarAction } from 'ra-core';
+import { toggleSidebar } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
 import DefaultUserMenu from './UserMenu';
@@ -54,15 +53,22 @@ const AppBar = ({
     logout,
     open,
     title,
-    toggleSidebar,
     userMenu,
     width,
     ...rest
 }) => {
     const classes = useStyles({ classes: classesOverride });
+    const dispatch = useDispatch();
+    const locale = useSelector(state => state.i18n.locale);
+
     return (
         <HideOnScroll>
-            <MuiAppBar className={className} color="secondary" {...rest}>
+            <MuiAppBar
+                className={className}
+                color="secondary"
+                locale={locale}
+                {...rest}
+            >
                 <Toolbar
                     disableGutters
                     variant={width === 'xs' ? 'regular' : 'dense'}
@@ -71,7 +77,7 @@ const AppBar = ({
                     <IconButton
                         color="inherit"
                         aria-label="open drawer"
-                        onClick={toggleSidebar}
+                        onClick={() => dispatch(toggleSidebar())}
                         className={classNames(classes.menuButton)}
                     >
                         <MenuIcon
@@ -106,7 +112,6 @@ AppBar.propTypes = {
     className: PropTypes.string,
     logout: PropTypes.element,
     open: PropTypes.bool,
-    toggleSidebar: PropTypes.func.isRequired,
     userMenu: PropTypes.element,
     width: PropTypes.string,
 };
@@ -115,16 +120,4 @@ AppBar.defaultProps = {
     userMenu: <DefaultUserMenu />,
 };
 
-const enhance = compose(
-    connect(
-        state => ({
-            locale: state.i18n.locale, // force redraw on locale change
-        }),
-        {
-            toggleSidebar: toggleSidebarAction,
-        }
-    ),
-    withWidth()
-);
-
-export default enhance(AppBar);
+export default withWidth()(AppBar);


### PR DESCRIPTION
Convert AppBar to use useDispatch, useSelector, useWidth.

The `useWidth` was taken from material-ui documentation example: https://material-ui.com/components/use-media-query/#migrating-from-withwidth

Maybe `useWidth` should be defined in `ra-core/src`  whereby it can be exported for other components that need it.

Done by request in #3582 