### PR TITLE
Remove the unused filter prop which in useGetMatchingReference

### DIFF
--- a/packages/ra-core/src/controller/input/useGetMatchingReferences.ts
+++ b/packages/ra-core/src/controller/input/useGetMatchingReferences.ts
@@ -66,7 +66,6 @@ export default ({
 
     const matchingReferences = useGetMatchingReferenceSelector({
         referenceSource,
-        filter,
         reference,
         resource,
         source,
@@ -98,7 +97,6 @@ export default ({
 
 const useGetMatchingReferenceSelector = ({
     referenceSource,
-    filter,
     reference,
     resource,
     source,


### PR DESCRIPTION
Fix #4313

The `useGetMatchingReference` hook has an unused property: `filter`. So I just remove it.

## Todo

- [x] Remove the unused prop
- [x] Fix tests if broken

