### PR TITLE
docs: use Yarn create command in tutorial

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -12,8 +12,7 @@ This 30 minutes tutorial will expose how to create a new admin app based on an e
 React-admin uses React. We'll use Facebook's [create-react-app](https://github.com/facebookincubator/create-react-app) to create an empty React app, and install the `react-admin` package:
 
 ```sh
-npm install -g create-react-app
-create-react-app test-admin
+yarn create react-app test-admin
 cd test-admin/
 yarn add react-admin ra-data-json-server prop-types
 yarn start


### PR DESCRIPTION
Instead of globally installing `create-react-app` with npm we can use [Yarn's create command](https://yarnpkg.com/lang/en/docs/cli/create/) to do this.
Yarn is already assumed to be installed since it's used in the next step.

Create React App has also [written that globally installing it is not supported](https://create-react-app.dev/docs/getting-started#quick-start) any more and `npx` or `yarn create` should be used instead.

Read more about `yarn create` here: https://yarnpkg.com/lang/en/docs/cli/create/