### PR TITLE
Add @testing-library/react in peerDep on ra-core packages

### DIFF
--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -54,6 +54,7 @@
         "rimraf": "^2.6.3"
     },
     "peerDependencies": {
+        "@testing-library/react": "^8.0.7",
         "connected-react-router": "^6.5.2",
         "final-form": "^4.18.5",
         "react": "^16.9.0",

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -37,6 +37,7 @@
         "@material-ui/core": "^4.3.3",
         "@material-ui/icons": "^4.2.1",
         "@material-ui/styles": "^4.3.3",
+        "@testing-library/react": "^8.0.7",
         "connected-react-router": "^6.5.2",
         "final-form": "^4.18.5",
         "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
Can't update from 3.0.0-beta.0 to 3.0.0-beta.2

```
/app/node_modules/ra-core/esm/util/renderWithRedux.js
Module not found: Can't resolve '@testing-library/react' in '/app/node_modules/ra-core/esm/util'
```
The issue comes from https://github.com/marmelab/react-admin/pull/3763