### PR TITLE
[RFR][v3] Notification - fix text color

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -20,11 +20,13 @@ interface Props {
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
-    confirm: {
-        backgroundColor: theme.palette.background.default,
+    error: {
+        backgroundColor: theme.palette.error.dark,
+        color: theme.palette.error.contrastText,
     },
     warning: {
         backgroundColor: theme.palette.error.light,
+        color: theme.palette.error.contrastText,
     },
     undo: {
         color: theme.palette.primary.light,


### PR DESCRIPTION
the default black font color is hard to see, so use MUI defined contrastText color

![be](https://user-images.githubusercontent.com/488136/65590364-f88d4700-df8a-11e9-96e7-7d8f3f99985f.png)

![foro](https://user-images.githubusercontent.com/488136/65589225-0641cd00-df89-11e9-82d0-6f46e71913af.png)
