### PR TITLE
Fix Autocomplete selection display with custom Component

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -249,7 +249,7 @@ Lastly, would you need to override the props of the suggestions container (a `Po
 | `matchSuggestion` | Optional | `Function` | - | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`
 | `optionText` | Optional | <code>string &#124; Function &#124; Component</code> | `name` | Fieldname of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`) |
 | `optionValue` | Optional | `string` | `id` | Fieldname of record containing the value to use as input value  |
-| `inputText` | Optional | <code>Function</code> | `-` | If `optionText` is a custom Component, This function is needed to determine the text displayed filter of the current selection. In Autocomplete, the current selection have to be an editable string and can not be a Component  (`(record)=> {string}`) |
+| `inputText` | Optional | <code>Function</code> | `-` | If `optionText` is a custom Component, this function is needed to determine the text displayed for the current selection. |
 | `setFilter` | Optional | `Function` | `null` | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |
 | `shouldRenderSuggestions` | Optional | Function | `() => true` | A function that returns a `boolean` to determine whether or not suggestions are rendered. Use this when working with large collections of data to improve performance and user experience. This function is passed into the underlying react-autosuggest component. Ex.`(value) => value.trim() > 2` |
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -162,7 +162,7 @@ const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
 <AutocompleteInput source="author_id" choices={choices} optionText={optionRenderer} />
 ```
 
-`optionText` also accepts a custom Component. If you provide one, you will have to set the `inputText` function wich determine the input text filter of the current selection:
+`optionText` also accepts a custom Component. However, as the underlying Autocomplete component requires that the current selection is a string, if you opt for a Component, you must pass a function as the `inputText` prop. This function should return text representation of the current selection:
 
 ```jsx
 const choices = [

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -162,7 +162,7 @@ const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
 <AutocompleteInput source="author_id" choices={choices} optionText={optionRenderer} />
 ```
 
-`optionText` also accepts a custom Component. If you do so, you will have to set the inputText function wich determine the input text filter of the current selection:
+`optionText` also accepts a custom Component. If you provide one, you will have to set the `inputText` function wich determine the input text filter of the current selection:
 
 ```jsx
 const choices = [

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -162,6 +162,28 @@ const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
 <AutocompleteInput source="author_id" choices={choices} optionText={optionRenderer} />
 ```
 
+`optionText` also accepts a custom Component. If you do so, you will have to set the inputText function wich determine the input text filter of the current selection:
+
+```jsx
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' avatar='/pengouin' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' avatar='/panda' },
+];
+const OptionRenderer = choice => (
+    <span>
+        <img src={choice.avatar}>
+        {choice.first_name} {choice.last_name}
+    </span>
+);
+const inputText = choice => `${choice.first_name} ${choice.last_name}`;
+<AutocompleteInput
+    source="author_id"
+    choices={choices}
+    optionText={<OptionRenderer />}
+    inputText={inputText}
+/>
+```
+
 The choices are translated by default, so you can use translation identifiers as choices:
 
 ```jsx
@@ -225,8 +247,9 @@ Lastly, would you need to override the props of the suggestions container (a `Po
 | `emptyValue` | Optional | anything | `''` | The value to use for the empty element |
 | `emptyText` | Optional | `string` | `''` | The text to use for the empty element |
 | `matchSuggestion` | Optional | `Function` | - | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`
-| `optionText` | Optional | <code>string &#124; Function</code> | `name` | Fieldname of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`) |
+| `optionText` | Optional | <code>string &#124; Function &#124; Component</code> | `name` | Fieldname of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`) |
 | `optionValue` | Optional | `string` | `id` | Fieldname of record containing the value to use as input value  |
+| `inputText` | Optional | <code>Function</code> | `-` | If `optionText` is a custom Component, This function is needed to determine the text displayed filter of the current selection. In Autocomplete, the current selection have to be an editable string and can not be a Component  (`(record)=> {string}`) |
 | `setFilter` | Optional | `Function` | `null` | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.  |
 | `shouldRenderSuggestions` | Optional | Function | `() => true` | A function that returns a `boolean` to determine whether or not suggestions are rendered. Use this when working with large collections of data to improve performance and user experience. This function is passed into the underlying react-autosuggest component. Ex.`(value) => value.trim() > 2` |
 

--- a/examples/simple/src/comments/CommentEdit.js
+++ b/examples/simple/src/comments/CommentEdit.js
@@ -35,11 +35,11 @@ const useEditStyles = makeStyles({
 
 const OptionRenderer = ({ record }) => (
     <span>
-        {record.title}-{record.id}
+        {record.title} - {record.id}
     </span>
 );
 
-const inputText = record => `${record.title}-${record.id}`;
+const inputText = record => `${record.title} - ${record.id}`;
 
 const CommentEdit = props => {
     const classes = useEditStyles();

--- a/examples/simple/src/comments/CommentEdit.js
+++ b/examples/simple/src/comments/CommentEdit.js
@@ -39,7 +39,7 @@ const OptionRenderer = ({ record }) => (
     </span>
 );
 
-const selectionText = record => `${record.title}-${record.id}`;
+const inputText = record => `${record.title}-${record.id}`;
 
 const CommentEdit = props => {
     const classes = useEditStyles();
@@ -86,22 +86,11 @@ const CommentEdit = props => {
                                     true
                                 }
                                 optionText={<OptionRenderer />}
-                                selectionText={selectionText}
+                                inputText={inputText}
                                 options={{ fullWidth: true }}
                             />
                         </ReferenceInput>
-                        <ReferenceInput
-                            source="post_id"
-                            reference="posts"
-                            perPage={15}
-                            sort={{ field: 'title', order: 'ASC' }}
-                            fullWidth
-                        >
-                            <AutocompleteInput
-                                optionText="title"
-                                options={{ fullWidth: true }}
-                            />
-                        </ReferenceInput>
+
                         <LinkToRelatedPost />
                         <TextInput
                             source="author.name"

--- a/examples/simple/src/comments/CommentEdit.js
+++ b/examples/simple/src/comments/CommentEdit.js
@@ -33,6 +33,14 @@ const useEditStyles = makeStyles({
     },
 });
 
+const OptionRenderer = ({ record }) => (
+    <span>
+        {record.title}-{record.id}
+    </span>
+);
+
+const selectionText = record => `${record.title}-${record.id}`;
+
 const CommentEdit = props => {
     const classes = useEditStyles();
     const {
@@ -66,6 +74,22 @@ const CommentEdit = props => {
                         version={version}
                     >
                         <TextInput disabled source="id" fullWidth />
+                        <ReferenceInput
+                            source="post_id"
+                            reference="posts"
+                            perPage={15}
+                            sort={{ field: 'title', order: 'ASC' }}
+                            fullWidth
+                        >
+                            <AutocompleteInput
+                                matchSuggestion={(filterValue, suggestion) =>
+                                    true
+                                }
+                                optionText={<OptionRenderer />}
+                                selectionText={selectionText}
+                                options={{ fullWidth: true }}
+                            />
+                        </ReferenceInput>
                         <ReferenceInput
                             source="post_id"
                             reference="posts"

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -418,6 +418,7 @@ describe('<AutocompleteInput />', () => {
                         <AutocompleteInput
                             {...defaultProps}
                             optionText={<SuggestionItem />}
+                            inputText={record => record.name}
                             matchSuggestion={(filter, choice) => true}
                             choices={[
                                 { id: 1, name: 'bar' },

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -124,7 +124,7 @@ const AutocompleteInput: FunctionComponent<
         InputProps: undefined,
     },
     optionText = 'name',
-    selectionText,
+    inputText,
     optionValue = 'id',
     parse,
     resource,
@@ -296,8 +296,8 @@ const AutocompleteInput: FunctionComponent<
     return (
         <Downshift
             inputValue={
-                selectionText
-                    ? selectionText(getChoiceText(selectedItem).props.record)
+                inputText
+                    ? inputText(getChoiceText(selectedItem).props.record)
                     : filterValue
             }
             onChange={handleChange}
@@ -379,8 +379,8 @@ const AutocompleteInput: FunctionComponent<
                             margin={margin}
                             fullWidth={fullWidth}
                             value={
-                                selectionText
-                                    ? selectionText(
+                                inputText
+                                    ? inputText(
                                           getChoiceText(selectedItem).props
                                               .record
                                       )

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -220,8 +220,20 @@ const AutocompleteInput: FunctionComponent<
 
         // If we have a value, set the filter to its text so that
         // Downshift displays it correctly
-        setFilterValue(input.value ? getChoiceText(selectedItem) : '');
-    }, [input.value, handleFilterChange, selectedItem, getChoiceText]);
+        setFilterValue(
+            input.value
+                ? inputText
+                    ? inputText(getChoiceText(selectedItem).props.record)
+                    : getChoiceText(selectedItem)
+                : ''
+        );
+    }, [
+        input.value,
+        handleFilterChange,
+        selectedItem,
+        getChoiceText,
+        inputText,
+    ]);
 
     const handleChange = useCallback(
         (item: any) => {
@@ -268,10 +280,16 @@ const AutocompleteInput: FunctionComponent<
             handleFilterChange('');
             // If we had a value before, set the filter back to its text so that
             // Downshift displays it correctly
-            setFilterValue(input.value ? getChoiceText(selectedItem) : '');
+            setFilterValue(
+                input.value
+                    ? inputText
+                        ? inputText(getChoiceText(selectedItem).props.record)
+                        : getChoiceText(selectedItem)
+                    : ''
+            );
             input.onBlur(event);
         },
-        [getChoiceText, handleFilterChange, input, selectedItem]
+        [getChoiceText, handleFilterChange, input, inputText, selectedItem]
     );
 
     const handleFocus = useCallback(
@@ -295,11 +313,7 @@ const AutocompleteInput: FunctionComponent<
 
     return (
         <Downshift
-            inputValue={
-                inputText
-                    ? inputText(getChoiceText(selectedItem).props.record)
-                    : filterValue
-            }
+            inputValue={filterValue}
             onChange={handleChange}
             selectedItem={selectedItem}
             itemToString={item => getChoiceValue(item)}
@@ -378,14 +392,7 @@ const AutocompleteInput: FunctionComponent<
                             variant={variant}
                             margin={margin}
                             fullWidth={fullWidth}
-                            value={
-                                inputText
-                                    ? inputText(
-                                          getChoiceText(selectedItem).props
-                                              .record
-                                      )
-                                    : filterValue
-                            }
+                            value={filterValue}
                             className={className}
                             {...inputProps}
                             {...options}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -124,6 +124,7 @@ const AutocompleteInput: FunctionComponent<
         InputProps: undefined,
     },
     optionText = 'name',
+    selectionText,
     optionValue = 'id',
     parse,
     resource,
@@ -294,7 +295,11 @@ const AutocompleteInput: FunctionComponent<
 
     return (
         <Downshift
-            inputValue={filterValue}
+            inputValue={
+                selectionText
+                    ? selectionText(getChoiceText(selectedItem).props.record)
+                    : filterValue
+            }
             onChange={handleChange}
             selectedItem={selectedItem}
             itemToString={item => getChoiceValue(item)}
@@ -373,7 +378,14 @@ const AutocompleteInput: FunctionComponent<
                             variant={variant}
                             margin={margin}
                             fullWidth={fullWidth}
-                            value={filterValue}
+                            value={
+                                selectionText
+                                    ? selectionText(
+                                          getChoiceText(selectedItem).props
+                                              .record
+                                      )
+                                    : filterValue
+                            }
                             className={className}
                             {...inputProps}
                             {...options}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -137,6 +137,13 @@ const AutocompleteInput: FunctionComponent<
     variant = 'filled',
     ...rest
 }) => {
+    if (isValidElement(optionText) && !inputText) {
+        throw new Error(`If the optionText prop is a React element, you must also specify the inputText prop:
+        <AutocompleteInput
+            inputText={(record) => record.title}
+        />`);
+    }
+
     warning(
         isValidElement(optionText) && !matchSuggestion,
         `If the optionText prop is a React element, you must also specify the matchSuggestion prop:


### PR DESCRIPTION
Closes #4281

## Issue

When an autocomplete use a custom Component as `optionText`, The selected value can't be display in the filter TextField.

## Solution

When you want to pass a custom component as `optionText` to an Autocomplete, 
you also have to pass a text rendering function returning the filter text to be displayed for your custom component
This `inputText` function must return a `string` which can be similary to the displayed component, or totally different

```jsx
const OptionRenderer = ({ record }) => (
    <span>
        {record.title}-{record.id}
    </span>
);

const inputText = record => `${record.title}-${record.id}`;

<AutocompleteInput
   matchSuggestion={(filterValue, suggestion) => true}
   optionText={<OptionRenderer />}
   inputText={inputText}
   options={{ fullWidth: true }}
/>
```
## Preview

![image](https://user-images.githubusercontent.com/39904906/73351947-56f76880-4290-11ea-9bec-a275bbe73b2e.png)

## Documentation

![image](https://user-images.githubusercontent.com/39904906/73533172-7e7c3b80-441e-11ea-9fe2-573b645de97b.png)

![image](https://user-images.githubusercontent.com/39904906/73533101-5db3e600-441e-11ea-9140-03216a551c0e.png)

