### PR TITLE
Doc: Use AutocompleteInput instead of SelectInput in filterToQuery examples 

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -978,7 +978,7 @@ The child component may further filter results (that's the case, for instance, f
      source="post_id"
      reference="posts"
      filterToQuery={searchText => ({ title: searchText })}>
-    <SelectInput optionText="title" />
+    <AutocompleteInput optionText="title" />
 </ReferenceInput>
 ```
 

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -107,7 +107,7 @@ interface Props {
  *      source="post_id"
  *      reference="posts"
  *      filterToQuery={searchText => ({ title: searchText })}>
- *     <SelectInput optionText="title" />
+ *     <AutocompleteInput optionText="title" />
  * </ReferenceInput>
  */
 const ReferenceInput: FunctionComponent<Props & InputProps> = ({


### PR DESCRIPTION
I believe the `filterToQuery` prop on [`ReferenceInput`](https://marmelab.com/react-admin/Inputs.html#referenceinput) is passed onto the children prop as `setFilter`, as the doc states in this section:

> The child component receives the following props from \<ReferenceInput\>:
> - setFilter: function to call to update the filter of the request for possible values

This seems to only matter to the [`AutocompleteInput`](https://marmelab.com/react-admin/Inputs.html#autocompleteinput). But the examples all use a [`SelectInput`](https://marmelab.com/react-admin/Inputs.html#selectinput), which (as far as I'm aware) doesn't do anything with it. Correct me if I'm wrong, but I guess it was meant to be using an `AutocompleteInput` instead. 


