### PR TITLE
Change to use length of values with useEffect in AutocompleteArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -396,7 +396,7 @@ describe('<AutocompleteArrayInput />', () => {
             expect(setFilter).toHaveBeenCalledWith('p');
             formApi.change('tags', ['p']);
             await waitForDomChange();
-            expect(setFilter).toHaveBeenCalledTimes(3);
+            expect(setFilter).toHaveBeenCalledTimes(2);
             expect(setFilter).toHaveBeenCalledWith('');
         });
 
@@ -432,7 +432,7 @@ describe('<AutocompleteArrayInput />', () => {
             expect(setFilter).toHaveBeenCalledWith('p');
             formApi.change('tags', ['p']);
             await waitForDomChange();
-            expect(setFilter).toHaveBeenCalledTimes(3);
+            expect(setFilter).toHaveBeenCalledTimes(2);
             expect(setFilter).toHaveBeenCalledWith('');
         });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -396,7 +396,7 @@ describe('<AutocompleteArrayInput />', () => {
             expect(setFilter).toHaveBeenCalledWith('p');
             formApi.change('tags', ['p']);
             await waitForDomChange();
-            expect(setFilter).toHaveBeenCalledTimes(2);
+            expect(setFilter).toHaveBeenCalledTimes(3);
             expect(setFilter).toHaveBeenCalledWith('');
         });
 
@@ -432,7 +432,7 @@ describe('<AutocompleteArrayInput />', () => {
             expect(setFilter).toHaveBeenCalledWith('p');
             formApi.change('tags', ['p']);
             await waitForDomChange();
-            expect(setFilter).toHaveBeenCalledTimes(2);
+            expect(setFilter).toHaveBeenCalledTimes(3);
             expect(setFilter).toHaveBeenCalledWith('');
         });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -217,7 +217,7 @@ const AutocompleteArrayInput: FunctionComponent<
     // would have to first clear the input before seeing any other choices
     useEffect(() => {
         handleFilterChange('');
-    }, [...values, handleFilterChange]);
+    }, [values.length, handleFilterChange]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent) => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -217,7 +217,7 @@ const AutocompleteArrayInput: FunctionComponent<
     // would have to first clear the input before seeing any other choices
     useEffect(() => {
         handleFilterChange('');
-    }, [values.length, handleFilterChange]);
+    }, [values.join(','), handleFilterChange]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent) => {


### PR DESCRIPTION
as if you spread values when this is nothing in values, the second parameter to useEffect will have 1 entry.
when there is a something in values, the second parameter to useEffect will have 2 entries. By using lenghth,
there are always 2 entries in the array