### PR TITLE
[RFR] Add `name` property to Layout

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -181,7 +181,7 @@ const EnhancedLayout = compose(
         {} // Avoid connect passing dispatch in props
     ),
     withRouter,
-    withStyles(styles)
+    withStyles(styles, { name: 'RaLayout' })
 )(Layout);
 
 const LayoutWithTheme = ({ theme: themeOverride, ...props }) => {


### PR DESCRIPTION
Right now, it's not possible to target the `Layout` component via a custom theme.

This PR aims to fix that, thus making code like the following work:
```jsx
const theme = createMuiTheme({
  overrides: {
    RaLayout: {
      root: {
        display: 'contents'
      },
      appFrame: {
        marginTop: '5rem'
      }
    }
  }
});

export default function Home() {
  return (
    <Admin theme={theme}>
      {/* your Resources here */}
    </Admin>
  );
}
```
Otherwise, you would need to create a custom `<Layout />` component using `withStyles()` to merge the changes and pass this custom component to the `<Admin />` component.