### PR TITLE
Fix - Sanitize the pagination prop passed to the SelectInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -44,6 +44,7 @@ const sanitizeRestProps = ({
     optionValue,
     optionText,
     disableValue,
+    pagination,
     perPage,
     record,
     reference,


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/5037 - ReferenceInput adds a buggy DOM property "pagination" to the inner SelectInput

## Todo

- [x] Sanitize the pagination prop passed to the `<SelectInput>`

## Screenshot

![Sélection_012](https://user-images.githubusercontent.com/5584839/87560086-5e35f580-c6bb-11ea-836f-40a31de89910.png)
