### PR TITLE
Add default margin to AutocompleteArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -108,7 +108,7 @@ const AutocompleteArrayInput: FunctionComponent<
         isRequired: isRequiredOverride,
         label,
         limitChoicesToValue,
-        margin,
+        margin = 'dense',
         matchSuggestion,
         meta: metaOverride,
         onBlur,


### PR DESCRIPTION
The `AutocompleteArrayInput` renders without separation from whichever component precedes it, unless a margin is set manually.

`AutocompleteInput` and other input components [provide a sensible default for the margin](https://github.com/marmelab/react-admin/blob/9a5f1f10d049aaa24430b47826c0c3c1a72af5d9/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx#L111). This PR extends the same default to `AutocompleteArrayInput`.