### PR TITLE
[RFR] Convert the Menu, MenuItem and DashboardMenuItem to TypeScript

### DIFF
--- a/packages/ra-ui-materialui/src/layout/DashboardMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/DashboardMenuItem.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { FC } from 'react';
 import PropTypes from 'prop-types';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import { useTranslate } from 'ra-core';
 
 import MenuItemLink from './MenuItemLink';
 
-const DashboardMenuItem = ({ locale, onClick, ...props }) => {
+const DashboardMenuItem: FC<DashboardMenuItemProps> = ({
+    locale,
+    onClick,
+    ...props
+}) => {
     const translate = useTranslate();
     return (
         <MenuItemLink
@@ -19,10 +23,20 @@ const DashboardMenuItem = ({ locale, onClick, ...props }) => {
     );
 };
 
+export interface DashboardMenuItemProps {
+    classes?: object;
+    locale?: string;
+    onClick?: () => void;
+    dense?: boolean;
+    sidebarIsOpen: boolean;
+}
+
 DashboardMenuItem.propTypes = {
     classes: PropTypes.object,
     locale: PropTypes.string,
     onClick: PropTypes.func,
+    dense: PropTypes.bool,
+    sidebarIsOpen: PropTypes.bool,
 };
 
 export default DashboardMenuItem;

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -69,7 +69,6 @@ const Menu: FC<MenuProps> = ({
                 .map(resource => (
                     <MenuItemLink
                         key={resource.name}
-                        // @ts-ignore
                         to={`/${resource.name}`}
                         primaryText={translatedResourceName(
                             resource,

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { FC, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector } from 'react-redux';
+// @ts-ignore
 import inflection from 'inflection';
-import { makeStyles, useMediaQuery } from '@material-ui/core';
+import { makeStyles, useMediaQuery, Theme } from '@material-ui/core';
 import DefaultIcon from '@material-ui/icons/ViewList';
 import classnames from 'classnames';
-import { getResources, useTranslate } from 'ra-core';
+import { getResources, useTranslate, Translate, ReduxState } from 'ra-core';
 
 import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
@@ -21,7 +22,7 @@ const useStyles = makeStyles(
     { name: 'RaMenu' }
 );
 
-const translatedResourceName = (resource, translate) =>
+const translatedResourceName = (resource: any, translate: Translate) =>
     translate(`resources.${resource.name}.name`, {
         smart_count: 2,
         _:
@@ -33,7 +34,7 @@ const translatedResourceName = (resource, translate) =>
                 : inflection.humanize(inflection.pluralize(resource.name)),
     });
 
-const Menu = ({
+const Menu: FC<MenuProps> = ({
     classes: classesOverride,
     className,
     dense,
@@ -44,14 +45,19 @@ const Menu = ({
 }) => {
     const translate = useTranslate();
     const classes = useStyles({ classes: classesOverride });
-    const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
-    const open = useSelector(state => state.admin.ui.sidebarOpen);
-    const resources = useSelector(getResources, shallowEqual);
-    useSelector(state => state.router.location.pathname); // used to force redraw on navigation
+    const isXSmall = useMediaQuery((theme: Theme) =>
+        theme.breakpoints.down('xs')
+    );
+    const open = useSelector((state: ReduxState) => state.admin.ui.sidebarOpen);
+    const resources = useSelector(getResources, shallowEqual) as Array<any>;
+
+    // Used to force redraw on navigation
+    useSelector((state: ReduxState) => state.router.location.pathname);
 
     return (
         <div className={classnames(classes.main, className)} {...rest}>
             {hasDashboard && (
+                // @ts-ignore
                 <DashboardMenuItem
                     onClick={onMenuClick}
                     dense={dense}
@@ -63,6 +69,7 @@ const Menu = ({
                 .map(resource => (
                     <MenuItemLink
                         key={resource.name}
+                        // @ts-ignore
                         to={`/${resource.name}`}
                         primaryText={translatedResourceName(
                             resource,
@@ -80,6 +87,15 @@ const Menu = ({
         </div>
     );
 };
+
+export interface MenuProps {
+    classes?: object;
+    className?: string;
+    dense?: boolean;
+    hasDashboard: boolean;
+    logout?: ReactElement;
+    onMenuClick?: () => void;
+}
 
 Menu.propTypes = {
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -57,7 +57,6 @@ const Menu: FC<MenuProps> = ({
     return (
         <div className={classnames(classes.main, className)} {...rest}>
             {hasDashboard && (
-                // @ts-ignore
                 <DashboardMenuItem
                     onClick={onMenuClick}
                     dense={dense}

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -32,9 +32,7 @@ const useStyles = makeStyles(
     { name: 'RaMenuItemLink' }
 );
 
-const MenuItemLink: FC<
-    MenuItemLinkProps & NavLinkProps & MenuItemProps<'li', { button?: true }> // HACK: https://github.com/mui-org/material-ui/issues/16245
-> = forwardRef(
+const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
     (
         {
             classes: classesOverride,
@@ -90,12 +88,16 @@ const MenuItemLink: FC<
     }
 );
 
-export interface MenuItemLinkProps {
+interface Props {
     leftIcon?: ReactElement;
     primaryText?: ReactNode;
     staticContext?: StaticContext;
     sidebarIsOpen: boolean;
 }
+
+export type MenuItemLinkProps = Props &
+    NavLinkProps &
+    MenuItemProps<'li', { button?: true }>; // HACK: https://github.com/mui-org/material-ui/issues/16245
 
 MenuItemLink.propTypes = {
     classes: PropTypes.object,
@@ -105,6 +107,7 @@ MenuItemLink.propTypes = {
     primaryText: PropTypes.node,
     staticContext: PropTypes.object,
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+    sidebarIsOpen: PropTypes.bool,
 };
 
 export default MenuItemLink;

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -1,13 +1,21 @@
-import React, { forwardRef, cloneElement, useCallback } from 'react';
+import React, {
+    forwardRef,
+    cloneElement,
+    useCallback,
+    FC,
+    ReactElement,
+    ReactNode,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { NavLink } from 'react-router-dom';
-import MenuItem from '@material-ui/core/MenuItem';
+import { StaticContext } from 'react-router';
+import { NavLink, NavLinkProps } from 'react-router-dom';
+import MenuItem, { MenuItemProps } from '@material-ui/core/MenuItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Tooltip from '@material-ui/core/Tooltip';
 import { makeStyles } from '@material-ui/core/styles';
 
-const NavLinkRef = React.forwardRef((props, ref) => (
+const NavLinkRef = forwardRef<HTMLAnchorElement, NavLinkProps>((props, ref) => (
     <NavLink innerRef={ref} {...props} />
 ));
 
@@ -24,7 +32,9 @@ const useStyles = makeStyles(
     { name: 'RaMenuItemLink' }
 );
 
-const MenuItemLink = forwardRef(
+const MenuItemLink: FC<
+    MenuItemLinkProps & NavLinkProps & MenuItemProps<'li', { button?: true }> // HACK: https://github.com/mui-org/material-ui/issues/16245
+> = forwardRef(
     (
         {
             classes: classesOverride,
@@ -79,6 +89,13 @@ const MenuItemLink = forwardRef(
         );
     }
 );
+
+export interface MenuItemLinkProps {
+    leftIcon?: ReactElement;
+    primaryText?: ReactNode;
+    staticContext?: StaticContext;
+    sidebarIsOpen: boolean;
+}
 
 MenuItemLink.propTypes = {
     classes: PropTypes.object,


### PR DESCRIPTION
I wanted to make an addition to the Menu component, when going into the source I discovered that it was still written in JavaScript and not yet converted to TypeScript. Therefore I have now first converted the existing component to TypeScript. Later a pull request will follow with an addition to the Menu.

I converted the Menu and its MenuItem and DashboardMenuItem child components to TypeScript. The functionality and interfaces have stayed the same.