### PR TITLE
[RFR] Update tutorial app creation command

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -12,8 +12,7 @@ This 30 minutes tutorial will expose how to create a new admin app based on an e
 React-admin uses React. We'll use Facebook's [create-react-app](https://github.com/facebookincubator/create-react-app) to create an empty React app, and install the `react-admin` package:
 
 ```sh
-npm install -g create-react-app
-create-react-app test-admin
+npx create-react-app test-admin
 cd test-admin/
 yarn add react-admin ra-data-json-server prop-types
 yarn start


### PR DESCRIPTION
In the tutorial, `create-react-app` is installed globally. Yet, it is no longer supported as shown with the following error message:

> Please note that global installs of create-react-app are no longer supported.

This PR uses `npx`, the way recommended by [create-react-app](https://github.com/facebook/create-react-app).