### PR TITLE
Fix Welcome message should be visible on narrow screens

### DIFF
--- a/packages/ra-core/src/CoreAdminRouter.tsx
+++ b/packages/ra-core/src/CoreAdminRouter.tsx
@@ -26,7 +26,7 @@ import {
 
 const welcomeStyles: CSSProperties = {
     width: '50%',
-    margin: '40vh',
+    margin: '40vh 40vw',
     textAlign: 'center',
 };
 

--- a/packages/ra-core/src/CoreAdminRouter.tsx
+++ b/packages/ra-core/src/CoreAdminRouter.tsx
@@ -26,7 +26,7 @@ import {
 
 const welcomeStyles: CSSProperties = {
     width: '50%',
-    margin: '40vh 40vw',
+    margin: '40vh 25vw',
     textAlign: 'center',
 };
 


### PR DESCRIPTION
Now it looks like this:
![image](https://user-images.githubusercontent.com/12277086/65383147-106e8c00-dd3b-11e9-9195-2fbe68c286ba.png)
