### PR TITLE
Fix bulk delete confirmation dialog does not close after success when using Datagrid in a non-list page

### DIFF
--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -80,18 +80,19 @@ const useDeleteWithConfirmController = ({
     const [deleteOne, { loading }] = useDelete(resource, null, null, {
         action: CRUD_DELETE,
         onSuccess: () => {
+            setOpen(false);
             notify('ra.notification.deleted', 'info', { smart_count: 1 });
             redirect(redirectTo, basePath);
             refresh();
         },
         onFailure: error => {
+            setOpen(false);
             notify(
                 typeof error === 'string'
                     ? error
                     : error.message || 'ra.notification.http_error',
                 'warning'
             );
-            setOpen(false);
         },
         undoable: false,
     });


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/4943

It allows the usage of BulkDeleteButton with undoable=false in non-list pages

## Todo

- [x] Close the delete confirmation dialog on success

