### PR TITLE
Intuitive way of unselecting all selected items in BulkActionsToolbar

### DIFF
--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -5,7 +5,6 @@ module.exports = {
             add: 'Add',
             back: 'Go Back',
             bulk_actions: '1 item selected |||| %{smart_count} items selected',
-            unselect_items: 'Unselect item |||| Unselect %{smart_count} items'
             cancel: 'Cancel',
             clear_input_value: 'Clear value',
             clone: 'Clone',
@@ -23,6 +22,7 @@ module.exports = {
             show: 'Show',
             sort: 'Sort',
             undo: 'Undo',
+            unselect: 'Unselect'
             expand: 'Expand',
             close: 'Close',
         },

--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -22,7 +22,7 @@ module.exports = {
             show: 'Show',
             sort: 'Sort',
             undo: 'Undo',
-            unselect: 'Unselect'
+            unselect: 'Unselect',
             expand: 'Expand',
             close: 'Close',
         },

--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -5,6 +5,7 @@ module.exports = {
             add: 'Add',
             back: 'Go Back',
             bulk_actions: '1 item selected |||| %{smart_count} items selected',
+            unselect_items: 'Unselect item |||| Unselect %{smart_count} items'
             cancel: 'Cancel',
             clear_input_value: 'Clear value',
             clone: 'Clone',

--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -23,7 +23,7 @@ module.exports = {
             show: 'Afficher',
             sort: 'Trier',
             undo: 'Annuler',
-            unselect: 'Désélectionner'
+            unselect: 'Désélectionner',
             expand: 'Étendre',
             close: 'Fermer',
         },

--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -6,7 +6,6 @@ module.exports = {
             back: 'Retour',
             bulk_actions:
                 '%{smart_count} selectionné |||| %{smart_count} selectionnés',
-            unselect_items: 'Désélectionner %{smart_count}'
             cancel: 'Annuler',
             clear_input_value: 'Vider le champ',
             clone: 'Dupliquer',
@@ -24,6 +23,7 @@ module.exports = {
             show: 'Afficher',
             sort: 'Trier',
             undo: 'Annuler',
+            unselect: 'Désélectionner'
             expand: 'Étendre',
             close: 'Fermer',
         },

--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -6,6 +6,7 @@ module.exports = {
             back: 'Retour',
             bulk_actions:
                 '%{smart_count} selectionné |||| %{smart_count} selectionnés',
+            unselect_items: 'Désélectionner %{smart_count}'
             cancel: 'Annuler',
             clear_input_value: 'Vider le champ',
             clone: 'Dupliquer',

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -68,8 +68,8 @@ const BulkActionsToolbar = ({
         >
             <IconButton
                 className={classes.icon}
-                aria-label={translate('ra.action.unselect_items')}
-                title={translate('ra.action.unselect_items')}
+                aria-label={translate('ra.action.unselect')}
+                title={translate('ra.action.unselect')}
                 onClick={onUnselectItems}
             >
                 <CloseIcon />

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -5,6 +5,8 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
 import { useTranslate, sanitizeListRestProps } from 'ra-core';
 
 import TopToolbar from '../layout/TopToolbar';
@@ -12,6 +14,7 @@ import TopToolbar from '../layout/TopToolbar';
 const useStyles = makeStyles(
     theme => ({
         toolbar: {
+            display: 'flex',
             zIndex: 3,
             color:
                 theme.palette.type === 'light'
@@ -35,7 +38,7 @@ const useStyles = makeStyles(
             overflowY: 'hidden',
         },
         title: {
-            flex: '0 0 auto',
+            flex: 1,
         },
     }),
     { name: 'RaBulkActionsToolbar' }
@@ -48,6 +51,7 @@ const BulkActionsToolbar = ({
     label,
     resource,
     selectedIds,
+    onUnselectItems,
     children,
     ...rest
 }) => {
@@ -62,6 +66,14 @@ const BulkActionsToolbar = ({
             })}
             {...sanitizeListRestProps(rest)}
         >
+            <IconButton
+                className={classes.icon}
+                aria-label={translate('ra.action.unselect_items')}
+                title={translate('ra.action.unselect_items')}
+                onClick={onUnselectItems}
+            >
+                <CloseIcon />
+            </IconButton>
             <div className={classes.title}>
                 <Typography color="inherit" variant="subtitle1">
                     {translate(label, {


### PR DESCRIPTION
This is inspired by Google Photos that intuitively starts offering the unselect feature (top-left) once one photo or more is selected.

![image](https://user-images.githubusercontent.com/465989/68589680-dd1fc200-048c-11ea-9832-78946a159e35.png)
