### PR TITLE
Add hasBulkActions to useMemo inputs

### DIFF
--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -61,7 +61,7 @@ const DatagridBody = ({
                 )}
             </TableBody>
         ),
-        [version, data, selectedIds, JSON.stringify(ids)] // eslint-disable-line
+        [version, data, selectedIds, JSON.stringify(ids), hasBulkActions] // eslint-disable-line
     );
 
 DatagridBody.propTypes = {


### PR DESCRIPTION
If hasBulkActions prop changed dynamically, DataGrid renders Checkbox only in the DataGridHeader and doesn't render Checkbox in every row because useMemo ignores this prop change.