### PR TITLE
[RFR] feat: Added disableIndex prop for SimpleFormIterator to omit rendering of the current index

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -114,7 +114,7 @@ import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admi
 
 `<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component accepting a `fields` object as passed by [react-final-form-array](https://github.com/final-form/react-final-form-arrays#fieldarrayrenderprops), and defining a layout for an array of fields. For instance, the `<SimpleFormIterator>` component displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record (a backlink in this example).
 
-You can pass `disableAdd` and `disableRemove` as props of `SimpleFormIterator`, to disable `ADD` and `REMOVE` button respectively. Default value of both is `false`.
+You can pass `disableAdd` and `disableRemove` as props of `SimpleFormIterator`, to disable `ADD` and `REMOVE` button respectively as well as `disableIndex` to omit rendering of the current index. Default value for all three props is `false`.
 
 ```jsx
 import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -138,12 +138,14 @@ const SimpleFormIterator = props => {
                         {...TransitionProps}
                     >
                         <li className={classes.line}>
-                        {!disableIndex && ( <Typography
-                                variant="body1"
-                                className={classes.index}
-                            >
-                                {index + 1})
-                            </Typography>
+                            {!disableIndex && (
+                                <Typography
+                                    variant="body1"
+                                    className={classes.index}
+                                >
+                                    {index + 1}
+                                </Typography>
+                            )}
                             <section className={classes.form}>
                                 {Children.map(children, (input, index2) =>
                                     isValidElement(input) ? (
@@ -153,7 +155,9 @@ const SimpleFormIterator = props => {
                                             }
                                             input={cloneElement(input, {
                                                 source: input.props.source
-                                                    ? `${member}.${input.props.source}`
+                                                    ? `${member}.${
+                                                          input.props.source
+                                                      }`
                                                     : member,
                                                 index: input.props.source
                                                     ? undefined
@@ -162,7 +166,10 @@ const SimpleFormIterator = props => {
                                                     typeof input.props.label ===
                                                     'undefined'
                                                         ? input.props.source
-                                                            ? `resources.${resource}.fields.${input.props.source}`
+                                                            ? `resources.${resource}.fields.${
+                                                                  input.props
+                                                                      .source
+                                                              }`
                                                             : undefined
                                                         : input.props.label,
                                             })}

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.js
@@ -73,6 +73,7 @@ const SimpleFormIterator = props => {
         source,
         disableAdd,
         disableRemove,
+        disableIndex,
         variant,
         margin,
         TransitionProps,
@@ -137,11 +138,11 @@ const SimpleFormIterator = props => {
                         {...TransitionProps}
                     >
                         <li className={classes.line}>
-                            <Typography
+                        {!disableIndex && ( <Typography
                                 variant="body1"
                                 className={classes.index}
                             >
-                                {index + 1}
+                                {index + 1})
                             </Typography>
                             <section className={classes.form}>
                                 {Children.map(children, (input, index2) =>
@@ -152,9 +153,7 @@ const SimpleFormIterator = props => {
                                             }
                                             input={cloneElement(input, {
                                                 source: input.props.source
-                                                    ? `${member}.${
-                                                          input.props.source
-                                                      }`
+                                                    ? `${member}.${input.props.source}`
                                                     : member,
                                                 index: input.props.source
                                                     ? undefined
@@ -163,10 +162,7 @@ const SimpleFormIterator = props => {
                                                     typeof input.props.label ===
                                                     'undefined'
                                                         ? input.props.source
-                                                            ? `resources.${resource}.fields.${
-                                                                  input.props
-                                                                      .source
-                                                              }`
+                                                            ? `resources.${resource}.fields.${input.props.source}`
                                                             : undefined
                                                         : input.props.label,
                                             })}
@@ -229,6 +225,7 @@ const SimpleFormIterator = props => {
 SimpleFormIterator.defaultProps = {
     disableAdd: false,
     disableRemove: false,
+    disableIndex: false,
 };
 
 SimpleFormIterator.propTypes = {
@@ -243,6 +240,7 @@ SimpleFormIterator.propTypes = {
     source: PropTypes.string,
     resource: PropTypes.string,
     translate: PropTypes.func,
+    disableIndex: PropTypes.bool,
     disableAdd: PropTypes.bool,
     disableRemove: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     TransitionProps: PropTypes.shape({}),


### PR DESCRIPTION
Hi,
added simple prop for SimpleFormIterator to disable rendering of index.

Here is how simple demo it looks like if prop `disableIndex` is passed

![Screenshot 2020-06-07 at 09 48 11](https://user-images.githubusercontent.com/2700828/83963152-10e88c00-a8a4-11ea-825a-458b1b9f1a83.png)


I am not sure how and where to write the test for this? Any advise or guidance would be greatly appreciated

