### PR TITLE
Reduce the default app weight by removing the image background on the Login screen

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -842,12 +842,17 @@ export default withRouter(Menu);
 
 ### Changing the Background Image
 
-By default, the login page displays a random background image changing every day. If you want to change that background image, you can use the default Login page component and pass an image URL as the `backgroundImage` prop.
+By default, the login page displays a gradient background. If you want to change the background, you can use the default Login page component and pass an image URL as the `backgroundImage` prop.
 
 ```jsx
 import { Admin, Login } from 'react-admin';
 
-const MyLoginPage = () => <Login backgroundImage="/background.jpg" />;
+const MyLoginPage = () => (
+    <Login
+        // A random image that changes everyday
+        backgroundImage="https://source.unsplash.com/random/1600x900/daily"
+    />
+);
 
 const App = () => (
     <Admin loginPage={MyLoginPage}>

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -160,7 +160,6 @@ Login.propTypes = {
 };
 
 Login.defaultProps = {
-    backgroundImage: 'https://source.unsplash.com/random/1600x900/daily',
     theme: defaultTheme,
     children: <DefaultLoginForm />,
 };

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -44,6 +44,8 @@ const useStyles = makeStyles(
             justifyContent: 'flex-start',
             backgroundRepeat: 'no-repeat',
             backgroundSize: 'cover',
+            backgroundImage:
+                'linear-gradient(135deg, #00023b 0%, #00023b 50%, #313264 100%)',
         },
         card: {
             minWidth: 300,

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles(
             backgroundRepeat: 'no-repeat',
             backgroundSize: 'cover',
             backgroundImage:
-                'linear-gradient(135deg, #00023b 0%, #00023b 50%, #313264 100%)',
+                'radial-gradient(circle at 50% 14em, #313264 0%, #00023b 60%, #00023b 100%)',
         },
         card: {
             minWidth: 300,


### PR DESCRIPTION
Replace default unsplash image for Login component by a simple gradient.

Demo login is unchanged.

Preview:

![image](https://user-images.githubusercontent.com/4034399/73068771-56d02500-3eac-11ea-91d9-b34b19116267.png)
