### PR TITLE
Add a default order prop in List Fields

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -552,7 +552,6 @@ export const PostList = (props) => (
 
 By default, when the user clicks on a column header, the list becomes sorted in the ascending order. You change this behavior by setting the `sortByOrder` prop to `"DESC"`:
 
-{% raw %}
 ```jsx
 // in src/posts.js
 import React from 'react';
@@ -575,7 +574,6 @@ export const PostList = (props) => (
     </List>
 );
 ```
-{% endraw %}
 
 ### Permanent Filter
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -550,7 +550,7 @@ export const PostList = (props) => (
 
 ### Specify Sort Order
 
-By default, a column is sorted by the `ASC` order. You can use `DESC` via the `sortByOrder` property:
+By default, when the user clicks on a column header, the list becomes sorted in the ascending order. You change this behavior by setting the `sortByOrder` prop to `"DESC"`:
 
 {% raw %}
 ```jsx

--- a/docs/List.md
+++ b/docs/List.md
@@ -550,7 +550,7 @@ export const PostList = (props) => (
 
 ### Specify Sort Order
 
-By default, a column is sorted by the `ASC` order property. You can use `DESC` via the `sortByOrder` property:
+By default, a column is sorted by the `ASC` order. You can use `DESC` via the `sortByOrder` property:
 
 {% raw %}
 ```jsx

--- a/docs/List.md
+++ b/docs/List.md
@@ -548,6 +548,35 @@ export const PostList = (props) => (
 ```
 {% endraw %}
 
+### Specify Sort Order
+
+By default, a column is sorted by the `ASC` order property. You can use `DESC` via the `sortByOrder` property:
+
+{% raw %}
+```jsx
+// in src/posts.js
+import React from 'react';
+import { List, Datagrid, TextField } from 'react-admin';
+
+export const PostList = (props) => (
+    <List {...props}>
+        <Datagrid>
+            <ReferenceField label="Post" source="id" reference="posts" sortByOrder="DESC">
+                <TextField source="title" />
+            </ReferenceField>
+            <FunctionField
+                label="Author"
+                sortBy="last_name"
+                sortByOrder="DESC"
+                render={record => `${record.author.first_name} ${record.author.last_name}`}
+            />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+```
+{% endraw %}
+
 ### Permanent Filter
 
 You can choose to always filter the list, without letting the user disable this filter - for instance to display only published posts. Write the filter to be passed to the REST client in the `filter` props:

--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -140,11 +140,7 @@ const PostList = props => {
             ) : (
                 <Datagrid rowClick={rowClick} expand={PostPanel} optimized>
                     <TextField source="id" />
-                    <TextField
-                        source="title"
-                        cellClassName={classes.title}
-                        sortBy="title"
-                    />
+                    <TextField source="title" cellClassName={classes.title} />
                     <DateField
                         source="published_at"
                         sortByOrder="DESC"

--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -140,7 +140,12 @@ const PostList = props => {
             ) : (
                 <Datagrid rowClick={rowClick} expand={PostPanel} optimized>
                     <TextField source="id" />
-                    <TextField source="title" cellClassName={classes.title} />
+                    <TextField
+                        source="title"
+                        cellClassName={classes.title}
+                        sortBy="title"
+                        sortByOrder="DESC"
+                    />
                     <DateField
                         source="published_at"
                         cellClassName={classes.publishedAt}

--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -144,10 +144,10 @@ const PostList = props => {
                         source="title"
                         cellClassName={classes.title}
                         sortBy="title"
-                        sortByOrder="DESC"
                     />
                     <DateField
                         source="published_at"
+                        sortByOrder="DESC"
                         cellClassName={classes.publishedAt}
                     />
 
@@ -156,7 +156,7 @@ const PostList = props => {
                         label="resources.posts.fields.commentable_short"
                         sortable={false}
                     />
-                    <NumberField source="views" />
+                    <NumberField source="views" sortByOrder="DESC" />
                     <ReferenceArrayField
                         label="Tags"
                         reference="tags"

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -67,7 +67,7 @@ export interface ListControllerProps<RecordType = Record> {
     setFilters: (filters: any, displayedFilters: any) => void;
     setPage: (page: number) => void;
     setPerPage: (page: number) => void;
-    setSort: (sort: string) => void;
+    setSort: (sort: string, order?: string) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
     total: number;
     version: number;

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -156,10 +156,10 @@ const useListParams = ({
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
 
     const setSort = useCallback(
-        (newSort: string, newOrder?: string) =>
+        (sort: string, order?: string) =>
             changeParams({
                 type: SET_SORT,
-                payload: { sort: newSort, order: newOrder || undefined },
+                payload: { sort, order },
             }),
         requestSignature // eslint-disable-line react-hooks/exhaustive-deps
     );

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -40,7 +40,7 @@ interface Modifiers {
     changeParams: (action: any) => void;
     setPage: (page: number) => void;
     setPerPage: (pageSize: number) => void;
-    setSort: (sort: string) => void;
+    setSort: (sort: string, order?: string) => void;
     setFilters: (filters: any, displayedFilters: any) => void;
     hideFilter: (filterName: string) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
@@ -156,8 +156,11 @@ const useListParams = ({
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
 
     const setSort = useCallback(
-        (newSort: string) =>
-            changeParams({ type: SET_SORT, payload: { sort: newSort } }),
+        (newSort: string, newOrder?: string) =>
+            changeParams({
+                type: SET_SORT,
+                payload: { sort: newSort, order: newOrder || undefined },
+            }),
         requestSignature // eslint-disable-line react-hooks/exhaustive-deps
     );
 

--- a/packages/ra-core/src/controller/useSortState.ts
+++ b/packages/ra-core/src/controller/useSortState.ts
@@ -9,7 +9,7 @@ import { Sort } from '../types';
 export interface SortProps {
     setSortField: (field: string) => void;
     setSortOrder: (order: string) => void;
-    setSort: (sort: Sort) => void;
+    setSort: (sort: Sort, order?: string) => void;
     sort: Sort;
 }
 
@@ -116,7 +116,8 @@ export default (initialSort: Sort = defaultSort): SortProps => {
 
     return {
         setSort: useCallback(
-            (sort: Sort) => dispatch({ type: 'SET_SORT', payload: { sort } }),
+            (sort: Sort, order?: string) =>
+                dispatch({ type: 'SET_SORT', payload: { sort, order } }),
             [dispatch]
         ),
         setSortField: useCallback(

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -83,6 +83,7 @@ ReferenceArrayField.propTypes = {
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
     sortBy: PropTypes.string,
+    sortByOrder: PropTypes.string,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -83,7 +83,7 @@ ReferenceArrayField.propTypes = {
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
     sortBy: PropTypes.string,
-    sortByOrder: PropTypes.string,
+    sortByOrder: fieldPropTypes.sortByOrder,
     source: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -118,6 +118,7 @@ ReferenceField.propTypes = {
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
     sortBy: PropTypes.string,
+    sortByOrder: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -15,7 +15,7 @@ import LinearProgress from '../layout/LinearProgress';
 import Link from '../Link';
 import sanitizeRestProps from './sanitizeRestProps';
 import { ClassNameMap } from '@material-ui/styles';
-import { FieldProps, InjectedFieldProps } from './types';
+import { FieldProps, fieldPropTypes, InjectedFieldProps } from './types';
 
 interface ReferenceFieldProps extends FieldProps, InjectedFieldProps {
     children: ReactElement;
@@ -118,7 +118,7 @@ ReferenceField.propTypes = {
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
     sortBy: PropTypes.string,
-    sortByOrder: PropTypes.string,
+    sortByOrder: fieldPropTypes.sortByOrder,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -138,6 +138,7 @@ ReferenceManyField.propTypes = {
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
     sortBy: PropTypes.string,
+    sortByOrder: PropTypes.string,
     source: PropTypes.string.isRequired,
     sort: PropTypes.exact({
         field: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -16,7 +16,7 @@ import {
     PaginationProps,
     SortProps,
 } from 'ra-core';
-import { FieldProps, InjectedFieldProps } from './types';
+import { FieldProps, fieldPropTypes, InjectedFieldProps } from './types';
 
 /**
  * Render related records to the current one.
@@ -138,7 +138,7 @@ ReferenceManyField.propTypes = {
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
     sortBy: PropTypes.string,
-    sortByOrder: PropTypes.string,
+    sortByOrder: fieldPropTypes.sortByOrder,
     source: PropTypes.string.isRequired,
     sort: PropTypes.exact({
         field: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/sanitizeRestProps.ts
+++ b/packages/ra-ui-materialui/src/field/sanitizeRestProps.ts
@@ -18,6 +18,7 @@ export default (props: object): object =>
         'resource',
         'sortable',
         'sortBy',
+        'sortByOrder',
         'source',
         'textAlign',
         'translateChoice',

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -2,10 +2,11 @@ import { Record } from 'ra-core';
 import PropTypes from 'prop-types';
 
 type TextAlign = 'right' | 'left';
+type SortOrder = 'ASC' | 'DESC';
 export interface FieldProps {
     addLabel?: boolean;
     sortBy?: string;
-    sortByOrder?: string;
+    sortByOrder?: SortOrder;
     source?: string;
     label?: string;
     sortable?: boolean;
@@ -26,7 +27,7 @@ export interface InjectedFieldProps {
 export const fieldPropTypes = {
     addLabel: PropTypes.bool,
     sortBy: PropTypes.string,
-    sortByOrder: PropTypes.string,
+    sortByOrder: PropTypes.oneOf<SortOrder>(['ASC', 'DESC']),
     source: PropTypes.string,
     label: PropTypes.string,
     sortable: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -5,6 +5,7 @@ type TextAlign = 'right' | 'left';
 export interface FieldProps {
     addLabel?: boolean;
     sortBy?: string;
+    sortByOrder?: string;
     source?: string;
     label?: string;
     sortable?: boolean;
@@ -25,6 +26,7 @@ export interface InjectedFieldProps {
 export const fieldPropTypes = {
     addLabel: PropTypes.bool,
     sortBy: PropTypes.string,
+    sortByOrder: PropTypes.string,
     source: PropTypes.string,
     label: PropTypes.string,
     sortable: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -203,7 +203,7 @@ interface ReferenceInputViewProps {
     resource: string;
     setFilter: (v: string) => void;
     setPagination: (pagination: Pagination) => void;
-    setSort: (sort: Sort) => void;
+    setSort: (sort: Sort, order?: string) => void;
     source: string;
     warning?: string;
 }

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -127,7 +127,10 @@ const Datagrid = props => {
     const updateSort = useCallback(
         event => {
             event.stopPropagation();
-            setSort(event.currentTarget.dataset.sort);
+            setSort(
+                event.currentTarget.dataset.sort,
+                event.currentTarget.dataset.order
+            );
         },
         [setSort]
     );

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -61,6 +61,7 @@ export const DatagridHeaderCell = props => {
                         }
                         direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
                         data-sort={field.props.sortBy || field.props.source}
+                        data-order={field.props.sortByOrder || 'ASC'}
                         onClick={updateSort}
                         classes={classes}
                     >

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
@@ -48,14 +48,16 @@ describe('<DatagridHeaderCell />', () => {
             expect(getByTitle('ra.action.sort').dataset.sort).toBe('title');
         });
 
-        it('should be enabled when field has a sortByOrder props', () => {
+        it('should be change order when field has a sortByOrder props', () => {
             const { getByTitle } = render(
                 <table>
                     <tbody>
                         <tr>
                             <DatagridHeaderCell
                                 currentSort={{}}
-                                field={<Field sortByOrder="DESC" />}
+                                field={
+                                    <Field sortBy="title" sortByOrder="DESC" />
+                                }
                                 updateSort={() => true}
                             />
                         </tr>
@@ -63,6 +65,23 @@ describe('<DatagridHeaderCell />', () => {
                 </table>
             );
             expect(getByTitle('ra.action.sort').dataset.order).toBe('DESC');
+        });
+
+        it('should be keep ASC order when field has not sortByOrder props', () => {
+            const { getByTitle } = render(
+                <table>
+                    <tbody>
+                        <tr>
+                            <DatagridHeaderCell
+                                currentSort={{}}
+                                field={<Field source="title" />}
+                                updateSort={() => true}
+                            />
+                        </tr>
+                    </tbody>
+                </table>
+            );
+            expect(getByTitle('ra.action.sort').dataset.order).toBe('ASC');
         });
 
         it('should be disabled when field has no sortby and no source', () => {

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
@@ -48,6 +48,23 @@ describe('<DatagridHeaderCell />', () => {
             expect(getByTitle('ra.action.sort').dataset.sort).toBe('title');
         });
 
+        it('should be enabled when field has a sortByOrder props', () => {
+            const { getByTitle } = render(
+                <table>
+                    <tbody>
+                        <tr>
+                            <DatagridHeaderCell
+                                currentSort={{}}
+                                field={<Field sortByOrder="DESC" />}
+                                updateSort={() => true}
+                            />
+                        </tr>
+                    </tbody>
+                </table>
+            );
+            expect(getByTitle('ra.action.sort').dataset.order).toBe('DESC');
+        });
+
         it('should be disabled when field has no sortby and no source', () => {
             const { queryAllByTitle } = render(
                 <table>


### PR DESCRIPTION
Closes #2736

## Issue

In Lists, columns are always sorted by `ASC` order by default
Sometimes, it's not the main desired behaviour (recent dates before, .....)

## Usage

```js
<TextField
    source="title"
    sortBy="title"
    sortByOrder="DESC"
/>
```

## Documentation

![image](https://user-images.githubusercontent.com/39904906/76609417-a5e31f80-6517-11ea-914e-0481d47e1f17.png)
