### PR TITLE
Fix AutocompleteArrayInput inside ReferenceArrayInput

### DIFF
--- a/packages/ra-core/src/controller/input/ReferenceArrayInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceArrayInputController.spec.tsx
@@ -564,7 +564,14 @@ describe('<ReferenceArrayInputController />', () => {
                 input={{ value: [5] }}
             >
                 {children}
-            </ReferenceArrayInputController>
+            </ReferenceArrayInputController>,
+            {
+                admin: {
+                    resources: { tags: { data: {}, list: {} } },
+                    references: { possibleValues: {} },
+                    ui: { viewVersion: 1 },
+                },
+            }
         );
 
         await wait();

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
@@ -102,14 +102,12 @@ const useReferenceArrayInputController = ({
         idsToFetch || []
     );
 
-    const referenceRecords = referenceRecordsFetched.concat(
-        referenceRecordsFromStore
-    );
+    const referenceRecords = referenceRecordsFetched
+        ? referenceRecordsFetched.concat(referenceRecordsFromStore)
+        : referenceRecordsFromStore;
 
     // filter out not found references - happens when the dataProvider doesn't guarantee referential integrity
-    const finalReferenceRecords = referenceRecords
-        ? referenceRecords.filter(Boolean)
-        : [];
+    const finalReferenceRecords = referenceRecords.filter(Boolean);
 
     const { data: matchingReferences } = useGetMatching(
         reference,

--- a/packages/ra-core/src/dataProvider/defaultDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/defaultDataProvider.ts
@@ -1,11 +1,11 @@
 export default {
-    create: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
-    delete: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
+    create: () => Promise.resolve({ data: null }), // avoids adding a context in tests
+    delete: () => Promise.resolve({ data: null }), // avoids adding a context in tests
     deleteMany: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
     getList: () => Promise.resolve({ data: [], total: 0 }), // avoids adding a context in tests
     getMany: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
-    getManyReference: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
-    getOne: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
-    update: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
+    getManyReference: () => Promise.resolve({ data: [], total: 0 }), // avoids adding a context in tests
+    getOne: () => Promise.resolve({ data: null }), // avoids adding a context in tests
+    update: () => Promise.resolve({ data: null }), // avoids adding a context in tests
     updateMany: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
 };

--- a/packages/ra-core/src/dataProvider/defaultDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/defaultDataProvider.ts
@@ -1,11 +1,11 @@
 export default {
-    create: () => Promise.resolve(null), // avoids adding a context in tests
-    delete: () => Promise.resolve(null), // avoids adding a context in tests
-    deleteMany: () => Promise.resolve(null), // avoids adding a context in tests
-    getList: () => Promise.resolve(null), // avoids adding a context in tests
-    getMany: () => Promise.resolve(null), // avoids adding a context in tests
-    getManyReference: () => Promise.resolve(null), // avoids adding a context in tests
-    getOne: () => Promise.resolve(null), // avoids adding a context in tests
-    update: () => Promise.resolve(null), // avoids adding a context in tests
-    updateMany: () => Promise.resolve(null), // avoids adding a context in tests
+    create: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
+    delete: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
+    deleteMany: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
+    getList: () => Promise.resolve({ data: [], total: 0 }), // avoids adding a context in tests
+    getMany: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
+    getManyReference: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
+    getOne: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
+    update: () => Promise.resolve({ data: {} }), // avoids adding a context in tests
+    updateMany: () => Promise.resolve({ data: [] }), // avoids adding a context in tests
 };


### PR DESCRIPTION
Some time ago, we added an optimization to avoid refetching already selected items each time a new item is selected. This is fine, except that we need to grab the already selected items from the store to get their option text...

closes #4021