### PR TITLE
[RFR] Fix useGetList after delete when using string identifiers

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -98,6 +98,7 @@ const useGetList = <RecordType = Record>(
         return ids
             .map(id => allResourceData[id])
             .reduce((acc, record) => {
+                if (!record) return acc;
                 acc[record.id] = record;
                 return acc;
             }, {});

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -132,6 +132,9 @@ export const addOneRecord = (
     });
 };
 
+const includesNotStrict = (items, element) =>
+    items.some(item => item == element);
+
 /**
  * Remove records from the pool
  */
@@ -140,12 +143,12 @@ const removeRecords = (
     oldRecords: RecordSetWithDate
 ): RecordSetWithDate => {
     const records = Object.entries(oldRecords)
-        .filter(([key]) => !removedRecordIds.includes(key))
+        .filter(([key]) => !includesNotStrict(removedRecordIds, key))
         .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {
             fetchedAt: {}, // TypeScript warns later if this is not defined
         });
     records.fetchedAt = Object.entries(oldRecords.fetchedAt)
-        .filter(([key]) => !removedRecordIds.includes(key))
+        .filter(([key]) => !includesNotStrict(removedRecordIds, key))
         .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
 
     return hideFetchedAt(records);

--- a/packages/ra-core/src/reducer/admin/resource/data.ts
+++ b/packages/ra-core/src/reducer/admin/resource/data.ts
@@ -138,7 +138,7 @@ const includesNotStrict = (items, element) =>
 /**
  * Remove records from the pool
  */
-const removeRecords = (
+export const removeRecords = (
     removedRecordIds: Identifier[] = [],
     oldRecords: RecordSetWithDate
 ): RecordSetWithDate => {


### PR DESCRIPTION
When using string identifiers and an inline delete undoable in a list, once the undo period ends, the getList following the delete threw the following error:

> An error occurred while selecting the store state: Cannot read property 'id' of undefined.

This is due to a combination of 2 bugs (one hiding the other) that this PR fixes. 