### PR TITLE
fix(ra-ui-materialui): bump prop-types package version to ^15.7.0

### DIFF
--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -75,7 +75,7 @@
         "inflection": "~1.12.0",
         "jsonexport": "^2.4.1",
         "lodash": "~4.17.5",
-        "prop-types": "^15.6.1",
+        "prop-types": "^15.7.0",
         "query-string": "^5.1.1",
         "react-dropzone": "^10.1.7",
         "react-transition-group": "^2.2.1",


### PR DESCRIPTION
`ra-ui-material` uses `PropTypes.elementType` in the following places:
```
./src/layout/Confirm.js:133:    ConfirmIcon: PropTypes.elementType.isRequired,
./src/layout/Confirm.js:134:    CancelIcon: PropTypes.elementType.isRequired,
./src/list/DatagridLoading.js:116:    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
./src/list/Datagrid.js:267:    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
./src/list/DatagridRow.js:193:    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
./src/list/DatagridBody.js:67:    expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
```

However, `elementType` was added in `prop-types` version [15.7.0](https://github.com/facebook/prop-types/blob/master/CHANGELOG.md#1570). This means it's not compatible with 15.6.1, as it says in package.json.