### PR TITLE
Add ability to make the <SaveButton> not disabled by default

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1173,7 +1173,7 @@ export const PostCreate = (props) => (
 );
 ```
 
-Another use case is to remove the `<DeleteButton>` from the toolbar in an edit view. In that case, create a custom toolbar containing only the `<SaveButton>` as a child;
+Another use case is to remove the `<DeleteButton>` from the toolbar in an edit view. In that case, create a custom toolbar containing only the `<SaveButton>` as a child:
 
 ```jsx
 import * as React from "react";
@@ -1188,6 +1188,21 @@ const PostEditToolbar = props => (
 export const PostEdit = (props) => (
     <Edit {...props}>
         <SimpleForm toolbar={<PostEditToolbar />}>
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+
+By default the `<SaveButton>` is disabled when the form is `pristine`. You can bypass this behavior and always enable it without recreating the whole `<Toolbar>`:
+
+```jsx
+import * as React from 'react';
+import { Edit, SimpleForm, Toolbar } from 'react-admin';
+
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm toolbar={<Toolbar alwaysEnableSaveButton />}>
             ...
         </SimpleForm>
     </Edit>
@@ -1248,7 +1263,7 @@ You can customize each row in a `<SimpleForm>` or in a `<TabbedForm>` by passing
 
 You can find more about these props in [the Input documentation](./Inputs.md#common-input-props).
 
-You can also [wrap inputs inside containers](#custom-row-container), or [create a custom Form component](#custom-form-component), alternative to `<SimpleForm>` or `<TabbedForm>`. 
+You can also [wrap inputs inside containers](#custom-row-container), or [create a custom Form component](#custom-form-component), alternative to `<SimpleForm>` or `<TabbedForm>`.
 
 ### Variant
 

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -22,6 +22,7 @@ const invalidButtonDomProps = {
     handleSubmitWithRedirect: jest.fn(),
     invalid: false,
     onSave: jest.fn(),
+    disabled: true,
     pristine: false,
     record: { id: 123, foo: 'bar' },
     redirect: 'list',
@@ -57,7 +58,7 @@ describe('<SaveButton />', () => {
         const { getByLabelText } = render(
             <TestContext>
                 <ThemeProvider theme={theme}>
-                    <SaveButton pristine={true} />
+                    <SaveButton disabled={true} />
                 </ThemeProvider>
             </TestContext>
         );

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -142,7 +142,7 @@ const SaveButton: FC<SaveButtonProps> = props => {
             onClick={handleClick}
             color={saving ? 'default' : 'primary'}
             aria-label={displayedLabel}
-            disabled={disabled || pristine}
+            disabled={disabled}
             {...sanitizeButtonRestProps(rest)}
         >
             {saving ? (

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -31,7 +31,7 @@ import { sanitizeButtonRestProps } from './Button';
  * @typedef {Object} Props the props you can use (other props are injected by Toolbar)
  * @prop {string} className
  * @prop {string} label Button label. Defaults to 'ra.action.save', translated.
- * @prop {boolean} disabled Injected by SimpleForm, which disables the SaveButton when it's pristine
+ * @prop {boolean} disabled Injected by SimpleForm, which disables the SaveButton
  * @prop {string} variant Material-ui variant for the button. Defaults to 'contained'.
  * @prop {ReactElement} icon
  * @prop {string|boolean} redirect Override of the default redirect in case of success. Can be 'list', 'show', 'edit' (for create views), or false (to stay on the creation form).
@@ -69,7 +69,6 @@ const SaveButton: FC<SaveButtonProps> = props => {
         invalid,
         label = 'ra.action.save',
         disabled,
-        pristine,
         redirect,
         saving,
         submitOnEnter,
@@ -191,7 +190,7 @@ interface Props {
     invalid?: boolean;
     label?: string;
     onClick?: () => void;
-    pristine?: boolean;
+    disabled?: boolean;
     redirect?: RedirectionSideEffect;
     saving?: boolean;
     submitOnEnter?: boolean;
@@ -214,7 +213,6 @@ SaveButton.propTypes = {
     onSave: PropTypes.func,
     invalid: PropTypes.bool,
     label: PropTypes.string,
-    pristine: PropTypes.bool,
     redirect: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.bool,

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -28,10 +28,10 @@ import { sanitizeButtonRestProps } from './Button';
 /**
  * Submit button for resource forms (Edit and Create).
  *
- * @typedef {Object} Props the props you can use (other props are injected by Toolbar)
+ * @typedef {Object} Props the props you can use (other props are injected by the <Toolbar>)
  * @prop {string} className
  * @prop {string} label Button label. Defaults to 'ra.action.save', translated.
- * @prop {boolean} disabled Injected by SimpleForm, which disables the SaveButton
+ * @prop {boolean} disabled Disable the button.
  * @prop {string} variant Material-ui variant for the button. Defaults to 'contained'.
  * @prop {ReactElement} icon
  * @prop {string|boolean} redirect Override of the default redirect in case of success. Can be 'list', 'show', 'edit' (for create views), or false (to stay on the creation form).

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -36,7 +36,7 @@ import CardContentInner from '../layout/CardContentInner';
  * @prop {Function} validate
  * @prop {boolean} submitOnEnter
  * @prop {string} redirect
- * @prop {ReactElement} toolbar The element displayed at the bottom of the form, contzining the SaveButton
+ * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
  * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
  *

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -71,7 +71,7 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  * @prop {Function} validate
  * @prop {boolean} submitOnEnter
  * @prop {string} redirect
- * @prop {ReactElement} toolbar The element displayed at the bottom of the form, contzining the SaveButton
+ * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
  * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
  *

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -89,7 +89,7 @@ const Toolbar = props => {
                             handleSubmitWithRedirect={
                                 handleSubmitWithRedirect || handleSubmit
                             }
-                            disabled={disabled}
+                            disabled={valueOrDefault(disabled, pristine)}
                             invalid={invalid}
                             redirect={redirect}
                             saving={saving}

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -47,6 +47,43 @@ const useStyles = makeStyles(
 const valueOrDefault = (value, defaultValue) =>
     typeof value === 'undefined' ? defaultValue : value;
 
+/**
+ * The Toolbar displayed at the bottom of forms.
+ *
+ * @example Never disable the <SaveButton />
+ *
+ * import * as React from 'react';
+ * import {
+ *     Create,
+ *     DateInput,
+ *     TextInput,
+ *     SimpleForm,
+ *     Toolbar,
+ *     required,
+ * } from 'react-admin';
+ *
+ * const now = new Date();
+ * const defaultSort = { field: 'title', order: 'ASC' };
+ *
+ * const CommentCreate = props => (
+ *     <Create {...props}>
+ *         <SimpleForm redirect={false} toolbar={<Toolbar disabled={false} />}>
+ *             <TextInput
+ *                 source="author.name"
+ *                 fullWidth
+ *             />
+ *             <DateInput source="created_at" defaultValue={now} />
+ *             <TextInput source="body" fullWidth={true} multiline={true} />
+ *         </SimpleForm>
+ *     </Create>
+ * );
+ *
+ * @typedef {Object} Props the props you can use (other props are injected by the <SimpleForm>)
+ * @prop {ReactElement[]} children Customize the buttons you want to display in the <Toolbar>.
+ * @prop {boolean} disabled Disable the default <SaveButton>. It it's not defined, the <SaveButton> will be disabled using the `pristine` prop.
+ * @prop {string} width Apply the mobile or the desktop classes depending on the width. Pass "xs" to display the mobile version.
+ *
+ */
 const Toolbar = props => {
     const {
         basePath,

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -57,6 +57,7 @@ const Toolbar = props => {
         handleSubmitWithRedirect,
         invalid,
         pristine,
+        disabled,
         record,
         redirect,
         resource,
@@ -67,6 +68,7 @@ const Toolbar = props => {
         ...rest
     } = props;
     const classes = useStyles(props);
+
     return (
         <Fragment>
             <MuiToolbar
@@ -87,6 +89,7 @@ const Toolbar = props => {
                             handleSubmitWithRedirect={
                                 handleSubmitWithRedirect || handleSubmit
                             }
+                            disabled={disabled}
                             invalid={invalid}
                             redirect={redirect}
                             saving={saving}

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -50,7 +50,7 @@ const valueOrDefault = (value, defaultValue) =>
 /**
  * The Toolbar displayed at the bottom of forms.
  *
- * @example Never disable the <SaveButton />
+ * @example Always enable the <SaveButton />
  *
  * import * as React from 'react';
  * import {
@@ -67,7 +67,7 @@ const valueOrDefault = (value, defaultValue) =>
  *
  * const CommentCreate = props => (
  *     <Create {...props}>
- *         <SimpleForm redirect={false} toolbar={<Toolbar disabled={false} />}>
+ *         <SimpleForm redirect={false} toolbar={<Toolbar alwaysEnableSaveButton={true} />}>
  *             <TextInput
  *                 source="author.name"
  *                 fullWidth

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -79,7 +79,7 @@ const valueOrDefault = (value, defaultValue) =>
  * );
  *
  * @typedef {Object} Props the props you can use (other props are injected by the <SimpleForm>)
- * @prop {boolean} alwaysEnableSaveButton Enable the default <SaveButton>. It it's not defined, the <SaveButton> will be disabled using the `pristine` prop.
+ * @prop {boolean} alwaysEnableSaveButton Force enabling the <SaveButton>. It it's not defined, the <SaveButton> will be enabled using the `pristine` prop (disabled if pristine, enabled otherwise).
  * @prop {ReactElement[]} children Customize the buttons you want to display in the <Toolbar>.
  * @prop {string} width Apply the mobile or the desktop classes depending on the width. Pass "xs" to display the mobile version.
  *

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -79,13 +79,14 @@ const valueOrDefault = (value, defaultValue) =>
  * );
  *
  * @typedef {Object} Props the props you can use (other props are injected by the <SimpleForm>)
+ * @prop {boolean} alwaysEnableSaveButton Enable the default <SaveButton>. It it's not defined, the <SaveButton> will be disabled using the `pristine` prop.
  * @prop {ReactElement[]} children Customize the buttons you want to display in the <Toolbar>.
- * @prop {boolean} disabled Disable the default <SaveButton>. It it's not defined, the <SaveButton> will be disabled using the `pristine` prop.
  * @prop {string} width Apply the mobile or the desktop classes depending on the width. Pass "xs" to display the mobile version.
  *
  */
 const Toolbar = props => {
     const {
+        alwaysEnableSaveButton,
         basePath,
         children,
         className,
@@ -94,7 +95,6 @@ const Toolbar = props => {
         handleSubmitWithRedirect,
         invalid,
         pristine,
-        disabled,
         record,
         redirect,
         resource,
@@ -126,7 +126,10 @@ const Toolbar = props => {
                             handleSubmitWithRedirect={
                                 handleSubmitWithRedirect || handleSubmit
                             }
-                            disabled={valueOrDefault(disabled, pristine)}
+                            disabled={valueOrDefault(
+                                !alwaysEnableSaveButton,
+                                pristine
+                            )}
                             invalid={invalid}
                             redirect={redirect}
                             saving={saving}

--- a/packages/ra-ui-materialui/src/form/Toolbar.js
+++ b/packages/ra-ui-materialui/src/form/Toolbar.js
@@ -106,6 +106,10 @@ const Toolbar = props => {
     } = props;
     const classes = useStyles(props);
 
+    // Use form pristine to enable or disable the save button
+    // if alwaysEnableSaveButton is undefined
+    const disabled = !valueOrDefault(alwaysEnableSaveButton, !pristine);
+
     return (
         <Fragment>
             <MuiToolbar
@@ -126,10 +130,7 @@ const Toolbar = props => {
                             handleSubmitWithRedirect={
                                 handleSubmitWithRedirect || handleSubmit
                             }
-                            disabled={valueOrDefault(
-                                !alwaysEnableSaveButton,
-                                pristine
-                            )}
+                            disabled={disabled}
                             invalid={invalid}
                             redirect={redirect}
                             saving={saving}


### PR DESCRIPTION
Implements https://github.com/marmelab/react-admin/issues/4913

To build this feature I allow the user to pass a new prop named `alwaysEnableSaveButton` to the `<Toolbar>` which forces enabling ou disabling the `<SaveButton>`. If the user doesn't specify this prop, we keep the classic behaviour by disabling the button until the form is dirty. 

## Todo

- [x] Allow the `<SaveButton>` to be disabled by passing the `disabled` prop
- [x] Create a new prop called `alwaysEnableSaveButton` in the `<Toolbar>` and implements its mechanism
- [x] Keep the condition _pristine equals to disabled_ only if the `alwaysEnableSaveButton` prop has not been explicitly passed to the `<Toolbar>` but move the logic to the `<Toolbar>` instead of the `<SaveButton>` (possible **breaking change here**)
- [x] Fix and improve the documentation
- [x] Fix tests

## Example

How to force enabling the `<SaveButton>` without rewriting the whole `<Toolbar>`:

``` js
import * as React from 'react';
import {
    Create,
    SimpleForm,
    Toolbar,
} from 'react-admin';
import PostReferenceInput from './PostReferenceInput';

export const CommentCreate = props => (
    <Create {...props}>
        <SimpleForm redirect={false} toolbar={<Toolbar alwaysEnableSaveButton />}>
            // Form goes here
        </SimpleForm>
    </Create>
);
```

If you don't pass the disabled prop, the behaviour "pristine equals to disabled" will be applied as before.

## Screenshots

The following screenshots are outdated because the prop has changed. You need to use `alwaysEnableSaveButton` instead of `disabled` and invert the condition.

**Force enabling the `<SaveButton>`**

![Sélection_006](https://user-images.githubusercontent.com/5584839/86456028-c5e65b00-bd21-11ea-8ca8-aca7ec02076f.png)

**Force disabling the `<SaveButton>`**

![Sélection_007](https://user-images.githubusercontent.com/5584839/86456132-e44c5680-bd21-11ea-887d-0d2dec8b55ea.png)

**Keep the pristine equals to disabled mechanism**

![Sélection_008](https://user-images.githubusercontent.com/5584839/86456217-0940c980-bd22-11ea-841e-5ff66efc7dcc.png)
