### PR TITLE
[RFR] Convert PaginationActions to hooks

### DIFF
--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -18,12 +18,12 @@ const styles = theme =>
         hellip: { padding: '1.2em' },
     });
 
-export class PaginationActions extends Component {
+export function PaginationActions(props) {
     /**
      * Warning: material-ui's page is 0-based
      */
-    range() {
-        const { page, rowsPerPage, count } = this.props;
+    const range = () => {
+        const { page, rowsPerPage, count } = props;
         const nbPages = Math.ceil(count / rowsPerPage) || 1;
         if (isNaN(page) || nbPages === 1) {
             return [];
@@ -57,45 +57,42 @@ export class PaginationActions extends Component {
         }
 
         return input;
-    }
-
-    getNbPages = () =>
-        Math.ceil(this.props.count / this.props.rowsPerPage) || 1;
-
-    prevPage = event => {
-        if (this.props.page === 0) {
-            throw new Error(
-                this.props.translate('ra.navigation.page_out_from_begin')
-            );
-        }
-        this.props.onChangePage(event, this.props.page - 1);
     };
 
-    nextPage = event => {
-        if (this.props.page > this.getNbPages() - 1) {
+    const getNbPages = () => Math.ceil(props.count / props.rowsPerPage) || 1;
+
+    const prevPage = event => {
+        if (props.page === 0) {
             throw new Error(
-                this.props.translate('ra.navigation.page_out_from_end')
+                props.translate('ra.navigation.page_out_from_begin')
             );
         }
-        this.props.onChangePage(event, this.props.page + 1);
+        props.onChangePage(event, props.page - 1);
     };
 
-    gotoPage = event => {
+    const nextPage = event => {
+        if (props.page > getNbPages() - 1) {
+            throw new Error(props.translate('ra.navigation.page_out_from_end'));
+        }
+        props.onChangePage(event, props.page + 1);
+    };
+
+    const gotoPage = event => {
         const page = parseInt(event.currentTarget.dataset.page, 10);
-        if (page < 0 || page > this.getNbPages() - 1) {
+        if (page < 0 || page > getNbPages() - 1) {
             throw new Error(
-                this.props.translate('ra.navigation.page_out_of_boundaries', {
+                props.translate('ra.navigation.page_out_of_boundaries', {
                     page: page + 1,
                 })
             );
         }
-        this.props.onChangePage(event, page);
+        props.onChangePage(event, page);
     };
 
-    renderPageNums() {
-        const { classes = {} } = this.props;
+    const renderPageNums = () => {
+        const { classes = {} } = props;
 
-        return this.range().map((pageNum, index) =>
+        return range().map((pageNum, index) =>
             pageNum === '.' ? (
                 <span key={`hyphen_${index}`} className={classes.hellip}>
                     &hellip;
@@ -103,55 +100,51 @@ export class PaginationActions extends Component {
             ) : (
                 <Button
                     className="page-number"
-                    color={
-                        pageNum === this.props.page + 1 ? 'default' : 'primary'
-                    }
+                    color={pageNum === props.page + 1 ? 'default' : 'primary'}
                     key={pageNum}
                     data-page={pageNum - 1}
-                    onClick={this.gotoPage}
+                    onClick={gotoPage}
                     size="small"
                 >
                     {pageNum}
                 </Button>
             )
         );
-    }
+    };
 
-    render() {
-        const { classes = {}, page, translate } = this.props;
+    const { classes = {}, page, translate } = props;
 
-        const nbPages = this.getNbPages();
-        if (nbPages === 1) return <div className={classes.actions} />;
-        return (
-            <div className={classes.actions}>
-                {page > 0 && (
-                    <Button
-                        color="primary"
-                        key="prev"
-                        onClick={this.prevPage}
-                        className="previous-page"
-                        size="small"
-                    >
-                        <ChevronLeft />
-                        {translate('ra.navigation.prev')}
-                    </Button>
-                )}
-                {this.renderPageNums()}
-                {page !== nbPages - 1 && (
-                    <Button
-                        color="primary"
-                        key="next"
-                        onClick={this.nextPage}
-                        className="next-page"
-                        size="small"
-                    >
-                        {translate('ra.navigation.next')}
-                        <ChevronRight />
-                    </Button>
-                )}
-            </div>
-        );
-    }
+    const nbPages = getNbPages();
+    if (nbPages === 1) return <div className={classes.actions} />;
+    return (
+        <div className={classes.actions}>
+            {page > 0 && (
+                <Button
+                    color="primary"
+                    key="prev"
+                    onClick={prevPage}
+                    className="previous-page"
+                    size="small"
+                >
+                    <ChevronLeft />
+                    {translate('ra.navigation.prev')}
+                </Button>
+            )}
+            {renderPageNums()}
+            {page !== nbPages - 1 && (
+                <Button
+                    color="primary"
+                    key="next"
+                    onClick={nextPage}
+                    className="next-page"
+                    size="small"
+                >
+                    {translate('ra.navigation.next')}
+                    <ChevronRight />
+                </Button>
+            )}
+        </div>
+    );
 }
 
 /**

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -17,13 +17,20 @@ const useStyles = makeStyles(theme => ({
     hellip: { padding: '1.2em' },
 }));
 
-export function PaginationActions({ classes: classesOverride, ...props }) {
+export function PaginationActions({
+    classes: classesOverride,
+    page,
+    rowsPerPage,
+    count,
+    translate,
+    onChangePage,
+    ...props
+}) {
     const classes = useStyles({ classes: classesOverride });
     /**
      * Warning: material-ui's page is 0-based
      */
     const range = () => {
-        const { page, rowsPerPage, count } = props;
         const nbPages = Math.ceil(count / rowsPerPage) || 1;
         if (isNaN(page) || nbPages === 1) {
             return [];
@@ -59,39 +66,35 @@ export function PaginationActions({ classes: classesOverride, ...props }) {
         return input;
     };
 
-    const getNbPages = () => Math.ceil(props.count / props.rowsPerPage) || 1;
+    const getNbPages = () => Math.ceil(count / rowsPerPage) || 1;
 
     const prevPage = event => {
-        if (props.page === 0) {
-            throw new Error(
-                props.translate('ra.navigation.page_out_from_begin')
-            );
+        if (page === 0) {
+            throw new Error(translate('ra.navigation.page_out_from_begin'));
         }
-        props.onChangePage(event, props.page - 1);
+        onChangePage(event, page - 1);
     };
 
     const nextPage = event => {
-        if (props.page > getNbPages() - 1) {
-            throw new Error(props.translate('ra.navigation.page_out_from_end'));
+        if (page > getNbPages() - 1) {
+            throw new Error(translate('ra.navigation.page_out_from_end'));
         }
-        props.onChangePage(event, props.page + 1);
+        onChangePage(event, page + 1);
     };
 
     const gotoPage = event => {
         const page = parseInt(event.currentTarget.dataset.page, 10);
         if (page < 0 || page > getNbPages() - 1) {
             throw new Error(
-                props.translate('ra.navigation.page_out_of_boundaries', {
+                translate('ra.navigation.page_out_of_boundaries', {
                     page: page + 1,
                 })
             );
         }
-        props.onChangePage(event, page);
+        onChangePage(event, page);
     };
 
     const renderPageNums = () => {
-        const { classes = {} } = props;
-
         return range().map((pageNum, index) =>
             pageNum === '.' ? (
                 <span key={`hyphen_${index}`} className={classes.hellip}>
@@ -100,7 +103,7 @@ export function PaginationActions({ classes: classesOverride, ...props }) {
             ) : (
                 <Button
                     className="page-number"
-                    color={pageNum === props.page + 1 ? 'default' : 'primary'}
+                    color={pageNum === page + 1 ? 'default' : 'primary'}
                     key={pageNum}
                     data-page={pageNum - 1}
                     onClick={gotoPage}
@@ -111,8 +114,6 @@ export function PaginationActions({ classes: classesOverride, ...props }) {
             )
         );
     };
-
-    const { classes = {}, page, translate } = props;
 
     const nbPages = getNbPages();
     if (nbPages === 1) return <div className={classes.actions} />;
@@ -156,6 +157,7 @@ export function PaginationActions({ classes: classesOverride, ...props }) {
 PaginationActions.propTypes = {
     backIconButtonProps: PropTypes.object,
     count: PropTypes.number.isRequired,
+    classes: PropTypes.object,
     nextIconButtonProps: PropTypes.object,
     onChangePage: PropTypes.func.isRequired,
     page: PropTypes.number.isRequired,

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -161,4 +161,4 @@ PaginationActions.propTypes = {
     rowsPerPage: PropTypes.number.isRequired,
 };
 
-export default React.memo(PaginationActions, () => true);
+export default React.memo(PaginationActions);

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -1,12 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
-import compose from 'recompose/compose';
-import { translate } from 'ra-core';
+import { useTranslate } from 'react-admin';
 
 const useStyles = makeStyles(theme => ({
     actions: {
@@ -22,11 +21,10 @@ export function PaginationActions({
     page,
     rowsPerPage,
     count,
-    translate,
     onChangePage,
-    ...props
 }) {
     const classes = useStyles({ classes: classesOverride });
+    const translate = useTranslate();
     /**
      * Warning: material-ui's page is 0-based
      */
@@ -164,9 +162,4 @@ PaginationActions.propTypes = {
     rowsPerPage: PropTypes.number.isRequired,
 };
 
-const enhance = compose(
-    pure,
-    translate
-);
-
-export default enhance(PaginationActions);
+export default pure(PaginationActions);

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import pure from 'recompose/pure';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
@@ -16,7 +15,7 @@ const useStyles = makeStyles(theme => ({
     hellip: { padding: '1.2em' },
 }));
 
-export function PaginationActions({
+function PaginationActions({
     classes: classesOverride,
     page,
     rowsPerPage,
@@ -162,4 +161,4 @@ PaginationActions.propTypes = {
     rowsPerPage: PropTypes.number.isRequired,
 };
 
-export default pure(PaginationActions);
+export default PaginationActions;

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -161,4 +161,4 @@ PaginationActions.propTypes = {
     rowsPerPage: PropTypes.number.isRequired,
 };
 
-export default PaginationActions;
+export default React.memo(PaginationActions, () => true);

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -2,23 +2,23 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
 import Button from '@material-ui/core/Button';
-import { withStyles, createStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import compose from 'recompose/compose';
 import { translate } from 'ra-core';
 
-const styles = theme =>
-    createStyles({
-        actions: {
-            flexShrink: 0,
-            color: theme.palette.text.secondary,
-            marginLeft: 20,
-        },
-        hellip: { padding: '1.2em' },
-    });
+const useStyles = makeStyles(theme => ({
+    actions: {
+        flexShrink: 0,
+        color: theme.palette.text.secondary,
+        marginLeft: 20,
+    },
+    hellip: { padding: '1.2em' },
+}));
 
-export function PaginationActions(props) {
+export function PaginationActions({ classes: classesOverride, ...props }) {
+    const classes = useStyles({ classes: classesOverride });
     /**
      * Warning: material-ui's page is 0-based
      */
@@ -164,8 +164,7 @@ PaginationActions.propTypes = {
 
 const enhance = compose(
     pure,
-    translate,
-    withStyles(styles)
+    translate
 );
 
 export default enhance(PaginationActions);

--- a/packages/ra-ui-materialui/src/list/PaginationActions.spec.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { PaginationActions } from './PaginationActions';
+import PaginationActions from './PaginationActions';
 
 describe('<PaginationActions />', () => {
     it('should not render any actions when no pagination is necessary', () => {


### PR DESCRIPTION
Convert `PaginationActions` to hooks.

This was mostly straightforward conversion done step-by-step (running `make test-unit` at every step). One note though...  I removed the HOC `recompose/pure` along with the non-default export. Using the pure-wrapped component does not pass the `PaginationActions.spec`.   Let me know if I got this wrong.