### PR TITLE
[RFR][v3] NumberInput - step needs to be passed in inputProps

### DIFF
--- a/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
@@ -28,6 +28,19 @@ describe('<NumberInput />', () => {
         expect(input.getAttribute('type')).toEqual('number');
     });
 
+    describe('props', () => {
+        it('should accept `step` prop and pass it to native input', () => {
+            const { getByLabelText } = render(
+                <Form
+                    onSubmit={jest.fn}
+                    render={() => <NumberInput {...defaultProps} step="0.1" />}
+                />
+            );
+            const input = getByLabelText('resources.posts.fields.views');
+            expect(input.step).toEqual('0.1');
+        });
+    });
+
     describe('onChange event', () => {
         it('should be customizable via the `onChange` prop', () => {
             let value;

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -45,6 +45,7 @@ const NumberInput: FunctionComponent<
     onChange,
     validate,
     variant = 'filled',
+    inputProps: overrideInputProps,
     ...rest
 }) => {
     const {
@@ -64,6 +65,8 @@ const NumberInput: FunctionComponent<
         ...rest,
     });
 
+    const inputProps = { ...overrideInputProps, step };
+
     return (
         <TextField
             id={id}
@@ -79,7 +82,6 @@ const NumberInput: FunctionComponent<
                     />
                 ) : null
             }
-            step={step}
             label={
                 <FieldTitle
                     label={label}
@@ -89,6 +91,7 @@ const NumberInput: FunctionComponent<
                 />
             }
             margin={margin}
+            inputProps={inputProps}
             {...options}
             {...sanitizeRestProps(rest)}
         />


### PR DESCRIPTION
the new version of material-ui in v3 does not pass all props to native input

so the step needs to be passed in inputProps to work