### PR TITLE
[RFR] Convert RichTextInput to a functional component

### DIFF
--- a/packages/ra-input-rich-text/src/index.spec.js
+++ b/packages/ra-input-rich-text/src/index.spec.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import debounce from 'lodash/debounce';
 import { render, fireEvent, waitForElement } from '@testing-library/react';
+import { Form } from 'react-final-form';
 
-import { RichTextInput } from './index';
+import RichTextInput from './index';
 
 let container;
 
@@ -30,12 +31,12 @@ describe('RichTextInput', () => {
         const handleChange = jest.fn();
         debounce.mockImplementation(fn => fn);
         const { getByTestId, rerender } = render(
-            <RichTextInput
-                input={{
-                    value: '<p>test</p>',
-                    onChange: handleChange,
-                }}
-                meta={{ error: null }}
+            <Form
+                initialValues={{ body: '<p>test</p>' }}
+                onSubmit={jest.fn()}
+                render={() => (
+                    <RichTextInput source="body" onChange={handleChange} />
+                )}
             />
         );
         const quillNode = await waitForElement(() => {
@@ -50,12 +51,12 @@ describe('RichTextInput', () => {
         jest.runOnlyPendingTimers();
 
         rerender(
-            <RichTextInput
-                input={{
-                    value: '<p>test1</p>',
-                    onChange: handleChange,
-                }}
-                meta={{ error: null }}
+            <Form
+                initialValues={{ body: '<p>test1</p>' }}
+                onSubmit={jest.fn()}
+                render={() => (
+                    <RichTextInput source="body" onChange={handleChange} />
+                )}
             />
         );
 


### PR DESCRIPTION
After migrating to react-final-form the `RichTextInput` is no longer showing the `helperText`. This PR fixes this bug and also converts it into a functional component.
![Screen Shot 2019-10-24 at 19 30 16](https://user-images.githubusercontent.com/42154031/67530260-edfec400-f694-11e9-99ae-545ebe412976.png)



