### PR TITLE
Small fixes for SSR

### DIFF
--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -73,9 +73,13 @@ React-admin requires a valid dataProvider function to work.`);
             <AuthContext.Provider value={finalAuthProvider}>
                 <DataProviderContext.Provider value={finalDataProvider}>
                     <TranslationProvider i18nProvider={i18nProvider}>
-                        <ConnectedRouter history={finalHistory}>
-                            {children}
-                        </ConnectedRouter>
+                        {typeof window !== 'undefined' ? (
+                            <ConnectedRouter history={finalHistory}>
+                                {children}
+                            </ConnectedRouter>
+                        ) : (
+                            children
+                        )}
                     </TranslationProvider>
                 </DataProviderContext.Provider>
             </AuthContext.Provider>

--- a/packages/ra-core/src/i18n/TranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TranslationProvider.tsx
@@ -2,7 +2,6 @@ import React, {
     useCallback,
     useMemo,
     Children,
-    ReactElement,
     FunctionComponent,
 } from 'react';
 
@@ -13,7 +12,6 @@ import { I18nProvider } from '../types';
 interface Props {
     locale?: string;
     i18nProvider: I18nProvider;
-    children: ReactElement<any>;
 }
 
 /**

--- a/packages/ra-ui-materialui/src/layout/Title.js
+++ b/packages/ra-ui-materialui/src/layout/Title.js
@@ -5,7 +5,10 @@ import { useTranslate, warning } from 'ra-core';
 
 const Title = ({ className, defaultTitle, locale, record, title, ...rest }) => {
     const translate = useTranslate();
-    const container = document.getElementById('react-admin-title');
+    const container =
+        typeof document !== 'undefined'
+            ? document.getElementById('react-admin-title')
+            : null;
     if (!container) return null;
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 


### PR DESCRIPTION
It doesn't seem like SSR is supported, and the process is complicated when it involves data fetching. Maybe it will never be supported out of the box, but I'm hoping I can make some changes to make it possible with a custom setup.

These are two small changes just to allow rendering to be successful server side (even though data is incomplete).
- `ConnectedRouter` interferes with `StaticRouter` and can just be ignored server side.
  https://github.com/supasate/connected-react-router/pull/322
- `Title` component was assuming `document` exists. Now it just silently fails, which is the same as not finding the `#react-admin-title` container. 
  What we really need here is a portal implementation that works server side. There's some POCs for this, but they are just that. I'm still thinking about a better way to implement this.