### PR TITLE
Fix resettable SelectInput with value doesn't show options on click

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -25,7 +25,11 @@ const useStyles = makeStyles({
         width: 24,
     },
     selectAdornment: {
-        marginRight: 12,
+        position: 'absolute',
+        right: 24,
+    },
+    inputAdornedEnd: {
+        paddingRight: 0,
     },
 });
 
@@ -79,6 +83,7 @@ function ResettableTextField({
     const {
         clearButton,
         clearIcon,
+        inputAdornedEnd,
         selectAdornment,
         visibleClearButton,
         visibleClearIcon,
@@ -90,6 +95,7 @@ function ResettableTextField({
             classes={restClasses}
             value={value}
             InputProps={{
+                classes: { adornedEnd: props.select ? inputAdornedEnd : null },
                 endAdornment: resettable && value && (
                     <InputAdornment
                         position="end"


### PR DESCRIPTION
Today, when a `SelectInput` is `resettable`, the end adorments prevents clicking on the select arrow on the right to open the dropdown (see https://codesandbox.io/s/intelligent-almeida-24cm2).

I also removed the padding on the right in order to avoid a zone where clicking isn't captured