### PR TITLE
Fix <SimpleListLoading> `link` style is not implemented error.

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -14,13 +14,19 @@ import SimpleListLoading from './SimpleListLoading';
 
 const useStyles = makeStyles(
     {
+        tertiary: { float: 'right', opacity: 0.541176 },
+    },
+    { name: 'RaSimpleList' }
+);
+
+const useLinkOrNotStyles = makeStyles(
+    {
         link: {
             textDecoration: 'none',
             color: 'inherit',
         },
-        tertiary: { float: 'right', opacity: 0.541176 },
     },
-    { name: 'RaSimpleList' }
+    { name: 'RaLinkOrNot' }
 );
 
 const LinkOrNot = ({
@@ -30,7 +36,7 @@ const LinkOrNot = ({
     id,
     children,
 }) => {
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useLinkOrNotStyles({ classes: classesOverride });
     return linkType === 'edit' || linkType === true ? (
         <Link to={linkToRecord(basePath, id)} className={classes.link}>
             {children}
@@ -70,12 +76,11 @@ const SimpleList = ({
     ...rest
 }) => {
     const classes = useStyles({ classes: classesOverride });
-    const { link, ...restClasses } = classes;
 
     if (loaded === false) {
         return (
             <SimpleListLoading
-                classes={restClasses}
+                classes={classes}
                 className={className}
                 hasLeftAvatarOrIcon={!!leftIcon || !!leftAvatar}
                 hasRightAvatarOrIcon={!!rightIcon || !!rightAvatar}

--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -70,11 +70,12 @@ const SimpleList = ({
     ...rest
 }) => {
     const classes = useStyles({ classes: classesOverride });
+    const { link, ...restClasses } = classes;
 
     if (loaded === false) {
         return (
             <SimpleListLoading
-                classes={classes}
+                classes={restClasses}
                 className={className}
                 hasLeftAvatarOrIcon={!!leftIcon || !!leftAvatar}
                 hasRightAvatarOrIcon={!!rightIcon || !!rightAvatar}


### PR DESCRIPTION
You get an error using `<SimpleListLoading>` component :

```
Material-UI: the key `link` provided to the classes prop is not implemented in undefined.
You can only override one of the following: primary,tertiary. 
    in SimpleListLoading (created by SimpleList)
    in SimpleList (at licencia.js:61)
    in LicenciaList (created by WithPermissions)
    in WithPermissions (created by Router.Consumer)
    in Router.Consumer (created by Route)
    in Route (created by ResourceRoutes)
    in ResourceRoutes (created by Resource)
    in Resource (at App.js:47)
    in App (at src/​index.js:7)`
`link` style is defined in `<SimpleList>`
