### PR TITLE
Fix Filter align with SearchFilter

### DIFF
--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -1,32 +1,21 @@
 import React, { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import SearchIcon from '@material-ui/icons/Search';
-import { makeStyles, InputAdornment } from '@material-ui/core';
+import { InputAdornment } from '@material-ui/core';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import { useTranslate, InputProps } from 'ra-core';
 
 import TextInput from './TextInput';
-
-const useStyles = makeStyles(
-    {
-        input: {
-            marginTop: 32,
-        },
-    },
-    { name: 'RaSearchInput' }
-);
 
 const SearchInput: FunctionComponent<
     InputProps<TextFieldProps> & Omit<TextFieldProps, 'label' | 'helperText'>
 > = props => {
     const { classes: classesOverride, ...rest } = props;
     const translate = useTranslate();
-    const classes = useStyles(props);
 
     return (
         <TextInput
-            hiddenLabel
-            label=""
+            label="Search"
             resettable
             placeholder={translate('ra.action.search')}
             InputProps={{
@@ -36,7 +25,6 @@ const SearchInput: FunctionComponent<
                     </InputAdornment>
                 ),
             }}
-            className={classes.input}
             {...rest}
         />
     );

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -12,10 +12,9 @@ import FilterFormInput from './FilterFormInput';
 const useStyles = makeStyles(
     theme => ({
         form: {
-            marginTop: -theme.spacing(2),
             paddingTop: 0,
             display: 'flex',
-            alignItems: 'flex-end',
+            alignItems: 'center',
             flexWrap: 'wrap',
             minHeight: theme.spacing(10),
         },

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles(
             display: 'flex',
             alignItems: 'center',
             flexWrap: 'wrap',
-            minHeight: theme.spacing(10),
+            minHeight: theme.spacing(8),
         },
         clearFix: { clear: 'right' },
     }),


### PR DESCRIPTION
Closes #4710 

## Issue

Filters are not properly aligned when there is no searchInput and not enouth space for having them all on one line.

SearchInput height is different from other inputs and make UI ugly.

## Solution

- SearchInput uses same height as other inputs for better UI (with label)
- Filters are center aligned
- Don't overload top margin of filter form div

## Screenshots

**With alwaysOn SearchInput**

![image](https://user-images.githubusercontent.com/39904906/80200412-e52a8300-8622-11ea-9875-47ab39e8620e.png)

![image](https://user-images.githubusercontent.com/39904906/80200516-068b6f00-8623-11ea-8db3-04ccc3e20c14.png)

**Without SearchInput**

![image](https://user-images.githubusercontent.com/39904906/80200582-215de380-8623-11ea-9b81-4ee07ccb149d.png)

![image](https://user-images.githubusercontent.com/39904906/80200737-5f5b0780-8623-11ea-9e1d-911bb5e8a1bb.png)
