### PR TITLE
Make boolean field less tall by default

### DIFF
--- a/examples/demo/src/reviews/StarRatingField.tsx
+++ b/examples/demo/src/reviews/StarRatingField.tsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     root: {
         opacity: 0.87,
         whiteSpace: 'nowrap',
+        display: 'flex',
     },
     large: {
         width: 20,
@@ -30,7 +31,7 @@ const StarRatingField: FC<FieldProps & OwnProps> = ({
 }) => {
     const classes = useStyles();
     return record ? (
-        <span>
+        <span className={classes.root}>
             {Array(record.rating)
                 .fill(true)
                 .map((_, i) => (

--- a/examples/demo/src/visitors/FullNameField.tsx
+++ b/examples/demo/src/visitors/FullNameField.tsx
@@ -13,6 +13,8 @@ const useStyles = makeStyles(theme => ({
     },
     avatar: {
         marginRight: theme.spacing(1),
+        marginTop: -theme.spacing(0.5),
+        marginBottom: -theme.spacing(0.5),
     },
 }));
 

--- a/examples/demo/src/visitors/SegmentsField.tsx
+++ b/examples/demo/src/visitors/SegmentsField.tsx
@@ -28,6 +28,7 @@ const SegmentsField: FC<FieldProps<Customer>> = ({ record }) => {
 
                     return segment ? (
                         <Chip
+                            size="small"
                             key={segment.id}
                             className={classes.chip}
                             label={translate(segment.name)}

--- a/examples/demo/src/visitors/VisitorList.tsx
+++ b/examples/demo/src/visitors/VisitorList.tsx
@@ -63,7 +63,11 @@ const VisitorList = (props: any) => {
                         options={{ style: 'currency', currency: 'USD' }}
                     />
                     <DateField source="latest_purchase" showTime />
-                    <BooleanField source="has_newsletter" label="News." />
+                    <BooleanField
+                        source="has_newsletter"
+                        label="News."
+                        size="small"
+                    />
                     <SegmentsField />
                 </Datagrid>
             )}

--- a/examples/simple/src/posts/PostList.js
+++ b/examples/simple/src/posts/PostList.js
@@ -163,7 +163,7 @@ const PostList = props => {
                         headerClassName={classes.hiddenOnSmallScreens}
                     >
                         <SingleFieldList>
-                            <ChipField source="name" />
+                            <ChipField source="name" size="small" />
                         </SingleFieldList>
                     </ReferenceArrayField>
                     <PostListActionToolbar>

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -17,11 +17,16 @@ interface Props extends FieldProps {
     valueLabelFalse?: string;
 }
 
-const useStyles = makeStyles({
-    root: {
-        display: 'flex',
+const useStyles = makeStyles(
+    {
+        root: {
+            display: 'flex',
+        },
     },
-});
+    {
+        name: 'RaBooleanField',
+    }
+);
 
 export const BooleanField: FunctionComponent<
     Props & InjectedFieldProps & TypographyProps

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { FunctionComponent, memo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
+import classnames from 'classnames';
 import FalseIcon from '@material-ui/icons/Clear';
 import TrueIcon from '@material-ui/icons/Done';
-import { Tooltip, Typography } from '@material-ui/core';
+import { Tooltip, Typography, makeStyles } from '@material-ui/core';
 import { TypographyProps } from '@material-ui/core/Typography';
 import { useTranslate } from 'ra-core';
 
@@ -16,10 +17,16 @@ interface Props extends FieldProps {
     valueLabelFalse?: string;
 }
 
+const useStyles = makeStyles({
+    root: {
+        display: 'flex',
+    },
+});
+
 export const BooleanField: FunctionComponent<
     Props & InjectedFieldProps & TypographyProps
-> = memo<Props & InjectedFieldProps & TypographyProps>(
-    ({
+> = memo<Props & InjectedFieldProps & TypographyProps>(props => {
+    const {
         className,
         classes: classesOverride,
         emptyText,
@@ -28,47 +35,46 @@ export const BooleanField: FunctionComponent<
         valueLabelTrue,
         valueLabelFalse,
         ...rest
-    }) => {
-        const translate = useTranslate();
-        const value = get(record, source);
-        let ariaLabel = value ? valueLabelTrue : valueLabelFalse;
+    } = props;
+    const translate = useTranslate();
+    const classes = useStyles(props);
+    const value = get(record, source);
+    let ariaLabel = value ? valueLabelTrue : valueLabelFalse;
 
-        if (!ariaLabel) {
-            ariaLabel =
-                value === false ? 'ra.boolean.false' : 'ra.boolean.true';
-        }
+    if (!ariaLabel) {
+        ariaLabel = value === false ? 'ra.boolean.false' : 'ra.boolean.true';
+    }
 
-        if (value === false || value === true) {
-            return (
-                <Typography
-                    component="span"
-                    variant="body2"
-                    className={className}
-                    {...sanitizeRestProps(rest)}
-                >
-                    <Tooltip title={translate(ariaLabel, { _: ariaLabel })}>
-                        {value === true ? (
-                            <TrueIcon data-testid="true" />
-                        ) : (
-                            <FalseIcon data-testid="false" />
-                        )}
-                    </Tooltip>
-                </Typography>
-            );
-        }
-
+    if (value === false || value === true) {
         return (
             <Typography
                 component="span"
                 variant="body2"
-                className={className}
+                className={classnames(classes.root, className)}
                 {...sanitizeRestProps(rest)}
             >
-                {emptyText}
+                <Tooltip title={translate(ariaLabel, { _: ariaLabel })}>
+                    {value === true ? (
+                        <TrueIcon data-testid="true" fontSize="small" />
+                    ) : (
+                        <FalseIcon data-testid="false" fontSize="small" />
+                    )}
+                </Tooltip>
             </Typography>
         );
     }
-);
+
+    return (
+        <Typography
+            component="span"
+            variant="body2"
+            className={className}
+            {...sanitizeRestProps(rest)}
+        >
+            {emptyText}
+        </Typography>
+    );
+});
 
 BooleanField.defaultProps = {
     addLabel: true,


### PR DESCRIPTION
## Problem

`<BooleanField>` makes all lines in a `<Datagrid>` taller. 

## Solution

Make it smaller. Also, use smaller chips in `<ReferenceManyField>` in datagrids. This makes the grid data density consistent whether it contains `<BooleanField>` components or not. 

## Before

![image](https://user-images.githubusercontent.com/99944/83906938-c0b6e000-a764-11ea-9f3f-e102947ff4f5.png)

## After

![image](https://user-images.githubusercontent.com/99944/83906730-6584ed80-a764-11ea-81fd-a9982a23bf9f.png)


