### PR TITLE
Allowing for more fine tuning of Quill without rewriting RichTextInput

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -961,6 +961,18 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 <RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
 ```
 
+If you need more customization, you can access the quill object through the `quillInit` callback that will be called just after its initialization.
+
+```js
+const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+    this.quill.format('bold', value)
+});
+
+// ...
+
+<RichTextInput source="text" quillInit={quillInit}/>
+```
+
 ## `<SelectInput>`
 
 To let users choose a value in a list using a dropdown, use `<SelectInput>`. It renders using [Material ui's `<Select>`](http://v1.material-ui.com/api/select). Set the `choices` attribute to determine the options (with `id`, `name` tuples):

--- a/packages/ra-input-rich-text/README.md
+++ b/packages/ra-input-rich-text/README.md
@@ -44,6 +44,18 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 <RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
 ```
 
+If you need more customization, you can access the quill object through the `quillInit` callback that will be called just after its initialization.
+
+```js
+const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+    this.quill.format('bold', value)
+});
+
+// ...
+
+<RichTextInput source="text" quillInit={quillInit}/>
+```
+
 ## License
 
 This library is licensed under the MIT License, and sponsored by [marmelab](http://marmelab.com).

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -29,7 +29,7 @@ export class RichTextInput extends Component {
             }),
         ]),
         fullWidth: PropTypes.bool,
-        quillInit: PropTypes.func
+        quillInit: PropTypes.func,
     };
 
     static defaultProps = {

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -29,6 +29,7 @@ export class RichTextInput extends Component {
             }),
         ]),
         fullWidth: PropTypes.bool,
+        quillInit: PropTypes.func
     };
 
     static defaultProps = {
@@ -51,6 +52,10 @@ export class RichTextInput extends Component {
             theme: 'snow',
             ...options,
         });
+
+        if (this.props.quillInit) {
+            this.props.quillInit(this.quill);
+        }
 
         this.quill.setContents(this.quill.clipboard.convert(value));
 


### PR DESCRIPTION
In Quill, there are a bunch of things you can't really do with *just* the options passed to the constructor. I propose adding a tiny callback for those who need more custom behaviors.

For example, if you want to restrict the formatting possibilities offered **and** customize the behavior of some of these formats, you need to do it in two steps:

```javascript
const quill = new Quill($ref, {
    modules: { 
        toolbar: ['bold', 'italic', 'link']
    }
});
quill.getModule('toolbar').addHandler('bold', function(value) {
    this.quill.format('bold', value)
});
```

With this proposed *pull request*, you'd be able to implement these behaviors very simply:

```javascript
const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
    this.quill.format('bold', value)
});

// ...

<RichTextInput source="text" toolbar={[ ['bold', 'italic', 'link'] ]} quillInit={quillInit}/>
```

The alternative is to re-implement the entire <RichTextInput> component and its style... :-(