### PR TITLE
Add support for disabled prop in BooleanInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -22,6 +22,7 @@ const BooleanInput: FunctionComponent<
     onChange,
     onFocus,
     options,
+    disabled,
     parse,
     resource,
     source,
@@ -63,6 +64,7 @@ const BooleanInput: FunctionComponent<
                         onChange={handleChange}
                         {...inputProps}
                         {...options}
+                        disabled={disabled}
                     />
                 }
                 label={
@@ -88,6 +90,7 @@ const BooleanInput: FunctionComponent<
 BooleanInput.propTypes = {
     ...InputPropTypes,
     options: PropTypes.shape(Switch.propTypes),
+    disabled: PropTypes.bool,
 };
 
 BooleanInput.defaultProps = {


### PR DESCRIPTION
Closes #4424 

## Issue

Adding disabled property in BooleanInput component must disable it.
But this prop is ignored

## Solution

Add disabled prop to BooleanInput
## Screenshot

![image](https://user-images.githubusercontent.com/39904906/75160649-b1aea380-571a-11ea-8110-e41d84ea859d.png)
