### PR TITLE
[RFR] Fix FileInput - need to define type

### DIFF
--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -112,6 +112,7 @@ const FileInput: FunctionComponent<
         format: transformFiles,
         parse: transformFiles,
         source,
+        type: 'file',
         validate,
         ...rest,
     });


### PR DESCRIPTION
without defined input type as file,
 the react-dropzone does not open on click and work's only on drop