### PR TITLE
Fix useFilterState: useCallback listens on permanent filter changes

### DIFF
--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -80,7 +80,7 @@ export default ({
             });
             latestValue.current = value;
         }, debounceTime),
-        [ permanentFilter ]
+        [permanentFilter]
     );
 
     return {

--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -80,7 +80,7 @@ export default ({
             });
             latestValue.current = value;
         }, debounceTime),
-        [permanentFilter]
+        [ permanentFilter ]
     );
 
     return {

--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -80,7 +80,7 @@ export default ({
             });
             latestValue.current = value;
         }, debounceTime),
-        []
+        [permanentFilter]
     );
 
     return {


### PR DESCRIPTION
Closes #4507 

Updating filter prop on referenceInput wasn't updating the filters for fetching. The last query uses the first filters provided.

Listening on permanentFilter on setFilter callback solved the issue.