### PR TITLE
Opt out sanitizeEmptyValues with SimpleForm and TabbedForm

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1581,7 +1581,7 @@ const FormBody = ({ handleSubmit }) => {
 
 ## Setting Empty Values To Null
 
-`<SimpleForm>` and `<TabbedForm>` recreates deleted or missing attributes based on its `initialValues` in order to send them to the data provider with a `null` value, as most APIs requires all attributes for a given record, even if they are nullable.
+`<SimpleForm>` and `<TabbedForm>` recreate deleted or missing attributes based on its `initialValues` in order to send them to the data provider with a `null` value, as most APIs requires all attributes for a given record, even if they are nullable.
 
 It is possible to opt-out this default behavior by passing the `sanitizeEmptyValues` prop:
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -648,6 +648,7 @@ Here are all the props you can set on the `<SimpleForm>` component:
 * [`variant`](#variant)
 * [`margin`](#margin)
 * [`warnWhenUnsavedChanges`](#warning-about-unsaved-changes)
+* [`sanitizeEmptyValues`](#setting-empty-values-to-null)
 
 ```jsx
 export const PostCreate = (props) => (
@@ -697,6 +698,7 @@ const PostEdit = (props) => (
 );
 ```
 
+
 ## The `<TabbedForm>` component
 
 Just like `<SimpleForm>`, `<TabbedForm>` receives the `record` prop, renders the actual form, and handles form validation on submit. However, the `<TabbedForm>` component renders inputs grouped by tab. The tabs are set by using `<FormTab>` components, which expect a `label` and an `icon` prop.
@@ -719,6 +721,7 @@ Here are all the props accepted by the `<TabbedForm>` component:
 * `save`: The function invoked when the form is submitted. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * `saving`: A boolean indicating whether a save operation is ongoing. This is passed automatically by `react-admin` when the form component is used inside `Create` and `Edit` components.
 * [`warnWhenUnsavedChanges`](#warning-about-unsaved-changes)
+* [`sanitizeEmptyValues`](#setting-empty-values-to-null)
 
 {% raw %}
 ```jsx
@@ -1575,6 +1578,23 @@ const FormBody = ({ handleSubmit }) => {
 ```
 
 **Tip**: You can customize the message displayed in the confirm dialog by setting the `ra.message.unsaved_changes` message in your i18nProvider.
+
+## Setting Empty Values To Null
+
+`<SimpleForm>` and `<TabbedForm>` recreates deleted or missing attributes based on its `initialValues` in order to send them to the data provider with a `null` value, as most APIs requires all attributes for a given record, even if they are nullable.
+
+It is possible to opt-out this default behavior by passing the `sanitizeEmptyValues` prop:
+
+```jsx
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm sanitizeEmptyValues={false}>
+            <TextInput source="title" />
+            <JsonInput source="body" />
+        </SimpleForm>
+    </Edit>
+);
+```
 
 ## Displaying Fields or Inputs Depending on the User Permissions
 

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -32,6 +32,7 @@ import { RedirectionSideEffect } from '../sideEffect';
  * @prop {Function} save
  * @prop {boolean} submitOnEnter
  * @prop {string} redirect
+ * @prop {boolean} sanitizeEmptyValues
  *
  * @param {Prop} props
  */
@@ -97,9 +98,21 @@ const FormWithRedirect: FC<FormWithRedirectOwnProps & FormProps> = ({
             typeof redirect.current === undefined
                 ? props.redirect
                 : redirect.current;
-        const finalValues = sanitizeEmptyValues(finalInitialValues, values);
 
-        onSave.current(finalValues, finalRedirect);
+        const shouldSanitizeEmptyValues =
+            typeof props.sanitizeEmptyValues === 'undefined'
+                ? true
+                : props.sanitizeEmptyValues;
+
+        if (shouldSanitizeEmptyValues) {
+            const sanitizedValues = sanitizeEmptyValues(
+                finalInitialValues,
+                values
+            );
+            onSave.current(sanitizedValues, finalRedirect);
+        } else {
+            onSave.current(values, finalRedirect);
+        }
     };
 
     return (
@@ -151,6 +164,7 @@ export interface FormWithRedirectOwnProps {
     saving: boolean;
     version: number;
     warnWhenUnsavedChanges?: boolean;
+    sanitizeEmptyValues?: boolean;
 }
 
 const defaultSubscription = {

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -39,6 +39,7 @@ import CardContentInner from '../layout/CardContentInner';
  * @prop {ReactElement} toolbar The element displayed at the bottom of the form, contzining the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
  * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
+ * @prop {boolean} sanitizeEmptyValues Wether or not deleted record attributes should be recreated with a `null` value (default: true)
  *
  * @param {Prop} props
  */
@@ -66,6 +67,7 @@ SimpleForm.propTypes = {
     undoable: PropTypes.bool,
     validate: PropTypes.func,
     version: PropTypes.number,
+    sanitizeEmptyValues: PropTypes.bool,
 };
 
 const SimpleFormView = ({

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -74,6 +74,7 @@ import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
  * @prop {ReactElement} toolbar The element displayed at the bottom of the form, contzining the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
  * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
+ * @prop {boolean} sanitizeEmptyValues Wether or not deleted record attributes should be recreated with a `null` value (default: true)
  *
  * @param {Prop} props
  */
@@ -99,6 +100,7 @@ TabbedForm.propTypes = {
     submitOnEnter: PropTypes.bool,
     undoable: PropTypes.bool,
     validate: PropTypes.func,
+    sanitizeEmptyValues: PropTypes.bool,
 };
 
 const useStyles = makeStyles(


### PR DESCRIPTION
Because final-form removes empty / null attributes, SimpleForm needs to recreate them with a `null` value from its initial values.
This is a good default as most REST APIs requires all the fields.

That said, in particular cases, it might conflicts with expected attributes removal, for example:
- A HTTP PUT query that expects field absence to remove them
- A JSON input, that requires to remove a field in the JSON

Moreover, GraphQL APIs don't require all nullable fields to be present in the query.

A workaround would be to create your own form and coping the behavior of `<FormWithRedirect>` (that's what I did in the meanwhile), but I think this is a common enough case, and I this is a good opportunity to document this behavior.

Feel free to edit the PR!