### PR TITLE
Fix Helper place on Inputs to avoid clipping/unclipping Forms

### DIFF
--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -249,7 +249,7 @@ describe('Create Page', () => {
     });
 
     it('should not show rich text input error message when field is untouched', () => {
-        cy.get(CreatePage.elements.richTextInputError).should('not.exist');
+        cy.get(CreatePage.elements.richTextInputError).should('not.have.value');
     });
 
     it('should show rich text input error message when form is submitted', () => {

--- a/examples/demo/src/ra-input-rich-text.d.ts
+++ b/examples/demo/src/ra-input-rich-text.d.ts
@@ -1,0 +1,1 @@
+declare module 'ra-input-rich-text';

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -107,18 +107,16 @@ const RichTextInput = ({
                 </InputLabel>
             )}
             <div data-testid="quill" ref={divRef} className={variant} />
-            {helperText || (touched && error) ? (
-                <FormHelperText
-                    error={!!error}
-                    className={!!error ? 'ra-rich-text-input-error' : ''}
-                >
-                    <InputHelperText
-                        error={error}
-                        helperText={helperText}
-                        touched={touched}
-                    />
-                </FormHelperText>
-            ) : null}
+            <FormHelperText
+                error={!!error}
+                className={!!error ? 'ra-rich-text-input-error' : ''}
+            >
+                <InputHelperText
+                    error={error}
+                    helperText={helperText}
+                    touched={touched}
+                />
+            </FormHelperText>
         </FormControl>
     );
 };

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -418,13 +418,11 @@ const AutocompleteArrayInput: FunctionComponent<
                                 htmlFor: id,
                             })}
                             helperText={
-                                (touched && error) || helperText ? (
-                                    <InputHelperText
-                                        touched={touched}
-                                        error={error}
-                                        helperText={helperText}
-                                    />
-                                ) : null
+                                <InputHelperText
+                                    touched={touched}
+                                    error={error}
+                                    helperText={helperText}
+                                />
                             }
                             variant={variant}
                             margin={margin}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -362,13 +362,11 @@ const AutocompleteInput: FunctionComponent<
                                 htmlFor: id,
                             })}
                             helperText={
-                                (touched && error) || helperText ? (
-                                    <InputHelperText
-                                        touched={touched}
-                                        error={error}
-                                        helperText={helperText}
-                                    />
-                                ) : null
+                                <InputHelperText
+                                    touched={touched}
+                                    error={error}
+                                    helperText={helperText}
+                                />
                             }
                             variant={variant}
                             margin={margin}

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -74,15 +74,13 @@ const BooleanInput: FunctionComponent<
                     />
                 }
             />
-            {(touched && error) || helperText ? (
-                <FormHelperText error={!!error}>
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                </FormHelperText>
-            ) : null}
+            <FormHelperText error={!!error}>
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
+            </FormHelperText>
         </FormGroup>
     );
 };

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.spec.tsx
@@ -147,7 +147,7 @@ describe('<CheckboxGroupInput />', () => {
                 render={() => (
                     <CheckboxGroupInput
                         {...defaultProps}
-                        optionText={<Foobar />}
+                        optionText={<Foobar record={{}} />}
                         choices={[{ id: 'foo', foobar: 'Bar' }]}
                     />
                 )}
@@ -223,17 +223,17 @@ describe('<CheckboxGroupInput />', () => {
                     render={() => <CheckboxGroupInput {...defaultProps} />}
                 />
             );
-            expect(container.querySelector('p')).toBeNull();
+            expect(container.querySelector('p').innerHTML).toBe('');
         });
 
-        it('should not be displayed if field has been touched but is valid', () => {
+        it('should be empty if field has been touched but is valid', () => {
             const { container } = render(
                 <Form
                     onSubmit={jest.fn}
                     render={() => <CheckboxGroupInput {...defaultProps} />}
                 />
             );
-            expect(container.querySelector('p')).toBeNull();
+            expect(container.querySelector('p').innerHTML).toBe('');
         });
 
         it('should be displayed if field has been touched and is invalid', () => {

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.spec.tsx
@@ -223,7 +223,7 @@ describe('<CheckboxGroupInput />', () => {
                     render={() => <CheckboxGroupInput {...defaultProps} />}
                 />
             );
-            expect(container.querySelector('p').innerHTML).toBe('');
+            expect(container.querySelector('p').innerHTML).toBe(' ');
         });
 
         it('should be empty if field has been touched but is valid', () => {

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.spec.tsx
@@ -233,7 +233,7 @@ describe('<CheckboxGroupInput />', () => {
                     render={() => <CheckboxGroupInput {...defaultProps} />}
                 />
             );
-            expect(container.querySelector('p').innerHTML).toBe('');
+            expect(container.querySelector('p').innerHTML).toBe(' ');
         });
 
         it('should be displayed if field has been touched and is invalid', () => {

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -187,15 +187,13 @@ const CheckboxGroupInput: FunctionComponent<
                     />
                 ))}
             </FormGroup>
-            {(touched && error) || helperText ? (
-                <FormHelperText>
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                </FormHelperText>
-            ) : null}
+            <FormHelperText>
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
+            </FormHelperText>
         </FormControl>
     );
 };

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -86,13 +86,11 @@ export const DateInput: FunctionComponent<
             type="date"
             error={!!(touched && error)}
             helperText={
-                (touched && error) || helperText ? (
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                ) : null
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
             }
             label={
                 <FieldTitle

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -105,13 +105,11 @@ export const DateTimeInput: FunctionComponent<
             margin={margin}
             error={!!(touched && error)}
             helperText={
-                (touched && error) || helperText ? (
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                ) : null
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
             }
             label={
                 <FieldTitle

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -213,15 +213,13 @@ const FileInput: FunctionComponent<
                         ))}
                     </div>
                 )}
-                {(touched && error) || helperText ? (
-                    <FormHelperText>
-                        <InputHelperText
-                            touched={touched}
-                            error={error}
-                            helperText={helperText}
-                        />
-                    </FormHelperText>
-                ) : null}
+                <FormHelperText>
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                </FormHelperText>
             </>
         </Labeled>
     );

--- a/packages/ra-ui-materialui/src/input/InputHelperText.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.spec.tsx
@@ -6,11 +6,11 @@ import InputHelperText from './InputHelperText';
 describe('InputHelperText', () => {
     afterEach(cleanup);
 
-    it('does not render anything when the input has not been touched yet and has no helper text', () => {
+    it('does render empty string when the input has not been touched yet and has no helper text', () => {
         const { container } = render(
             <InputHelperText touched={false} error="Crap!" />
         );
-        expect(container.innerHTML).toBe('');
+        expect(container.innerHTML).toBe(' ');
     });
 
     it('renders the helperText when there is no error', () => {

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -19,7 +19,7 @@ const InputHelperText: FunctionComponent<Props> = ({
     ) : helperText ? (
         <>{translate(helperText, { _: helperText })}</>
     ) : (
-        <>' '</>
+        <> </>
     );
 };
 

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -19,7 +19,7 @@ const InputHelperText: FunctionComponent<Props> = ({
     ) : helperText ? (
         <>{translate(helperText, { _: helperText })}</>
     ) : (
-        <></>
+        ' '
     );
 };
 

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -19,7 +19,7 @@ const InputHelperText: FunctionComponent<Props> = ({
     ) : helperText ? (
         <>{translate(helperText, { _: helperText })}</>
     ) : (
-        ' '
+        <>' '</>
     );
 };
 

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -18,7 +18,9 @@ const InputHelperText: FunctionComponent<Props> = ({
         <ValidationError error={error} />
     ) : helperText ? (
         <>{translate(helperText, { _: helperText })}</>
-    ) : null;
+    ) : (
+        <></>
+    );
 };
 
 export default InputHelperText;

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -82,13 +82,11 @@ const NullableBooleanInput: FunctionComponent<
             }
             error={!!(touched && error)}
             helperText={
-                (touched && error) || helperText ? (
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                ) : null
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
             }
             className={classnames(classes.input, className)}
             variant={variant}

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -77,13 +77,11 @@ const NumberInput: FunctionComponent<
             variant={variant}
             error={!!(touched && error)}
             helperText={
-                (touched && error) || helperText ? (
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                ) : null
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
             }
             label={
                 <FieldTitle

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -156,15 +156,13 @@ export const RadioButtonGroupInput: FunctionComponent<
                     />
                 ))}
             </RadioGroup>
-            {(touched && error) || helperText ? (
-                <FormHelperText>
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                </FormHelperText>
-            ) : null}
+            <FormHelperText>
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
+            </FormHelperText>
         </FormControl>
     );
 };

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -73,13 +73,11 @@ export const TextInput: FunctionComponent<TextInputProps> = ({
             }
             error={!!(touched && error)}
             helperText={
-                (touched && error) || helperText ? (
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                ) : null
+                <InputHelperText
+                    touched={touched}
+                    error={error}
+                    helperText={helperText}
+                />
             }
             {...options}
             {...sanitizeRestProps(rest)}


### PR DESCRIPTION
This PR makes the helper text space always reserved in forms inputs (even if there isn't any error or help text). This prevent forms to change height brutally upon validation, and the submit buttons to move under the mouse pointer.

Forms will be a bit taller than before with this change

![image](https://user-images.githubusercontent.com/39904906/73248791-e11dcf00-41b3-11ea-846b-466303e5c707.png)
