### PR TITLE
[Doc] Fix previous / next pagination

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -1852,9 +1852,9 @@ Alternately, if you want to replace the default pagination by a "<previous - nex
 
 ```jsx
 import Button from '@material-ui/core/Button';
+import Toolbar from '@material-ui/core/Toolbar';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
-import Toolbar from '@material-ui/core/Toolbar';
 
 const PostPagination = ({ page, perPage, total, setPage }) => {
     const nbPages = Math.ceil(total / perPage) || 1;
@@ -1862,13 +1862,15 @@ const PostPagination = ({ page, perPage, total, setPage }) => {
         nbPages > 1 &&
             <Toolbar>
                 {page > 1 &&
-                    <Button color="primary" key="prev" icon={ChevronLeft} onClick={() => setPage(page - 1)}>
+                    <Button color="primary" key="prev" onClick={() => setPage(page - 1)}>
+                        <ChevronLeft />
                         Prev
                     </Button>
                 }
                 {page !== nbPages &&
-                    <Button color="primary" key="next" icon={ChevronRight} onClick={() => setPage(page + 1)} labelPosition="before">
+                    <Button color="primary" key="next" onClick={() => setPage(page + 1)}>
                         Next
+                        <ChevronRight />
                     </Button>
                 }
             </Toolbar>


### PR DESCRIPTION
I've changed the previous / next pagination example with a better implementation.

In the previous one, the icons were not working and the `labelPosition` prop doesn't exist.

Now, the texts are also translated and RTL is managed.