### PR TITLE
Fix unnecessary AutocompleteArrayInput filter reset

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -397,6 +397,43 @@ describe('<AutocompleteArrayInput />', () => {
             formApi.change('tags', ['p']);
             await waitForDomChange();
             expect(setFilter).toHaveBeenCalledTimes(3);
+            expect(setFilter).toHaveBeenCalledWith('');
+        });
+
+        it('should reset filter only when needed, even if the value is an array of objects (fixes #4454)', async () => {
+            const setFilter = jest.fn();
+            let formApi;
+            const { getByLabelText } = render(
+                <Form
+                    onSubmit={jest.fn()}
+                    initialValues={{ tags: [{ id: 't' }] }}
+                    render={({ form }) => {
+                        formApi = form;
+                        return (
+                            <AutocompleteArrayInput
+                                {...defaultProps}
+                                choices={[
+                                    { id: 't', name: 'Technical' },
+                                    { id: 'p', name: 'Programming' },
+                                ]}
+                                parse={value =>
+                                    value && value.map(v => ({ id: v }))
+                                }
+                                format={value => value && value.map(v => v.id)}
+                                setFilter={setFilter}
+                            />
+                        );
+                    }}
+                />
+            );
+            const input = getByLabelText('resources.posts.fields.tags');
+            fireEvent.change(input, { target: { value: 'p' } });
+            expect(setFilter).toHaveBeenCalledTimes(2);
+            expect(setFilter).toHaveBeenCalledWith('p');
+            formApi.change('tags', ['p']);
+            await waitForDomChange();
+            expect(setFilter).toHaveBeenCalledTimes(3);
+            expect(setFilter).toHaveBeenCalledWith('');
         });
 
         it('should allow customized rendering of suggesting item', () => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -167,6 +167,8 @@ const AutocompleteArrayInput: FunctionComponent<
         ...rest,
     });
 
+    const values = input.value || [];
+
     const [filterValue, setFilterValue] = React.useState('');
 
     const getSuggestionFromValue = useCallback(
@@ -174,10 +176,10 @@ const AutocompleteArrayInput: FunctionComponent<
         [choices, optionValue]
     );
 
-    const selectedItems = useMemo(
-        () => (input.value || []).map(getSuggestionFromValue),
-        [input.value, getSuggestionFromValue]
-    );
+    const selectedItems = useMemo(() => values.map(getSuggestionFromValue), [
+        ...values,
+        getSuggestionFromValue,
+    ]);
 
     const { getChoiceText, getChoiceValue, getSuggestions } = useSuggestions({
         allowDuplicates,
@@ -215,7 +217,7 @@ const AutocompleteArrayInput: FunctionComponent<
     // would have to first clear the input before seeing any other choices
     useEffect(() => {
         handleFilterChange('');
-    }, [input.value, handleFilterChange]);
+    }, [...values, handleFilterChange]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent) => {


### PR DESCRIPTION
Fixes #4454

Ok, this solution is not the best I can find.
@fzaninotto's idea is to let the user deal this situtation.

If the user write a tricky `parse` function, it's his job to make sure the input do not refresh too much by having a useMemo or useCallback above.
The issue is that I can't make it work since `parse` is a function that I cannot define with its value.

**Considered alternatives**

- Force the user who wrote the parse function to wrap the AutocompleteArrayInput into an appropriate memo or useCallback
The issue is that I didn't succeed so because we can't access to the input values outside of this component, so we can't use it as a dependency for useCallback, for example
I didn't tried with a FormDataConsumer, it would not be developer friendly IMHO 

- Use `hash-sum` to hash `input.value` inside the useEffect dependency. It works, but I'm wondering if it's necessary to add a new library in the dependencies for that purpose