### PR TITLE
[RFR] Fix ESLint @material-ui/core rule configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,13 +24,8 @@
                 "paths": [
                     {
                         "name": "@material-ui/core",
-                        "importNames": ["makeStyles"],
-                        "message": "Please import makeStyles from @material-ui/core/styles instead. See https://material-ui.com/guides/minimizing-bundle-size/#option-2 for more information"
-                    },
-                    {
-                        "name": "@material-ui/core",
-                        "importNames": ["createMuiTheme"],
-                        "message": "Please import createMuiTheme from @material-ui/core/styles instead. See https://material-ui.com/guides/minimizing-bundle-size/#option-2 for more information"
+                        "importNames": ["makeStyles", "createMuiTheme"],
+                        "message": "Please import from @material-ui/core/styles instead. See https://material-ui.com/guides/minimizing-bundle-size/#option-2 for more information"
                     }
                 ]
             }

--- a/examples/demo/src/dashboard/CardWithIcon.tsx
+++ b/examples/demo/src/dashboard/CardWithIcon.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FC, createElement } from 'react';
-import { Card, makeStyles, Box, Typography, Divider } from '@material-ui/core';
+import { Card, Box, Typography, Divider } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 
 import cartouche from './cartouche.png';

--- a/examples/demo/src/dashboard/PendingReviews.tsx
+++ b/examples/demo/src/dashboard/PendingReviews.tsx
@@ -6,8 +6,8 @@ import {
     ListItemAvatar,
     ListItemText,
     Avatar,
-    makeStyles,
 } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import CommentIcon from '@material-ui/icons/Comment';
 import { Link } from 'react-router-dom';
 import { useTranslate } from 'react-admin';

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -5,7 +5,8 @@ import get from 'lodash/get';
 import classnames from 'classnames';
 import FalseIcon from '@material-ui/icons/Clear';
 import TrueIcon from '@material-ui/icons/Done';
-import { Tooltip, Typography, makeStyles } from '@material-ui/core';
+import { Tooltip, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { TypographyProps } from '@material-ui/core/Typography';
 import { useTranslate } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Children, cloneElement, FC, memo, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { LinearProgress, makeStyles } from '@material-ui/core';
+import { LinearProgress } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import {
     ListContext,
     ListControllerProps,

--- a/packages/ra-ui-materialui/src/list/Empty.tsx
+++ b/packages/ra-ui-materialui/src/list/Empty.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FC } from 'react';
-import { Typography, makeStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import Inbox from '@material-ui/icons/Inbox';
 import { useTranslate, useListContext } from 'ra-core';
 import inflection from 'inflection';

--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { FC, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { Toolbar, ToolbarProps, makeStyles } from '@material-ui/core';
+import { Toolbar, ToolbarProps } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { Exporter } from 'ra-core';
 
 import { ClassesOverride } from '../types';

--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -10,8 +10,8 @@ import {
     ListItemIcon,
     ListItemSecondaryAction,
     ListItemText,
-    makeStyles,
 } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import {
     linkToRecord,

--- a/packages/ra-ui-materialui/src/list/useDatagridStyles.tsx
+++ b/packages/ra-ui-materialui/src/list/useDatagridStyles.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useDatagridStyles = makeStyles(
     theme => ({


### PR DESCRIPTION
This is a continuation of #4983. Apparently, I have been overly optimistic about ESLint's capability at configuration parsing and application, which lead to error reporting only on one of two restricted imports. This PR corrects it and also fixes all the issues this caused.