### PR TITLE
Fix error when passing custom link style to SingleFieldList

### DIFF
--- a/packages/ra-ui-materialui/src/list/SingleFieldList.js
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.js
@@ -15,6 +15,7 @@ const useStyles = makeStyles(
             marginTop: -theme.spacing(1),
             marginBottom: -theme.spacing(1),
         },
+        link: {},
     }),
     { name: 'RaSingleFieldList' }
 );


### PR DESCRIPTION
Using
```
const useSingleFieldListStyles = makeStyles({
  root: {
    display: "block",
    flexWrap: "unset",
    marginTop: 0,
    marginBottom: 0
  },
  link: {
    display: "block"
  }
});

const Demo = props => {
  const singleFieldListClasses = useSingleFieldListStyles();
  return (
    <SingleFieldList classes={singleFieldListClasses}>
      <TextField source="name"/>
    </SingleFieldList>
  );
};
```

Got an error in console:
`Material-UI: the key link provided to the classes prop is not implemented in undefined.`

Because styles in `SingleFieldList` doesn't have `link` class