### PR TITLE
Add scroll buttons to tabs when they go beyond the available space

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -7,13 +7,12 @@ module.exports = on => {
     };
     on('before:browser:launch', (browser = {}, launchOptions) => {
         if (browser.name === 'chrome') {
-            return [
-                ...launchOptions.args.filter(
-                    arg => arg !== '--disable-blink-features=RootLayerScrolling'
-                ),
-                '--disable-gpu',
-                '--proxy-bypass-list=<-loopback>',
-            ];
+            launchOptions.args.push(
+                '--disable-blink-features=RootLayerScrolling'
+            );
+            launchOptions.args.push('--disable-gpu');
+            launchOptions.args.push('--proxy-bypass-list=<-loopback>');
+            return launchOptions;
         }
     });
     on('file:preprocessor', wp(options));

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -6,6 +6,8 @@ module.exports = on => {
         webpackOptions: require('../webpack.config'),
     };
     on('before:browser:launch', (browser = {}, launchOptions) => {
+        // Fix for Cypress 4:
+        // https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage
         if (browser.name === 'chrome') {
             launchOptions.args.push(
                 '--disable-blink-features=RootLayerScrolling'

--- a/cypress/support/CreatePage.js
+++ b/cypress/support/CreatePage.js
@@ -96,7 +96,7 @@ export default url => ({
     },
 
     gotoTab(index) {
-        cy.get(this.elements.tab(index)).click();
+        cy.get(this.elements.tab(index)).click({ force: true });
     },
 
     logout() {

--- a/cypress/support/EditPage.js
+++ b/cypress/support/EditPage.js
@@ -45,7 +45,7 @@ export default url => ({
     },
 
     gotoTab(index) {
-        cy.get(this.elements.tab(index)).click();
+        cy.get(this.elements.tab(index)).click({ force: true });
     },
 
     submit() {

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -719,6 +719,7 @@ Here are all the props accepted by the `<TabbedForm>` component:
 * `save`: The function invoked when the form is submitted. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * `saving`: A boolean indicating whether a save operation is ongoing. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * [`warnWhenUnsavedChanges`](#warning-about-unsaved-changes)
+* `scrollable`: A boolean, `true` by default. `<TabbedForm>` use MaterialUI scrollable buttons when there is too much FormTabs to display. If you preferer the screen to expands with the tabs, set it `false`.
 
 {% raw %}
 ```jsx

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -719,7 +719,7 @@ Here are all the props accepted by the `<TabbedForm>` component:
 * `save`: The function invoked when the form is submitted. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * `saving`: A boolean indicating whether a save operation is ongoing. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * [`warnWhenUnsavedChanges`](#warning-about-unsaved-changes)
-* `scrollable`: A boolean, `true` by default. `<TabbedForm>` use MaterialUI scrollable buttons when there is too much FormTabs to display. If you preferer the screen to expands with the tabs, set it `false`.
+* `scrollable`: A boolean, `true` by default. `<TabbedForm>` use MaterialUI scrollable buttons when there are too many FormTabs to display. If you prefer the screen to expands with the tabs, set it `false`.
 
 {% raw %}
 ```jsx

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -719,7 +719,7 @@ Here are all the props accepted by the `<TabbedForm>` component:
 * `save`: The function invoked when the form is submitted. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * `saving`: A boolean indicating whether a save operation is ongoing. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * [`warnWhenUnsavedChanges`](#warning-about-unsaved-changes)
-* `scrollable`: A boolean, `true` by default. `<TabbedForm>` use MaterialUI scrollable buttons when there are too many FormTabs to display. If you prefer the screen to expands with the tabs, set it `false`.
+* `scrollable`: A boolean, `true` by default. `<TabbedForm>` use Material UI scrollable buttons when there are too many tabs to display. If you prefer the screen to expand with the tabs, set it to `false`.
 
 {% raw %}
 ```jsx

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -314,7 +314,7 @@ export const PostShow = (props) => (
 ```
 {% endraw %}
 
-**Tip**: By default, `<TabbedShowLayout>` use MaterialUI scrollable buttons when there is too much Tabs to display. If you preferer the screen to expands with the tabs, use `scrollable={false}`.
+**Tip**: By default, `<TabbedShowLayout>` use MaterialUI scrollable buttons when there are too many Tabs to display. If you prefer the screen to expands with the tabs, use `scrollable={false}`.
 
 To style the tabs, the `<Tab>` component accepts two props:
 

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -314,7 +314,7 @@ export const PostShow = (props) => (
 ```
 {% endraw %}
 
-**Tip**: By default, `<TabbedShowLayout>` use MaterialUI scrollable buttons when there are too many Tabs to display. If you prefer the screen to expands with the tabs, use `scrollable={false}`.
+**Tip**: By default, `<TabbedShowLayout>` use Material UI scrollable buttons when there are too many tabs to display. If you prefer the screen to expand with the tabs, add this prop: `scrollable={false}`.
 
 To style the tabs, the `<Tab>` component accepts two props:
 

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -314,6 +314,8 @@ export const PostShow = (props) => (
 ```
 {% endraw %}
 
+**Tip**: By default, `<TabbedShowLayout>` use MaterialUI scrollable buttons when there is too much Tabs to display. If you preferer the screen to expands with the tabs, use `scrollable={false}`.
+
 To style the tabs, the `<Tab>` component accepts two props:
 
 - `className` is passed to the tab *header*

--- a/examples/simple/src/posts/PostEdit.js
+++ b/examples/simple/src/posts/PostEdit.js
@@ -31,6 +31,8 @@ import {
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import PostTitle from './PostTitle';
 import TagReferenceInput from './TagReferenceInput';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
 
 const EditActions = ({ basePath, data, hasShow }) => (
     <TopToolbar>
@@ -163,6 +165,26 @@ const PostEdit = ({ permissions, ...props }) => (
                     </Datagrid>
                 </ReferenceManyField>
             </FormTab>
+            <FormTab label="SuperTab 1">
+                <Tabs variant="scrollable" scrollButtons="auto">
+                    <Tab label="Item One" />
+                    <Tab label="Item Two" />
+                    <Tab label="Item Three" />
+                    <Tab label="Item Four" />
+                    <Tab label="Item Five" />
+                    <Tab label="Item Six" />
+                    <Tab label="Item Seven" />
+                </Tabs>
+            </FormTab>
+            <FormTab label="SuperTab 2" />
+            <FormTab label="SuperTab 3" />
+            <FormTab label="SuperTab 4" />
+            <FormTab label="SuperTab 5" />
+            <FormTab label="SuperTab 6" />
+            <FormTab label="SuperTab 7" />
+            <FormTab label="SuperTab 8" />
+            <FormTab label="SuperTab 9" />
+            <FormTab label="SuperTab 10" />
         </TabbedForm>
     </Edit>
 );

--- a/examples/simple/src/posts/PostEdit.js
+++ b/examples/simple/src/posts/PostEdit.js
@@ -31,8 +31,6 @@ import {
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import PostTitle from './PostTitle';
 import TagReferenceInput from './TagReferenceInput';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
 
 const EditActions = ({ basePath, data, hasShow }) => (
     <TopToolbar>

--- a/examples/simple/src/posts/PostEdit.js
+++ b/examples/simple/src/posts/PostEdit.js
@@ -165,26 +165,6 @@ const PostEdit = ({ permissions, ...props }) => (
                     </Datagrid>
                 </ReferenceManyField>
             </FormTab>
-            <FormTab label="SuperTab 1">
-                <Tabs variant="scrollable" scrollButtons="auto">
-                    <Tab label="Item One" />
-                    <Tab label="Item Two" />
-                    <Tab label="Item Three" />
-                    <Tab label="Item Four" />
-                    <Tab label="Item Five" />
-                    <Tab label="Item Six" />
-                    <Tab label="Item Seven" />
-                </Tabs>
-            </FormTab>
-            <FormTab label="SuperTab 2" />
-            <FormTab label="SuperTab 3" />
-            <FormTab label="SuperTab 4" />
-            <FormTab label="SuperTab 5" />
-            <FormTab label="SuperTab 6" />
-            <FormTab label="SuperTab 7" />
-            <FormTab label="SuperTab 8" />
-            <FormTab label="SuperTab 9" />
-            <FormTab label="SuperTab 10" />
         </TabbedForm>
     </Edit>
 );

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Divider from '@material-ui/core/Divider';
 import { Route } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
+import classnames from 'classnames';
 import { useRouteMatch } from 'react-router-dom';
 import { escapePath } from 'ra-core';
 
@@ -15,6 +16,7 @@ const sanitizeRestProps = ({
     record,
     resource,
     basePath,
+    scrollable,
     version,
     initialValues,
     staticContext,
@@ -29,6 +31,14 @@ const useStyles = makeStyles(
             paddingTop: theme.spacing(1),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
+            marginTop: 48,
+        },
+        scrollableTabs: {
+            position: 'absolute',
+            width: '100%',
+        },
+        formRelative: {
+            position: 'relative',
         },
     }),
     { name: 'RaTabbedShowLayout' }
@@ -81,6 +91,7 @@ const TabbedShowLayout = props => {
         className,
         record,
         resource,
+        scrollable,
         version,
         value,
         tabs,
@@ -89,9 +100,18 @@ const TabbedShowLayout = props => {
     const match = useRouteMatch();
 
     const classes = useStyles(props);
+
+    const scrollableProps = scrollable
+        ? { scrollable: true, scrollButtons: 'auto', variant: 'scrollable' }
+        : {};
+
     return (
-        <div className={className} key={version} {...sanitizeRestProps(rest)}>
-            {cloneElement(tabs, {}, children)}
+        <div
+            className={classnames(className, classes.formRelative)}
+            key={version}
+            {...sanitizeRestProps(rest)}
+        >
+            {cloneElement(tabs, { classes, ...scrollableProps }, children)}
 
             <Divider />
             <div className={classes.content}>
@@ -126,6 +146,7 @@ TabbedShowLayout.propTypes = {
     record: PropTypes.object,
     resource: PropTypes.string,
     basePath: PropTypes.string,
+    scrollable: PropTypes.bool,
     value: PropTypes.number,
     version: PropTypes.number,
     tabs: PropTypes.element,
@@ -133,6 +154,7 @@ TabbedShowLayout.propTypes = {
 
 TabbedShowLayout.defaultProps = {
     tabs: <TabbedShowLayoutTabs />,
+    scrollable: true,
 };
 
 export default TabbedShowLayout;

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -107,7 +107,7 @@ const TabbedShowLayout = props => {
     const classes = useStyles(props);
 
     const scrollableProps = scrollable
-        ? { scrollable: true, scrollButtons: 'auto', variant: 'scrollable' }
+        ? { scrollable: true, scrollButtons: 'on', variant: 'scrollable' }
         : {};
 
     return (

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles(
     theme => ({
         content: {
             paddingTop: props =>
-                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enougth height to tab content
+                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enough height for the tab content
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
         },

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -28,10 +28,15 @@ const sanitizeRestProps = ({
 const useStyles = makeStyles(
     theme => ({
         content: {
-            paddingTop: theme.spacing(1),
+            paddingTop: props =>
+                props.scrollable ? 48 + theme.spacing(1) : theme.spacing(1),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
+        },
+        scrollableDivider: {
             marginTop: 48,
+            position: 'absolute',
+            width: '100%',
         },
         scrollableTabs: {
             position: 'absolute',
@@ -113,7 +118,11 @@ const TabbedShowLayout = props => {
         >
             {cloneElement(tabs, { classes, ...scrollableProps }, children)}
 
-            <Divider />
+            <Divider
+                className={classnames({
+                    [classes.scrollableDivider]: scrollable,
+                })}
+            />
             <div className={classes.content}>
                 {Children.map(children, (tab, index) =>
                     tab && isValidElement(tab) ? (

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles(
     theme => ({
         content: {
             paddingTop: props =>
-                props.scrollable ? 48 + theme.spacing(1) : theme.spacing(1),
+                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enougth height to tab content
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
         },

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles(
     theme => ({
         content: {
             paddingTop: props =>
-                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enough height for the tab content
+                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, leave enough height for the tab content
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
         },

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.js
@@ -34,7 +34,7 @@ const useStyles = makeStyles(
             paddingRight: theme.spacing(2),
         },
         scrollableDivider: {
-            marginTop: 48,
+            marginTop: theme.spacing(6),
             position: 'absolute',
             width: '100%',
         },

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -9,7 +9,7 @@ export const getTabFullPath = (tab, index, baseUrl) =>
         tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
     }`;
 
-const TabbedShowLayoutTabs = ({ children, ...rest }) => {
+const TabbedShowLayoutTabs = ({ classes, children, ...rest }) => {
     const location = useLocation();
     const match = useRouteMatch();
 
@@ -17,8 +17,17 @@ const TabbedShowLayoutTabs = ({ children, ...rest }) => {
     // so we can use it as a way to determine the current tab
     const value = location.pathname;
 
+    const scrollableProps = rest.scrollable
+        ? { className: classes.scrollableTabs }
+        : {};
+
     return (
-        <Tabs indicatorColor="primary" value={value} {...rest}>
+        <Tabs
+            indicatorColor="primary"
+            value={value}
+            {...scrollableProps}
+            {...rest}
+        >
             {Children.map(children, (tab, index) => {
                 if (!tab || !isValidElement(tab)) return null;
                 // Builds the full tab tab which is the concatenation of the last matched route in the
@@ -37,6 +46,7 @@ const TabbedShowLayoutTabs = ({ children, ...rest }) => {
 };
 
 TabbedShowLayoutTabs.propTypes = {
+    classes: PropTypes.object,
     children: PropTypes.node,
 };
 

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayoutTabs.js
@@ -9,7 +9,7 @@ export const getTabFullPath = (tab, index, baseUrl) =>
         tab.props.path ? `/${tab.props.path}` : index > 0 ? `/${index}` : ''
     }`;
 
-const TabbedShowLayoutTabs = ({ classes, children, ...rest }) => {
+const TabbedShowLayoutTabs = ({ classes, children, scrollable, ...rest }) => {
     const location = useLocation();
     const match = useRouteMatch();
 
@@ -17,7 +17,7 @@ const TabbedShowLayoutTabs = ({ classes, children, ...rest }) => {
     // so we can use it as a way to determine the current tab
     const value = location.pathname;
 
-    const scrollableProps = rest.scrollable
+    const scrollableProps = scrollable
         ? { className: classes.scrollableTabs }
         : {};
 

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -79,14 +79,12 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  * @param {Prop} props
  */
 
-const TabbedForm = props => {
-    return (
-        <FormWithRedirect
-            {...props}
-            render={formProps => <TabbedFormView {...formProps} />}
-        />
-    );
-};
+const TabbedForm = props => (
+    <FormWithRedirect
+        {...props}
+        render={formProps => <TabbedFormView {...formProps} />}
+    />
+);
 
 TabbedForm.propTypes = {
     children: PropTypes.node,

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -162,7 +162,7 @@ export const TabbedFormView = props => {
 
     const url = match ? match.url : location.pathname;
     const scrollableProps = scrollable
-        ? { scrollable: true, scrollButtons: 'auto', variant: 'scrollable' }
+        ? { scrollable: true, scrollButtons: 'on', variant: 'scrollable' }
         : {};
     return (
         <form
@@ -181,7 +181,6 @@ export const TabbedFormView = props => {
                     tabsWithErrors,
                     ...scrollableProps,
                 },
-                // ...scrollableProps,
                 children
             )}
             <Divider

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -108,7 +108,7 @@ const useStyles = makeStyles(
         errorTabButton: { color: theme.palette.error.main },
         content: {
             paddingTop: props =>
-                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enough height for the tab content
+                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, leave enough height for the tab content
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
         },

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -74,7 +74,7 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
  * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
- * @prop {boolean} scrollable The multiple tabs becomes scrollable when they go beyond form witdh
+ * @prop {boolean} scrollable The tabs become scrollable when they extend beyond the witdh of the form
  *
  * @param {Prop} props
  */
@@ -108,7 +108,7 @@ const useStyles = makeStyles(
         errorTabButton: { color: theme.palette.error.main },
         content: {
             paddingTop: props =>
-                props.scrollable ? 48 + theme.spacing(1) : theme.spacing(1),
+                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enougth height to tab content
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
         },

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -108,7 +108,7 @@ const useStyles = makeStyles(
         errorTabButton: { color: theme.palette.error.main },
         content: {
             paddingTop: props =>
-                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enougth height to tab content
+                props.scrollable ? theme.spacing(7) : theme.spacing(1), // When using scrollable tabs, let enough height for the tab content
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
         },

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -78,7 +78,6 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  *
  * @param {Prop} props
  */
-
 const TabbedForm = props => (
     <FormWithRedirect
         {...props}
@@ -111,14 +110,11 @@ const useStyles = makeStyles(
             paddingTop: theme.spacing(1),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
-            marginTop: 68,
+            marginTop: 48,
         },
         scrollableTabs: {
             position: 'absolute',
-            // All the screen less the menu and the paddings
-            // width: 'calc(100% - 240px - 5px - 24px - 20px)',
-            width: 'calc(100% - 20px)',
-            padding: 10,
+            width: '100%',
         },
         formRelative: {
             position: 'relative',

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -107,10 +107,15 @@ const useStyles = makeStyles(
     theme => ({
         errorTabButton: { color: theme.palette.error.main },
         content: {
-            paddingTop: theme.spacing(1),
+            paddingTop: props =>
+                props.scrollable ? 48 + theme.spacing(1) : theme.spacing(1),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
+        },
+        scrollableDivider: {
             marginTop: 48,
+            position: 'absolute',
+            width: '100%',
         },
         scrollableTabs: {
             position: 'absolute',
@@ -179,7 +184,11 @@ export const TabbedFormView = props => {
                 // ...scrollableProps,
                 children
             )}
-            <Divider />
+            <Divider
+                className={classnames({
+                    [classes.scrollableDivider]: scrollable,
+                })}
+            />
             <div className={classes.content}>
                 {/* All tabs are rendered (not only the one in focus), to allow validation
                 on tabs not in focus. The tabs receive a `hidden` property, which they'll

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -77,12 +77,15 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  *
  * @param {Prop} props
  */
-const TabbedForm = props => (
-    <FormWithRedirect
-        {...props}
-        render={formProps => <TabbedFormView {...formProps} />}
-    />
-);
+
+const TabbedForm = props => {
+    return (
+        <FormWithRedirect
+            {...props}
+            render={formProps => <TabbedFormView {...formProps} />}
+        />
+    );
+};
 
 TabbedForm.propTypes = {
     children: PropTypes.node,
@@ -108,6 +111,13 @@ const useStyles = makeStyles(
             paddingTop: theme.spacing(1),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
+            marginTop: 50,
+        },
+        root: {
+            position: 'absolute',
+            width: '80%',
+            boxSizing: 'content-box',
+            padding: '10px',
         },
     }),
     { name: 'RaTabbedForm' }
@@ -154,6 +164,8 @@ export const TabbedFormView = props => {
                 tabs,
                 {
                     classes,
+                    scrollable: true,
+                    scrollButtons: 'on',
                     url,
                     tabsWithErrors,
                 },

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -74,6 +74,7 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
  * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
+ * @prop {boolean} scrollable The multiple tabs becomes scrollable when they go beyond form witdh
  *
  * @param {Prop} props
  */
@@ -102,6 +103,7 @@ TabbedForm.propTypes = {
     submitOnEnter: PropTypes.bool,
     undoable: PropTypes.bool,
     validate: PropTypes.func,
+    scrollable: PropTypes.bool,
 };
 
 const useStyles = makeStyles(
@@ -111,13 +113,17 @@ const useStyles = makeStyles(
             paddingTop: theme.spacing(1),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
-            marginTop: 50,
+            marginTop: 68,
         },
-        root: {
+        scrollableTabs: {
             position: 'absolute',
-            width: '80%',
-            boxSizing: 'content-box',
-            padding: '10px',
+            // All the screen less the menu and the paddings
+            // width: 'calc(100% - 240px - 5px - 24px - 20px)',
+            width: 'calc(100% - 20px)',
+            padding: 10,
+        },
+        formRelative: {
+            position: 'relative',
         },
     }),
     { name: 'RaTabbedForm' }
@@ -138,6 +144,7 @@ export const TabbedFormView = props => {
         redirect: defaultRedirect,
         resource,
         saving,
+        scrollable = true,
         setRedirect,
         submitOnEnter,
         tabs,
@@ -155,20 +162,27 @@ export const TabbedFormView = props => {
     const location = useLocation();
 
     const url = match ? match.url : location.pathname;
+    const scrollableProps = scrollable
+        ? { scrollable: true, scrollButtons: 'auto', variant: 'scrollable' }
+        : {};
     return (
         <form
-            className={classnames('tabbed-form', className)}
+            className={classnames(
+                'tabbed-form',
+                className,
+                classes.formRelative
+            )}
             {...sanitizeRestProps(rest)}
         >
             {React.cloneElement(
                 tabs,
                 {
                     classes,
-                    scrollable: true,
-                    scrollButtons: 'on',
                     url,
                     tabsWithErrors,
+                    ...scrollableProps,
                 },
+                // ...scrollableProps,
                 children
             )}
             <Divider />
@@ -297,6 +311,7 @@ const sanitizeRestProps = ({
     reset,
     resetSection,
     save,
+    scrollable,
     staticContext,
     submit,
     submitAsSideEffect,

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -113,7 +113,7 @@ const useStyles = makeStyles(
             paddingRight: theme.spacing(2),
         },
         scrollableDivider: {
-            marginTop: 48,
+            marginTop: theme.spacing(6),
             position: 'absolute',
             width: '100%',
         },

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -178,6 +178,7 @@ export const TabbedFormView = props => {
                 {
                     classes,
                     url,
+                    title: 'FormTabRow',
                     tabsWithErrors,
                     ...scrollableProps,
                 },

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
@@ -92,4 +92,55 @@ describe('<TabbedForm />', () => {
             expect(tabs).toEqual(['tab1', 'tab3', 'tab4']);
         });
     });
+
+    it('should have scroll buttons when too much Tabs />', () => {
+        const { queryByLabelText } = renderWithRedux(
+            <MemoryRouter initialEntries={['/']}>
+                <TabbedForm
+                    style={{
+                        width: 200,
+                        maxWidth: 200,
+                    }}
+                >
+                    <FormTab label="A Useful Tab 1" />
+                    <FormTab label="A Useful Tab 2" />
+                    <FormTab label="A Useful Tab 3" />
+                    <FormTab label="A Useful Tab 4" />
+                    <FormTab label="A Useful Tab 5" />
+                    <FormTab label="A Useful Tab 6" />
+                    <FormTab label="A Useful Tab 7" />
+                </TabbedForm>
+            </MemoryRouter>
+        );
+
+        const tabs = queryByLabelText('Form-tabs');
+
+        expect(tabs.children).toHaveLength(4);
+    });
+
+    it('should not have scroll buttons when too much Tabs />', () => {
+        const { queryByLabelText } = renderWithRedux(
+            <MemoryRouter initialEntries={['/']}>
+                <TabbedForm
+                    style={{
+                        width: 200,
+                        maxWidth: 200,
+                    }}
+                    scrollable={false}
+                >
+                    <FormTab label="A Useful Tab 1" />
+                    <FormTab label="A Useful Tab 2" />
+                    <FormTab label="A Useful Tab 3" />
+                    <FormTab label="A Useful Tab 4" />
+                    <FormTab label="A Useful Tab 5" />
+                    <FormTab label="A Useful Tab 6" />
+                    <FormTab label="A Useful Tab 7" />
+                </TabbedForm>
+            </MemoryRouter>
+        );
+
+        const tabs = queryByLabelText('Form-tabs');
+
+        expect(tabs.children).toHaveLength(1);
+    });
 });

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.js
@@ -94,7 +94,7 @@ describe('<TabbedForm />', () => {
     });
 
     it('should have scroll buttons when too much Tabs />', () => {
-        const { queryByLabelText } = renderWithRedux(
+        const { queryByLabelText, queryByTitle } = renderWithRedux(
             <MemoryRouter initialEntries={['/']}>
                 <TabbedForm
                     style={{
@@ -115,11 +115,15 @@ describe('<TabbedForm />', () => {
 
         const tabs = queryByLabelText('Form-tabs');
 
-        expect(tabs.children).toHaveLength(4);
+        expect(tabs.children).toHaveLength(7);
+
+        const tabRow = queryByTitle('FormTabRow');
+
+        expect(tabRow.children).toHaveLength(4);
     });
 
     it('should not have scroll buttons when too much Tabs />', () => {
-        const { queryByLabelText } = renderWithRedux(
+        const { queryByLabelText, queryByTitle } = renderWithRedux(
             <MemoryRouter initialEntries={['/']}>
                 <TabbedForm
                     style={{
@@ -141,6 +145,10 @@ describe('<TabbedForm />', () => {
 
         const tabs = queryByLabelText('Form-tabs');
 
-        expect(tabs.children).toHaveLength(1);
+        expect(tabs.children).toHaveLength(7);
+
+        const tabRow = queryByTitle('FormTabRow');
+
+        expect(tabRow.children).toHaveLength(1);
     });
 });

--- a/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
+++ b/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
@@ -35,7 +35,14 @@ const TabbedFormTabs = ({
         : validTabPaths[0];
 
     return (
-        <Tabs value={tabValue} indicatorColor="primary" {...rest}>
+        <Tabs
+            className={classes.root}
+            value={tabValue}
+            indicatorColor="primary"
+            {...rest}
+            // scrollButtons="auto"
+            variant="scrollable"
+        >
             {Children.map(children, (tab, index) => {
                 if (!isValidElement(tab)) return null;
 

--- a/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
+++ b/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
@@ -40,6 +40,7 @@ const TabbedFormTabs = ({
 
     return (
         <Tabs
+            aria-label="Form-tabs"
             value={tabValue}
             indicatorColor="primary"
             {...scrollableProps}

--- a/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
+++ b/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
@@ -34,14 +34,16 @@ const TabbedFormTabs = ({
         ? location.pathname
         : validTabPaths[0];
 
+    const scrollableProps = rest.scrollable
+        ? { className: classes.scrollableTabs }
+        : {};
+
     return (
         <Tabs
-            className={classes.root}
             value={tabValue}
             indicatorColor="primary"
+            {...scrollableProps}
             {...rest}
-            // scrollButtons="auto"
-            variant="scrollable"
         >
             {Children.map(children, (tab, index) => {
                 if (!isValidElement(tab)) return null;

--- a/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
+++ b/packages/ra-ui-materialui/src/form/TabbedFormTabs.js
@@ -14,6 +14,7 @@ const TabbedFormTabs = ({
     classes,
     url,
     tabsWithErrors,
+    scrollable,
     ...rest
 }) => {
     const location = useLocation();
@@ -34,7 +35,7 @@ const TabbedFormTabs = ({
         ? location.pathname
         : validTabPaths[0];
 
-    const scrollableProps = rest.scrollable
+    const scrollableProps = scrollable
         ? { className: classes.scrollableTabs }
         : {};
 


### PR DESCRIPTION
Closes #1689 

## Issue

A lot of tabs in TabbedForm or TabbedShow make all page wide and scrollable instead of using scrolling tab buttons.

## Solution

Enable scrollable tabs by default, and add a prop to keep possibility to disable it

```js
<TabbedForm
   scrollable={false}
>
```


## Screenshots

![image](https://user-images.githubusercontent.com/39904906/76748703-851b0400-677b-11ea-840e-42605cdf19f0.png)
