### PR TITLE
Export ExpandRowButton for reuse

### DIFF
--- a/packages/ra-ui-materialui/src/list/index.js
+++ b/packages/ra-ui-materialui/src/list/index.js
@@ -6,6 +6,7 @@ import DatagridBody, { PureDatagridBody } from './DatagridBody';
 import DatagridRow, { PureDatagridRow } from './DatagridRow';
 import DatagridHeaderCell from './DatagridHeaderCell';
 import DatagridCell from './DatagridCell';
+import ExpandRowButton from './ExpandRowButton';
 import Filter from './Filter';
 import FilterButton from './FilterButton';
 import FilterForm from './FilterForm';
@@ -30,6 +31,7 @@ export {
     DatagridRow,
     DatagridHeaderCell,
     DatagridCell,
+    ExpandRowButton,
     Filter,
     FilterButton,
     FilterForm,


### PR DESCRIPTION
I need the `ExpandRowButton` in case I want to extend  react-admin `Datagrid` with my own behaviour, and keep the expandable grid lines.