### PR TITLE
Add create / edit side effects and transform

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -84,10 +84,10 @@ You can customize the `<Create>` and `<Edit>` components using the following pro
 * [`aside`](#aside-component)
 * [`component`](#component)
 * [`undoable`](#undoable) (`<Edit>` only)
-* [`successMessage`](#success-message) (deprecated - use `onSuccess` instead)
 * [`onSuccess`](#onSuccess)
 * [`onFailure`](#onFailure)
 * [`transform`](#transform)
+* [`successMessage`](#success-message) (deprecated - use `onSuccess` instead)
 
 `<Create>` also accepts a `record` prop, to initialize the form based on a value object.
 
@@ -256,24 +256,7 @@ const PostEdit = props => (
 );
 ```
 
-### Success message
-
-**Deprecated**: use the `onSuccess` prop instead. See [Changing The Success or Failure Notification Message](#changing-the-success-or-failure-notification-message) for the new syntax. 
-
-Once the `dataProvider` returns successfully after save, users see a generic notification ("Element created" / "Element updated"). You can customize this message by passing a `successMessage` prop:
-
-```jsx
-const PostEdit = props => (
-    <Edit successMessage="messages.post_saved" {...props}>
-        ...
-    </Edit>
-```
-
-**Tip**: The message will be translated.
-
 ### `onSuccess`
-
-Sometimes `successMessage` isn't enough, and you may need to completely override what should happen after the save action succeeds at the dataProvider level.
 
 By default, when the save action succeeds, react-admin shows a notification, and redirects to another page. You can override this behavior and pass custom side effects by providing a function as `onSuccess` prop:
 
@@ -303,6 +286,22 @@ const PostEdit = props => {
 ```
 
 The `onSuccess` function receives the response from the dataProvider call (`dataProvider.create()` or `dataProvider.update()`), which is the created/edited record (see [the dataProvider documentation for details](./DataProviders.md#response-format))
+
+The default `onSuccess` function is:
+
+```jsx
+// for the <Create> component:
+() => {
+    notify('ra.notification.created', 'info', { smart_count: 1 }, undoable);
+    redirect('edit', basePath, data.id, data);
+}
+
+// for the <Edit> component: 
+() => {
+    notify('ra.notification.updated', 'info', { smart_count: 1 }, undoable);
+    redirect('list', basePath, data.id, data);
+}
+```
 
 To learn more about built-in side effect hooks like `useNotify`, `useRedirect` and `useRefresh`, check the [Querying the API documentation](./Actions.md#handling-side-effects-in-usedataprovider).
 
@@ -343,6 +342,23 @@ const PostEdit = props => {
 
 The `onFailure` function receives the error from the dataProvider call (`dataProvider.create()` or `dataProvider.update()`), which is a JavaScript Error object (see [the dataProvider documentation for details](./DataProviders.md#error-format)).
 
+The default `onOnFailure` function is:
+
+```jsx
+// for the <Create> component:
+(error) => {
+    notify(typeof error === 'string' ? error : error.message || 'ra.notification.http_error', 'warning');
+}
+
+// for the <Edit> component: 
+(error) => {
+    notify(typeof error === 'string' ? error : error.message || 'ra.notification.http_error', 'warning');
+    if (undoable) {
+        refresh();
+    }
+}
+```
+
 **Tip**: If you want to have different failure side effects based on the button clicked by the user, you can set the `onFailure` prop on the `<SaveButton>` component, too.
 
 ### `transform`
@@ -366,6 +382,21 @@ export const UserCreate = (props) => {
 The `transform` function can also return a `Promise`, which allows you to do all sorts of asynchronous calls (e.g. to the `dataProvider`) during the transformation.
 
 **Tip**: If you want to have different transformations based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save", and another to "save and notify other admins"), you can set the `transform` prop on the `<SaveButton>` component, too. See [Altering the Form Values Before Submitting](#altering-the-form-values-before-submitting) for an example.
+
+### Success message
+
+**Deprecated**: use the `onSuccess` prop instead. See [Changing The Success or Failure Notification Message](#changing-the-success-or-failure-notification-message) for the new syntax. 
+
+Once the `dataProvider` returns successfully after save, users see a generic notification ("Element created" / "Element updated"). You can customize this message by passing a `successMessage` prop:
+
+```jsx
+const PostEdit = props => (
+    <Edit successMessage="messages.post_saved" {...props}>
+        ...
+    </Edit>
+```
+
+**Tip**: The message will be translated.
 
 ## Prefilling a `<Create>` Record
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -84,7 +84,7 @@ You can customize the `<Create>` and `<Edit>` components using the following pro
 * [`aside`](#aside-component)
 * [`component`](#component)
 * [`undoable`](#undoable) (`<Edit>` only)
-* [`successMessage`](#success-message)
+* [`successMessage`](#success-message) (deprecated - use `onSuccess` instead)
 * [`onSuccess`](#onSuccess)
 * [`onFailure`](#onFailure)
 * [`transform`](#transform)
@@ -257,6 +257,8 @@ const PostEdit = props => (
 ```
 
 ### Success message
+
+**Deprecated**: use the `onSuccess` prop instead. See [Changing The Success or Failure Notification Message](#changing-the-success-or-failure-notification-message) for the new syntax. 
 
 Once the `dataProvider` returns successfully after save, users see a generic notification ("Element created" / "Element updated"). You can customize this message by passing a `successMessage` prop:
 
@@ -1079,6 +1081,10 @@ export const PostEdit = (props) => {
 
 This affects both the submit button, and the form submission when the user presses `ENTER` in one of the form fields.
 
+**Tip**: The `redirect` prop is ignored if you've set the `onSuccess` prop in the `<Edit>`/`<Create>` component, or in the `<SaveButton>` component.
+
+**Tip**: You may wonder why the `redirect` prop does the same thing as `onSuccess`: that's for historical reasons. The recommendd way is to change redirection using `onSuccess` rather than `redirect`. 
+
 ## Toolbar
 
 At the bottom of the form, the toolbar displays the submit button. You can override this component by setting the `toolbar` prop, to display the buttons of your choice.
@@ -1524,7 +1530,7 @@ const FormBody = ({ handleSubmit }) => {
 
 **Tip**: You can customize the message displayed in the confirm dialog by setting the `ra.message.unsaved_changes` message in your i18nProvider.
 
-## Displaying Fields or Inputs depending on the user permissions
+## Displaying Fields or Inputs Depending on the User Permissions
 
 You might want to display some fields, inputs or filters only to users with specific permissions. 
 
@@ -1585,6 +1591,56 @@ export const UserEdit = ({ permissions, ...props }) =>
     </Edit>;
 ```
 {% endraw %}
+
+## Changing The Success or Failure Notification Message
+
+Once the `dataProvider` returns successfully after save, users see a generic notification ("Element created" / "Element updated"). You can customize this message by passing a custom success side effect function as [the `<Edit onSuccess>` prop](#onsuccess):
+
+```jsx
+import { Edit, useNotify, useRedirect } from 'react-admin';
+
+const PostEdit = props => {
+    const notify = useNotify();
+    const redirect = useRedirect();
+    const onSuccess = () => {
+        notify('Post saved successfully'); // default message is 'ra.notification.updated'
+        redirect('list', props.basePath);
+    }
+    return (
+        <Edit {...props} onSuccess={onSuccess}>
+            ...
+        </Edit>
+    );
+}
+```
+
+You can do the same for error notifications, e.g. to display a different message depending on the error returned by the `dataProvider`:
+
+```jsx
+import { Edit, useNotify, useRedirect } from 'react-admin';
+
+const PostEdit = props => {
+    const notify = useNotify();
+    const redirect = useRedirect();
+    const onFailure = (error) => {
+        if (error.code == 123) {
+            notify('Could not save changes: concurrent edition in progress', 'warning');
+        } else {
+            notify('ra.notification.http_error', 'warning')
+        }
+        redirect('list', props.basePath);
+    }
+    return (
+        <Edit {...props} onFailure={onFailure}>
+            ...
+        </Edit>
+    );
+}
+```
+
+If the form has several save buttons, you can also pass a custom `onSuccess` or `onFailure` function to the `<SaveButton>` components, to have a different message and/or redirection depending on the submit button clicked.
+
+**Tip**: The notify message will be translated.
 
 ## Altering the Form Values Before Submitting
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1694,3 +1694,49 @@ const dataProvider = {
     },
 }
 ```
+
+## Using `onSave` To Alter the Form Submission Behavior
+
+**Deprecated**: use the `<Save onSuccess>` prop instead.
+
+React-admin provides a way to override the data provider call executed upon submission, and its side effects, in the `<SaveButton>`. It's called `onSave`, and here is how you would use it:
+
+```jsx
+import React, { useCallback } from 'react';
+import {
+    SaveButton,
+    Toolbar,
+    useCreate,
+    useRedirect,
+    useNotify,
+} from 'react-admin';
+
+const SaveWithNoteButton = props => {
+    const [create] = useCreate('posts');
+    const redirectTo = useRedirect();
+    const notify = useNotify();
+    const { basePath } = props;
+    const handleSave = useCallback(
+        (values, redirect) => {
+            create(
+                {
+                    payload: { data: { ...values, average_note: 10 } },
+                },
+                {
+                    onSuccess: ({ data: newRecord }) => {
+                        notify('ra.notification.created', 'info', {
+                            smart_count: 1,
+                        });
+                        redirectTo(redirect, basePath, newRecord.id, newRecord);
+                    },
+                }
+            );
+        },
+        [create, notify, redirectTo, basePath]
+    );
+    // set onSave props instead of handleSubmitWithRedirect
+    return <SaveButton {...props} onSave={handleSave} />;
+};
+```
+
+The `onSave` value should be a function expecting 2 arguments: the form values to save, and the redirection to perform.

--- a/examples/simple/src/posts/PostCreate.js
+++ b/examples/simple/src/posts/PostCreate.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import RichTextInput from 'ra-input-rich-text';
 import {
     ArrayInput,
@@ -16,41 +16,8 @@ import {
     TextInput,
     Toolbar,
     required,
-    useCreate,
-    useRedirect,
-    useNotify,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import { FormSpy } from 'react-final-form';
-
-const SaveWithNoteButton = props => {
-    const [create] = useCreate('posts');
-    const redirectTo = useRedirect();
-    const notify = useNotify();
-    const { basePath } = props;
-
-    const handleSave = useCallback(
-        (values, redirect) => {
-            create(
-                {
-                    payload: {
-                        data: { ...values, average_note: 10 },
-                    },
-                },
-                {
-                    onSuccess: ({ data: newRecord }) => {
-                        notify('ra.notification.created', 'info', {
-                            smart_count: 1,
-                        });
-                        redirectTo(redirect, basePath, newRecord.id, newRecord);
-                    },
-                }
-            );
-        },
-        [create, notify, redirectTo, basePath]
-    );
-
-    return <SaveButton {...props} onSave={handleSave} />;
-};
 
 const PostCreateToolbar = props => (
     <Toolbar {...props}>
@@ -71,8 +38,9 @@ const PostCreateToolbar = props => (
             submitOnEnter={false}
             variant="text"
         />
-        <SaveWithNoteButton
+        <SaveButton
             label="post.action.save_with_average_note"
+            transform={data => ({ ...data, average_note: 10 })}
             redirect="show"
             submitOnEnter={false}
             variant="text"

--- a/packages/ra-core/src/controller/SideEffectContext.tsx
+++ b/packages/ra-core/src/controller/SideEffectContext.tsx
@@ -1,8 +1,0 @@
-import { createContext } from 'react';
-
-const SideEffectContext = createContext({
-    setOnSuccess: () => {},
-    setOnFailure: () => null,
-});
-
-export default SideEffectContext;

--- a/packages/ra-core/src/controller/SideEffectContext.tsx
+++ b/packages/ra-core/src/controller/SideEffectContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const SideEffectContext = createContext({
+    setOnSuccess: () => {},
+    setOnFailure: () => null,
+});
+
+export default SideEffectContext;

--- a/packages/ra-core/src/controller/index.ts
+++ b/packages/ra-core/src/controller/index.ts
@@ -2,6 +2,7 @@ import CreateController from './CreateController';
 import EditController from './EditController';
 import ListController from './ListController';
 import ShowController from './ShowController';
+import SideEffectContext from './SideEffectContext';
 import useRecordSelection from './useRecordSelection';
 import useVersion from './useVersion';
 import useExpanded from './useExpanded';
@@ -28,6 +29,7 @@ export {
     EditController,
     ListController,
     ShowController,
+    SideEffectContext,
     useCheckMinimumRequiredProps,
     useListController,
     useEditController,

--- a/packages/ra-core/src/controller/index.ts
+++ b/packages/ra-core/src/controller/index.ts
@@ -2,7 +2,6 @@ import CreateController from './CreateController';
 import EditController from './EditController';
 import ListController from './ListController';
 import ShowController from './ShowController';
-import SideEffectContext from './SideEffectContext';
 import useRecordSelection from './useRecordSelection';
 import useVersion from './useVersion';
 import useExpanded from './useExpanded';
@@ -29,7 +28,6 @@ export {
     EditController,
     ListController,
     ShowController,
-    SideEffectContext,
     useCheckMinimumRequiredProps,
     useListController,
     useEditController,
@@ -55,3 +53,4 @@ export {
 export * from './field';
 export * from './input';
 export * from './button';
+export * from './saveModifiers';

--- a/packages/ra-core/src/controller/saveModifiers.tsx
+++ b/packages/ra-core/src/controller/saveModifiers.tsx
@@ -1,0 +1,80 @@
+import { createContext, useRef } from 'react';
+
+export const SideEffectContext = createContext<SideEffectContextType>({});
+
+/**
+ * Get modifiers for a save() function, and the way to update them.
+ *
+ * Used in useCreateController and useEditController.
+ *
+ * @example
+ *
+ * const {
+ *     onSuccessRef,
+ *     setOnSuccess,
+ *     onFailureRef,
+ *     setOnFailure,
+ *     transformRef,
+ *     setTransform,
+ * } = useSaveModifiers({ onSuccess, onFailure, transform });
+ */
+export const useSaveModifiers = ({
+    onSuccess,
+    onFailure,
+    transform,
+}: SaveModifiers) => {
+    const onSuccessRef = useRef(onSuccess);
+    const setOnSuccess: SetOnSuccess = onSuccess => {
+        onSuccessRef.current = response => {
+            // reset onSuccess for next submission
+            onSuccessRef.current = undefined;
+            return onSuccess(response);
+        };
+    };
+
+    const onFailureRef = useRef(onFailure);
+    const setOnFailure: SetOnFailure = onFailure => {
+        onFailureRef.current = error => {
+            // reset onSuccess for next submission
+            onFailureRef.current = undefined;
+            return onFailure(error);
+        };
+    };
+
+    const transformRef = useRef(transform);
+    const setTransform: SetTransformData = transform => {
+        transformRef.current = data => {
+            // reset transform for next submission
+            transformRef.current = undefined;
+            return transform(data);
+        };
+    };
+
+    return {
+        onSuccessRef,
+        setOnSuccess,
+        onFailureRef,
+        setOnFailure,
+        transformRef,
+        setTransform,
+    };
+};
+
+export type OnSuccess = (response: any) => void;
+export type SetOnSuccess = (onSuccess: OnSuccess) => void;
+export type OnFailure = (error: { message?: string }) => void;
+export type SetOnFailure = (onFailure: OnFailure) => void;
+export type TransformData = (data: any) => any | Promise<any>;
+export type SetTransformData = (transform: TransformData) => void;
+
+export interface SideEffectContextType {
+    setOnSuccess?: SetOnSuccess;
+    setOnFailure?: SetOnFailure;
+    setTransform?: SetTransformData;
+}
+
+export interface SaveModifiers {
+    onSuccess?: OnSuccess;
+    onFailure?: OnFailure;
+    transform?: TransformData;
+}

--- a/packages/ra-core/src/controller/useCreateController.spec.tsx
+++ b/packages/ra-core/src/controller/useCreateController.spec.tsx
@@ -1,6 +1,16 @@
+import React from 'react';
+import expect from 'expect';
+import { act, cleanup, wait } from '@testing-library/react';
+
 import { getRecord } from './useCreateController';
+import CreateController from './CreateController';
+import renderWithRedux from '../util/renderWithRedux';
+import { DataProviderContext } from '../dataProvider';
+import { DataProvider } from '../types';
 
 describe('useCreateController', () => {
+    afterEach(cleanup);
+
     describe('getRecord', () => {
         const location = {
             pathname: '/foo',
@@ -48,6 +58,295 @@ describe('useCreateController', () => {
                     undefined
                 )
             ).toEqual({ foo: 'bar' });
+        });
+    });
+
+    const defaultProps = {
+        basePath: '',
+        hasCreate: true,
+        hasEdit: true,
+        hasList: true,
+        hasShow: true,
+        resource: 'posts',
+        debounce: 200,
+    };
+
+    it('should call the dataProvider.create() function on save', async () => {
+        const create = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create,
+        } as unknown) as DataProvider;
+        let saveCallback;
+        renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(create).toHaveBeenCalledWith('posts', {
+            data: { foo: 'bar' },
+        });
+    });
+
+    it('should execute default success side effects on success', async () => {
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create: (_, { data }) => Promise.resolve({ data }),
+        } as unknown) as DataProvider;
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify[0]).toEqual({
+            type: 'RA/SHOW_NOTIFICATION',
+            payload: {
+                messageArgs: { smart_count: 1 },
+                undoable: false,
+                autoHideDuration: undefined,
+                type: 'info',
+                message: 'ra.notification.created',
+            },
+        });
+    });
+
+    it('should execute default failure side effects on failure', async () => {
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create: () => Promise.reject({ message: 'not good' }),
+        } as unknown) as DataProvider;
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify[0]).toEqual({
+            type: 'RA/SHOW_NOTIFICATION',
+            payload: {
+                messageArgs: {},
+                undoable: false,
+                autoHideDuration: undefined,
+                type: 'warning',
+                message: 'not good',
+            },
+        });
+    });
+
+    it('should allow onSuccess to override the default success side effects', async () => {
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create: (_, { data }) => Promise.resolve({ data }),
+        } as unknown) as DataProvider;
+        const onSuccess = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps} onSuccess={onSuccess}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(onSuccess).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow the save onSuccess option to override the success side effects override', async () => {
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create: (_, { data }) => Promise.resolve({ data }),
+        } as unknown) as DataProvider;
+        const onSuccess = jest.fn();
+        const onSuccessSave = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps} onSuccess={onSuccess}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () =>
+            saveCallback({ foo: 'bar' }, undefined, {
+                onSuccess: onSuccessSave,
+            })
+        );
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onSuccessSave).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow onFailure to override the default failure side effects', async () => {
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create: () => Promise.reject({ message: 'not good' }),
+        } as unknown) as DataProvider;
+        const onFailure = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps} onFailure={onFailure}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(onFailure).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow the save onFailure option to override the failure side effects override', async () => {
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create: () => Promise.reject({ message: 'not good' }),
+        } as unknown) as DataProvider;
+        const onFailure = jest.fn();
+        const onFailureSave = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps} onFailure={onFailure}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () =>
+            saveCallback({ foo: 'bar' }, undefined, {
+                onFailure: onFailureSave,
+            })
+        );
+        expect(onFailure).not.toHaveBeenCalled();
+        expect(onFailureSave).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow transform to transform the data before calling create', async () => {
+        let saveCallback;
+        const create = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create,
+        } as unknown) as DataProvider;
+        const transform = jest.fn().mockImplementationOnce(data => ({
+            ...data,
+            transformed: true,
+        }));
+        renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps} transform={transform}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(transform).toHaveBeenCalledWith({ foo: 'bar' });
+        expect(create).toHaveBeenCalledWith('posts', {
+            data: { foo: 'bar', transformed: true },
+        });
+    });
+
+    it('should allow the save transform option to override the controller transform option', async () => {
+        let saveCallback;
+        const create = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            create,
+        } as unknown) as DataProvider;
+        const transform = jest.fn();
+        const transformSave = jest.fn().mockImplementationOnce(data => ({
+            ...data,
+            transformed: true,
+        }));
+        renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <CreateController {...defaultProps} transform={transform}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () =>
+            saveCallback({ foo: 'bar' }, undefined, {
+                transform: transformSave,
+            })
+        );
+        expect(transform).not.toHaveBeenCalled();
+        expect(transformSave).toHaveBeenCalledWith({ foo: 'bar' });
+        expect(create).toHaveBeenCalledWith('posts', {
+            data: { foo: 'bar', transformed: true },
         });
     });
 });

--- a/packages/ra-core/src/controller/useCreateController.spec.tsx
+++ b/packages/ra-core/src/controller/useCreateController.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import expect from 'expect';
-import { act, cleanup, wait } from '@testing-library/react';
+import { act, cleanup } from '@testing-library/react';
 
 import { getRecord } from './useCreateController';
 import CreateController from './CreateController';

--- a/packages/ra-core/src/controller/useCreateController.ts
+++ b/packages/ra-core/src/controller/useCreateController.ts
@@ -100,6 +100,12 @@ const useCreateController = (props: CreateProps): CreateControllerProps => {
     const recordToUse = getRecord(location, record);
     const version = useVersion();
 
+    if (process.env.NODE_ENV !== 'production' && successMessage) {
+        console.log(
+            '<Edit successMessage> prop is deprecated, use the onSuccess prop instead.'
+        );
+    }
+
     const {
         onSuccessRef,
         setOnSuccess,

--- a/packages/ra-core/src/controller/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/useEditController.spec.tsx
@@ -21,9 +21,30 @@ describe('useEditController', () => {
         debounce: 200,
     };
 
-    it('should query the data provider for the record using a GET_ONE query', () => {
+    it('should call the dataProvider.getOne() function on mount', async () => {
+        const getOne = jest
+            .fn()
+            .mockImplementationOnce(() =>
+                Promise.resolve({ data: { id: 12, title: 'hello' } })
+            );
+        const dataProvider = ({ getOne } as unknown) as DataProvider;
+        const { queryAllByText } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController {...defaultProps}>
+                    {({ record }) => <div>{record && record.title}</div>}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await wait(() => {
+            expect(getOne).toHaveBeenCalled();
+            expect(queryAllByText('hello')).toHaveLength(1);
+        });
+    });
+
+    it('should dispatch a CRUD_GET_ONE action on mount', () => {
         const dataProvider = ({
-            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            getOne: () => Promise.resolve({ data: { id: 12, title: 'hello' } }),
         } as unknown) as DataProvider;
         const { dispatch } = renderWithRedux(
             <DataProviderContext.Provider value={dataProvider}>
@@ -39,11 +60,16 @@ describe('useEditController', () => {
         expect(crudGetOneAction.meta.resource).toEqual('posts');
     });
 
-    it('should grab the record from the store based on the id', async () => {
-        const { getByText } = renderWithRedux(
-            <EditController {...defaultProps}>
-                {({ record }) => <div>{record && record.title}</div>}
-            </EditController>,
+    it('should grab the record from the store based on the id', () => {
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12, title: 'world' } }),
+        } as unknown) as DataProvider;
+        const { queryAllByText } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController {...defaultProps}>
+                    {({ record }) => <div>{record && record.title}</div>}
+                </EditController>
+            </DataProviderContext.Provider>,
             {
                 admin: {
                     resources: {
@@ -52,14 +78,43 @@ describe('useEditController', () => {
                 },
             }
         );
-        await wait();
-        expect(getByText('hello')).toBeDefined();
+        expect(queryAllByText('hello')).toHaveLength(1);
     });
 
-    it('should return an undoable save callback by default', () => {
+    it('should call the dataProvider.update() function on save', async () => {
+        const update = jest
+            .fn()
+            .mockImplementationOnce((_, { id, data, previousData }) =>
+                Promise.resolve({ data: { ...previousData, ...data } })
+            );
         const dataProvider = ({
             getOne: () => Promise.resolve({ data: { id: 12 } }),
-            update: ({ id, data, previousData }) =>
+            update,
+        } as unknown) as DataProvider;
+        let saveCallback;
+        renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController {...defaultProps} undoable={false}>
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(update).toHaveBeenCalledWith('posts', {
+            id: 12,
+            data: { foo: 'bar' },
+            previousData: undefined,
+        });
+    });
+
+    it('should return an undoable save callback by default', async () => {
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: (_, { id, data, previousData }) =>
                 Promise.resolve({ data: { ...previousData, ...data } }),
         } as unknown) as DataProvider;
         let saveCallback;
@@ -74,7 +129,7 @@ describe('useEditController', () => {
             </DataProviderContext.Provider>,
             { admin: { resources: { posts: { data: {} } } } }
         );
-        act(() => saveCallback({ foo: 'bar' }));
+        await act(async () => saveCallback({ foo: 'bar' }));
         const call = dispatch.mock.calls.find(
             params => params[0].type === 'RA/CRUD_UPDATE_OPTIMISTIC'
         );
@@ -88,11 +143,11 @@ describe('useEditController', () => {
         expect(crudUpdateAction.meta.resource).toEqual('posts');
     });
 
-    it('should return a save callback when undoable is false', () => {
+    it('should return a save callback when undoable is false', async () => {
         let saveCallback;
         const dataProvider = ({
             getOne: () => Promise.resolve({ data: { id: 12 } }),
-            update: ({ id, data, previousData }) =>
+            update: (_, { id, data, previousData }) =>
                 Promise.resolve({ data: { ...previousData, ...data } }),
         } as unknown) as DataProvider;
         const { dispatch } = renderWithRedux(
@@ -106,7 +161,7 @@ describe('useEditController', () => {
             </DataProviderContext.Provider>,
             { admin: { resources: { posts: { data: {} } } } }
         );
-        act(() => saveCallback({ foo: 'bar' }));
+        await act(async () => saveCallback({ foo: 'bar' }));
         const call = dispatch.mock.calls.find(
             params => params[0].type === 'RA/CRUD_UPDATE_OPTIMISTIC'
         );
@@ -122,5 +177,229 @@ describe('useEditController', () => {
             previousData: undefined,
         });
         expect(crudUpdateAction.meta.resource).toEqual('posts');
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).not.toBeUndefined();
+    });
+
+    it('should allow onSuccess to override the default success side effects', async () => {
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: (_, { id, data, previousData }) =>
+                Promise.resolve({ data: { ...previousData, ...data } }),
+        } as unknown) as DataProvider;
+        const onSuccess = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    undoable={false}
+                    onSuccess={onSuccess}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(onSuccess).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow the save onSuccess option to override the success side effects override', async () => {
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: (_, { id, data, previousData }) =>
+                Promise.resolve({ data: { ...previousData, ...data } }),
+        } as unknown) as DataProvider;
+        const onSuccess = jest.fn();
+        const onSuccessSave = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    undoable={false}
+                    onSuccess={onSuccess}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () =>
+            saveCallback({ foo: 'bar' }, undefined, {
+                onSuccess: onSuccessSave,
+            })
+        );
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onSuccessSave).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow onFailure to override the default failure side effects', async () => {
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: () => Promise.reject({ message: 'not good' }),
+        } as unknown) as DataProvider;
+        const onFailure = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    undoable={false}
+                    onFailure={onFailure}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(onFailure).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow the save onFailure option to override the failure side effects override', async () => {
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: () => Promise.reject({ message: 'not good' }),
+        } as unknown) as DataProvider;
+        const onFailure = jest.fn();
+        const onFailureSave = jest.fn();
+        const { dispatch } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    undoable={false}
+                    onFailure={onFailure}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () =>
+            saveCallback({ foo: 'bar' }, undefined, {
+                onFailure: onFailureSave,
+            })
+        );
+        expect(onFailure).not.toHaveBeenCalled();
+        expect(onFailureSave).toHaveBeenCalled();
+        const notify = dispatch.mock.calls.find(
+            params => params[0].type === 'RA/SHOW_NOTIFICATION'
+        );
+        expect(notify).toBeUndefined();
+    });
+
+    it('should allow transform to transform the data before save', async () => {
+        let saveCallback;
+        const update = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update,
+        } as unknown) as DataProvider;
+        const transform = jest.fn().mockImplementationOnce(data => ({
+            ...data,
+            transformed: true,
+        }));
+        renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    undoable={false}
+                    transform={transform}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(transform).toHaveBeenCalledWith({
+            foo: 'bar',
+        });
+        expect(update).toHaveBeenCalledWith('posts', {
+            id: 12,
+            data: { foo: 'bar', transformed: true },
+            previousData: undefined,
+        });
+    });
+
+    it('should the save transform option to override the transform side effect', async () => {
+        let saveCallback;
+        const update = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update,
+        } as unknown) as DataProvider;
+        const transform = jest.fn();
+        const transformSave = jest.fn().mockImplementationOnce(data => ({
+            ...data,
+            transformed: true,
+        }));
+        renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    undoable={false}
+                    transform={transform}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </EditController>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        await act(async () =>
+            saveCallback({ foo: 'bar' }, undefined, {
+                transform: transformSave,
+            })
+        );
+        expect(transform).not.toHaveBeenCalled();
+        expect(transformSave).toHaveBeenCalledWith({
+            foo: 'bar',
+        });
+        expect(update).toHaveBeenCalledWith('posts', {
+            id: 12,
+            data: { foo: 'bar', transformed: true },
+            previousData: undefined,
+        });
     });
 });

--- a/packages/ra-core/src/controller/useEditController.ts
+++ b/packages/ra-core/src/controller/useEditController.ts
@@ -98,6 +98,12 @@ const useEditController = (props: EditProps): EditControllerProps => {
     const refresh = useRefresh();
     const version = useVersion();
 
+    if (process.env.NODE_ENV !== 'production' && successMessage) {
+        console.log(
+            '<Edit successMessage> prop is deprecated, use the onSuccess prop instead.'
+        );
+    }
+
     const {
         onSuccessRef,
         setOnSuccess,

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -1,9 +1,18 @@
-import { render, cleanup, fireEvent } from '@testing-library/react';
 import React from 'react';
 import expect from 'expect';
-import { TestContext } from 'ra-core';
+import { render, cleanup, wait, fireEvent } from '@testing-library/react';
+import {
+    TestContext,
+    renderWithRedux,
+    DataProviderContext,
+    DataProvider,
+} from 'ra-core';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core';
+
 import SaveButton from './SaveButton';
+import { Toolbar, SimpleForm } from '../form';
+import { Edit } from '../detail';
+import { TextInput } from '../input';
 
 const theme = createMuiTheme();
 
@@ -135,5 +144,156 @@ describe('<SaveButton />', () => {
             type: 'RA/SHOW_NOTIFICATION',
         });
         expect(onSubmit).toHaveBeenCalled();
+    });
+
+    const defaultEditProps = {
+        basePath: '',
+        id: '123',
+        resource: 'posts',
+        location: {},
+        match: {},
+        undoable: false,
+    };
+
+    it('should allow to override the onSuccess side effects', async () => {
+        const dataProvider = ({
+            getOne: () =>
+                Promise.resolve({
+                    data: { id: 123, title: 'lorem' },
+                }),
+            update: (_, { data }) => Promise.resolve({ data }),
+        } as unknown) as DataProvider;
+        const onSuccess = jest.fn();
+        const EditToolbar = props => (
+            <Toolbar {...props}>
+                <SaveButton onSuccess={onSuccess} />
+            </Toolbar>
+        );
+        const {
+            queryByDisplayValue,
+            getByLabelText,
+            getByText,
+        } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <Edit {...defaultEditProps}>
+                    <SimpleForm toolbar={<EditToolbar />}>
+                        <TextInput source="title" />
+                    </SimpleForm>
+                </Edit>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        // wait for the dataProvider.getOne() return
+        await wait(() => {
+            expect(queryByDisplayValue('lorem')).toBeDefined();
+        });
+        // change one input to enable the SaveButton (which is disabled when the form is pristine)
+        fireEvent.change(getByLabelText('resources.posts.fields.title'), {
+            target: { value: 'ipsum' },
+        });
+        fireEvent.click(getByText('ra.action.save'));
+        await wait(() => {
+            expect(onSuccess).toHaveBeenCalledWith({
+                data: { id: 123, title: 'ipsum' },
+            });
+        });
+    });
+
+    it('should allow to override the onFailure side effects', async () => {
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        const dataProvider = ({
+            getOne: () =>
+                Promise.resolve({
+                    data: { id: 123, title: 'lorem' },
+                }),
+            update: () => Promise.reject({ message: 'not good' }),
+        } as unknown) as DataProvider;
+        const onFailure = jest.fn();
+        const EditToolbar = props => (
+            <Toolbar {...props}>
+                <SaveButton onFailure={onFailure} />
+            </Toolbar>
+        );
+        const {
+            queryByDisplayValue,
+            getByLabelText,
+            getByText,
+        } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <Edit {...defaultEditProps}>
+                    <SimpleForm toolbar={<EditToolbar />}>
+                        <TextInput source="title" />
+                    </SimpleForm>
+                </Edit>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        // wait for the dataProvider.getOne() return
+        await wait(() => {
+            expect(queryByDisplayValue('lorem')).toBeDefined();
+        });
+        // change one input to enable the SaveButton (which is disabled when the form is pristine)
+        fireEvent.change(getByLabelText('resources.posts.fields.title'), {
+            target: { value: 'ipsum' },
+        });
+        fireEvent.click(getByText('ra.action.save'));
+        await wait(() => {
+            expect(onFailure).toHaveBeenCalledWith({
+                message: 'not good',
+            });
+        });
+    });
+
+    it('should allow to transform the record before save', async () => {
+        const update = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = ({
+            getOne: () =>
+                Promise.resolve({
+                    data: { id: 123, title: 'lorem' },
+                }),
+            update,
+        } as unknown) as DataProvider;
+        const transform = jest.fn().mockImplementationOnce(data => ({
+            ...data,
+            transformed: true,
+        }));
+        const EditToolbar = props => (
+            <Toolbar {...props}>
+                <SaveButton transform={transform} />
+            </Toolbar>
+        );
+        const {
+            queryByDisplayValue,
+            getByLabelText,
+            getByText,
+        } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <Edit {...defaultEditProps}>
+                    <SimpleForm toolbar={<EditToolbar />}>
+                        <TextInput source="title" />
+                    </SimpleForm>
+                </Edit>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+        // wait for the dataProvider.getOne() return
+        await wait(() => {
+            expect(queryByDisplayValue('lorem')).toBeDefined();
+        });
+        // change one input to enable the SaveButton (which is disabled when the form is pristine)
+        fireEvent.change(getByLabelText('resources.posts.fields.title'), {
+            target: { value: 'ipsum' },
+        });
+        fireEvent.click(getByText('ra.action.save'));
+        await wait(() => {
+            expect(transform).toHaveBeenCalledWith({ id: 123, title: 'ipsum' });
+            expect(update).toHaveBeenCalledWith('posts', {
+                id: '123',
+                data: { id: 123, title: 'ipsum', transformed: true },
+                previousData: { id: 123, title: 'lorem' },
+            });
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -94,6 +94,11 @@ const SaveButton: FC<SaveButtonProps> = props => {
     const handleClick = event => {
         // deprecated: use onSuccess and transform insted of onSave
         if (typeof onSave === 'function') {
+            if (process.env.NODE_ENV !== 'production') {
+                console.log(
+                    '<SaveButton onSave> prop is deprecated, use the onSuccess prop instead.'
+                );
+            }
             setOnSave(onSave);
         } else {
             // we reset to the Form default save function
@@ -177,6 +182,7 @@ interface Props {
     classes?: object;
     className?: string;
     handleSubmitWithRedirect?: (redirect?: RedirectionSideEffect) => void;
+    // @deprecated
     onSave?: (values: object, redirect: RedirectionSideEffect) => void;
     onSuccess?: OnSuccess;
     onFailure?: OnFailure;
@@ -204,6 +210,7 @@ SaveButton.propTypes = {
     className: PropTypes.string,
     classes: PropTypes.object,
     handleSubmitWithRedirect: PropTypes.func,
+    // @deprecated
     onSave: PropTypes.func,
     invalid: PropTypes.bool,
     label: PropTypes.string,

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -92,19 +92,20 @@ const SaveButton: FC<SaveButtonProps> = props => {
     );
 
     const handleClick = event => {
+        // deprecated: use onSuccess and transform insted of onSave
         if (typeof onSave === 'function') {
             setOnSave(onSave);
         } else {
             // we reset to the Form default save function
             setOnSave();
         }
-        if (typeof onSuccess === 'function') {
+        if (onSuccess) {
             setOnSuccess(onSuccess);
         }
-        if (typeof onFailure === 'function') {
+        if (onFailure) {
             setOnFailure(onFailure);
         }
-        if (typeof transform === 'function') {
+        if (transform) {
             setTransform(transform);
         }
         if (saving) {

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -15,12 +15,53 @@ import {
     useTranslate,
     useNotify,
     RedirectionSideEffect,
+    SideEffectContext,
+    OnSuccess,
+    OnFailure,
+    TransformData,
     Record,
     FormContext,
 } from 'ra-core';
 
 import { sanitizeButtonRestProps } from './Button';
 
+/**
+ * Submit button for resource forms (Edit and Create).
+ *
+ * @typedef {Object} Props the props you can use (other props are injected by Toolbar)
+ * @prop {string} className
+ * @prop {string} label Button label. Defaults to 'ra.action.save', translated.
+ * @prop {boolean} disabled Injected by SimpleForm, which disables the SaveButton when it's pristine
+ * @prop {string} variant Material-ui variant for the button. Defaults to 'contained'.
+ * @prop {ReactElement} icon
+ * @prop {string|boolean} redirect Override of the default redirect in case of success. Can be 'list', 'show', 'edit' (for create views), or false (to stay on the creation form).
+ * @prop {function} onSave (deprecated)
+ * @prop {function} onSuccess Callback to execute instead of the default success side effects. Receives the dataProvider response as argument.
+ * @prop {function} onFailure Callback to execute instead of the default error side effects. Receives the dataProvider error response as argument.
+ * @prop {function} transform Callback to execute before calling the dataProvider. Receives the data from the form, must return that transformed data. Can be asynchronous (and return a Promise)
+ *
+ * @param {Prop} props
+ *
+ * @example // with custom redirection
+ *
+ * <SaveButton label="post.action.save_and_edit" redirect="edit" />
+ *
+ * @example // with no redirection
+ *
+ * <SaveButton label="post.action.save_and_add" redirect={false} />
+ *
+ * @example // with custom success side effect
+ *
+ * const MySaveButton = props => {
+ *     const notify = useNotify();
+ *     const redirect = useRedirect();
+ *     const onSuccess = (response) => {
+ *         notify(`Post "${response.data.title}" saved!`);
+ *         redirect('/posts');
+ *     };
+ *     return <SaveButton {...props} onSuccess={onSuccess} />;
+ * }
+ */
 const SaveButton: FC<SaveButtonProps> = props => {
     const {
         className,
@@ -37,12 +78,18 @@ const SaveButton: FC<SaveButtonProps> = props => {
         onClick,
         handleSubmitWithRedirect,
         onSave,
+        onSuccess,
+        onFailure,
+        transform,
         ...rest
     } = props;
     const classes = useStyles(props);
     const notify = useNotify();
     const translate = useTranslate();
     const { setOnSave } = useContext(FormContext);
+    const { setOnSuccess, setOnFailure, setTransform } = useContext(
+        SideEffectContext
+    );
 
     const handleClick = event => {
         if (typeof onSave === 'function') {
@@ -50,6 +97,15 @@ const SaveButton: FC<SaveButtonProps> = props => {
         } else {
             // we reset to the Form default save function
             setOnSave();
+        }
+        if (typeof onSuccess === 'function') {
+            setOnSuccess(onSuccess);
+        }
+        if (typeof onFailure === 'function') {
+            setOnFailure(onFailure);
+        }
+        if (typeof transform === 'function') {
+            setTransform(transform);
         }
         if (saving) {
             // prevent double submission
@@ -121,6 +177,9 @@ interface Props {
     className?: string;
     handleSubmitWithRedirect?: (redirect?: RedirectionSideEffect) => void;
     onSave?: (values: object, redirect: RedirectionSideEffect) => void;
+    onSuccess?: OnSuccess;
+    onFailure?: OnFailure;
+    transform?: TransformData;
     icon?: ReactElement;
     invalid?: boolean;
     label?: string;

--- a/packages/ra-ui-materialui/src/detail/Create.js
+++ b/packages/ra-ui-materialui/src/detail/Create.js
@@ -74,6 +74,7 @@ Create.propTypes = {
     successMessage: PropTypes.string,
     onSuccess: PropTypes.func,
     onFailure: PropTypes.func,
+    transform: PropTypes.func,
 };
 
 export const CreateView = props => {
@@ -94,6 +95,7 @@ export const CreateView = props => {
         save,
         setOnSuccess,
         setOnFailure,
+        setTransform,
         saving,
         title,
         version,
@@ -101,13 +103,12 @@ export const CreateView = props => {
     } = props;
     useCheckMinimumRequiredProps('Create', ['children'], props);
     const classes = useStyles(props);
+    const sideEffectContextValue = useMemo(
+        () => ({ setOnSuccess, setOnFailure, setTransform }),
+        [setOnFailure, setOnSuccess, setTransform]
+    );
     return (
-        <SideEffectContext.Provider
-            value={useMemo(() => ({ setOnSuccess, setOnFailure }), [
-                setOnFailure,
-                setOnSuccess,
-            ])}
-        >
+        <SideEffectContext.Provider value={sideEffectContextValue}>
             <div
                 className={classnames('create-page', classes.root, className)}
                 {...sanitizeRestProps(rest)}
@@ -178,6 +179,7 @@ CreateView.propTypes = {
     onFailure: PropTypes.func,
     setOnSuccess: PropTypes.func,
     setOnFailure: PropTypes.func,
+    setTransform: PropTypes.func,
 };
 
 CreateView.defaultProps = {
@@ -228,6 +230,8 @@ const sanitizeRestProps = ({
     setOnSuccess,
     onFailure,
     setOnFailure,
+    transform,
+    setTransform,
     translate,
     ...rest
 }) => rest;

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -4,7 +4,11 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import { makeStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
-import { useEditController, ComponentPropType } from 'ra-core';
+import {
+    useEditController,
+    ComponentPropType,
+    SideEffectContext,
+} from 'ra-core';
 
 import DefaultActions from './EditActions';
 import TitleForRecord from '../layout/TitleForRecord';
@@ -70,6 +74,8 @@ Edit.propTypes = {
     resource: PropTypes.string.isRequired,
     title: PropTypes.node,
     successMessage: PropTypes.string,
+    onSuccess: PropTypes.func,
+    onFailure: PropTypes.func,
 };
 
 export const EditView = props => {
@@ -88,6 +94,8 @@ export const EditView = props => {
         redirect,
         resource,
         save,
+        setOnSuccess,
+        setOnFailure,
         saving,
         title,
         undoable,
@@ -180,6 +188,10 @@ EditView.propTypes = {
     save: PropTypes.func,
     title: PropTypes.node,
     version: PropTypes.number,
+    onSuccess: PropTypes.func,
+    onFailure: PropTypes.func,
+    setOnSuccess: PropTypes.func,
+    setOnFailure: PropTypes.func,
 };
 
 EditView.defaultProps = {
@@ -224,6 +236,10 @@ const sanitizeRestProps = ({
     permissions,
     undoable,
     successMessage,
+    onSuccess,
+    setOnSuccess,
+    onFailure,
+    setOnFailure,
     translate,
     ...rest
 }) => rest;

--- a/packages/ra-ui-materialui/src/detail/Edit.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.js
@@ -77,6 +77,7 @@ Edit.propTypes = {
     onSuccess: PropTypes.func,
     onFailure: PropTypes.func,
     transform: PropTypes.func,
+    undoable: PropTypes.bool,
 };
 
 export const EditView = props => {

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.js
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import expect from 'expect';
-import { cleanup } from '@testing-library/react';
+import { cleanup, wait, fireEvent } from '@testing-library/react';
 import { renderWithRedux, DataProviderContext } from 'ra-core';
 
 import Edit from './Edit';
@@ -9,27 +9,386 @@ describe('<Edit />', () => {
     afterEach(cleanup);
 
     const defaultEditProps = {
-        basePath: '/',
+        basePath: '',
         id: '123',
         resource: 'foo',
         location: {},
         match: {},
     };
 
-    it('should display aside component', () => {
-        const Aside = () => <div id="aside">Hello</div>;
+    it('should call dataProvider.getOne() and pass the result to its child as record', async () => {
         const dataProvider = {
-            getOne: () => Promise.resolve({ data: { id: 123 } }),
+            getOne: () =>
+                Promise.resolve({ data: { id: 123, title: 'lorem' } }),
         };
-        const Dummy = () => <div />;
+        const FakeForm = ({ record }) => <>{record.title}</>;
         const { queryAllByText } = renderWithRedux(
             <DataProviderContext.Provider value={dataProvider}>
-                <Edit {...defaultEditProps} aside={<Aside />}>
-                    <Dummy />
+                <Edit {...defaultEditProps}>
+                    <FakeForm />
                 </Edit>
             </DataProviderContext.Provider>,
             { admin: { resources: { foo: { data: {} } } } }
         );
-        expect(queryAllByText('Hello')).toHaveLength(1);
+        await wait(() => {
+            expect(queryAllByText('lorem')).toHaveLength(1);
+        });
+    });
+
+    it('should call dataProvider.update() when the child calls the save callback', async () => {
+        const update = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) => Promise.resolve({ data }));
+        const dataProvider = {
+            getOne: () =>
+                Promise.resolve({
+                    data: { id: 123, title: 'lorem' },
+                }),
+            update,
+        };
+        const FakeForm = ({ record, save }) => (
+            <>
+                <span>{record.title}</span>
+                <button onClick={() => save({ ...record, title: 'ipsum' })}>
+                    Update
+                </button>
+            </>
+        );
+        const { queryAllByText, getByText } = renderWithRedux(
+            <DataProviderContext.Provider value={dataProvider}>
+                <Edit {...defaultEditProps} undoable={false}>
+                    <FakeForm />
+                </Edit>
+            </DataProviderContext.Provider>,
+            { admin: { resources: { foo: { data: {} } } } }
+        );
+        await wait(() => {
+            expect(queryAllByText('lorem')).toHaveLength(1);
+        });
+        fireEvent.click(getByText('Update'));
+        await wait(() => {
+            expect(update).toHaveBeenCalledWith('foo', {
+                id: '123',
+                data: { id: 123, title: 'ipsum' },
+                previousData: { id: 123, title: 'lorem' },
+            });
+        });
+    });
+
+    describe('onSuccess prop', () => {
+        it('should allow to override the default success side effects', async () => {
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update: (_, { data }) => Promise.resolve({ data }),
+            };
+            const onSuccess = jest.fn();
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button onClick={() => save({ ...record, title: 'ipsum' })}>
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        onSuccess={onSuccess}
+                        undoable={false}
+                    >
+                        <FakeForm />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            await wait(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await wait(() => {
+                expect(onSuccess).toHaveBeenCalledWith({
+                    data: { id: 123, title: 'ipsum' },
+                });
+            });
+        });
+
+        it('should be overridden by onSuccess save option', async () => {
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update: (_, { data }) => Promise.resolve({ data }),
+            };
+            const onSuccess = jest.fn();
+            const onSuccessSave = jest.fn();
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button
+                        onClick={() =>
+                            save({ ...record, title: 'ipsum' }, undefined, {
+                                onSuccess: onSuccessSave,
+                            })
+                        }
+                    >
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        onSuccess={onSuccess}
+                        undoable={false}
+                    >
+                        <FakeForm />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            await wait(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await wait(() => {
+                expect(onSuccessSave).toHaveBeenCalledWith({
+                    data: { id: 123, title: 'ipsum' },
+                });
+                expect(onSuccess).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('onFailure prop', () => {
+        it('should allow to override the default error side effects', async () => {
+            jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update: () => Promise.reject({ message: 'not good' }),
+            };
+            const onFailure = jest.fn();
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button onClick={() => save({ ...record, title: 'ipsum' })}>
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        onFailure={onFailure}
+                        undoable={false}
+                    >
+                        <FakeForm />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            await wait(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await wait(() => {
+                expect(onFailure).toHaveBeenCalledWith({ message: 'not good' });
+            });
+        });
+
+        it('should be overridden by onFailure save option', async () => {
+            jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update: () => Promise.reject({ message: 'not good' }),
+            };
+            const onFailure = jest.fn();
+            const onFailureSave = jest.fn();
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button
+                        onClick={() =>
+                            save({ ...record, title: 'ipsum' }, undefined, {
+                                onFailure: onFailureSave,
+                            })
+                        }
+                    >
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        onFailure={onFailure}
+                        undoable={false}
+                    >
+                        <FakeForm />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            await wait(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await wait(() => {
+                expect(onFailureSave).toHaveBeenCalledWith({
+                    message: 'not good',
+                });
+                expect(onFailure).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('transform prop', () => {
+        it('should allow to transform the data before calling update', async () => {
+            const update = jest
+                .fn()
+                .mockImplementationOnce((_, { data }) =>
+                    Promise.resolve({ data })
+                );
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update,
+            };
+            const transform = jest.fn().mockImplementationOnce(data => ({
+                ...data,
+                transformed: true,
+            }));
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button onClick={() => save({ ...record, title: 'ipsum' })}>
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        transform={transform}
+                        undoable={false}
+                    >
+                        <FakeForm />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            await wait(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await wait(() => {
+                expect(transform).toHaveBeenCalledWith({
+                    id: 123,
+                    title: 'ipsum',
+                });
+                expect(update).toHaveBeenCalledWith('foo', {
+                    id: '123',
+                    data: { id: 123, title: 'ipsum', transformed: true },
+                    previousData: { id: 123, title: 'lorem' },
+                });
+            });
+        });
+
+        it('should be overridden by transform save option', async () => {
+            const update = jest
+                .fn()
+                .mockImplementationOnce((_, { data }) =>
+                    Promise.resolve({ data })
+                );
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update,
+            };
+            const transform = jest.fn();
+            const transformSave = jest.fn().mockImplementationOnce(data => ({
+                ...data,
+                transformed: true,
+            }));
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button
+                        onClick={() =>
+                            save({ ...record, title: 'ipsum' }, undefined, {
+                                transform: transformSave,
+                            })
+                        }
+                    >
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        transform={transform}
+                        undoable={false}
+                    >
+                        <FakeForm />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            await wait(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await wait(() => {
+                expect(transform).not.toHaveBeenCalled();
+                expect(transformSave).toHaveBeenCalledWith({
+                    id: 123,
+                    title: 'ipsum',
+                });
+                expect(update).toHaveBeenCalledWith('foo', {
+                    id: '123',
+                    data: { id: 123, title: 'ipsum', transformed: true },
+                    previousData: { id: 123, title: 'lorem' },
+                });
+            });
+        });
+    });
+
+    describe('aside prop', () => {
+        it('should display aside component', () => {
+            const Aside = () => <div id="aside">Hello</div>;
+            const dataProvider = {
+                getOne: () => Promise.resolve({ data: { id: 123 } }),
+            };
+            const Dummy = () => <div />;
+            const { queryAllByText } = renderWithRedux(
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit {...defaultEditProps} aside={<Aside />}>
+                        <Dummy />
+                    </Edit>
+                </DataProviderContext.Provider>,
+                { admin: { resources: { foo: { data: {} } } } }
+            );
+            expect(queryAllByText('Hello')).toHaveLength(1);
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -61,6 +61,7 @@ SimpleForm.propTypes = {
     save: PropTypes.func,
     saving: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
     submitOnEnter: PropTypes.bool,
+    toolbar: PropTypes.element,
     undoable: PropTypes.bool,
     validate: PropTypes.func,
     version: PropTypes.number,


### PR DESCRIPTION
## Problem

I wanted to force a refresh after save in a `<Create>` view. I found it super hard to do even though I know the react-admin internals. I realized it's probably impossible for someone who doesn't know react-admin. 

Also, there are ways to override the notification message in the Create/Edit view (`successMessage`) and ways to override the `redirect` in `SimpleForm`. These are both side effects that should be the responsibility of the main controller, not the form. These props allow a very granular customization, but don't allow adding another side effect.

Finally, the recent addition of the `onSave` prop requires too much documentation and too much boilerplate for most common use cases. 

## Solution

Allow users to declare success and failure side effects at the controller side, and to override them for each `SaveButton`.

Introduce a `transform` function to transform a submitted record before it is sent to the `dataProvider`.

## Examples

Customizing the notification based on the error from the `dataProvider`:

```jsx
import { Edit, useNotify, useRedirect } from 'react-admin';

const PostEdit = props => {
    const notify = useNotify();
    const redirect = useRedirect();
    const onFailure = (error) => {
        if (error.code == 123) {
            notify('Could not save changes: concurrent edition in progress', 'warning');
        } else {
            notify('ra.notification.http_error', 'warning')
        }
        redirect('list', props.basePath);
    }
    return (
        <Edit {...props} onFailure={onFailure}>
            ...
        </Edit>
    );
}
```

Altering the form value when the user clicks on a particular save button:

```jsx
const PostCreateToolbar = props => (
    <Toolbar {...props}>
        <SaveButton submitOnEnter={true} />
        <SaveButton
            label="post.action.save_and_notify"
            transform={data => ({ ...data, notify: true })}
            submitOnEnter={false}
        />
    </Toolbar>
);

const PostCreate = (props) => (
    <Create {...props}>
        <SimpleForm toolbar={<PostCreateToolbar />}>
            // ...
        </SimpleForm>
    </Create>
);
```

## Tasks

- [x] Add `onSuccess`, `onFailure` and `transform` support in `<Create>` and `<Edit>`
- [x] Add `onSuccess`, `onFailure` and `transform` support in `<SaveButton>`
- [x] Deprecate `successMessage`
- [x] Deprecate `onSave`
- [x] Add unit & integration tests for the new props
- [x] Update documentation