### PR TITLE
[RFR] fix doc - dataProvider uses onFailure instead of onError

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -262,7 +262,7 @@ class ApproveButton extends Component {
 +               notification: { body: 'Comment approved', level: 'info' },
 +               redirectTo: '/comments',
 +           },
-+           onError: {
++           onFailure: {
 +               notification: { body: 'Error: comment not approved', level: 'warning' }
 +           }
 +       })
@@ -312,7 +312,7 @@ class ApproveButton extends Component {
                 notification: { body: 'Comment approved', level: 'info' },
                 redirectTo: '/comments',
             },
-            onError: {
+            onFailure: {
                 notification: { body: 'Error: comment not approved', level: 'warning' }
             }
         })
@@ -390,7 +390,7 @@ const options = {
         notification: { body: 'Comment approved', level: 'info' },
         redirectTo: '/comments',
     },
-    onError: {
+    onFailure: {
         notification: { body: 'Error: comment not approved', level: 'warning' }
     }
 };


### PR DESCRIPTION
The documentation does not use the right action 'onFailure', it uses 'onError'. So if an exception occurs the notification is never shown.