### PR TITLE
[RFR] CoreAdminRouter - log initializeResources errors

### DIFF
--- a/packages/ra-core/src/CoreAdminRouter.tsx
+++ b/packages/ra-core/src/CoreAdminRouter.tsx
@@ -105,6 +105,7 @@ export class CoreAdminRouter extends Component<
                 });
             }
         } catch (error) {
+            console.error(error);
             this.props.userLogout();
         }
     };


### PR DESCRIPTION
sometimes when you make error in authprovider, the app just goes into cycle of login and logout

and you don't even know why

so its better to report the error to console, so you can fix the problem