### PR TITLE
Set AutocompleteInput value to an empty string when it's selected item is null

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -12,7 +12,6 @@ import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
 
 describe('<AutocompleteInput />', () => {
-
     //Fix document.createRange is not a function error on fireEvent usage (Fixed in jsdom v16.0.0)
     //reported by https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813
     global.document.createRange = () => ({
@@ -48,15 +47,15 @@ describe('<AutocompleteInput />', () => {
 
     it('should set AutocompleteInput value to an empty string when the selected item is null', () => {
         const { queryByDisplayValue } = render(
-          <Form
-            onSubmit={jest.fn()}
-            render={() => (
-              <AutocompleteInput
-                {...defaultProps}
-                choices={[{ id: 2, name: 'foo' }]}
-              />
-            )}
-          />
+            <Form
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteInput
+                        {...defaultProps}
+                        choices={[{ id: 2, name: 'foo' }]}
+                    />
+                )}
+            />
         );
         expect(queryByDisplayValue('')).not.toBeNull();
     });

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -12,6 +12,18 @@ import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
 
 describe('<AutocompleteInput />', () => {
+
+    //Fix document.createRange is not a function error on fireEvent usage (Fixed in jsdom v16.0.0)
+    //reported by https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813
+    global.document.createRange = () => ({
+        setStart: () => {},
+        setEnd: () => {},
+        commonAncestorContainer: {
+            nodeName: 'BODY',
+            ownerDocument: document,
+        },
+    });
+
     const defaultProps = {
         source: 'role',
         resource: 'users',
@@ -32,6 +44,21 @@ describe('<AutocompleteInput />', () => {
             />
         );
         expect(getByRole('combobox')).not.toBeNull();
+    });
+
+    it('should set AutocompleteInput value to an empty string when the selected item is null', () => {
+        const { queryByDisplayValue } = render(
+          <Form
+            onSubmit={jest.fn()}
+            render={() => (
+              <AutocompleteInput
+                {...defaultProps}
+                choices={[{ id: 2, name: 'foo' }]}
+              />
+            )}
+          />
+        );
+        expect(queryByDisplayValue('')).not.toBeNull();
     });
 
     it('should use the input parameter value as the initial state and input searchText', () => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -230,7 +230,9 @@ const AutocompleteInput: FunctionComponent<
         // If we have a value, set the filter to its text so that
         // Downshift displays it correctly
         setFilterValue(
-            typeof input.value === 'undefined' || input.value === null || selectedItem === null
+            typeof input.value === 'undefined' ||
+                input.value === null ||
+                selectedItem === null
                 ? ''
                 : inputText
                 ? inputText(getChoiceText(selectedItem).props.record)

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -230,7 +230,7 @@ const AutocompleteInput: FunctionComponent<
         // If we have a value, set the filter to its text so that
         // Downshift displays it correctly
         setFilterValue(
-            typeof input.value === 'undefined' || input.value === null
+            typeof input.value === 'undefined' || input.value === null || selectedItem === null
                 ? ''
                 : inputText
                 ? inputText(getChoiceText(selectedItem).props.record)


### PR DESCRIPTION
Most AutocompleteInput tests threw console errors regarding initial state.

```
VM74:37 Warning: A component is changing a controlled input of type text to be uncontrolled. Input elements should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. 

VM74:37 downshift: A component has changed the controlled prop "inputValue" to be - uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide - between using a controlled or uncontrolled Downshift element for the lifetime of the component. - More info: https://github.com/downshift-js/downshift#control-props 
     in Downshift (created by AutocompleteInput)
     in AutocompleteInput (at horascuentascorrientes.js:90)
    in HorasCCCreate (created by WithPermissions)
     in WithPermissions (created by Router.Consumer)
     in Router.Consumer (created by Route)
     in Route (created by ResourceRoutes)
     in ResourceRoutes (created by Resource)
     in Resource (at App.js:52)
     in App (at src/​index.js:20)