### PR TITLE
Update documentation regarding pre-configured props of `react-final-form` 

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -381,7 +381,7 @@ React-admin provides guessers for the `List` view (`ListGuesser`), the `Edit` vi
 
 The `<SimpleForm>` component receives the `record` as prop from its parent component. It is responsible for rendering the actual form. It is also responsible for validating the form data. Finally, it receives a `handleSubmit` function as prop, to be called with the updated record as argument when the user submits the form.
 
-The `<SimpleForm>` renders its child components line by line (within `<div>` components). It accepts Input and Field components as children. It relies on `react-final-form` for form handling. Note that some props of `react-final-form` is given by `react-admin` as the result of a design choice. For instance, `keepDirtyOnReinitialize` is set to be `true` in `react-admin`, but it's `false` in `react-final-form` by default. However, you can override this props with any values you want because `react-admin` passes down props to to the underlying component in order to give flexibility to developers.
+The `<SimpleForm>` renders its child components line by line (within `<div>` components). It accepts Input and Field components as children. It relies on `react-final-form` for form handling. Note that some props of `react-final-form` is given by `react-admin` as the result of a design choice. For instance, `keepDirtyOnReinitialize` is set to be `true` in `react-admin`, but it's `false` in `react-final-form` by default. However, you can override this props with any values you want because `react-admin` passes down props to to the underlying component.
 
 ![post edition form](./img/post-edition.png)
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -381,7 +381,7 @@ React-admin provides guessers for the `List` view (`ListGuesser`), the `Edit` vi
 
 The `<SimpleForm>` component receives the `record` as prop from its parent component. It is responsible for rendering the actual form. It is also responsible for validating the form data. Finally, it receives a `handleSubmit` function as prop, to be called with the updated record as argument when the user submits the form.
 
-The `<SimpleForm>` renders its child components line by line (within `<div>` components). It accepts Input and Field components as children. It relies on `react-final-form` for form handling. Note that some props of `react-final-form` is given by `react-admin` as the result of a design choice. For instance, `keepDirtyOnReinitialize` is set to be `true` in `react-admin`, but it's `false` in `react-final-form` by default. However, you can override this props with any values you want because `react-admin` passes down props to to the underlying component.
+The `<SimpleForm>` renders its child components line by line (within `<div>` components). It accepts Input and Field components as children. It relies on `react-final-form` for form handling. Note that some props of `react-final-form` are given by `react-admin` as the result of a design choice. For instance, `keepDirtyOnReinitialize` is set to be `true` in `react-admin`, but it's `false` in `react-final-form` by default. However, you can override this props with any values you want because `react-admin` passes down props to to the underlying component.
 
 ![post edition form](./img/post-edition.png)
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -381,7 +381,7 @@ React-admin provides guessers for the `List` view (`ListGuesser`), the `Edit` vi
 
 The `<SimpleForm>` component receives the `record` as prop from its parent component. It is responsible for rendering the actual form. It is also responsible for validating the form data. Finally, it receives a `handleSubmit` function as prop, to be called with the updated record as argument when the user submits the form.
 
-The `<SimpleForm>` renders its child components line by line (within `<div>` components). It accepts Input and Field components as children. It relies on `react-final-form` for form handling.
+The `<SimpleForm>` renders its child components line by line (within `<div>` components). It accepts Input and Field components as children. It relies on `react-final-form` for form handling. Note that some props of `react-final-form` is given by `react-admin` as the result of a design choice. For instance, `keepDirtyOnReinitialize` is set to be `true` in `react-admin`, but it's `false` in `react-final-form` by default. However, you can override this props with any values you want because `react-admin` passes down props to to the underlying component in order to give flexibility to developers.
 
 ![post edition form](./img/post-edition.png)
 


### PR DESCRIPTION
# Summary
- ~~It closes #4201~~ (already closed by @fzaninotto). I made this PR to address the issue in #4201. Some props of `react-final-form` are pre-configured. For instance. `keepDirtyOnReinitialize` for `SimpleForm` because of better design choice. Since there is a chance where newcomers might not expect it, I made this PR to explain a little bit more detail of the idea of @fzaninotto. Please see https://github.com/marmelab/react-admin/issues/4201#issuecomment-571471919 understand @fzaninotto's thoughts on the overridden props of dependencies more in detail.
- I did not change any existing explanation but add new sentences. I hope this helps other developers in the future including my team.
