### PR TITLE
Fix mobile version of ReviewList on the example demo

### DIFF
--- a/examples/demo/src/reviews/ReviewListMobile.js
+++ b/examples/demo/src/reviews/ReviewListMobile.js
@@ -29,10 +29,10 @@ const useStyles = makeStyles({
     },
 });
 
-const ReviewMobileList = ({ basePath, data, ids, loading, total }) => {
+const ReviewMobileList = ({ basePath, data, ids, loaded, total }) => {
     const classes = useStyles();
     return (
-        (loading || total > 0) && (
+        (loaded || total > 0) && (
             <List className={classes.root}>
                 {ids.map(id => (
                     <Link

--- a/packages/ra-ui-materialui/src/list/SimpleList.js
+++ b/packages/ra-ui-materialui/src/list/SimpleList.js
@@ -96,7 +96,7 @@ const SimpleList = props => {
     }
 
     return (
-        (loading || total > 0) && (
+        total > 0 && (
             <List className={className} {...sanitizeListRestProps(rest)}>
                 {ids.map(id => (
                     <LinkOrNot


### PR DESCRIPTION
Checking the `loading` prop for rendering the `SimpleList` was wrong, it should be `!loading` or `loaded`.

The `ReviewMobileList` component in the demo has also been fixed (it's coming from the `SimpleList` component).