### PR TITLE
fix: Export button is not getting updated when  is updated - 4217

### DIFF
--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -81,4 +81,5 @@ export default onlyUpdateForKeys([
     'displayedFilters',
     'filterValues',
     'selectedIds',
+    'total',
 ])(Actions);


### PR DESCRIPTION
Closes #4217

The `Export` button was not updating (enable/disable) when the total no. of items is changed.

`Fix:` the `total` key was missing in the `onlyUpdateForKeys` call.

