### PR TITLE
fix(LoadingIndicator): remove unused isLoading props (https://material-ui.com/api/circular-progress/)

### DIFF
--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -36,7 +36,6 @@ export const LoadingIndicator = ({
 LoadingIndicator.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
-    isLoading: PropTypes.bool,
     width: PropTypes.string,
 };
 


### PR DESCRIPTION
Please double-check as I may be doing a mistake.

I haven't been able to use `isLoading`, according to `<CircularProgress />` [documentation](https://material-ui.com/api/circular-progress/), the `props.isLoading` is not used by mui nor `<LoadingComponent />`