### PR TITLE
[RFR] Migrate tests to react-testing-library

### DIFF
--- a/packages/ra-core/src/core/RoutesWithLayout.spec.tsx
+++ b/packages/ra-core/src/core/RoutesWithLayout.spec.tsx
@@ -3,7 +3,6 @@ import { Route, MemoryRouter } from 'react-router-dom';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { render, cleanup } from '@testing-library/react';
-import assert from 'assert';
 
 import RoutesWithLayout from './RoutesWithLayout';
 
@@ -34,7 +33,7 @@ describe('<RoutesWithLayout>', () => {
             </Provider>
         );
 
-        assert.notEqual(queryByText('Dashboard'), null);
+        expect(queryByText('Dashboard')).not.toBeNull();
     });
 
     it('should show the first resource on / when there is only one resource and no dashboard', () => {
@@ -48,7 +47,7 @@ describe('<RoutesWithLayout>', () => {
             </Provider>
         );
 
-        assert.notEqual(queryByText('Default'), null);
+        expect(queryByText('Default')).not.toBeNull();
     });
 
     it('should show the first resource on / when there are multiple resource and no dashboard', () => {
@@ -64,8 +63,8 @@ describe('<RoutesWithLayout>', () => {
             </Provider>
         );
 
-        assert.notEqual(queryByText('Default'), null);
-        assert.equal(queryByText('Resource'), null);
+        expect(queryByText('Default')).not.toBeNull();
+        expect(queryByText('Resource')).toBeNull();
     });
 
     it('should accept custom routes', () => {
@@ -83,6 +82,7 @@ describe('<RoutesWithLayout>', () => {
                 </MemoryRouter>
             </Provider>
         );
-        assert.notEqual(queryByText('Custom'), null);
+
+        expect(queryByText('Custom')).not.toBeNull();
     });
 });

--- a/packages/ra-core/src/core/RoutesWithLayout.spec.tsx
+++ b/packages/ra-core/src/core/RoutesWithLayout.spec.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Route, MemoryRouter } from 'react-router-dom';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { mount } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 import assert from 'assert';
 
 import RoutesWithLayout from './RoutesWithLayout';
 
 describe('<RoutesWithLayout>', () => {
+    afterEach(cleanup);
+
     const Dashboard = () => <div>Dashboard</div>;
     const Custom = ({ name }) => <div>Custom</div>;
     const FirstResource = ({ name }) => <div>Default</div>;
@@ -20,7 +22,7 @@ describe('<RoutesWithLayout>', () => {
     }));
 
     it('should show dashboard on / when provided', () => {
-        const wrapper = mount(
+        const { queryByText } = render(
             <Provider store={store}>
                 <MemoryRouter initialEntries={['/']}>
                     <RoutesWithLayout dashboard={Dashboard}>
@@ -31,11 +33,12 @@ describe('<RoutesWithLayout>', () => {
                 </MemoryRouter>
             </Provider>
         );
-        assert.equal(wrapper.find(Dashboard).length, 1);
+
+        assert.notEqual(queryByText('Dashboard'), null);
     });
 
     it('should show the first resource on / when there is only one resource and no dashboard', () => {
-        const wrapper = mount(
+        const { queryByText } = render(
             <Provider store={store}>
                 <MemoryRouter initialEntries={['/']}>
                     <RoutesWithLayout>
@@ -45,11 +48,11 @@ describe('<RoutesWithLayout>', () => {
             </Provider>
         );
 
-        assert.equal(wrapper.find(FirstResource).length, 1);
+        assert.notEqual(queryByText('Default'), null);
     });
 
     it('should show the first resource on / when there are multiple resource and no dashboard', () => {
-        const wrapper = mount(
+        const { queryByText } = render(
             <Provider store={store}>
                 <MemoryRouter initialEntries={['/']}>
                     <RoutesWithLayout>
@@ -61,15 +64,15 @@ describe('<RoutesWithLayout>', () => {
             </Provider>
         );
 
-        assert.equal(wrapper.find(FirstResource).length, 1);
-        assert.equal(wrapper.find(Resource).length, 0);
+        assert.notEqual(queryByText('Default'), null);
+        assert.equal(queryByText('Resource'), null);
     });
 
     it('should accept custom routes', () => {
         const customRoutes = [
             <Route key="custom" path="/custom" component={Custom} />,
         ]; // eslint-disable-line react/jsx-key
-        const wrapper = mount(
+        const { queryByText } = render(
             <Provider store={store}>
                 <MemoryRouter initialEntries={['/custom']}>
                     <RoutesWithLayout customRoutes={customRoutes}>
@@ -80,6 +83,6 @@ describe('<RoutesWithLayout>', () => {
                 </MemoryRouter>
             </Provider>
         );
-        assert.equal(wrapper.find(Custom).length, 1);
+        assert.notEqual(queryByText('Custom'), null);
     });
 });

--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 
 import { FormDataConsumerView } from './FormDataConsumer';
 
 describe('FormDataConsumerView', () => {
+    afterEach(cleanup);
+
     it('does not call its children function with scopedFormData and getSource if it did not receive an index prop', () => {
         const children = jest.fn();
         const formData = { id: 123, title: 'A title' };
 
-        shallow(
+        render(
             <FormDataConsumerView
                 form="a-form"
                 formData={formData}
@@ -29,7 +31,7 @@ describe('FormDataConsumerView', () => {
         });
         const formData = { id: 123, title: 'A title', authors: [{ id: 0 }] };
 
-        shallow(
+        render(
             <FormDataConsumerView
                 form="a-form"
                 source="authors[0]"

--- a/packages/ra-core/src/form/FormField.spec.tsx
+++ b/packages/ra-core/src/form/FormField.spec.tsx
@@ -1,7 +1,6 @@
-import assert from 'assert';
-import { render, fireEvent, cleanup } from '@testing-library/react';
-import { Form } from 'react-final-form';
 import React from 'react';
+import { Form } from 'react-final-form';
+import { render, fireEvent, cleanup } from '@testing-library/react';
 import FormField from './FormField';
 
 describe('<FormField>', () => {
@@ -22,7 +21,7 @@ describe('<FormField>', () => {
         );
         const input = getByRole('textbox');
         fireEvent.change(input, { target: { value: 'Lorem' } });
-        assert.equal(formApi.getState().values.title, 'Lorem');
+        expect(formApi.getState().values.title).toEqual('Lorem');
     });
 
     it('should not render a <Field /> component if the field has an input', () => {
@@ -40,6 +39,6 @@ describe('<FormField>', () => {
         );
         const input = getByRole('textbox');
         fireEvent.change(input, { target: { value: 'Lorem' } });
-        assert.notEqual(formApi.getState().values.title, 'Lorem');
+        expect(formApi.getState().values.title).not.toEqual('Lorem');
     });
 });

--- a/packages/ra-core/src/form/FormField.spec.tsx
+++ b/packages/ra-core/src/form/FormField.spec.tsx
@@ -1,21 +1,45 @@
 import assert from 'assert';
-import { shallow } from 'enzyme';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { Form } from 'react-final-form';
 import React from 'react';
 import FormField from './FormField';
 
 describe('<FormField>', () => {
-    const Foo = () => <div />;
+    afterEach(cleanup);
+
+    const Foo = ({ input }) => <input type="text" {...input} />;
+
     it('should render a <Field/> component for the input component', () => {
-        const wrapper = shallow(<FormField source="title" component={Foo} />);
-        const component = wrapper.find('Field');
-        assert.equal(component.length, 1);
-        assert.equal(wrapper.prop('component'), Foo);
-    });
-    it('should not render a <Field /> component the field has an input', () => {
-        const wrapper = shallow(
-            <FormField source="title" component={Foo} input={{}} />
+        let formApi;
+        const { getByRole } = render(
+            <Form
+                onSubmit={jest.fn()}
+                render={({ form }) => {
+                    formApi = form;
+                    return <FormField source="title" component={Foo} />;
+                }}
+            />
         );
-        const component = wrapper.find('Field');
-        assert.equal(component.length, 0);
+        const input = getByRole('textbox');
+        fireEvent.change(input, { target: { value: 'Lorem' } });
+        assert.equal(formApi.getState().values.title, 'Lorem');
+    });
+
+    it('should not render a <Field /> component if the field has an input', () => {
+        let formApi;
+        const { getByRole } = render(
+            <Form
+                onSubmit={jest.fn()}
+                render={({ form }) => {
+                    formApi = form;
+                    return (
+                        <FormField source="title" component={Foo} input={{}} />
+                    );
+                }}
+            />
+        );
+        const input = getByRole('textbox');
+        fireEvent.change(input, { target: { value: 'Lorem' } });
+        assert.notEqual(formApi.getState().values.title, 'Lorem');
     });
 });

--- a/packages/ra-ui-materialui/src/button/CloneButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/CloneButton.spec.tsx
@@ -1,19 +1,28 @@
 import expect from 'expect';
-import { shallow } from 'enzyme';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core';
+import { render } from '@testing-library/react';
 import React from 'react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 
 import { CloneButton } from './CloneButton';
 
+const theme = createMuiTheme();
+
 describe('<CloneButton />', () => {
     it('should pass a clone of the record in the location state', () => {
-        const wrapper = shallow(
-            <CloneButton record={{ id: 123, foo: 'bar' }} basePath="" />
+        const history = createMemoryHistory();
+        const { getByRole } = render(
+            <Router history={history}>
+                <ThemeProvider theme={theme}>
+                    <CloneButton record={{ id: 123, foo: 'bar' }} basePath="" />
+                </ThemeProvider>
+            </Router>
         );
 
-        expect(wrapper.prop('to')).toEqual(
-            expect.objectContaining({
-                search: 'source=%7B%22foo%22%3A%22bar%22%7D',
-            })
+        const button = getByRole('button');
+        expect(button.getAttribute('href')).toEqual(
+            '/create?source=%7B%22foo%22%3A%22bar%22%7D'
         );
     });
 });

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.spec.js
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.spec.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import SimpleShowLayout from './SimpleShowLayout';
 import TextField from '../field/TextField';
 
 describe('<SimpleShowLayout />', () => {
     it('should display children inputs of SimpleShowLayout', () => {
-        const wrapper = shallow(
-            <SimpleShowLayout>
+        const { queryByText } = render(
+            <SimpleShowLayout record={{ foo: 'foo', bar: 'bar' }}>
                 <TextField source="foo" />
                 <TextField source="bar" />
             </SimpleShowLayout>
         );
-        const inputs = wrapper.find('EnhancedTextField');
-        expect(inputs.map(i => i.prop('source'))).toEqual(['foo', 'bar']);
+        expect(queryByText('foo')).not.toBeNull();
+        expect(queryByText('bar')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/FunctionField.spec.js
+++ b/packages/ra-ui-materialui/src/field/FunctionField.spec.js
@@ -1,26 +1,27 @@
 import React from 'react';
 import assert from 'assert';
-import { render, shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 import FunctionField from './FunctionField';
 
 describe('<FunctionField />', () => {
+    afterEach(cleanup);
+
     it('should render using the render function', () => {
         const record = { foo: 'bar' };
-        const wrapper = render(
+        const { queryByText } = render(
             <FunctionField record={record} render={r => r.foo.substr(0, 2)} />
         );
-        assert.equal(wrapper.text(), 'ba');
+        assert.notEqual(queryByText('ba'), null);
     });
 
-    it('should use custom className', () =>
-        assert.deepEqual(
-            shallow(
-                <FunctionField
-                    record={{ foo: true }}
-                    render={r => r.foo.substr(0, 2)}
-                    className="foo"
-                />
-            ).prop('className'),
-            'foo'
-        ));
+    it('should use custom className', () => {
+        const { queryByText } = render(
+            <FunctionField
+                record={{ foo: 'bar' }}
+                render={r => r.foo}
+                className="foo"
+            />
+        );
+        assert.ok(queryByText('bar').classList.contains('foo'));
+    });
 });

--- a/packages/ra-ui-materialui/src/field/FunctionField.spec.js
+++ b/packages/ra-ui-materialui/src/field/FunctionField.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import assert from 'assert';
 import { render, cleanup } from '@testing-library/react';
 import FunctionField from './FunctionField';
 
@@ -11,7 +10,7 @@ describe('<FunctionField />', () => {
         const { queryByText } = render(
             <FunctionField record={record} render={r => r.foo.substr(0, 2)} />
         );
-        assert.notEqual(queryByText('ba'), null);
+        expect(queryByText('ba')).not.toBeNull();
     });
 
     it('should use custom className', () => {
@@ -22,6 +21,6 @@ describe('<FunctionField />', () => {
                 className="foo"
             />
         );
-        assert.ok(queryByText('bar').classList.contains('foo'));
+        expect(queryByText('bar').classList).toContain('foo');
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.spec.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.spec.js
@@ -1,61 +1,60 @@
 import React from 'react';
-import assert from 'assert';
-import { shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 import { ReferenceManyFieldView } from './ReferenceManyField';
 import TextField from './TextField';
 import SingleFieldList from '../list/SingleFieldList';
 
 describe('<ReferenceManyField />', () => {
+    afterEach(cleanup);
+
     it('should render a list of the child component', () => {
         const data = {
             1: { id: 1, title: 'hello' },
             2: { id: 2, title: 'world' },
         };
-        const wrapper = shallow(
-            <ReferenceManyFieldView
-                resource="foo"
-                reference="bar"
-                basePath=""
-                data={data}
-                ids={[1, 2]}
-            >
-                <SingleFieldList>
-                    <TextField source="title" />
-                </SingleFieldList>
-            </ReferenceManyFieldView>,
-            { disableLifecycleMethods: true }
+        const history = createMemoryHistory();
+        const { queryAllByRole } = render(
+            <Router history={history}>
+                <ReferenceManyFieldView
+                    resource="foo"
+                    reference="bar"
+                    referenceBasePath="posts"
+                    data={data}
+                    ids={[1, 2]}
+                >
+                    <SingleFieldList>
+                        <TextField source="title" />
+                    </SingleFieldList>
+                </ReferenceManyFieldView>
+            </Router>
         );
-        const ProgressElements = wrapper.find('WithStyles(LinearProgress)');
-        assert.equal(ProgressElements.length, 0);
-        const SingleFieldListElement = wrapper.find('SingleFieldList');
-        assert.equal(SingleFieldListElement.length, 1);
-        assert.equal(SingleFieldListElement.at(0).prop('resource'), 'bar');
-        assert.deepEqual(SingleFieldListElement.at(0).prop('data'), data);
-        assert.deepEqual(SingleFieldListElement.at(0).prop('ids'), [1, 2]);
+        expect(queryAllByRole('progressbar')).toHaveLength(0);
+        const links = queryAllByRole('link');
+        expect(links).toHaveLength(2);
+        expect(links[0].textContent).toEqual('hello');
+        expect(links[1].textContent).toEqual('world');
+        expect(links[0].getAttribute('href')).toEqual('/posts/1');
+        expect(links[1].getAttribute('href')).toEqual('/posts/2');
     });
 
     it('should render nothing when there are no related records', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = render(
             <ReferenceManyFieldView
                 resource="foo"
                 reference="bar"
-                basePath=""
+                referenceBasePath="posts"
                 data={{}}
                 ids={[]}
             >
                 <SingleFieldList>
                     <TextField source="title" />
                 </SingleFieldList>
-            </ReferenceManyFieldView>,
-            { disableLifecycleMethods: true }
+            </ReferenceManyFieldView>
         );
-        const ProgressElements = wrapper.find('WithStyles(LinearProgress)');
-        assert.equal(ProgressElements.length, 0);
-        const SingleFieldListElement = wrapper.find('SingleFieldList');
-        assert.equal(SingleFieldListElement.length, 1);
-        assert.equal(SingleFieldListElement.at(0).prop('resource'), 'bar');
-        assert.deepEqual(SingleFieldListElement.at(0).prop('data'), {});
-        assert.deepEqual(SingleFieldListElement.at(0).prop('ids'), []);
+        expect(queryAllByRole('progressbar')).toHaveLength(0);
+        expect(queryAllByRole('link')).toHaveLength(0);
     });
 
     it('should support record with string identifier', () => {
@@ -63,30 +62,29 @@ describe('<ReferenceManyField />', () => {
             'abc-1': { id: 'abc-1', title: 'hello' },
             'abc-2': { id: 'abc-2', title: 'world' },
         };
-        const wrapper = shallow(
-            <ReferenceManyFieldView
-                resource="foo"
-                reference="bar"
-                basePath=""
-                data={data}
-                ids={['abc-1', 'abc-2']}
-            >
-                <SingleFieldList>
-                    <TextField source="title" />
-                </SingleFieldList>
-            </ReferenceManyFieldView>,
-            { disableLifecycleMethods: true }
+        const history = createMemoryHistory();
+        const { queryAllByRole } = render(
+            <Router history={history}>
+                <ReferenceManyFieldView
+                    resource="foo"
+                    reference="bar"
+                    referenceBasePath="posts"
+                    data={data}
+                    ids={['abc-1', 'abc-2']}
+                >
+                    <SingleFieldList>
+                        <TextField source="title" />
+                    </SingleFieldList>
+                </ReferenceManyFieldView>
+            </Router>
         );
-        const ProgressElements = wrapper.find('widthStyles(LinearProgress)');
-        assert.equal(ProgressElements.length, 0);
-        const SingleFieldListElement = wrapper.find('SingleFieldList');
-        assert.equal(SingleFieldListElement.length, 1);
-        assert.equal(SingleFieldListElement.at(0).prop('resource'), 'bar');
-        assert.deepEqual(SingleFieldListElement.at(0).prop('data'), data);
-        assert.deepEqual(SingleFieldListElement.at(0).prop('ids'), [
-            'abc-1',
-            'abc-2',
-        ]);
+        expect(queryAllByRole('progressbar')).toHaveLength(0);
+        const links = queryAllByRole('link');
+        expect(links).toHaveLength(2);
+        expect(links[0].textContent).toEqual('hello');
+        expect(links[1].textContent).toEqual('world');
+        expect(links[0].getAttribute('href')).toEqual('/posts/abc-1');
+        expect(links[1].getAttribute('href')).toEqual('/posts/abc-2');
     });
 
     it('should support record with number identifier', () => {
@@ -94,26 +92,28 @@ describe('<ReferenceManyField />', () => {
             1: { id: 1, title: 'hello' },
             2: { id: 2, title: 'world' },
         };
-        const wrapper = shallow(
-            <ReferenceManyFieldView
-                resource="foo"
-                reference="bar"
-                basePath=""
-                data={data}
-                ids={[1, 2]}
-            >
-                <SingleFieldList>
-                    <TextField source="title" />
-                </SingleFieldList>
-            </ReferenceManyFieldView>,
-            { disableLifecycleMethods: true }
+        const history = createMemoryHistory();
+        const { queryAllByRole } = render(
+            <Router history={history}>
+                <ReferenceManyFieldView
+                    resource="foo"
+                    reference="bar"
+                    referenceBasePath="posts"
+                    data={data}
+                    ids={[1, 2]}
+                >
+                    <SingleFieldList>
+                        <TextField source="title" />
+                    </SingleFieldList>
+                </ReferenceManyFieldView>
+            </Router>
         );
-        const ProgressElements = wrapper.find('WithStyles(LinearProgress)');
-        assert.equal(ProgressElements.length, 0);
-        const SingleFieldListElement = wrapper.find('SingleFieldList');
-        assert.equal(SingleFieldListElement.length, 1);
-        assert.equal(SingleFieldListElement.at(0).prop('resource'), 'bar');
-        assert.deepEqual(SingleFieldListElement.at(0).prop('data'), data);
-        assert.deepEqual(SingleFieldListElement.at(0).prop('ids'), [1, 2]);
+        expect(queryAllByRole('progressbar')).toHaveLength(0);
+        const links = queryAllByRole('link');
+        expect(links).toHaveLength(2);
+        expect(links[0].textContent).toEqual('hello');
+        expect(links[1].textContent).toEqual('world');
+        expect(links[0].getAttribute('href')).toEqual('/posts/1');
+        expect(links[1].getAttribute('href')).toEqual('/posts/2');
     });
 });

--- a/packages/ra-ui-materialui/src/layout/Responsive.spec.js
+++ b/packages/ra-ui-materialui/src/layout/Responsive.spec.js
@@ -1,16 +1,17 @@
-import assert from 'assert';
-import { shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 import React from 'react';
 
 import { Responsive } from './Responsive';
 
 describe('<Responsive>', () => {
-    const Small = () => <div />;
-    const Medium = () => <div />;
-    const Large = () => <div />;
+    afterEach(cleanup);
+
+    const Small = () => <div>Small</div>;
+    const Medium = () => <div>Medium</div>;
+    const Large = () => <div>Large</div>;
 
     it('should render the small component on small screens', () => {
-        const wrapper = shallow(
+        const { queryByText } = render(
             <Responsive
                 small={<Small />}
                 medium={<Medium />}
@@ -18,22 +19,22 @@ describe('<Responsive>', () => {
                 width="xs"
             />
         );
-        const component = wrapper.find('Small');
-        assert.equal(component.length, 1);
+        expect(queryByText('Small')).not.toBeNull();
+        expect(queryByText('Medium')).toBeNull();
+        expect(queryByText('Large')).toBeNull();
     });
-    it('should render the small component on small screens and small is null', () => {
-        const wrapper = shallow(
-            <Responsive
-                small={null}
-                medium={<Medium />}
-                large={<Large />}
-                width="xs"
-            />
+
+    it('should render the medium component on small screens and small is null', () => {
+        const { queryByText } = render(
+            <Responsive medium={<Medium />} large={<Large />} width="xs" />
         );
-        assert.equal(wrapper.get(0), null);
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).not.toBeNull();
+        expect(queryByText('Large')).toBeNull();
     });
+
     it('should render the medium component on medium screens', () => {
-        const wrapper = shallow(
+        const { queryByText } = render(
             <Responsive
                 small={<Small />}
                 medium={<Medium />}
@@ -41,116 +42,103 @@ describe('<Responsive>', () => {
                 width="md"
             />
         );
-        const component = wrapper.find('Medium');
-        assert.equal(component.length, 1);
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).not.toBeNull();
+        expect(queryByText('Large')).toBeNull();
     });
-    it('should render the medium component on medium screens and medium is null', () => {
-        const wrapper = shallow(
-            <Responsive
-                small={<Small />}
-                medium={null}
-                large={<Large />}
-                width="md"
-            />
-        );
-        assert.equal(wrapper.get(0), null);
-    });
-    it('should render the large component on large screens', () => {
-        const wrapper = shallow(
-            <Responsive
-                small={<Small />}
-                medium={<Medium />}
-                large={<Large />}
-                width="lg"
-            />
-        );
-        const component = wrapper.find('Large');
-        assert.equal(component.length, 1);
-    });
-    it('should render the large component on large screens and large is null', () => {
-        const wrapper = shallow(
-            <Responsive
-                small={<Small />}
-                medium={<Medium />}
-                large={null}
-                width="lg"
-            />
-        );
-        assert.equal(wrapper.get(0), null);
-    });
-    it('should render the small component on all screens when no other component is passed', () => {
-        assert.equal(
-            shallow(<Responsive small={<Small />} width="xs" />).find('Small')
-                .length,
-            1
-        );
-        assert.equal(
-            shallow(<Responsive small={<Small />} width="sm" />).find('Small')
-                .length,
-            1
-        );
-        assert.equal(
-            shallow(<Responsive small={<Small />} width="lg" />).find('Small')
-                .length,
-            1
-        );
-    });
-    it('should render the medium component on all screens when no other component is passed', () => {
-        assert.equal(
-            shallow(<Responsive medium={<Medium />} width="xs" />).find(
-                'Medium'
-            ).length,
-            1
-        );
-        assert.equal(
-            shallow(<Responsive medium={<Medium />} width="sm" />).find(
-                'Medium'
-            ).length,
-            1
-        );
-        assert.equal(
-            shallow(<Responsive medium={<Medium />} width="lg" />).find(
-                'Medium'
-            ).length,
-            1
-        );
-    });
-    it('should render the large component on all screens when no other component is passed', () => {
-        assert.equal(
-            shallow(<Responsive large={<Large />} width="xs" />).find('Large')
-                .length,
-            1
-        );
-        assert.equal(
-            shallow(<Responsive large={<Large />} width="sm" />).find('Large')
-                .length,
-            1
-        );
-        assert.equal(
-            shallow(<Responsive large={<Large />} width="lg" />).find('Large')
-                .length,
-            1
-        );
-    });
-    it('should fallback to the large component on medium screens', () => {
-        const wrapper = shallow(
+
+    it('should render the large component on medium screens and medium is null', () => {
+        const { queryByText } = render(
             <Responsive small={<Small />} large={<Large />} width="md" />
         );
-        const component = wrapper.find('Large');
-        assert.equal(component.length, 1);
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).toBeNull();
+        expect(queryByText('Large')).not.toBeNull();
     });
-    it('should fallback to the medium component on small screens', () => {
-        const wrapper = shallow(
-            <Responsive medium={<Medium />} large={<Large />} width="sm" />
+
+    it('should render the large component on large screens', () => {
+        const { queryByText } = render(
+            <Responsive
+                small={<Small />}
+                medium={<Medium />}
+                large={<Large />}
+                width="lg"
+            />
         );
-        const component = wrapper.find('Medium');
-        assert.equal(component.length, 1);
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).toBeNull();
+        expect(queryByText('Large')).not.toBeNull();
     });
-    it('should fallback to the medium component on large screens', () => {
-        const wrapper = shallow(
+
+    it('should render the medium component on large screens and large is null', () => {
+        const { queryByText } = render(
             <Responsive small={<Small />} medium={<Medium />} width="lg" />
         );
-        const component = wrapper.find('Medium');
-        assert.equal(component.length, 1);
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).not.toBeNull();
+        expect(queryByText('Large')).toBeNull();
+    });
+
+    it('should render the small component on all screens when no other component is passed', () => {
+        ['xs', 'sm', 'lg'].forEach(width => {
+            const { queryByText } = render(
+                <Responsive small={<Small />} width={width} />
+            );
+            expect(queryByText('Small')).not.toBeNull();
+            expect(queryByText('Medium')).toBeNull();
+            expect(queryByText('Large')).toBeNull();
+            cleanup();
+        });
+    });
+
+    it('should render the medium component on all screens when no other component is passed', () => {
+        ['xs', 'sm', 'lg'].forEach(width => {
+            const { queryByText } = render(
+                <Responsive medium={<Medium />} width={width} />
+            );
+            expect(queryByText('Small')).toBeNull();
+            expect(queryByText('Medium')).not.toBeNull();
+            expect(queryByText('Large')).toBeNull();
+            cleanup();
+        });
+    });
+
+    it('should render the large component on all screens when no other component is passed', () => {
+        ['xs', 'sm', 'lg'].forEach(width => {
+            const { queryByText } = render(
+                <Responsive large={<Large />} width={width} />
+            );
+            expect(queryByText('Small')).toBeNull();
+            expect(queryByText('Medium')).toBeNull();
+            expect(queryByText('Large')).not.toBeNull();
+            cleanup();
+        });
+    });
+
+    it('should fallback to the large component on medium screens', () => {
+        const { queryByText } = render(
+            <Responsive small={<Small />} large={<Large />} width="md" />
+        );
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).toBeNull();
+        expect(queryByText('Large')).not.toBeNull();
+    });
+
+    it('should fallback to the medium component on small screens', () => {
+        const { queryByText } = render(
+            <Responsive medium={<Medium />} large={<Large />} width="sm" />
+        );
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).not.toBeNull();
+        expect(queryByText('Large')).toBeNull();
+    });
+
+    it('should fallback to the medium component on large screens', () => {
+        const { queryByText } = render(
+            <Responsive small={<Small />} medium={<Medium />} width="lg" />
+        );
+        expect(queryByText('Small')).toBeNull();
+        expect(queryByText('Medium')).not.toBeNull();
+        expect(queryByText('Large')).toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/list/DatagridCell.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridCell.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { render, cleanup } from '@testing-library/react';
@@ -15,6 +14,8 @@ const renderWithTable = element =>
     );
 
 describe('<DatagridCell />', () => {
+    afterEach(cleanup);
+
     const Field = ({ basePath }) => <div>{basePath}</div>;
     Field.propTypes = {
         type: PropTypes.string,
@@ -29,20 +30,20 @@ describe('<DatagridCell />', () => {
         const { getByRole } = renderWithTable(
             <DatagridCell field={<Field />} />
         );
-        assert.equal(getByRole('cell').className, 'MuiTableCell-root');
+        expect(getByRole('cell').className).toEqual('MuiTableCell-root');
     });
 
     it('should pass the Datagrid basePath by default', () => {
         const { queryByText } = renderWithTable(
             <DatagridCell basePath="default" field={<Field />} />
         );
-        assert.notEqual(queryByText('default'), null);
+        expect(queryByText('default')).not.toBeNull();
     });
 
     it('should allow to overwrite the `basePath` field', () => {
         const { queryByText } = renderWithTable(
             <DatagridCell basePath="default" field={<Field basePath="new" />} />
         );
-        assert.notEqual(queryByText('new'), null);
+        expect(queryByText('new')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/list/DatagridCell.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridCell.spec.js
@@ -1,12 +1,21 @@
 import assert from 'assert';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 
 import DatagridCell from './DatagridCell';
 
+const renderWithTable = element =>
+    render(
+        <table>
+            <tbody>
+                <tr>{element}</tr>
+            </tbody>
+        </table>
+    );
+
 describe('<DatagridCell />', () => {
-    const Field = () => <div />;
+    const Field = ({ basePath }) => <div>{basePath}</div>;
     Field.propTypes = {
         type: PropTypes.string,
         basePath: PropTypes.string,
@@ -16,25 +25,24 @@ describe('<DatagridCell />', () => {
         type: 'foo',
     };
 
-    it('should render as a mui <TableRowColumn /> component', () => {
-        const wrapper = shallow(<DatagridCell field={<Field />} />);
-        const col = wrapper.find('WithStyles(ForwardRef(TableCell))');
-        assert.equal(col.length, 1);
+    it('should render as a mui <TableCell /> component', () => {
+        const { getByRole } = renderWithTable(
+            <DatagridCell field={<Field />} />
+        );
+        assert.equal(getByRole('cell').className, 'MuiTableCell-root');
     });
 
     it('should pass the Datagrid basePath by default', () => {
-        const wrapper = shallow(
+        const { queryByText } = renderWithTable(
             <DatagridCell basePath="default" field={<Field />} />
         );
-        const col = wrapper.find('Field');
-        assert.equal(col.prop('basePath'), 'default');
+        assert.notEqual(queryByText('default'), null);
     });
 
     it('should allow to overwrite the `basePath` field', () => {
-        const wrapper = shallow(
+        const { queryByText } = renderWithTable(
             <DatagridCell basePath="default" field={<Field basePath="new" />} />
         );
-        const col = wrapper.find('Field');
-        assert.equal(col.prop('basePath'), 'new');
+        assert.notEqual(queryByText('new'), null);
     });
 });

--- a/packages/ra-ui-materialui/src/list/PaginationActions.spec.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.spec.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 
 import PaginationActions from './PaginationActions';
 
 describe('<PaginationActions />', () => {
+    afterEach(cleanup);
+
     it('should not render any actions when no pagination is necessary', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = render(
             <PaginationActions
                 page={0}
                 rowsPerPage={20}
@@ -15,13 +17,11 @@ describe('<PaginationActions />', () => {
                 classes={{}}
             />
         );
-        expect(wrapper.find('WithStyles(ForwardRef(Button))')).toHaveLength(0);
-        expect(wrapper.find('WithStyles(ForwardRef(Typography))')).toHaveLength(
-            0
-        );
+        expect(queryAllByRole('button')).toHaveLength(0);
     });
+
     it('should render action buttons when pagination is necessary', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = render(
             <PaginationActions
                 page={0}
                 rowsPerPage={5}
@@ -32,11 +32,11 @@ describe('<PaginationActions />', () => {
             />
         );
         // 1 2 3 next
-        expect(wrapper.find('WithStyles(ForwardRef(Button))')).toHaveLength(4);
+        expect(queryAllByRole('button')).toHaveLength(4);
     });
 
     it('should skip page action buttons when there are too many', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = render(
             <PaginationActions
                 page={7}
                 rowsPerPage={1}
@@ -47,6 +47,6 @@ describe('<PaginationActions />', () => {
             />
         );
         // prev 1 ... 7 8 9 ... 15 next
-        expect(wrapper.find('WithStyles(ForwardRef(Button))')).toHaveLength(7);
+        expect(queryAllByRole('button')).toHaveLength(7);
     });
 });

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.spec.js
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.spec.js
@@ -1,13 +1,26 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 
 import SingleFieldList from './SingleFieldList';
 import ChipField from '../field/ChipField';
 
+const renderWithRouter = children => {
+    const history = createMemoryHistory();
+
+    return {
+        history,
+        ...render(<Router history={history}>{children}</Router>),
+    };
+};
+
 describe('<SingleFieldList />', () => {
+    afterEach(cleanup);
+
     it('should render a link to the Edit page of the related record by default', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = renderWithRouter(
             <SingleFieldList
                 ids={[1, 2]}
                 data={{
@@ -20,16 +33,16 @@ describe('<SingleFieldList />', () => {
                 <ChipField source="title" />
             </SingleFieldList>
         );
-        const linkElements = wrapper.find('Link');
+        const linkElements = queryAllByRole('link');
         assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+        assert.deepEqual(linkElements.map(link => link.getAttribute('href')), [
             '/posts/1',
             '/posts/2',
         ]);
     });
 
     it('should render a link to the Edit page of the related record when the resource contains slashes', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = renderWithRouter(
             <SingleFieldList
                 ids={[1, 2]}
                 data={{
@@ -42,58 +55,41 @@ describe('<SingleFieldList />', () => {
                 <ChipField source="title" />
             </SingleFieldList>
         );
-        const linkElements = wrapper.find('Link');
+        const linkElements = queryAllByRole('link');
         assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+        assert.deepEqual(linkElements.map(link => link.getAttribute('href')), [
             '/posts/1',
             '/posts/2',
         ]);
     });
 
     it('should render a link to the Edit page of the related record when the resource is named edit or show', () => {
-        let wrapper = shallow(
-            <SingleFieldList
-                ids={[1, 2]}
-                data={{
-                    1: { id: 1, title: 'foo' },
-                    2: { id: 2, title: 'bar' },
-                }}
-                resource="edit"
-                basePath="/edit"
-            >
-                <ChipField source="title" />
-            </SingleFieldList>
-        );
-        let linkElements = wrapper.find('Link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/edit/1',
-            '/edit/2',
-        ]);
-
-        wrapper = shallow(
-            <SingleFieldList
-                ids={[1, 2]}
-                data={{
-                    1: { id: 1, title: 'foo' },
-                    2: { id: 2, title: 'bar' },
-                }}
-                resource="show"
-                basePath="/show"
-            >
-                <ChipField source="title" />
-            </SingleFieldList>
-        );
-        linkElements = wrapper.find('Link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/show/1',
-            '/show/2',
-        ]);
+        ['edit', 'show'].forEach(action => {
+            const { queryAllByRole } = renderWithRouter(
+                <SingleFieldList
+                    ids={[1, 2]}
+                    data={{
+                        1: { id: 1, title: 'foo' },
+                        2: { id: 2, title: 'bar' },
+                    }}
+                    resource={action}
+                    basePath={`/${action}`}
+                >
+                    <ChipField source="title" />
+                </SingleFieldList>
+            );
+            const linkElements = queryAllByRole('link');
+            assert.equal(linkElements.length, 2);
+            assert.deepEqual(
+                linkElements.map(link => link.getAttribute('href')),
+                [`/${action}/1`, `/${action}/2`]
+            );
+            cleanup();
+        });
     });
 
     it('should render a link to the Show page of the related record when the linkType is show', () => {
-        const wrapper = shallow(
+        const { queryAllByRole } = renderWithRouter(
             <SingleFieldList
                 ids={[1, 2]}
                 data={{
@@ -108,60 +104,42 @@ describe('<SingleFieldList />', () => {
             </SingleFieldList>
         );
 
-        const linkElements = wrapper.find('Link');
+        const linkElements = queryAllByRole('link');
         assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+        assert.deepEqual(linkElements.map(link => link.getAttribute('href')), [
             '/prefix/bar/1/show',
             '/prefix/bar/2/show',
         ]);
     });
 
     it('should render a link to the Edit page of the related record when the resource is named edit or show and linkType is show', () => {
-        let wrapper = shallow(
-            <SingleFieldList
-                ids={[1, 2]}
-                data={{
-                    1: { id: 1, title: 'foo' },
-                    2: { id: 2, title: 'bar' },
-                }}
-                resource="edit"
-                basePath="/edit"
-                linkType="show"
-            >
-                <ChipField source="title" />
-            </SingleFieldList>
-        );
-        let linkElements = wrapper.find('Link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/edit/1/show',
-            '/edit/2/show',
-        ]);
-
-        wrapper = shallow(
-            <SingleFieldList
-                ids={[1, 2]}
-                data={{
-                    1: { id: 1, title: 'foo' },
-                    2: { id: 2, title: 'bar' },
-                }}
-                resource="show"
-                basePath="/show"
-                linkType="show"
-            >
-                <ChipField source="title" />
-            </SingleFieldList>
-        );
-        linkElements = wrapper.find('Link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/show/1/show',
-            '/show/2/show',
-        ]);
+        ['edit', 'show'].forEach(action => {
+            const { queryAllByRole } = renderWithRouter(
+                <SingleFieldList
+                    ids={[1, 2]}
+                    data={{
+                        1: { id: 1, title: 'foo' },
+                        2: { id: 2, title: 'bar' },
+                    }}
+                    resource={action}
+                    basePath={`/${action}`}
+                    linkType="show"
+                >
+                    <ChipField source="title" />
+                </SingleFieldList>
+            );
+            const linkElements = queryAllByRole('link');
+            assert.equal(linkElements.length, 2);
+            assert.deepEqual(
+                linkElements.map(link => link.getAttribute('href')),
+                [`/${action}/1/show`, `/${action}/2/show`]
+            );
+            cleanup();
+        });
     });
 
     it('should render no link when the linkType is false', () => {
-        const wrapper = shallow(
+        const { queryAllByRole, queryByText } = renderWithRouter(
             <SingleFieldList
                 ids={[1, 2]}
                 data={{
@@ -176,9 +154,9 @@ describe('<SingleFieldList />', () => {
             </SingleFieldList>
         );
 
-        const linkElements = wrapper.find('Link');
+        const linkElements = queryAllByRole('link');
         assert.equal(linkElements.length, 0);
-        const chipElements = wrapper.find('EnhancedChipField');
-        assert.equal(chipElements.length, 2);
+        assert.notEqual(queryByText('foo'), null);
+        assert.notEqual(queryByText('bar'), null);
     });
 });

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.spec.js
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import assert from 'assert';
 import { render, cleanup } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
@@ -34,8 +33,8 @@ describe('<SingleFieldList />', () => {
             </SingleFieldList>
         );
         const linkElements = queryAllByRole('link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.getAttribute('href')), [
+        expect(linkElements).toHaveLength(2);
+        expect(linkElements.map(link => link.getAttribute('href'))).toEqual([
             '/posts/1',
             '/posts/2',
         ]);
@@ -56,8 +55,8 @@ describe('<SingleFieldList />', () => {
             </SingleFieldList>
         );
         const linkElements = queryAllByRole('link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.getAttribute('href')), [
+        expect(linkElements).toHaveLength(2);
+        expect(linkElements.map(link => link.getAttribute('href'))).toEqual([
             '/posts/1',
             '/posts/2',
         ]);
@@ -79,9 +78,8 @@ describe('<SingleFieldList />', () => {
                 </SingleFieldList>
             );
             const linkElements = queryAllByRole('link');
-            assert.equal(linkElements.length, 2);
-            assert.deepEqual(
-                linkElements.map(link => link.getAttribute('href')),
+            expect(linkElements).toHaveLength(2);
+            expect(linkElements.map(link => link.getAttribute('href'))).toEqual(
                 [`/${action}/1`, `/${action}/2`]
             );
             cleanup();
@@ -105,8 +103,8 @@ describe('<SingleFieldList />', () => {
         );
 
         const linkElements = queryAllByRole('link');
-        assert.equal(linkElements.length, 2);
-        assert.deepEqual(linkElements.map(link => link.getAttribute('href')), [
+        expect(linkElements).toHaveLength(2);
+        expect(linkElements.map(link => link.getAttribute('href'))).toEqual([
             '/prefix/bar/1/show',
             '/prefix/bar/2/show',
         ]);
@@ -129,9 +127,8 @@ describe('<SingleFieldList />', () => {
                 </SingleFieldList>
             );
             const linkElements = queryAllByRole('link');
-            assert.equal(linkElements.length, 2);
-            assert.deepEqual(
-                linkElements.map(link => link.getAttribute('href')),
+            expect(linkElements).toHaveLength(2);
+            expect(linkElements.map(link => link.getAttribute('href'))).toEqual(
                 [`/${action}/1/show`, `/${action}/2/show`]
             );
             cleanup();
@@ -155,8 +152,8 @@ describe('<SingleFieldList />', () => {
         );
 
         const linkElements = queryAllByRole('link');
-        assert.equal(linkElements.length, 0);
-        assert.notEqual(queryByText('foo'), null);
-        assert.notEqual(queryByText('bar'), null);
+        expect(linkElements).toHaveLength(0);
+        expect(queryByText('foo')).not.toBeNull();
+        expect(queryByText('bar')).not.toBeNull();
     });
 });

--- a/test-setup.js
+++ b/test-setup.js
@@ -6,11 +6,6 @@ require('raf/polyfill');
  */
 require('mutationobserver-shim');
 
-var enzyme = require('enzyme');
-var Adapter = require('enzyme-adapter-react-16');
-
-enzyme.configure({ adapter: new Adapter() });
-
 /**
  * Mock PopperJS
  *


### PR DESCRIPTION
This PR migrates to react-testing-library all test cases that still use enzyme.

TODO
- [x] DataGridCell
- [x] SingleFieldList
- [x] CloneButton
- [x] PaginationActions
- [x] RoutesWithLayout
- [x] FormDataConsumerView
- [x] FormField
- [x] SimpleShowLayout
- [x] FunctionField
- [x] ReferenceManyField
- [x] ReferenceArrayInput
- [x] Responsive