### PR TITLE
upgrade redux-saga

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -24,7 +24,7 @@
         "react-scripts": "^2.0.5",
         "recompose": "~0.26.0",
         "redux-form": "~7.4.0",
-        "redux-saga": "~0.16.0"
+        "redux-saga": "~1.1.1"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -64,7 +64,7 @@
         "recompose": "~0.26.0",
         "redux": "~3.7.2",
         "redux-form": "~7.4.0",
-        "redux-saga": "~0.16.0",
+        "redux-saga": "~1.1.1",
         "reselect": "~3.0.0"
     }
 }

--- a/packages/ra-realtime/package.json
+++ b/packages/ra-realtime/package.json
@@ -39,13 +39,13 @@
         "react-admin": "^2.5.3",
         "react-router": "^4.2.0",
         "react-router-redux": "~5.0.0-alpha.9",
-        "redux-saga": "~0.16.0"
+        "redux-saga": "~1.1.1"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",
         "react-router": "^4.2.0",
         "react-router-redux": "~5.0.0-alpha.9",
-        "redux-saga": "~0.16.0",
+        "redux-saga": "~1.1.1",
         "rimraf": "^2.6.2"
     }
 }


### PR DESCRIPTION
Might be a good change to include in the upcoming 3.0.0 release.

It is a breaking change for users that currently use redux-saga in their projects. They would also need to upgrade.

Besides a few import renames there are no breaking changes in redux-saga 1.1.1