### PR TITLE
Full height Layout & Sidebar margins

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -43,6 +43,7 @@ const styles = theme =>
         appFrame: {
             display: 'flex',
             flexDirection: 'column',
+            flexGrow: 1,
             [theme.breakpoints.up('xs')]: {
                 marginTop: theme.spacing(6),
             },

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -14,13 +14,20 @@ import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
 
 const useStyles = makeStyles(
-    {
+    theme => ({
         main: {
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'flex-start',
+            marginTop: '0.5em',
+            [theme.breakpoints.only('xs')]: {
+                marginTop: 0,
+            },
+            [theme.breakpoints.up('md')]: {
+                marginTop: '1.5em',
+            },
         },
-    },
+    }),
     { name: 'RaMenu' }
 );
 

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -29,7 +29,6 @@ const useStyles = makeStyles(
                 duration: theme.transitions.duration.leavingScreen,
             }),
             backgroundColor: 'transparent',
-            marginTop: '0.5em',
             borderRight: 'none',
             [theme.breakpoints.only('xs')]: {
                 marginTop: 0,
@@ -39,7 +38,6 @@ const useStyles = makeStyles(
             },
             [theme.breakpoints.up('md')]: {
                 border: 'none',
-                marginTop: '1.5em',
             },
             zIndex: 'inherit',
         },


### PR DESCRIPTION
- [x] Ensure main section takes the full height available by default 
- [x] Move margins from the Sidebar to the Menu

Nothing changes visually by default but it is now easier to have a full height sidebar with a different background. For example:
![image](https://user-images.githubusercontent.com/1122076/89303860-0876bc80-d66d-11ea-8883-2b77ab6f5439.png)

This only requires a little bit of styling using MUI overrides mechanism