### PR TITLE
Change id for RadioButtonGroupInputItem to use value rather than label

### DIFF
--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.spec.tsx
@@ -41,6 +41,45 @@ describe('<RadioButtonGroupInput />', () => {
         expect(input2.checked).toBeFalsy();
     });
 
+    it('should set labels correctly for react component choices', () => {
+        const FullNameField = ({ record }) => (
+            <span>
+                {record.first_name} {record.last_name}
+            </span>
+        );
+
+        const { getByLabelText, queryByText } = render(
+            <Form
+                onSubmit={jest.fn}
+                render={() => (
+                    <RadioButtonGroupInput
+                        resource={'people'}
+                        source="type"
+                        choices={[
+                            {
+                                id: 123,
+                                first_name: 'Leo',
+                                last_name: 'Tolstoi',
+                            },
+                            {
+                                id: 456,
+                                first_name: 'Jane',
+                                last_name: 'Austen',
+                            },
+                        ]}
+                        optionText={record => <FullNameField record={record} />}
+                        label="People"
+                    />
+                )}
+            />
+        );
+        expect(queryByText('People')).not.toBeNull();
+        const input1 = getByLabelText('Leo Tolstoi');
+        expect(input1.id).toBe('type_123');
+        const input2 = getByLabelText('Jane Austen');
+        expect(input2.id).toBe('type_456');
+    });
+
     it('should trigger custom onChange when clicking radio button', async () => {
         const onChange = jest.fn();
         const { getByLabelText, queryByText } = render(

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInputItem.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInputItem.tsx
@@ -26,7 +26,7 @@ const RadioButtonGroupInputItem = ({
         value,
     });
 
-    const nodeId = `${source}_${label}`;
+    const nodeId = `${source}_${value}`;
 
     return (
         <FormControlLabel


### PR DESCRIPTION
Fixes #4924
(as this supports choices rendered as react components)