### PR TITLE
Fix ReferenceField when used inside form

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -110,7 +110,6 @@ ReferenceField.defaultProps = {
     addLabel: true,
     classes: {},
     link: 'edit',
-    record: {},
 };
 
 const useStyles = makeStyles(theme => ({

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -59,10 +59,9 @@ const ReferenceField = ({ children, record, source, ...props }) => {
     if (React.Children.count(children) !== 1) {
         throw new Error('<ReferenceField> only accepts a single child');
     }
-    const id = get(record, source);
     const { loaded, error, referenceRecord } = useReference({
-        ...props,
-        id,
+        reference: props.reference,
+        id: get(record, source),
     });
     const resourceLinkPath = getResourceLinkPath({ record, source, ...props });
 


### PR DESCRIPTION
Closes #4124

The bug is a bit tricky: FormInput decorates Field components with Labeled, passing them their props. Then, it renders the Field, passing them the `record`. 

```jsx
export const FormInput = ({ input, classes: classesOverride, ...rest }) => {
    const classes = useStyles({ classes: classesOverride });
    return input ? (
        <div
            className={classnames(
                'ra-input',
                `ra-input-${input.props.source}`,
                input.props.formClassName
            )}
        >
            {input.props.addLabel ? (
                <Labeled
                    id={input.props.id || input.props.source}
                    {...input.props}
                    {...sanitizeRestProps(rest)}
                >
                    {React.cloneElement(input, {
                        className: classnames(
                            {
                                [classes.input]: !input.props.fullWidth,
                            },
                            input.props.className
                        ),
                        id: input.props.id || input.props.source,
                        ...rest,
                    })}
                </Labeled>
            ) : (
                React.cloneElement(input, {
                    className: classnames(
                        {
                            [classes.input]: !input.props.fullWidth,
                        },
                        input.props.className
                    ),
                    id: input.props.id || input.props.source,
                    ...rest,
                })
            )}
        </div>
    ) : null;
};
```

The problem is that the `record` value for `ReferenceField` is `{}` due to `defaultProps`, so it overrides the `record` passed by `FormInput`.

 Then you might ask: how come this used to work in 2.x? Well, my friend, that's because in 2.x we didn't export `ReferenceField`, but `withStyles(styles)(ReferenceField)`, so the `defaultProps` of `ReferenceField` were never passed to the `Labeled` element...

And you might also ask: Why did we need a `defaultValue` in the first place? It probably dates before we used `lodash.get` to get the `id` form the `record`, or before the `useGetMany` implementation ignored undefined ids. Anyway, it's no longer necessary in 3.x.