### PR TITLE
Add an optional Polyglot.js-Options prop

### DIFF
--- a/packages/ra-core/src/CoreAdmin.tsx
+++ b/packages/ra-core/src/CoreAdmin.tsx
@@ -40,6 +40,7 @@ export interface AdminProps {
     dataProvider: DataProvider;
     history: History;
     i18nProvider?: I18nProvider;
+    polyglotOptions?: object;
     initialState?: object;
     loading: ComponentType;
     locale?: string;
@@ -102,6 +103,7 @@ React-admin requires a valid dataProvider function to work.`);
             loading,
             loginPage,
             logoutButton,
+            polyglotOptions,
         } = this.props;
 
         const logout = authProvider ? createElement(logoutButton) : null;
@@ -113,7 +115,7 @@ React-admin requires a valid dataProvider function to work.`);
         }
 
         return (
-            <TranslationProvider>
+            <TranslationProvider options={polyglotOptions}>
                 <ConnectedRouter history={this.history}>
                     <Switch>
                         {loginPage !== false && loginPage !== true ? (

--- a/packages/ra-core/src/i18n/TranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TranslationProvider.tsx
@@ -12,7 +12,6 @@ import {
 interface MappedProps {
     locale: string;
     messages: object;
-    options?: object;
 }
 
 interface State {
@@ -20,6 +19,7 @@ interface State {
 }
 
 interface Props {
+    options?: object;
     children: ReactElement<any>;
 }
 

--- a/packages/ra-core/src/i18n/TranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TranslationProvider.tsx
@@ -12,6 +12,7 @@ import {
 interface MappedProps {
     locale: string;
     messages: object;
+    options?: object;
 }
 
 interface State {
@@ -41,10 +42,11 @@ interface ViewProps extends MappedProps, Props {}
 class TranslationProviderView extends Component<ViewProps, State> {
     constructor(props) {
         super(props);
-        const { locale, messages } = props;
+        const { locale, messages, options } = props;
         const polyglot = new Polyglot({
             locale,
             phrases: defaultsDeep({ '': '' }, messages, defaultMessages),
+            ...options,
         });
 
         this.state = {
@@ -60,11 +62,12 @@ class TranslationProviderView extends Component<ViewProps, State> {
             prevProps.locale !== this.props.locale ||
             prevProps.messages !== this.props.messages
         ) {
-            const { locale, messages } = this.props;
+            const { locale, messages, options } = this.props;
 
             const polyglot = new Polyglot({
                 locale,
                 phrases: defaultsDeep({ '': '' }, messages, defaultMessages),
+                ...options,
             });
 
             this.setState({


### PR DESCRIPTION
I was in the need of using Polyglot.js' onMissingKey-callback to send missing translations automatically to my API. To do so i have added an optional **polyglotOptions**-prop in **CoreAdmin** to pass an additional settings object to use Polyglot's full features.