### PR TITLE
Fix a typo in documentation about the <SimpleFormIterator>

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -133,7 +133,7 @@ You can also use `addButton` and `removeButton` props to pass your custom add an
 import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
 
 <ArrayInput source="backlinks">
-    <SimpleFormIterator addButton={<CustomAddButton />} addButton={<CustomRemoveButton />}>
+    <SimpleFormIterator addButton={<CustomAddButton />} removeButton={<CustomRemoveButton />}>
         <DateInput source="date" />
         <TextInput source="url" />
     </SimpleFormIterator>


### PR DESCRIPTION
Follows https://github.com/marmelab/react-admin/pull/4818

## Todo

- [x] Fix a typo in documentation about the `<SimpleFormIterator>` new props