### PR TITLE
[RFR][v3] useQuery/useQueryWithStore - fix loading state not resetting

### DIFF
--- a/packages/ra-core/src/controller/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/useListController.spec.tsx
@@ -178,7 +178,7 @@ describe('useListController', () => {
             expect(updatedCrudGetListCalls[1][0].payload.filter).toEqual({
                 foo: 2,
             });
-            expect(children).toBeCalledTimes(4);
+            expect(children).toBeCalledTimes(5);
             // Check that the permanent filter is not included in the displayedFilters (passed to Filter form and button)
             expect(children.mock.calls[3][0].displayedFilters).toEqual({});
             // Check that the permanent filter is not included in the filterValues (passed to Filter form and button)

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -155,7 +155,7 @@ const useMutation = (
                 callTimeOptions
             );
 
-            setState({ loading: true });
+            setState(prevState => ({ ...prevState, loading: true }));
 
             finalDataProvider[params.type](
                 params.resource,

--- a/packages/ra-core/src/dataProvider/useQuery.ts
+++ b/packages/ra-core/src/dataProvider/useQuery.ts
@@ -90,6 +90,8 @@ const useQuery = (query: Query, options: QueryOptions = {}): UseQueryValue => {
             ? dataProviderWithDeclarativeSideEffects
             : dataProvider;
 
+        setState(prevState => ({ ...prevState, loading: true }));
+
         dataProviderWithSideEffects[type](resource, payload, rest)
             .then(({ data, total }) => {
                 setState({

--- a/packages/ra-core/src/dataProvider/useQueryWithStore.ts
+++ b/packages/ra-core/src/dataProvider/useQueryWithStore.ts
@@ -126,6 +126,8 @@ const useQueryWithStore = (
     }
     const dataProvider = useDataProvider();
     useEffect(() => {
+        setState(prevState => ({ ...prevState, loading: true }));
+
         dataProvider[type](resource, payload, options)
             .then(() => {
                 // We don't care about the dataProvider response here, because


### PR DESCRIPTION
we need to set loading to true ( like in withMutation ) to support reload

without it the loading is then always false on subsequent re-renders

and withMutation fix loaded being undefined for while