### PR TITLE
Set HttpError name to be HttpError

### DIFF
--- a/packages/ra-core/src/dataProvider/HttpError.ts
+++ b/packages/ra-core/src/dataProvider/HttpError.ts
@@ -5,7 +5,7 @@ class HttpError extends Error {
         public readonly body = null
     ) {
         super(message);
-        this.name = this.constructor.name;
+        this.name = 'HttpError';
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, this.constructor);
         } else {

--- a/packages/ra-core/src/dataProvider/HttpError.ts
+++ b/packages/ra-core/src/dataProvider/HttpError.ts
@@ -5,7 +5,8 @@ class HttpError extends Error {
         public readonly body = null
     ) {
         super(message);
-        this.name = 'HttpError';
+        Object.setPrototypeOf(this, HttpError.prototype);
+        this.name = this.constructor.name;
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, this.constructor);
         } else {


### PR DESCRIPTION
While trying to use `error.name`, I noticed that the HttpError used by react-admin has its name set to `Error` instead of `HttpError`. I believe this is probably due to https://github.com/Microsoft/TypeScript/issues/14099

Setting it explicitly seems like it would be fine in this case, but let me know if you prefer a different solution.