### PR TITLE
Fix error in Confirm due to bad prop-types package version

### DIFF
--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -75,7 +75,7 @@
         "inflection": "~1.12.0",
         "jsonexport": "^2.4.1",
         "lodash": "~4.17.5",
-        "prop-types": "^15.6.1",
+        "prop-types": "^15.7.0",
         "query-string": "^5.1.1",
         "react-dropzone": "^10.1.7",
         "react-transition-group": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12359,7 +12359,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
#3812 introduced PropTypes.elementType, which is only available as of prop-types 15.7. We need to update the version required by ra-ui-material-ui to avoid an error.

Closes #4283