### PR TITLE
fix ArrayField initial state value

### DIFF
--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -134,8 +134,8 @@ export const ArrayField: FunctionComponent<
         fieldKey,
         ...rest
     }) => {
-        const [ids, setIds] = useState();
-        const [data, setData] = useState();
+        const [ids, setIds] = useState(initialState.ids);
+        const [data, setData] = useState(initialState.data);
 
         useEffect(() => {
             const { ids, data } = getDataAndIds(record, source, fieldKey);


### PR DESCRIPTION
Hi,

When I am using `<SingleFieldList>` component as children of `<ArrayField>`, there seems to have a race condition that will make the whole `<List>` view of a resource crash sometime.

The error message is:
> TypeError: ids is undefined

I have traced the issue to its parent component. The useState hook is not initializing ids and data properly, setting them to undefined value. The useEffect hook will run during first render, but the state update function setIds and setData are asynchronous. This will cause the undefined ids to be passed down and ids.map function cannot be called properly.

The fix is also simple, just adding initial states.

Thank you