### PR TITLE
[RFR] Add icon props to Logout component

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -54,6 +54,7 @@ title: "Reference"
 * `<Labeled>`
 * [`<Layout>`](./Theming.md#using-a-custom-layout)
 * [`<Loading>`](./Theming.md#Loading)
+* [`<Logout>`](./Theming.md#using-a-custom-logout-button)
 * [`<List>`](./List.md#the-list-component)
 * [`<ListGuesser>`](./List.md#the-listguesser-component)
 * `<ListButton>`

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -856,6 +856,25 @@ const App = () => (
 );
 ```
 
+## Using a Custom Logout Button
+
+### Changing the Icon
+
+It is possible to use a completely [custom logout button](./Authentication.md#the-datagrid-component) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
+
+```jsx
+import { Admin, Logout } from 'react-admin';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp'
+
+const MyLogoutButton = props => <Logout {...props} icon={<ExitToAppIcon/>} />;
+
+const App = () => (
+    <Admin logoutButton={MyLogoutButton}>
+        // ...
+    </Admin>
+);
+```
+
 ## Notifications
 
 You can override the notification component, for instance to change the notification duration. It defaults to 4000, i.e. 4 seconds, and you can override it using the `autoHideDuration` prop. For instance, to create a custom Notification component with a 5 seconds default:

--- a/packages/ra-ui-materialui/src/auth/Logout.tsx
+++ b/packages/ra-ui-materialui/src/auth/Logout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, FunctionComponent } from 'react';
+import React, { useCallback, FunctionComponent, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { ListItemIcon, MenuItem, makeStyles } from '@material-ui/core';
 import { MenuItemProps } from '@material-ui/core/MenuItem';
@@ -11,6 +11,7 @@ import { useTranslate, useLogout } from 'ra-core';
 interface Props {
     className?: string;
     redirectTo?: string;
+    icon?: ReactElement;
 }
 
 const useStyles = makeStyles(
@@ -31,7 +32,7 @@ const useStyles = makeStyles(
 const LogoutWithRef: FunctionComponent<
     Props & MenuItemProps<'li', { button: true }> // HACK: https://github.com/mui-org/material-ui/issues/16245
 > = React.forwardRef(function Logout(props, ref) {
-    const { className, redirectTo, ...rest } = props;
+    const { className, redirectTo, icon, ...rest } = props;
     const classes = useStyles({}); // the empty {} is a temp fix for https://github.com/mui-org/material-ui/issues/15942
     const translate = useTranslate();
     const logout = useLogout();
@@ -48,7 +49,7 @@ const LogoutWithRef: FunctionComponent<
             {...rest}
         >
             <ListItemIcon className={classes.icon}>
-                <ExitIcon />
+                {icon ? icon : <ExitIcon />}
             </ListItemIcon>
             {translate('ra.auth.logout')}
         </MenuItem>
@@ -58,6 +59,7 @@ const LogoutWithRef: FunctionComponent<
 LogoutWithRef.propTypes = {
     className: PropTypes.string,
     redirectTo: PropTypes.string,
+    icon: PropTypes.element,
 };
 
 export default LogoutWithRef;


### PR DESCRIPTION
**Goal**
For an admin web application I'm building I have applied quite some theming to the default `react-admin` layout and style. A bit of work, but it is supported quite well and also documented surprisingly well.

I wanted to use a different icon for the logout button. By default it uses the `<ExitIcon />` (power symbol). I personally prefer using a different icon to represent the logout action in applications: `<ExitToAppIcon/>`.

With help of the documentation I found that it was only possible to achieve this by using a completely custom login button component. So I copied the source of the original `Logout` component and I changed the icon in my application. All good! But not great.

**Motivation**
The `Logout` component contains quite a bit of logic. All this logic is now in my custom login button component. The logout button of my app won't benefit from future updates of the `react-admin` framework to the `Logout` component due to the usage of a custom component.

Therefore I thought it would be nice to add the option to only change the icon of the default `Logout` component.

**Changes described**
I modified the component, described this option in the Theming documentation and also added an entry for the `Logout` component to the Reference file. I've used it in the simple example locally (not committed) with the following result:
<img width="170" alt="Screenshot 2019-12-31 at 15 03 22" src="https://user-images.githubusercontent.com/32896803/71627100-f0c7e900-2bf0-11ea-85e2-eaddf449553c.png">

If this PR is accepted and included in a release I can drop the custom login button component and simply configure the icon.