### PR TITLE
Fix error occur when use SimpleForm with ArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -48,7 +48,6 @@ const SimpleForm = ({ initialValues, defaultValue, saving, ...props }) => {
             onSubmit={submit}
             mutators={{ ...arrayMutators }}
             keepDirtyOnReinitialize
-            destroyOnUnregister
             subscription={defaultSubscription}
             {...props}
             render={formProps => (

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -63,7 +63,6 @@ const TabbedForm = ({ initialValues, defaultValue, saving, ...props }) => {
             mutators={{ ...arrayMutators }}
             setRedirect={setRedirect}
             keepDirtyOnReinitialize
-            destroyOnUnregister
             subscription={defaultSubscription}
             {...props}
             render={formProps => (


### PR DESCRIPTION
The issue:
Now destroyOnUnregister configuration of react-final-form has problem.
If set destroyOnUnregister to true on Form component of react-final-form, the following problems arise.

![error](https://user-images.githubusercontent.com/13689418/67616967-5aa2cb80-f819-11e9-9efa-c89334cafad2.gif)

Of course I can use it wrapped, but I modified it myself cuz I wanted to use SimpleForm that the react-admin provides as it is.

The fixed:
Remove destroyOnUnregister configuration on SimpleForm.

![success](https://user-images.githubusercontent.com/13689418/67617257-50360100-f81c-11e9-89c9-a694d27cc2a7.gif)

please check and accept my pull request. :)
