### PR TITLE
Fix FilterForm layout broken by bottom margin on Inputs

### DIFF
--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { useTranslate, ValidationError, ValidationErrorMessage } from 'ra-core';
 
 interface Props {
-    helperText?: string;
+    helperText?: string | boolean;
     error?: ValidationErrorMessage;
     touched: boolean;
 }
@@ -16,9 +16,9 @@ const InputHelperText: FunctionComponent<Props> = ({
 
     return touched && error ? (
         <ValidationError error={error} />
-    ) : helperText ? (
+    ) : typeof helperText === 'string' ? (
         <>{translate(helperText, { _: helperText })}</>
-    ) : (
+    ) : helperText !== false ? (
         // material-ui's HelperText cannot reserve space unless we pass a single
         // space as child, which isn't possible when the child is a component.
         // Therefore, we must reserve the space ourselves by passing the same
@@ -26,7 +26,7 @@ const InputHelperText: FunctionComponent<Props> = ({
         // @see https://github.com/mui-org/material-ui/blob/62e439b7022d519ab638d65201e204b59b77f8da/packages/material-ui/src/FormHelperText/FormHelperText.js#L85-L90
         // eslint-disable-next-line react/no-danger
         <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
-    );
+    ) : null;
 };
 
 export default InputHelperText;

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -48,6 +48,7 @@ const FilterFormInput = ({
                 record: emptyRecord,
                 variant,
                 margin,
+                helperText: false,
             })}
             <div className={classes.spacer}>&nbsp;</div>
         </div>


### PR DESCRIPTION
Closes #4389

Before:

![image](https://user-images.githubusercontent.com/99944/73854379-c215e180-4832-11ea-8eac-803941556c54.png)

After:

![image](https://user-images.githubusercontent.com/99944/73854349-b1fe0200-4832-11ea-9d20-550028fe2181.png)
