### PR TITLE
304 noop

### DIFF
--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -20,6 +20,7 @@ import {
     DataProvider,
     DataProviderProxy,
     UseDataProviderOptions,
+    NOOP,
 } from '../types';
 import useLogoutIfAccessDenied from '../auth/useLogoutIfAccessDenied';
 
@@ -312,6 +313,10 @@ const performUndoableQuery = ({
         try {
             dataProvider[type](resource, payload)
                 .then(response => {
+                    if (response === NOOP) {
+                        dispatch({ type: FETCH_END });
+                        return;
+                    }
                     if (process.env.NODE_ENV !== 'production') {
                         validateResponseFormat(response, type);
                     }
@@ -425,6 +430,10 @@ const performQuery = ({
     try {
         return dataProvider[type](resource, payload)
             .then(response => {
+                if (response === NOOP) {
+                    dispatch({ type: FETCH_END });
+                    return;
+                }
                 if (process.env.NODE_ENV !== 'production') {
                     validateResponseFormat(response, type);
                 }

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -7,7 +7,13 @@ import union from 'lodash/union';
 import isEqual from 'lodash/isEqual';
 
 import { CRUD_GET_MANY } from '../actions/dataActions/crudGetMany';
-import { Identifier, Record, ReduxState, DataProviderProxy } from '../types';
+import {
+    Identifier,
+    Record,
+    ReduxState,
+    DataProviderProxy,
+    NOOP,
+} from '../types';
 import { useSafeSetState } from '../util/hooks';
 import useDataProvider from './useDataProvider';
 import { useEffect } from 'react';
@@ -183,9 +189,12 @@ const callQueries = debounce(() => {
         }
         dataProvider
             .getMany(resource, { ids: accumulatedIds }, DataProviderOptions)
-            .then(response =>
+            .then(response => {
+                if (response === NOOP) {
+                    return;
+                }
                 // Forces batching, see https://stackoverflow.com/questions/48563650/does-react-keep-the-order-for-state-updates/48610973#48610973
-                ReactDOM.unstable_batchedUpdates(() =>
+                return ReactDOM.unstable_batchedUpdates(() =>
                     queries.forEach(({ ids, setState, onSuccess }) => {
                         setState(prevState => ({
                             ...prevState,
@@ -201,8 +210,8 @@ const callQueries = debounce(() => {
                             onSuccess({ data: subData });
                         }
                     })
-                )
-            )
+                );
+            })
             .catch(error =>
                 ReactDOM.unstable_batchedUpdates(() =>
                     queries.forEach(({ setState, onFailure }) => {

--- a/packages/ra-core/src/export/fetchRelatedRecords.ts
+++ b/packages/ra-core/src/export/fetchRelatedRecords.ts
@@ -1,4 +1,4 @@
-import { DataProvider, Record, Identifier } from '../types';
+import { DataProvider, Record, Identifier, NOOP } from '../types';
 
 /**
  * Helper function for calling the dataProvider.getMany() method,
@@ -18,12 +18,15 @@ const fetchRelatedRecords = (dataProvider: DataProvider) => (
 ) =>
     dataProvider
         .getMany(resource, { ids: getRelatedIds(data, field) })
-        .then(({ data }) =>
-            data.reduce((acc, post) => {
+        .then(response => {
+            if (response === NOOP) {
+                return {};
+            }
+            return response.data.reduce((acc, post) => {
                 acc[post.id] = post;
                 return acc;
-            }, {})
-        );
+            }, {});
+        });
 
 /**
  * Extracts, aggregates and deduplicates the ids of related records

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -79,19 +79,22 @@ export type DataProvider = {
     getList: (
         resource: string,
         params: GetListParams
-    ) => Promise<GetListResult>;
+    ) => Promise<GetListResult | NOOP>;
 
-    getOne: (resource: string, params: GetOneParams) => Promise<GetOneResult>;
+    getOne: (
+        resource: string,
+        params: GetOneParams
+    ) => Promise<GetOneResult | NOOP>;
 
     getMany: (
         resource: string,
         params: GetManyParams
-    ) => Promise<GetManyResult>;
+    ) => Promise<GetManyResult | NOOP>;
 
     getManyReference: (
         resource: string,
         params: GetManyReferenceParams
-    ) => Promise<GetManyReferenceResult>;
+    ) => Promise<GetManyReferenceResult | NOOP>;
 
     update: (resource: string, params: UpdateParams) => Promise<UpdateResult>;
 

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -205,30 +205,33 @@ export type DataProviderResult =
     | UpdateResult
     | UpdateManyResult;
 
+export type NOOP = 'NOOP';
+export const NOOP = 'NOOP';
+
 export type DataProviderProxy = {
     getList: (
         resource: string,
         params: GetListParams,
         options?: UseDataProviderOptions
-    ) => Promise<GetListResult>;
+    ) => Promise<GetListResult | NOOP>;
 
     getOne: (
         resource: string,
         params: GetOneParams,
         options?: UseDataProviderOptions
-    ) => Promise<GetOneResult>;
+    ) => Promise<GetOneResult | NOOP>;
 
     getMany: (
         resource: string,
         params: GetManyParams,
         options?: UseDataProviderOptions
-    ) => Promise<GetManyResult>;
+    ) => Promise<GetManyResult | NOOP>;
 
     getManyReference: (
         resource: string,
         params: GetManyReferenceParams,
         options?: UseDataProviderOptions
-    ) => Promise<GetManyReferenceResult>;
+    ) => Promise<GetManyReferenceResult | NOOP>;
 
     update: (
         resource: string,

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -1,5 +1,5 @@
 import { stringify } from 'query-string';
-import { fetchUtils, DataProvider } from 'ra-core';
+import { fetchUtils, DataProvider, NOOP } from 'ra-core';
 
 /**
  * Maps react-admin queries to a simple REST API
@@ -44,7 +44,10 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-        return httpClient(url).then(({ headers, json }) => {
+        return httpClient(url).then(({ status, headers, json }) => {
+            if (status === 304) {
+                return NOOP;
+            }
             if (!headers.has('content-range')) {
                 throw new Error(
                     'The Content-Range header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare Content-Range in the Access-Control-Expose-Headers header?'
@@ -64,16 +67,29 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
     },
 
     getOne: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
-            data: json,
-        })),
+        httpClient(`${apiUrl}/${resource}/${params.id}`).then(
+            ({ status, json }) => {
+                if (status === 304) {
+                    return NOOP;
+                }
+
+                return {
+                    data: json,
+                };
+            }
+        ),
 
     getMany: (resource, params) => {
         const query = {
             filter: JSON.stringify({ id: params.ids }),
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        return httpClient(url).then(({ json }) => ({ data: json }));
+        return httpClient(url).then(({ status, json }) => {
+            if (status === 304) {
+                return NOOP;
+            }
+            return { data: json };
+        });
     },
 
     getManyReference: (resource, params) => {
@@ -89,7 +105,11 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-        return httpClient(url).then(({ headers, json }) => {
+        return httpClient(url).then(({ headers, status, json }) => {
+            if (status === 304) {
+                return NOOP;
+            }
+
             if (!headers.has('content-range')) {
                 throw new Error(
                     'The Content-Range header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare Content-Range in the Access-Control-Expose-Headers header?'
@@ -112,7 +132,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
         httpClient(`${apiUrl}/${resource}/${params.id}`, {
             method: 'PUT',
             body: JSON.stringify(params.data),
-        }).then(({ json }) => ({ data: json })),
+        }).then(({ status, json }) => ({ data: json })),
 
     // simple-rest doesn't handle provide an updateMany route, so we fallback to calling update n times instead
     updateMany: (resource, params) =>

--- a/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
@@ -9,6 +9,7 @@ import {
     Identifier,
     Exporter,
     useListContext,
+    NOOP,
 } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
@@ -34,14 +35,17 @@ const BulkExportButton: FunctionComponent<BulkExportButtonProps> = props => {
             exporter &&
                 dataProvider
                     .getMany(resource, { ids: selectedIds })
-                    .then(({ data }) =>
-                        exporter(
-                            data,
+                    .then(response => {
+                        if (response === NOOP) {
+                            return;
+                        }
+                        return exporter(
+                            response.data,
                             fetchRelatedRecords(dataProvider),
                             dataProvider,
                             resource
-                        )
-                    )
+                        );
+                    })
                     .catch(error => {
                         console.error(error);
                         notify('ra.notification.http_error', 'warning');

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -10,6 +10,7 @@ import {
     Sort,
     Exporter,
     Filter,
+    NOOP,
 } from 'ra-core';
 import Button, { ButtonProps } from './Button';
 
@@ -40,16 +41,20 @@ const ExportButton: FunctionComponent<ExportButtonProps> = props => {
                     filter: filterValues,
                     pagination: { page: 1, perPage: maxResults },
                 })
-                .then(
-                    ({ data }) =>
+                .then(response => {
+                    if (response === NOOP) {
+                        return;
+                    }
+                    return (
                         exporter &&
                         exporter(
-                            data,
+                            response.data,
                             fetchRelatedRecords(dataProvider),
                             dataProvider,
                             resource
                         )
-                )
+                    );
+                })
                 .catch(error => {
                     console.error(error);
                     notify('ra.notification.http_error', 'warning');


### PR DESCRIPTION
Allow the dataProvider to returns a NOOP result, indicating there is no change to apply. Useful for request with status 304 (Not modified) for example.