### PR TITLE
Fix warning on catchall page due to improper sanitization in <NotFound> component.

### DIFF
--- a/packages/ra-ui-materialui/src/layout/NotFound.js
+++ b/packages/ra-ui-materialui/src/layout/NotFound.js
@@ -69,7 +69,7 @@ const NotFound = ({ className, classes: classesOverride, title, ...rest }) => {
     );
 };
 
-const sanitizeRestProps = ({ 
+const sanitizeRestProps = ({
     staticContext,
     history,
     location,

--- a/packages/ra-ui-materialui/src/layout/NotFound.js
+++ b/packages/ra-ui-materialui/src/layout/NotFound.js
@@ -69,7 +69,13 @@ const NotFound = ({ className, classes: classesOverride, title, ...rest }) => {
     );
 };
 
-const sanitizeRestProps = ({ location, ...rest }) => rest;
+const sanitizeRestProps = ({ 
+    staticContext,
+    history,
+    location,
+    match,
+    ...rest
+}) => rest;
 
 NotFound.propTypes = {
     className: PropTypes.string,


### PR DESCRIPTION
This could happend from `RoutesWithLayout.tsx`.
```jsx
...
<Route
    render={routeProps =>
        createElement(catchAll, {
            ...routeProps,
            title,
        })
    }
 />
...