### PR TITLE
[RFR][V3] TabbedFormTabs - validTabPaths fix index

### DIFF
--- a/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
+++ b/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
@@ -17,9 +17,10 @@ const TabbedFormTabs = ({
 }) => {
     const location = useLocation();
 
-    const validTabPaths = Children.toArray(children).map((tab, index) =>
-        getTabFullPath(tab, index, url)
-    );
+    const validTabPaths = Children.map(children, (tab, index) => {
+        if (!isValidElement(tab)) return undefined;
+        return getTabFullPath(tab, index, url);
+    });
 
     // This ensure we don't get warnings from material-ui Tabs component when
     // the current location pathname targets a dynamically added Tab


### PR DESCRIPTION
validTabPaths needs to contain all valid elements indexed by existence
else conditional tabs leave space and are not considered valid for active tab

problem was that Children.toArray(children) strips them before map so the indexes are different from the rendering Children.map

![Nov-12-2019 10-04-11](https://user-images.githubusercontent.com/488136/68657390-ea43bc00-0533-11ea-9136-066d7d1b1696.gif)


repo: https://codesandbox.io/s/simple-i0xmz
1) edit post
2) try clicking tabs
3) you will see the index starting at 2
4) and comments not working right