### PR TITLE
Update documentation for delete

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -345,7 +345,7 @@ Method             | Response format
 `create`           | `{ data: {Record} }`
 `update`           | `{ data: {Record} }`
 `updateMany`       | `{ data: {mixed[]} }` The ids which have been updated
-`delete`           | `{ data: {Record|null} }` The record that has been deleted (optional)
+`delete`           | `{ data: {Record} }` The record that has been deleted
 `deleteMany`       | `{ data: {mixed[]} }` The ids of the deleted records (optional)
 
 A `{Record}` is an object literal with at least an `id` property, e.g. `{ id: 123, title: "hello, world" }`.


### PR DESCRIPTION
`id` of deleted record is required in `selectedIdsReducer`.

https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/reducer/admin/resource/list/selectedIds.ts#L51

Returning null as documentation stated, would raise Error:

```
index.js:1 TypeError: Cannot read property 'id' of null
    at selectedIdsReducer (selectedIds.js:19)
    at combination (redux.js:459)
    at index.js:46
    at Array.reduce (<anonymous>)
    at index.js:40
    at combination (redux.js:459)
    at combination (redux.js:459)
    at resettableAppReducer (createAdminStore.js:50)
    at dispatch (redux.js:213)
    at middleware.js:22
    at redux-saga-core.esm.js:1410
    at useDataProvider.js:291
```