### PR TITLE
Fix withTranslate HOC uses defualt translate prop instead of the one from context

### DIFF
--- a/packages/ra-core/src/i18n/translate.tsx
+++ b/packages/ra-core/src/i18n/translate.tsx
@@ -36,7 +36,7 @@ const MyHelloButton = ({ translate }) => (
         const locale = useLocale();
 
         return (
-            <BaseComponent translate={translate} locale={locale} {...props} />
+            <BaseComponent {...props} translate={translate} locale={locale} />
         );
     };
 


### PR DESCRIPTION
fix #4208 

In translate hoc prevent component props to overrides injected translate and locale.