### PR TITLE
Export Reference Utilities

### DIFF
--- a/packages/ra-core/src/controller/input/index.ts
+++ b/packages/ra-core/src/controller/input/index.ts
@@ -2,8 +2,16 @@ import ReferenceArrayInputController from './ReferenceArrayInputController';
 import ReferenceInputController from './ReferenceInputController';
 import useReferenceInputController from './useReferenceInputController';
 import useReferenceArrayInputController from './useReferenceArrayInputController';
+import {
+    getStatusForInput,
+    getSelectedReferencesStatus,
+    getStatusForArrayInput,
+} from './referenceDataStatus';
 
 export {
+    getStatusForInput,
+    getSelectedReferencesStatus,
+    getStatusForArrayInput,
     ReferenceArrayInputController,
     ReferenceInputController,
     useReferenceInputController,


### PR DESCRIPTION
This will avoid duplication in addons related to references.
@fzaninotto Should I target the `next` branch ?