### PR TITLE
Fix filter form inputs appear too high when there is no search input

### DIFF
--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(
             display: 'flex',
             alignItems: 'flex-end',
             flexWrap: 'wrap',
-            minHeight: theme.spacing(9.5),
+            minHeight: theme.spacing(10),
         },
         clearFix: { clear: 'right' },
     }),


### PR DESCRIPTION
Filter form inputs didn't appear at the same height whether the form contained a search input or not. This PR fixes it. 

These 4px make a huge difference, believe me.

## Before

![image](https://user-images.githubusercontent.com/99944/76025674-bc90e180-5f2d-11ea-998c-4d8a2dcc2841.png)
![image](https://user-images.githubusercontent.com/99944/76025586-894e5280-5f2d-11ea-8fbc-feb43a86ba31.png) 

## After

![image](https://user-images.githubusercontent.com/99944/76025674-bc90e180-5f2d-11ea-998c-4d8a2dcc2841.png)
![image](https://user-images.githubusercontent.com/99944/76025489-586e1d80-5f2d-11ea-9a64-d9fef6583f45.png)
