### PR TITLE
[RFR]: Allow SimpleList linkType prop to be resolved as a function.

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -35,13 +35,18 @@ const LinkOrNot = ({
     basePath,
     id,
     children,
+    record,
 }) => {
     const classes = useLinkOrNotStyles({ classes: classesOverride });
-    return linkType === 'edit' || linkType === true ? (
+    const link = typeof linkType === 'function'
+      ? linkType(record, id)
+      : linkType;
+
+    return link === 'edit' || link === true ? (
         <Link to={linkToRecord(basePath, id)} className={classes.link}>
             {children}
         </Link>
-    ) : linkType === 'show' ? (
+    ) : link === 'show' ? (
         <Link
             to={`${linkToRecord(basePath, id)}/show`}
             className={classes.link}
@@ -100,6 +105,7 @@ const SimpleList = props => {
                         basePath={basePath}
                         id={id}
                         key={id}
+                        record={data[id]}
                     >
                         <ListItem button={!!linkType}>
                             {leftIcon && (

--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -38,9 +38,8 @@ const LinkOrNot = ({
     record,
 }) => {
     const classes = useLinkOrNotStyles({ classes: classesOverride });
-    const link = typeof linkType === 'function'
-      ? linkType(record, id)
-      : linkType;
+    const link =
+        typeof linkType === 'function' ? linkType(record, id) : linkType;
 
     return link === 'edit' || link === true ? (
         <Link to={linkToRecord(basePath, id)} className={classes.link}>


### PR DESCRIPTION
The main use case is to allow to decide wich action to take on each record by evaluating the record itself like the other `SimpleList` main props.
You can do that with the `Datagrid` for large screens easilly but for small screens the `SimpleList` doesn't have a simple way to do this.

```jsx
// in src/posts.js
import React from 'react';
import { useMediaQuery } from '@material-ui/core';
import { List, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'react-admin';

export const PostList = props => {
    const isSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
    return (
        <List {...props}>
            {isSmall ? (
                <SimpleList
                    primaryText={record => record.title}
                    secondaryText={record => `${record.views} views`}
                    tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
                    linkType={record => record.canEdit ? "edit" : "show"} 
                />
            ) : (
                <Datagrid>
                    ...
                </Datagrid>
            )}
        </List>
    );
}