### PR TITLE
fix(simple-form-iterator): Fixes object-object when there is a single TextInput without source param.

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -103,9 +103,14 @@ export class SimpleFormIterator extends Component {
     };
 
     addField = () => {
-        const { fields } = this.props;
+        const { fields, children } = this.props;
         this.ids.push(this.nextId++);
-        fields.push({});
+        // Checks if there is just 1 children without source param then push string since it's not an {}
+        if (children.props && children.props.source === undefined) {
+            fields.push('');
+        } else {
+            fields.push({});
+        }
     };
 
     render() {


### PR DESCRIPTION
This could be a good start to fix [Object object] issue on SimpleFormIterator. I was able to reproduce and fix the issue if you have a plain array (such as [''tag1, 'tag2', 'tag3'].

I didn't edited docs, but the idea is if you don't specify a `source` param in the TextInput and it's just 1 input > it's a plain string array otherwise it's an object (you could add more than just input or just name property as you wish on `source`)

#2489