### PR TITLE
Fix : Resource name case in confirm for multi-language

### DIFF
--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -605,7 +605,7 @@ If you want to override these messages in a specific resource you can add the fo
 In confirm messages and in the empty page, the resource name appears in the middle of sentences, and react-admin automatically sets the resource name translation to lower case.  
 ie: `Are you sure you want to delete this comment?`
 
-This have been done to have a correct syntax in english, but you may want to force it elseway to match with another language, like German where names are always capitalized.  
+This works in English, but you may want to display resources in another way to match with language rules, like in German, where names are always capitalized.  
 ie: `Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?`
 
 To do this, simply add a `forcedCaseName` key next to the `name` key in your translation file.

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -602,7 +602,7 @@ If you want to override these messages in a specific resource you can add the fo
 
 ## Specific case in Confirm messages and Empty Page
 
-In confirm messages and in the empty page, the resource name translations are automatically set to lower case.  
+In confirm messages and in the empty page, the resource name appears in the middle of sentences, and react-admin automatically sets the resource name translation to lower case.  
 ie: `Are you sure you want to delete this comment?`
 
 This have been done to have a correct syntax in english, but you may want to force it elseway to match with another language, like German where names are always capitalized.  

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -602,32 +602,25 @@ If you want to override these messages in a specific resource you can add the fo
 
 ## Specific case in Confirm messages and Empty Page
 
-In confirm messages and in the empty page, the resource name translations are automatically set to lower case.
+In confirm messages and in the empty page, the resource name translations are automatically set to lower case.  
 ie: `Are you sure you want to delete this comment?`
 
-This have been done to have a correct syntax in english language, but you ay want to force it elseway to match with another language, like German where names are always capitalized.
+This have been done to have a correct syntax in english, but you may want to force it elseway to match with another language, like German where names are always capitalized.  
 ie: `Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?`
 
 To do this, simply add a `forcedCaseName` key next to the `name` key in tour translation file.
 
 ```json
 resources: {
-        comments: {
-            name: 'Kommentar |||| Kommentare',
-            forcedCaseName: 'Kommentar |||| Kommentare',
-            fields: {
-                id: 'Id',
-                name: 'Bezeichnung',
-            },
+    comments: {
+        name: 'Kommentar |||| Kommentare',
+        forcedCaseName: 'Kommentar |||| Kommentare',
+        fields: {
+            id: 'Id',
+            name: 'Bezeichnung',
         },
+    },
 ```
-
-React-admin uses the keys `ra.page.empty` and `ra.page.invite` when displaying the page inviting the user to create the first record.
-
-If you want to override these messages in a specific resource you can add the following keys to your translation:
-
-- `resources.${resourceName}.empty` for the primary message (e.g. "No posts yet.")
-- `resources.${resourceName}.invite` for the message inviting the user to create one (e.g. "Do you want to create one?")
 
 ## Silencing Translation Warnings
 

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -613,15 +613,11 @@ To do this, simply add a `forcedCaseName` key next to the `name` key in tour tra
 ```json
 resources: {
         comments: {
-            name: 'Comment |||| Comments',
-            forcedCaseName: 'Comment |||| Comments',
+            name: 'Kommentar |||| Kommentare',
+            forcedCaseName: 'Kommentar |||| Kommentare',
             fields: {
-                body: 'Body',
-                created_at: 'Created at',
-                post_id: 'Posts',
-                author: {
-                    name: 'Author',
-                },
+                id: 'Id',
+                name: 'Bezeichnung',
             },
         },
 ```

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -600,6 +600,39 @@ If you want to override these messages in a specific resource you can add the fo
 - `resources.${resourceName}.empty` for the primary message (e.g. "No posts yet.")
 - `resources.${resourceName}.invite` for the message inviting the user to create one (e.g. "Do you want to create one?")
 
+## Specific case in Confirm messages and Empty Page
+
+In confirm messages and in the empty page, the resource name translations are automatically set to lower case.
+ie: `Are you sure you want to delete this comment?`
+
+This have been done to have a correct syntax in english language, but you ay want to force it elseway to match with another language, like German where names are always capitalized.
+ie: `Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?`
+
+To do this, simply add a `forcedCaseName` key next to the `name` key in tour translation file.
+
+```json
+resources: {
+        comments: {
+            name: 'Comment |||| Comments',
+            forcedCaseName: 'Comment |||| Comments',
+            fields: {
+                body: 'Body',
+                created_at: 'Created at',
+                post_id: 'Posts',
+                author: {
+                    name: 'Author',
+                },
+            },
+        },
+```
+
+React-admin uses the keys `ra.page.empty` and `ra.page.invite` when displaying the page inviting the user to create the first record.
+
+If you want to override these messages in a specific resource you can add the following keys to your translation:
+
+- `resources.${resourceName}.empty` for the primary message (e.g. "No posts yet.")
+- `resources.${resourceName}.invite` for the message inviting the user to create one (e.g. "Do you want to create one?")
+
 ## Silencing Translation Warnings
 
 By default, the `polyglotI18nProvider` logs a warning in the console each time it is called with a message that can't be found in the current translations. This is a Polyglot feature that helps tracking missing translation messages.

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -610,7 +610,7 @@ ie: `Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?`
 
 To do this, simply add a `forcedCaseName` key next to the `name` key in tour translation file.
 
-```json
+```js
 resources: {
     comments: {
         name: 'Kommentar |||| Kommentare',

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -608,7 +608,7 @@ ie: `Are you sure you want to delete this comment?`
 This have been done to have a correct syntax in english, but you may want to force it elseway to match with another language, like German where names are always capitalized.  
 ie: `Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?`
 
-To do this, simply add a `forcedCaseName` key next to the `name` key in tour translation file.
+To do this, simply add a `forcedCaseName` key next to the `name` key in your translation file.
 
 ```js
 resources: {

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -603,7 +603,8 @@ If you want to override these messages in a specific resource you can add the fo
 ## Specific case in Confirm messages and Empty Page
 
 In confirm messages and in the empty page, the resource name appears in the middle of sentences, and react-admin automatically sets the resource name translation to lower case.  
-ie: `Are you sure you want to delete this comment?`
+
+> Are you sure you want to delete this comment?
 
 This works in English, but you may want to display resources in another way to match with language rules, like in German, where names are always capitalized.  
 ie: `Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?`

--- a/examples/demo/src/i18n/en.ts
+++ b/examples/demo/src/i18n/en.ts
@@ -40,6 +40,7 @@ const customEnglishMessages: TranslationMessages = {
     resources: {
         customers: {
             name: 'Customer |||| Customers',
+            forcedCaseName: 'Customer |||| Customers',
             fields: {
                 commands: 'Orders',
                 first_seen: 'First seen',
@@ -81,6 +82,7 @@ const customEnglishMessages: TranslationMessages = {
         },
         commands: {
             name: 'Order |||| Orders',
+            forcedCaseName: 'Order |||| Orders',
             amount: '1 order |||| %{smart_count} orders',
             title: 'Order %{reference}',
             fields: {
@@ -103,6 +105,7 @@ const customEnglishMessages: TranslationMessages = {
         },
         invoices: {
             name: 'Invoice |||| Invoices',
+            forcedCaseName: 'Invoice |||| Invoices',
             fields: {
                 date: 'Invoice date',
                 customer_id: 'Customer',
@@ -115,6 +118,7 @@ const customEnglishMessages: TranslationMessages = {
         },
         products: {
             name: 'Poster |||| Posters',
+            forcedCaseName: 'Poster |||| Posters',
             fields: {
                 category_id: 'Category',
                 height_gte: 'Min height',
@@ -139,12 +143,14 @@ const customEnglishMessages: TranslationMessages = {
         },
         categories: {
             name: 'Category |||| Categories',
+            forcedCaseName: 'Category |||| Categories',
             fields: {
                 products: 'Products',
             },
         },
         reviews: {
             name: 'Review |||| Reviews',
+            forcedCaseName: 'Review |||| Reviews',
             amount: '1 review |||| %{smart_count} reviews',
             relative_to_poster: 'Review on poster',
             detail: 'Review detail',
@@ -170,7 +176,8 @@ const customEnglishMessages: TranslationMessages = {
             },
         },
         segments: {
-            name: 'Segments',
+            name: 'Segment || Segments',
+            forcedCaseName: 'Segment || Segments',
             fields: {
                 customers: 'Customers',
                 name: 'Name',

--- a/examples/demo/src/i18n/en.ts
+++ b/examples/demo/src/i18n/en.ts
@@ -40,7 +40,6 @@ const customEnglishMessages: TranslationMessages = {
     resources: {
         customers: {
             name: 'Customer |||| Customers',
-            forcedCaseName: 'Customer |||| Customers',
             fields: {
                 commands: 'Orders',
                 first_seen: 'First seen',
@@ -82,7 +81,6 @@ const customEnglishMessages: TranslationMessages = {
         },
         commands: {
             name: 'Order |||| Orders',
-            forcedCaseName: 'Order |||| Orders',
             amount: '1 order |||| %{smart_count} orders',
             title: 'Order %{reference}',
             fields: {
@@ -105,7 +103,6 @@ const customEnglishMessages: TranslationMessages = {
         },
         invoices: {
             name: 'Invoice |||| Invoices',
-            forcedCaseName: 'Invoice |||| Invoices',
             fields: {
                 date: 'Invoice date',
                 customer_id: 'Customer',
@@ -118,7 +115,6 @@ const customEnglishMessages: TranslationMessages = {
         },
         products: {
             name: 'Poster |||| Posters',
-            forcedCaseName: 'Poster |||| Posters',
             fields: {
                 category_id: 'Category',
                 height_gte: 'Min height',
@@ -143,14 +139,12 @@ const customEnglishMessages: TranslationMessages = {
         },
         categories: {
             name: 'Category |||| Categories',
-            forcedCaseName: 'Category |||| Categories',
             fields: {
                 products: 'Products',
             },
         },
         reviews: {
             name: 'Review |||| Reviews',
-            forcedCaseName: 'Review |||| Reviews',
             amount: '1 review |||| %{smart_count} reviews',
             relative_to_poster: 'Review on poster',
             detail: 'Review detail',
@@ -177,7 +171,6 @@ const customEnglishMessages: TranslationMessages = {
         },
         segments: {
             name: 'Segment || Segments',
-            forcedCaseName: 'Segment || Segments',
             fields: {
                 customers: 'Customers',
                 name: 'Name',

--- a/examples/simple/src/i18n/en.js
+++ b/examples/simple/src/i18n/en.js
@@ -12,7 +12,6 @@ export const messages = {
     resources: {
         posts: {
             name: 'Post |||| Posts',
-            forcedCaseName: 'Post |||| Posts',
             fields: {
                 average_note: 'Average note',
                 body: 'Body',
@@ -34,7 +33,6 @@ export const messages = {
         },
         comments: {
             name: 'Comment |||| Comments',
-            forcedCaseName: 'Comment |||| Comments',
             fields: {
                 body: 'Body',
                 created_at: 'Created at',
@@ -46,7 +44,6 @@ export const messages = {
         },
         users: {
             name: 'User |||| Users',
-            forcedCaseName: 'User |||| Users',
             fields: {
                 name: 'Name',
                 role: 'Role',

--- a/examples/simple/src/i18n/en.js
+++ b/examples/simple/src/i18n/en.js
@@ -12,6 +12,7 @@ export const messages = {
     resources: {
         posts: {
             name: 'Post |||| Posts',
+            forcedCaseName: 'Post |||| Posts',
             fields: {
                 average_note: 'Average note',
                 body: 'Body',
@@ -33,6 +34,7 @@ export const messages = {
         },
         comments: {
             name: 'Comment |||| Comments',
+            forcedCaseName: 'Comment |||| Comments',
             fields: {
                 body: 'Body',
                 created_at: 'Created at',
@@ -44,6 +46,7 @@ export const messages = {
         },
         users: {
             name: 'User |||| Users',
+            forcedCaseName: 'User |||| Users',
             fields: {
                 name: 'Name',
                 role: 'Role',

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -109,13 +109,19 @@ const BulkDeleteWithConfirmButton: FC<
                 content={confirmContent}
                 translateOptions={{
                     smart_count: selectedIds.length,
-                    name: inflection.humanize(
-                        translate(`resources.${resource}.name`, {
-                            smart_count: selectedIds.length,
-                            _: inflection.inflect(resource, selectedIds.length),
-                        }),
-                        true
-                    ),
+                    name: translate(`resources.${resource}.forcedCaseName`, {
+                        smart_count: selectedIds.length,
+                        _: inflection.humanize(
+                            translate(`resources.${resource}.name`, {
+                                smart_count: selectedIds.length,
+                                _: inflection.inflect(
+                                    resource,
+                                    selectedIds.length
+                                ),
+                            }),
+                            true
+                        ),
+                    }),
                 }}
                 onConfirm={handleDelete}
                 onClose={handleDialogClose}

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -73,13 +73,16 @@ const DeleteWithConfirmButton: FC<DeleteWithConfirmButtonProps> = props => {
                 title={confirmTitle}
                 content={confirmContent}
                 translateOptions={{
-                    name: inflection.humanize(
-                        translate(`resources.${resource}.name`, {
-                            smart_count: 1,
-                            _: inflection.singularize(resource),
-                        }),
-                        true
-                    ),
+                    name: translate(`resources.${resource}.forcedCaseName`, {
+                        smart_count: 1,
+                        _: inflection.humanize(
+                            translate(`resources.${resource}.name`, {
+                                smart_count: 1,
+                                _: inflection.singularize(resource),
+                            }),
+                            true
+                        ),
+                    }),
                     id: record.id,
                 }}
                 onConfirm={handleDelete}

--- a/packages/ra-ui-materialui/src/list/Empty.js
+++ b/packages/ra-ui-materialui/src/list/Empty.js
@@ -34,13 +34,16 @@ const Empty = props => {
     const classes = useStyles(props);
     const translate = useTranslate();
 
-    const resourceName = inflection.humanize(
-        translate(`resources.${resource}.name`, {
-            smart_count: 0,
-            _: inflection.pluralize(resource),
-        }),
-        true
-    );
+    const resourceName = translate(`resources.${resource}.forcedCaseName`, {
+        smart_count: 0,
+        _: inflection.humanize(
+            translate(`resources.${resource}.name`, {
+                smart_count: 0,
+                _: inflection.pluralize(resource),
+            }),
+            true
+        ),
+    });
 
     const emptyMessage = translate('ra.page.empty', { name: resourceName });
     const inviteMessage = translate('ra.page.invite');


### PR DESCRIPTION
Closes #4783 

## Issue

Resources names are always set to lower case in confirm messages and it doesn't match with all language synxates (ie : in German, names should be capitalized)

## Solution

Allow to force case in translation file

## Documentation

![Capture d’écran de 2020-06-19 10-35-26](https://user-images.githubusercontent.com/39904906/85114143-c9092380-b218-11ea-9632-a8c1b829ce65.png)
