### PR TITLE
Fix default total selector in useQueryWithStore

### DIFF
--- a/packages/ra-core/src/dataProvider/useQueryWithStore.ts
+++ b/packages/ra-core/src/dataProvider/useQueryWithStore.ts
@@ -56,7 +56,12 @@ const defaultDataSelector = query => (state: ReduxState) => {
         : undefined;
 };
 
-const defaultTotalSelector = () => null;
+const defaultTotalSelector = query => (state: ReduxState) => {
+    const key = JSON.stringify({ ...query, type: getFetchType(query.type) });
+    return state.admin.customQueries[key]
+        ? state.admin.customQueries[key].total
+        : null;
+};
 
 /**
  * Fetch the data provider through Redux, return the value from the store.
@@ -106,7 +111,7 @@ const useQueryWithStore = (
     query: Query,
     options: QueryOptions = { action: 'CUSTOM_QUERY' },
     dataSelector: (state: ReduxState) => any = defaultDataSelector(query),
-    totalSelector: (state: ReduxState) => number = defaultTotalSelector
+    totalSelector: (state: ReduxState) => number = defaultTotalSelector(query)
 ): {
     data?: any;
     total?: number;


### PR DESCRIPTION
Using `useQueryWithStore` with the default parameters is not working as expected for the `total` state value (it was always `null`).