### PR TITLE
[RFR][v3] FormDataConsumer - add subscription prop to the FormDataConsumer

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -1511,3 +1511,22 @@ import { FormDataConsumer } from 'react-admin';
      </Edit>
  );
 ```
+
+**Tip**: When using a `FormDataConsumer` you can define `subscription` prop to pass to the `react-final-form`
+
+```jsx
+import { FormDataConsumer } from 'react-admin';
+
+ const PostEdit = (props) => (
+     <Edit {...props}>
+         <SimpleForm>
+             <BooleanInput source="hasEmail" />
+             <FormDataConsume subscription={{ values: true }}>
+                 {({ formData, ...rest }) => formData.hasEmail &&
+                      <TextInput source="email" {...rest} />
+                 }
+             </FormDataConsumer>
+         </SimpleForm>
+     </Edit>
+ );
+```

--- a/packages/ra-core/src/form/FormDataConsumer.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, SFC } from 'react';
 import { useFormState } from 'react-final-form';
+import { FormSubscription } from 'final-form';
 import get from 'lodash/get';
 
 import warning from '../util/warning';
@@ -15,6 +16,7 @@ interface ConnectedProps {
     form?: string;
     record?: any;
     source?: string;
+    subscription?: FormSubscription;
     [key: string]: any;
 }
 
@@ -117,8 +119,8 @@ export const FormDataConsumerView: SFC<Props> = ({
     return ret === undefined ? null : ret;
 };
 
-const FormDataConsumer = (props: ConnectedProps) => {
-    const formState = useFormState();
+const FormDataConsumer = ({ subscription, ...props }: ConnectedProps) => {
+    const formState = useFormState({ subscription });
 
     return <FormDataConsumerView formData={formState.values} {...props} />;
 };


### PR DESCRIPTION
by default subscribe's to all changes like it is now
but user could change it by passing the subscription prop