### PR TITLE
Fix useless line in ra-data-graphcool readme

### DIFF
--- a/packages/ra-data-graphcool/README.md
+++ b/packages/ra-data-graphcool/README.md
@@ -33,8 +33,6 @@ import { Admin, Resource, Delete } from 'react-admin';
 
 import { PostCreate, PostEdit, PostList } from './posts';
 
-const client = new ApolloClient();
-
 class App extends Component {
     constructor() {
         super();


### PR DESCRIPTION
Linked #2174 

Client in never used in the example in graphcool
(Same as previously in graphql-simple)