### PR TITLE
Fix sorting a list using a <Datagrid> inside a <ReferenceManyField>

### DIFF
--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -17,7 +17,7 @@ export default url => ({
         datagridHeaders: 'th',
         sortBy: name => `th span[data-field="${name}"]`,
         svg: (name, criteria = '') =>
-            `th span[data-sort="${name}"] svg${criteria}`,
+            `th span[data-field="${name}"] svg${criteria}`,
         logout: '.logout',
         bulkActionsToolbar: '[data-test=bulk-actions-toolbar]',
         customBulkActionsButton:

--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -15,7 +15,7 @@ export default url => ({
         recordRows: '.datagrid-body tr',
         viewsColumn: '.datagrid-body tr td:nth-child(7)',
         datagridHeaders: 'th',
-        sortBy: name => `th span[data-sort="${name}"]`,
+        sortBy: name => `th span[data-field="${name}"]`,
         svg: (name, criteria = '') =>
             `th span[data-sort="${name}"] svg${criteria}`,
         logout: '.logout',

--- a/packages/ra-ui-materialui/src/list/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/Datagrid.tsx
@@ -101,13 +101,15 @@ const Datagrid: FC<DatagridProps> = props => {
             event.stopPropagation();
             const newField = event.currentTarget.dataset.field;
             const newOrder =
-                currentSort.field === newField &&
-                event.currentTarget.dataset.order === 'ASC'
-                    ? 'DESC'
-                    : 'ASC';
+                currentSort.field === newField
+                    ? currentSort.order === 'ASC'
+                        ? 'DESC'
+                        : 'ASC'
+                    : event.currentTarget.dataset.order;
+
             setSort(newField, newOrder);
         },
-        [currentSort.field, setSort]
+        [currentSort.field, currentSort.order, setSort]
     );
 
     const handleSelectAll = useCallback(

--- a/packages/ra-ui-materialui/src/list/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/Datagrid.tsx
@@ -100,7 +100,7 @@ const Datagrid: FC<DatagridProps> = props => {
         event => {
             event.stopPropagation();
             setSort(
-                event.currentTarget.dataset.sort,
+                event.currentTarget.dataset.field,
                 event.currentTarget.dataset.order
             );
         },

--- a/packages/ra-ui-materialui/src/list/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/Datagrid.tsx
@@ -99,12 +99,14 @@ const Datagrid: FC<DatagridProps> = props => {
     const updateSort = useCallback(
         event => {
             event.stopPropagation();
-            setSort(
-                event.currentTarget.dataset.field,
-                event.currentTarget.dataset.order
-            );
+            const newField = event.currentTarget.dataset.field;
+            const newOrder =
+                currentSort.field === newField && currentSort.order === 'ASC'
+                    ? 'DESC'
+                    : 'ASC';
+            setSort(newField, newOrder);
         },
-        [setSort]
+        [currentSort.field, currentSort.order, setSort]
     );
 
     const handleSelectAll = useCallback(
@@ -197,8 +199,8 @@ const Datagrid: FC<DatagridProps> = props => {
                             />
                         </TableCell>
                     )}
-                    {Children.map(children, (field, index) =>
-                        isValidElement(field) ? (
+                    {Children.map(children, (field, index) => {
+                        return isValidElement(field) ? (
                             <DatagridHeaderCell
                                 className={classes.headerCell}
                                 currentSort={currentSort}
@@ -212,8 +214,8 @@ const Datagrid: FC<DatagridProps> = props => {
                                 resource={resource}
                                 updateSort={updateSort}
                             />
-                        ) : null
-                    )}
+                        ) : null;
+                    })}
                 </TableRow>
             </TableHead>
             {cloneElement(

--- a/packages/ra-ui-materialui/src/list/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/Datagrid.tsx
@@ -101,12 +101,13 @@ const Datagrid: FC<DatagridProps> = props => {
             event.stopPropagation();
             const newField = event.currentTarget.dataset.field;
             const newOrder =
-                currentSort.field === newField && currentSort.order === 'ASC'
+                currentSort.field === newField &&
+                event.currentTarget.dataset.order === 'ASC'
                     ? 'DESC'
                     : 'ASC';
             setSort(newField, newOrder);
         },
-        [currentSort.field, currentSort.order, setSort]
+        [currentSort.field, setSort]
     );
 
     const handleSelectAll = useCallback(

--- a/packages/ra-ui-materialui/src/list/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/Datagrid.tsx
@@ -199,8 +199,8 @@ const Datagrid: FC<DatagridProps> = props => {
                             />
                         </TableCell>
                     )}
-                    {Children.map(children, (field, index) => {
-                        return isValidElement(field) ? (
+                    {Children.map(children, (field, index) =>
+                        isValidElement(field) ? (
                             <DatagridHeaderCell
                                 className={classes.headerCell}
                                 currentSort={currentSort}
@@ -214,8 +214,8 @@ const Datagrid: FC<DatagridProps> = props => {
                                 resource={resource}
                                 updateSort={updateSort}
                             />
-                        ) : null;
-                    })}
+                        ) : null
+                    )}
                 </TableRow>
             </TableHead>
             {cloneElement(

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -61,7 +61,7 @@ export const DatagridHeaderCell = props => {
                             (field.props.sortBy || field.props.source)
                         }
                         direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
-                        data-sort={field.props.sortBy || field.props.source}
+                        data-field={field.props.sortBy || field.props.source}
                         data-order={field.props.sortByOrder || 'ASC'}
                         onClick={updateSort}
                         classes={classes}

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -36,6 +36,7 @@ export const DatagridHeaderCell = props => {
     } = props;
     const classes = useStyles(props);
     const translate = useTranslate();
+
     return (
         <TableCell
             className={classnames(className, field.props.headerClassName)}
@@ -97,11 +98,11 @@ DatagridHeaderCell.propTypes = {
     updateSort: PropTypes.func.isRequired,
 };
 
-export default memo(
-    DatagridHeaderCell,
-    (props, nextProps) =>
+export default memo(DatagridHeaderCell, (props, nextProps) => {
+    return (
         props.updateSort === nextProps.updateSort &&
-        props.currentSort.sort === nextProps.currentSort.sort &&
+        props.currentSort.field === nextProps.currentSort.field &&
         props.currentSort.order === nextProps.currentSort.order &&
         !(nextProps.isSorting && props.sortable !== nextProps.sortable)
-);
+    );
+});

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -61,6 +61,7 @@ export const DatagridHeaderCell = props => {
                             (field.props.sortBy || field.props.source)
                         }
                         direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
+                        data-sort={field.props.sortBy || field.props.source} // @deprecated. Use data-field instead.
                         data-field={field.props.sortBy || field.props.source}
                         data-order={field.props.sortByOrder || 'ASC'}
                         onClick={updateSort}

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
@@ -47,7 +47,7 @@ describe('<DatagridHeaderCell />', () => {
                     </tbody>
                 </table>
             );
-            expect(getByTitle('ra.action.sort').dataset.sort).toBe('title');
+            expect(getByTitle('ra.action.sort').dataset.field).toBe('title');
         });
 
         it('should be enabled when field has a sortBy props', () => {
@@ -64,7 +64,7 @@ describe('<DatagridHeaderCell />', () => {
                     </tbody>
                 </table>
             );
-            expect(getByTitle('ra.action.sort').dataset.sort).toBe('title');
+            expect(getByTitle('ra.action.sort').dataset.field).toBe('title');
         });
 
         it('should be change order when field has a sortByOrder props', () => {


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/5059

Several bugs are fixed:

- Fix the switch between `ASC` and `DESC` orders inside `<ReferenceManyField>` and `<ReferenceArrayField>`
- Fix sorting using another field than the default one or the first selected one

I introduced a new prop named `field` in the `<DatagridHeaderCell>` which contains the same data as the prop named `sort` which is now deprecated.

This renaming is motivated by the confusion introduced by two similar names (sort in `<Datagrid>` and sort in `<DatagridHeaderCell>`) containing different content. The first one contains an object `{ field: 'id', order: 'ASC' }` named `sort` and the second one `{ sort: 'id', order: 'ASC' }`.

## Todo

- [x] Fix props used to memorize the `<DatagridHeaderCell>`
- [x] Fix the sorting issue of the `<Datagrid>`
- [x] Fix the updateSort method in the `<Datagrid>` to query the right order
- [x] Fix tests

## Screenshots

![Peek 28-07-2020 12-27](https://user-images.githubusercontent.com/5584839/88656989-77826d00-d0d1-11ea-83b1-766a46634a7d.gif)
