### PR TITLE
Fix types on CoreAdminUI

### DIFF
--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -20,13 +20,13 @@ const DefaultLayout: FunctionComponent<LayoutProps> = ({ children }) => (
 );
 
 export interface CoreAdminUIProps {
-    catchAll: CatchAllComponent;
+    catchAll?: CatchAllComponent;
     children?: AdminChildren;
     customRoutes?: CustomRoutes;
     dashboard?: DashboardComponent;
-    layout: LayoutComponent;
-    loading: ComponentType;
-    loginPage: LoginComponent | boolean;
+    layout?: LayoutComponent;
+    loading?: ComponentType;
+    loginPage?: LoginComponent | boolean;
     logout?: ComponentType;
     menu?: ComponentType;
     theme?: object;


### PR DESCRIPTION
All "required" props had default values, which means they aren't required. 