### PR TITLE
Docs: Add react-admin-firebase to Authentication Providers

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -28,6 +28,7 @@ See the [Translation](./Translation.md#available-locales) page.
 ## Authentication Providers
 
 - **[AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/setting-up-the-javascript-sdk.html)**: [thedistance/ra-cognito](https://github.com/thedistance/ra-cognito)
+- **[Firebase Auth (Google, Facebook, Github etc)](https://firebase.google.com/docs/auth/web/firebaseui)**: [benwinding/react-admin-firebase](https://github.com/benwinding/react-admin-firebase#auth-provider)
 
 ## Authorization Management
 


### PR DESCRIPTION
Hey guys,

Adding [react-admin-firebase](https://github.com/benwinding/react-admin-firebase#auth-provider) to the "Authentication Providers" in Ecosystem.md. 

We've implemented various Authentication features which are now widely used:

- Login with: Google, Facebook, Github etc... ([Example Here](https://github.com/benwinding/react-admin-firebase/blob/master/src-demo/src/CustomLoginPage.js))
- A "Forgot password" button... ([Example Here](https://github.com/benwinding/react-admin-firebase/blob/master/src-demo/src/CustomForgotPassword.js))

Thought it might be good to put in the docs for new people.

Thanks for all your work on this amazing platform!

Cheers,
Ben