### PR TITLE
Changes `declaration` to true.

### DIFF
--- a/packages/react-admin/tsconfig.json
+++ b/packages/react-admin/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "declaration": false,
+        "declaration": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],


### PR DESCRIPTION
In order for this library to be usable in a TypeScript project, declaration files need to be generated.  This is trivially easy for a TS project, you just need to set this flag to true and they will be generated automatically on compile.  No idea why this wasn't set before, but it should basically always be set for libraries.