### PR TITLE
Throw an error when useGetOne is called for an undefined resource

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -39,10 +39,14 @@ const useGetOne = (
     useQueryWithStore(
         { type: 'getOne', resource, payload: { id } },
         options,
-        (state: ReduxState) =>
-            state.admin.resources[resource]
-                ? state.admin.resources[resource].data[id]
-                : null
+        (state: ReduxState) => {
+            if (!state.admin.resources[resource]) {
+                throw new Error(
+                    `No <Resource> defined for "${resource}". useGetOne() relies on the Redux store, so it cannot work if you don't include a <Resource>.`
+                );
+            }
+            return state.admin.resources[resource].data[id];
+        }
     );
 
 export type UseGetOneHookValue = {

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { cleanup } from '@testing-library/react';
-import { renderWithRedux } from 'ra-core';
+import { renderWithRedux, DataProviderContext } from 'ra-core';
 
 import Edit from './Edit';
 
@@ -18,10 +18,17 @@ describe('<Edit />', () => {
 
     it('should display aside component', () => {
         const Aside = () => <div id="aside">Hello</div>;
+        const dataProvider = {
+            getOne: () => Promise.resolve({ data: { id: 123 } }),
+        };
+        const Dummy = () => <div />;
         const { queryAllByText } = renderWithRedux(
-            <Edit {...defaultEditProps} aside={<Aside />}>
-                <div />
-            </Edit>
+            <DataProviderContext.Provider value={dataProvider}>
+                <Edit {...defaultEditProps} aside={<Aside />}>
+                    <Dummy />
+                </Edit>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { foo: { data: {} } } } }
         );
         expect(queryAllByText('Hello')).toHaveLength(1);
     });

--- a/packages/ra-ui-materialui/src/detail/Show.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { cleanup } from '@testing-library/react';
-import { renderWithRedux } from 'ra-core';
+import { renderWithRedux, DataProviderContext } from 'ra-core';
 
 import Show from './Show';
 
@@ -18,10 +18,17 @@ describe('<Show />', () => {
 
     it('should display aside component', () => {
         const Aside = () => <div id="aside">Hello</div>;
+        const dataProvider = {
+            getOne: () => Promise.resolve({ data: { id: 123 } }),
+        };
+        const Dummy = () => <div />;
         const { queryAllByText } = renderWithRedux(
-            <Show {...defaultShowProps} aside={<Aside />}>
-                <div />
-            </Show>
+            <DataProviderContext.Provider value={dataProvider}>
+                <Show {...defaultShowProps} aside={<Aside />}>
+                    <Dummy />
+                </Show>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { foo: { data: {} } } } }
         );
         expect(queryAllByText('Hello')).toHaveLength(1);
     });


### PR DESCRIPTION
## Problem

`useQuery` works even without a `<Resource>` because it doesn't rely on the Redux store. However, developers may want to use the more specialized hooks, like `useGetOne()`. These only work if there is a `<Resource>`, but for now if there is no resource the hook returns null - which is not a good developer experience.

## Solution

This change throws an error in case of missing Resource for useGetOne. It's a start. It's a bit harder to do for other data Provider hooks, so let's start with this baby step/  