### PR TITLE
Fix saveOnEnter : Use normal click on Save button and fix helperText linked issue 

### DIFF
--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -127,7 +127,7 @@ describe('Create Page', () => {
         EditPage.delete();
     });
 
-    it.only('should redirect to edit page after submit on enter', () => {
+    it('should redirect to edit page after submit on enter', () => {
         const values = [
             {
                 type: 'input',

--- a/cypress/integration/create.js
+++ b/cypress/integration/create.js
@@ -127,6 +127,38 @@ describe('Create Page', () => {
         EditPage.delete();
     });
 
+    it.only('should redirect to edit page after submit on enter', () => {
+        const values = [
+            {
+                type: 'input',
+                name: 'title',
+                value: 'Test title',
+            },
+            {
+                type: 'textarea',
+                name: 'teaser',
+                value: 'Test teaser',
+            },
+            {
+                type: 'rich-text-input',
+                name: 'body',
+                value: 'Test body',
+            },
+        ];
+
+        CreatePage.setValues(values);
+        CreatePage.submitWithKeyboard();
+        EditPage.waitUntilVisible();
+        cy.get(EditPage.elements.input('title')).should(el =>
+            expect(el).to.have.value('Test title')
+        );
+        cy.get(EditPage.elements.input('teaser')).should(el =>
+            expect(el).to.have.value('Test teaser')
+        );
+
+        EditPage.delete();
+    });
+
     it('should redirect to show page after create success with "Save and show"', () => {
         const values = [
             {

--- a/cypress/support/CreatePage.js
+++ b/cypress/support/CreatePage.js
@@ -67,6 +67,13 @@ export default url => ({
         cy.wait(200); // let the notification disappear (could block further submits)
     },
 
+    submitWithKeyboard() {
+        cy.get('input:first').type('{enter}');
+        cy.get(this.elements.snackbar);
+        cy.get(this.elements.body).click(); // dismiss notification
+        cy.wait(200); // let the notification disappear (could block further submits)
+    },
+
     submitAndShow() {
         cy.get(this.elements.submitAndShowButton).click();
         cy.get(this.elements.snackbar);

--- a/packages/ra-input-rich-text/src/index.js
+++ b/packages/ra-input-rich-text/src/index.js
@@ -17,7 +17,7 @@ const RichTextInput = ({
     toolbar = true,
     fullWidth = true,
     configureQuill,
-    helperText = false,
+    helperText,
     label,
     source,
     resource,

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -42,7 +42,7 @@ describe('<SaveButton />', () => {
             </TestContext>
         );
 
-        fireEvent.mouseDown(getByLabelText('ra.action.save'));
+        fireEvent.click(getByLabelText('ra.action.save'));
         expect(onSubmit).toHaveBeenCalled();
     });
 
@@ -55,7 +55,7 @@ describe('<SaveButton />', () => {
             </TestContext>
         );
 
-        fireEvent.mouseDown(getByLabelText('ra.action.save'));
+        fireEvent.click(getByLabelText('ra.action.save'));
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
@@ -77,7 +77,7 @@ describe('<SaveButton />', () => {
             </TestContext>
         );
 
-        fireEvent.mouseDown(getByLabelText('ra.action.save'));
+        fireEvent.click(getByLabelText('ra.action.save'));
         expect(dispatchSpy).toHaveBeenCalledWith({
             payload: {
                 message: 'ra.message.invalid_form',

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import expect from 'expect';
 import { TestContext } from 'ra-core';
 
+import Create from '../detail/Create';
+import SimpleForm from '../form/SimpleForm';
+import Toolbar from '../form/Toolbar';
+import TextInput from '../input/TextInput';
 import SaveButton from './SaveButton';
 
 describe('<SaveButton />', () => {
@@ -41,8 +45,50 @@ describe('<SaveButton />', () => {
                 />
             </TestContext>
         );
-
         fireEvent.click(getByLabelText('ra.action.save'));
+        expect(onSubmit).toHaveBeenCalled();
+    });
+
+    it('should trigger submit action when Enter key if no saving is in progress', () => {
+        const onSubmit = jest.fn();
+
+        const defaultCreateProps = {
+            basePath: '/foo',
+            id: '123',
+            resource: 'foo',
+            location: {},
+            match: {},
+        };
+
+        const SaveToolbar = props => (
+            <Toolbar {...props}>
+                <SaveButton
+                    label="enterButton"
+                    handleSubmitWithRedirect={onSubmit}
+                    submitOnEnter={true}
+                    saving={false}
+                />
+            </Toolbar>
+        );
+
+        const { getByLabelText } = render(
+            <TestContext>
+                <Create {...defaultCreateProps}>
+                    <SimpleForm toolbar={<SaveToolbar />}>
+                        <TextInput label="Title" source="title" />
+                    </SimpleForm>
+                </Create>
+            </TestContext>
+        );
+
+        const input = getByLabelText('Title');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: 'test' } });
+
+        const button = getByLabelText('enterButton');
+        //console.log(button);
+        //fireEvent.click(getByLabelText('ra.action.save'));
+        fireEvent.keyPress(input, { key: 'Enter', keyCode: 13 });
         expect(onSubmit).toHaveBeenCalled();
     });
 

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -3,10 +3,6 @@ import React from 'react';
 import expect from 'expect';
 import { TestContext } from 'ra-core';
 
-import Create from '../detail/Create';
-import SimpleForm from '../form/SimpleForm';
-import Toolbar from '../form/Toolbar';
-import TextInput from '../input/TextInput';
 import SaveButton from './SaveButton';
 
 describe('<SaveButton />', () => {
@@ -45,50 +41,8 @@ describe('<SaveButton />', () => {
                 />
             </TestContext>
         );
+
         fireEvent.click(getByLabelText('ra.action.save'));
-        expect(onSubmit).toHaveBeenCalled();
-    });
-
-    it('should trigger submit action when Enter key if no saving is in progress', () => {
-        const onSubmit = jest.fn();
-
-        const defaultCreateProps = {
-            basePath: '/foo',
-            id: '123',
-            resource: 'foo',
-            location: {},
-            match: {},
-        };
-
-        const SaveToolbar = props => (
-            <Toolbar {...props}>
-                <SaveButton
-                    label="enterButton"
-                    handleSubmitWithRedirect={onSubmit}
-                    submitOnEnter={true}
-                    saving={false}
-                />
-            </Toolbar>
-        );
-
-        const { getByLabelText } = render(
-            <TestContext>
-                <Create {...defaultCreateProps}>
-                    <SimpleForm toolbar={<SaveToolbar />}>
-                        <TextInput label="Title" source="title" />
-                    </SimpleForm>
-                </Create>
-            </TestContext>
-        );
-
-        const input = getByLabelText('Title');
-        fireEvent.focus(input);
-        fireEvent.change(input, { target: { value: 'test' } });
-
-        const button = getByLabelText('enterButton');
-        //console.log(button);
-        //fireEvent.click(getByLabelText('ra.action.save'));
-        fireEvent.keyPress(input, { key: 'Enter', keyCode: 13 });
         expect(onSubmit).toHaveBeenCalled();
     });
 

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -31,12 +31,7 @@ const SaveButton: FC<SaveButtonProps> = ({
     const notify = useNotify();
     const translate = useTranslate();
 
-    // We handle the click event through mousedown because of an issue when
-    // the button is not as the same place when mouseup occurs, preventing the click
-    // event to fire.
-    // It can happen when some errors appear under inputs, pushing the button
-    // towards the window bottom.
-    const handleMouseDown = event => {
+    const handleClick = event => {
         if (saving) {
             // prevent double submission
             event.preventDefault();
@@ -56,14 +51,6 @@ const SaveButton: FC<SaveButtonProps> = ({
         }
     };
 
-    // As we handle the "click" through the mousedown event, we have to make sure we cancel
-    // the default click in case the issue mentionned above does not occur.
-    // Otherwise, this would trigger a standard HTML submit, not the final-form one.
-    const handleClick = event => {
-        event.preventDefault();
-        event.stopPropagation();
-    };
-
     const type = submitOnEnter ? 'submit' : 'button';
     const displayedLabel = label && translate(label, { _: label });
     return (
@@ -71,7 +58,6 @@ const SaveButton: FC<SaveButtonProps> = ({
             className={classnames(classes.button, className)}
             variant={variant}
             type={type}
-            onMouseDown={handleMouseDown}
             onClick={handleClick}
             color={saving ? 'default' : 'primary'}
             aria-label={displayedLabel}

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -273,7 +273,7 @@ export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
     // But in a Filter component, the child helperText have to be forced to false
     warningLog(
         helperText !== undefined && helperText !== false,
-        "<ReferenceInput> doesn't accept an helperText value, it should be set on the child component"
+        "<ReferenceInput> doesn't accept a helperText prop. Set the helperText prop on the child component instead"
     );
 
     const disabledHelperText = helperText === false ? { helperText } : {};

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -12,6 +12,7 @@ import {
     InputProps,
     Pagination,
     Sort,
+    warning as warningLog,
 } from 'ra-core';
 
 import sanitizeInputProps from './sanitizeRestProps';
@@ -192,7 +193,7 @@ interface ReferenceInputViewProps {
     classes?: object;
     className?: string;
     error?: string;
-    helperText?: string;
+    helperText?: string | boolean;
     id: string;
     input: FieldInputProps<any, HTMLElement>;
     isRequired: boolean;
@@ -268,6 +269,15 @@ export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
           }
         : meta;
 
+    // helperText should never be set on ReferenceInput, only in child component
+    // But in a Filter component, the child helperText have to be forced to false
+    warningLog(
+        helperText !== undefined && helperText !== false,
+        "<ReferenceInput> doesn't accept an helperText value, it should be set on the child component"
+    );
+
+    const disabledHelperText = helperText === false ? { helperText } : {};
+
     return cloneElement(children, {
         allowEmpty,
         classes,
@@ -283,8 +293,8 @@ export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
         setFilter,
         setPagination,
         setSort,
-        helperText,
         translateChoice: false,
+        ...disabledHelperText,
         ...sanitizeRestProps(rest),
     });
 };

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -283,6 +283,7 @@ export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
         setFilter,
         setPagination,
         setSort,
+        helperText,
         translateChoice: false,
         ...sanitizeRestProps(rest),
     });


### PR DESCRIPTION
Closes #4170 

- [x] Use normal click on Save button
- [x] Fix helperText place issue on ReferenceInput
- [x] Fix helperText place issue on RichTextInput
- [x] Fix tests

## Fixes and behaviour

- The Create or Edit Forms can now be validated with a click or with the Enter key
- The helperText place is reserved for all inputs to ensure the Save button won't move down if a requirement text fires at validation.
- It's possible to disable this default helperText by adding helperText={false} on inputs
- The ReferenceInputs in Filters won't have a bad margin anymore.
- ReferenceInput doesn't accept an helperText value, it should be set on the child component

## Screenshots

![SubmitOnEnter](https://user-images.githubusercontent.com/39904906/74230544-dd666e00-4cc4-11ea-9dfc-5962efd62f62.gif)

![image](https://user-images.githubusercontent.com/39904906/74227629-29161900-4cbf-11ea-90ec-f7f5c79ee580.png)
