### PR TITLE
Revert "Fix Dashboard components cannot use useGetOne hook"

### DIFF
--- a/packages/ra-core/src/core/RoutesWithLayout.spec.tsx
+++ b/packages/ra-core/src/core/RoutesWithLayout.spec.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import expect from 'expect';
 import { Route, MemoryRouter } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { waitForDomChange, cleanup } from '@testing-library/react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render, cleanup } from '@testing-library/react';
 
 import RoutesWithLayout from './RoutesWithLayout';
-import renderWithRedux from '../util/renderWithRedux';
-import { registerResource } from '../actions';
 
 describe('<RoutesWithLayout>', () => {
     afterEach(cleanup);
@@ -17,21 +15,14 @@ describe('<RoutesWithLayout>', () => {
     const Resource = ({ name }) => <div>Resource</div>;
 
     // the Provider is required because the dashboard is wrapped by <Authenticated>, which is a connected component
-    const initialState = {
-        admin: { resources: {} },
+    const store = createStore(() => ({
+        admin: {},
         router: { location: { pathname: '/' } },
-    };
+    }));
 
-    it('should show dashboard on / when provided', async () => {
-        const App = () => {
-            const dispatch = useDispatch();
-            React.useEffect(() => {
-                setTimeout(
-                    () => dispatch(registerResource({ name: 'foo' })),
-                    10
-                );
-            }, [dispatch]);
-            return (
+    it('should show dashboard on / when provided', () => {
+        const { queryByText } = render(
+            <Provider store={store}>
                 <MemoryRouter initialEntries={['/']}>
                     <RoutesWithLayout dashboard={Dashboard}>
                         <FirstResource name="default" />
@@ -39,40 +30,37 @@ describe('<RoutesWithLayout>', () => {
                         <Resource name="yetanother" />
                     </RoutesWithLayout>
                 </MemoryRouter>
-            );
-        };
-        const { queryByText } = renderWithRedux(<App />, initialState);
+            </Provider>
+        );
 
-        // dashboard should be hidden on first render, until the resources register
-        expect(queryByText('Dashboard')).toBeNull();
-        // then it shows once the resources have registered
-        await waitForDomChange();
         expect(queryByText('Dashboard')).not.toBeNull();
     });
 
     it('should show the first resource on / when there is only one resource and no dashboard', () => {
-        const { queryByText } = renderWithRedux(
-            <MemoryRouter initialEntries={['/']}>
-                <RoutesWithLayout>
-                    <FirstResource name="default" />
-                </RoutesWithLayout>
-            </MemoryRouter>,
-            initialState
+        const { queryByText } = render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={['/']}>
+                    <RoutesWithLayout>
+                        <FirstResource name="default" />
+                    </RoutesWithLayout>
+                </MemoryRouter>
+            </Provider>
         );
 
         expect(queryByText('Default')).not.toBeNull();
     });
 
     it('should show the first resource on / when there are multiple resource and no dashboard', () => {
-        const { queryByText } = renderWithRedux(
-            <MemoryRouter initialEntries={['/']}>
-                <RoutesWithLayout>
-                    <FirstResource name="default" />
-                    <Resource name="another" />
-                    <Resource name="yetanother" />
-                </RoutesWithLayout>
-            </MemoryRouter>,
-            initialState
+        const { queryByText } = render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={['/']}>
+                    <RoutesWithLayout>
+                        <FirstResource name="default" />
+                        <Resource name="another" />
+                        <Resource name="yetanother" />
+                    </RoutesWithLayout>
+                </MemoryRouter>
+            </Provider>
         );
 
         expect(queryByText('Default')).not.toBeNull();
@@ -83,15 +71,16 @@ describe('<RoutesWithLayout>', () => {
         const customRoutes = [
             <Route key="custom" path="/custom" component={Custom} />,
         ]; // eslint-disable-line react/jsx-key
-        const { queryByText } = renderWithRedux(
-            <MemoryRouter initialEntries={['/custom']}>
-                <RoutesWithLayout customRoutes={customRoutes}>
-                    <FirstResource name="default" />
-                    <Resource name="another" />
-                    <Resource name="yetanother" />
-                </RoutesWithLayout>
-            </MemoryRouter>,
-            initialState
+        const { queryByText } = render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={['/custom']}>
+                    <RoutesWithLayout customRoutes={customRoutes}>
+                        <FirstResource name="default" />
+                        <Resource name="another" />
+                        <Resource name="yetanother" />
+                    </RoutesWithLayout>
+                </MemoryRouter>
+            </Provider>
         );
 
         expect(queryByText('Custom')).not.toBeNull();

--- a/packages/ra-core/src/core/RoutesWithLayout.tsx
+++ b/packages/ra-core/src/core/RoutesWithLayout.tsx
@@ -5,7 +5,6 @@ import React, {
     FunctionComponent,
 } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 
 import WithPermissions from '../auth/WithPermissions';
 import {
@@ -14,7 +13,6 @@ import {
     CatchAllComponent,
     TitleComponent,
     DashboardComponent,
-    ReduxState,
 } from '../types';
 
 interface Props {
@@ -37,12 +35,6 @@ const RoutesWithLayout: FunctionComponent<Props> = ({
         childrenAsArray.length > 0
             ? (childrenAsArray[0] as React.ReactElement<any>)
             : null;
-    // In order to let the Dashboard component use Redux-based dataProvider
-    // hooks like useGetOne, we must wait for the resource registration before
-    // displaying the dashboard.
-    const resourcesAreRegistered = useSelector(
-        (state: ReduxState) => Object.keys(state.admin.resources).length > 0
-    );
 
     return (
         <Switch>
@@ -63,23 +55,19 @@ const RoutesWithLayout: FunctionComponent<Props> = ({
                 />
             ))}
             {dashboard ? (
-                resourcesAreRegistered ? (
-                    <Route
-                        exact
-                        path="/"
-                        render={routeProps => (
-                            <WithPermissions
-                                authParams={{
-                                    route: 'dashboard',
-                                }}
-                                component={dashboard}
-                                {...routeProps}
-                            />
-                        )}
-                    />
-                ) : (
-                    <></>
-                )
+                <Route
+                    exact
+                    path="/"
+                    render={routeProps => (
+                        <WithPermissions
+                            authParams={{
+                                route: 'dashboard',
+                            }}
+                            component={dashboard}
+                            {...routeProps}
+                        />
+                    )}
+                />
             ) : firstChild ? (
                 <Route
                     exact


### PR DESCRIPTION
Reverts marmelab/react-admin#4988

The problem was introduced in #4430, and the fix needs to be in `useGetOne`, and nowhere else. 