### PR TITLE
[RFR][v3] useSuggestions - don't crash on empty value

### DIFF
--- a/packages/ra-core/src/form/useSuggestions.spec.ts
+++ b/packages/ra-core/src/form/useSuggestions.spec.ts
@@ -31,6 +31,12 @@ describe('getSuggestions', () => {
             { id: 1, value: 'one' },
             { id: 2, value: 'two' },
         ]);
+        expect(
+            getSuggestions({
+                ...defaultOptions,
+                choices: [{ id: 0, value: '0' }, { id: 1, value: 'one' }],
+            })('0')
+        ).toEqual([{ id: 0, value: '0' }]);
     });
 
     it('should filter choices according to the filter argument when it contains RegExp reserved characters', () => {
@@ -107,5 +113,11 @@ describe('getSuggestions', () => {
             { id: 1, value: 'one' },
             { id: 2, value: 'two' },
         ]);
+    });
+
+    it('should return all choices on empty/falsy values', () => {
+        expect(getSuggestions(defaultOptions)(undefined)).toEqual(choices);
+        expect(getSuggestions(defaultOptions)(false)).toEqual(choices);
+        expect(getSuggestions(defaultOptions)(null)).toEqual(choices);
     });
 });

--- a/packages/ra-core/src/form/useSuggestions.ts
+++ b/packages/ra-core/src/form/useSuggestions.ts
@@ -84,7 +84,8 @@ const useSuggestions = ({
 
 export default useSuggestions;
 
-const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+const escapeRegExp = value =>
+    value ? value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; // $& means the whole matched string
 
 interface Options extends UseChoicesOptions {
     choices: any[];


### PR DESCRIPTION
if default value is undefined it crashes on String.replace

> useSuggestions.js:77 Uncaught TypeError: Cannot read property 'replace' of undefined
>     at escapeRegExp (useSuggestions.js:77)
>     at useSuggestions.js:91
>     at useSuggestions.js:151
>     at Array.filter (<anonymous>)
>     at useSuggestions.js:150