### PR TITLE
Fix to keep displayed filters through navigation, even if they are empty

### DIFF
--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -96,6 +96,27 @@ describe('List Page', () => {
             ListPagePosts.setFilterValue('q', '');
         });
 
+        it('should keep added filters when emptying it after navigating away and back', () => {
+            ListPagePosts.logout();
+            LoginPage.login('admin', 'password');
+            ListPagePosts.showFilter('title');
+            ListPagePosts.setFilterValue('title', 'quis culpa impedit');
+            cy.contains('1-1 of 1');
+
+            cy.get('[href="#/users"]').click();
+
+            cy.get('[href="#/posts"]').click();
+
+            cy.get(ListPagePosts.elements.filter('title')).should(el =>
+                expect(el).to.have.value('quis culpa impedit')
+            );
+            ListPagePosts.setFilterValue('title', '');
+            ListPagePosts.waitUntilDataLoaded();
+            cy.get(ListPagePosts.elements.filter('title')).should(
+                el => expect(el).to.exist
+            );
+        });
+
         it('should allow to disable alwaysOn filters with default value', () => {
             ListPagePosts.logout();
             LoginPage.login('admin', 'password');

--- a/packages/ra-core/src/actions/listActions.ts
+++ b/packages/ra-core/src/actions/listActions.ts
@@ -8,6 +8,7 @@ export interface ListParams {
     page: number;
     perPage: number;
     filter: any;
+    displayedFilters: any;
 }
 
 export interface ChangeListParamsAction {

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -63,7 +63,7 @@ export interface ListControllerProps {
     perPage: number;
     resource: string;
     selectedIds: Identifier[];
-    setFilters: (filters: any) => void;
+    setFilters: (filters: any, displayedFilters: any) => void;
     setPage: (page: number) => void;
     setPerPage: (page: number) => void;
     setSort: (sort: string) => void;

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -185,9 +185,9 @@ const useListParams = ({
                 payload.displayedFilters = Object.keys(
                     newDisplayedFilters
                 ).reduce((filters, filter) => {
-                    if (newDisplayedFilters[filter])
-                        return { ...filters, [filter]: true };
-                    return { ...filters };
+                    return newDisplayedFilters[filter]
+                        ? { ...filters, [filter]: true }
+                        : filters;
                 }, {});
             }
             changeParams({

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -8,7 +8,6 @@ import { Location } from 'history';
 
 import queryReducer, {
     SET_FILTER,
-    SET_DISPLAYEDFILTER,
     SET_PAGE,
     SET_PER_PAGE,
     SET_SORT,
@@ -178,24 +177,23 @@ const useListParams = ({
 
     const debouncedSetFilters = lodashDebounce(
         (newFilters, newDisplayedFilters) => {
+            let payload = {
+                filter: removeEmpty(newFilters),
+                displayedFilters: undefined,
+            };
+            if (newDisplayedFilters) {
+                payload.displayedFilters = Object.keys(
+                    newDisplayedFilters
+                ).reduce((filters, filter) => {
+                    if (newDisplayedFilters[filter])
+                        return { ...filters, [filter]: true };
+                    return { ...filters };
+                }, {});
+            }
             changeParams({
                 type: SET_FILTER,
-                payload: removeEmpty(newFilters),
+                payload,
             });
-            if (newDisplayedFilters) {
-                const displayable = Object.keys(newDisplayedFilters).reduce(
-                    (filters, filter) => {
-                        if (newDisplayedFilters[filter])
-                            return { ...filters, [filter]: true };
-                        return { ...filters };
-                    },
-                    {}
-                );
-                changeParams({
-                    type: SET_DISPLAYEDFILTER,
-                    payload: displayable,
-                });
-            }
         },
         debounce
     );
@@ -208,8 +206,11 @@ const useListParams = ({
 
     const hideFilter = useCallback((filterName: string) => {
         const newFilters = removeKey(filterValues, filterName);
-        const newDsplayedFilters = removeKey(displayedFilterValues, filterName);
-        setFilters(newFilters, newDsplayedFilters);
+        const newDisplayedFilters = removeKey(
+            displayedFilterValues,
+            filterName
+        );
+        setFilters(newFilters, newDisplayedFilters);
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
 
     const showFilter = useCallback((filterName: string, defaultValue: any) => {

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -8,6 +8,7 @@ import { Location } from 'history';
 
 import queryReducer, {
     SET_FILTER,
+    SET_DISPLAYEDFILTER,
     SET_PAGE,
     SET_PER_PAGE,
     SET_SORT,
@@ -41,7 +42,7 @@ interface Modifiers {
     setPage: (page: number) => void;
     setPerPage: (pageSize: number) => void;
     setSort: (sort: string) => void;
-    setFilters: (filters: any) => void;
+    setFilters: (filters: any, displayedFilters: any) => void;
     hideFilter: (filterName: string) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
 }
@@ -112,10 +113,8 @@ const useListParams = ({
     perPage = 10,
     debounce = 500,
 }: ListParamsOptions): [Parameters, Modifiers] => {
-    const [displayedFilters, setDisplayedFilters] = useState({});
     const dispatch = useDispatch();
     const history = useHistory();
-
     const params = useSelector(
         (reduxState: ReduxState) =>
             reduxState.admin.resources[resource]
@@ -151,6 +150,7 @@ const useListParams = ({
             search: `?${stringify({
                 ...newParams,
                 filter: JSON.stringify(newParams.filter),
+                displayedFilters: JSON.stringify(newParams.displayedFilters),
             })}`,
         });
         dispatch(changeListParams(resource, newParams));
@@ -174,43 +174,54 @@ const useListParams = ({
     );
 
     const filterValues = query.filter || emptyObject;
+    const displayedFilterValues = query.displayedFilters || emptyObject;
 
     const debouncedSetFilters = lodashDebounce(
-        newFilters =>
+        (newFilters, newDisplayedFilters) => {
             changeParams({
                 type: SET_FILTER,
                 payload: removeEmpty(newFilters),
-            }),
+            });
+            if (newDisplayedFilters) {
+                const displayable = Object.keys(newDisplayedFilters).reduce(
+                    (filters, filter) => {
+                        if (newDisplayedFilters[filter])
+                            return { ...filters, [filter]: true };
+                        return { ...filters };
+                    },
+                    {}
+                );
+                changeParams({
+                    type: SET_DISPLAYEDFILTER,
+                    payload: displayable,
+                });
+            }
+        },
         debounce
     );
 
     const setFilters = useCallback(
-        filters => debouncedSetFilters(filters),
+        (filters, displayedFilters) =>
+            debouncedSetFilters(filters, displayedFilters),
         requestSignature // eslint-disable-line react-hooks/exhaustive-deps
     );
 
     const hideFilter = useCallback((filterName: string) => {
-        setDisplayedFilters(previousFilters => ({
-            ...previousFilters,
-            [filterName]: false,
-        }));
         const newFilters = removeKey(filterValues, filterName);
-        setFilters(newFilters);
+        const newDsplayedFilters = removeKey(displayedFilterValues, filterName);
+        setFilters(newFilters, newDsplayedFilters);
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
 
     const showFilter = useCallback((filterName: string, defaultValue: any) => {
-        setDisplayedFilters(previousFilters => ({
-            ...previousFilters,
-            [filterName]: true,
-        }));
-        if (typeof defaultValue !== 'undefined') {
-            setFilters(set(filterValues, filterName, defaultValue));
-        }
+        setFilters(
+            set(filterValues, filterName, defaultValue),
+            set(displayedFilterValues, filterName, true)
+        );
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
 
     return [
         {
-            displayedFilters,
+            displayedFilters: displayedFilterValues,
             filterValues,
             requestSignature,
             ...query,
@@ -227,20 +238,32 @@ const useListParams = ({
     ];
 };
 
-export const validQueryParams = ['page', 'perPage', 'sort', 'order', 'filter'];
+export const validQueryParams = [
+    'page',
+    'perPage',
+    'sort',
+    'order',
+    'filter',
+    'displayedFilters',
+];
+
+const parseObject = (query, field) => {
+    if (query[field] && typeof query[field] === 'string') {
+        try {
+            query[field] = JSON.parse(query[field]);
+        } catch (err) {
+            delete query[field];
+        }
+    }
+};
 
 export const parseQueryFromLocation = ({ search }) => {
     const query = pickBy(
         parse(search),
         (v, k) => validQueryParams.indexOf(k) !== -1
     );
-    if (query.filter && typeof query.filter === 'string') {
-        try {
-            query.filter = JSON.parse(query.filter);
-        } catch (err) {
-            delete query.filter;
-        }
-    }
+    parseObject(query, 'filter');
+    parseObject(query, 'displayedFilters');
     return query;
 };
 

--- a/packages/ra-core/src/reducer/admin/resource/list/queryReducer.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/queryReducer.spec.ts
@@ -36,7 +36,7 @@ describe('Query Reducer', () => {
                 {},
                 {
                     type: 'SET_FILTER',
-                    payload: { title: 'foo' },
+                    payload: { filter: { title: 'foo' } },
                 }
             );
             assert.deepEqual(updatedState.filter, { title: 'foo' });
@@ -51,11 +51,26 @@ describe('Query Reducer', () => {
                 },
                 {
                     type: 'SET_FILTER',
-                    payload: { title: 'bar' },
+                    payload: { filter: { title: 'bar' } },
                 }
             );
 
             assert.deepEqual(updatedState.filter, { title: 'bar' });
+        });
+
+        it('should add new filter and displayedFilter with given value when set', () => {
+            const updatedState = queryReducer(
+                {},
+                {
+                    type: 'SET_FILTER',
+                    payload: {
+                        filter: { title: 'foo' },
+                        displayedFilters: { title: true },
+                    },
+                }
+            );
+            assert.deepEqual(updatedState.filter, { title: 'foo' });
+            assert.deepEqual(updatedState.displayedFilters, { title: true });
         });
 
         it('should reset page to 1', () => {

--- a/packages/ra-core/src/reducer/admin/resource/list/queryReducer.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/queryReducer.ts
@@ -8,6 +8,7 @@ export const SET_PAGE = 'SET_PAGE';
 export const SET_PER_PAGE = 'SET_PER_PAGE';
 
 export const SET_FILTER = 'SET_FILTER';
+export const SET_DISPLAYEDFILTER = 'SET_DISPLAYEDFILTER';
 
 const oppositeOrder = direction =>
     direction === SORT_DESC ? SORT_ASC : SORT_DESC;
@@ -44,6 +45,10 @@ const queryReducer: Reducer<ListParams> = (
 
         case SET_FILTER: {
             return { ...previousState, page: 1, filter: payload };
+        }
+
+        case SET_DISPLAYEDFILTER: {
+            return { ...previousState, page: 1, displayedFilters: payload };
         }
 
         default:

--- a/packages/ra-core/src/reducer/admin/resource/list/queryReducer.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/queryReducer.ts
@@ -8,7 +8,6 @@ export const SET_PAGE = 'SET_PAGE';
 export const SET_PER_PAGE = 'SET_PER_PAGE';
 
 export const SET_FILTER = 'SET_FILTER';
-export const SET_DISPLAYEDFILTER = 'SET_DISPLAYEDFILTER';
 
 const oppositeOrder = direction =>
     direction === SORT_DESC ? SORT_ASC : SORT_DESC;
@@ -44,11 +43,14 @@ const queryReducer: Reducer<ListParams> = (
             return { ...previousState, page: 1, perPage: payload };
 
         case SET_FILTER: {
-            return { ...previousState, page: 1, filter: payload };
-        }
-
-        case SET_DISPLAYEDFILTER: {
-            return { ...previousState, page: 1, displayedFilters: payload };
+            return {
+                ...previousState,
+                page: 1,
+                filter: payload.filter,
+                displayedFilters: payload.displayedFilters
+                    ? payload.displayedFilters
+                    : previousState.displayedFilters,
+            };
         }
 
         default:

--- a/packages/ra-ui-materialui/src/list/FilterButton.js
+++ b/packages/ra-ui-materialui/src/list/FilterButton.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles(
 
 const FilterButton = ({
     filters,
-    displayedFilters,
+    displayedFilters = {},
     filterValues,
     showFilter,
     classes: classesOverride,
@@ -91,7 +91,7 @@ const FilterButton = ({
 FilterButton.propTypes = {
     resource: PropTypes.string.isRequired,
     filters: PropTypes.arrayOf(PropTypes.node).isRequired,
-    displayedFilters: PropTypes.object.isRequired,
+    displayedFilters: PropTypes.object,
     filterValues: PropTypes.object.isRequired,
     showFilter: PropTypes.func.isRequired,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -89,7 +89,7 @@ export const FilterForm = ({
     margin,
     variant,
     filters,
-    displayedFilters,
+    displayedFilters = {},
     hideFilter,
     initialValues,
     ...rest
@@ -147,7 +147,7 @@ const handleSubmit = event => {
 FilterForm.propTypes = {
     resource: PropTypes.string.isRequired,
     filters: PropTypes.arrayOf(PropTypes.node).isRequired,
-    displayedFilters: PropTypes.object.isRequired,
+    displayedFilters: PropTypes.object,
     hideFilter: PropTypes.func.isRequired,
     initialValues: PropTypes.object,
     classes: PropTypes.object,


### PR DESCRIPTION
Closes #4308 

## Issue

Displayed filters were lost when reloading a page because nothing was keeping information through user navigation

## Solution

Keep list of displayed filters in url, next to filters value. This allow to separe value of values and presence of filters

## Screenshot

![displayFilters](https://user-images.githubusercontent.com/39904906/75142812-228e9500-56f4-11ea-96e4-3bbfaf677189.gif)
