### PR TITLE
Enhance dark theme contrast in demo

### DIFF
--- a/examples/demo/src/layout/themes.ts
+++ b/examples/demo/src/layout/themes.ts
@@ -1,5 +1,8 @@
 export const darkTheme = {
     palette: {
+        primary: {
+            main: '#7f90f0',
+        },
         type: 'dark', // Switching the dark mode on is a single property value change.
     },
 };

--- a/examples/demo/src/layout/themes.ts
+++ b/examples/demo/src/layout/themes.ts
@@ -1,7 +1,7 @@
 export const darkTheme = {
     palette: {
         primary: {
-            main: '#7f90f0',
+            main: '#90caf9',
         },
         type: 'dark', // Switching the dark mode on is a single property value change.
     },


### PR DESCRIPTION
## Issue

React-admin Demo is not lisible in dark theme due to bad constrast

Closes #4180 

## Solution

Change main color to be lighter in demo custom theme

## Screenshots

![image](https://user-images.githubusercontent.com/39904906/74024007-38d0ed00-49a1-11ea-9257-213ede0a110b.png)
