### PR TITLE
Revert permanentFilter in setFilter's useCallback [FIX]

### DIFF
--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -81,7 +81,7 @@ export default ({
             });
             latestValue.current = value;
         }, debounceTime),
-        [permanentFilter]
+        []
     );
 
     return {


### PR DESCRIPTION
This reverts #4508 which resulted in a bug where setFilter is re-rendered on every input, wiping out any user text. Alongside the recent #4650, this feature seems to work now and I can successfully filter a referenceInput based on another form's input. Please merge at your convenience. Thanks!