### PR TITLE
DeleteWithConfirmButton record.id Undefined

### DIFF
--- a/cypress/support/EditPage.js
+++ b/cypress/support/EditPage.js
@@ -1,7 +1,7 @@
 export default url => ({
     elements: {
         body: 'body',
-        deleteButton: '.ra-delete-button',
+        deleteButton: '[class*="RaDeleteWithUndoButton"]',
         input: (name, type = 'input') => {
             if (type === 'rich-text-input') {
                 return `.ra-input-${name} .ql-editor`;

--- a/examples/simple/src/posts/PostEdit.js
+++ b/examples/simple/src/posts/PostEdit.js
@@ -28,11 +28,12 @@ import {
     number,
     required,
     FormDataConsumer,
+    DeleteButton,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import PostTitle from './PostTitle';
 import TagReferenceInput from './TagReferenceInput';
 
-const EditActions = ({ basePath, data, hasShow }) => (
+const EditActions = ({ basePath, data, hasShow, resource }) => (
     <TopToolbar>
         <CloneButton
             className="button-clone"
@@ -40,6 +41,12 @@ const EditActions = ({ basePath, data, hasShow }) => (
             record={data}
         />
         {hasShow && <ShowButton basePath={basePath} record={data} />}
+        <DeleteButton
+            basePath={basePath}
+            record={data}
+            resource={resource}
+            undoable={false}
+        />
     </TopToolbar>
 );
 

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -83,7 +83,7 @@ const DeleteWithConfirmButton: FC<DeleteWithConfirmButtonProps> = props => {
                             true
                         ),
                     }),
-                    id: record.id,
+                    id: record ? record.id : null,
                 }}
                 onConfirm={handleDelete}
                 onClose={handleDialogClose}


### PR DESCRIPTION
Fixes a record.id undefined bug which occurs when using the DeleteButton with undoable set to false. Adds the DeleteButton with undoable set to false to simple for the edit integration test (and updated tests to click on the undo=true delete button). This is likely related to #4635