### PR TITLE
Add ability to create custom DeleteButton views without rewriting the logic

### DIFF
--- a/packages/ra-core/src/controller/button/index.ts
+++ b/packages/ra-core/src/controller/button/index.ts
@@ -1,0 +1,4 @@
+import useDeleteWithUndoController from './useDeleteWithUndoController';
+import useDeleteWithConfirmController from './useDeleteWithConfirmController';
+
+export { useDeleteWithUndoController, useDeleteWithConfirmController };

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -1,0 +1,140 @@
+import {
+    useState,
+    useCallback,
+    ReactEventHandler,
+    SyntheticEvent,
+} from 'react';
+import { useDelete } from '../../dataProvider';
+import { CRUD_DELETE } from '../../actions';
+import {
+    useRefresh,
+    useNotify,
+    useRedirect,
+    RedirectionSideEffect,
+} from '../../sideEffect';
+import { Record } from '../../types';
+
+/**
+ * Prepare a set of callbacks for a delete button guarded by confirmation dialog
+ *
+ * @example
+ *
+ * const DeleteButton = ({
+ *     resource,
+ *     record,
+ *     basePath,
+ *     redirect,
+ *     onClick,
+ *     ...rest
+ * }) => {
+ *     const {
+ *         open,
+ *         loading,
+ *         handleDialogOpen,
+ *         handleDialogClose,
+ *         handleDelete,
+ *     } = useDeleteWithConfirmController({
+ *         resource,
+ *         record,
+ *         redirect,
+ *         basePath,
+ *         onClick,
+ *     });
+ *
+ *     return (
+ *         <Fragment>
+ *             <Button
+ *                 onClick={handleDialogOpen}
+ *                 label="ra.action.delete"
+ *                 {...rest}
+ *             >
+ *                 {icon}
+ *             </Button>
+ *             <Confirm
+ *                 isOpen={open}
+ *                 loading={loading}
+ *                 title="ra.message.delete_title"
+ *                 content="ra.message.delete_content"
+ *                 translateOptions={{
+ *                     name: resource,
+ *                     id: record.id,
+ *                 }}
+ *                 onConfirm={handleDelete}
+ *                 onClose={handleDialogClose}
+ *             />
+ *         </Fragment>
+ *     );
+ * };
+ */
+const useDeleteWithConfirmController = ({
+    resource,
+    record,
+    redirect: redirectTo,
+    basePath,
+    onClick,
+}: UseDeleteWithConfirmControllerParams): UseDeleteWithConfirmControllerReturn => {
+    const [open, setOpen] = useState(false);
+    const notify = useNotify();
+    const redirect = useRedirect();
+    const refresh = useRefresh();
+    const [deleteOne, { loading }] = useDelete(resource, null, null, {
+        action: CRUD_DELETE,
+        onSuccess: () => {
+            notify('ra.notification.deleted', 'info', { smart_count: 1 });
+            redirect(redirectTo, basePath);
+            refresh();
+        },
+        onFailure: error => {
+            notify(
+                typeof error === 'string'
+                    ? error
+                    : error.message || 'ra.notification.http_error',
+                'warning'
+            );
+            setOpen(false);
+        },
+        undoable: false,
+    });
+
+    const handleDialogOpen = e => {
+        setOpen(true);
+        e.stopPropagation();
+    };
+
+    const handleDialogClose = e => {
+        setOpen(false);
+        e.stopPropagation();
+    };
+
+    const handleDelete = useCallback(
+        event => {
+            deleteOne({
+                payload: { id: record.id, previousData: record },
+            });
+            if (typeof onClick === 'function') {
+                onClick(event);
+            }
+        },
+        [deleteOne, onClick, record]
+    );
+
+    return { open, loading, handleDialogOpen, handleDialogClose, handleDelete };
+};
+
+export interface UseDeleteWithConfirmControllerParams {
+    basePath?: string;
+    record?: Record;
+    redirect?: RedirectionSideEffect;
+    resource: string;
+    onClick?: ReactEventHandler<any>;
+}
+
+export interface UseDeleteWithConfirmControllerReturn {
+    open: boolean;
+    loading: boolean;
+    handleDialogOpen: (e: SyntheticEvent) => void;
+    handleDialogClose: (e: SyntheticEvent) => void;
+    handleDelete: ReactEventHandler<any>;
+}
+
+export default useDeleteWithConfirmController;

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -1,0 +1,105 @@
+import { useCallback, ReactEventHandler } from 'react';
+import { useDelete } from '../../dataProvider';
+import { CRUD_DELETE } from '../../actions';
+import {
+    useRefresh,
+    useNotify,
+    useRedirect,
+    RedirectionSideEffect,
+} from '../../sideEffect';
+import { Record } from '../../types';
+
+/**
+ * Prepare callback for a Delete button with undo support
+ *
+ * @example
+ *
+ * import React from 'react';
+ * import ActionDelete from '@material-ui/icons/Delete';
+ * import { Button, useDeleteWithUndoController } from 'react-admin';
+ *
+ * const DeleteButton = ({
+ *     resource,
+ *     record,
+ *     basePath,
+ *     redirect,
+ *     onClick,
+ *     ...rest
+ * }) => {
+ *     const { loading, handleDelete } = useDeleteWithUndoController({
+ *         resource,
+ *         record,
+ *         basePath,
+ *         redirect,
+ *         onClick,
+ *     });
+ *
+ *     return (
+ *         <Button
+ *             onClick={handleDelete}
+ *             disabled={loading}
+ *             label="ra.action.delete"
+ *             {...rest}
+ *         >
+ *             <ActionDelete />
+ *         </Button>
+ *     );
+ * };
+ */
+const useDeleteWithUndoController = ({
+    resource,
+    record,
+    basePath,
+    redirect: redirectTo = 'list',
+    onClick,
+}: UseDeleteWithUndoControllerParams): UseDeleteWithUndoControllerReturn => {
+    const notify = useNotify();
+    const redirect = useRedirect();
+    const refresh = useRefresh();
+
+    const [deleteOne, { loading }] = useDelete(resource, null, null, {
+        action: CRUD_DELETE,
+        onSuccess: () => {
+            notify('ra.notification.deleted', 'info', { smart_count: 1 }, true);
+            redirect(redirectTo, basePath);
+            refresh();
+        },
+        onFailure: error =>
+            notify(
+                typeof error === 'string'
+                    ? error
+                    : error.message || 'ra.notification.http_error',
+                'warning'
+            ),
+        undoable: true,
+    });
+    const handleDelete = useCallback(
+        event => {
+            event.stopPropagation();
+            deleteOne({
+                payload: { id: record.id, previousData: record },
+            });
+            if (typeof onClick === 'function') {
+                onClick(event);
+            }
+        },
+        [deleteOne, onClick, record]
+    );
+
+    return { loading, handleDelete };
+};
+
+export interface UseDeleteWithUndoControllerParams {
+    basePath?: string;
+    record?: Record;
+    redirect?: RedirectionSideEffect;
+    resource: string;
+    onClick?: ReactEventHandler<any>;
+}
+
+export interface UseDeleteWithUndoControllerReturn {
+    loading: boolean;
+    handleDelete: ReactEventHandler<any>;
+}
+
+export default useDeleteWithUndoController;

--- a/packages/ra-core/src/controller/index.ts
+++ b/packages/ra-core/src/controller/index.ts
@@ -46,3 +46,4 @@ export {
 
 export * from './field';
 export * from './input';
+export * from './button';

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -137,7 +137,6 @@ interface Props {
     label?: string;
     size?: 'small' | 'medium' | 'large';
     icon?: ReactElement;
-    onClick?: (e: MouseEvent) => void;
     redirect?: RedirectionSideEffect;
     variant?: string;
     // May be injected by Toolbar

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
@@ -1,17 +1,18 @@
-import React, { useCallback, FC, ReactElement, SyntheticEvent } from 'react';
+import React, {
+    FC,
+    ReactElement,
+    ReactEventHandler,
+    SyntheticEvent,
+} from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import ActionDelete from '@material-ui/icons/Delete';
 import classnames from 'classnames';
 import {
-    useDelete,
-    useRefresh,
-    useNotify,
-    useRedirect,
-    CRUD_DELETE,
     Record,
     RedirectionSideEffect,
+    useDeleteWithUndoController,
 } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
@@ -26,42 +27,17 @@ const DeleteWithUndoButton: FC<DeleteWithUndoButtonProps> = props => {
         resource,
         record,
         basePath,
-        redirect: redirectTo = 'list',
+        redirect = 'list',
         ...rest
     } = props;
     const classes = useStyles(props);
-    const notify = useNotify();
-    const redirect = useRedirect();
-    const refresh = useRefresh();
-
-    const [deleteOne, { loading }] = useDelete(resource, null, null, {
-        action: CRUD_DELETE,
-        onSuccess: () => {
-            notify('ra.notification.deleted', 'info', { smart_count: 1 }, true);
-            redirect(redirectTo, basePath);
-            refresh();
-        },
-        onFailure: error =>
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                'warning'
-            ),
-        undoable: true,
+    const { loading, handleDelete } = useDeleteWithUndoController({
+        resource,
+        record,
+        basePath,
+        redirect,
+        onClick,
     });
-    const handleDelete = useCallback(
-        event => {
-            event.stopPropagation();
-            deleteOne({
-                payload: { id: record.id, previousData: record },
-            });
-            if (typeof onClick === 'function') {
-                onClick(event);
-            }
-        },
-        [deleteOne, onClick, record]
-    );
 
     return (
         <Button
@@ -103,7 +79,7 @@ interface Props {
     className?: string;
     icon?: ReactElement;
     label?: string;
-    onClick?: (e: MouseEvent) => void;
+    onClick?: ReactEventHandler<any>;
     record?: Record;
     redirect?: RedirectionSideEffect;
     resource?: string;


### PR DESCRIPTION
I wanted a DeleteIconButton, and I found myself copying the DeleteButton logic code. Better move it to `ra-core`.  