### PR TITLE
[RFR][v3][BC break] SimpleFormIterator - use resource fields label

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -162,8 +162,17 @@ export class SimpleFormIterator extends Component {
                                                         ? undefined
                                                         : index2,
                                                     label:
-                                                        input.props.label ||
-                                                        input.props.source,
+                                                        typeof input.props
+                                                            .label ===
+                                                        'undefined'
+                                                            ? input.props.source
+                                                                ? `resources.${resource}.fields.${
+                                                                      input
+                                                                          .props
+                                                                          .source
+                                                                  }`
+                                                                : undefined
+                                                            : input.props.label,
                                                 })}
                                                 record={
                                                     (records &&

--- a/packages/ra-ui-materialui/src/input/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.spec.tsx
@@ -112,15 +112,17 @@ describe('<ArrayInput />', () => {
                 )}
             />
         );
-        expect(queryAllByLabelText('id')).toHaveLength(2);
-        expect(queryAllByLabelText('id').map(input => input.value)).toEqual([
-            '123',
-            '456',
-        ]);
-        expect(queryAllByLabelText('foo')).toHaveLength(2);
-        expect(queryAllByLabelText('foo').map(input => input.value)).toEqual([
-            'bar',
-            'baz',
-        ]);
+        expect(queryAllByLabelText('resources.bar.fields.id')).toHaveLength(2);
+        expect(
+            queryAllByLabelText('resources.bar.fields.id').map(
+                input => input.value
+            )
+        ).toEqual(['123', '456']);
+        expect(queryAllByLabelText('resources.bar.fields.foo')).toHaveLength(2);
+        expect(
+            queryAllByLabelText('resources.bar.fields.foo').map(
+                input => input.value
+            )
+        ).toEqual(['bar', 'baz']);
     });
 });


### PR DESCRIPTION
aka. use same format as FieldTitle to get translated labels in SImpleFormIterator from source without the need to write label's manually