### PR TITLE
Fix cache timeout reload list

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/data.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import { DELETE, DELETE_MANY } from '../../../core';
 import getFetchedAt from '../../../util/getFetchedAt';
-import dataReducer, { addRecords } from './data';
+import dataReducer, { addRecords, addOneRecord } from './data';
 
 jest.mock('../../../util/getFetchedAt');
 
@@ -103,6 +103,56 @@ describe('data addRecordsFactory', () => {
         assert.deepEqual(newState, {
             record1: { id: 'record1', title: 'new title' },
             record2: { id: 'record2' },
+        });
+    });
+});
+
+describe('data addOneRecord', () => {
+    it('should add given record without changing the others', () => {
+        const now = new Date();
+        const before = new Date(0);
+        const newRecord = { id: 'new_record', title: 'new title' };
+        const oldRecords = {
+            record1: { id: 'record1', title: 'title 1' },
+            record2: { id: 'record2', title: 'title 2' },
+            fetchedAt: { record1: before, record2: before },
+        };
+
+        const newState = addOneRecord(newRecord, oldRecords, now);
+
+        assert.deepEqual(newState, {
+            record1: { id: 'record1', title: 'title 1' },
+            record2: { id: 'record2', title: 'title 2' },
+            new_record: { id: 'new_record', title: 'new title' },
+        });
+
+        assert.deepEqual(newState.fetchedAt, {
+            record1: before,
+            record2: before,
+            new_record: now,
+        });
+    });
+
+    it('should update given record without changing the others', () => {
+        const now = new Date();
+        const before = new Date(0);
+        const newRecord = { id: 'record1', title: 'new title' };
+        const oldRecords = {
+            record1: { id: 'record1', title: 'title 1' },
+            record2: { id: 'record2', title: 'title 2' },
+            fetchedAt: { record1: before, record2: before },
+        };
+
+        const newState = addOneRecord(newRecord, oldRecords, now);
+
+        assert.deepEqual(newState, {
+            record1: { id: 'record1', title: 'new title' },
+            record2: { id: 'record2', title: 'title 2' },
+        });
+
+        assert.deepEqual(newState.fetchedAt, {
+            record1: now,
+            record2: before,
         });
     });
 });

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.ts
@@ -1,8 +1,15 @@
 import assert from 'assert';
 
-import { DELETE, DELETE_MANY, UPDATE } from '../../../core';
+import {
+    DELETE,
+    DELETE_MANY,
+    UPDATE,
+    GET_MANY,
+    GET_MANY_REFERENCE,
+} from '../../../core';
 import getFetchedAt from '../../../util/getFetchedAt';
 import dataReducer, { replaceRecords, addOneRecord } from './data';
+import { FETCH_END } from '../../../actions';
 
 jest.mock('../../../util/getFetchedAt');
 
@@ -251,6 +258,55 @@ describe('Resources data reducer', () => {
             assert.deepEqual(newState.fetchedAt.record3, before);
 
             assert.notDeepEqual(newState.fetchedAt.record2, before);
+        });
+    });
+
+    describe.each([GET_MANY_REFERENCE, GET_MANY])('%s', actionType => {
+        it('should add new records to the old one', () => {
+            const before = new Date(0);
+            const now = new Date();
+
+            // @ts-ignore
+            getFetchedAt.mockImplementationOnce(() => ({
+                new_record: now,
+                record2: now,
+            }));
+
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+                fetchedAt: {
+                    record1: before,
+                    record2: before,
+                    record3: before,
+                },
+            };
+
+            const newState = dataReducer(state, {
+                type: actionType,
+                payload: {
+                    data: [
+                        { id: 'record2', prop: 'updated value' },
+                        { id: 'new_record', prop: 'new value' },
+                    ],
+                },
+                meta: {
+                    fetchResponse: actionType,
+                    fetchStatus: FETCH_END,
+                },
+            });
+            assert.deepEqual(newState, {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'updated value' },
+                record3: { id: 'record3', prop: 'value' },
+                new_record: { id: 'new_record', prop: 'new value' },
+            });
+            assert.deepEqual(newState.fetchedAt.record1, before);
+            assert.deepEqual(newState.fetchedAt.record3, before);
+
+            assert.notDeepEqual(newState.fetchedAt.record2, before);
+            assert.notDeepEqual(newState.fetchedAt.new_record, before);
         });
     });
 });

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.ts
@@ -6,6 +6,8 @@ import {
     UPDATE,
     GET_MANY,
     GET_MANY_REFERENCE,
+    CREATE,
+    GET_ONE,
 } from '../../../core';
 import getFetchedAt from '../../../util/getFetchedAt';
 import dataReducer, { replaceRecords, addRecords, addOneRecord } from './data';
@@ -347,6 +349,40 @@ describe('Resources data reducer', () => {
                 meta: {
                     fetch: UPDATE,
                     optimistic: true,
+                },
+            });
+            assert.deepEqual(newState, {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'new value' },
+                record3: { id: 'record3', prop: 'value' },
+            });
+            assert.deepEqual(newState.fetchedAt.record1, before);
+            assert.deepEqual(newState.fetchedAt.record3, before);
+
+            assert.notDeepEqual(newState.fetchedAt.record2, before);
+        });
+    });
+
+    describe.each([UPDATE, CREATE, GET_ONE])('%s', actionType => {
+        it('update the given record without touching the other', () => {
+            const before = new Date(0);
+            const state = {
+                record1: { id: 'record1', prop: 'value' },
+                record2: { id: 'record2', prop: 'value' },
+                record3: { id: 'record3', prop: 'value' },
+                fetchedAt: {
+                    record1: before,
+                    record2: before,
+                    record3: before,
+                },
+            };
+
+            const newState = dataReducer(state, {
+                type: 'FOO',
+                payload: { data: { id: 'record2', prop: 'new value' } },
+                meta: {
+                    fetchResponse: actionType,
+                    fetchStatus: FETCH_END,
                 },
             });
             assert.deepEqual(newState, {

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.ts
@@ -2,11 +2,11 @@ import assert from 'assert';
 
 import { DELETE, DELETE_MANY, UPDATE } from '../../../core';
 import getFetchedAt from '../../../util/getFetchedAt';
-import dataReducer, { addRecords, addOneRecord } from './data';
+import dataReducer, { replaceRecords, addOneRecord } from './data';
 
 jest.mock('../../../util/getFetchedAt');
 
-describe('data addRecordsFactory', () => {
+describe('data replaceRecordsFactory', () => {
     it('should call getFetchedAt with newRecords ids and oldRecordFetchedAt and return records returned by getFetchedAt', () => {
         const newRecords = [{ id: 'record1' }, { id: 'record2' }];
         const oldFetchedAt = {};
@@ -21,7 +21,7 @@ describe('data addRecordsFactory', () => {
             record2: date2,
         }));
 
-        const newState = addRecords(newRecords, oldRecords);
+        const newState = replaceRecords(newRecords, oldRecords);
 
         // @ts-ignore
         assert.deepEqual(getFetchedAt.mock.calls[0], [
@@ -53,7 +53,7 @@ describe('data addRecordsFactory', () => {
             record2: new Date(),
         }));
 
-        const newState = addRecords(newRecords, oldRecords);
+        const newState = replaceRecords(newRecords, oldRecords);
 
         assert.deepEqual(newState, {
             record1: { id: 'record1' },
@@ -74,7 +74,7 @@ describe('data addRecordsFactory', () => {
             record3: new Date(),
         }));
 
-        const newState = addRecords(newRecords, oldRecords);
+        const newState = replaceRecords(newRecords, oldRecords);
 
         assert.deepEqual(newState, {
             record1: { id: 'record1' },
@@ -98,7 +98,7 @@ describe('data addRecordsFactory', () => {
             record2: new Date(),
         }));
 
-        const newState = addRecords(newRecords, oldRecords);
+        const newState = replaceRecords(newRecords, oldRecords);
 
         assert.deepEqual(newState, {
             record1: { id: 'record1', title: 'new title' },

--- a/packages/ra-core/src/reducer/admin/resource/data.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.spec.ts
@@ -10,12 +10,16 @@ import {
     GET_ONE,
 } from '../../../core';
 import getFetchedAt from '../../../util/getFetchedAt';
-import dataReducer, { replaceRecords, addRecords, addOneRecord } from './data';
+import dataReducer, {
+    addRecordsAndRemoveOutdated,
+    addRecords,
+    addOneRecord,
+} from './data';
 import { FETCH_END } from '../../../actions';
 
 jest.mock('../../../util/getFetchedAt');
 
-describe('data replaceRecordsFactory', () => {
+describe('data addRecordsAndRemoveOutdated', () => {
     it('should call getFetchedAt with newRecords ids and oldRecordFetchedAt and return records returned by getFetchedAt', () => {
         const newRecords = [{ id: 'record1' }, { id: 'record2' }];
         const oldFetchedAt = {};
@@ -30,7 +34,7 @@ describe('data replaceRecordsFactory', () => {
             record2: date2,
         }));
 
-        const newState = replaceRecords(newRecords, oldRecords);
+        const newState = addRecordsAndRemoveOutdated(newRecords, oldRecords);
 
         // @ts-ignore
         assert.deepEqual(getFetchedAt.mock.calls[0], [
@@ -62,7 +66,7 @@ describe('data replaceRecordsFactory', () => {
             record2: new Date(),
         }));
 
-        const newState = replaceRecords(newRecords, oldRecords);
+        const newState = addRecordsAndRemoveOutdated(newRecords, oldRecords);
 
         assert.deepEqual(newState, {
             record1: { id: 'record1' },
@@ -83,7 +87,7 @@ describe('data replaceRecordsFactory', () => {
             record3: new Date(),
         }));
 
-        const newState = replaceRecords(newRecords, oldRecords);
+        const newState = addRecordsAndRemoveOutdated(newRecords, oldRecords);
 
         assert.deepEqual(newState, {
             record1: { id: 'record1' },
@@ -107,7 +111,7 @@ describe('data replaceRecordsFactory', () => {
             record2: new Date(),
         }));
 
-        const newState = replaceRecords(newRecords, oldRecords);
+        const newState = addRecordsAndRemoveOutdated(newRecords, oldRecords);
 
         assert.deepEqual(newState, {
             record1: { id: 'record1', title: 'new title' },

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -62,7 +62,7 @@ export const hideFetchedAt = (
  * The cached data is displayed before fetching, and stale data is removed
  * only once fresh data is fetched.
  */
-export const addRecords = (
+export const replaceRecords = (
     newRecords: Record[] = [],
     oldRecords: RecordSetWithDate
 ): RecordSetWithDate => {
@@ -142,7 +142,7 @@ const dataReducer: Reducer<RecordSetWithDate> = (
                 ...previousState[id],
                 ...payload.data,
             }));
-            return addRecords(updatedRecords, previousState);
+            return replaceRecords(updatedRecords, previousState);
         }
         if (meta.fetch === DELETE) {
             return removeRecords([payload.id], previousState);
@@ -157,10 +157,10 @@ const dataReducer: Reducer<RecordSetWithDate> = (
 
     switch (meta.fetchResponse) {
         case GET_LIST:
-            return addRecords(payload.data, previousState);
+            return replaceRecords(payload.data, previousState);
         case GET_MANY:
         case GET_MANY_REFERENCE:
-            return addRecords(
+            return replaceRecords(
                 Object.values(previousState).concat(payload.data) as Record[],
                 previousState
             );

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -88,7 +88,8 @@ export const addRecords = (
 };
 export const addOneRecord = (
     newRecord: Record,
-    oldRecords: RecordSetWithDate
+    oldRecords: RecordSetWithDate,
+    date = new Date()
 ): RecordSetWithDate => {
     const newRecordsById = {
         ...oldRecords,
@@ -97,14 +98,10 @@ export const addOneRecord = (
             : newRecord,
     };
 
-    const newFetchedAt = getFetchedAt(
-        Object.keys(newRecordsById),
-        oldRecords.fetchedAt
-    );
-
     return Object.defineProperty(newRecordsById, 'fetchedAt', {
-        value: newFetchedAt,
-    }); // non enumerable by default
+        value: { ...oldRecords.fetchedAt, [newRecord.id]: date },
+        enumerable: false,
+    });
 };
 
 /**

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -86,6 +86,26 @@ export const addRecords = (
 
     return hideFetchedAt(records);
 };
+export const addOneRecord = (
+    newRecord: Record,
+    oldRecords: RecordSetWithDate
+): RecordSetWithDate => {
+    const newRecordsById = {
+        ...oldRecords,
+        [newRecord.id]: isEqual(newRecord, oldRecords[newRecord.id])
+            ? oldRecords[newRecord.id] // do not change the record to avoid a redraw
+            : newRecord,
+    };
+
+    const newFetchedAt = getFetchedAt(
+        Object.keys(newRecordsById),
+        oldRecords.fetchedAt
+    );
+
+    return Object.defineProperty(newRecordsById, 'fetchedAt', {
+        value: newFetchedAt,
+    }); // non enumerable by default
+};
 
 /**
  * Remove records from the pool
@@ -146,7 +166,7 @@ const dataReducer: Reducer<RecordSetWithDate> = (
         case GET_ONE:
         case UPDATE:
         case CREATE:
-            return addRecords([payload.data], previousState);
+            return addOneRecord(payload.data, previousState);
         default:
             return previousState;
     }

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -62,7 +62,7 @@ export const hideFetchedAt = (
  * The cached data is displayed before fetching, and stale data is removed
  * only once fresh data is fetched.
  */
-export const replaceRecords = (
+export const addRecordsAndRemoveOutdated = (
     newRecords: Record[] = [],
     oldRecords: RecordSetWithDate
 ): RecordSetWithDate => {
@@ -170,7 +170,7 @@ const dataReducer: Reducer<RecordSetWithDate> = (
                 ...previousState[id],
                 ...payload.data,
             }));
-            return replaceRecords(updatedRecords, previousState);
+            return addRecordsAndRemoveOutdated(updatedRecords, previousState);
         }
         if (meta.fetch === DELETE) {
             return removeRecords([payload.id], previousState);
@@ -185,7 +185,7 @@ const dataReducer: Reducer<RecordSetWithDate> = (
 
     switch (meta.fetchResponse) {
         case GET_LIST:
-            return replaceRecords(payload.data, previousState);
+            return addRecordsAndRemoveOutdated(payload.data, previousState);
         case GET_MANY:
         case GET_MANY_REFERENCE:
             return addRecords(payload.data, previousState);

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -138,7 +138,7 @@ const dataReducer: Reducer<RecordSetWithDate> = (
                 ...previousState[payload.id],
                 ...payload.data,
             };
-            return addRecords([updatedRecord], previousState);
+            return addOneRecord(updatedRecord, previousState);
         }
         if (meta.fetch === UPDATE_MANY) {
             const updatedRecords = payload.ids.map(id => ({
@@ -160,12 +160,16 @@ const dataReducer: Reducer<RecordSetWithDate> = (
 
     switch (meta.fetchResponse) {
         case GET_LIST:
+            return addRecords(payload.data, previousState);
         case GET_MANY:
         case GET_MANY_REFERENCE:
-            return addRecords(payload.data, previousState);
-        case GET_ONE:
+            return addRecords(
+                Object.values(previousState).concat(payload.data) as Record[],
+                previousState
+            );
         case UPDATE:
         case CREATE:
+        case GET_ONE:
             return addOneRecord(payload.data, previousState);
         default:
             return previousState;

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.spec.ts
@@ -1,8 +1,12 @@
 import assert from 'assert';
 
-import { IdentifierArrayWithDate, addRecordIdsFactory } from './ids';
+import {
+    IdentifierArrayWithDate,
+    addRecordIdsFactory,
+    addOneRecordId,
+} from './ids';
 
-describe('data addRecordIdsFactory', () => {
+describe('ids addRecordIdsFactory', () => {
     it('should call getFetchedAt with newRecords ids and oldRecordFetchedAt and return records returned by getFetchedAt', () => {
         const newRecords: IdentifierArrayWithDate = ['record1', 'record2'];
         const oldRecords: IdentifierArrayWithDate = [];
@@ -64,5 +68,55 @@ describe('data addRecordIdsFactory', () => {
         );
 
         assert.deepEqual(newState, ['record3', 'record1', 'record2']);
+    });
+});
+
+describe('ids addOneRecordId', () => {
+    it('should add new RecordId without touching the existing ones', () => {
+        const now = new Date();
+        const before = new Date(0);
+        const oldRecords = ['record1', 'record2', 'record3'];
+        // @ts-ignore
+        oldRecords.fetchedAt = {
+            record1: before,
+            record2: before,
+            record3: before,
+        };
+
+        const newState = addOneRecordId('new_record', oldRecords);
+
+        assert.deepEqual(newState, [
+            'record1',
+            'record2',
+            'record3',
+            'new_record',
+        ]);
+        assert.deepEqual(newState.fetchedAt, {
+            record1: before,
+            record2: before,
+            record3: before,
+            new_record: now,
+        });
+    });
+
+    it('should update fetchedAt for given id when he is already here', () => {
+        const now = new Date();
+        const before = new Date(0);
+        const oldRecords = ['record1', 'record2', 'record3'];
+        // @ts-ignore
+        oldRecords.fetchedAt = {
+            record1: before,
+            record2: before,
+            record3: before,
+        };
+
+        const newState = addOneRecordId('record1', oldRecords);
+
+        assert.deepEqual(newState, ['record1', 'record2', 'record3']);
+        assert.deepEqual(newState.fetchedAt, {
+            record1: now,
+            record2: before,
+            record3: before,
+        });
     });
 });

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.ts
@@ -40,11 +40,11 @@ export const addRecordIdsFactory = getFetchedAtCallback => (
 
 const addRecordIds = addRecordIdsFactory(getFetchedAt);
 
-export const addOneRecordId = (id, oldRecordIds) => {
+export const addOneRecordId = (id, oldRecordIds, date = new Date()) => {
     const newRecordIds = uniq(oldRecordIds.concat(id));
 
     Object.defineProperty(newRecordIds, 'fetchedAt', {
-        value: { ...oldRecordIds.fetchedAt, [id]: new Date() },
+        value: { ...oldRecordIds.fetchedAt, [id]: date },
     }); // non enumerable by default
 
     return newRecordIds;

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.ts
@@ -3,52 +3,14 @@ import uniq from 'lodash/uniq';
 import {
     CRUD_GET_LIST_SUCCESS,
     CrudGetListSuccessAction,
-    CRUD_GET_ONE_SUCCESS,
     CrudGetOneSuccessAction,
     CRUD_CREATE_SUCCESS,
     CrudCreateSuccessAction,
 } from '../../../../actions';
-import getFetchedAt from '../../../../util/getFetchedAt';
 import { DELETE, DELETE_MANY } from '../../../../core';
 import { Identifier } from '../../../../types';
 
 type IdentifierArray = Identifier[];
-
-export interface IdentifierArrayWithDate extends IdentifierArray {
-    fetchedAt?: Date;
-}
-
-type State = IdentifierArrayWithDate;
-
-export const addRecordIdsFactory = getFetchedAtCallback => (
-    newRecordIds: IdentifierArrayWithDate = [],
-    oldRecordIds: IdentifierArrayWithDate
-): IdentifierArrayWithDate => {
-    const newFetchedAt = getFetchedAtCallback(
-        newRecordIds,
-        oldRecordIds.fetchedAt
-    );
-    const recordIds = uniq(
-        oldRecordIds.filter(id => !!newFetchedAt[id]).concat(newRecordIds)
-    );
-
-    Object.defineProperty(recordIds, 'fetchedAt', {
-        value: newFetchedAt,
-    }); // non enumerable by default
-    return recordIds;
-};
-
-const addRecordIds = addRecordIdsFactory(getFetchedAt);
-
-export const addOneRecordId = (id, oldRecordIds, date = new Date()) => {
-    const newRecordIds = uniq(oldRecordIds.concat(id));
-
-    Object.defineProperty(newRecordIds, 'fetchedAt', {
-        value: { ...oldRecordIds.fetchedAt, [id]: date },
-    }); // non enumerable by default
-
-    return newRecordIds;
-};
 
 type ActionTypes =
     | CrudGetListSuccessAction
@@ -60,7 +22,7 @@ type ActionTypes =
           meta: any;
       };
 
-const idsReducer: Reducer<State> = (
+const idsReducer: Reducer<IdentifierArray> = (
     previousState = [],
     action: ActionTypes
 ) => {
@@ -72,24 +34,15 @@ const idsReducer: Reducer<State> = (
             if (index === -1) {
                 return previousState;
             }
-            const newState = [
+            return [
                 ...previousState.slice(0, index),
                 ...previousState.slice(index + 1),
             ];
-
-            Object.defineProperty(newState, 'fetchedAt', {
-                value: previousState.fetchedAt,
-            });
-
-            return newState;
         }
         if (action.meta.fetch === DELETE_MANY) {
             const newState = previousState.filter(
                 el => !action.payload.ids.includes(el)
             );
-            Object.defineProperty(newState, 'fetchedAt', {
-                value: previousState.fetchedAt,
-            });
 
             return newState;
         }
@@ -97,10 +50,9 @@ const idsReducer: Reducer<State> = (
 
     switch (action.type) {
         case CRUD_GET_LIST_SUCCESS:
-            return addRecordIds(action.payload.data.map(({ id }) => id), []);
-        case CRUD_GET_ONE_SUCCESS:
+            return action.payload.data.map(({ id }) => id);
         case CRUD_CREATE_SUCCESS:
-            return addOneRecordId(action.payload.data.id, previousState);
+            return uniq([action.payload.data.id, ...previousState]);
         default:
             return previousState;
     }

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.ts
@@ -40,6 +40,16 @@ export const addRecordIdsFactory = getFetchedAtCallback => (
 
 const addRecordIds = addRecordIdsFactory(getFetchedAt);
 
+export const addOneRecordId = (id, oldRecordIds) => {
+    const newRecordIds = uniq(oldRecordIds.concat(id));
+
+    Object.defineProperty(newRecordIds, 'fetchedAt', {
+        value: { ...oldRecordIds.fetchedAt, [id]: new Date() },
+    }); // non enumerable by default
+
+    return newRecordIds;
+};
+
 type ActionTypes =
     | CrudGetListSuccessAction
     | CrudGetOneSuccessAction
@@ -90,7 +100,7 @@ const idsReducer: Reducer<State> = (
             return addRecordIds(action.payload.data.map(({ id }) => id), []);
         case CRUD_GET_ONE_SUCCESS:
         case CRUD_CREATE_SUCCESS:
-            return addRecordIds([action.payload.data.id], previousState);
+            return addOneRecordId(action.payload.data.id, previousState);
         default:
             return previousState;
     }


### PR DESCRIPTION
fixes #4245, #3727, #3227 
To fix the issue, I add to change the reducer so as to never remove data not impacted by an action even if it is outdated.
For example a GET_ONE would update the other items of the same resources removing all outdated value.
Same for GET_REFERENCE_MANY that would replace all the previous items.

The issue is that if we display an edit form along the list.
Then by opening this edit form (that trigger a GET_ONE) Then this GET_ONE would remove all items except the edited one as well as all reference linket to these items

As an added bonus, now if we are on an edit page and return on the list after the cache has expired: The old list will first be displayed, before fetching the new data and if the data did not change, we get no rerender. As opposed to displaying the list with only the edited item, before reloading the rest.

