### PR TITLE
Class throw error in ResettableTextField.

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -79,6 +79,7 @@ function ResettableTextField({
     const {
         clearButton,
         clearIcon,
+        selectAdornment,
         visibleClearButton,
         visibleClearIcon,
         ...restClasses
@@ -93,7 +94,7 @@ function ResettableTextField({
                     <InputAdornment
                         position="end"
                         classes={{
-                            root: props.select ? classes.selectAdornment : null,
+                            root: props.select ? selectAdornment : null,
                         }}
                     >
                         <IconButton


### PR DESCRIPTION
The following error was logged in the console:

`Warning: Material-UI: the key 'selectAdornment' provided to the classes prop is not implemented in ForwardRef(TextField). ...`