### PR TITLE
[RFR] Fix AutocompleteInput suggestion list placement

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteSuggestionList.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteSuggestionList.tsx
@@ -35,6 +35,7 @@ const AutocompleteSuggestionList: FunctionComponent<Props> = ({
             open={isOpen}
             anchorEl={inputEl}
             className={classes.suggestionsContainer}
+            modifiers={{}}
             {...suggestionsContainerProps}
         >
             <div {...(isOpen ? menuProps : {})}>


### PR DESCRIPTION
Not sure why, but it fixes the problem. Must be a Popper bug in material-ui. 

Closes #3940