### PR TITLE
Fix build of ra-input-rich-text

### DIFF
--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -41,11 +41,11 @@
     },
     "peerDependencies": {
         "ra-core": "^3.0.0",
+        "ra-ui-materialui": "^3.0.0",
         "react": "^16.9.0",
         "react-dom": "^16.9.0"
     },
     "dependencies": {
-        "ra-ui-materialui": "^3.0.0",
         "@types/quill": "~1.3.0",
         "lodash": "~4.17.5",
         "prop-types": "^15.6.0",

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -45,6 +45,7 @@
         "react-dom": "^16.9.0"
     },
     "dependencies": {
+        "ra-ui-materialui": "^3.0.0",
         "@types/quill": "~1.3.0",
         "lodash": "~4.17.5",
         "prop-types": "^15.6.0",


### PR DESCRIPTION
Hi there,

Thank you for such a nice library!

I don't know too much about lerna but I learnt that for the build to work I
need to add a dependency from ra-input-rich-text to ra-ui-materialui. 

I don't know if this is exactly the right thing to do, but I'd appreciate any feed back.

Regards


`npm run build` fails on a fresh checkout

Cannot find module **'ra-ui-materialui** when building **ra-input-rich-text**

```
> ra-input-rich-text@3.2.0 build C:\dev\oss\react-admin\packages\ra-input-rich-text
> yarn run build-cjs && yarn run build-esm

yarn run v1.15.2
$ rimraf ./lib && tsc
src/index.tsx(11,33): error TS2307: Cannot find module 'ra-ui-materialui'.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

    at C:\dev\OSS\react-admin\node_modules\lerna\node_modules\execa\index.js:236:11
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  code: 2,
  killed: false,
  stdout: '\n' +
    '> ra-input-rich-text@3.2.0 build C:\\dev\\oss\\react-admin\\packages\\ra-input-rich-text\n' +
    '> yarn run build-cjs && yarn run build-esm\n' +
    '\n' +
    'yarn run v1.15.2\n' +
    '$ rimraf ./lib && tsc\n' +
    "src/index.tsx(11,33): error TS2307: Cannot find module 'ra-ui-materialui'.\r\n" +
    'info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.\n',
  stderr: 'error Command failed with exit code 2.\n' +
    'npm ERR! code ELIFECYCLE\n' +
    'npm ERR! errno 2\n' +
    'npm ERR! ra-input-rich-text@3.2.0 build: `yarn run build-cjs && yarn run build-esm`\n' +
    'npm ERR! Exit status 2\n' +
    'npm ERR! \n' +
    'npm ERR! Failed at the ra-input-rich-text@3.2.0 build script.\n' +
    'npm ERR! This is probably not a problem with npm. There is likely additional logging output above.\n' +
    '\n' +
    'npm ERR! A complete log of this run can be found in:\n' +
    'npm ERR!     C:\\Users\\teyc\\AppData\\Roaming\\npm-cache\\_logs\\2020-02-27T10_31_20_950Z-debug.log\n',

```
src/index.tsx(11,33): error TS2307:
Cannot find module 'ra-ui-materialui'.