### PR TITLE
Improve NumberInput "parse" documentation for Firefox

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -1363,7 +1363,7 @@ Mnemonic for the two functions:
 Say the user would like to input values of 0-100 to a percentage field but your API (hence record) expects 0-1.0. You can use simple `parse()` and `format()` functions to archive the transform:
 
 ```jsx
-<NumberInput source="percent" format={v => v*100} parse={v => v/100} label="Formatted number" />
+<NumberInput source="percent" format={v => v * 100} parse={v => parseFloat(v) / 100} label="Formatted number" />
 ```
 
 `<DateInput>` stores and returns a string. If you would like to store a JavaScript Date object in your record instead:


### PR DESCRIPTION
Fixes #4646

On Firefox, the following example crashes.