### PR TITLE
[Docs] Changing Firestore Dataprovider

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -68,8 +68,8 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[Django Rest Framework](https://www.django-rest-framework.org/)**: [synaptic-cl/ra-data-drf](https://github.com/synaptic-cl/ra-data-drf)
 * **[Express & Sequelize](https://github.com/lalalilo/express-sequelize-crud)**: [express-sequelize-crud](https://github.com/lalalilo/express-sequelize-crud)
 * **[Feathersjs](http://www.feathersjs.com/)**: [josx/ra-data-feathers](https://github.com/josx/ra-data-feathers)
-* **[Firebase](https://firebase.google.com/docs/database)**: [aymendhaya/ra-data-firebase-client](https://github.com/aymendhaya/ra-data-firebase-client).
-* **[Firestore](https://firebase.google.com/docs/firestore)**: [rafalzawadzki/ra-data-firestore-client](https://github.com/rafalzawadzki/ra-data-firestore-client).
+* **[Firebase Firestore](https://firebase.google.com/docs/firestore)**: [benwinding/react-admin-firebase](https://github.com/benwinding/react-admin-firebase).
+* **[Firebase Realtime Database](https://firebase.google.com/docs/database)**: [aymendhaya/ra-data-firebase-client](https://github.com/aymendhaya/ra-data-firebase-client).
 * **[GraphCool](http://www.graph.cool/)**: [marmelab/ra-data-graphcool](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphcool) (uses [Apollo](http://www.apollodata.com/))
 * **[GraphQL](http://graphql.org/)**: [marmelab/ra-data-graphql](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql) (uses [Apollo](http://www.apollodata.com/))
 * **[HAL](http://stateless.co/hal_specification.html)**: [b-social/ra-data-hal](https://github.com/b-social/ra-data-hal)


### PR DESCRIPTION
The maintainer of the current Firestore DataProvider in the docs ([rafalzawadzki/ra-data-firestore-client](https://github.com/rafalzawadzki/ra-data-firestore-client)) has agreed to retire his project and is advising people move to the newer Firestore DataProvider ([benwinding/react-admin-firebase](https://github.com/benwinding/react-admin-firebase)) which supports `react-admin` v3.

Comment from maintainer: https://github.com/benwinding/react-admin-firebase/issues/72#issuecomment-633595970

### In the PR
- Changed the Firestore provider to [benwinding/react-admin-firebase](https://github.com/benwinding/react-admin-firebase)
- Improved dataprovider labels, as they're both technically Firebase databases, but the names are a little more specific (to avoid confusion).
  - Firebase Realtime Database is 
  - Firebase Firestore 
![image](https://user-images.githubusercontent.com/11782590/82852110-19a29f00-9f41-11ea-8a86-80d1132b44e2.png)

- Reordered labels alphabetically

Let me know if there's any issues, or anything else you need.

Kind regards,
Ben