### PR TITLE
Fix remove props warnings in CheckboxGroupInput 

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -17,6 +17,7 @@ const sanitizeRestProps = ({
     setFilter,
     setPagination,
     setSort,
+    loaded,
     ...rest
 }: any) => defaultSanitizeRestProps(rest);
 

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -201,7 +201,7 @@ const CheckboxGroupInput: FunctionComponent<
 };
 
 CheckboxGroupInput.propTypes = {
-    choices: PropTypes.arrayOf(PropTypes.object).isRequired,
+    choices: PropTypes.arrayOf(PropTypes.object),
     className: PropTypes.string,
     label: PropTypes.string,
     source: PropTypes.string,


### PR DESCRIPTION
- Dropping the required flag since a default value is provided when destructuring. Proptypes complains when component is child of a `ReferenceArrayInput` component.
- Pull out loaded attribute from `rest` to avoid fieldet from complaining. 
`index.js:1375 Warning: Received `true` for a non-boolean attribute "loaded".`