### PR TITLE
[RFR][v3] SimpleFormIterator - don't display error if its object

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -127,7 +127,7 @@ export class SimpleFormIterator extends Component {
         const records = get(record, source);
         return fields ? (
             <ul className={classes.root}>
-                {submitFailed && error && (
+                {submitFailed && typeof error !== 'object' && error && (
                     <FormHelperText error>{error}</FormHelperText>
                 )}
                 <TransitionGroup>


### PR DESCRIPTION
object means it's error's for children so we can ignore it as children will display the errors by themself's

fixes error - passing object to react
