### PR TITLE
[RFR] Add allowDuplicates for AutocompleteArrayInput

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -325,8 +325,10 @@ If you need to override the props of the suggestions container (a `Popper` eleme
 
 | Prop | Required | Type | Default | Description |
 | ---|---|---|---|--- |
+| `allowEmpty` | Optional | `boolean` | `false` | If `true`, the first option is an empty one |
+| `allowDuplicates` | Optional | `boolean` | `false` | If `true`, the options can be selected several times |
 | `choices` | Required | `Object[]` | - | List of items to autosuggest |
-| `matchSuggestion` | Optional | `Function` | - | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`
+| `matchSuggestion` | Optional | `Function` | - | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean` |
 | `optionValue` | Optional | `string` | `id` | Fieldname of record containing the value to use as input value  |
 | `optionText` | Optional | <code>string &#124; Function</code> | `name` | Fieldname of record to display in the suggestion item or function which accepts the current record as argument (`(record)=> {string}`) |
 | `setFilter` | Optional | `Function` | `null` | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |

--- a/packages/ra-core/src/form/useSuggestions.spec.ts
+++ b/packages/ra-core/src/form/useSuggestions.spec.ts
@@ -120,4 +120,28 @@ describe('getSuggestions', () => {
         expect(getSuggestions(defaultOptions)(false)).toEqual(choices);
         expect(getSuggestions(defaultOptions)(null)).toEqual(choices);
     });
+
+    it('should return all choices if allowDuplicates is true', () => {
+        expect(
+            getSuggestions({
+                ...defaultOptions,
+                allowDuplicates: true,
+                selectedItem: choices[0],
+            })('')
+        ).toEqual([
+            { id: 1, value: 'one' },
+            { id: 2, value: 'two' },
+            { id: 3, value: 'three' },
+        ]);
+    });
+
+    it('should return all the filtered choices if allowDuplicates is true', () => {
+        expect(
+            getSuggestions({
+                ...defaultOptions,
+                allowDuplicates: true,
+                selectedItem: [choices[0]],
+            })('o')
+        ).toEqual([{ id: 1, value: 'one' }, { id: 2, value: 'two' }]);
+    });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -93,6 +93,7 @@ interface Options {
 const AutocompleteArrayInput: FunctionComponent<
     InputProps<TextFieldProps & Options> & DownshiftProps<any>
 > = ({
+    allowDuplicates,
     allowEmpty,
     classes: classesOverride,
     choices = [],
@@ -178,6 +179,7 @@ const AutocompleteArrayInput: FunctionComponent<
     );
 
     const { getChoiceText, getChoiceValue, getSuggestions } = useSuggestions({
+        allowDuplicates,
         allowEmpty,
         choices,
         emptyText,
@@ -234,13 +236,14 @@ const AutocompleteArrayInput: FunctionComponent<
 
     const handleChange = useCallback(
         (item: any) => {
-            let newSelectedItems = selectedItems.includes(item)
-                ? [...selectedItems]
-                : [...selectedItems, item];
+            let newSelectedItems =
+                !allowDuplicates && selectedItems.includes(item)
+                    ? [...selectedItems]
+                    : [...selectedItems, item];
             setFilterValue('');
             input.onChange(newSelectedItems.map(getChoiceValue));
         },
-        [getChoiceValue, input, selectedItems, setFilterValue]
+        [allowDuplicates, getChoiceValue, input, selectedItems, setFilterValue]
     );
 
     const handleDelete = useCallback(


### PR DESCRIPTION
Following https://github.com/marmelab/react-admin/pull/2912 and fixes https://github.com/marmelab/react-admin/issues/2311.

In React-admin 3, it's not possible to have duplicated values anymore for the `AutocompleteArrayInput`. However it could be useful to allow this behavior in some cases.