### PR TITLE
Fix components / hooks error in react-devtools

### DIFF
--- a/packages/ra-core/src/dataProvider/cacheDataProviderProxy.ts
+++ b/packages/ra-core/src/dataProvider/cacheDataProviderProxy.ts
@@ -26,27 +26,24 @@ export default (
         get: (target, name: string) => {
             if (typeof name === 'symbol') {
                 return;
-            } else {
-                return (resource, params) => {
-                    if (
-                        name === 'getList' ||
-                        name === 'getMany' ||
-                        name === 'getOne'
-                    ) {
-                        // @ts-ignore
-                        return dataProvider[name](resource, params).then(
-                            response => {
-                                const validUntil = new Date();
-                                validUntil.setTime(
-                                    validUntil.getTime() + duration
-                                );
-                                response.validUntil = validUntil;
-                                return response;
-                            }
-                        );
-                    }
-                    return dataProvider[name](resource, params);
-                };
             }
+            return (resource, params) => {
+                if (
+                    name === 'getList' ||
+                    name === 'getMany' ||
+                    name === 'getOne'
+                ) {
+                    // @ts-ignore
+                    return dataProvider[name](resource, params).then(
+                        response => {
+                            const validUntil = new Date();
+                            validUntil.setTime(validUntil.getTime() + duration);
+                            response.validUntil = validUntil;
+                            return response;
+                        }
+                    );
+                }
+                return dataProvider[name](resource, params);
+            };
         },
     });

--- a/packages/ra-core/src/dataProvider/cacheDataProviderProxy.ts
+++ b/packages/ra-core/src/dataProvider/cacheDataProviderProxy.ts
@@ -23,16 +23,30 @@ export default (
     duration: number = fiveMinutes
 ): DataProvider =>
     new Proxy(dataProvider, {
-        get: (target, name: string) => (resource, params) => {
-            if (name === 'getList' || name === 'getMany' || name === 'getOne') {
-                // @ts-ignore
-                return dataProvider[name](resource, params).then(response => {
-                    const validUntil = new Date();
-                    validUntil.setTime(validUntil.getTime() + duration);
-                    response.validUntil = validUntil;
-                    return response;
-                });
+        get: (target, name: string) => {
+            if (typeof name === 'symbol') {
+                return;
+            } else {
+                return (resource, params) => {
+                    if (
+                        name === 'getList' ||
+                        name === 'getMany' ||
+                        name === 'getOne'
+                    ) {
+                        // @ts-ignore
+                        return dataProvider[name](resource, params).then(
+                            response => {
+                                const validUntil = new Date();
+                                validUntil.setTime(
+                                    validUntil.getTime() + duration
+                                );
+                                response.validUntil = validUntil;
+                                return response;
+                            }
+                        );
+                    }
+                    return dataProvider[name](resource, params);
+                };
             }
-            return dataProvider[name](resource, params);
         },
     });

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -129,66 +129,65 @@ const useDataProvider = (): DataProviderProxy => {
             get: (target, name) => {
                 if (typeof name === 'symbol') {
                     return;
-                } else {
-                    return (
-                        resource: string,
-                        payload: any,
-                        options: UseDataProviderOptions
-                    ) => {
-                        const type = name.toString();
-                        const {
-                            action = 'CUSTOM_FETCH',
-                            undoable = false,
-                            onSuccess = undefined,
-                            onFailure = undefined,
-                            ...rest
-                        } = options || {};
-
-                        if (typeof dataProvider[type] !== 'function') {
-                            throw new Error(
-                                `Unknown dataProvider function: ${type}`
-                            );
-                        }
-                        if (onSuccess && typeof onSuccess !== 'function') {
-                            throw new Error(
-                                'The onSuccess option must be a function'
-                            );
-                        }
-                        if (onFailure && typeof onFailure !== 'function') {
-                            throw new Error(
-                                'The onFailure option must be a function'
-                            );
-                        }
-                        if (undoable && !onSuccess) {
-                            throw new Error(
-                                'You must pass an onSuccess callback calling notify() to use the undoable mode'
-                            );
-                        }
-
-                        const params = {
-                            action,
-                            dataProvider,
-                            dispatch,
-                            logoutIfAccessDenied,
-                            onFailure,
-                            onSuccess,
-                            payload,
-                            resource,
-                            rest,
-                            store,
-                            type,
-                            undoable,
-                        };
-                        if (isOptimistic) {
-                            // in optimistic mode, all fetch calls are stacked, to be
-                            // executed once the dataProvider leaves optimistic mode.
-                            // In the meantime, the admin uses data from the store.
-                            optimisticCalls.push(params);
-                            return Promise.resolve();
-                        }
-                        return doQuery(params);
-                    };
                 }
+                return (
+                    resource: string,
+                    payload: any,
+                    options: UseDataProviderOptions
+                ) => {
+                    const type = name.toString();
+                    const {
+                        action = 'CUSTOM_FETCH',
+                        undoable = false,
+                        onSuccess = undefined,
+                        onFailure = undefined,
+                        ...rest
+                    } = options || {};
+
+                    if (typeof dataProvider[type] !== 'function') {
+                        throw new Error(
+                            `Unknown dataProvider function: ${type}`
+                        );
+                    }
+                    if (onSuccess && typeof onSuccess !== 'function') {
+                        throw new Error(
+                            'The onSuccess option must be a function'
+                        );
+                    }
+                    if (onFailure && typeof onFailure !== 'function') {
+                        throw new Error(
+                            'The onFailure option must be a function'
+                        );
+                    }
+                    if (undoable && !onSuccess) {
+                        throw new Error(
+                            'You must pass an onSuccess callback calling notify() to use the undoable mode'
+                        );
+                    }
+
+                    const params = {
+                        action,
+                        dataProvider,
+                        dispatch,
+                        logoutIfAccessDenied,
+                        onFailure,
+                        onSuccess,
+                        payload,
+                        resource,
+                        rest,
+                        store,
+                        type,
+                        undoable,
+                    };
+                    if (isOptimistic) {
+                        // in optimistic mode, all fetch calls are stacked, to be
+                        // executed once the dataProvider leaves optimistic mode.
+                        // In the meantime, the admin uses data from the store.
+                        optimisticCalls.push(params);
+                        return Promise.resolve();
+                    }
+                    return doQuery(params);
+                };
             },
         });
     }, [dataProvider, dispatch, isOptimistic, logoutIfAccessDenied, store]);

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -127,64 +127,68 @@ const useDataProvider = (): DataProviderProxy => {
     const dataProviderProxy = useMemo(() => {
         return new Proxy(dataProvider, {
             get: (target, name) => {
-                return (
-                    resource: string,
-                    payload: any,
-                    options: UseDataProviderOptions
-                ) => {
-                    const type = name.toString();
-                    const {
-                        action = 'CUSTOM_FETCH',
-                        undoable = false,
-                        onSuccess = undefined,
-                        onFailure = undefined,
-                        ...rest
-                    } = options || {};
+                if (typeof name === 'symbol') {
+                    return;
+                } else {
+                    return (
+                        resource: string,
+                        payload: any,
+                        options: UseDataProviderOptions
+                    ) => {
+                        const type = name.toString();
+                        const {
+                            action = 'CUSTOM_FETCH',
+                            undoable = false,
+                            onSuccess = undefined,
+                            onFailure = undefined,
+                            ...rest
+                        } = options || {};
 
-                    if (typeof dataProvider[type] !== 'function') {
-                        throw new Error(
-                            `Unknown dataProvider function: ${type}`
-                        );
-                    }
-                    if (onSuccess && typeof onSuccess !== 'function') {
-                        throw new Error(
-                            'The onSuccess option must be a function'
-                        );
-                    }
-                    if (onFailure && typeof onFailure !== 'function') {
-                        throw new Error(
-                            'The onFailure option must be a function'
-                        );
-                    }
-                    if (undoable && !onSuccess) {
-                        throw new Error(
-                            'You must pass an onSuccess callback calling notify() to use the undoable mode'
-                        );
-                    }
+                        if (typeof dataProvider[type] !== 'function') {
+                            throw new Error(
+                                `Unknown dataProvider function: ${type}`
+                            );
+                        }
+                        if (onSuccess && typeof onSuccess !== 'function') {
+                            throw new Error(
+                                'The onSuccess option must be a function'
+                            );
+                        }
+                        if (onFailure && typeof onFailure !== 'function') {
+                            throw new Error(
+                                'The onFailure option must be a function'
+                            );
+                        }
+                        if (undoable && !onSuccess) {
+                            throw new Error(
+                                'You must pass an onSuccess callback calling notify() to use the undoable mode'
+                            );
+                        }
 
-                    const params = {
-                        action,
-                        dataProvider,
-                        dispatch,
-                        logoutIfAccessDenied,
-                        onFailure,
-                        onSuccess,
-                        payload,
-                        resource,
-                        rest,
-                        store,
-                        type,
-                        undoable,
+                        const params = {
+                            action,
+                            dataProvider,
+                            dispatch,
+                            logoutIfAccessDenied,
+                            onFailure,
+                            onSuccess,
+                            payload,
+                            resource,
+                            rest,
+                            store,
+                            type,
+                            undoable,
+                        };
+                        if (isOptimistic) {
+                            // in optimistic mode, all fetch calls are stacked, to be
+                            // executed once the dataProvider leaves optimistic mode.
+                            // In the meantime, the admin uses data from the store.
+                            optimisticCalls.push(params);
+                            return Promise.resolve();
+                        }
+                        return doQuery(params);
                     };
-                    if (isOptimistic) {
-                        // in optimistic mode, all fetch calls are stacked, to be
-                        // executed once the dataProvider leaves optimistic mode.
-                        // In the meantime, the admin uses data from the store.
-                        optimisticCalls.push(params);
-                        return Promise.resolve();
-                    }
-                    return doQuery(params);
-                };
+                }
             },
         });
     }, [dataProvider, dispatch, isOptimistic, logoutIfAccessDenied, store]);

--- a/packages/ra-core/src/dataProvider/useDataProviderWithDeclarativeSideEffects.ts
+++ b/packages/ra-core/src/dataProvider/useDataProviderWithDeclarativeSideEffects.ts
@@ -16,27 +16,31 @@ const useDataProviderWithDeclarativeSideEffects = (): DataProvider => {
     const dataProviderProxy = useMemo(() => {
         return new Proxy(dataProvider, {
             get: (target, name) => {
-                return (
-                    resource: string,
-                    payload: any,
-                    options: UseDataProviderOptions
-                ) => {
-                    const { onSuccess, onFailure } = getSideEffects(
-                        resource,
-                        options
-                    );
-                    try {
-                        return target[name.toString()](resource, payload, {
-                            ...options,
-                            onSuccess,
-                            onFailure,
-                        });
-                    } catch (e) {
-                        // turn synchronous exceptions (e.g. in parameter preparation)
-                        // into async ones, otherwise they'll be lost
-                        return Promise.reject(e);
-                    }
-                };
+                if (typeof name === 'symbol') {
+                    return;
+                } else {
+                    return (
+                        resource: string,
+                        payload: any,
+                        options: UseDataProviderOptions
+                    ) => {
+                        const { onSuccess, onFailure } = getSideEffects(
+                            resource,
+                            options
+                        );
+                        try {
+                            return target[name.toString()](resource, payload, {
+                                ...options,
+                                onSuccess,
+                                onFailure,
+                            });
+                        } catch (e) {
+                            // turn synchronous exceptions (e.g. in parameter preparation)
+                            // into async ones, otherwise they'll be lost
+                            return Promise.reject(e);
+                        }
+                    };
+                }
             },
         });
     }, [dataProvider, getSideEffects]);

--- a/packages/ra-core/src/dataProvider/useDataProviderWithDeclarativeSideEffects.ts
+++ b/packages/ra-core/src/dataProvider/useDataProviderWithDeclarativeSideEffects.ts
@@ -18,29 +18,28 @@ const useDataProviderWithDeclarativeSideEffects = (): DataProvider => {
             get: (target, name) => {
                 if (typeof name === 'symbol') {
                     return;
-                } else {
-                    return (
-                        resource: string,
-                        payload: any,
-                        options: UseDataProviderOptions
-                    ) => {
-                        const { onSuccess, onFailure } = getSideEffects(
-                            resource,
-                            options
-                        );
-                        try {
-                            return target[name.toString()](resource, payload, {
-                                ...options,
-                                onSuccess,
-                                onFailure,
-                            });
-                        } catch (e) {
-                            // turn synchronous exceptions (e.g. in parameter preparation)
-                            // into async ones, otherwise they'll be lost
-                            return Promise.reject(e);
-                        }
-                    };
                 }
+                return (
+                    resource: string,
+                    payload: any,
+                    options: UseDataProviderOptions
+                ) => {
+                    const { onSuccess, onFailure } = getSideEffects(
+                        resource,
+                        options
+                    );
+                    try {
+                        return target[name.toString()](resource, payload, {
+                            ...options,
+                            onSuccess,
+                            onFailure,
+                        });
+                    } catch (e) {
+                        // turn synchronous exceptions (e.g. in parameter preparation)
+                        // into async ones, otherwise they'll be lost
+                        return Promise.reject(e);
+                    }
+                };
             },
         });
     }, [dataProvider, getSideEffects]);


### PR DESCRIPTION
Fixes #4697

React-devtools uses `obj[Symbol.iterator] === 'function'` to decide whether an object is an iterator. If it is, react-devtools will call that `obj[Symbol.iterator]` function. Since a dataProvider proxy's GET trap always returns a function, the comparison will always be true. The real dataProvider doesn't have the `Symbol.iterator` property, so it throws an error. When `name` is `Symbol.iterator`, returning `undefined` can make react-devtools think the dataProvider is an object and won't call `obj[Symbol.iterator]`.