### PR TITLE
Fix update or delete resets the pagination

### DIFF
--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -174,15 +174,17 @@ const useListController = <RecordType = Record>(
             get(state.admin.resources, [resource, 'list', 'total'], 0)
     );
 
+    const finalIds = typeof total === 'undefined' ? defaultIds : ids;
+
     useEffect(() => {
         if (
             query.page <= 0 ||
-            (!loading && query.page > 1 && (ids || []).length === 0)
+            (!loading && query.page > 1 && (finalIds || []).length === 0)
         ) {
             // query for a page that doesn't exist, set page to 1
             queryModifiers.setPage(1);
         }
-    }, [loading, query.page, ids, queryModifiers]);
+    }, [loading, query.page, finalIds, queryModifiers, total, defaultIds]);
 
     const currentSort = useMemo(
         () => ({
@@ -209,7 +211,7 @@ const useListController = <RecordType = Record>(
         filterValues: query.filterValues,
         hasCreate,
         hideFilter: queryModifiers.hideFilter,
-        ids: typeof total === 'undefined' ? defaultIds : ids,
+        ids: finalIds,
         loaded: loaded || defaultIds.length > 0,
         loading,
         onSelect: selectionModifiers.select,


### PR DESCRIPTION
The problem was that the update or delete removes the cachedRequests from the store. The list controller properly uses the ids reducer in that case - but not the effect checking the validity of the pagination.

Closes #4902