### PR TITLE
Moving FormHelperText above previews element

### DIFF
--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -205,6 +205,13 @@ const FileInput: FunctionComponent<
                         <p>{translate(labelSingle)}</p>
                     )}
                 </div>
+                <FormHelperText>
+                    <InputHelperText
+                        touched={touched}
+                        error={error}
+                        helperText={helperText}
+                    />
+                </FormHelperText>
                 {children && (
                     <div className="previews">
                         {files.map((file, index) => (
@@ -222,13 +229,6 @@ const FileInput: FunctionComponent<
                         ))}
                     </div>
                 )}
-                <FormHelperText>
-                    <InputHelperText
-                        touched={touched}
-                        error={error}
-                        helperText={helperText}
-                    />
-                </FormHelperText>
             </>
         </Labeled>
     );


### PR DESCRIPTION
fixes #4679

(from issue)
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/1244112/79081055-94618300-7d22-11ea-8068-52d642ed5711.png">
vs
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/1244112/79081254-654c1100-7d24-11ea-9ee7-768a007b3061.png">
