### PR TITLE
fix: ReferenceArrayInput might pass non-array to children as values

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
@@ -97,7 +97,7 @@ const ReferenceArrayInput = ({
     onFocus,
     validate,
     parse,
-    format,
+    format = v => (Array.isArray(v) ? v : []),
     ...props
 }) => {
     if (React.Children.count(children) !== 1) {


### PR DESCRIPTION
I noticed that when you use multiple Filters using the same resource (or a sub-property) and one uses a `ReferenceArrayInput`, it might receive its value from another filter. When this is not an array, it will crash, at it will assume that the value is an array.

E.g. consider these filters:

```
 <ReferenceInput label="School" source="user.school"  reference="School">
   <AutocompleteInput {... some props} />
</ReferenceInput>
 <ReferenceArrayInput label="Teacher" source="user"  reference="User">
   <AutocompleteInput {... some props} />
</ReferenceArrayInput>
   
```

the second one will receive a value of `{ school: { id: "some-schoolId", ...}}` and therefore crash

The quickfix is to define a format, altough this is not so obvious.

```
  format={(e) => {
        if (Array.isArray(e)) {
          return e;
        }
        return [];
      }}
```

I think it makes sense to define that as default for `ReferenceArrayInput` as they assume that if they have a non-falsy value, it is an array.

