### PR TITLE
Allowing for more fine tuning of Quill without rewriting RichTextInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,20 @@
 
 ## v2.9.6
 
-* Fix too drastic validation of `DELETE` and `DELETE_MANY` dataProvider responses ([3441](https://gihub.com/marmelab/react-admin/pull/3441)) ([Kmaschta](https://github.com/Kmaschta))
-* Fix `SimpleList` showing `ListItem` as button even though `linkType` is false ([3543](https://gihub.com/marmelab/react-admin/pull/3543)) ([b-raines](https://github.com/b-raines))
-* Fix infinite loading when declaring resource at runtime with no `authProvider` ([3505](https://gihub.com/marmelab/react-admin/pull/3505)) ([Kunnu01](https://github.com/Kunnu01))
-* Fix typo in `ra-data-graphql` README ([3508](https://gihub.com/marmelab/react-admin/pull/3508)) ([bookvik](https://github.com/bookvik))
-* Fix `<DeleteButton undoable={false} />` does not refresh `List` ([3506](https://gihub.com/marmelab/react-admin/pull/3506)) ([natrim](https://github.com/natrim))
-* Fix typo in Readme ([3497](https://gihub.com/marmelab/react-admin/pull/3497)) ([arturcarvalho](https://github.com/arturcarvalho))
-* Fix various typos in documentation and demo ([3493](https://gihub.com/marmelab/react-admin/pull/3493)) ([yumi2011](https://github.com/yumi2011))
-* Fix `sortable` update has no effect in `Field` components ([3494](https://gihub.com/marmelab/react-admin/pull/3494)) ([Kunnu01](https://github.com/Kunnu01))
-* Fix `AutocompleteArrayInput` not accepting options ([3479](https://gihub.com/marmelab/react-admin/pull/3479)) ([djhi](https://github.com/djhi))
-* Fix `List` data does not update when default `filters` Change ([3308](https://gihub.com/marmelab/react-admin/pull/3308)) ([djhi](https://github.com/djhi))
-* Fix missing imports in `List` documentation ([3469](https://gihub.com/marmelab/react-admin/pull/3469)) ([Kunnu01](https://github.com/Kunnu01))
-* Add link to Swedish translation ([3466](https://gihub.com/marmelab/react-admin/pull/3466)) ([Kladdy](https://github.com/Kladdy))
-* Improve bug report template ([3488](https://gihub.com/marmelab/react-admin/pull/3488)) ([Kmaschta](https://github.com/Kmaschta))
-* Change documentation search engine to Algolia ([3459](https://gihub.com/marmelab/react-admin/pull/3459)) ([fzaninotto](https://github.com/fzaninotto))
+* Fix too drastic validation of `DELETE` and `DELETE_MANY` dataProvider responses ([3441](https://github.com/marmelab/react-admin/pull/3441)) ([Kmaschta](https://github.com/Kmaschta))
+* Fix `SimpleList` showing `ListItem` as button even though `linkType` is false ([3543](https://github.com/marmelab/react-admin/pull/3543)) ([b-raines](https://github.com/b-raines))
+* Fix infinite loading when declaring resource at runtime with no `authProvider` ([3505](https://github.com/marmelab/react-admin/pull/3505)) ([Kunnu01](https://github.com/Kunnu01))
+* Fix typo in `ra-data-graphql` README ([3508](https://github.com/marmelab/react-admin/pull/3508)) ([bookvik](https://github.com/bookvik))
+* Fix `<DeleteButton undoable={false} />` does not refresh `List` ([3506](https://github.com/marmelab/react-admin/pull/3506)) ([natrim](https://github.com/natrim))
+* Fix typo in Readme ([3497](https://github.com/marmelab/react-admin/pull/3497)) ([arturcarvalho](https://github.com/arturcarvalho))
+* Fix various typos in documentation and demo ([3493](https://github.com/marmelab/react-admin/pull/3493)) ([yumi2011](https://github.com/yumi2011))
+* Fix `sortable` update has no effect in `Field` components ([3494](https://github.com/marmelab/react-admin/pull/3494)) ([Kunnu01](https://github.com/Kunnu01))
+* Fix `AutocompleteArrayInput` not accepting options ([3479](https://github.com/marmelab/react-admin/pull/3479)) ([djhi](https://github.com/djhi))
+* Fix `List` data does not update when default `filters` Change ([3308](https://github.com/marmelab/react-admin/pull/3308)) ([djhi](https://github.com/djhi))
+* Fix missing imports in `List` documentation ([3469](https://github.com/marmelab/react-admin/pull/3469)) ([Kunnu01](https://github.com/Kunnu01))
+* Add link to Swedish translation ([3466](https://github.com/marmelab/react-admin/pull/3466)) ([Kladdy](https://github.com/Kladdy))
+* Improve bug report template ([3488](https://github.com/marmelab/react-admin/pull/3488)) ([Kmaschta](https://github.com/Kmaschta))
+* Change documentation search engine to Algolia ([3459](https://github.com/marmelab/react-admin/pull/3459)) ([fzaninotto](https://github.com/fzaninotto))
 
 ## v2.9.5
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -961,16 +961,16 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 <RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
 ```
 
-If you need more customization, you can access the quill object through the `quillInit` callback that will be called just after its initialization.
+If you need more customization, you can access the quill object through the `configureQuill` callback that will be called just after its initialization.
 
 ```js
-const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+const configureQuill = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
     this.quill.format('bold', value)
 });
 
 // ...
 
-<RichTextInput source="text" quillInit={quillInit}/>
+<RichTextInput source="text" configureQuill={configureQuill}/>
 ```
 
 ## `<SelectInput>`

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -961,6 +961,18 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 <RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
 ```
 
+If you need more customization, you can access the quill object through the `quillInit` callback that will be called just after its initialization.
+
+```js
+const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+    this.quill.format('bold', value)
+});
+
+// ...
+
+<RichTextInput source="text" quillInit={quillInit}/>
+```
+
 ## `<SelectInput>`
 
 To let users choose a value in a list using a dropdown, use `<SelectInput>`. It renders using [Material ui's `<Select>`](http://v1.material-ui.com/api/select). Set the `choices` attribute to determine the options (with `id`, `name` tuples):

--- a/packages/ra-input-rich-text/README.md
+++ b/packages/ra-input-rich-text/README.md
@@ -44,6 +44,18 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 <RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
 ```
 
+If you need more customization, you can access the quill object through the `quillInit` callback that will be called just after its initialization.
+
+```js
+const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+    this.quill.format('bold', value)
+});
+
+// ...
+
+<RichTextInput source="text" quillInit={quillInit}/>
+```
+
 ## License
 
 This library is licensed under the MIT License, and sponsored by [marmelab](http://marmelab.com).

--- a/packages/ra-input-rich-text/README.md
+++ b/packages/ra-input-rich-text/README.md
@@ -44,16 +44,16 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 <RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
 ```
 
-If you need more customization, you can access the quill object through the `quillInit` callback that will be called just after its initialization.
+If you need more customization, you can access the quill object through the `configureQuill` callback that will be called just after its initialization.
 
 ```js
-const quillInit = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+const configureQuill = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
     this.quill.format('bold', value)
 });
 
 // ...
 
-<RichTextInput source="text" quillInit={quillInit}/>
+<RichTextInput source="text" configureQuill={configureQuill}/>
 ```
 
 ## License

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -29,7 +29,7 @@ export class RichTextInput extends Component {
             }),
         ]),
         fullWidth: PropTypes.bool,
-        quillInit: PropTypes.func,
+        configureQuill: PropTypes.func,
     };
 
     static defaultProps = {
@@ -53,8 +53,8 @@ export class RichTextInput extends Component {
             ...options,
         });
 
-        if (this.props.quillInit) {
-            this.props.quillInit(this.quill);
+        if (this.props.configureQuill) {
+            this.props.configureQuill(this.quill);
         }
 
         this.quill.setContents(this.quill.clipboard.convert(value));

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -29,7 +29,7 @@ export class RichTextInput extends Component {
             }),
         ]),
         fullWidth: PropTypes.bool,
-        quillInit: PropTypes.func
+        quillInit: PropTypes.func,
     };
 
     static defaultProps = {

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -29,6 +29,7 @@ export class RichTextInput extends Component {
             }),
         ]),
         fullWidth: PropTypes.bool,
+        quillInit: PropTypes.func
     };
 
     static defaultProps = {
@@ -51,6 +52,10 @@ export class RichTextInput extends Component {
             theme: 'snow',
             ...options,
         });
+
+        if (this.props.quillInit) {
+            this.props.quillInit(this.quill);
+        }
 
         this.quill.setContents(this.quill.clipboard.convert(value));
 


### PR DESCRIPTION
- Implementing the changes mentioned in https://github.com/marmelab/react-admin/pull/3653 
- Documenting changes in ra-rich-text-input/README.md
- Documenting changes in docs/Inputs.md
- Requesting pull into `next` branch