### PR TITLE
fix: default app loading is not not center vertically - 4302

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Loading.js
+++ b/packages/ra-ui-materialui/src/layout/Loading.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(
             [theme.breakpoints.up('md')]: {
                 height: '100%',
             },
-            [theme.breakpoints.down('sm')]: {
+            [theme.breakpoints.down('lg')]: {
                 height: '100vh',
                 marginTop: '-3em',
             },


### PR DESCRIPTION
As mentioned in https://github.com/marmelab/react-admin/issues/4302
The default loading component was not vertically center for large screens (greater than `md`).

Fix: This was due to the breakpoints defined in the loading theme. I have updated that to `lg` from `md`.

Let me know if it requires any further updates.

Closes #4302