### PR TITLE
Fix pagination reset after filtering

### DIFF
--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -140,7 +140,14 @@ const useListParams = ({
     );
 
     const changeParams = useCallback(action => {
-        const newParams = queryReducer(query, action);
+        const newQuery = getQuery({
+            location: window.location,
+            params,
+            filterDefaultValues,
+            sort,
+            perPage,
+        });
+        const newParams = queryReducer(newQuery, action);
         history.push({
             search: `?${stringify({
                 ...newParams,


### PR DESCRIPTION
Closes #3703 

Proposed solution: refresh local query variable inside `changeParams` (now it uses outdated values from closure).

P.S: This is a sort of ad-hoc solution, but works.