### PR TITLE
Support for GraphQL Interface type

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.js
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.js
@@ -15,7 +15,7 @@ export const buildFields = (introspectionResults, path = []) => fields =>
             return acc;
         }
 
-        if (type.kind !== TypeKind.OBJECT) {
+        if (type.kind !== TypeKind.OBJECT && type.kind !== TypeKind.INTERFACE) {
             return [...acc, gqlTypes.field(gqlTypes.name(field.name))];
         }
 


### PR DESCRIPTION
This PR simply adds support for `Interface` types.

For example if you have a similar GraphQL schema
```
interface Device {
  ...    
}

type MotionSensor implements Device {
  ...    
}

type TemperatureSensor implements Device {
  ...
}
```

`Device` will then be picked up as a resource.