### PR TITLE
Make AutocompleteInput's suggestionContainer above Dialog window

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.js
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.js
@@ -25,7 +25,7 @@ const styles = theme =>
         suggestionsContainerOpen: {
             position: 'absolute',
             marginBottom: theme.spacing.unit * 3,
-            zIndex: 2,
+            zIndex: 1300,
         },
         suggestionsPaper: {
             maxHeight: '50vh',


### PR DESCRIPTION
Change suggestionContainer zIndex to 1300 according to material-ui SelectInput suggestionContainer zIndex value.

Otherwise it's overlapped by any Dialog window. 
![Image of AutocompleteInput overllaping](https://i.imgur.com/Kur24W9.jpg)

And somehow previous hack with overwritten AutocompleteInput theme styles are ignored in react-admin@3.0.0.beta-6 and generating error:

```
const AutocompleteInputZIndexFixed = withStyles(theme =>
    createStyles({
        suggestionsContainerOpen: { zIndex: 3000 }
    })
)(AutocompleteInput);
``` 

```
index.js:1375 Material-UI: the key `suggestionsContainerOpen` provided to the classes prop is not implemented in undefined.
You can only override one of the following: root,container,paper,chip,chipContainerFilled,inputRoot,inputRootFilled,inputInput,divider. 
```