### PR TITLE
Don't force the sidebar to be opened by default

### DIFF
--- a/packages/ra-core/src/reducer/admin/ui.ts
+++ b/packages/ra-core/src/reducer/admin/ui.ts
@@ -28,7 +28,7 @@ export interface UIState {
 
 // Match the medium breakpoint defined in the material-ui theme
 // See https://material-ui.com/customization/breakpoints/#breakpoints
-const isDesktop: Boolean = () =>
+const isDesktop = (): boolean =>
     // (min-width: 960px) => theme.breakpoints.up('md')
     window ? window.matchMedia('(min-width:960px)').matches : false;
 

--- a/packages/ra-core/src/reducer/admin/ui.ts
+++ b/packages/ra-core/src/reducer/admin/ui.ts
@@ -26,8 +26,14 @@ export interface UIState {
     readonly viewVersion: number;
 }
 
+// Match the medium breakpoint defined in the material-ui theme
+// See https://material-ui.com/customization/breakpoints/#breakpoints
+const isDesktop: Boolean = () =>
+    // (min-width: 960px) => theme.breakpoints.up('md')
+    window ? window.matchMedia('(min-width:960px)') : false;
+
 const defaultState: UIState = {
-    sidebarOpen: false,
+    sidebarOpen: isDesktop(),
     optimistic: false,
     viewVersion: 0,
 };

--- a/packages/ra-core/src/reducer/admin/ui.ts
+++ b/packages/ra-core/src/reducer/admin/ui.ts
@@ -30,7 +30,7 @@ export interface UIState {
 // See https://material-ui.com/customization/breakpoints/#breakpoints
 const isDesktop: Boolean = () =>
     // (min-width: 960px) => theme.breakpoints.up('md')
-    window ? window.matchMedia('(min-width:960px)') : false;
+    window ? window.matchMedia('(min-width:960px)').matches : false;
 
 const defaultState: UIState = {
     sidebarOpen: isDesktop(),

--- a/packages/ra-core/src/reducer/admin/ui.ts
+++ b/packages/ra-core/src/reducer/admin/ui.ts
@@ -30,7 +30,9 @@ export interface UIState {
 // See https://material-ui.com/customization/breakpoints/#breakpoints
 const isDesktop = (): boolean =>
     // (min-width: 960px) => theme.breakpoints.up('md')
-    window ? window.matchMedia('(min-width:960px)').matches : false;
+    window && window.matchMedia && typeof window.matchMedia === 'function'
+        ? window.matchMedia('(min-width:960px)').matches
+        : false;
 
 const defaultState: UIState = {
     sidebarOpen: isDesktop(),

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { useEffect, Children, cloneElement } from 'react';
+import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Drawer, makeStyles, useMediaQuery } from '@material-ui/core';

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -56,15 +56,6 @@ const Sidebar = props => {
     const dispatch = useDispatch();
     const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
     const isSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
-    // FIXME negating isXSmall and isSmall should be enough, but unfortunately
-    // mui media queries use a two pass system and are always false at first
-    // see https://github.com/mui-org/material-ui/issues/14336
-    const isDesktop = useMediaQuery(theme => theme.breakpoints.up('md'));
-    useEffect(() => {
-        if (isDesktop) {
-            dispatch(setSidebarVisibility(true)); // FIXME renders with a closed sidebar at first
-        }
-    }, [isDesktop, dispatch]);
     const open = useSelector(state => state.admin.ui.sidebarOpen);
     useSelector(state => state.locale); // force redraw on locale change
     const handleClose = () => dispatch(setSidebarVisibility(false));


### PR DESCRIPTION
Currently, the sidebar is opened on desktop and closed on mobile. But this feature uses the material-ui [useMediaQuery](https://material-ui.com/components/use-media-query/) hook, which triggers two renders (the first one is always `false` to work on SSR). To fix it, react-admin forces the sidebar to be opened after the second render.

But as a consequence, it's impossible to define another behaviour by **changing the initial state of the application**.

The solution imagined is to only rely on the initial state of the application (and not force a reopening afterward). And to open the sidebar by default on desktop, we will use directly the `window.matchMedia` method.

## Todo

- [x] Remove the hack that forces

## Screenshots

**Opened on desktop**

![Sélection_002](https://user-images.githubusercontent.com/5584839/78991666-c2d03a00-7b39-11ea-819c-623e1ac0ae8c.png)

**Closed on mobile**

![Sélection_001](https://user-images.githubusercontent.com/5584839/78991673-c5329400-7b39-11ea-8413-f1069f4ae08e.png)
