### PR TITLE
Fix typo in CreateEdit.md missing payload key in create call.

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1284,7 +1284,7 @@ const SaveWithNoteButton = props => {
 
         create(
             {
-                data: { ...formState.values, average_note: 10 },
+                payload: { data: { ...formState.values, average_note: 10 } },
             },
             {
                 onSuccess: ({ data: newRecord }) => {


### PR DESCRIPTION
Updated the example of useCreate, if you use just data, no data will be sent to the backend.