### PR TITLE
[RFR] Added canSelectRow function prop to Datagrid component.

### DIFF
--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -110,7 +110,7 @@ function Datagrid({ classes: classesOverride, ...props }) {
         setSort,
         size = 'small',
         total,
-        selectableRows = () => true,
+        canSelectRow = () => true,
         version,
         ...rest
     } = props;
@@ -130,13 +130,13 @@ function Datagrid({ classes: classesOverride, ...props }) {
                 onSelect(
                     ids
                         .concat(selectedIds.filter(id => !ids.includes(id)))
-                        .filter(id => selectableRows(data[id]))
+                        .filter(id => canSelectRow(data[id]))
                 );
             } else {
                 onSelect([]);
             }
         },
-        [data, ids, onSelect, selectableRows, selectedIds]
+        [data, ids, onSelect, canSelectRow, selectedIds]
     );
 
     /**
@@ -196,7 +196,7 @@ function Datagrid({ classes: classesOverride, ...props }) {
                                     selectedIds.length > 0 &&
                                     ids.length > 0 &&
                                     ids
-                                        .filter(id => selectableRows(data[id]))
+                                        .filter(id => canSelectRow(data[id]))
                                         .every(id => selectedIds.includes(id))
                                 }
                                 onChange={handleSelectAll}
@@ -237,7 +237,7 @@ function Datagrid({ classes: classesOverride, ...props }) {
                     resource,
                     rowStyle,
                     selectedIds,
-                    selectableRows,
+                    canSelectRow,
                     version,
                 },
                 children
@@ -271,7 +271,7 @@ Datagrid.propTypes = {
     setSort: PropTypes.func,
     total: PropTypes.number,
     version: PropTypes.number,
-    selectableRows: PropTypes.func,
+    canSelectRow: PropTypes.func,
 };
 
 Datagrid.defaultProps = {

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -110,7 +110,7 @@ function Datagrid({ classes: classesOverride, ...props }) {
         setSort,
         size = 'small',
         total,
-        canSelectRow = () => true,
+        canSelectRow,
         version,
         ...rest
     } = props;
@@ -126,11 +126,13 @@ function Datagrid({ classes: classesOverride, ...props }) {
     const handleSelectAll = useCallback(
         event => {
             if (event.target.checked) {
-                //
+                const all = ids.concat(
+                    selectedIds.filter(id => !ids.includes(id))
+                );
                 onSelect(
-                    ids
-                        .concat(selectedIds.filter(id => !ids.includes(id)))
-                        .filter(id => canSelectRow(data[id]))
+                    canSelectRow
+                        ? all.filter(id => canSelectRow(data[id]))
+                        : all
                 );
             } else {
                 onSelect([]);
@@ -166,6 +168,8 @@ function Datagrid({ classes: classesOverride, ...props }) {
         return null;
     }
 
+    const all = canSelectRow ? ids.filter(id => canSelectRow(data[id])) : ids;
+
     /**
      * After the initial load, if the data for the list isn't empty,
      * and even if the data is refreshing (e.g. after a filter change),
@@ -194,10 +198,8 @@ function Datagrid({ classes: classesOverride, ...props }) {
                                 color="primary"
                                 checked={
                                     selectedIds.length > 0 &&
-                                    ids.length > 0 &&
-                                    ids
-                                        .filter(id => canSelectRow(data[id]))
-                                        .every(id => selectedIds.includes(id))
+                                    all.length > 0 &&
+                                    all.every(id => selectedIds.includes(id))
                                 }
                                 onChange={handleSelectAll}
                             />

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -110,6 +110,7 @@ function Datagrid({ classes: classesOverride, ...props }) {
         setSort,
         size = 'small',
         total,
+        selectableRows = () => true,
         version,
         ...rest
     } = props;
@@ -125,14 +126,17 @@ function Datagrid({ classes: classesOverride, ...props }) {
     const handleSelectAll = useCallback(
         event => {
             if (event.target.checked) {
+                //
                 onSelect(
-                    ids.concat(selectedIds.filter(id => !ids.includes(id)))
+                    ids
+                        .concat(selectedIds.filter(id => !ids.includes(id)))
+                        .filter(id => selectableRows(data[id]))
                 );
             } else {
                 onSelect([]);
             }
         },
-        [ids, onSelect, selectedIds]
+        [data, ids, onSelect, selectableRows, selectedIds]
     );
 
     /**
@@ -191,7 +195,9 @@ function Datagrid({ classes: classesOverride, ...props }) {
                                 checked={
                                     selectedIds.length > 0 &&
                                     ids.length > 0 &&
-                                    ids.every(id => selectedIds.includes(id))
+                                    ids
+                                        .filter(id => selectableRows(data[id]))
+                                        .every(id => selectedIds.includes(id))
                                 }
                                 onChange={handleSelectAll}
                             />
@@ -231,6 +237,7 @@ function Datagrid({ classes: classesOverride, ...props }) {
                     resource,
                     rowStyle,
                     selectedIds,
+                    selectableRows,
                     version,
                 },
                 children
@@ -264,6 +271,7 @@ Datagrid.propTypes = {
     setSort: PropTypes.func,
     total: PropTypes.number,
     version: PropTypes.number,
+    selectableRows: PropTypes.func,
 };
 
 Datagrid.defaultProps = {

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -24,7 +24,7 @@ const DatagridBody = ({
     selectedIds,
     styles,
     version,
-    selectableRows = () => true,
+    canSelectRow = () => true,
     ...rest
 }) => (
     <TableBody className={classnames('datagrid-body', className)} {...rest}>
@@ -48,7 +48,7 @@ const DatagridBody = ({
                     record: data[id],
                     resource,
                     rowClick,
-                    selectable: selectableRows(data[id]),
+                    selectable: canSelectRow(data[id]),
                     selected: selectedIds.includes(id),
                     style: rowStyle ? rowStyle(data[id], rowIndex) : null,
                 },
@@ -75,7 +75,7 @@ DatagridBody.propTypes = {
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     styles: PropTypes.object,
-    selectableRows: PropTypes.func,
+    canSelectRow: PropTypes.func,
     version: PropTypes.number,
 };
 

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -24,7 +24,7 @@ const DatagridBody = ({
     selectedIds,
     styles,
     version,
-    canSelectRow = () => true,
+    canSelectRow,
     ...rest
 }) => (
     <TableBody className={classnames('datagrid-body', className)} {...rest}>
@@ -48,7 +48,7 @@ const DatagridBody = ({
                     record: data[id],
                     resource,
                     rowClick,
-                    selectable: canSelectRow(data[id]),
+                    selectable: !canSelectRow || canSelectRow(data[id]),
                     selected: selectedIds.includes(id),
                     style: rowStyle ? rowStyle(data[id], rowIndex) : null,
                 },

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -24,6 +24,7 @@ const DatagridBody = ({
     selectedIds,
     styles,
     version,
+    selectableRows = () => true,
     ...rest
 }) => (
     <TableBody className={classnames('datagrid-body', className)} {...rest}>
@@ -47,6 +48,7 @@ const DatagridBody = ({
                     record: data[id],
                     resource,
                     rowClick,
+                    selectable: selectableRows(data[id]),
                     selected: selectedIds.includes(id),
                     style: rowStyle ? rowStyle(data[id], rowIndex) : null,
                 },
@@ -73,6 +75,7 @@ DatagridBody.propTypes = {
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     styles: PropTypes.object,
+    selectableRows: PropTypes.func,
     version: PropTypes.number,
 };
 

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -42,6 +42,7 @@ const DatagridRow = ({
     rowClick,
     selected,
     style,
+    isSelectable = () => true,
     ...rest
 }) => {
     const [expanded, setExpanded] = useState(false);
@@ -135,12 +136,14 @@ const DatagridRow = ({
                 )}
                 {hasBulkActions && (
                     <TableCell padding="checkbox">
-                        <Checkbox
-                            color="primary"
-                            className={`select-item ${classes.checkbox}`}
-                            checked={selected}
-                            onClick={handleToggleSelection}
-                        />
+                        {isSelectable(record) && (
+                            <Checkbox
+                                color="primary"
+                                className={`select-item ${classes.checkbox}`}
+                                checked={selected}
+                                onClick={handleToggleSelection}
+                            />
+                        )}
                     </TableCell>
                 )}
                 {React.Children.map(children, (field, index) =>
@@ -195,6 +198,7 @@ DatagridRow.propTypes = {
     rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     selected: PropTypes.bool,
     style: PropTypes.object,
+    isSelectable: PropTypes.func,
 };
 
 DatagridRow.defaultProps = {

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -42,7 +42,7 @@ const DatagridRow = ({
     rowClick,
     selected,
     style,
-    isSelectable = () => true,
+    selectable,
     ...rest
 }) => {
     const [expanded, setExpanded] = useState(false);
@@ -136,7 +136,7 @@ const DatagridRow = ({
                 )}
                 {hasBulkActions && (
                     <TableCell padding="checkbox">
-                        {isSelectable(record) && (
+                        {selectable && (
                             <Checkbox
                                 color="primary"
                                 className={`select-item ${classes.checkbox}`}
@@ -198,7 +198,7 @@ DatagridRow.propTypes = {
     rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     selected: PropTypes.bool,
     style: PropTypes.object,
-    isSelectable: PropTypes.func,
+    selectable: PropTypes.bool,
 };
 
 DatagridRow.defaultProps = {
@@ -206,6 +206,7 @@ DatagridRow.defaultProps = {
     hover: true,
     record: {},
     selected: false,
+    selectable: true,
 };
 
 const areEqual = (prevProps, nextProps) => {


### PR DESCRIPTION
`DatagridRow` components of a `<Datagrid/>` will show a checkbox if `canSelectRow` prop returns true.
Solves the select all problem described here: https://github.com/marmelab/react-admin/issues/3470#issuecomment-551280562.


```jsx
<Datagrid
    {...props}
    canSelectRow={ record => record.id > 300 } 
>
...
</Datagrid>
```
![chrome-capturee](https://user-images.githubusercontent.com/8268610/68535659-77b0c180-0324-11ea-8110-29b1ccc3fc2b.gif)
