### PR TITLE
Autocomplete defaults to margin="dense" prop

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -326,7 +326,6 @@ const AutocompleteInput: FunctionComponent<
                         <TextField
                             id={id}
                             name={input.name}
-                            fullWidth
                             InputProps={{
                                 inputRef: storeInputRef,
                                 classes: {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -105,7 +105,7 @@ const AutocompleteInput: FunctionComponent<
     isRequired: isRequiredOverride,
     label,
     limitChoicesToValue,
-    margin,
+    margin = 'dense',
     matchSuggestion,
     meta: metaOverride,
     onBlur,


### PR DESCRIPTION
For consistency with other inputs

Should it also default to not being fullWidth ? Or even leverage `ResttableTextInput` to have the same visual aspect ?

Here's a codesandbox showing both side by side: https://codesandbox.io/s/practical-chandrasekhar-869ep
![image](https://user-images.githubusercontent.com/6230277/67689955-64a10780-f99c-11e9-9b99-76943fe6497c.png)
