### PR TITLE
Fix typo, autocomplete to autoComplete

### DIFF
--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -95,7 +95,7 @@ const LoginForm: SFC<Props & EnhancedProps> = ({
                     label={translate('ra.auth.password')}
                     type="password"
                     disabled={isLoading}
-                    autocomplete="current-password"
+                    autoComplete="current-password"
                 />
             </div>
         </div>


### PR DESCRIPTION
Fix this:

Warning: Invalid DOM property `autocomplete`. Did you mean `autoComplete`?
    in div (created by FormControl)
    in FormControl (created by WithStyles(FormControl))
    in WithStyles(FormControl) (created by TextField)
    in TextField (created by renderInput)
    in renderInput (created by ConnectedField)
    in ConnectedField (created by Connect(ConnectedField))
    in Connect(ConnectedField) (created by Field)
    in Field (created by LoginForm)
    in div (created by LoginForm)
    in div (created by LoginForm)
    in form (created by LoginForm)
    in LoginForm (created by Form(LoginForm))
    in Form(LoginForm) (created by Connect(Form(LoginForm)))
    in Connect(Form(LoginForm)) (created by ReduxForm)
    in ReduxForm (created by Connect(ReduxForm))
    in Connect(ReduxForm) (created by Context.Consumer)
    in translate(Connect(ReduxForm)) (created by WithStyles(translate(Connect(ReduxForm))))
    in WithStyles(translate(Connect(ReduxForm)))
    in div (created by Paper)
    in Paper (created by WithStyles(Paper))
    in WithStyles(Paper) (created by Card)
    in Card (created by WithStyles(Card))
    in WithStyles(Card) (created by Login)
    in div (created by Login)
    in MuiThemeProvider (created by Login)
    in Login (created by WithStyles(Login))
    in WithStyles(Login) (created by Route)
    in Route (created by CoreAdminBase)
    in Switch (created by CoreAdminBase)
    in Router (created by ConnectedRouter)
    in ConnectedRouter (created by CoreAdminBase)
    in TranslationProviderView (created by Connect(TranslationProviderView))
    in Connect(TranslationProviderView) (created by CoreAdminBase)
    in Provider (created by CoreAdminBase)
    in CoreAdminBase (created by withContext(CoreAdminBase))
    in withContext(CoreAdminBase) (at App.js:20)
    in App (at src/index.js:7) index.js:1375
