### PR TITLE
[RFR] Fix Export button fails to export data when using default exporter

### DIFF
--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -12,6 +12,7 @@ import { useTranslate } from '../i18n';
 import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
 import { CRUD_GET_LIST } from '../actions';
 import { useNotify } from '../sideEffect';
+import defaultExporter from '../export/defaultExporter';
 import {
     Filter,
     Sort,
@@ -104,7 +105,7 @@ const useListController = <RecordType = Record>(
 
     const {
         basePath,
-        exporter,
+        exporter = defaultExporter,
         resource,
         hasCreate,
         filterDefaultValues,


### PR DESCRIPTION
## Problem

In a List view with no custom exporter (e.g. the Users list in the simple demo), the export button no longer works

## Cause

In 3.7, the ExporterContext was merged into the ListContext, but the default exporter was only set in ExporterContext