### PR TITLE
Prevent crash when passing an undefined record to the <DeleteButton>

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -99,6 +99,7 @@ title: "Reference"
 * `<Title>`
 * [`translate`](./Translation.md#withtranslate-hoc)
 * `<Toolbar>`
+* `<TopToolbar>`
 * [`<UrlField>`](./Fields.md#urlfield)
 * [`useAuthenticated`](./Authentication.md#useauthenticated-hook)
 * `useAuthProvider`

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -7,6 +7,41 @@ import { ButtonProps } from './Button';
 import DeleteWithUndoButton from './DeleteWithUndoButton';
 import DeleteWithConfirmButton from './DeleteWithConfirmButton';
 
+/**
+ * Delete button used to delete a single record. Used by default in the <Toolbar> of edit and show views.
+ *
+ * @typedef {Object} Props the props you can use (other props are injected if you used it in the <Toolbar>)
+ * @param {Prop} props
+ * @prop {boolean} undoable Confirm the deletion using an undo button in a notification or a confirm dialog. Defaults to 'false'.
+ * @prop {string} className
+ * @prop {string} label Button label. Defaults to 'ra.action.delete, translated.
+ * @prop {boolean} disabled Disable the button.
+ * @prop {string} variant Material-ui variant for the button. Defaults to 'contained'.
+ * @prop {ReactElement} icon Override the icon. Default to the Delete icon from material-ui.
+ *
+ * @example Usage in the <TopToolbar> of an <Edit> form
+ *
+ * import * as React from 'react';
+ * import { Edit, DeleteButton, TopToolbar } from 'react-admin';
+ *
+ * const EditActions = props => {
+ *     const { basePath, data, resource } = props;
+ *     return (
+ *         <TopToolbar>
+ *             <DeleteButton
+ *                 basePath={basePath}
+ *                 record={data}
+ *                 resource={resource}
+ *                 undoable={false} // Renders the <DeleteWithConfirmButton>
+ *             />
+ *         </TopToolbar>
+ *     );
+ * };
+ *
+ * const Edit = props => {
+ *     return <Edit actions={<EditActions />} {...props} />;
+ * };
+ */
 const DeleteButton: FC<DeleteButtonProps> = ({
     undoable,
     record,

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -7,12 +7,20 @@ import { ButtonProps } from './Button';
 import DeleteWithUndoButton from './DeleteWithUndoButton';
 import DeleteWithConfirmButton from './DeleteWithConfirmButton';
 
-const DeleteButton: FC<DeleteButtonProps> = ({ undoable, ...props }) =>
-    undoable ? (
-        <DeleteWithUndoButton {...props} />
+const DeleteButton: FC<DeleteButtonProps> = ({
+    undoable,
+    record,
+    ...props
+}) => {
+    if (!record || record.id == null) {
+        return null;
+    }
+    return undoable ? (
+        <DeleteWithUndoButton record={record} {...props} />
     ) : (
-        <DeleteWithConfirmButton {...props} />
+        <DeleteWithConfirmButton record={record} {...props} />
     );
+};
 
 interface Props {
     basePath?: string;

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -17,7 +17,7 @@ import DeleteWithConfirmButton from './DeleteWithConfirmButton';
  * @prop {string} label Button label. Defaults to 'ra.action.delete, translated.
  * @prop {boolean} disabled Disable the button.
  * @prop {string} variant Material-ui variant for the button. Defaults to 'contained'.
- * @prop {ReactElement} icon Override the icon. Default to the Delete icon from material-ui.
+ * @prop {ReactElement} icon Override the icon. Defaults to the Delete icon from material-ui.
  *
  * @example Usage in the <TopToolbar> of an <Edit> form
  *

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -8,7 +8,7 @@ import DeleteWithUndoButton from './DeleteWithUndoButton';
 import DeleteWithConfirmButton from './DeleteWithConfirmButton';
 
 /**
- * Delete button used to delete a single record. Used by default in the <Toolbar> of edit and show views.
+ * Button used to delete a single record. Added by default by the <Toolbar> of edit and show views.
  *
  * @typedef {Object} Props The props you can use (other props are injected if you used it in the <Toolbar>)
  * @param {Prop} props

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -10,7 +10,7 @@ import DeleteWithConfirmButton from './DeleteWithConfirmButton';
 /**
  * Delete button used to delete a single record. Used by default in the <Toolbar> of edit and show views.
  *
- * @typedef {Object} Props the props you can use (other props are injected if you used it in the <Toolbar>)
+ * @typedef {Object} Props The props you can use (other props are injected if you used it in the <Toolbar>)
  * @param {Prop} props
  * @prop {boolean} undoable Confirm the deletion using an undo button in a notification or a confirmation dialog. Defaults to 'false'.
  * @prop {string} className

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -12,7 +12,7 @@ import DeleteWithConfirmButton from './DeleteWithConfirmButton';
  *
  * @typedef {Object} Props the props you can use (other props are injected if you used it in the <Toolbar>)
  * @param {Prop} props
- * @prop {boolean} undoable Confirm the deletion using an undo button in a notification or a confirm dialog. Defaults to 'false'.
+ * @prop {boolean} undoable Confirm the deletion using an undo button in a notification or a confirmation dialog. Defaults to 'false'.
  * @prop {string} className
  * @prop {string} label Button label. Defaults to 'ra.action.delete, translated.
  * @prop {boolean} disabled Disable the button.


### PR DESCRIPTION
Replaces https://github.com/marmelab/react-admin/pull/5056

The `<DeleteButton>` has been built to be used as a child of a `<Toolbar>` in an edit or a list view. Or at least inside a component that injects to it a `record`, a `resource` and a `basePath` props.

But it's not always the case. For example, some user may want to use the `<DeleteButton>` inside the `<TopToolbar>` for styling purpose. And at some step of the loading process, the record could be equals to `null` or `undefined` (if the page is not yet loaded for example).

In the beginning, I thought it was the responsibility of the parent to be sure it passes a record to its child and that's true in general. But I changed my mind because of TypeScript.

If we take a look at the TypeScript type named `Props`, we saw that the record is optional: `record?: Record;`. if we remove the optional mark, we cannot rely on the auto-inject feature of React.

``` jsx
<Toolbar>
    <DeleteButton /> // The <Toolbar> auto-injects the record, but TypeScript doesn't like that
</Toolbar>
``` 

So to harmonize the documentation provided by TypeScript (an optional record) and the `cannot read property id of undefined` issue, I think it's better to prevent the issue inside the `<DeleteButton>`.

## Todo

- [x] Don't render the `<DeleteButton>` if there are no record
- [x] Write documentation for the `<DeleteButton>`
