### PR TITLE
Fix FilterForm doesn't use default values for BooleanInput

### DIFF
--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -66,6 +66,7 @@ describe('List Page', () => {
 
         it('should hide filter when clicking on hide button', () => {
             ListPagePosts.showFilter('title');
+            cy.contains('1-1 of 1');
             ListPagePosts.hideFilter('title');
 
             cy.get(ListPagePosts.elements.filter('title')).should(

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -60,7 +60,6 @@ const BooleanInput: FunctionComponent<
                     <Switch
                         id={id}
                         color="primary"
-                        checked={!!value}
                         onChange={handleChange}
                         {...inputProps}
                         {...options}

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -42,16 +42,13 @@ const FilterFormInput = ({
                     <ActionHide />
                 </IconButton>
             )}
-            <Field
-                allowEmpty
-                {...sanitizeRestProps(filterElement.props)}
-                name={filterElement.props.source}
-                component={filterElement.type}
-                resource={resource}
-                record={emptyRecord}
-                variant={variant}
-                margin={margin}
-            />
+            {React.cloneElement(filterElement, {
+                allowEmpty: true,
+                resource,
+                record: emptyRecord,
+                variant,
+                margin,
+            })}
             <div className={classes.spacer}>&nbsp;</div>
         </div>
     );

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'react-final-form';
 import IconButton from '@material-ui/core/IconButton';
 import ActionHide from '@material-ui/icons/HighlightOff';
 import { makeStyles } from '@material-ui/core/styles';
@@ -8,8 +7,6 @@ import classnames from 'classnames';
 import { useTranslate } from 'ra-core';
 
 const emptyRecord = {};
-
-const sanitizeRestProps = ({ alwaysOn, ...props }) => props;
 
 const useStyles = makeStyles(theme => ({
     body: { display: 'flex', alignItems: 'flex-end' },


### PR DESCRIPTION
Closes #4091

`FilterFormInput` used to decorate Input components with `Field`, which is not necessary since every Input component has to do the decoration themselves. Also, this double decoration made `checked` computation by final-form fail. 