### PR TITLE
[Feature] added rootSagaMiddleware to have an ability pass preconfigured saga-middleware

### DIFF
--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -29,6 +29,7 @@ export interface AdminContextProps {
     authProvider?: AuthProvider | LegacyAuthProvider;
     children?: AdminChildren;
     customSagas?: any[];
+    rootSagaMiddleware?: Function;
     customReducers?: object;
     customRoutes?: CustomRoutes;
     dashboard?: DashboardComponent;
@@ -48,6 +49,7 @@ const CoreAdminContext: FunctionComponent<AdminContextProps> = ({
     customReducers,
     customSagas,
     initialState,
+    rootSagaMiddleware,
 }) => {
     const reduxIsAlreadyInitialized = !!useContext(ReactReduxContext);
 
@@ -96,6 +98,7 @@ React-admin uses this history for its own ConnectedRouter.`);
                     authProvider: finalAuthProvider,
                     customReducers,
                     customSagas,
+                    rootSagaMiddleware,
                     dataProvider: finalDataProvider,
                     initialState,
                     history: finalHistory,

--- a/packages/ra-core/src/core/createAdminStore.ts
+++ b/packages/ra-core/src/core/createAdminStore.ts
@@ -24,6 +24,7 @@ interface Params {
     authProvider?: AuthProvider;
     customReducers?: any;
     customSagas?: any[];
+    rootSagaMiddleware?: Function;
     i18nProvider?: I18nProvider;
     initialState?: InitialState;
     locale?: string;
@@ -36,6 +37,7 @@ export default ({
     authProvider = null,
     customSagas = [],
     initialState,
+    rootSagaMiddleware = null,
 }: Params) => {
     const appReducer = createAppReducer(customReducers, history);
 
@@ -61,7 +63,7 @@ export default ({
             [adminSaga(dataProvider, authProvider), ...customSagas].map(fork)
         );
     };
-    const sagaMiddleware = createSagaMiddleware();
+    const sagaMiddleware = rootSagaMiddleware || createSagaMiddleware();
     const typedWindow = window as Window;
 
     const composeEnhancers =

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -370,6 +370,7 @@ export interface AdminProps {
     customReducers?: object;
     customRoutes?: CustomRoutes;
     customSagas?: any[];
+    rootSagaMiddleware?: Function;
     dashboard?: DashboardComponent;
     dataProvider: DataProvider | LegacyDataProvider;
     history?: History;

--- a/packages/react-admin/src/Admin.tsx
+++ b/packages/react-admin/src/Admin.tsx
@@ -89,6 +89,7 @@ const Admin: FunctionComponent<AdminProps> = ({
     children,
     customReducers,
     customRoutes = [],
+    rootSagaMiddleware,
     customSagas,
     dashboard,
     dataProvider,
@@ -128,6 +129,7 @@ const Admin: FunctionComponent<AdminProps> = ({
             history={history}
             customReducers={customReducers}
             customSagas={customSagas}
+            rootSagaMiddleware={rootSagaMiddleware}
             initialState={initialState}
         >
             <AdminUI


### PR DESCRIPTION
### Feature
Ability to register custom middlewares

#### Context
I want to connect Sentry.io as logger to my frontend.
In order to do that I need pass pre-configured middleware https://rafaelfragoso.com/catching-errors-with-redux-sagas-and-sentry/ with onError/and logger
