### PR TITLE
Add a data refresh when the App comes back from background

### DIFF
--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -21,6 +21,7 @@ import useUpdateMany from './useUpdateMany';
 import useCreate from './useCreate';
 import useDelete from './useDelete';
 import useDeleteMany from './useDeleteMany';
+import useRefreshWhenVisible from './useRefreshWhenVisible';
 
 export {
     cacheDataProviderProxy,
@@ -45,5 +46,6 @@ export {
     useDelete,
     useDeleteMany,
     useQueryWithStore,
+    useRefreshWhenVisible,
     withDataProvider,
 };

--- a/packages/ra-core/src/dataProvider/useRefreshWhenVisible.ts
+++ b/packages/ra-core/src/dataProvider/useRefreshWhenVisible.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+import { useRefresh } from '../sideEffect';
+
+/**
+ * Trigger a refresh of the page when the page comes back from background after a certain delay
+ *
+ * @param {number} delay Delay in milliseconds since the time the page was hidden. Defaults to 5 minutes.
+ */
+const useRefreshWhenVisible = (delay = 1000 * 60 * 5) => {
+    const refresh = useRefresh();
+    let lastHiddenTime;
+    const handleVisibilityChange = () => {
+        if (document.hidden) {
+            // tab goes hidden
+            lastHiddenTime = Date.now();
+        } else {
+            // tab goes visible
+            if (Date.now() - lastHiddenTime > delay) {
+                refresh();
+            }
+            lastHiddenTime = null;
+        }
+    };
+    useEffect(() => {
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () =>
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange
+            );
+    }, [handleVisibilityChange]);
+};
+
+export default useRefreshWhenVisible;

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import { useRefreshWhenVisible } from 'ra-core';
 
 import RefreshIconButton from '../button/RefreshIconButton';
 
@@ -18,6 +19,7 @@ const useStyles = makeStyles(
 
 const LoadingIndicator = props => {
     const { classes: classesOverride, className, ...rest } = props;
+    useRefreshWhenVisible();
     const loading = useSelector(state => state.admin.loading > 0);
     const classes = useStyles(props);
     return loading ? (


### PR DESCRIPTION
When the user comes back to the app after leaving it more than 5 minutes in the background, the app triggers a refresh.