### PR TITLE
Meta for Data Providers

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -339,15 +339,15 @@ Data Providers methods must return a Promise for an object with a `data` propert
 
 Method             | Response format
 ------------------ | ----------------
-`getList`          | `{ data: {Record[]}, total: {int}, validUntil?: {Date} }`
-`getOne`           | `{ data: {Record}, validUntil?: {Date} }`
-`getMany`          | `{ data: {Record[]}, validUntil?: {Date} }`
-`getManyReference` | `{ data: {Record[]}, total: {int} }`
-`create`           | `{ data: {Record} }`
-`update`           | `{ data: {Record} }`
-`updateMany`       | `{ data: {mixed[]} }` The ids which have been updated
-`delete`           | `{ data: {Record} }` The record that has been deleted
-`deleteMany`       | `{ data: {mixed[]} }` The ids of the deleted records (optional)
+`getList`          | `{ data: {Record[]}, total: {int}, meta?: {object}, validUntil?: {Date} }`
+`getOne`           | `{ data: {Record}, meta?: {object}, validUntil?: {Date} }`
+`getMany`          | `{ data: {Record[]}, meta?: {object}, validUntil?: {Date} }`
+`getManyReference` | `{ data: {Record[]}, meta?: {object}, total: {int} }`
+`create`           | `{ data: {Record}, meta?: {object} }`
+`update`           | `{ data: {Record}, meta?: {object} }`
+`updateMany`       | `{ data: {mixed[]}, meta?: {object} }` The ids which have been updated
+`delete`           | `{ data: {Record}, meta?: {object} }` The record that has been deleted
+`deleteMany`       | `{ data: {mixed[]}, meta?: {object} }` The ids of the deleted records (optional)
 
 A `{Record}` is an object literal with at least an `id` property, e.g. `{ id: 123, title: "hello, world" }`.
 
@@ -444,6 +444,8 @@ dataProvider.deleteMany('posts', { ids: [123, 234] })
 ```
 
 **Tip**: The `validUntil` field in the response is optional. It enables the Application cache, a client-side optimization to speed up rendering and reduce network traffic. Check [the Caching documentation](./Caching.md#application-cache) for more details.
+
+**Tip**: The `meta` field in the response is optional. It allows to pass arbitrary information received by the data provider to your custom components.
 
 ### Example Implementation
 

--- a/packages/ra-core/src/actions/dataActions/crudCreate.ts
+++ b/packages/ra-core/src/actions/dataActions/crudCreate.ts
@@ -87,6 +87,7 @@ export interface CrudCreateSuccessAction {
     readonly type: typeof CRUD_CREATE_SUCCESS;
     readonly payload: {
         data: Record;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudDelete.ts
+++ b/packages/ra-core/src/actions/dataActions/crudDelete.ts
@@ -93,6 +93,7 @@ export interface CrudDeleteSuccessAction {
     readonly type: typeof CRUD_DELETE_SUCCESS;
     readonly payload: {
         data: Record;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudDeleteMany.ts
+++ b/packages/ra-core/src/actions/dataActions/crudDeleteMany.ts
@@ -86,6 +86,7 @@ export interface CrudDeleteManySuccessAction {
     readonly type: typeof CRUD_DELETE_MANY_SUCCESS;
     readonly payload: {
         data: Record[];
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudGetAll.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetAll.ts
@@ -78,6 +78,7 @@ export interface CrudGetAllSuccessAction {
     readonly payload: {
         data: Record[];
         total: number;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudGetList.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetList.ts
@@ -71,6 +71,7 @@ export interface CrudGetListSuccessAction {
     readonly payload: {
         data: Record[];
         total: number;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudGetManyReference.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetManyReference.ts
@@ -85,6 +85,7 @@ export interface CrudGetManyReferenceSuccessAction {
     readonly payload: {
         data: Record[];
         total: number;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudGetMatching.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetMatching.ts
@@ -76,6 +76,7 @@ export interface CrudGetMatchingSuccessAction {
     readonly payload: {
         data: Record[];
         total: number;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudGetOne.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetOne.ts
@@ -81,6 +81,7 @@ export interface CrudGetOneSuccessAction {
     readonly type: typeof CRUD_GET_ONE_SUCCESS;
     readonly payload: {
         data: Record;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudUpdate.ts
+++ b/packages/ra-core/src/actions/dataActions/crudUpdate.ts
@@ -95,6 +95,7 @@ export interface CrudUpdateSuccessAction {
     readonly type: typeof CRUD_UPDATE_SUCCESS;
     readonly payload: {
         data: Record;
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/actions/dataActions/crudUpdateMany.ts
+++ b/packages/ra-core/src/actions/dataActions/crudUpdateMany.ts
@@ -88,6 +88,7 @@ export interface CrudUpdateManySuccessAction {
     readonly type: typeof CRUD_UPDATE_MANY_SUCCESS;
     readonly payload: {
         data: Identifier[];
+        meta?: object;
     };
     readonly requestPayload: RequestPayload;
     readonly meta: {

--- a/packages/ra-core/src/controller/useCreateController.ts
+++ b/packages/ra-core/src/controller/useCreateController.ts
@@ -16,6 +16,7 @@ import { Record } from '../types';
 export interface CreateControllerProps {
     loading: boolean;
     loaded: boolean;
+    meta: object;
     saving: boolean;
     defaultTitle: string;
     save: (
@@ -81,7 +82,7 @@ const useCreateController = (props: CreateProps): CreateControllerProps => {
     const recordToUse = getRecord(location, record);
     const version = useVersion();
 
-    const [create, { loading: saving }] = useCreate(resource);
+    const [create, { meta, loading: saving }] = useCreate(resource);
 
     const save = useCallback(
         (
@@ -137,6 +138,7 @@ const useCreateController = (props: CreateProps): CreateControllerProps => {
     return {
         loading: false,
         loaded: true,
+        meta,
         saving,
         defaultTitle,
         save,

--- a/packages/ra-core/src/controller/useEditController.ts
+++ b/packages/ra-core/src/controller/useEditController.ts
@@ -29,6 +29,7 @@ export interface EditProps {
 export interface EditControllerProps {
     loading: boolean;
     loaded: boolean;
+    meta: object;
     saving: boolean;
     defaultTitle: string;
     save: (
@@ -72,7 +73,7 @@ const useEditController = (props: EditProps): EditControllerProps => {
     const redirect = useRedirect();
     const refresh = useRefresh();
     const version = useVersion();
-    const { data: record, loading, loaded } = useGetOne(resource, id, {
+    const { data: record, meta, loading, loaded } = useGetOne(resource, id, {
         action: CRUD_GET_ONE,
         onFailure: () => {
             notify('ra.notification.item_doesnt_exist', 'warning');
@@ -144,6 +145,7 @@ const useEditController = (props: EditProps): EditControllerProps => {
     return {
         loading,
         loaded,
+        meta,
         saving,
         defaultTitle,
         save,

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -57,6 +57,7 @@ export interface ListControllerProps<RecordType = Record> {
     ids: Identifier[];
     loading: boolean;
     loaded: boolean;
+    meta: object;
     onSelect: (ids: Identifier[]) => void;
     onToggleItem: (id: Identifier) => void;
     onUnselectItems: () => void;
@@ -132,7 +133,7 @@ const useListController = <RecordType = Record>(
      * We want the list of ids to be always available for optimistic rendering,
      * and therefore we need a custom action (CRUD_GET_LIST) that will be used.
      */
-    const { ids, total, loading, loaded } = useGetList<RecordType>(
+    const { ids, total, meta, loading, loaded } = useGetList<RecordType>(
         resource,
         {
             page: query.page,
@@ -212,6 +213,7 @@ const useListController = <RecordType = Record>(
         ids: typeof total === 'undefined' ? defaultIds : ids,
         loaded: loaded || defaultIds.length > 0,
         loading,
+        meta,
         onSelect: selectionModifiers.select,
         onToggleItem: selectionModifiers.toggle,
         onUnselectItems: selectionModifiers.clearSelection,
@@ -244,6 +246,7 @@ export const injectedProps = [
     'onSelect',
     'onToggleItem',
     'onUnselectItems',
+    'meta',
     'page',
     'perPage',
     'refresh',

--- a/packages/ra-core/src/controller/useShowController.ts
+++ b/packages/ra-core/src/controller/useShowController.ts
@@ -22,6 +22,7 @@ export interface ShowProps {
 export interface ShowControllerProps {
     loading: boolean;
     loaded: boolean;
+    meta: object;
     defaultTitle: string;
     resource: string;
     basePath: string;
@@ -54,7 +55,7 @@ const useShowController = (props: ShowProps): ShowControllerProps => {
     const redirect = useRedirect();
     const refresh = useRefresh();
     const version = useVersion();
-    const { data: record, loading, loaded } = useGetOne(resource, id, {
+    const { data: record, meta, loading, loaded } = useGetOne(resource, id, {
         action: CRUD_GET_ONE,
         onFailure: () => {
             notify('ra.notification.item_doesnt_exist', 'warning');
@@ -76,6 +77,7 @@ const useShowController = (props: ShowProps): ShowControllerProps => {
     return {
         loading,
         loaded,
+        meta,
         defaultTitle,
         resource,
         basePath,

--- a/packages/ra-core/src/dataProvider/Mutation.spec.tsx
+++ b/packages/ra-core/src/dataProvider/Mutation.spec.tsx
@@ -47,6 +47,7 @@ describe('Mutation', () => {
             total: null,
             loaded: false,
             loading: false,
+            meta: null,
         });
     });
 

--- a/packages/ra-core/src/dataProvider/replyWithCache.ts
+++ b/packages/ra-core/src/dataProvider/replyWithCache.ts
@@ -41,19 +41,29 @@ export const canReplyWithCache = (type, payload, resourceState) => {
 };
 
 export const getResultFromCache = (type, payload, resourceState) => {
+    const requestSignature = JSON.stringify(payload);
+    const cachedRequest = resourceState.cachedRequests[requestSignature];
+
     switch (type) {
         case 'getList': {
             const data = resourceState.data;
-            const requestSignature = JSON.stringify(payload);
-            const cachedRequest =
+            const cachedListRequest =
                 resourceState.list.cachedRequests[requestSignature];
             return {
-                data: cachedRequest.ids.map(id => data[id]),
-                total: cachedRequest.total,
+                ...{
+                    data: cachedListRequest.ids.map(id => data[id]),
+                    total: cachedListRequest.total,
+                },
+                ...(cachedRequest ? { meta: cachedRequest.meta } : {}),
             } as GetListResult;
         }
         case 'getOne':
-            return { data: resourceState.data[payload.id] } as GetOneResult;
+            return {
+                ...{
+                    data: resourceState.data[payload.id],
+                },
+                ...(cachedRequest ? { meta: cachedRequest.meta } : {}),
+            } as GetOneResult;
         case 'getMany':
             return {
                 data: payload.ids.map(id => resourceState.data[id]),

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -6,14 +6,14 @@ import useMutation from './useMutation';
  * The return value updates according to the request state:
  *
  * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
+ * - success: [callback, { data: [data from response], meta: [meta information from response], loading: false, loaded: true }]
  * - error: [callback, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param data The data to initialize the new record with, e.g. { title: 'hello, world" }
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [create, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [create, { data, meta, error, loading, loaded }].
  *
  * @example
  *

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -8,7 +8,7 @@ import { Identifier } from '../types';
  * The return value updates according to the request state:
  *
  * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
+ * - success: [callback, { data: [data from response], meta: [meta information from response], loading: false, loaded: true }]
  * - error: [callback, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
@@ -16,7 +16,7 @@ import { Identifier } from '../types';
  * @param previousData The record before the delete is applied
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [delete, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [delete, { data, meta, error, loading, loaded }].
  *
  * @example
  *

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -8,14 +8,14 @@ import { Identifier } from '../types';
  * The return value updates according to the request state:
  *
  * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
+ * - success: [callback, { data: [data from response], meta: [meta information from response], loading: false, loaded: true }]
  * - error: [callback, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param ids The resource identifiers, e.g. [123, 456]
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [delete, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [delete, { data, meta, error, loading, loaded }].
  *
  * @example
  *

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -20,7 +20,7 @@ const defaultData = {};
  * The return value updates according to the request state:
  *
  * - start: { loading: true, loaded: false }
- * - success: { data: [data from store], ids: [ids from response], total: [total from response], loading: false, loaded: true }
+ * - success: { data: [data from store], ids: [ids from response], total: [total from response], meta: [meta information from response], loading: false, loaded: true }
  * - error: { error: [error from response], loading: false, loaded: true }
  *
  * This hook will return the cached result when called a second time
@@ -32,7 +32,7 @@ const defaultData = {};
  * @param {Object} filter The request filters, e.g. { title: 'hello, world' }
  * @param {Object} options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as { data, total, ids, error, loading, loaded }.
+ * @returns The current request state. Destructure as { data, total, ids, meta, error, loading, loaded }.
  *
  * @example
  *
@@ -61,13 +61,21 @@ const useGetList = <RecordType = Record>(
     data?: RecordMap<RecordType>;
     ids?: Identifier[];
     total?: number;
+    meta?: object;
     error?: any;
     loading: boolean;
     loaded: boolean;
 } => {
     const requestSignature = JSON.stringify({ pagination, sort, filter });
 
-    const { data: ids, total, error, loading, loaded } = useQueryWithStore(
+    const {
+        data: ids,
+        total,
+        meta,
+        error,
+        loading,
+        loaded,
+    } = useQueryWithStore(
         { type: 'getList', resource, payload: { pagination, sort, filter } },
         options,
         // data selector (may return [])
@@ -85,6 +93,14 @@ const useGetList = <RecordType = Record>(
                 'cachedRequests',
                 requestSignature,
                 'total',
+            ]),
+        // meta selector (may return undefined)
+        (state: ReduxState): object =>
+            get(state.admin.resources, [
+                resource,
+                'cachedRequests',
+                requestSignature,
+                'meta',
             ])
     );
 
@@ -104,7 +120,7 @@ const useGetList = <RecordType = Record>(
             }, {});
     }, shallowEqual);
 
-    return { data, ids, total, error, loading, loaded };
+    return { data, ids, total, meta, error, loading, loaded };
 };
 
 export default useGetList;

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -5,6 +5,7 @@ import useQueryWithStore from './useQueryWithStore';
 import {
     getReferences,
     getIds,
+    getMeta,
     getTotal,
     nameRelatedTo,
 } from '../reducer/admin/references/oneToMany';
@@ -17,7 +18,7 @@ import { useMemo } from 'react';
  * The return value updates according to the request state:
  *
  * - start: { loading: true, loaded: false }
- * - success: { data: [data from store], ids: [ids from response], total: [total from response], loading: false, loaded: true }
+ * - success: { data: [data from store], ids: [ids from response], total: [total from response], meta: [meta information from response], loading: false, loaded: true }
  * - error: { error: [error from response], loading: false, loaded: true }
  *
  * This hook will return the cached result when called a second time
@@ -32,7 +33,7 @@ import { useMemo } from 'react';
  * @param {string} referencingResource The resource name, e.g. 'posts'. Used to generate a cache key
  * @param {Object} options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as { data, total, ids, error, loading, loaded }.
+ * @returns The current request state. Destructure as { data, total, ids, meta, error, loading, loaded }.
  *
  * @example
  *
@@ -70,7 +71,14 @@ const useGetManyReference = (
         [filter, resource, id, referencingResource, target]
     );
 
-    const { data: ids, total, error, loading, loaded } = useQueryWithStore(
+    const {
+        data: ids,
+        total,
+        meta,
+        error,
+        loading,
+        loaded,
+    } = useQueryWithStore(
         {
             type: 'getManyReference',
             resource: resource,
@@ -78,11 +86,12 @@ const useGetManyReference = (
         },
         { ...options, relatedTo, action: CRUD_GET_MANY_REFERENCE },
         selectIds(relatedTo),
-        selectTotal(relatedTo)
+        selectTotal(relatedTo),
+        selectMeta(relatedTo)
     );
     const data = useSelector(selectData(resource, relatedTo), shallowEqual);
 
-    return { data, ids, total, error, loading, loaded };
+    return { data, ids, total, meta, error, loading, loaded };
 };
 
 export default useGetManyReference;
@@ -96,3 +105,6 @@ const selectIds = (relatedTo: string) => (state: ReduxState) =>
 
 const selectTotal = (relatedTo: string) => (state: ReduxState) =>
     getTotal(state, relatedTo);
+
+const selectMeta = (relatedTo: string) => (state: ReduxState) =>
+    getMeta(state, relatedTo);

--- a/packages/ra-core/src/dataProvider/useGetMatching.ts
+++ b/packages/ra-core/src/dataProvider/useGetMatching.ts
@@ -23,7 +23,7 @@ const referenceSource = (resource, source) => `${resource}@${source}`;
  * The return value updates according to the request state:
  *
  * - start: { loading: true, loaded: false }
- * - success: { data: [data from store], ids: [ids from response], total: [total from response], loading: false, loaded: true }
+ * - success: { data: [data from store], ids: [ids from response], total: [total from response], meta: [meta information from response], loading: false, loaded: true }
  * - error: { error: [error from response], loading: false, loaded: true }
  *
  * This hook will return the cached result when called a second time
@@ -37,7 +37,7 @@ const referenceSource = (resource, source) => `${resource}@${source}`;
  * @param {string} referencingResource The resource name, e.g. 'posts'. Used to build a cache key
  * @param {Object} options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as { data, total, ids, error, loading, loaded }.
+ * @returns The current request state. Destructure as { data, total, ids, meta, error, loading, loaded }.
  *
  * @example
  *
@@ -74,6 +74,7 @@ const useGetMatching = (
     const {
         data: possibleValues,
         total,
+        meta,
         error,
         loading,
         loaded,
@@ -105,6 +106,12 @@ const useGetMatching = (
                     'total',
                 ],
                 null
+            ),
+        (state: ReduxState) =>
+            get(
+                state.admin.resources,
+                [resource, 'cachedRequests', JSON.stringify(payload), 'meta'],
+                null
             )
     );
 
@@ -124,6 +131,7 @@ const useGetMatching = (
         data: possibleReferences,
         ids: possibleValues,
         total,
+        meta,
         error,
         loading,
         loaded,
@@ -134,6 +142,7 @@ interface UseGetMatchingResult {
     data: Record[];
     ids: Identifier[];
     total: number;
+    meta: object;
     error?: any;
     loading: boolean;
     loaded: boolean;

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -41,7 +41,7 @@ import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDecl
  *
  * - mount:         [mutate, { loading: false, loaded: false }]
  * - mutate called: [mutate, { loading: true, loaded: false }]
- * - success:       [mutate, { data: [data from response], total: [total from response], loading: false, loaded: true }]
+ * - success:       [mutate, { data: [data from response], total: [total from response], meta: [meta information from response], loading: false, loaded: true }]
  * - error:         [mutate, { error: [error from response], loading: false, loaded: true }]
  *
  * The mutate function accepts the following arguments
@@ -128,6 +128,7 @@ const useMutation = (
         data: null,
         error: null,
         total: null,
+        meta: null,
         loading: false,
         loaded: false,
     });
@@ -161,10 +162,11 @@ const useMutation = (
                 params.payload,
                 params.options
             )
-                .then(({ data, total }) => {
+                .then(({ data, total, meta }) => {
                     setState({
                         data,
                         total,
+                        meta,
                         loading: false,
                         loaded: true,
                     });
@@ -209,6 +211,7 @@ export type UseMutationValue = [
     {
         data?: any;
         total?: number;
+        meta?: object;
         error?: any;
         loading: boolean;
         loaded: boolean;

--- a/packages/ra-core/src/dataProvider/useQuery.ts
+++ b/packages/ra-core/src/dataProvider/useQuery.ts
@@ -10,7 +10,7 @@ import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDecl
  * The return value updates according to the request state:
  *
  * - start: { loading: true, loaded: false }
- * - success: { data: [data from response], total: [total from response], loading: false, loaded: true }
+ * - success: { data: [data from response], total: [total from response], meta: [meta information from response], loading: false, loaded: true }
  * - error: { error: [error from response], loading: false, loaded: true }
  *
  * @param {Object} query
@@ -23,7 +23,7 @@ import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDecl
  * @param {Function} options.onFailure Side effect function to be executed upon failure, e.g. { onFailure: error => notify(error.message) } }
  * @param {boolean} options.withDeclarativeSideEffectsSupport Set to true to support legacy side effects (e.g. { onSuccess: { refresh: true } })
  *
- * @returns The current request state. Destructure as { data, total, error, loading, loaded }.
+ * @returns The current request state. Destructure as { data, total, meta, error, loading, loaded }.
  *
  * @example
  *
@@ -73,6 +73,7 @@ const useQuery = (query: Query, options: QueryOptions = {}): UseQueryValue => {
         data: undefined,
         error: null,
         total: null,
+        meta: null,
         loading: true,
         loaded: false,
     });
@@ -93,10 +94,11 @@ const useQuery = (query: Query, options: QueryOptions = {}): UseQueryValue => {
         setState(prevState => ({ ...prevState, loading: true }));
 
         dataProviderWithSideEffects[type](resource, payload, rest)
-            .then(({ data, total }) => {
+            .then(({ data, total, meta }) => {
                 setState({
                     data,
                     total,
+                    meta,
                     loading: false,
                     loaded: true,
                 });
@@ -136,6 +138,7 @@ export interface QueryOptions {
 export type UseQueryValue = {
     data?: any;
     total?: number;
+    meta?: object;
     error?: any;
     loading: boolean;
     loaded: boolean;

--- a/packages/ra-core/src/dataProvider/useQueryWithStore.ts
+++ b/packages/ra-core/src/dataProvider/useQueryWithStore.ts
@@ -17,6 +17,7 @@ export interface Query {
 export interface StateResult {
     data?: any;
     total?: number;
+    meta?: object;
     error?: any;
     loading: boolean;
     loaded: boolean;
@@ -64,13 +65,20 @@ const defaultTotalSelector = query => (state: ReduxState) => {
         : null;
 };
 
+const defaultMetaSelector = query => (state: ReduxState) => {
+    const key = JSON.stringify({ ...query, type: getFetchType(query.type) });
+    return state.admin.customQueries[key]
+        ? state.admin.customQueries[key].meta
+        : null;
+};
+
 /**
  * Fetch the data provider through Redux, return the value from the store.
  *
  * The return value updates according to the request state:
  *
  * - start: { loading: true, loaded: false }
- * - success: { data: [data from response], total: [total from response], loading: false, loaded: true }
+ * - success: { data: [data from response], total: [total from response], meta: [meta information from response], loading: false, loaded: true }
  * - error: { error: [error from response], loading: false, loaded: true }
  *
  * This hook will return the cached result when called a second time
@@ -86,8 +94,9 @@ const defaultTotalSelector = query => (state: ReduxState) => {
  * @param {Function} options.onFailure Side effect function to be executed upon failure, e.g. { onFailure: error => notify(error.message) } }
  * @param {Function} dataSelector Redux selector to get the result. Required.
  * @param {Function} totalSelector Redux selector to get the total (optional, only for LIST queries)
+ * @param {Function} metaSelector Redux selector to get meta information (optional)
  *
- * @returns The current request state. Destructure as { data, total, error, loading, loaded }.
+ * @returns The current request state. Destructure as { data, total, meta, error, loading, loaded }.
  *
  * @example
  *
@@ -112,10 +121,12 @@ const useQueryWithStore = (
     query: Query,
     options: QueryOptions = { action: 'CUSTOM_QUERY' },
     dataSelector: (state: ReduxState) => any = defaultDataSelector(query),
-    totalSelector: (state: ReduxState) => number = defaultTotalSelector(query)
+    totalSelector: (state: ReduxState) => number = defaultTotalSelector(query),
+    metaSelector: (state: ReduxState) => object = defaultMetaSelector(query)
 ): {
     data?: any;
     total?: number;
+    meta?: object;
     error?: any;
     loading: boolean;
     loaded: boolean;
@@ -126,12 +137,14 @@ const useQueryWithStore = (
     const requestSignatureRef = useRef(requestSignature);
     const data = useSelector(dataSelector);
     const total = useSelector(totalSelector);
+    const meta = useSelector(metaSelector);
     const [state, setState]: [
         StateResult,
         (StateResult) => void
     ] = useSafeSetState({
         data,
         total,
+        meta,
         error: null,
         loading: true,
         loaded: data !== undefined && !isEmptyList(data),
@@ -144,12 +157,13 @@ const useQueryWithStore = (
             setState({
                 data,
                 total,
+                meta,
                 error: null,
                 loading: true,
                 loaded: data !== undefined && !isEmptyList(data),
             });
         }
-    }, [data, requestSignature, setState, total]);
+    }, [data, requestSignature, setState, total, meta]);
 
     useEffect(() => {
         const signaturesAreEqual =
@@ -157,7 +171,9 @@ const useQueryWithStore = (
 
         if (
             signaturesAreEqual &&
-            (!isEqual(state.data, data) || state.total !== total)
+            (!isEqual(state.data, data) ||
+                state.total !== total ||
+                !isEqual(state.meta, meta))
         ) {
             // the dataProvider response arrived in the Redux store
             if (typeof total !== 'undefined' && isNaN(total)) {
@@ -169,11 +185,12 @@ const useQueryWithStore = (
                     ...prevState,
                     data,
                     total,
+                    meta,
                     loaded: true,
                 }));
             }
         }
-    }, [data, requestSignature, setState, state, total]);
+    }, [data, requestSignature, setState, state, total, meta]);
 
     const dataProvider = useDataProvider();
     useEffect(() => {

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -7,7 +7,7 @@ import useMutation from './useMutation';
  * The return value updates according to the request state:
  *
  * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
+ * - success: [callback, { data: [data from response], meta: [meta information from response], loading: false, loaded: true }]
  * - error: [callback, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
@@ -16,7 +16,7 @@ import useMutation from './useMutation';
  * @param previousData The record before the update is applied
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [update, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [update, { data, meta, error, loading, loaded }].
  *
  * @example
  *

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -8,7 +8,7 @@ import { Identifier } from '../types';
  * The return value updates according to the request state:
  *
  * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
+ * - success: [callback, { data: [data from response], meta: [meta information from response], loading: false, loaded: true }]
  * - error: [callback, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
@@ -16,7 +16,7 @@ import { Identifier } from '../types';
  * @param data The updates to merge into all records, e.g. { views: 10 }
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success of failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [update, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [update, { data, meta, error, loading, loaded }].
  *
  * @example
  *

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.ts
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.ts
@@ -10,7 +10,7 @@ import { DELETE, DELETE_MANY } from '../../../core';
 const initialState = {};
 
 export interface OneToManyState {
-    [relatedTo: string]: { ids: Identifier[]; total: number };
+    [relatedTo: string]: { ids: Identifier[]; total: number; meta: object };
 }
 
 type ActionTypes =
@@ -49,6 +49,7 @@ const oneToManyReducer: Reducer<OneToManyState> = (
                 [action.meta.relatedTo]: {
                     ids: action.payload.data.map(record => record.id),
                     total: action.payload.total,
+                    meta: action.payload.meta,
                 },
             };
 
@@ -64,6 +65,10 @@ export const getIds = (state: ReduxState, relatedTo: string) =>
 export const getTotal = (state: ReduxState, relatedTo: string) =>
     state.admin.references.oneToMany[relatedTo] &&
     state.admin.references.oneToMany[relatedTo].total;
+
+export const getMeta = (state: ReduxState, relatedTo: string) =>
+    state.admin.references.oneToMany[relatedTo] &&
+    state.admin.references.oneToMany[relatedTo].meta;
 
 export const getReferences = (state: ReduxState, reference, relatedTo) => {
     const ids = getIds(state, relatedTo);
@@ -160,6 +165,7 @@ const removeDeletedReferences = (removedIds: Identifier[]) => (
         [key]: {
             ids: idsToKeep,
             total: idsToKeep.length,
+            meta: previousState[key].meta,
         },
     };
 };

--- a/packages/ra-core/src/reducer/admin/resource/cachedRequests.ts
+++ b/packages/ra-core/src/reducer/admin/resource/cachedRequests.ts
@@ -1,0 +1,42 @@
+import { Reducer } from 'redux';
+
+import { FETCH_END, REFRESH_VIEW } from '../../../actions';
+import meta from './cachedRequests/meta';
+interface CachedRequestState {
+    meta: object;
+}
+
+interface State {
+    [key: string]: CachedRequestState;
+}
+
+const initialState = {};
+const initialSubstate = { meta: {} };
+
+const cachedRequestsReducer: Reducer<State> = (
+    previousState = initialState,
+    action
+) => {
+    if (action.type === REFRESH_VIEW) {
+        // force refresh
+        return initialState;
+    }
+    if (!action.meta || action.meta.fetchStatus !== FETCH_END) {
+        // not a return from the dataProvider
+        return previousState;
+    }
+    if (action.meta.fromCache) {
+        // looks like a cached response
+        return previousState;
+    }
+    const requestKey = JSON.stringify(action.requestPayload);
+    const previousSubState = previousState[requestKey] || initialSubstate;
+    return {
+        ...previousState,
+        [requestKey]: {
+            meta: meta(previousSubState.meta, action),
+        },
+    };
+};
+
+export default cachedRequestsReducer;

--- a/packages/ra-core/src/reducer/admin/resource/cachedRequests/meta.ts
+++ b/packages/ra-core/src/reducer/admin/resource/cachedRequests/meta.ts
@@ -1,0 +1,52 @@
+import { Reducer } from 'redux';
+import { FETCH_END, REFRESH_VIEW } from '../../../../actions';
+import {
+    CREATE,
+    DELETE,
+    DELETE_MANY,
+    GET_LIST,
+    GET_MANY,
+    GET_MANY_REFERENCE,
+    GET_ONE,
+    UPDATE,
+    UPDATE_MANY,
+} from '../../../../core';
+
+type State = object;
+
+const initialState = {};
+
+const metaReducer: Reducer<State> = (
+    previousState = initialState,
+    { type, payload, meta }
+) => {
+    if (type === REFRESH_VIEW) {
+        return initialState;
+    }
+    if (
+        !meta ||
+        !meta.fetchResponse ||
+        meta.fetchStatus !== FETCH_END ||
+        meta.fromCache === true
+    ) {
+        return previousState;
+    }
+    if (payload.meta) {
+        switch (meta.fetchResponse) {
+            case GET_LIST:
+            case GET_ONE:
+            case GET_MANY:
+            case GET_MANY_REFERENCE:
+            case UPDATE:
+            case UPDATE_MANY:
+            case CREATE:
+            case DELETE:
+            case DELETE_MANY:
+                return payload.meta;
+            default:
+                return previousState;
+        }
+    }
+};
+
+export default metaReducer;

--- a/packages/ra-core/src/reducer/admin/resource/index.spec.ts
+++ b/packages/ra-core/src/reducer/admin/resource/index.spec.ts
@@ -19,6 +19,7 @@ describe('Resources Reducer', () => {
             reducer(
                 {
                     posts: {
+                        cachedRequests: {},
                         data: {},
                         list: {
                             params: {
@@ -39,6 +40,7 @@ describe('Resources Reducer', () => {
                         props: { name: 'posts' },
                     },
                     comments: {
+                        cachedRequests: {},
                         data: {},
                         list: {
                             params: {
@@ -69,6 +71,7 @@ describe('Resources Reducer', () => {
             )
         ).toEqual({
             posts: {
+                cachedRequests: {},
                 data: {},
                 list: {
                     params: {
@@ -89,6 +92,7 @@ describe('Resources Reducer', () => {
                 props: { name: 'posts' },
             },
             comments: {
+                cachedRequests: {},
                 data: {},
                 list: {
                     params: {
@@ -109,6 +113,7 @@ describe('Resources Reducer', () => {
                 props: { name: 'comments' },
             },
             users: {
+                cachedRequests: {},
                 data: {},
                 list: {
                     params: {
@@ -136,6 +141,7 @@ describe('Resources Reducer', () => {
             reducer(
                 {
                     posts: {
+                        cachedRequests: {},
                         data: {},
                         list: {
                             params: {
@@ -156,6 +162,7 @@ describe('Resources Reducer', () => {
                         props: { name: 'posts' },
                     },
                     comments: {
+                        cachedRequests: {},
                         data: {},
                         list: {
                             params: {
@@ -183,6 +190,7 @@ describe('Resources Reducer', () => {
             )
         ).toEqual({
             posts: {
+                cachedRequests: {},
                 data: {},
                 list: {
                     params: {
@@ -210,6 +218,7 @@ describe('Resources Reducer', () => {
             reducer(
                 {
                     posts: {
+                        cachedRequests: {},
                         data: {},
                         list: {
                             params: {
@@ -230,6 +239,7 @@ describe('Resources Reducer', () => {
                         props: { name: 'posts' },
                     },
                     comments: {
+                        cachedRequests: {},
                         data: {},
                         list: {
                             params: {
@@ -265,6 +275,7 @@ describe('Resources Reducer', () => {
             )
         ).toEqual({
             posts: {
+                cachedRequests: {},
                 data: {},
                 list: {
                     params: {
@@ -285,6 +296,7 @@ describe('Resources Reducer', () => {
                 props: { name: 'posts' },
             },
             comments: {
+                cachedRequests: {},
                 data: {},
                 list: {
                     params: {

--- a/packages/ra-core/src/reducer/admin/resource/index.ts
+++ b/packages/ra-core/src/reducer/admin/resource/index.ts
@@ -7,6 +7,7 @@ import {
     RefreshViewAction,
 } from '../../../actions';
 
+import cachedRequests from './cachedRequests';
 import data from './data';
 import list from './list';
 import validity from './validity';
@@ -25,6 +26,7 @@ export default (previousState = initialState, action: ActionTypes) => {
             props: action.payload,
             data: data(undefined, action),
             list: list(undefined, action),
+            cachedRequests: cachedRequests(undefined, action),
             validity: validity(undefined, action),
         };
         return {
@@ -61,6 +63,10 @@ export default (previousState = initialState, action: ActionTypes) => {
                           props: previousState[resource].props,
                           data: data(previousState[resource].data, action),
                           list: list(previousState[resource].list, action),
+                          cachedRequests: cachedRequests(
+                              previousState[resource].cachedRequests,
+                              action
+                          ),
                           validity: validity(
                               previousState[resource].validity,
                               action

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -121,6 +121,7 @@ export interface GetListResult {
     data: Record[];
     total: number;
     validUntil?: ValidUntil;
+    meta?: object;
 }
 
 export interface GetOneParams {
@@ -129,6 +130,7 @@ export interface GetOneParams {
 export interface GetOneResult {
     data: Record;
     validUntil?: ValidUntil;
+    meta?: object;
 }
 
 export interface GetManyParams {
@@ -136,6 +138,7 @@ export interface GetManyParams {
 }
 export interface GetManyResult {
     data: Record[];
+    meta?: object;
     validUntil?: ValidUntil;
 }
 
@@ -150,6 +153,7 @@ export interface GetManyReferenceResult {
     data: Record[];
     total: number;
     validUntil?: ValidUntil;
+    meta?: object;
 }
 
 export interface UpdateParams {
@@ -160,6 +164,7 @@ export interface UpdateParams {
 export interface UpdateResult {
     data: Record;
     validUntil?: ValidUntil;
+    meta?: object;
 }
 
 export interface UpdateManyParams {
@@ -169,6 +174,7 @@ export interface UpdateManyParams {
 export interface UpdateManyResult {
     data?: Identifier[];
     validUntil?: ValidUntil;
+    meta?: object;
 }
 
 export interface CreateParams {
@@ -177,6 +183,7 @@ export interface CreateParams {
 export interface CreateResult {
     data: Record;
     validUntil?: ValidUntil;
+    meta?: object;
 }
 
 export interface DeleteParams {
@@ -185,6 +192,7 @@ export interface DeleteParams {
 }
 export interface DeleteResult {
     data?: Record;
+    meta?: object;
 }
 
 export interface DeleteManyParams {
@@ -192,6 +200,7 @@ export interface DeleteManyParams {
 }
 export interface DeleteManyResult {
     data?: Identifier[];
+    meta?: object;
 }
 
 export type DataProviderResult =
@@ -297,9 +306,11 @@ export interface ReduxState {
                 };
                 list: {
                     cachedRequests?: {
-                        ids: Identifier[];
-                        total: number;
-                        validity: Date;
+                        [key: string]: {
+                            ids: Identifier[];
+                            total: number;
+                            validity: Date;
+                        };
                     };
                     expanded: Identifier[];
                     ids: Identifier[];
@@ -307,6 +318,11 @@ export interface ReduxState {
                     params: any;
                     selectedIds: Identifier[];
                     total: number;
+                };
+                cachedRequests?: {
+                    [key: string]: {
+                        meta: object;
+                    };
                 };
                 validity: {
                     [key: string]: Date;
@@ -316,7 +332,11 @@ export interface ReduxState {
         };
         references: {
             oneToMany: {
-                [relatedTo: string]: { ids: Identifier[]; total: number };
+                [relatedTo: string]: {
+                    ids: Identifier[];
+                    total: number;
+                    meta: object;
+                };
             };
         };
         loading: number;

--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -116,6 +116,7 @@ Pagination.propTypes = {
     setPage: PropTypes.func,
     setPerPage: PropTypes.func,
     total: PropTypes.number,
+    meta: PropTypes.object,
 };
 
 Pagination.defaultProps = {


### PR DESCRIPTION
Add a `meta` object to be returned by any method of a data provider.

This allows to add some information about the response.

It could be useful for a lot of things, for instance to tell if a pagination is partial or not (https://github.com/api-platform/admin/pull/297, see comment from @fzaninotto https://github.com/api-platform/admin/pull/297#issuecomment-627817098) or to add cursor-based pagination information (https://github.com/marmelab/react-admin/issues/1510).