### PR TITLE
Fix override of defaultValue in FormInput

### DIFF
--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -49,6 +49,8 @@ const FilterFormInput = ({
                 variant,
                 margin,
                 helperText: false,
+                // ignore defaultValue in Field because it was already set in Form (via mergedInitialValuesWithDefaultValues)
+                defaultValue: undefined,
             })}
             <div className={classes.spacer}>&nbsp;</div>
         </div>


### PR DESCRIPTION
## Issue

Issue introduced by the persistency of the empty filters that was implemented.

defaultValue of a FormInput can be set by mistake if this situation :
- Add a displayed filter containing a defaultValue in your list
- Clean it's value (but don't remove the filter)
- Navigate elsewere
- Come back in the initial list
=> The defaultValue has been set again, and the filter is "un-removable"

## Solution

Ignore defaultValue in Field because it is always set at Form level

## Notes

https://github.com/final-form/react-final-form/issues/387