### PR TITLE
Set default redux state for desktop sidebar

### DIFF
--- a/packages/ra-core/src/reducer/admin/ui.ts
+++ b/packages/ra-core/src/reducer/admin/ui.ts
@@ -26,8 +26,14 @@ export interface UIState {
     readonly viewVersion: number;
 }
 
+let isDesktop = false;
+
+if (typeof window !== 'undefined') {
+    isDesktop = window.matchMedia('(min-width: 960px)').matches;
+}
+
 const defaultState: UIState = {
-    sidebarOpen: false,
+    sidebarOpen: isDesktop,
     optimistic: false,
     viewVersion: 0,
 };

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -54,15 +54,6 @@ const Sidebar = ({
     const dispatch = useDispatch();
     const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
     const isSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
-    // FIXME negating isXSmall and isSmall should be enough, but unfortunately
-    // mui media queries use a two pass system and are always false at first
-    // see https://github.com/mui-org/material-ui/issues/14336
-    const isDesktop = useMediaQuery(theme => theme.breakpoints.up('md'));
-    useEffect(() => {
-        if (isDesktop) {
-            dispatch(setSidebarVisibility(true)); // FIXME renders with a closed sidebar at first
-        }
-    }, [isDesktop, dispatch]);
     const open = useSelector(state => state.admin.ui.sidebarOpen);
     useSelector(state => state.locale); // force redraw on locale change
     const handleClose = () => dispatch(setSidebarVisibility(false));


### PR DESCRIPTION
This allows redux-persist to function correctly. Otherwise, the state is being forced overridden by react-admin.

It would be better to do a dynamic media query against the active `theme` coming from MUI, but this is a more simple solution that assumes `md` is always the default.