### PR TITLE
[RFR] Also pass the dense prop from the Menu to the DashboardMenuItem

### DIFF
--- a/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
+++ b/packages/ra-ui-materialui/src/layout/DashboardMenuItem.js
@@ -14,7 +14,6 @@ const DashboardMenuItem = ({ locale, onClick, ...props }) => {
             primaryText={translate('ra.page.dashboard')}
             leftIcon={<DashboardIcon />}
             exact
-            dense
             {...props}
         />
     );

--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -52,7 +52,11 @@ const Menu = ({
     return (
         <div className={classnames(classes.main, className)} {...rest}>
             {hasDashboard && (
-                <DashboardMenuItem onClick={onMenuClick} sidebarIsOpen={open} />
+                <DashboardMenuItem
+                    onClick={onMenuClick}
+                    dense={dense}
+                    sidebarIsOpen={open}
+                />
             )}
             {resources
                 .filter(r => r.hasList)


### PR DESCRIPTION
**Issue**
When I was applying custom styling to the sidebar menu, I noticed that the `Dashboard` menu item didn't always have the same styling as the other menu items.

**Cause**
When looking in detail, I discovered that the regular menu items dynamically get a `dense` value set, but that the `DashboardMenuItem` doesn't get this value. Besides that it configures the `dense` prop to always be true.

**Changes described**
I modified the `DashboardMenuItem` so it doesn't configure the `dense` prop itself, but it instead relies on the props passed. I changed the `Menu` so it passes the `dense` prop to the `DashboardMenuItem` just like it does for the other menu items.