### PR TITLE
Change Docs: menu item to use an instance of icon

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -193,7 +193,7 @@ const Menu = ({ onMenuClick, logout }) => {
             <MenuItemLink
                 to="/custom-route"
                 primaryText="Miscellaneous"
-                leftIcon={LabelIcon}
+                leftIcon={<LabelIcon />}
                 onClick={onMenuClick}
                 sidebarIsOpen={open}
             />


### PR DESCRIPTION
The existing way throws and error `Error: Expected ref to be a function, a string, an object returned by React.createRef(), or nul`. 
This fix works.