### PR TITLE
useQueryWithStore and useGetMany returns error: null when success after firs fail

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -189,6 +189,7 @@ const callQueries = debounce(() => {
                     queries.forEach(({ ids, setState, onSuccess }) => {
                         setState(prevState => ({
                             ...prevState,
+                            error: null,
                             loading: false,
                             loaded: true,
                         }));

--- a/packages/ra-core/src/dataProvider/useQueryWithStore.ts
+++ b/packages/ra-core/src/dataProvider/useQueryWithStore.ts
@@ -138,6 +138,7 @@ const useQueryWithStore = (
                 // will be empty, so it should not be used at all.
                 setState(prevState => ({
                     ...prevState,
+                    error: null,
                     loading: false,
                     loaded: true,
                 }));


### PR DESCRIPTION
I use useGetManyReference to get referenced data.

```
  const { data, ids, error, loaded } = useGetManyReference(
    "decks",
    "branchId",
    branch.id,
    { page: 1, perPage: 200 },
    { field: "id", order: "ASC" },
    {},
    "branches"
  );
```


When get fails at first call I got this log (from last render):
```
data: undefined, error: Error: ra.notification.data_provider_error, loading: false, loaded: false
```
In this case we show error text because data is undefined and error is present.


When get fails after some success calls before I got this log (from last render):
```
data: [object Object], error: Error: ra.notification.data_provider_error, loading: false, loaded: true
```
In this case we show error text, because error is present. Even if data is present and loaded is true, because this data may be outdated.


Then refresh again, for now I got success response:
```
data: [object Object], error: Error: ra.notification.data_provider_error, loading: false, loaded: true
```
But in this case error is presented again and I need to show error instead of data.


With fix after success response:
```
data: [object Object], error: null, loading: false, loaded: true
```

And in this case  success response will return error: null so I can show data.