### PR TITLE
[RFR] Fix css-mediaquery Dependency

### DIFF
--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -28,7 +28,6 @@
     "devDependencies": {
         "@testing-library/react": "^8.0.7",
         "cross-env": "^5.2.0",
-        "css-mediaquery": "^0.1.2",
         "enzyme": "~3.9.0",
         "enzyme-adapter-react-16": "~1.12.1",
         "file-api": "~0.10.4",
@@ -49,6 +48,7 @@
         "autosuggest-highlight": "^3.1.1",
         "classnames": "~2.2.5",
         "connected-react-router": "^6.4.0",
+        "css-mediaquery": "^0.1.2",
         "final-form": "^4.18.5",
         "final-form-arrays": "^3.0.1",
         "inflection": "~1.12.0",


### PR DESCRIPTION
Fixes #3597

We export `DeviceTestWrapper` which uses the `css-mediaquery` package but it was a dev dependency