### PR TITLE
Replace recompose's shallowEqual with react-redux's shallowEqual.

### DIFF
--- a/packages/ra-core/src/util/removeEmpty.ts
+++ b/packages/ra-core/src/util/removeEmpty.ts
@@ -1,4 +1,4 @@
-import { shallowEqual } from 'recompose';
+import { shallowEqual } from 'react-redux';
 
 const isObject = obj =>
     obj && Object.prototype.toString.call(obj) === '[object Object]';

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -6,7 +6,7 @@ import React, {
     ReactElement,
 } from 'react';
 import PropTypes from 'prop-types';
-import { shallowEqual } from 'recompose';
+import { shallowEqual } from 'react-redux';
 import { useDropzone, DropzoneOptions } from 'react-dropzone';
 import { makeStyles } from '@material-ui/core/styles';
 import FormHelperText from '@material-ui/core/FormHelperText';


### PR DESCRIPTION
Continuing #4786

Boath functions are identical.

https://github.com/reduxjs/react-redux/blob/master/src/utils/shallowEqual.js
https://github.com/acdlite/recompose/blob/master/src/packages/recompose/shallowEqual.js

As a side note, its now posible to remove `recompose` dependency from `ra-core`