### PR TITLE
Add fieldKey prop to <ArrayField> to improve performance on large arrays

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -94,10 +94,12 @@ Ideal for embedded arrays of objects, e.g. `tags` and `backlinks` in the followi
   ],
   backlinks: [
         {
+            uuid: '34fdf393-f449-4b04-a423-38ad02ae159e',
             date: '2012-08-10T00:00:00.000Z',
             url: 'http://example.com/foo/bar.html',
         },
         {
+            uuid: 'd907743a-253d-4ec1-8329-404d4c5e6cf1',
             date: '2012-08-14T00:00:00.000Z',
             url: 'https://blog.johndoe.com/2012/08/12/foobar.html',
         }
@@ -108,9 +110,11 @@ Ideal for embedded arrays of objects, e.g. `tags` and `backlinks` in the followi
 The child must be an iterator component (like `<Datagrid>` or `<SingleFieldList>`).
 
 Here is how to display all the backlinks of the current post as a `<Datagrid>`
+Optional prop fieldKey can be pass to ArrayField to use as Key
+Which reduces time and memory to generate key
 
 ```jsx
-<ArrayField source="backlinks">
+<ArrayField source="backlinks" fieldKey="uuid">
     <Datagrid>
         <DateField source="date" />
         <UrlField source="url" />

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -109,12 +109,10 @@ Ideal for embedded arrays of objects, e.g. `tags` and `backlinks` in the followi
 
 The child must be an iterator component (like `<Datagrid>` or `<SingleFieldList>`).
 
-Here is how to display all the backlinks of the current post as a `<Datagrid>`
-Optional prop fieldKey can be pass to ArrayField to use as Key
-Which reduces time and memory to generate key
+Here is how to display all the backlinks of the current post as a `<Datagrid>`:
 
 ```jsx
-<ArrayField source="backlinks" fieldKey="uuid">
+<ArrayField source="backlinks">
     <Datagrid>
         <DateField source="date" />
         <UrlField source="url" />
@@ -129,6 +127,18 @@ And here is how to display all the tags of the current post as `<Chip>` componen
     <SingleFieldList>
         <ChipField source="name" />
     </SingleFieldList>
+</ArrayField>
+```
+
+**Tip**: If the array value contains a lot of items, you may experience slowdowns in the UI. In such cases, set the `fieldKey` prop to use one field as key, and reduce CPU and memory usage:
+
+```diff
+-<ArrayField source="backlinks">
++<ArrayField source="backlinks" fieldKey="uuid">
+    <Datagrid>
+        <DateField source="date" />
+        <UrlField source="url" />
+    </Datagrid>
 </ArrayField>
 ```
 

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -46,9 +46,7 @@ const initialState = {
  * //       }
  * //    ]
  * // }
- * // Optional prop fieldKey can be pass to ArrayField to use as Key
- * // Which reduces time and memory to generate key
- *     <ArrayField source="backlinks" fieldKey="uuid">
+ *     <ArrayField source="backlinks">
  *         <Datagrid>
  *             <DateField source="date" />
  *             <UrlField source="url" />
@@ -67,6 +65,14 @@ const initialState = {
  *         <SingleFieldList>
  *             <ChipField source="name" />
  *         </SingleFieldList>
+ *     </ArrayField>
+ *
+ * If the array value contains a lot of items, you may experience slowdowns in the UI.
+ * In such cases, set the `fieldKey` prop to use one field as key, and reduce CPU and memory usage:
+ *
+ * @example
+ *     <ArrayField source="backlinks" fieldKey="uuid">
+ *         ...
  *     </ArrayField>
  *
  * If you need to render a collection in a custom way, it's often simpler

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -35,16 +35,20 @@ const initialState = {
  * //   id: 123
  * //   backlinks: [
  * //       {
+ * //           uuid: '34fdf393-f449-4b04-a423-38ad02ae159e',
  * //           date: '2012-08-10T00:00:00.000Z',
  * //           url: 'http://example.com/foo/bar.html',
  * //       },
  * //       {
+ * //           uuid: 'd907743a-253d-4ec1-8329-404d4c5e6cf1',
  * //           date: '2012-08-14T00:00:00.000Z',
  * //           url: 'https://blog.johndoe.com/2012/08/12/foobar.html',
  * //       }
  * //    ]
  * // }
- *     <ArrayField source="backlinks">
+ * // Optional prop fieldKey can be pass to ArrayField to use as Key
+ * // Which reduces time and memory to generate key
+ *     <ArrayField source="backlinks" fieldKey="uuid">
  *         <Datagrid>
  *             <DateField source="date" />
  *             <UrlField source="url" />

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -85,7 +85,7 @@ export class ArrayField extends Component<
     constructor(props: FieldProps & InjectedFieldProps) {
         super(props);
         this.state = props.record
-            ? this.getDataAndIds(props.record, props.source)
+            ? this.getDataAndIds(props.record, props.source, props.fieldKey)
             : initialState;
     }
 
@@ -95,22 +95,35 @@ export class ArrayField extends Component<
     ) {
         if (nextProps.record !== prevProps.record) {
             this.setState(
-                this.getDataAndIds(nextProps.record, nextProps.source)
+                this.getDataAndIds(
+                    nextProps.record,
+                    nextProps.source,
+                    nextProps.fieldKey
+                )
             );
         }
     }
 
-    getDataAndIds(record: object, source: string) {
+    getDataAndIds(record: object, source: string, fieldKey: string) {
         const list = get(record, source);
-        return list
+        if (!list) {
+            return initialState;
+        }
+        return fieldKey
             ? {
+                  data: list.reduce((prev, item) => {
+                      prev[item[fieldKey]] = item;
+                      return prev;
+                  }, {}),
+                  ids: list.map(item => item[fieldKey]),
+              }
+            : {
                   data: list.reduce((prev, item) => {
                       prev[JSON.stringify(item)] = item;
                       return prev;
                   }, {}),
                   ids: list.map(JSON.stringify),
-              }
-            : initialState;
+              };
     }
 
     render() {
@@ -121,6 +134,7 @@ export class ArrayField extends Component<
             record,
             sortable,
             source,
+            fieldKey,
             ...rest
         } = this.props;
         const { ids, data } = this.state;

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -13,6 +13,7 @@ export interface FieldProps {
     headerClassName?: string;
     textAlign?: TextAlign;
     emptyText?: string;
+    fieldKey?: string;
 }
 
 // Props injected by react-admin
@@ -32,4 +33,5 @@ export const fieldPropTypes = {
     headerClassName: PropTypes.string,
     textAlign: PropTypes.oneOf<TextAlign>(['right', 'left']),
     emptyText: PropTypes.string,
+    fieldKey: PropTypes.string,
 };


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
using JSON.stringify results with a very large key. Passing a fieldKey when available reduces the overhead

