### PR TITLE
Tweak ResettableTextField adornment style

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -93,9 +93,7 @@ function ResettableTextField({
                     <InputAdornment
                         position="end"
                         classes={{
-                            root: props.select
-                                ? classes.selectAdornment
-                                : null,
+                            root: props.select ? classes.selectAdornment : null,
                         }}
                     >
                         <IconButton

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -18,10 +18,14 @@ const useStyles = makeStyles({
     },
     clearButton: {
         height: 24,
+        padding: 0,
         width: 0,
     },
     visibleClearButton: {
         width: 24,
+    },
+    selectAdornment: {
+        marginRight: 12,
     },
 });
 
@@ -86,7 +90,14 @@ function ResettableTextField({
             value={value}
             InputProps={{
                 endAdornment: resettable && value && (
-                    <InputAdornment position="end">
+                    <InputAdornment
+                        position="end"
+                        classes={{
+                            root: props.select
+                                ? classes.selectAdornment
+                                : null,
+                        }}
+                    >
                         <IconButton
                             className={classNames(clearButton, {
                                 [visibleClearButton]:


### PR DESCRIPTION
In general, the clear icon hover background wasn't centered with
the icon itself. Also, on a SelectInput, the clear icon was
overlapping with the select's arrow:

Before:
<img width="283" alt="Screenshot 2019-10-28 at 16 20 06" src="https://user-images.githubusercontent.com/6230277/67691839-8780eb00-f99f-11e9-94a0-d1a8d1a393d2.png">

After:
<img width="496" alt="Screenshot 2019-10-28 at 16 20 15" src="https://user-images.githubusercontent.com/6230277/67691855-8c459f00-f99f-11e9-8760-f4dd71e77d1f.png">
