### PR TITLE
Add generics to TranslationMessage

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -2,11 +2,9 @@ interface StringMap {
     [key: string]: StringMap | string | undefined;
 }
 
-export interface TranslationMessages extends StringMap {
+export interface RATranslationMessages {
     ra: {
         action: {
-            // for custom translation strings
-            [key: string]: StringMap | string;
             add_filter: string;
             add: string;
             back: string;
@@ -34,13 +32,11 @@ export interface TranslationMessages extends StringMap {
             close_menu: string;
         };
         boolean: {
-            [key: string]: StringMap | string;
             true: string;
             false: string;
             null: string;
         };
         page: {
-            [key: string]: StringMap | string;
             create: string;
             dashboard: string;
             edit: string;
@@ -53,31 +49,25 @@ export interface TranslationMessages extends StringMap {
             invite: string;
         };
         input: {
-            [key: string]: StringMap | string;
             file: {
-                [key: string]: StringMap | string;
                 upload_several: string;
                 upload_single: string;
             };
             image: {
-                [key: string]: StringMap | string;
                 upload_several: string;
                 upload_single: string;
             };
             references: {
-                [key: string]: StringMap | string;
                 all_missing: string;
                 many_missing: string;
                 single_missing: string;
             };
             password: {
-                [key: string]: StringMap | string;
                 toggle_visible: string;
                 toggle_hidden: string;
             };
         };
         message: {
-            [key: string]: StringMap | string;
             about: string;
             are_you_sure: string;
             bulk_delete_content: string;
@@ -94,7 +84,6 @@ export interface TranslationMessages extends StringMap {
             unsaved_changes: string;
         };
         navigation: {
-            [key: string]: StringMap | string;
             no_results: string;
             no_more_results: string;
             page_out_of_boundaries: string;
@@ -106,7 +95,6 @@ export interface TranslationMessages extends StringMap {
             prev: string;
         };
         auth: {
-            [key: string]: StringMap | string;
             auth_check_error: string;
             user_menu: string;
             username: string;
@@ -116,7 +104,6 @@ export interface TranslationMessages extends StringMap {
             logout: string;
         };
         notification: {
-            [key: string]: StringMap | string;
             updated: string;
             created: string;
             deleted: string;
@@ -129,7 +116,6 @@ export interface TranslationMessages extends StringMap {
             logged_out: string;
         };
         validation: {
-            [key: string]: StringMap | string;
             required: string;
             minLength: string;
             maxLength: string;
@@ -142,3 +128,5 @@ export interface TranslationMessages extends StringMap {
         };
     };
 }
+
+export type TranslationMessages<T = {}> = RATranslationMessages & T;


### PR DESCRIPTION
This will allow translations to be typed and extended with custom translations.

If this change is fine, I will continue working on it to fully include it in react-admin.