### PR TITLE
Easier customization of sidebar

### DIFF
--- a/examples/demo/src/layout/Menu.tsx
+++ b/examples/demo/src/layout/Menu.tsx
@@ -5,7 +5,6 @@ import LabelIcon from '@material-ui/icons/Label';
 import { useMediaQuery, Theme } from '@material-ui/core';
 import { useTranslate, DashboardMenuItem, MenuItemLink } from 'react-admin';
 import { makeStyles } from '@material-ui/core/styles';
-import { CSSProperties } from '@material-ui/core/styles/withStyles';
 
 import visitors from '../visitors';
 import orders from '../orders';
@@ -25,22 +24,25 @@ interface Props {
 }
 
 const useStyles = makeStyles({
-    sidebarIsFixed: {
-        position: 'fixed',
-        top: '4em',
-        zIndex: 100,
-        backgroud: 'blue',
-    },
     sideBarCatalog: {
         backgroundColor: 'red',
-        padding: '1em',
-        textDecorationColor: 'blue',
+        fontSize: '1.5em',
     },
     sideBarSales: {
-        backgroundColor: 'blue',
+        backgroundColor: 'yellow',
+        fontSize: '1.5em',
     },
     sideBarCustomers: {
         backgroundColor: 'green',
+        fontSize: '1.5em',
+    },
+    sideBarDashboard: {
+        backgroundColor: 'violet',
+        fontSize: '1.5em',
+    },
+    sideBarReview: {
+        backgroundColor: 'brown',
+        fontSize: '1.5em',
     },
 });
 
@@ -62,9 +64,13 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
     };
     const classes = useStyles();
     return (
-        <div className={classes.sidebarIsFixed}>
+        <div>
             {' '}
-            <DashboardMenuItem onClick={onMenuClick} sidebarIsOpen={open} />
+            <DashboardMenuItem
+                onClick={onMenuClick}
+                sidebarIsOpen={open}
+                className={classes.sideBarDashboard}
+            />
             {console.log(classes.sideBarSales)}
             <SubMenu
                 handleToggle={() => handleToggle('menuSales')}
@@ -165,6 +171,7 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
                 onClick={onMenuClick}
                 sidebarIsOpen={open}
                 dense={dense}
+                className={classes.sideBarReview}
             />
             {isXSmall && (
                 <MenuItemLink

--- a/examples/demo/src/layout/Menu.tsx
+++ b/examples/demo/src/layout/Menu.tsx
@@ -4,6 +4,8 @@ import SettingsIcon from '@material-ui/icons/Settings';
 import LabelIcon from '@material-ui/icons/Label';
 import { useMediaQuery, Theme } from '@material-ui/core';
 import { useTranslate, DashboardMenuItem, MenuItemLink } from 'react-admin';
+import { makeStyles } from '@material-ui/core/styles';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 
 import visitors from '../visitors';
 import orders from '../orders';
@@ -22,6 +24,26 @@ interface Props {
     onMenuClick: () => void;
 }
 
+const useStyles = makeStyles({
+    sidebarIsFixed: {
+        position: 'fixed',
+        top: '4em',
+        zIndex: 100,
+        backgroud: 'blue',
+    },
+    sideBarCatalog: {
+        backgroundColor: 'red',
+        padding: '1em',
+        textDecorationColor: 'blue',
+    },
+    sideBarSales: {
+        backgroundColor: 'blue',
+    },
+    sideBarCustomers: {
+        backgroundColor: 'green',
+    },
+});
+
 const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
     const [state, setState] = useState({
         menuCatalog: false,
@@ -38,11 +60,12 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
     const handleToggle = (menu: MenuName) => {
         setState(state => ({ ...state, [menu]: !state[menu] }));
     };
-
+    const classes = useStyles();
     return (
-        <div>
+        <div className={classes.sidebarIsFixed}>
             {' '}
             <DashboardMenuItem onClick={onMenuClick} sidebarIsOpen={open} />
+            {console.log(classes.sideBarSales)}
             <SubMenu
                 handleToggle={() => handleToggle('menuSales')}
                 isOpen={state.menuSales}
@@ -50,6 +73,7 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
                 name="pos.menu.sales"
                 icon={<orders.icon />}
                 dense={dense}
+                style={classes.sideBarSales}
             >
                 <MenuItemLink
                     to={`/commands`}
@@ -79,6 +103,7 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
                 name="pos.menu.catalog"
                 icon={<products.icon />}
                 dense={dense}
+                style={classes.sideBarCatalog}
             >
                 <MenuItemLink
                     to={`/products`}
@@ -108,6 +133,7 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
                 name="pos.menu.customers"
                 icon={<visitors.icon />}
                 dense={dense}
+                style={classes.sideBarCustomers}
             >
                 <MenuItemLink
                     to={`/customers`}

--- a/examples/demo/src/layout/Menu.tsx
+++ b/examples/demo/src/layout/Menu.tsx
@@ -71,7 +71,6 @@ const Menu: FC<Props> = ({ onMenuClick, dense, logout }) => {
                 sidebarIsOpen={open}
                 className={classes.sideBarDashboard}
             />
-            {console.log(classes.sideBarSales)}
             <SubMenu
                 handleToggle={() => handleToggle('menuSales')}
                 isOpen={state.menuSales}

--- a/examples/demo/src/layout/SubMenu.tsx
+++ b/examples/demo/src/layout/SubMenu.tsx
@@ -9,7 +9,6 @@ import Collapse from '@material-ui/core/Collapse';
 import Tooltip from '@material-ui/core/Tooltip';
 import { makeStyles } from '@material-ui/core/styles';
 import { useTranslate } from 'react-admin';
-import { CSSProperties } from '@material-ui/core/styles/withStyles';
 
 const useStyles = makeStyles(theme => ({
     icon: {
@@ -19,10 +18,6 @@ const useStyles = makeStyles(theme => ({
     sidebarIsOpen: {
         paddingLeft: 25,
         transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
-        // backgroundColor: '#FFFFF0',
-        // padding: '2em',
-        // border:'red 5px solid',
-        // fontSize:'5em'
     },
     sidebarIsClosed: {
         paddingLeft: 0,
@@ -54,11 +49,15 @@ const SubMenu: FC<Props> = ({
     const classes = useStyles();
 
     const header = (
-        <MenuItem dense={dense} button onClick={handleToggle}>
+        <MenuItem dense={dense} button onClick={handleToggle} className={style}>
             <ListItemIcon className={classes.icon}>
                 {isOpen ? <ExpandMore /> : icon}
             </ListItemIcon>
-            <Typography variant="inherit" color="textSecondary">
+            <Typography
+                variant="inherit"
+                color="textSecondary"
+                className={style}
+            >
                 {translate(name)}
             </Typography>
         </MenuItem>

--- a/examples/demo/src/layout/SubMenu.tsx
+++ b/examples/demo/src/layout/SubMenu.tsx
@@ -13,7 +13,6 @@ import { useTranslate } from 'react-admin';
 const useStyles = makeStyles(theme => ({
     icon: {
         minWidth: theme.spacing(5),
-        fontSize: '2em',
     },
     sidebarIsOpen: {
         paddingLeft: 25,

--- a/examples/demo/src/layout/SubMenu.tsx
+++ b/examples/demo/src/layout/SubMenu.tsx
@@ -9,12 +9,20 @@ import Collapse from '@material-ui/core/Collapse';
 import Tooltip from '@material-ui/core/Tooltip';
 import { makeStyles } from '@material-ui/core/styles';
 import { useTranslate } from 'react-admin';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 
 const useStyles = makeStyles(theme => ({
-    icon: { minWidth: theme.spacing(5) },
+    icon: {
+        minWidth: theme.spacing(5),
+        fontSize: '2em',
+    },
     sidebarIsOpen: {
         paddingLeft: 25,
         transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+        // backgroundColor: '#FFFFF0',
+        // padding: '2em',
+        // border:'red 5px solid',
+        // fontSize:'5em'
     },
     sidebarIsClosed: {
         paddingLeft: 0,
@@ -29,6 +37,7 @@ interface Props {
     isOpen: boolean;
     name: string;
     sidebarIsOpen: boolean;
+    style: string;
 }
 
 const SubMenu: FC<Props> = ({
@@ -39,6 +48,7 @@ const SubMenu: FC<Props> = ({
     icon,
     children,
     dense,
+    style,
 }) => {
     const translate = useTranslate();
     const classes = useStyles();
@@ -59,11 +69,20 @@ const SubMenu: FC<Props> = ({
             {sidebarIsOpen || isOpen ? (
                 header
             ) : (
-                <Tooltip title={translate(name)} placement="right">
+                <Tooltip
+                    title={translate(name)}
+                    placement="right"
+                    className={style}
+                >
                     {header}
                 </Tooltip>
             )}
-            <Collapse in={isOpen} timeout="auto" unmountOnExit>
+            <Collapse
+                in={isOpen}
+                timeout="auto"
+                unmountOnExit
+                className={style}
+            >
                 <List
                     dense={dense}
                     component="div"
@@ -76,7 +95,7 @@ const SubMenu: FC<Props> = ({
                 >
                     {children}
                 </List>
-                <Divider />
+                <Divider className={style} />
             </Collapse>
         </Fragment>
     );


### PR DESCRIPTION
Resolves #4407 

It resolves it by passing a CSS props from the parent to the child component. In this case, the SubMenu parent class defines the Style variable and passes it to Menu and using the passed props; I was able to style the sideBar. 

`Submenu.tsx`

`interface Props {
    dense: boolean;
    handleToggle: () => void;
    icon: ReactElement;
    isOpen: boolean;
    name: string;
    sidebarIsOpen: boolean;
    style: string;
}`
then will pass the style props, wherever styling is needed. 

`<Divider className={style} />`

In 'Menu.tsx'

Just define makeStyles and add use it to style the sidebar. 

`const useStyles = makeStyles({
    sideBarSales: {
        backgroundColor: 'red',
        fontSize: '1.5em',
    }
}
`
`const classes = useStyles();`
and use it to style sidebar menu like: 

`<SubMenu
                handleToggle={() => handleToggle('menuSales')}
                isOpen={state.menuSales}
                sidebarIsOpen={open}
                name="pos.menu.sales"
                icon={<orders.icon />}
                dense={dense}
                style={classes.sideBarSales}>`

![Screen Shot 2020-05-08 at 12 28 35 PM](https://user-images.githubusercontent.com/35715329/81426634-7a4f7080-9127-11ea-935b-3600e627cd33.png)



Is that a good direction to pursue? Is there a reference in the code on how this is done in the project? 