### PR TITLE
Fix empty item option height in SelectInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -196,6 +196,8 @@ const SelectInput: FunctionComponent<
     const renderEmptyItemOption = useCallback(() => {
         return React.isValidElement(emptyText)
             ? React.cloneElement(emptyText)
+            : emptyText === ''
+            ? ' ' // em space, forces the display of an empty line of normal height
             : translate(emptyText, { _: emptyText });
     }, [emptyText, translate]);
 


### PR DESCRIPTION
By default, the empty option in SelectInput has a very small height and is barely clickable. This PR fixes this problem. 

Before

![image](https://user-images.githubusercontent.com/99944/76023175-ec89b600-5f28-11ea-9e43-5fe0174c9632.png)


After

![image](https://user-images.githubusercontent.com/99944/76023127-d5e35f00-5f28-11ea-9bc1-a57641241727.png)
