### PR TITLE
Fix translateChoice warning in ReferenceField

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -119,7 +119,7 @@ ReferenceField.propTypes = {
     resource: PropTypes.string,
     sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
-    translateChoice: PropTypes.func,
+    translateChoice: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     linkType: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.bool,
@@ -245,7 +245,7 @@ ReferenceFieldView.propTypes = {
         PropTypes.oneOf([false]),
     ]) as React.Validator<string | false>,
     source: PropTypes.string,
-    translateChoice: PropTypes.bool,
+    translateChoice: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 };
 
 const PureReferenceFieldView = memo(ReferenceFieldView);


### PR DESCRIPTION
## Issue

A warning is displayed about the boolean type of `translateChoice` prop in a `ReferenceField`.
But it's not an error, this type can be func or bool.

![image](https://user-images.githubusercontent.com/39904906/80690020-7b9cef80-8ace-11ea-86b5-cf3bb7602a2e.png)

## To reproduce

Use nested `ReferenceField` in a list view.

```js
<List {...props} >
    <Datagrid>
      <DateField source="created_at" />
      <ReferenceField
        label="region_name"
        source="customer_id"
        reference="customers"
        link={false}
      >
        <ReferenceField
          source="customer_region_id"
          reference="customer_regions"
        >
          <TextField source="name" />
        </ReferenceField>
      </ReferenceField>
    </Datagrid>
  </List>
```

## Solution

The type of translateChoice can be func or bool in PropTypes