### PR TITLE
Fix SimpleFormIterator for non empty array inputs

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -95,7 +95,9 @@ const SimpleFormIterator = props => {
     // the fields prop which will always be empty for a new record.
     // Without it, our ids wouldn't match the default value and we would get key warnings
     // on the CssTransition element inside our render method
-    const ids = useRef(nextId.current > 0 ? Array.from(Array(nextId.current).keys()) : []);
+    const ids = useRef(
+        nextId.current > 0 ? Array.from(Array(nextId.current).keys()) : []
+    );
 
     const removeField = index => () => {
         ids.current.splice(index, 1);

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -95,7 +95,7 @@ const SimpleFormIterator = props => {
     // the fields prop which will always be empty for a new record.
     // Without it, our ids wouldn't match the default value and we would get key warnings
     // on the CssTransition element inside our render method
-    const ids = useRef(nextId > 0 ? Array.from(Array(nextId).keys()) : []);
+    const ids = useRef(nextId.current > 0 ? Array.from(Array(nextId.current).keys()) : []);
 
     const removeField = index => () => {
         ids.current.splice(index, 1);


### PR DESCRIPTION
### Issue

A warning 

> Each child in a list should have a unique "key" prop

inside CssTransition shows if a record with none empty array input was loaded, and the animation of adding a new element is broken.

### How to reproduce

It can be reproduced using any resource with ArrayInput and SimpleFormIterator:

1. Open Edit for some record
2. Add few items to an array input
3. Save
4. Open Edit for that record again and see a warning
5. Add few more elements to the array input and see broken animation

For example you can add this input to the CategoryEdit form in the demo app:
```
import { ArrayInput, SimpleFormIterator } from 'react-admin';
...

<ArrayInput label="Test array" source="test">
    <SimpleFormIterator>
        <NumberInput
            source="weight"
            label="Weight"
            defaultValue={1}
        />
    </SimpleFormIterator>
</ArrayInput>
```

### Reason

**nextId** is a ref, it is an object like `{current: value}`.
`(nextId > 0)` will always be false because `({} > 0)` is always false.

### Fix

Seems like `.current` is forgotten there.
With this fix there is no warnings and animation works fine.