### PR TITLE
enhancement: allow custom add and remove buttons in SimpleFormIterator

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -127,6 +127,19 @@ import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admi
 </ArrayInput>
 ```
 
+You can also use `addButton` and `removeButton` props to pass your custom add and remove buttons to `SimpleFormIterator`.
+
+```jsx
+import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+
+<ArrayInput source="backlinks">
+    <SimpleFormIterator  addButton={<CustomAddButton />} addButton={<CustomRemoveButton />}>
+        <DateInput source="date" />
+        <TextInput source="url" />
+    </SimpleFormIterator>
+</ArrayInput>
+```
+
 **Note**: `SimpleFormIterator` only accepts `Input` components as children. If you want to use some `Fields` instead, you have to use a `<FormDataConsumer>` to get the correct source, as follows:
 
 ```jsx

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -133,7 +133,7 @@ You can also use `addButton` and `removeButton` props to pass your custom add an
 import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
 
 <ArrayInput source="backlinks">
-    <SimpleFormIterator  addButton={<CustomAddButton />} addButton={<CustomRemoveButton />}>
+    <SimpleFormIterator addButton={<CustomAddButton />} addButton={<CustomRemoveButton />}>
         <DateInput source="date" />
         <TextInput source="url" />
     </SimpleFormIterator>

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -64,6 +64,8 @@ const useStyles = makeStyles(
 
 const SimpleFormIterator = props => {
     const {
+        addButton,
+        removeButton,
         basePath,
         children,
         fields,
@@ -118,6 +120,63 @@ const SimpleFormIterator = props => {
     const addField = () => {
         ids.current.push(nextId.current++);
         fields.push(undefined);
+    };
+
+    // check if a custom add button was passed as a prop
+    // If yes, then clone that add the addField() method before its onClick event
+    // If no, then just use the original add button
+    const getAddButton = () => {
+        if (!addButton) {
+            return (
+                <Button
+                    className={classNames('button-add', `button-add-${source}`)}
+                    size="small"
+                    onClick={addField}
+                >
+                    <AddIcon className={classes.leftIcon} />
+                    {translate('ra.action.add')}
+                </Button>
+            );
+        }
+
+        const { props: addButtonProps = {} } = addButton;
+        const { onClick: addButtonOnClick = () => {} } = addButtonProps;
+        return cloneElement(addButton, {
+            onClick: e => {
+                addField();
+                addButtonOnClick(e);
+            },
+        });
+    };
+
+    // check if a custom remove button was passed as a prop
+    // If yes, then clone that remove the removeField() method before its onClick event
+    // If no, then just use the original remove button
+    const getRemoveButton = index => {
+        if (!removeButton) {
+            return (
+                <Button
+                    className={classNames(
+                        'button-remove',
+                        `button-remove-${source}-${index}`
+                    )}
+                    size="small"
+                    onClick={removeField(index)}
+                >
+                    <CloseIcon className={classes.leftIcon} />
+                    {translate('ra.action.remove')}
+                </Button>
+            );
+        }
+
+        const { props: removeButtonProps = {} } = removeButton;
+        const { onClick: removeButtonOnClick = () => {} } = removeButtonProps;
+        return cloneElement(removeButton, {
+            onClick: e => {
+                removeField(index);
+                removeButtonOnClick(e);
+            },
+        });
     };
 
     const records = get(record, source);
@@ -186,19 +245,7 @@ const SimpleFormIterator = props => {
                                 disableRemove
                             ) && (
                                 <span className={classes.action}>
-                                    <Button
-                                        className={classNames(
-                                            'button-remove',
-                                            `button-remove-${source}-${index}`
-                                        )}
-                                        size="small"
-                                        onClick={removeField(index)}
-                                    >
-                                        <CloseIcon
-                                            className={classes.leftIcon}
-                                        />
-                                        {translate('ra.action.remove')}
-                                    </Button>
+                                    {getRemoveButton(index)}
                                 </span>
                             )}
                         </li>
@@ -207,19 +254,7 @@ const SimpleFormIterator = props => {
             </TransitionGroup>
             {!disableAdd && (
                 <li className={classes.line}>
-                    <span className={classes.action}>
-                        <Button
-                            className={classNames(
-                                'button-add',
-                                `button-add-${source}`
-                            )}
-                            size="small"
-                            onClick={addField}
-                        >
-                            <AddIcon className={classes.leftIcon} />
-                            {translate('ra.action.add')}
-                        </Button>
-                    </span>
+                    <span className={classes.action}>{getAddButton()}</span>
                 </li>
             )}
         </ul>
@@ -229,10 +264,14 @@ const SimpleFormIterator = props => {
 SimpleFormIterator.defaultProps = {
     disableAdd: false,
     disableRemove: false,
+    addButton: null,
+    removeButton: null,
 };
 
 SimpleFormIterator.propTypes = {
     defaultValue: PropTypes.any,
+    addButton: PropTypes.element,
+    removeButton: PropTypes.element,
     basePath: PropTypes.string,
     children: PropTypes.node,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -63,11 +63,10 @@ const useStyles = makeStyles(
 );
 
 const DefaultAddButton = props => {
-    const { onClick = () => {}, className = '' } = props;
     const classes = useStyles(props);
     const translate = useTranslate();
     return (
-        <Button className={className} size="small" onClick={onClick}>
+        <Button size="small" {...props}>
             <AddIcon className={classes.leftIcon} />
             {translate('ra.action.add')}
         </Button>
@@ -75,11 +74,10 @@ const DefaultAddButton = props => {
 };
 
 const DefaultRemoveButton = props => {
-    const { onClick = () => {}, className = '' } = props;
     const classes = useStyles(props);
     const translate = useTranslate();
     return (
-        <Button className={className} size="small" onClick={onClick}>
+        <Button size="small" {...props}>
             <CloseIcon className={classes.leftIcon} />
             {translate('ra.action.remove')}
         </Button>

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
@@ -230,7 +230,7 @@ describe('<SimpleFormIterator />', () => {
 
     it('should not display remove button if custom removeButton is passed', () => {
         const { queryAllByText } = renderWithRedux(
-            <SimpleForm record={{ emails: [{ email: '' }, { email: '' }] }}>
+            <SimpleForm record={{ emails: [{ email: '' }] }}>
                 <ArrayInput source="emails">
                     <SimpleFormIterator
                         translate={x => x}
@@ -243,5 +243,81 @@ describe('<SimpleFormIterator />', () => {
         );
 
         expect(queryAllByText('ra.action.remove').length).toBe(0);
+    });
+
+    it('should display custom add button if custom addButton is passed', () => {
+        const { getByText } = renderWithRedux(
+            <SimpleForm>
+                <ArrayInput source="emails">
+                    <SimpleFormIterator
+                        translate={x => x}
+                        addButton={<button>Custom Add Button</button>}
+                    >
+                        <TextInput source="email" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        );
+
+        expect(getByText('Custom Add Button')).toBeDefined();
+    });
+
+    it('should display custom remove button if custom removeButton is passed', () => {
+        const { getByText } = renderWithRedux(
+            <SimpleForm record={{ emails: [{ email: '' }] }}>
+                <ArrayInput source="emails">
+                    <SimpleFormIterator
+                        translate={x => x}
+                        removeButton={<button>Custom Remove Button</button>}
+                    >
+                        <TextInput source="email" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        );
+
+        expect(getByText('Custom Remove Button')).toBeDefined();
+    });
+
+    it('should call onClick method, when custom add button is clicked', async () => {
+        const onClick = jest.fn();
+        const { getByText } = renderWithRedux(
+            <SimpleForm>
+                <ArrayInput source="emails">
+                    <SimpleFormIterator
+                        translate={x => x}
+                        addButton={
+                            <button onClick={onClick}>Custom Add Button</button>
+                        }
+                    >
+                        <TextInput source="email" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        );
+        fireEvent.click(getByText('Custom Add Button'));
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    it('should call onClick method, when custom remove button is clicked', async () => {
+        const onClick = jest.fn();
+        const { getByText } = renderWithRedux(
+            <SimpleForm record={{ emails: [{ email: '' }] }}>
+                <ArrayInput source="emails">
+                    <SimpleFormIterator
+                        translate={x => x}
+                        removeButton={
+                            <button onClick={onClick}>
+                                Custom Remove Button
+                            </button>
+                        }
+                    >
+                        <TextInput source="email" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        );
+        fireEvent.click(getByText('Custom Remove Button'));
+        expect(onClick).toHaveBeenCalled();
     });
 });

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
@@ -212,7 +212,7 @@ describe('<SimpleFormIterator />', () => {
         });
     });
 
-    it('should not display add buttom if custom addButton is passed', () => {
+    it('should not display add button if custom addButton is passed', () => {
         const { queryAllByText } = renderWithRedux(
             <SimpleForm>
                 <ArrayInput source="emails">

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
@@ -212,7 +212,7 @@ describe('<SimpleFormIterator />', () => {
         });
     });
 
-    it('should not display add button if custom addButton is passed', () => {
+    it('should not display the default add button if a custom add button is passed', () => {
         const { queryAllByText } = renderWithRedux(
             <SimpleForm>
                 <ArrayInput source="emails">
@@ -228,7 +228,7 @@ describe('<SimpleFormIterator />', () => {
         expect(queryAllByText('ra.action.add').length).toBe(0);
     });
 
-    it('should not display remove button if custom removeButton is passed', () => {
+    it('should not display the default remove button if a custom remove button is passed', () => {
         const { queryAllByText } = renderWithRedux(
             <SimpleForm record={{ emails: [{ email: '' }] }}>
                 <ArrayInput source="emails">
@@ -245,7 +245,7 @@ describe('<SimpleFormIterator />', () => {
         expect(queryAllByText('ra.action.remove').length).toBe(0);
     });
 
-    it('should display custom add button if custom addButton is passed', () => {
+    it('should display the custom add button', () => {
         const { getByText } = renderWithRedux(
             <SimpleForm>
                 <ArrayInput source="emails">
@@ -262,7 +262,7 @@ describe('<SimpleFormIterator />', () => {
         expect(getByText('Custom Add Button')).toBeDefined();
     });
 
-    it('should display custom remove button if custom removeButton is passed', () => {
+    it('should display the custom remove button', () => {
         const { getByText } = renderWithRedux(
             <SimpleForm record={{ emails: [{ email: '' }] }}>
                 <ArrayInput source="emails">
@@ -279,7 +279,7 @@ describe('<SimpleFormIterator />', () => {
         expect(getByText('Custom Remove Button')).toBeDefined();
     });
 
-    it('should call onClick method, when custom add button is clicked', async () => {
+    it('should call the onClick method when the custom add button is clicked', async () => {
         const onClick = jest.fn();
         const { getByText } = renderWithRedux(
             <SimpleForm>
@@ -299,7 +299,7 @@ describe('<SimpleFormIterator />', () => {
         expect(onClick).toHaveBeenCalled();
     });
 
-    it('should call onClick method, when custom remove button is clicked', async () => {
+    it('should call the onClick method when the custom remove button is clicked', async () => {
         const onClick = jest.fn();
         const { getByText } = renderWithRedux(
             <SimpleForm record={{ emails: [{ email: '' }] }}>

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.js
@@ -211,4 +211,37 @@ describe('<SimpleFormIterator />', () => {
             ).toEqual([{ email: 'bar@foo.com' }]);
         });
     });
+
+    it('should not display add buttom if custom addButton is passed', () => {
+        const { queryAllByText } = renderWithRedux(
+            <SimpleForm>
+                <ArrayInput source="emails">
+                    <SimpleFormIterator
+                        translate={x => x}
+                        addButton={<button>Custom Add Button</button>}
+                    >
+                        <TextInput source="email" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        );
+        expect(queryAllByText('ra.action.add').length).toBe(0);
+    });
+
+    it('should not display remove button if custom removeButton is passed', () => {
+        const { queryAllByText } = renderWithRedux(
+            <SimpleForm record={{ emails: [{ email: '' }, { email: '' }] }}>
+                <ArrayInput source="emails">
+                    <SimpleFormIterator
+                        translate={x => x}
+                        removeButton={<button>Custom Remove Button</button>}
+                    >
+                        <TextInput source="email" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        );
+
+        expect(queryAllByText('ra.action.remove').length).toBe(0);
+    });
 });


### PR DESCRIPTION
As mentioned in https://github.com/marmelab/react-admin/issues/4676

This is an enhancement that will allow us to pass our own custom add and remove buttons to the SimpleFormIterator component.

**Changes**
- feature: add addButton and removeButton as props in SimpleFormIterator
- refactor: moved the add and remove button logic to separate functions
- test cases: added test cases for addButton and removeButton props
- docs: added an example of the same in docs

Let me know if it requires any further updates.