### PR TITLE
fix instrospection grapgql query

### DIFF
--- a/packages/ra-data-graphql/src/introspection.js
+++ b/packages/ra-data-graphql/src/introspection.js
@@ -1,4 +1,4 @@
-import { introspectionQuery } from 'graphql';
+import { getIntrospectionQuery } from 'graphql';
 import gql from 'graphql-tag';
 import { GET_LIST, GET_ONE } from 'ra-core';
 
@@ -35,7 +35,7 @@ export default async (client, options) => {
               .query({
                   fetchPolicy: 'network-only',
                   query: gql`
-                      ${introspectionQuery}
+                      ${getIntrospectionQuery()}
                   `,
               })
               .then(({ data: { __schema } }) => __schema);


### PR DESCRIPTION
### Context
As it was reported on [Issue-4670](https://github.com/marmelab/react-admin/issues/4670)
**ra-data-graphql** uses introspectionQuery from graphql-js. 
The export was finally deprecated  on graphql:15.0.0 [graphql/graphql-js@6b55019](https://github.com/graphql/graphql-js/commit/6b550192e0ce3b458abaec92e4c65d36eeafb7d0), and must be use **getIntrospectionQuery()** instead.

### Error
The Error shown **when grapqhql:15.0.0 is installed** in ra-data-graphq and other packages that use the library as ra-data-graphcool  was:
`WARNING in ./node_modules/ra-data-graphql/esm/introspection.js 94:202-220
"export 'introspectionQuery' was not found in 'graphql'
`

### Fix
Due to ra-data-graphql use graphql:14.1.1, which exports both introspectionQuery and getIntrospectionQuery(), the fix proposed is to replaced depracated export on the newer version of grapqhl (introspectionQuery) to the function getIntrospectionQuery().

