### PR TITLE
Fix Menu overlapps the AppBar with material-ui > 4.8

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -39,6 +39,7 @@ const useStyles = makeStyles(
                 border: 'none',
                 marginTop: '1.5em',
             },
+            zIndex: 'inherit',
         },
     }),
     { name: 'RaSidebar' }


### PR DESCRIPTION
Closes #4304

Before:

![Capture d’écran de 2020-01-17 16-42-56](https://user-images.githubusercontent.com/99944/72625112-731e1000-3948-11ea-8b73-7e21b88db63b.png)

After:

![image](https://user-images.githubusercontent.com/99944/72624983-26d2d000-3948-11ea-80f2-481e884e1346.png)

Note: The fact that the menu items look smaller is due to [a change in material-ui 4.5](https://github.com/mui-org/material-ui/pull/17332) (that I consider a regression, but that's their call...). 