### PR TITLE
Fix warning in SelectArrayInput when alwaysOn is true

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -26,6 +26,7 @@ import { FormControlProps } from '@material-ui/core/FormControl';
 const sanitizeRestProps = ({
     addLabel,
     allowEmpty,
+    alwaysOn,
     basePath,
     choices,
     classNamInputWithOptionsPropse,


### PR DESCRIPTION
Basically a copy of #4174 (same warning appearing for `SelectArrayInput`).