### PR TITLE
Fix useGetMany hook accumulatedIds filter function

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -153,11 +153,11 @@ const callQueries = debounce(() => {
         /**
          * Extract ids from queries, aggregate and deduplicate them
          *
-         * @example from [[1, 2], [2, null, 3], [4, null]] to [1, 2, 3, 4]
+         * @example from [[1, 2], [2, null, 3], [4, '']] to [1, 2, 3, 4]
          */
         const accumulatedIds = queries
             .reduce((acc, { ids }) => union(acc, ids), []) // concat + unique
-            .filter(v => v != null); // remove null values
+            .filter(v => v); // remove falsey values
         if (accumulatedIds.length === 0) {
             // no need to call the data provider if all the ids are null
             queries.forEach(({ ids, setState, onSuccess }) => {


### PR DESCRIPTION
The issue:
ReferenceInput initialises an empty string value before any selection is made. This empty string value gets passed to useGetMany hook under the hood. And then it triggers the dataProvider `getMany` function and causes an error because the received params was an empty id string.

The fix:
Inside useGetMany hook, remove all falsey values in accumulatedIds. The current implementation just filters out null value only which is not sufficient.
