### PR TITLE
[RFR] Allow to extend useEditController

### DIFF
--- a/packages/ra-core/src/controller/useCreateController.ts
+++ b/packages/ra-core/src/controller/useCreateController.ts
@@ -18,7 +18,14 @@ export interface CreateControllerProps {
     loaded: boolean;
     saving: boolean;
     defaultTitle: string;
-    save: (record: Partial<Record>, redirect: RedirectionSideEffect) => void;
+    save: (
+        record: Partial<Record>,
+        redirect: RedirectionSideEffect,
+        callbacks?: {
+            onSuccess: () => void;
+            onFailure: (error: string | { message?: string }) => void;
+        }
+    ) => void;
     resource: string;
     basePath: string;
     record?: Partial<Record>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4981,6 +4981,14 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-generator-retail@^2.7.0:
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/data-generator-retail/-/data-generator-retail-2.9.5.tgz#9a1a541f7bc19c00b633b0d17e6b39837e398976"
+  integrity sha512-scx3c91hhTMxFIvNgAO2Y2Xor4eIR8FfZ7LBCHVlsUt7DEIUvH6juHIVjT6ytzQjwBuR03UzEOlZpIMim1+KqQ==
+  dependencies:
+    date-fns "~1.29.0"
+    faker "^4.1.0"
+
 data-urls@^1.0.0, data-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"


### PR DESCRIPTION
`useCreateController` accepts a onSuccess and a onFailure props, but `useEditController` don't
So, I made this PR to have the same behavior for both of them