### PR TITLE
Fix typo in ra-data-graphcool and ra-data-graphql-simple README's.

### DIFF
--- a/packages/ra-data-graphcool/README.md
+++ b/packages/ra-data-graphcool/README.md
@@ -153,7 +153,7 @@ const introspectionOptions = {
 };
 ```
 
-**Note**: `exclude` and `include` are mutually exclusives and `include` will take precendance.
+**Note**: `exclude` and `include` are mutually exclusives and `include` will take precedence.
 
 **Note**: When using functions, the `type` argument will be a type returned by the introspection query. Refer to the [introspection](http://graphql.org/learn/introspection/) documentation for more information.
 

--- a/packages/ra-data-graphql-simple/README.md
+++ b/packages/ra-data-graphql-simple/README.md
@@ -202,7 +202,7 @@ const introspectionOptions = {
 };
 ```
 
-**Note**: `exclude` and `include` are mutually exclusives and `include` will take precendance.
+**Note**: `exclude` and `include` are mutually exclusives and `include` will take precedence.
 
 **Note**: When using functions, the `type` argument will be a type returned by the introspection query. Refer to the [introspection](http://graphql.org/learn/introspection/) documentation for more information.
 


### PR DESCRIPTION
I was reading the docs and found this typo.