### PR TITLE
Replace authProvider function by object

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -438,15 +438,15 @@ export default Foo;
 
 ## `authProvider`
 
-The `authProvider` prop expect a function returning a Promise, to control the application authentication strategy:
+The `authProvider` prop expect an object with 5 methods, each returning a Promise, to control the authentication strategy:
 
 ```jsx
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'react-admin';
-
-const authProvider(type, params) {
-    // type can be any of AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, and AUTH_CHECK
-    // ...
-    return Promise.resolve();
+const authProvider = {
+    login: params => Promise.resolve(),
+    logout: params => Promise.resolve(),
+    checkAuth: params => Promise.resolve(),
+    checkError: error => Promise.resolve(),
+    getPermissions: params => Promise.resolve(),
 };
 
 const App = () => (
@@ -550,7 +550,7 @@ The `locale` and `i18nProvider` props let you translate the GUI. The [Translatio
 
 ## Declaring resources at runtime
 
-You might want to dynamically define the resources when the app starts. The `<Admin>` component accepts a function as its child and this function can return a Promise. If you also defined an `authProvider`, the function will receive the result of a call to `authProvider` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+You might want to dynamically define the resources when the app starts. The `<Admin>` component accepts a function as its child and this function can return a Promise. If you also defined an `authProvider`, the child function will receive the result of a call to `authProvider.getPermissions()` (you can read more about this in the [Authorization](./Authorization.md) chapter).
 
 For instance, getting the resource from an API might look like:
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -198,7 +198,7 @@ export default {
 }
 ```
 
-Note that react-admin will call the `authProvider.logout()` method before redirecting. If you specify the `redirectTo` here, it will override the url which may have been return by the call to `logout()`.
+Note that react-admin will call the `authProvider.logout()` method before redirecting. If you specify the `redirectTo` here, it will override the url which may have been returned by the call to `logout()`.
 
 **Tip**: In addition to `login()`, `logout()`, `checkError()`, and `checkAuth()`, react-admin calls the `authProvider.getPermissions()` method to check user permissions. It's useful to enable or disable features on a per user basis. Read the [Authorization Documentation](./Authorization.md) to learn how to implement that type.
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -24,16 +24,19 @@ const App = () => (
 );
 ```
 
-What's an `authProvider`? Just like a `dataProvider`, an `authProvider` is a function that react-admin calls when needed, and that returns a Promise. The signature of an `authProvider` is:
+What's an `authProvider`? Just like a `dataProvider`, an `authProvider` is an object that handles authentication logic. It exposes methods that react-admin calls when needed, and that return a Promise. The simplest `authProvider` is:
 
 ```js
-// in src/authProvider.js
-
-// type is one of AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK, and AUTH_GET_PERMISSIONS 
-const authProvider = (type, params) => Promise.resolve;
-
-export default authProvider;
+const authProvider = {
+    login: params => Promise.resolve(),
+    logout: params => Promise.resolve(),
+    checkAuth: params => Promise.resolve(),
+    checkError: error => Promise.resolve(),
+    getPermissions: params => Promise.resolve(),
+};
 ```
+
+**Tip**: In react-admin version 2.0, the `authProvider` used to be a function instead of an object. React-admin 3.0 accepts both object and (legacy) function authProviders.
 
 Let's see when react-admin calls the `authProvider`, and how to write one for your own authentication provider. 
 
@@ -43,17 +46,14 @@ Once an admin has an `authProvider`, react-admin enables a new page on the `/log
 
 ![Default Login Form](./img/login-form.png)
 
-Upon submission, this form calls the `authProvider` with the `AUTH_LOGIN` type, and `{ login, password }` as parameters. It's the ideal place to authenticate the user, and store their credentials.
+Upon submission, this form calls the `authProvider.login({ login, password })` method. It's the ideal place to authenticate the user, and store their credentials.
 
 For instance, to query an authentication route via HTTPS and store the credentials (a token) in local storage, configure `authProvider` as follows:
 
 ```jsx
 // in src/authProvider.js
-import { AUTH_LOGIN } from 'react-admin';
-
-const authProvider = (type, params) => {
-    if (type === AUTH_LOGIN) {
-        const { username, password } = params;
+export default {
+    login: ({ username, password }) =>  {
         const request = new Request('https://mydomain.com/authenticate', {
             method: 'POST',
             body: JSON.stringify({ username, password }),
@@ -69,8 +69,8 @@ const authProvider = (type, params) => {
             .then(({ token }) => {
                 localStorage.setItem('token', token);
             });
-    }
-    return Promise.resolve();
+    },
+    // ...
 }
 
 export default authProvider;
@@ -113,23 +113,19 @@ If you have a custom REST client, don't forget to add credentials yourself.
 
 ## Logout Configuration
 
-If you provide an `authProvider` prop to `<Admin>`, react-admin displays a logout button in the top bar (or in the menu on mobile). When the user clicks on the logout button, this calls the `authProvider` with the `AUTH_LOGOUT` type and removes potentially sensitive data from the Redux store. Then the user gets redirected to the login page.
+As soon as you provide an `authProvider` prop to `<Admin>`, react-admin displays a logout button in the top bar (or in the menu on mobile). When the user clicks on the logout button, this calls the `authProvider.logout()` method, and removes potentially sensitive data from the Redux store. Then the user gets redirected to the login page.
 
 So it's the responsibility of the `authProvider` to cleanup the current authentication data. For instance, if the authentication was a token stored in local storage, here the code to remove it:
 
 ```jsx
 // in src/authProvider.js
-import { AUTH_LOGIN, AUTH_LOGOUT } from 'react-admin';
-
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        // ...
-    }
-    if (type === AUTH_LOGOUT) {
+export default {
+    login: ({ username, password }) => { /* ... */ },
+    logout: () => {
         localStorage.removeItem('token');
         return Promise.resolve();
-    }
-    return Promise.resolve();
+    },
+    // ...
 };
 ```
 
@@ -137,98 +133,74 @@ export default (type, params) => {
 
 The `authProvider` is also a good place to notify the authentication API that the user credentials are no longer valid after logout.
 
-Note that the `authProvider` can return the url to which the user will be redirected once logged out. By default, this is the `/login` route.
+Note that the `authProvider.logout()` method can return the url to which the user will be redirected once logged out. By default, this is the `/login` route.
 
 ## Catching Authentication Errors On The API
 
 If the API requires authentication, and the user credentials are missing in the request or invalid, the API usually answers with an HTTP error code 401 or 403.
 
-Fortunately, each time the API returns an error, react-admin calls the `authProvider` with the `AUTH_ERROR` type. Once again, it's up to you to decide which HTTP status codes should let the user continue (by returning a resolved promise) or log them out (by returning a rejected promise).
+Fortunately, each time the API returns an error, react-admin calls the `authProvider.checkError()` method. Once again, it's up to you to decide which HTTP status codes should let the user continue (by returning a resolved promise) or log them out (by returning a rejected promise).
 
 For instance, to redirect the user to the login page for both 401 and 403 codes:
 
 ```jsx
 // in src/authProvider.js
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR } from 'react-admin';
-
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        // ...
-    }
-    if (type === AUTH_LOGOUT) {
-        // ...
-    }
-    if (type === AUTH_ERROR) {
-        const status  = params.status;
+export default {
+    login: ({ username, password }) => { /* ... */ },
+    logout: () => { /* ... */ },
+    checkError: (error) => {
+        const status  = error.status;
         if (status === 401 || status === 403) {
             localStorage.removeItem('token');
             return Promise.reject();
         }
         return Promise.resolve();
-    }
-    return Promise.resolve();
+    },
+    // ...
 };
 ```
 
-Note that react-admin will call the `authProvider` with the `AUTH_LOGOUT` type before redirecting when you reject the promise and will use the url which may have been return by the call to `AUTH_LOGOUT`.
+Note that when `checkError()` returns a rejected promise, react-admin calls the `authProvider.logout()` method before redirecting, and uses the url which may have been returned by the call to `logout()`.
 
 ## Checking Credentials During Navigation
 
 Redirecting to the login page whenever a REST response uses a 401 status code is usually not enough, because react-admin keeps data on the client side, and could display stale data while contacting the server - even after the credentials are no longer valid.
 
-Fortunately, each time the user navigates, react-admin calls the `authProvider` with the `AUTH_CHECK` type, so it's the ideal place to validate the credentials.
+Fortunately, each time the user navigates, react-admin calls the `authProvider.checkAuth()` method, so it's the ideal place to validate the credentials.
 
 For instance, to check for the existence of the token in local storage:
 
 ```jsx
 // in src/authProvider.js
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'react-admin';
-
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        // ...
-    }
-    if (type === AUTH_LOGOUT) {
-        // ...
-    }
-    if (type === AUTH_ERROR) {
-        // ...
-    }
-    if (type === AUTH_CHECK) {
-        return localStorage.getItem('token') ? Promise.resolve() : Promise.reject();
-    }
-    return Promise.resolve();
+export default {
+    login: ({ username, password }) => { /* ... */ },
+    logout: () => { /* ... */ },
+    checkError: (error) => { /* ... */ },
+    checkAuth: () => localStorage.getItem('token')
+        ? Promise.resolve()
+        : Promise.reject(),
+    // ...
 };
 ```
 
-If the promise is rejected, react-admin redirects by default to the `/login` page. You can override where to redirect the user by passing an argument with a `redirectTo` property to the rejected promise:
+If the promise is rejected, react-admin redirects by default to the `/login` page. You can override where to redirect the user in `checkAuth()`, by rejecting an object with a `redirectTo` property:
 
 ```jsx
 // in src/authProvider.js
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'react-admin';
-
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        // ...
-    }
-    if (type === AUTH_LOGOUT) {
-        // ...
-    }
-    if (type === AUTH_ERROR) {
-        // ...
-    }
-    if (type === AUTH_CHECK) {
-        return localStorage.getItem('token')
-            ? Promise.resolve()
-            : Promise.reject({ redirectTo: '/no-access' });
-    }
-    return Promise.resolve();
-};
+export default {
+    login: ({ username, password }) => { /* ... */ },
+    logout: () => { /* ... */ },
+    checkError: (error) => { /* ... */ },
+    checkAuth: () => localStorage.getItem('token')
+        ? Promise.resolve()
+        : Promise.reject({ redirectTo: '/no-access' }),
+    // ...
+}
 ```
 
-Note that react-admin will call the `authProvider` with the `AUTH_LOGOUT` type before redirecting. If you specify the `redirectTo` here, it will override the url which may have been return by the call to `AUTH_LOGOUT`.
+Note that react-admin will call the `authProvider.logout()` method before redirecting. If you specify the `redirectTo` here, it will override the url which may have been return by the call to `logout()`.
 
-**Tip**: In addition to `AUTH_LOGIN`, `AUTH_LOGOUT`, `AUTH_ERROR`, and `AUTH_CHECK`, react-admin calls the `authProvider` with the `AUTH_GET_PERMISSIONS` type to check user permissions. It's useful to enable or disable features on a per user basis. Read the [Authorization Documentation](./Authorization.md) to learn how to implement that type.
+**Tip**: In addition to `login()`, `logout()`, `checkError()`, and `checkAuth()`, react-admin calls the `authProvider.getPermissions()` method to check user permissions. It's useful to enable or disable features on a per user basis. Read the [Authorization Documentation](./Authorization.md) to learn how to implement that type.
 
 ## Customizing The Login and Logout Components
 
@@ -314,7 +286,7 @@ const App = () => (
 
 ## `useAuthenticated()` Hook
 
-If you add [custom pages](./Actions.md), of if you [create an admin app from scratch](./CustomApp.md), you may need to secure access to pages manually. That's the purpose of the `useAuthenticated()` hook, which calls the `authProvider` with the `AUTH_CHECK` type on mount, and redirects to login if it returns a rejected Promise.
+If you add [custom pages](./Actions.md), of if you [create an admin app from scratch](./CustomApp.md), you may need to secure access to pages manually. That's the purpose of the `useAuthenticated()` hook, which calls the `authProvider.checkAuth()` method on mount, and redirects to login if it returns a rejected Promise.
 
 ```jsx
 // in src/MyPage.js
@@ -336,7 +308,7 @@ If you call `useAuthenticated()` with a parameter, this parameter is passed to t
 
 ```jsx
 const MyPage = () => {
-    useAuthenticated({ foo: 'bar' }); // calls authProvider(AUTH_CHECK, { foo: 'bar' })
+    useAuthenticated({ foo: 'bar' }); // calls authProvider.checkAuth({ foo: 'bar' })
     return (
         <div>
             ...

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -11,19 +11,17 @@ By default, a react-admin app doesn't check authorization. However, if needed, i
 
 ## Configuring the Auth Provider
 
-Each time react-admin needs to determine the user permissions, it calls the `authProvider` with the `AUTH_GET_PERMISSIONS` type. It's up to you to return the user permissions, be it a string (e.g. `'admin'`) or an array of roles (e.g. `['post_editor', 'comment_moderator', 'super_admin']`).
+Each time react-admin needs to determine the user permissions, it calls the `authProvider.getPermissions()` method. It's up to you to return the user permissions, be it a string (e.g. `'admin'`) or an array of roles (e.g. `['post_editor', 'comment_moderator', 'super_admin']`).
 
-Following is an example where the `authProvider` stores the user's permissions in `localStorage` upon authentication, and returns these permissions when called with `AUTH_GET_PERMISSIONS`:
+Following is an example where the `authProvider` stores the user's permissions in `localStorage` upon authentication, and returns these permissions when called with `getPermissions`:
 
 {% raw %}
 ```jsx
 // in src/authProvider.js
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_GET_PERMISSIONS } from 'react-admin';
 import decodeJwt from 'jwt-decode';
 
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        const { username, password } = params;
+export default {
+    login: ({ username, password }) => {
         const request = new Request('https://mydomain.com/authenticate', {
             method: 'POST',
             body: JSON.stringify({ username, password }),
@@ -41,23 +39,22 @@ export default (type, params) => {
                 localStorage.setItem('token', token);
                 localStorage.setItem('permissions', decodedToken.permissions);
             });
-    }
-    if (type === AUTH_LOGOUT) {
+    },
+    logout: () => {
         localStorage.removeItem('token');
         localStorage.removeItem('permissions');
         return Promise.resolve();
-    }
-    if (type === AUTH_ERROR) {
+    },
+    checkError: error => {
         // ...
-    }
-    if (type === AUTH_CHECK) {
+    },
+    checkAuth: () => {
         return localStorage.getItem('token') ? Promise.resolve() : Promise.reject();
-    }
-    if (type === AUTH_GET_PERMISSIONS) {
+    },
+    getPermissions: () => {
         const role = localStorage.getItem('permissions');
         return role ? Promise.resolve(role) : Promise.reject();
     }
-    return Promise.reject('Unknown method');
 };
 ```
 {% endraw %}
@@ -161,8 +158,6 @@ export const UserList = ({ permissions, ...props }) =>
     </List>;
 ```
 
-**Tip**: When calling the `authProvider` with the `AUTH_GET_PERMISSIONS` type, react-admin passes the current location. You can use this information to implement location-based authorization.
-
 ## Restricting Access to the Dashboard
 
 React-admin injects the permissions into the component provided as a [`dashboard`]('./Admin.md#dashboard), too:
@@ -188,7 +183,7 @@ export default ({ permissions }) => (
 
 ## `usePermissions()` Hook
 
-You might want to check user permissions inside a [custom page](./Admin.md#customroutes). That's the purpose of the `usePermissions()` hook, which calls the `authProvider` with the `AUTH_GET_PERMISSIONS` type on mount, and returns the result when available:
+You might want to check user permissions inside a [custom page](./Admin.md#customroutes). That's the purpose of the `usePermissions()` hook, which calls the `authProvider.getPermissions()` method on mount, and returns the result when available:
 
 ```jsx
 // in src/MyPage.js

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -886,11 +886,11 @@ export const UserEdit = props => {
 
 ## Displaying Fields or Inputs depending on the user permissions
 
-You might want to display some fields, inputs or filters only to users with specific permissions. Those permissions are retrieved for each route and will provided to your component as a `permissions` prop.
+You might want to display some fields, inputs or filters only to users with specific permissions. 
 
-Each route will call the `authProvider` with the `AUTH_GET_PERMISSIONS` type and some parameters including the current location and route parameters. It's up to you to return whatever you need to check inside your component such as the user's role, etc.
+Before rendering the `Create` and `Edit` components, react-admin calls the `authProvider.getPermissions()` method, and passes the result to the component as the `permissions` prop. It's up to your `authProvider` to return whatever you need to check roles and permissions inside your component.
 
-Here's an example inside a `Create` view with a `SimpleForm` and a custom `Toolbar`:
+Here is an example inside a `Create` view with a `SimpleForm` and a custom `Toolbar`:
 
 {% raw %}
 ```jsx

--- a/docs/List.md
+++ b/docs/List.md
@@ -1281,9 +1281,9 @@ As you can see, nothing prevents you from using `<Field>` components inside your
 
 ## Displaying Fields depending on the user permissions
 
-You might want to display some fields or filters only to users with specific permissions. Those permissions are retrieved for each route and will provided to your component as a `permissions` prop.
+You might want to display some fields or filters only to users with specific permissions. 
 
-Each route will call the `authProvider` with the `AUTH_GET_PERMISSIONS` type and some parameters including the current location and route parameters. It's up to you to return whatever you need to check inside your component such as the user's role, etc.
+Before rendering the `List`, react-admin calls the `authProvider.getPermissions()` method, and passes the result to the component as the `permissions` prop. It's up to your `authProvider` to return whatever you need to check roles and permissions inside your component.
 
 {% raw %}
 ```jsx
@@ -1327,4 +1327,4 @@ export const UserList = ({ permissions, ...props }) => {
 ```
 {% endraw %}
 
-**Tip** Note how the `permissions` prop is passed down to the custom `filters` component.
+**Tip**: Note how the `permissions` prop is passed down to the custom `filters` component.

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -271,9 +271,9 @@ export default ScrollableTabbedShowLayout;
 
 ## Displaying Fields depending on the user permissions
 
-You might want to display some fields only to users with specific permissions. Those permissions are retrieved for each route and will provided to your component as a `permissions` prop.
+You might want to display some fields only to users with specific permissions. 
 
-Each route will call the `authProvider` with the `AUTH_GET_PERMISSIONS` type and some parameters including the current location and route parameters. It's up to you to return whatever you need to check inside your component such as the user's role, etc.
+Before rendering the `Show` component, react-admin calls the `authProvider.getPermissions()` method, and passes the result to the component as the `permissions` prop. It's up to your `authProvider` to return whatever you need to check roles and permissions inside your component.
 
 Here's an example inside a `Show` view with a `SimpleShowLayout` and a custom `actions` component:
 

--- a/examples/demo/src/authProvider.js
+++ b/examples/demo/src/authProvider.js
@@ -1,23 +1,15 @@
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_CHECK, AUTH_ERROR } from 'react-admin';
-
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        const { username } = params;
+export default {
+    login: ({ username }) => {
         localStorage.setItem('username', username);
         // accept all username/password combinations
         return Promise.resolve();
-    }
-    if (type === AUTH_LOGOUT) {
+    },
+    logout: () => {
         localStorage.removeItem('username');
         return Promise.resolve();
-    }
-    if (type === AUTH_ERROR) {
-        return Promise.resolve();
-    }
-    if (type === AUTH_CHECK) {
-        return localStorage.getItem('username')
-            ? Promise.resolve()
-            : Promise.reject();
-    }
-    return Promise.reject('Unkown method');
+    },
+    checkError: () => Promise.resolve(),
+    checkAuth: () =>
+        localStorage.getItem('username') ? Promise.resolve() : Promise.reject(),
+    getPermissions: () => Promise.reject('Unknown method'),
 };

--- a/examples/simple/src/authProvider.js
+++ b/examples/simple/src/authProvider.js
@@ -1,15 +1,6 @@
-import {
-    AUTH_GET_PERMISSIONS,
-    AUTH_LOGIN,
-    AUTH_LOGOUT,
-    AUTH_ERROR,
-    AUTH_CHECK,
-} from 'react-admin'; // eslint-disable-line import/no-unresolved
-
 // Authenticatd by default
-export default (type, params) => {
-    if (type === AUTH_LOGIN) {
-        const { username, password } = params;
+export default {
+    login: ({ username, password }) => {
         if (username === 'login' && password === 'password') {
             localStorage.removeItem('not_authenticated');
             localStorage.removeItem('role');
@@ -27,27 +18,24 @@ export default (type, params) => {
         }
         localStorage.setItem('not_authenticated', true);
         return Promise.reject();
-    }
-    if (type === AUTH_LOGOUT) {
+    },
+    logout: () => {
         localStorage.setItem('not_authenticated', true);
         localStorage.removeItem('role');
         return Promise.resolve();
-    }
-    if (type === AUTH_ERROR) {
-        const { status } = params;
+    },
+    checkError: ({ status }) => {
         return status === 401 || status === 403
             ? Promise.reject()
             : Promise.resolve();
-    }
-    if (type === AUTH_CHECK) {
+    },
+    checkAuth: () => {
         return localStorage.getItem('not_authenticated')
             ? Promise.reject()
             : Promise.resolve();
-    }
-    if (type === AUTH_GET_PERMISSIONS) {
+    },
+    getPermissions: () => {
         const role = localStorage.getItem('role');
         return Promise.resolve(role);
-    }
-
-    return Promise.reject('Unknown method');
+    },
 };

--- a/examples/tutorial/src/authProvider.js
+++ b/examples/tutorial/src/authProvider.js
@@ -1,32 +1,29 @@
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'react-admin';
-
-export default (type, params) => {
+export default {
     // called when the user attempts to log in
-    if (type === AUTH_LOGIN) {
-        const { username } = params;
+    login: ({ username }) => {
         localStorage.setItem('username', username);
         // accept all username/password combinations
         return Promise.resolve();
-    }
+    },
     // called when the user clicks on the logout button
-    if (type === AUTH_LOGOUT) {
+    logout: () => {
         localStorage.removeItem('username');
         return Promise.resolve();
-    }
+    },
     // called when the API returns an error
-    if (type === AUTH_ERROR) {
-        const { status } = params;
+    checkError: ({ status }) => {
         if (status === 401 || status === 403) {
             localStorage.removeItem('username');
             return Promise.reject();
         }
         return Promise.resolve();
-    }
-    // called when the user navigates to a new location
-    if (type === AUTH_CHECK) {
+    },
+    // called when the user navigates to a new location, to check for authentication
+    checkAuth: () => {
         return localStorage.getItem('username')
             ? Promise.resolve()
             : Promise.reject();
-    }
-    return Promise.reject('Unknown method');
+    },
+    // called when the user navigates to a new location, to check for permissions / roles
+    getPermissions: () => Promise.resolve(),
 };

--- a/packages/ra-core/src/CoreAdminRouter.spec.tsx
+++ b/packages/ra-core/src/CoreAdminRouter.spec.tsx
@@ -11,7 +11,7 @@ import Resource from './Resource';
 
 const Layout = ({ children }) => <div>Layout {children}</div>;
 
-describe('<AdminRouter>', () => {
+describe('<CoreAdminRouter>', () => {
     afterEach(cleanup);
 
     const defaultProps = {
@@ -74,8 +74,16 @@ describe('<AdminRouter>', () => {
     describe('With resources returned from a function as children', () => {
         it('should render all resources with a registration intent', async () => {
             const history = createMemoryHistory();
+            const authProvider = {
+                login: jest.fn().mockResolvedValue(''),
+                logout: jest.fn().mockResolvedValue(''),
+                checkAuth: jest.fn().mockResolvedValue(''),
+                checkError: jest.fn().mockResolvedValue(''),
+                getPermissions: jest.fn().mockResolvedValue(''),
+            };
+
             const { getByText } = renderWithRedux(
-                <AuthContext.Provider value={() => Promise.resolve()}>
+                <AuthContext.Provider value={authProvider}>
                     <Router history={history}>
                         <CoreAdminRouter {...defaultProps} layout={Layout}>
                             {() => [

--- a/packages/ra-core/src/Resource.spec.tsx
+++ b/packages/ra-core/src/Resource.spec.tsx
@@ -79,10 +79,14 @@ describe('<Resource>', () => {
     });
     it('injects permissions to the resource routes', async () => {
         const history = createMemoryHistory();
-        const authProvider = type =>
-            type === 'AUTH_GET_PERMISSIONS'
-                ? Promise.resolve('admin')
-                : Promise.resolve();
+        const authProvider = {
+            login: jest.fn().mockResolvedValue(''),
+            logout: jest.fn().mockResolvedValue(''),
+            checkAuth: jest.fn().mockResolvedValue(''),
+            checkError: jest.fn().mockResolvedValue(''),
+            getPermissions: jest.fn().mockResolvedValue('admin'),
+        };
+
         const { getByText } = renderWithRedux(
             <AuthContext.Provider value={authProvider}>
                 <Router history={history}>

--- a/packages/ra-core/src/auth/AuthContext.tsx
+++ b/packages/ra-core/src/auth/AuthContext.tsx
@@ -2,7 +2,15 @@ import { createContext } from 'react';
 
 import { AuthProvider } from '../types';
 
-const AuthContext = createContext<AuthProvider>(() => Promise.resolve());
+const defaultProvider: AuthProvider = {
+    login: () => Promise.resolve(),
+    logout: () => Promise.resolve(),
+    checkAuth: () => Promise.resolve(),
+    checkError: () => Promise.resolve(),
+    getPermissions: () => Promise.resolve(),
+};
+
+const AuthContext = createContext<AuthProvider>(defaultProvider);
 
 AuthContext.displayName = 'AuthContext';
 

--- a/packages/ra-core/src/auth/Authenticated.spec.tsx
+++ b/packages/ra-core/src/auth/Authenticated.spec.tsx
@@ -25,9 +25,13 @@ describe('<Authenticated>', () => {
     });
 
     it('should logout, redirect to login and show a notification after a tick if the auth fails', async () => {
-        const authProvider = jest.fn(type =>
-            type === 'AUTH_CHECK' ? Promise.reject() : Promise.resolve()
-        );
+        const authProvider = {
+            login: jest.fn().mockResolvedValue(''),
+            logout: jest.fn().mockResolvedValue(''),
+            checkAuth: jest.fn().mockRejectedValue(undefined),
+            checkError: jest.fn().mockResolvedValue(''),
+            getPermissions: jest.fn().mockResolvedValue(''),
+        };
         const { dispatch } = renderWithRedux(
             <AuthContext.Provider value={authProvider}>
                 <Authenticated>
@@ -36,8 +40,8 @@ describe('<Authenticated>', () => {
             </AuthContext.Provider>
         );
         await wait();
-        expect(authProvider.mock.calls[0][0]).toBe('AUTH_CHECK');
-        expect(authProvider.mock.calls[1][0]).toBe('AUTH_LOGOUT');
+        expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({});
+        expect(authProvider.logout.mock.calls[0][0]).toEqual({});
         expect(dispatch).toHaveBeenCalledTimes(3);
         expect(dispatch.mock.calls[0][0]).toEqual(
             showNotification('ra.auth.auth_check_error', 'warning', {

--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -43,7 +43,7 @@ const Authenticated: FunctionComponent<Props> = ({
     ...rest
 }) => {
     useAuthenticated(authParams);
-    // render the child even though the AUTH_CHECK isn't finished (optimistic rendering)
+    // render the child even though the useAuthenticated() call isn't finished (optimistic rendering)
     // the above hook will log out if the authProvider doesn't validate that the user is authenticated
     return cloneElement(children, rest);
 };

--- a/packages/ra-core/src/auth/WithPermissions.tsx
+++ b/packages/ra-core/src/auth/WithPermissions.tsx
@@ -82,8 +82,7 @@ const WithPermissions: FunctionComponent<Props> = ({
 
     useAuthenticated(authParams);
     const { permissions } = usePermissions(authParams);
-    // render even though the AUTH_GET_PERMISSIONS
-    // isn't finished (optimistic rendering)
+    // render even though the usePermissions() call isn't finished (optimistic rendering)
     if (component) {
         return createElement(component, { permissions, ...props });
     }

--- a/packages/ra-core/src/auth/convertLegacyAuthProvider.ts
+++ b/packages/ra-core/src/auth/convertLegacyAuthProvider.ts
@@ -1,0 +1,28 @@
+import {
+    AUTH_LOGIN,
+    AUTH_LOGOUT,
+    AUTH_CHECK,
+    AUTH_ERROR,
+    AUTH_GET_PERMISSIONS,
+} from './types';
+import { AuthActionType, AuthProvider, LegacyAuthProvider } from '../types';
+
+/**
+ * Turn a function-based authProvider to an object-based one
+ *
+ * Allows using legacy authProviders transparently.
+ *
+ * @param {Function} authProvider A legacy authProvider (type, params) => Promise<any>
+ *
+ * @returns {Object} An authProvider that react-admin can use
+ */
+export default (legacyAuthProvider: LegacyAuthProvider): AuthProvider => {
+    const authProvider = (...args) => legacyAuthProvider.apply(null, args);
+    authProvider.login = params => legacyAuthProvider(AUTH_LOGIN, params);
+    authProvider.logout = params => legacyAuthProvider(AUTH_LOGOUT, params);
+    authProvider.checkAuth = params => legacyAuthProvider(AUTH_CHECK, params);
+    authProvider.checkError = error => legacyAuthProvider(AUTH_ERROR, error);
+    authProvider.getPermissions = params =>
+        legacyAuthProvider(AUTH_GET_PERMISSIONS, params);
+    return authProvider;
+};

--- a/packages/ra-core/src/auth/index.ts
+++ b/packages/ra-core/src/auth/index.ts
@@ -10,11 +10,13 @@ import useLogout from './useLogout';
 import useCheckAuth from './useCheckAuth';
 import useGetPermissions from './useGetPermissions';
 import useLogoutIfAccessDenied from './useLogoutIfAccessDenied';
+import convertLegacyAuthProvider from './convertLegacyAuthProvider';
 export * from './types';
 
 export {
     AuthContext,
     useAuthProvider,
+    convertLegacyAuthProvider,
     // low-vevel hooks for calling a particular verb on the authProvider
     useLogin,
     useLogout,

--- a/packages/ra-core/src/auth/useAuthState.spec.tsx
+++ b/packages/ra-core/src/auth/useAuthState.spec.tsx
@@ -42,7 +42,13 @@ describe('useAuthState', () => {
     });
 
     it('should return an error after a tick if the auth fails', async () => {
-        const authProvider = () => Promise.reject('not good');
+        const authProvider = {
+            login: () => Promise.reject('bad method'),
+            logout: () => Promise.reject('bad method'),
+            checkAuth: () => Promise.reject('failed'),
+            checkError: () => Promise.reject('bad method'),
+            getPermissions: () => Promise.reject('bad method'),
+        };
         const { queryByText } = renderWithRedux(
             <AuthContext.Provider value={authProvider}>
                 <UseAuth options={{ logoutOnFailure: false }}>

--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -14,7 +14,7 @@ const emptyParams = {};
 /**
  * Hook for getting the authentication status and restricting access to authenticated users
  *
- * Calls the authProvider asynchronously with the AUTH_CHECK verb.
+ * Calls the authProvider.checkAuth() method asynchronously.
  * If the authProvider returns a rejected promise, logs the user out.
  *
  * The return value updates according to the authProvider request state:

--- a/packages/ra-core/src/auth/useCheckAuth.ts
+++ b/packages/ra-core/src/auth/useCheckAuth.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
 
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
-import { AUTH_CHECK } from './types';
 import useLogout from './useLogout';
 import useNotify from '../sideEffect/useNotify';
 
 /**
- * Get a callback for calling the authProvider with the AUTH_CHECK verb.
+ * Get a callback for calling the authProvider.checkAuth() method.
  * In case of rejection, redirects to the login page, displays a notification,
  * and throws an error.
  *
@@ -52,7 +51,7 @@ const useCheckAuth = (): CheckAuth => {
             logoutOnFailure = true,
             redirectTo = defaultAuthParams.loginUrl
         ) =>
-            authProvider(AUTH_CHECK, params).catch(error => {
+            authProvider.checkAuth(params).catch(error => {
                 if (logoutOnFailure) {
                     logout(
                         {},
@@ -76,7 +75,7 @@ const useCheckAuth = (): CheckAuth => {
 const checkAuthWithoutAuthProvider = () => Promise.resolve();
 
 /**
- * Check if the current user is authenticated by calling the authProvider AUTH_CHECK verb.
+ * Check if the current user is authenticated by calling authProvider.checkAuth().
  * Logs the user out on failure.
  *
  * @param {Object} params The parameters to pass to the authProvider

--- a/packages/ra-core/src/auth/useGetPermissions.ts
+++ b/packages/ra-core/src/auth/useGetPermissions.ts
@@ -1,10 +1,9 @@
 import { useCallback } from 'react';
 
 import useAuthProvider from './useAuthProvider';
-import { AUTH_GET_PERMISSIONS } from './types';
 
 /**
- * Get a callback for calling the authProvider with the AUTH_GET_PERMISSIONS verb.
+ * Get a callback for calling the authProvider.getPermissions() method.
  *
  * @see useAuthProvider
  *
@@ -37,7 +36,7 @@ import { AUTH_GET_PERMISSIONS } from './types';
 const useGetPermissions = (): GetPermissions => {
     const authProvider = useAuthProvider();
     const getPermissions = useCallback(
-        (params: any = {}) => authProvider(AUTH_GET_PERMISSIONS, params),
+        (params: any = {}) => authProvider.getPermissions(params),
         [authProvider]
     );
 
@@ -47,7 +46,7 @@ const useGetPermissions = (): GetPermissions => {
 const getPermissionsWithoutProvider = () => Promise.resolve([]);
 
 /**
- * Ask the permissions to the  authProvider using the AUTH_GET_PERMISSIONS verb
+ * Proxy for calling authProvider.getPermissions()
  *
  * @param {Object} params The parameters to pass to the authProvider
  *

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -3,11 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
 
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
-import { AUTH_LOGIN } from './types';
 import { ReduxState } from '../types';
 
 /**
- * Get a callback for calling the authProvider with the AUTH_LOGIN verb
+ * Get a callback for calling the authProvider.login() method
  * and redirect to the previous authenticated page (or the home page) on success.
  *
  * @see useAuthProvider
@@ -40,7 +39,7 @@ const useLogin = (): Login => {
 
     const login = useCallback(
         (params: any = {}, pathName = defaultAuthParams.afterLoginUrl) =>
-            authProvider(AUTH_LOGIN, params).then(ret => {
+            authProvider.login(params).then(ret => {
                 dispatch(push(nextPathName || pathName));
                 return ret;
             }),
@@ -59,7 +58,7 @@ const useLogin = (): Login => {
 };
 
 /**
- * Log a user in by calling the authProvider AUTH_LOGIN verb
+ * Log a user in by calling the authProvider.login() method
  *
  * @param {object} params Login parameters to pass to the authProvider. May contain username/email, password, etc
  * @param {string} pathName The path to redirect to after login. By default, redirects to the home page, or to the last page visited after deconnexion.

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -3,11 +3,10 @@ import { useDispatch, useStore } from 'react-redux';
 import { push } from 'connected-react-router';
 
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
-import { AUTH_LOGOUT } from './types';
 import { clearState } from '../actions/clearActions';
 
 /**
- * Get a callback for calling the authProvider with the AUTH_LOGOUT verb,
+ * Get a callback for calling the authProvider.logout() method,
  * redirect to the login page, and clear the Redux state.
  *
  * @see useAuthProvider
@@ -44,7 +43,7 @@ const useLogout = (): Logout => {
 
     const logout = useCallback(
         (params = {}, redirectTo = defaultAuthParams.loginUrl) =>
-            authProvider(AUTH_LOGOUT, params).then(redirectToFromProvider => {
+            authProvider.logout(params).then(redirectToFromProvider => {
                 dispatch(clearState());
                 const currentLocation = store.getState().router.location;
                 dispatch(
@@ -83,7 +82,7 @@ const useLogout = (): Logout => {
 };
 
 /**
- * Log the current user out by calling the authProvider AUTH_LOGOUT verb,
+ * Log the current user out by calling the authProvider.logout() method,
  * and redirect them to the login screen.
  *
  * @param {Object} params The parameters to pass to the authProvider

--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.spec.tsx
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.spec.tsx
@@ -6,6 +6,7 @@ import useLogoutIfAccessDenied from './useLogoutIfAccessDenied';
 import AuthContext from './AuthContext';
 import useLogout from './useLogout';
 import useNotify from '../sideEffect/useNotify';
+import { AuthProvider } from '../types';
 
 jest.mock('./useLogout');
 jest.mock('../sideEffect/useNotify');
@@ -24,14 +25,18 @@ const TestComponent = ({ error }: { error?: any }) => {
     return <div>{loggedOut ? '' : 'logged in'}</div>;
 };
 
-const authProvider = (type, params) =>
-    new Promise((resolve, reject) => {
-        if (type !== 'AUTH_ERROR') reject('bad method');
+const authProvider: AuthProvider = {
+    login: () => Promise.reject('bad method'),
+    logout: () => Promise.reject('bad method'),
+    checkAuth: () => Promise.reject('bad method'),
+    checkError: params => {
         if (params instanceof Error && params.message === 'denied') {
-            reject(new Error('logout'));
+            return Promise.reject(new Error('logout'));
         }
-        resolve();
-    });
+        return Promise.resolve();
+    },
+    getPermissions: () => Promise.reject('bad method'),
+};
 
 describe('useLogoutIfAccessDenied', () => {
     afterEach(cleanup);

--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
 
-import { AUTH_ERROR } from './types';
 import useAuthProvider from './useAuthProvider';
 import useLogout from './useLogout';
 import { useNotify } from '../sideEffect';
 
 /**
- * Returns a callback used to call the authProvidr with the AUTH_ERROR verb
+ * Returns a callback used to call the authProvider.checkError() method
  * and an error from the dataProvider. If the authProvider rejects the call,
  * the hook logs the user out and shows a logged out notification.
  *
@@ -42,7 +41,8 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
     const notify = useNotify();
     const logoutIfAccessDenied = useCallback(
         (error?: any) =>
-            authProvider(AUTH_ERROR, error)
+            authProvider
+                .checkError(error)
                 .then(() => false)
                 .catch(e => {
                     const redirectTo =
@@ -65,7 +65,7 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
 const logoutIfAccessDeniedWithoutProvider = () => Promise.resolve(false);
 
 /**
- * Call the authProvidr with the AUTH_ERROR verb and the error passed as argument.
+ * Call the authProvider.authError() method, unsing the error passed as argument.
  * If the authProvider rejects the call, logs the user out and shows a logged out notification.
  *
  * @param {Error} error An Error object (usually returned by the dataProvider)

--- a/packages/ra-core/src/auth/usePermissions.spec.tsx
+++ b/packages/ra-core/src/auth/usePermissions.spec.tsx
@@ -42,7 +42,13 @@ describe('usePermissions', () => {
     });
 
     it('should return the permissions after a tick', async () => {
-        const authProvider = () => Promise.resolve('admin');
+        const authProvider = {
+            login: () => Promise.reject('bad method'),
+            logout: () => Promise.reject('bad method'),
+            checkAuth: () => Promise.reject('bad method'),
+            checkError: () => Promise.reject('bad method'),
+            getPermissions: () => Promise.resolve('admin'),
+        };
         const { queryByText } = renderWithRedux(
             <AuthContext.Provider value={authProvider}>
                 <UsePermissions>{stateInpector}</UsePermissions>
@@ -55,7 +61,13 @@ describe('usePermissions', () => {
     });
 
     it('should return an error after a tick if the auth call fails', async () => {
-        const authProvider = () => Promise.reject('not good');
+        const authProvider = {
+            login: () => Promise.reject('bad method'),
+            logout: () => Promise.reject('bad method'),
+            checkAuth: () => Promise.reject('bad method'),
+            checkError: () => Promise.reject('bad method'),
+            getPermissions: () => Promise.reject('not good'),
+        };
         const { queryByText } = renderWithRedux(
             <AuthContext.Provider value={authProvider}>
                 <UsePermissions>{stateInpector}</UsePermissions>

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -15,7 +15,7 @@ const emptyParams = {};
 /**
  * Hook for getting user permissions
  *
- * Calls the authProvider asynchronously with the AUTH_GET_PERMISSIONS verb.
+ * Calls the authProvider.getPrmissions() method asynchronously.
  * If the authProvider returns a rejected promise, returns empty permissions.
  *
  * The return value updates according to the request state:

--- a/packages/ra-core/src/sideEffect/auth.ts
+++ b/packages/ra-core/src/sideEffect/auth.ts
@@ -58,7 +58,7 @@ export const handleLogin = (authProvider: AuthProvider) =>
         const { payload, meta } = action;
         try {
             yield put({ type: USER_LOGIN_LOADING });
-            const authPayload = yield call(authProvider, AUTH_LOGIN, payload);
+            const authPayload = yield call([authProvider, 'login'], payload);
             yield put({
                 type: USER_LOGIN_SUCCESS,
                 payload: authPayload,
@@ -81,9 +81,9 @@ export const handleCheck = (authProvider: AuthProvider) =>
     function*(action) {
         const { payload, meta } = action;
         try {
-            yield call(authProvider, AUTH_CHECK, payload);
+            yield call([authProvider, 'checkAuth'], payload);
         } catch (error) {
-            const redirectTo = yield call(authProvider, AUTH_LOGOUT);
+            const redirectTo = yield call([authProvider, 'logout'], undefined);
             yield put(
                 replace({
                     pathname:
@@ -105,7 +105,7 @@ export const handleCheck = (authProvider: AuthProvider) =>
 export const handleLogout = (authProvider: AuthProvider) =>
     function*(action) {
         const { payload } = action;
-        const redirectTo = yield call(authProvider, AUTH_LOGOUT);
+        const redirectTo = yield call([authProvider, 'logout'], undefined);
         yield put(
             push((payload && payload.redirectTo) || redirectTo || '/login')
         );
@@ -116,10 +116,10 @@ export const handleFetchError = (authProvider: AuthProvider) =>
     function*(action) {
         const { error } = action;
         try {
-            yield call(authProvider, AUTH_ERROR, error);
+            yield call([authProvider, 'checkError'], error);
         } catch (e) {
             const nextPathname = yield select(currentPathnameSelector);
-            const redirectTo = yield call(authProvider, AUTH_LOGOUT);
+            const redirectTo = yield call([authProvider, 'logout'], undefined);
             yield put(
                 push({
                     pathname: redirectTo || '/login',

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -42,7 +42,18 @@ export type AuthActionType =
     | 'AUTH_CHECK'
     | 'AUTH_GET_PERMISSIONS';
 
-export type AuthProvider = (type: AuthActionType, params?: any) => Promise<any>;
+export type AuthProvider = {
+    login: (params: any) => Promise<any>;
+    logout: (params: any) => Promise<void | string>;
+    checkAuth: (params: any) => Promise<void>;
+    checkError: (error: any) => Promise<void>;
+    getPermissions: (params: any) => Promise<any>;
+};
+
+export type LegacyAuthProvider = (
+    type: AuthActionType,
+    params?: any
+) => Promise<any>;
 
 export type DataProvider = (
     type: string,

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -61,8 +61,8 @@ const useStyles = makeStyles((theme: Theme) => ({
  * A standalone login page, to serve as authentication gate to the admin
  *
  * Expects the user to enter a login and a password, which will be checked
- * by the `authProvider` using the AUTH_LOGIN verb. Redirects to the root page
- * (/) upon success, otherwise displays an authentication error message.
+ * by the `authProvider.login()` method. Redirects to the root page (/)
+ * upon success, otherwise displays an authentication error message.
  *
  * Copy and adapt this component to implement your own login logic
  * (e.g. to authenticate via email or facebook or anything else).


### PR DESCRIPTION
Refs #3686 

Example of `authProvider` with the new signature:

```js
export default {
    login: ({ username, password }) => {
        if (username === 'login' && password === 'password') {
            localStorage.removeItem('not_authenticated');
            localStorage.removeItem('role');
            return Promise.resolve();
        }
        if (username === 'user' && password === 'password') {
            localStorage.setItem('role', 'user');
            localStorage.removeItem('not_authenticated');
            return Promise.resolve();
        }
        if (username === 'admin' && password === 'password') {
            localStorage.setItem('role', 'admin');
            localStorage.removeItem('not_authenticated');
            return Promise.resolve();
        }
        localStorage.setItem('not_authenticated', true);
        return Promise.reject();
    },
    logout: () => {
        localStorage.setItem('not_authenticated', true);
        localStorage.removeItem('role');
        return Promise.resolve();
    },
    checkError: ({ status }) => {
        return status === 401 || status === 403
            ? Promise.reject()
            : Promise.resolve();
    },
    checkAuth: () => {
        return localStorage.getItem('not_authenticated')
            ? Promise.reject()
            : Promise.resolve();
    },
    getPermissions: () => {
        const role = localStorage.getItem('role');
        return Promise.resolve(role);
    },
};
```

This change is backward compatible