### PR TITLE
[WIP] Add RowIndexComponent to SimpleFormIterator

### DIFF
--- a/packages/ra-ui-materialui/src/form/FormInput.js
+++ b/packages/ra-ui-materialui/src/form/FormInput.js
@@ -58,6 +58,12 @@ const FormInput = ({ input, classes: classesOverride, ...rest }) => {
 };
 
 FormInput.propTypes = {
+    basePath: PropTypes.string,
+    source: PropTypes.string,
+    record: PropTypes.object,
+    resource: PropTypes.string,
+    variant: PropTypes.string,
+    margin: PropTypes.any,
     className: PropTypes.string,
     classes: PropTypes.object,
     input: PropTypes.object,


### PR DESCRIPTION
Hello!

This is an implementation for https://github.com/marmelab/react-admin/issues/4525

Currently, the functionality is implemented, but there is still a job to set up types and PropTypes correctly for the SimpleFormIterator and related components.

**Worklog**
- [x] Basic Implementation
- [x] Test cases for new functionality 
- [ ] **???** Split the component into a multiple files
- [ ] Correct typings
- [ ] Correct PropTypes
- [ ] Documentation for the new feature

**Questionnaire**

Also, the component itself becomes pretty massive (300 LOC currently) and I am thinking of splitting the component into multiple files, so there will be a folder SimpleFormIterator containing the SFI itself and surrounding components. Should I process this change as well?

@fzaninotto could you please check if I'm on a track?