### PR TITLE
[RFR] Fix SelectInput Warnings

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -245,7 +245,7 @@ SelectInput.propTypes = {
     allowEmpty: PropTypes.bool.isRequired,
     emptyText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     emptyValue: PropTypes.any,
-    choices: PropTypes.arrayOf(PropTypes.object).isRequired,
+    choices: PropTypes.arrayOf(PropTypes.object),
     classes: PropTypes.object,
     className: PropTypes.string,
     label: PropTypes.string,


### PR DESCRIPTION
When using a `SelectInput` inside a `ReferenceInput`, `choices` prop should not be required as this is the job of the `ReferenceInput` to provide them, not the user