### PR TITLE
feat(file-input): use theme for dropzone background

### DIFF
--- a/packages/ra-ui-materialui/src/input/FileInput.js
+++ b/packages/ra-ui-materialui/src/input/FileInput.js
@@ -12,18 +12,19 @@ import Labeled from './Labeled';
 import FileInputPreview from './FileInputPreview';
 import sanitizeRestProps from './sanitizeRestProps';
 
-const styles = createStyles({
-    dropZone: {
-        background: '#efefef',
-        cursor: 'pointer',
-        padding: '1rem',
-        textAlign: 'center',
-        color: '#999',
-    },
-    preview: {},
-    removeButton: {},
-    root: { width: '100%' },
-});
+const styles = theme =>
+    createStyles({
+        dropZone: {
+            background: theme.palette.background.default,
+            cursor: 'pointer',
+            padding: '1rem',
+            textAlign: 'center',
+            color: theme.palette.text.hint,
+        },
+        preview: {},
+        removeButton: {},
+        root: { width: '100%' },
+    });
 
 export class FileInput extends Component {
     static propTypes = {

--- a/packages/ra-ui-materialui/src/input/ImageInput.js
+++ b/packages/ra-ui-materialui/src/input/ImageInput.js
@@ -4,32 +4,33 @@ import { addField, translate } from 'ra-core';
 
 import { FileInput } from './FileInput';
 
-const styles = createStyles({
-    root: { width: '100%' },
-    dropZone: {
-        background: '#efefef',
-        cursor: 'pointer',
-        padding: '1rem',
-        textAlign: 'center',
-        color: '#999',
-    },
-    preview: {},
-    removeButton: {
-        display: 'inline-block',
-        position: 'relative',
-        float: 'left',
-        '& button': {
-            position: 'absolute',
-            top: '0.5rem',
-            right: '0.5rem',
-            minWidth: '2rem',
-            opacity: 0,
+const styles = theme =>
+    createStyles({
+        root: { width: '100%' },
+        dropZone: {
+            background: theme.palette.background.default,
+            cursor: 'pointer',
+            padding: '1rem',
+            textAlign: 'center',
+            color: theme.palette.text.hint,
         },
-        '&:hover button': {
-            opacity: 1,
+        preview: {},
+        removeButton: {
+            display: 'inline-block',
+            position: 'relative',
+            float: 'left',
+            '& button': {
+                position: 'absolute',
+                top: '0.5rem',
+                right: '0.5rem',
+                minWidth: '2rem',
+                opacity: 0,
+            },
+            '&:hover button': {
+                opacity: 1,
+            },
         },
-    },
-});
+    });
 
 export class ImageInput extends FileInput {
     static defaultProps = {


### PR DESCRIPTION
Background color for FileInput dropzone is hardcoded.
In dark theme, it still keeps a light background.

![dropzone-input-before-dark](https://user-images.githubusercontent.com/3403829/66843590-3fa89f80-ef6d-11e9-9c4b-9b0b8ce11897.png)

With this code, it will use color issued from the theme to be uniform with the rest of the design.

![dropzone-input-after-dark](https://user-images.githubusercontent.com/3403829/66843680-6a92f380-ef6d-11e9-8c0b-008b3e3f4659.png)


Of course, in light theme, it will use theme colors too.
Before:

![dropzone-input-before-light](https://user-images.githubusercontent.com/3403829/66843825-99a96500-ef6d-11e9-8129-35198c1b0a6d.png)

After:

![dropzone-input-after-light](https://user-images.githubusercontent.com/3403829/66843845-9f9f4600-ef6d-11e9-8cda-5b441c7cdf0c.png)
