### PR TITLE
Fix rerender caused by style override

### DIFF
--- a/packages/ra-ui-materialui/src/Link.tsx
+++ b/packages/ra-ui-materialui/src/Link.tsx
@@ -22,14 +22,15 @@ export interface LinkProps extends RRLinkProps {
     className?: string;
 }
 
-const Link: FC<LinkProps> = ({
-    to,
-    children,
-    classes: classesOverride,
-    className,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const Link: FC<LinkProps> = props => {
+    const {
+        to,
+        children,
+        classes: classesOverride,
+        className,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     return (
         <RRLink
             to={to}

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -83,17 +83,18 @@ const useStyles = makeStyles(
  */
 const Login: React.FunctionComponent<
     Props & HtmlHTMLAttributes<HTMLDivElement>
-> = ({
-    theme,
-    classes: classesOverride,
-    className,
-    children,
-    staticContext,
-    backgroundImage,
-    ...rest
-}) => {
+> = props => {
+    const {
+        theme,
+        classes: classesOverride,
+        className,
+        children,
+        staticContext,
+        backgroundImage,
+        ...rest
+    } = props;
     const containerRef = useRef<HTMLDivElement>();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     const muiTheme = useMemo(() => createMuiTheme(theme), [theme]);
     let backgroundImageLoaded = false;
     const checkAuth = useCheckAuth();

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -49,12 +49,13 @@ const Input = ({
     />
 );
 
-const LoginForm: FunctionComponent<Props> = ({ redirectTo }) => {
+const LoginForm: FunctionComponent<Props> = props => {
+    const { redirectTo } = props;
     const [loading, setLoading] = useSafeSetState(false);
     const login = useLogin();
     const translate = useTranslate();
     const notify = useNotify();
-    const classes = useStyles({});
+    const classes = useStyles(props);
 
     const validate = (values: FormData) => {
         const errors = { username: undefined, password: undefined };

--- a/packages/ra-ui-materialui/src/auth/Logout.tsx
+++ b/packages/ra-ui-materialui/src/auth/Logout.tsx
@@ -32,8 +32,14 @@ const useStyles = makeStyles(
 const LogoutWithRef: FunctionComponent<
     Props & MenuItemProps<'li', { button: true }> // HACK: https://github.com/mui-org/material-ui/issues/16245
 > = React.forwardRef(function Logout(props, ref) {
-    const { className, redirectTo, icon, ...rest } = props;
-    const classes = useStyles({}); // the empty {} is a temp fix for https://github.com/mui-org/material-ui/issues/15942
+    const {
+        className,
+        classes: classesOverride,
+        redirectTo,
+        icon,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
     const logout = useLogout();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -33,20 +33,23 @@ const useStyles = makeStyles(
     { name: 'RaBulkDeleteWithConfirmButton' }
 );
 
-const BulkDeleteWithConfirmButton: FC<BulkDeleteWithConfirmButtonProps> = ({
-    basePath,
-    classes: classesOverride,
-    confirmTitle,
-    confirmContent,
-    icon,
-    label,
-    onClick,
-    resource,
-    selectedIds,
-    ...rest
-}) => {
+const BulkDeleteWithConfirmButton: FC<
+    BulkDeleteWithConfirmButtonProps
+> = props => {
+    const {
+        basePath,
+        classes: classesOverride,
+        confirmTitle,
+        confirmContent,
+        icon,
+        label,
+        onClick,
+        resource,
+        selectedIds,
+        ...rest
+    } = props;
     const [isOpen, setOpen] = useState(false);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     const notify = useNotify();
     const unselectAll = useUnselectAll();
     const refresh = useRefresh();

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -30,17 +30,18 @@ const useStyles = makeStyles(
     { name: 'RaBulkDeleteWithUndoButton' }
 );
 
-const BulkDeleteWithUndoButton: FC<BulkDeleteWithUndoButtonProps> = ({
-    basePath,
-    classes: classesOverride,
-    icon,
-    label,
-    onClick,
-    resource,
-    selectedIds,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const BulkDeleteWithUndoButton: FC<BulkDeleteWithUndoButtonProps> = props => {
+    const {
+        basePath,
+        classes: classesOverride,
+        icon,
+        label,
+        onClick,
+        resource,
+        selectedIds,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const notify = useNotify();
     const unselectAll = useUnselectAll();
     const refresh = useRefresh();

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -26,19 +26,20 @@ import { useTranslate } from 'ra-core';
  * </Button>
  *
  */
-const Button: FC<ButtonProps> = ({
-    alignIcon = 'left',
-    children,
-    classes: classesOverride,
-    className,
-    color,
-    disabled,
-    label,
-    size,
-    ...rest
-}) => {
+const Button: FC<ButtonProps> = props => {
+    const {
+        alignIcon = 'left',
+        children,
+        classes: classesOverride,
+        className,
+        color,
+        disabled,
+        label,
+        size,
+        ...rest
+    } = props;
     const translate = useTranslate();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     const isXSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('xs')
     );

--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -9,15 +9,16 @@ import { useTranslate } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
-const CreateButton: FC<CreateButtonProps> = ({
-    basePath = '',
-    className,
-    classes: classesOverride,
-    label = 'ra.action.create',
-    icon = defaultIcon,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const CreateButton: FC<CreateButtonProps> = props => {
+    const {
+        basePath = '',
+        className,
+        classes: classesOverride,
+        label = 'ra.action.create',
+        icon = defaultIcon,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
     const isSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('sm')

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -26,26 +26,27 @@ import {
 import Confirm from '../layout/Confirm';
 import Button, { ButtonProps } from './Button';
 
-const DeleteWithConfirmButton: FC<DeleteWithConfirmButtonProps> = ({
-    basePath,
-    classes: classesOverride,
-    className,
-    confirmTitle = 'ra.message.delete_title',
-    confirmContent = 'ra.message.delete_content',
-    icon = defaultIcon,
-    label = 'ra.action.delete',
-    onClick,
-    record,
-    resource,
-    redirect: redirectTo = 'list',
-    ...rest
-}) => {
+const DeleteWithConfirmButton: FC<DeleteWithConfirmButtonProps> = props => {
+    const {
+        basePath,
+        classes: classesOverride,
+        className,
+        confirmTitle = 'ra.message.delete_title',
+        confirmContent = 'ra.message.delete_content',
+        icon = defaultIcon,
+        label = 'ra.action.delete',
+        onClick,
+        record,
+        resource,
+        redirect: redirectTo = 'list',
+        ...rest
+    } = props;
     const [open, setOpen] = useState(false);
     const translate = useTranslate();
     const notify = useNotify();
     const redirect = useRedirect();
     const refresh = useRefresh();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     const [deleteOne, { loading }] = useDelete(
         resource,

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
@@ -16,19 +16,20 @@ import {
 
 import Button, { ButtonProps } from './Button';
 
-const DeleteWithUndoButton: FC<DeleteWithUndoButtonProps> = ({
-    label = 'ra.action.delete',
-    classes: classesOverride,
-    className,
-    icon = defaultIcon,
-    onClick,
-    resource,
-    record,
-    basePath,
-    redirect: redirectTo = 'list',
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const DeleteWithUndoButton: FC<DeleteWithUndoButtonProps> = props => {
+    const {
+        label = 'ra.action.delete',
+        classes: classesOverride,
+        className,
+        icon = defaultIcon,
+        onClick,
+        resource,
+        record,
+        basePath,
+        redirect: redirectTo = 'list',
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const notify = useNotify();
     const redirect = useRedirect();
     const refresh = useRefresh();

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -19,23 +19,24 @@ import {
     FormContext,
 } from 'ra-core';
 
-const SaveButton: FC<SaveButtonProps> = ({
-    className,
-    classes: classesOverride = {},
-    invalid,
-    label = 'ra.action.save',
-    pristine,
-    redirect,
-    saving,
-    submitOnEnter,
-    variant = 'contained',
-    icon = defaultIcon,
-    onClick,
-    handleSubmitWithRedirect,
-    onSave,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const SaveButton: FC<SaveButtonProps> = props => {
+    const {
+        className,
+        classes: classesOverride,
+        invalid,
+        label = 'ra.action.save',
+        pristine,
+        redirect,
+        saving,
+        submitOnEnter,
+        variant = 'contained',
+        icon = defaultIcon,
+        onClick,
+        handleSubmitWithRedirect,
+        onSave,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const notify = useNotify();
     const translate = useTranslate();
     const { setOnSave } = useContext(FormContext);

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -92,7 +92,7 @@ export const CreateView = props => {
         ...rest
     } = props;
     useCheckMinimumRequiredProps('Create', ['children'], props);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     return (
         <div
             className={classnames('create-page', classes.root, className)}

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -72,31 +72,36 @@ Edit.propTypes = {
     successMessage: PropTypes.string,
 };
 
-export const EditView = ({
-    actions,
-    aside,
-    basePath,
-    children,
-    classes: classesOverride,
-    className,
-    component: Content,
-    defaultTitle,
-    hasList,
-    hasShow,
-    record,
-    redirect,
-    resource,
-    save,
-    saving,
-    title,
-    undoable,
-    version,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
-    if (typeof actions === 'undefined' && hasShow) {
-        actions = <DefaultActions />;
-    }
+export const EditView = props => {
+    const {
+        actions,
+        aside,
+        basePath,
+        children,
+        classes: classesOverride,
+        className,
+        component: Content,
+        defaultTitle,
+        hasList,
+        hasShow,
+        record,
+        redirect,
+        resource,
+        save,
+        saving,
+        title,
+        undoable,
+        version,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
+    const finalActions =
+        typeof actions === 'undefined' && hasShow ? (
+            <DefaultActions />
+        ) : (
+            actions
+        );
+
     if (!children) {
         return null;
     }
@@ -110,19 +115,19 @@ export const EditView = ({
                 record={record}
                 defaultTitle={defaultTitle}
             />
-            {actions &&
-                cloneElement(actions, {
+            {finalActions &&
+                cloneElement(finalActions, {
                     basePath,
                     data: record,
                     hasShow,
                     hasList,
                     resource,
                     //  Ensure we don't override any user provided props
-                    ...actions.props,
+                    ...finalActions.props,
                 })}
             <div
                 className={classnames(classes.main, {
-                    [classes.noActions]: !actions,
+                    [classes.noActions]: !finalActions,
                 })}
             >
                 <Content className={classes.card}>

--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -68,27 +68,32 @@ Show.propTypes = {
     title: PropTypes.node,
 };
 
-export const ShowView = ({
-    actions,
-    aside,
-    basePath,
-    children,
-    classes: classesOverride,
-    className,
-    component: Content,
-    defaultTitle,
-    hasEdit,
-    hasList,
-    record,
-    resource,
-    title,
-    version,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
-    if (typeof actions === 'undefined' && hasEdit) {
-        actions = <DefaultActions />;
-    }
+export const ShowView = props => {
+    const {
+        actions,
+        aside,
+        basePath,
+        children,
+        classes: classesOverride,
+        className,
+        component: Content,
+        defaultTitle,
+        hasEdit,
+        hasList,
+        record,
+        resource,
+        title,
+        version,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
+    const finalActions =
+        typeof actions === 'undefined' && hasEdit ? (
+            <DefaultActions />
+        ) : (
+            actions
+        );
+
     if (!children) {
         return null;
     }
@@ -102,19 +107,19 @@ export const ShowView = ({
                 record={record}
                 defaultTitle={defaultTitle}
             />
-            {actions &&
-                cloneElement(actions, {
+            {finalActions &&
+                cloneElement(finalActions, {
                     basePath,
                     data: record,
                     hasList,
                     hasEdit,
                     resource,
                     //  Ensure we don't override any user provided props
-                    ...actions.props,
+                    ...finalActions.props,
                 })}
             <div
                 className={classnames(classes.main, {
-                    [classes.noActions]: !actions,
+                    [classes.noActions]: !finalActions,
                 })}
             >
                 <Content className={classes.card}>

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -72,21 +72,22 @@ const useStyles = makeStyles(
  *     );
  *     export default App;
  */
-const TabbedShowLayout = ({
-    basePath,
-    children,
-    classes: classesOverride,
-    className,
-    record,
-    resource,
-    version,
-    value,
-    tabs,
-    ...rest
-}) => {
+const TabbedShowLayout = props => {
+    const {
+        basePath,
+        children,
+        classes: classesOverride,
+        className,
+        record,
+        resource,
+        version,
+        value,
+        tabs,
+        ...rest
+    } = props;
     const match = useRouteMatch();
 
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     return (
         <div className={className} key={version} {...sanitizeRestProps(rest)}>
             {cloneElement(tabs, {}, children)}

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -19,15 +19,16 @@ const useStyles = makeStyles(
 
 export const ChipField: FunctionComponent<
     FieldProps & InjectedFieldProps & ChipProps
-> = ({
-    className,
-    classes: classesOverride,
-    source,
-    record = {},
-    emptyText,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+> = props => {
+    const {
+        className,
+        classes: classesOverride,
+        source,
+        record = {},
+        emptyText,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const value = get(record, source);
 
     if (value == null && emptyText) {

--- a/packages/ra-ui-materialui/src/field/FileField.tsx
+++ b/packages/ra-ui-materialui/src/field/FileField.tsx
@@ -22,19 +22,20 @@ interface Props extends FieldProps {
     classes?: object;
 }
 
-const FileField: FunctionComponent<Props & InjectedFieldProps> = ({
-    className,
-    classes: classesOverride,
-    emptyText,
-    record,
-    source,
-    title,
-    src,
-    target,
-    ...rest
-}) => {
+const FileField: FunctionComponent<Props & InjectedFieldProps> = props => {
+    const {
+        className,
+        classes: classesOverride,
+        emptyText,
+        record,
+        source,
+        title,
+        src,
+        target,
+        ...rest
+    } = props;
     const sourceValue = get(record, source);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     if (!sourceValue) {
         return emptyText ? (

--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -28,18 +28,19 @@ interface Props extends FieldProps {
     classes?: object;
 }
 
-const ImageField: FunctionComponent<Props & InjectedFieldProps> = ({
-    className,
-    classes: classesOverride,
-    emptyText,
-    record,
-    source,
-    src,
-    title,
-    ...rest
-}) => {
+const ImageField: FunctionComponent<Props & InjectedFieldProps> = props => {
+    const {
+        className,
+        classes: classesOverride,
+        emptyText,
+        record,
+        source,
+        src,
+        title,
+        ...rest
+    } = props;
     const sourceValue = get(record, source);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     if (!sourceValue) {
         return emptyText ? (
             <Typography

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -105,17 +105,19 @@ interface ReferenceArrayFieldViewProps extends FieldProps, ReferenceArrayProps {
     reference: string;
 }
 
-export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = ({
-    children,
-    className,
-    classes: classesOverride,
-    data,
-    ids,
-    loaded,
-    reference,
-    referenceBasePath,
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+export const ReferenceArrayFieldView: FC<
+    ReferenceArrayFieldViewProps
+> = props => {
+    const {
+        children,
+        className,
+        data,
+        ids,
+        loaded,
+        reference,
+        referenceBasePath,
+    } = props;
+    const classes = useStyles(props);
     if (!loaded) {
         return <LinearProgress className={classes.progress} />;
     }

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -164,24 +164,25 @@ interface ReferenceFieldViewProps
     children?: ReactElement;
 }
 
-export const ReferenceFieldView: FC<ReferenceFieldViewProps> = ({
-    basePath,
-    children,
-    className,
-    classes: classesOverride,
-    error,
-    loaded,
-    loading,
-    record,
-    reference,
-    referenceRecord,
-    resource,
-    resourceLinkPath,
-    source,
-    translateChoice = false,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
+    const {
+        basePath,
+        children,
+        className,
+        classes: classesOverride,
+        error,
+        loaded,
+        loading,
+        record,
+        reference,
+        referenceRecord,
+        resource,
+        resourceLinkPath,
+        source,
+        translateChoice = false,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     if (!loaded) {
         return <LinearProgress />;
     }

--- a/packages/ra-ui-materialui/src/form/FormInput.js
+++ b/packages/ra-ui-materialui/src/form/FormInput.js
@@ -14,8 +14,9 @@ const useStyles = makeStyles(
     { name: 'RaFormInput' }
 );
 
-const FormInput = ({ input, classes: classesOverride, ...rest }) => {
-    const classes = useStyles({ classes: classesOverride });
+const FormInput = props => {
+    const { input, classes: classesOverride, ...rest } = props;
+    const classes = useStyles(props);
     return input ? (
         <div
             className={classnames(

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -62,24 +62,24 @@ const useStyles = makeStyles(
     { name: 'RaSimpleFormIterator' }
 );
 
-const SimpleFormIterator = ({
-    basePath,
-    classes: classesOverride,
-    children,
-    fields,
-    meta: { error, submitFailed },
-    record,
-    resource,
-    source,
-    disableAdd,
-    disableRemove,
-    variant,
-    margin,
-    TransitionProps,
-    defaultValue,
-}) => {
+const SimpleFormIterator = props => {
+    const {
+        basePath,
+        children,
+        fields,
+        meta: { error, submitFailed },
+        record,
+        resource,
+        source,
+        disableAdd,
+        disableRemove,
+        variant,
+        margin,
+        TransitionProps,
+        defaultValue,
+    } = props;
     const translate = useTranslate();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     // We need a unique id for each field for a proper enter/exit animation
     // so we keep an internal map between the field position and an auto-increment id

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -112,33 +112,34 @@ const useStyles = makeStyles(
     { name: 'RaTabbedForm' }
 );
 
-export const TabbedFormView = ({
-    basePath,
-    children,
-    className,
-    classes: classesOverride,
-    form,
-    handleSubmit,
-    handleSubmitWithRedirect,
-    invalid,
-    pristine,
-    record,
-    redirect: defaultRedirect,
-    resource,
-    saving,
-    setRedirect,
-    submitOnEnter,
-    tabs,
-    toolbar,
-    translate,
-    undoable,
-    value,
-    variant,
-    margin,
-    ...rest
-}) => {
+export const TabbedFormView = props => {
+    const {
+        basePath,
+        children,
+        className,
+        classes: classesOverride,
+        form,
+        handleSubmit,
+        handleSubmitWithRedirect,
+        invalid,
+        pristine,
+        record,
+        redirect: defaultRedirect,
+        resource,
+        saving,
+        setRedirect,
+        submitOnEnter,
+        tabs,
+        toolbar,
+        translate,
+        undoable,
+        value,
+        variant,
+        margin,
+        ...rest
+    } = props;
     const tabsWithErrors = findTabsWithErrors(children, form.getState().errors);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     const match = useRouteMatch();
     const location = useLocation();
 

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -46,25 +46,26 @@ const useStyles = makeStyles(
 const valueOrDefault = (value, defaultValue) =>
     typeof value === 'undefined' ? defaultValue : value;
 
-const Toolbar = ({
-    basePath,
-    children,
-    className,
-    classes: classesOverride,
-    handleSubmit,
-    handleSubmitWithRedirect,
-    invalid,
-    pristine,
-    record,
-    redirect,
-    resource,
-    saving,
-    submitOnEnter,
-    undoable,
-    width,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const Toolbar = props => {
+    const {
+        basePath,
+        children,
+        className,
+        classes: classesOverride,
+        handleSubmit,
+        handleSubmitWithRedirect,
+        invalid,
+        pristine,
+        record,
+        redirect,
+        resource,
+        saving,
+        submitOnEnter,
+        undoable,
+        width,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     return (
         <Fragment>
             <MuiToolbar

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -92,46 +92,47 @@ interface Options {
  */
 const AutocompleteArrayInput: FunctionComponent<
     InputProps<TextFieldProps & Options> & DownshiftProps<any>
-> = ({
-    allowDuplicates,
-    allowEmpty,
-    classes: classesOverride,
-    choices = [],
-    emptyText,
-    emptyValue,
-    format,
-    fullWidth,
-    helperText,
-    id: idOverride,
-    input: inputOverride,
-    isRequired: isRequiredOverride,
-    label,
-    limitChoicesToValue,
-    margin,
-    matchSuggestion,
-    meta: metaOverride,
-    onBlur,
-    onChange,
-    onFocus,
-    options: {
-        suggestionsContainerProps,
-        labelProps,
-        InputProps,
-        ...options
-    } = {},
-    optionText = 'name',
-    optionValue = 'id',
-    parse,
-    resource,
-    setFilter,
-    shouldRenderSuggestions: shouldRenderSuggestionsOverride,
-    source,
-    suggestionLimit,
-    translateChoice = true,
-    validate,
-    variant = 'filled',
-    ...rest
-}) => {
+> = props => {
+    const {
+        allowDuplicates,
+        allowEmpty,
+        classes: classesOverride,
+        choices = [],
+        emptyText,
+        emptyValue,
+        format,
+        fullWidth,
+        helperText,
+        id: idOverride,
+        input: inputOverride,
+        isRequired: isRequiredOverride,
+        label,
+        limitChoicesToValue,
+        margin,
+        matchSuggestion,
+        meta: metaOverride,
+        onBlur,
+        onChange,
+        onFocus,
+        options: {
+            suggestionsContainerProps,
+            labelProps,
+            InputProps,
+            ...options
+        } = {} as TextFieldProps & Options,
+        optionText = 'name',
+        optionValue = 'id',
+        parse,
+        resource,
+        setFilter,
+        shouldRenderSuggestions: shouldRenderSuggestionsOverride,
+        source,
+        suggestionLimit,
+        translateChoice = true,
+        validate,
+        variant = 'filled',
+        ...rest
+    } = props;
     warning(
         isValidElement(optionText) && !matchSuggestion,
         `If the optionText prop is a React element, you must also specify the matchSuggestion prop:
@@ -141,7 +142,7 @@ const AutocompleteArrayInput: FunctionComponent<
         `
     );
 
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     let inputEl = useRef<HTMLInputElement>();
     let anchorEl = useRef<any>();

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -92,51 +92,52 @@ interface Options {
  */
 const AutocompleteInput: FunctionComponent<
     InputProps<TextFieldProps & Options> & DownshiftProps<any>
-> = ({
-    allowEmpty,
-    className,
-    classes: classesOverride,
-    choices = [],
-    emptyText,
-    emptyValue,
-    format,
-    fullWidth,
-    helperText,
-    id: idOverride,
-    input: inputOverride,
-    isRequired: isRequiredOverride,
-    label,
-    limitChoicesToValue,
-    margin = 'dense',
-    matchSuggestion,
-    meta: metaOverride,
-    onBlur,
-    onChange,
-    onFocus,
-    options: {
-        suggestionsContainerProps,
-        labelProps,
-        InputProps,
-        ...options
-    } = {
-        suggestionsContainerProps: undefined,
-        labelProps: undefined,
-        InputProps: undefined,
-    },
-    optionText = 'name',
-    inputText,
-    optionValue = 'id',
-    parse,
-    resource,
-    setFilter,
-    shouldRenderSuggestions: shouldRenderSuggestionsOverride,
-    source,
-    suggestionLimit,
-    translateChoice = true,
-    validate,
-    variant = 'filled',
-    ...rest
-}) => {
+> = props => {
+    const {
+        allowEmpty,
+        className,
+        classes: classesOverride,
+        choices = [],
+        emptyText,
+        emptyValue,
+        format,
+        fullWidth,
+        helperText,
+        id: idOverride,
+        input: inputOverride,
+        isRequired: isRequiredOverride,
+        label,
+        limitChoicesToValue,
+        margin = 'dense',
+        matchSuggestion,
+        meta: metaOverride,
+        onBlur,
+        onChange,
+        onFocus,
+        options: {
+            suggestionsContainerProps,
+            labelProps,
+            InputProps,
+            ...options
+        } = {
+            suggestionsContainerProps: undefined,
+            labelProps: undefined,
+            InputProps: undefined,
+        },
+        optionText = 'name',
+        inputText,
+        optionValue = 'id',
+        parse,
+        resource,
+        setFilter,
+        shouldRenderSuggestions: shouldRenderSuggestionsOverride,
+        source,
+        suggestionLimit,
+        translateChoice = true,
+        validate,
+        variant = 'filled',
+        ...rest
+    } = props;
     if (isValidElement(optionText) && !inputText) {
         throw new Error(`If the optionText prop is a React element, you must also specify the inputText prop:
         <AutocompleteInput
@@ -153,7 +154,7 @@ const AutocompleteInput: FunctionComponent<
         `
     );
 
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     let inputEl = useRef<HTMLInputElement>();
     let anchorEl = useRef<any>();

--- a/packages/ra-ui-materialui/src/input/AutocompleteSuggestionItem.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteSuggestionItem.tsx
@@ -35,17 +35,18 @@ interface Props {
 
 const AutocompleteSuggestionItem: FunctionComponent<
     Props & MenuItemProps<'li', { button?: true }>
-> = ({
-    suggestion,
-    index,
-    highlightedIndex,
-    isSelected,
-    filterValue,
-    classes: classesOverride,
-    getSuggestionText,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+> = props => {
+    const {
+        suggestion,
+        index,
+        highlightedIndex,
+        isSelected,
+        filterValue,
+        classes: classesOverride,
+        getSuggestionText,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const isHighlighted = highlightedIndex === index;
     const suggestionText = getSuggestionText(suggestion);
     let matches;

--- a/packages/ra-ui-materialui/src/input/AutocompleteSuggestionList.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteSuggestionList.tsx
@@ -23,15 +23,15 @@ interface Props {
     suggestionsContainerProps?: any;
 }
 
-const AutocompleteSuggestionList: FunctionComponent<Props> = ({
-    children,
-    isOpen,
-    menuProps,
-    inputEl,
-    classes: classesOverride = undefined,
-    suggestionsContainerProps,
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const AutocompleteSuggestionList: FunctionComponent<Props> = props => {
+    const {
+        children,
+        isOpen,
+        menuProps,
+        inputEl,
+        suggestionsContainerProps,
+    } = props;
+    const classes = useStyles(props);
 
     return (
         <Popper

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -98,28 +98,30 @@ const useStyles = makeStyles(
  */
 const CheckboxGroupInput: FunctionComponent<
     ChoicesProps & InputProps<CheckboxProps> & FormControlProps
-> = ({
-    choices = [],
-    format,
-    helperText,
-    label,
-    margin = 'dense',
-    onBlur,
-    onChange,
-    onFocus,
-    optionText,
-    optionValue,
-    options,
-    parse,
-    resource,
-    row,
-    source,
-    translate,
-    translateChoice,
-    validate,
-    ...rest
-}) => {
-    const classes = useStyles({});
+> = props => {
+    const {
+        choices = [],
+        classes: classesOverride,
+        format,
+        helperText,
+        label,
+        margin = 'dense',
+        onBlur,
+        onChange,
+        onFocus,
+        optionText,
+        optionValue,
+        options,
+        parse,
+        resource,
+        row,
+        source,
+        translate,
+        translateChoice,
+        validate,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
 
     const {
         id,

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInputItem.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInputItem.tsx
@@ -13,17 +13,19 @@ const useStyles = makeStyles(
     { name: 'RaCheckboxGroupInputItem' }
 );
 
-const CheckboxGroupInputItem = ({
-    id,
-    choice,
-    onChange,
-    optionText,
-    optionValue,
-    translateChoice,
-    value,
-    ...rest
-}) => {
-    const classes = useStyles({});
+const CheckboxGroupInputItem = props => {
+    const {
+        classes: classesOverride,
+        id,
+        choice,
+        onChange,
+        optionText,
+        optionValue,
+        translateChoice,
+        value,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const { getChoiceText, getChoiceValue } = useChoices({
         optionText,
         optionValue,

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -51,29 +51,33 @@ export interface FileInputOptions extends DropzoneOptions {
 
 const FileInput: FunctionComponent<
     FileInputProps & InputProps<FileInputOptions>
-> = ({
-    accept,
-    children,
-    className,
-    classes: classesOverride,
-    format,
-    helperText,
-    label,
-    labelMultiple = 'ra.input.file.upload_several',
-    labelSingle = 'ra.input.file.upload_single',
-    maxSize,
-    minSize,
-    multiple = false,
-    options: { inputProps: inputPropsOptions, ...options } = {},
-    parse,
-    placeholder,
-    resource,
-    source,
-    validate,
-    ...rest
-}) => {
+> = props => {
+    const {
+        accept,
+        children,
+        className,
+        classes: classesOverride,
+        format,
+        helperText,
+        label,
+        labelMultiple = 'ra.input.file.upload_several',
+        labelSingle = 'ra.input.file.upload_single',
+        maxSize,
+        minSize,
+        multiple = false,
+        options: {
+            inputProps: inputPropsOptions,
+            ...options
+        } = {} as FileInputOptions,
+        parse,
+        placeholder,
+        resource,
+        source,
+        validate,
+        ...rest
+    } = props;
     const translate = useTranslate();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     // turn a browser dropped file structure into expected structure
     const transformFile = file => {

--- a/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
@@ -18,18 +18,21 @@ const useStyles = makeStyles(
 interface Props {
     children: ReactNode;
     className?: string;
+    classes?: object;
     onRemove: () => void;
     file: any;
 }
 
-const FileInputPreview: FunctionComponent<Props> = ({
-    children,
-    className,
-    onRemove,
-    file,
-    ...rest
-}) => {
-    const classes = useStyles(rest);
+const FileInputPreview: FunctionComponent<Props> = props => {
+    const {
+        children,
+        classes: classesOverride,
+        className,
+        onRemove,
+        file,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
 
     useEffect(() => {

--- a/packages/ra-ui-materialui/src/input/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/input/Labeled.tsx
@@ -55,22 +55,23 @@ interface Props {
  *     <FooComponent source="title" />
  * </Labeled>
  */
-const Labeled: FunctionComponent<Props> = ({
-    children,
-    className,
-    classes: classesOverride,
-    fullWidth,
-    id,
-    input,
-    isRequired,
-    label,
-    margin = 'dense',
-    meta,
-    resource,
-    source,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const Labeled: FunctionComponent<Props> = props => {
+    const {
+        children,
+        className,
+        classes: classesOverride,
+        fullWidth,
+        id,
+        input,
+        isRequired,
+        label,
+        margin = 'dense',
+        meta,
+        resource,
+        source,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     if (!label && !source) {
         // @ts-ignore
         const name = children && children.type && children.type.name;

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -30,25 +30,27 @@ const getStringFromBoolean = (value?: boolean | null): string => {
 
 const NullableBooleanInput: FunctionComponent<
     InputProps<TextFieldProps> & Omit<TextFieldProps, 'label' | 'helperText'>
-> = ({
-    className,
-    format = getStringFromBoolean,
-    helperText,
-    label,
-    margin = 'dense',
-    onBlur,
-    onChange,
-    onFocus,
-    options,
-    displayNull,
-    parse = getBooleanFromString,
-    resource,
-    source,
-    validate,
-    variant = 'filled',
-    ...rest
-}) => {
-    const classes = useStyles({});
+> = props => {
+    const {
+        className,
+        classes: classesOverride,
+        format = getStringFromBoolean,
+        helperText,
+        label,
+        margin = 'dense',
+        onBlur,
+        onChange,
+        onFocus,
+        options,
+        displayNull,
+        parse = getBooleanFromString,
+        resource,
+        source,
+        validate,
+        variant = 'filled',
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
 
     const {

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -87,28 +87,29 @@ const useStyles = makeStyles(
  */
 const RadioButtonGroupInput: FunctionComponent<
     ChoicesProps & InputProps<RadioGroupProps> & FormControlProps
-> = ({
-    choices = [],
-    classes: classesOverride,
-    format,
-    helperText,
-    label,
-    margin = 'dense',
-    onBlur,
-    onChange,
-    onFocus,
-    options,
-    optionText,
-    optionValue,
-    parse,
-    resource,
-    row,
-    source,
-    translateChoice,
-    validate,
-    ...rest
-}) => {
-    const classes = useStyles(classesOverride);
+> = props => {
+    const {
+        choices = [],
+        classes: classesOverride,
+        format,
+        helperText,
+        label,
+        margin = 'dense',
+        onBlur,
+        onChange,
+        onFocus,
+        options,
+        optionText,
+        optionValue,
+        parse,
+        resource,
+        row,
+        source,
+        translateChoice,
+        validate,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
 
     const {
         id,

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.js
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.js
@@ -40,18 +40,19 @@ const handleMouseDownClearButton = event => {
 /**
  * An override of the default Material-UI TextField which is resettable
  */
-function ResettableTextField({
-    classes: classesOverride,
-    clearAlwaysVisible,
-    InputProps,
-    value,
-    resettable,
-    disabled,
-    variant = 'filled',
-    margin = 'dense',
-    ...props
-}) {
-    const classes = useStyles({ classes: classesOverride });
+function ResettableTextField(props) {
+    const {
+        classes: classesOverride,
+        clearAlwaysVisible,
+        InputProps,
+        value,
+        resettable,
+        disabled,
+        variant = 'filled',
+        margin = 'dense',
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
 
     const { onChange, onFocus, onBlur } = props;
@@ -187,7 +188,7 @@ function ResettableTextField({
             disabled={disabled}
             variant={variant}
             margin={margin}
-            {...props}
+            {...rest}
             onFocus={handleFocus}
             onBlur={handleBlur}
         />

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -18,9 +18,10 @@ const useStyles = makeStyles(
 
 const SearchInput: FunctionComponent<
     InputProps<TextFieldProps> & Omit<TextFieldProps, 'label' | 'helperText'>
-> = ({ classes: classesOverride, ...props }) => {
+> = props => {
+    const { classes: classesOverride, ...rest } = props;
     const translate = useTranslate();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     return (
         <TextInput
@@ -36,7 +37,7 @@ const SearchInput: FunctionComponent<
                 ),
             }}
             className={classes.input}
-            {...props}
+            {...rest}
         />
     );
 };

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -136,29 +136,30 @@ const useStyles = makeStyles(
  */
 const SelectArrayInput: FunctionComponent<
     ChoicesProps & InputProps<SelectProps> & FormControlProps
-> = ({
-    choices = [],
-    classes: classesOverride,
-    className,
-    format,
-    helperText,
-    label,
-    margin = 'dense',
-    onBlur,
-    onChange,
-    onFocus,
-    options,
-    optionText,
-    optionValue,
-    parse,
-    resource,
-    source,
-    translateChoice,
-    validate,
-    variant = 'filled',
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+> = props => {
+    const {
+        choices = [],
+        classes: classesOverride,
+        className,
+        format,
+        helperText,
+        label,
+        margin = 'dense',
+        onBlur,
+        onChange,
+        onFocus,
+        options,
+        optionText,
+        optionValue,
+        parse,
+        resource,
+        source,
+        translateChoice,
+        validate,
+        variant = 'filled',
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const { getChoiceText, getChoiceValue } = useChoices({
         optionText,
         optionValue,

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -145,31 +145,33 @@ const SelectInput: FunctionComponent<
     ChoicesProps &
         InputProps<TextFieldProps> &
         Omit<TextFieldProps, 'label' | 'helperText'>
-> = ({
-    allowEmpty,
-    choices = [],
-    className,
-    disableValue,
-    emptyText,
-    emptyValue,
-    format,
-    helperText,
-    label,
-    onBlur,
-    onChange,
-    onFocus,
-    options,
-    optionText,
-    optionValue,
-    parse,
-    resource,
-    source,
-    translateChoice,
-    validate,
-    ...rest
-}) => {
+> = props => {
+    const {
+        allowEmpty,
+        choices = [],
+        classes: classesOverride,
+        className,
+        disableValue,
+        emptyText,
+        emptyValue,
+        format,
+        helperText,
+        label,
+        onBlur,
+        onChange,
+        onFocus,
+        options,
+        optionText,
+        optionValue,
+        parse,
+        resource,
+        source,
+        translateChoice,
+        validate,
+        ...rest
+    } = props;
     const translate = useTranslate();
-    const classes = useStyles({});
+    const classes = useStyles(props);
     const { getChoiceText, getChoiceValue } = useChoices({
         optionText,
         optionValue,

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -48,18 +48,19 @@ const useStyles = makeStyles(
     { name: 'RaAppBar' }
 );
 
-const AppBar = ({
-    children,
-    classes: classesOverride,
-    className,
-    logo,
-    logout,
-    open,
-    title,
-    userMenu,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const AppBar = props => {
+    const {
+        children,
+        classes: classesOverride,
+        className,
+        logo,
+        logout,
+        open,
+        title,
+        userMenu,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const dispatch = useDispatch();
     const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
 

--- a/packages/ra-ui-materialui/src/layout/CardActions.tsx
+++ b/packages/ra-ui-materialui/src/layout/CardActions.tsx
@@ -18,12 +18,13 @@ const useStyles = makeStyles(
     { name: 'RaCardActions' }
 );
 
-const CardActions = ({ className, children, ...rest }) => {
+const CardActions = props => {
+    const { classes: classesOverride, className, children, ...rest } = props;
     warning(
         true,
         '<CardActions> is deprecated. Please use the <TopToolbar> component instead to wrap your action buttons'
     );
-    const classes = useStyles({}); // the empty {} is a temp fix for https://github.com/mui-org/material-ui/issues/15942
+    const classes = useStyles(props);
     return (
         <div className={classnames(classes.cardActions, className)} {...rest}>
             {children}

--- a/packages/ra-ui-materialui/src/layout/CardContentInner.js
+++ b/packages/ra-ui-materialui/src/layout/CardContentInner.js
@@ -30,12 +30,9 @@ const useStyles = makeStyles(
  * padding double the spacing between each CardContent, leading to too much
  * wasted space. Use this component as a CardContent alternative.
  */
-const CardContentInner = ({
-    classes: classesOverride,
-    className,
-    children,
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const CardContentInner = props => {
+    const { className, children } = props;
+    const classes = useStyles(props);
     return (
         <CardContent className={classnames(classes.root, className)}>
             {children}

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -55,22 +55,22 @@ const useStyles = makeStyles(
  *     onClose={() => { // do something }}
  * />
  */
-const Confirm: FC<ConfirmProps> = ({
-    isOpen,
-    loading,
-    title,
-    content,
-    confirm,
-    cancel,
-    confirmColor,
-    ConfirmIcon,
-    CancelIcon,
-    onClose,
-    onConfirm,
-    classes: classesOverride,
-    translateOptions = {},
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const Confirm: FC<ConfirmProps> = props => {
+    const {
+        isOpen,
+        loading,
+        title,
+        content,
+        confirm,
+        cancel,
+        confirmColor,
+        ConfirmIcon,
+        CancelIcon,
+        onClose,
+        onConfirm,
+        translateOptions = {},
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
 
     const handleConfirm = useCallback(

--- a/packages/ra-ui-materialui/src/layout/Error.js
+++ b/packages/ra-ui-materialui/src/layout/Error.js
@@ -52,15 +52,16 @@ function goBack() {
     window.history.go(-1);
 }
 
-const Error = ({
-    error,
-    errorInfo,
-    classes: classesOverride,
-    className,
-    title,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const Error = props => {
+    const {
+        error,
+        errorInfo,
+        classes: classesOverride,
+        className,
+        title,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
     return (
         <Fragment>

--- a/packages/ra-ui-materialui/src/layout/LinearProgress.js
+++ b/packages/ra-ui-materialui/src/layout/LinearProgress.js
@@ -24,8 +24,9 @@ const useStyles = makeStyles(
  *
  * @param {object} classes CSS class names
  */
-const LinearProgress = ({ classes: classesOverride, className, ...rest }) => {
-    const classes = useStyles({ classes: classesOverride });
+const LinearProgress = props => {
+    const { classes: classesOverride, className, ...rest } = props;
+    const classes = useStyles(props);
     return (
         <Progress className={classnames(classes.root, className)} {...rest} />
     );

--- a/packages/ra-ui-materialui/src/layout/Loading.js
+++ b/packages/ra-ui-materialui/src/layout/Loading.js
@@ -33,13 +33,13 @@ const useStyles = makeStyles(
     { name: 'RaLoading' }
 );
 
-const Loading = ({
-    classes: classesOverride,
-    className,
-    loadingPrimary = 'ra.page.loading',
-    loadingSecondary = 'ra.message.loading',
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const Loading = props => {
+    const {
+        className,
+        loadingPrimary = 'ra.page.loading',
+        loadingSecondary = 'ra.message.loading',
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
     return (
         <div className={classnames(classes.container, className)}>

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -16,9 +16,10 @@ const useStyles = makeStyles(
     { name: 'RaLoadingIndicator' }
 );
 
-const LoadingIndicator = ({ classes: classesOverride, className, ...rest }) => {
+const LoadingIndicator = props => {
+    const { classes: classesOverride, className, ...rest } = props;
     const loading = useSelector(state => state.admin.loading > 0);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     return loading ? (
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -34,17 +34,18 @@ const translatedResourceName = (resource: any, translate: Translate) =>
                 : inflection.humanize(inflection.pluralize(resource.name)),
     });
 
-const Menu: FC<MenuProps> = ({
-    classes: classesOverride,
-    className,
-    dense,
-    hasDashboard,
-    onMenuClick,
-    logout,
-    ...rest
-}) => {
+const Menu: FC<MenuProps> = props => {
+    const {
+        classes: classesOverride,
+        className,
+        dense,
+        hasDashboard,
+        onMenuClick,
+        logout,
+        ...rest
+    } = props;
     const translate = useTranslate();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     const isXSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('xs')
     );

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -32,61 +32,57 @@ const useStyles = makeStyles(
     { name: 'RaMenuItemLink' }
 );
 
-const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
-    (
-        {
-            classes: classesOverride,
-            className,
-            primaryText,
-            leftIcon,
-            onClick,
-            sidebarIsOpen,
-            ...props
+const MenuItemLink: FC<MenuItemLinkProps> = forwardRef((props, ref) => {
+    const {
+        classes: classesOverride,
+        className,
+        primaryText,
+        leftIcon,
+        onClick,
+        sidebarIsOpen,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
+
+    const handleMenuTap = useCallback(
+        e => {
+            onClick && onClick(e);
         },
-        ref
-    ) => {
-        const classes = useStyles({ classes: classesOverride });
+        [onClick]
+    );
 
-        const handleMenuTap = useCallback(
-            e => {
-                onClick && onClick(e);
-            },
-            [onClick]
-        );
-
-        const renderMenuItem = () => {
-            return (
-                <MenuItem
-                    className={classnames(classes.root, className)}
-                    activeClassName={classes.active}
-                    component={NavLinkRef}
-                    ref={ref}
-                    {...props}
-                    onClick={handleMenuTap}
-                >
-                    {leftIcon && (
-                        <ListItemIcon className={classes.icon}>
-                            {cloneElement(leftIcon, {
-                                titleAccess: primaryText,
-                            })}
-                        </ListItemIcon>
-                    )}
-                    {primaryText}
-                </MenuItem>
-            );
-        };
-
-        if (sidebarIsOpen) {
-            return renderMenuItem();
-        }
-
+    const renderMenuItem = () => {
         return (
-            <Tooltip title={primaryText} placement="right">
-                {renderMenuItem()}
-            </Tooltip>
+            <MenuItem
+                className={classnames(classes.root, className)}
+                activeClassName={classes.active}
+                component={NavLinkRef}
+                ref={ref}
+                {...rest}
+                onClick={handleMenuTap}
+            >
+                {leftIcon && (
+                    <ListItemIcon className={classes.icon}>
+                        {cloneElement(leftIcon, {
+                            titleAccess: primaryText,
+                        })}
+                    </ListItemIcon>
+                )}
+                {primaryText}
+            </MenuItem>
         );
+    };
+
+    if (sidebarIsOpen) {
+        return renderMenuItem();
     }
-);
+
+    return (
+        <Tooltip title={primaryText} placement="right">
+            {renderMenuItem()}
+        </Tooltip>
+    );
+});
 
 interface Props {
     leftIcon?: ReactElement;

--- a/packages/ra-ui-materialui/src/layout/NotFound.js
+++ b/packages/ra-ui-materialui/src/layout/NotFound.js
@@ -45,8 +45,9 @@ function goBack() {
     window.history.go(-1);
 }
 
-const NotFound = ({ className, classes: classesOverride, title, ...rest }) => {
-    const classes = useStyles({ classes: classesOverride });
+const NotFound = props => {
+    const { className, classes: classesOverride, title, ...rest } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
     useAuthenticated();
     return (

--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -38,12 +38,19 @@ const useStyles = makeStyles(
 
 const Notification: React.FunctionComponent<
     Props & Omit<SnackbarProps, 'open'>
-> = ({ type, className, autoHideDuration, ...rest }) => {
+> = props => {
+    const {
+        classes: classesOverride,
+        type,
+        className,
+        autoHideDuration,
+        ...rest
+    } = props;
     const [open, setOpen] = useState(false);
     const notification = useSelector(getNotification);
     const dispatch = useDispatch();
     const translate = useTranslate();
-    const styles = useStyles({});
+    const styles = useStyles(props);
 
     useEffect(() => {
         setOpen(!!notification);

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -45,13 +45,14 @@ const useStyles = makeStyles(
     { name: 'RaSidebar' }
 );
 
-const Sidebar = ({
-    children,
-    closedSize,
-    size,
-    classes: classesOverride,
-    ...rest
-}) => {
+const Sidebar = props => {
+    const {
+        children,
+        closedSize,
+        size,
+        classes: classesOverride,
+        ...rest
+    } = props;
     const dispatch = useDispatch();
     const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
     const isSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
@@ -68,7 +69,7 @@ const Sidebar = ({
     useSelector(state => state.locale); // force redraw on locale change
     const handleClose = () => dispatch(setSidebarVisibility(false));
     const toggleSidebar = () => dispatch(setSidebarVisibility(!open));
-    const classes = useStyles({ classes: classesOverride, open });
+    const classes = useStyles({ ...props, open });
 
     return isXSmall ? (
         <Drawer

--- a/packages/ra-ui-materialui/src/layout/TopToolbar.js
+++ b/packages/ra-ui-materialui/src/layout/TopToolbar.js
@@ -29,8 +29,9 @@ const useStyles = makeStyles(
     { name: 'RaTopToolbar' }
 );
 
-const TopToolbar = ({ className, children, ...rest }) => {
-    const classes = useStyles();
+const TopToolbar = props => {
+    const { className, children, ...rest } = props;
+    const classes = useStyles(props);
     return (
         <Toolbar className={classnames(classes.root, className)} {...rest}>
             {children}

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.js
@@ -41,17 +41,18 @@ const useStyles = makeStyles(
     { name: 'RaBulkActionsToolbar' }
 );
 
-const BulkActionsToolbar = ({
-    basePath,
-    classes: classesOverride,
-    filterValues,
-    label,
-    resource,
-    selectedIds,
-    children,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const BulkActionsToolbar = props => {
+    const {
+        basePath,
+        classes: classesOverride,
+        filterValues,
+        label,
+        resource,
+        selectedIds,
+        children,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
 
     return (

--- a/packages/ra-ui-materialui/src/list/Empty.js
+++ b/packages/ra-ui-materialui/src/list/Empty.js
@@ -29,8 +29,9 @@ const useStyles = makeStyles(
     { name: 'RaEmpty' }
 );
 
-const Empty = ({ resource, basePath }) => {
-    const classes = useStyles();
+const Empty = props => {
+    const { resource, basePath } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
 
     const resourceName = inflection.humanize(

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(
 );
 
 const Filter = props => {
-    const classes = useStyles({ classes: props.classes });
+    const classes = useStyles(props);
     const renderButton = () => {
         const {
             classes: classesOverride,

--- a/packages/ra-ui-materialui/src/list/FilterButton.js
+++ b/packages/ra-ui-materialui/src/list/FilterButton.js
@@ -16,19 +16,20 @@ const useStyles = makeStyles(
     { name: 'RaFilterButton' }
 );
 
-const FilterButton = ({
-    filters,
-    displayedFilters = {},
-    filterValues,
-    showFilter,
-    classes: classesOverride,
-    className,
-    resource,
-    ...rest
-}) => {
+const FilterButton = props => {
+    const {
+        filters,
+        displayedFilters = {},
+        filterValues,
+        showFilter,
+        classes: classesOverride,
+        className,
+        resource,
+        ...rest
+    } = props;
     const [open, setOpen] = useState(false);
     const anchorEl = useRef();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
 
     const hiddenFilters = filters.filter(
         filterElement =>

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -175,14 +175,15 @@ export const mergeInitialValuesWithDefaultValues = ({
     ...initialValues,
 });
 
-const EnhancedFilterForm = ({ classes: classesOverride, ...props }) => {
-    const classes = useStyles({ classes: classesOverride });
+const EnhancedFilterForm = props => {
+    const { classes: classesOverride, ...rest } = props;
+    const classes = useStyles(props);
 
     const mergedInitialValuesWithDefaultValues = mergeInitialValuesWithDefaultValues(
         props
     );
 
-    const { initialValues, ...rest } = props;
+    const { initialValues, ...rest2 } = rest;
 
     return (
         <Form
@@ -197,10 +198,10 @@ const EnhancedFilterForm = ({ classes: classesOverride, ...props }) => {
                             if (pristine) {
                                 return;
                             }
-                            props && props.setFilters(values);
+                            rest && rest.setFilters(values);
                         }}
                     />
-                    <FilterForm classes={classes} {...formProps} {...rest} />
+                    <FilterForm classes={classes} {...formProps} {...rest2} />
                 </>
             )}
         />

--- a/packages/ra-ui-materialui/src/list/FilterFormInput.js
+++ b/packages/ra-ui-materialui/src/list/FilterFormInput.js
@@ -17,16 +17,10 @@ const useStyles = makeStyles(
     { name: 'RaFilterFormInput' }
 );
 
-const FilterFormInput = ({
-    filterElement,
-    handleHide,
-    classes: classesOverride,
-    resource,
-    variant,
-    margin,
-}) => {
+const FilterFormInput = props => {
+    const { filterElement, handleHide, resource, variant, margin } = props;
     const translate = useTranslate();
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     return (
         <div
             data-source={filterElement.props.source}

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -120,7 +120,7 @@ export const ListView = props => {
         ...rest
     } = props;
     useCheckMinimumRequiredProps('List', ['children'], props);
-    const classes = useStyles({ classes: classesOverride });
+    const classes = useStyles(props);
     const {
         defaultTitle,
         version,

--- a/packages/ra-ui-materialui/src/list/ListToolbar.js
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.js
@@ -29,20 +29,19 @@ const useStyles = makeStyles(
     { name: 'RaListToolbar' }
 );
 
-const defaultClasses = {}; // avoid needless updates
-
-const ListToolbar = ({
-    classes = defaultClasses,
-    filters,
-    filterValues, // dynamically set via the UI by the user
-    permanentFilter, // set in the List component by the developer
-    actions,
-    exporter,
-    ...rest
-}) => {
-    const styles = useStyles({ classes });
+const ListToolbar = props => {
+    const {
+        classes: classesOverride,
+        filters,
+        filterValues, // dynamically set via the UI by the user
+        permanentFilter, // set in the List component by the developer
+        actions,
+        exporter,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     return (
-        <Toolbar className={styles.toolbar}>
+        <Toolbar className={classes.toolbar}>
             {filters &&
                 React.cloneElement(filters, {
                     ...rest,
@@ -53,7 +52,7 @@ const ListToolbar = ({
             {actions &&
                 React.cloneElement(actions, {
                     ...rest,
-                    className: styles.actions,
+                    className: classes.actions,
                     exporter,
                     filters,
                     filterValues,

--- a/packages/ra-ui-materialui/src/list/PaginationActions.js
+++ b/packages/ra-ui-materialui/src/list/PaginationActions.js
@@ -18,16 +18,9 @@ const useStyles = makeStyles(
     { name: 'RaPaginationActions' }
 );
 
-function PaginationActions({
-    classes: classesOverride,
-    page,
-    rowsPerPage,
-    count,
-    onChangePage,
-    color,
-    size,
-}) {
-    const classes = useStyles({ classes: classesOverride });
+function PaginationActions(props) {
+    const { page, rowsPerPage, count, onChangePage, color, size } = props;
+    const classes = useStyles(props);
     const translate = useTranslate();
     /**
      * Warning: material-ui's page is 0-based

--- a/packages/ra-ui-materialui/src/list/Placeholder.tsx
+++ b/packages/ra-ui-materialui/src/list/Placeholder.tsx
@@ -17,9 +17,11 @@ interface Props {
     classes?: Record<'root', string>;
 }
 
-const Placeholder: FC<Props> = ({ className, classes: classesOverride }) => {
-    const classes = useStyles({ classes: classesOverride });
-    return <div className={classnames(className, classes.root)}>&nbsp;</div>;
+const Placeholder: FC<Props> = props => {
+    const classes = useStyles(props);
+    return (
+        <div className={classnames(props.className, classes.root)}>&nbsp;</div>
+    );
 };
 
 export default Placeholder;

--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -53,29 +53,30 @@ const LinkOrNot = ({
     );
 };
 
-const SimpleList = ({
-    basePath,
-    className,
-    classes: classesOverride,
-    data,
-    hasBulkActions,
-    ids,
-    loaded,
-    loading,
-    leftAvatar,
-    leftIcon,
-    linkType,
-    onToggleItem,
-    primaryText,
-    rightAvatar,
-    rightIcon,
-    secondaryText,
-    selectedIds,
-    tertiaryText,
-    total,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const SimpleList = props => {
+    const {
+        basePath,
+        className,
+        classes: classesOverride,
+        data,
+        hasBulkActions,
+        ids,
+        loaded,
+        loading,
+        leftAvatar,
+        leftIcon,
+        linkType,
+        onToggleItem,
+        primaryText,
+        rightAvatar,
+        rightIcon,
+        secondaryText,
+        selectedIds,
+        tertiaryText,
+        total,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
 
     if (loaded === false) {
         return (

--- a/packages/ra-ui-materialui/src/list/SimpleListLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleListLoading.tsx
@@ -35,17 +35,18 @@ interface Props {
     nbFakeLines?: number;
 }
 
-const SimpleListLoading: FC<Props & ListProps> = ({
-    classes: classesOverride,
-    className,
-    hasLeftAvatarOrIcon,
-    hasRightAvatarOrIcon,
-    hasSecondaryText,
-    hasTertiaryText,
-    nbFakeLines = 5,
-    ...rest
-}) => {
-    const classes = useStyles({ classes: classesOverride });
+const SimpleListLoading: FC<Props & ListProps> = props => {
+    const {
+        classes: classesOverride,
+        className,
+        hasLeftAvatarOrIcon,
+        hasRightAvatarOrIcon,
+        hasSecondaryText,
+        hasTertiaryText,
+        nbFakeLines = 5,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
     const oneSecondHasPassed = useTimeout(1000);
 
     return oneSecondHasPassed ? (

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.js
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.js
@@ -67,19 +67,20 @@ const handleClick = () => {};
  *     </SingleFieldList>
  * </ReferenceManyField>
  */
-function SingleFieldList({
-    classes: classesOverride,
-    className,
-    ids,
-    data,
-    loaded,
-    resource,
-    basePath,
-    children,
-    linkType,
-    ...rest
-}) {
-    const classes = useStyles({ classes: classesOverride });
+function SingleFieldList(props) {
+    const {
+        classes: classesOverride,
+        className,
+        ids,
+        data,
+        loaded,
+        resource,
+        basePath,
+        children,
+        linkType,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
 
     if (loaded === false) {
         return <LinearProgress />;


### PR DESCRIPTION
## Problem

1. Many components allow style override by way of a custom `classes` prop (as accepted by `useStyles`), but implement it a way that causes unwanted re-renders (`useStyles({ classes: classesOverride })`, which defeats React.memo because the parameter is always a new object) and harm performance
2. Some components allow style override by will pass the `classes` prop down to their children

## Solution

This PR makes all components work the same way:

- either they allow style override by `classes`, in which case it's performant and dosn't leak, or
- they don't allow style override. 

This change is backwards compatible. 