### PR TITLE
docs: Replaced UrlInput with TextInput in ArrayInput comments

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.tsx
@@ -11,12 +11,12 @@ import sanitizeRestProps from './sanitizeRestProps';
  *
  *  @example
  *
- *      import { ArrayInput, SimpleFormIterator, DateInput, UrlInput } from 'react-admin';
+ *      import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
  *
  *      <ArrayInput source="backlinks">
  *          <SimpleFormIterator>
  *              <DateInput source="date" />
- *              <UrlInput source="url" />
+ *              <TextInput source="url" />
  *          </SimpleFormIterator>
  *      </ArrayInput>
  *


### PR DESCRIPTION
Hi,
while trying to understand how `ArrayInput` works, I came across `UrlInput` which seems deprecated because the docs say `TextInput` handles a.o. URLs.

I am not sure if the `master` branch is the right one for the PR because `README` says to open PR into the `next` if its a feature, but did not find info what to do in case such minor changes like in this PR