### PR TITLE
Fix: getPermissionsWithoutProvider is not defined

### DIFF
--- a/packages/ra-core/src/auth/useGetPermissions.ts
+++ b/packages/ra-core/src/auth/useGetPermissions.ts
@@ -45,7 +45,6 @@ const useGetPermissions = (): GetPermissions => {
     return authProvider ? getPermissions : getPermissionsWithoutProvider;
 };
 
-
 /**
  * Proxy for calling authProvider.getPermissions()
  *

--- a/packages/ra-core/src/auth/useGetPermissions.ts
+++ b/packages/ra-core/src/auth/useGetPermissions.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 
 import useAuthProvider from './useAuthProvider';
 
+const getPermissionsWithoutProvider = () => Promise.resolve([]);
+
 /**
  * Get a callback for calling the authProvider.getPermissions() method.
  *
@@ -43,7 +45,6 @@ const useGetPermissions = (): GetPermissions => {
     return authProvider ? getPermissions : getPermissionsWithoutProvider;
 };
 
-const getPermissionsWithoutProvider = () => Promise.resolve([]);
 
 /**
  * Proxy for calling authProvider.getPermissions()


### PR DESCRIPTION
Because getPermissionsWithoutProvider is initialized with a var, it can't be placed below useGetPermissions.

Fix #4184