### PR TITLE
[Doc] Add a link to Clipboard List Field third-party package

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -13,7 +13,11 @@ title: "Ecosystem"
 - [User Interface](#user-interface)
 - [Miscellaneous](#miscellaneous)
 
-## Inputs and Fields
+## Fields
+
+See the [Field](./Fields.md#third-party-components) page.
+
+## Inputs
 
 See the [Input](./Inputs.md#third-party-components) page.
 

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -152,7 +152,7 @@ const TagsField = ({ record }) => (
         ))}
     </ul>
 )
-TagsField.defaultProps = { 
+TagsField.defaultProps = {
     addLabel: true
 };
 ```
@@ -893,6 +893,14 @@ PriceField.defaultProps = {
 };
 ```
 {% endraw %}
+
+
+## Third-Party Components
+
+You can find components for react-admin in third-party repositories.
+
+- [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): a quick and customizable copy-to-clipboard field.
+
 
 ## Writing Your Own Field Component
 


### PR DESCRIPTION
Here is a copy-to-clipboard field.
https://github.com/OoDeLally/react-admin-clipboard-list-field
Being new to both React Admin and MaterialUI, I would be grateful if anyone can review my component and suggest improvements.