### PR TITLE
[RFC] Theming documentation: MyUserMenu passed as component

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -465,7 +465,7 @@ const MyCustomIcon = () => {
 
 const MyUserMenu = props => (<UserMenu {...props} icon={MyCustomIcon} />);
 
-const MyAppBar = props => <AppBar {...props} userMenu={MyUserMenu} />;
+const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
 ```
 {% endraw %}
 


### PR DESCRIPTION
I think that the userMenu prop for the custom AppBar MyAppBar should be passed as a component, or it will trigger an "Error: Element type is invalid"