### PR TITLE
[RFR] Change docs menu Fields item order with Create and Edit item.

### DIFF
--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -13,13 +13,13 @@
                 View</a></li>
 <li {% if page.path contains 'Show.md' %} class="active" {% endif %}><a href="./Show.html"><code>&lt;Show&gt;</code>
                 View</a></li>
-<li {% if page.path contains 'Fields.md' %} class="active" {% endif %}><a
-                href="./Fields.html"><code>&lt;Field&gt;</code>
-                Components</a></li>
 <li {% if page.path contains 'CreateEdit.md' %} class="active" {% endif %}><a
                 href="./CreateEdit.html"><code>&lt;Create&gt;</code>
                 and <code>&lt;Edit&gt;</code> Views</a>
 </li>
+<li {% if page.path contains 'Fields.md' %} class="active" {% endif %}><a
+    href="./Fields.html"><code>&lt;Field&gt;</code>
+    Components</a></li>
 <li {% if page.path contains 'Inputs.md' %} class="active" {% endif %}><a
                 href="./Inputs.html"><code>&lt;Input&gt;</code>
                 Components</a></li>


### PR DESCRIPTION
I often found hard to find intuitivelly the `<Field> Components` menu item since is in between the items of the main views.

```
Before:

<List> View
<Show> View
<Field> Components
<Create> and <Edit> Views
<Input> Components
...

After:

<List> View
<Show> View
<Create> and <Edit> Views
<Field> Components
<Input> Components
...
