### PR TITLE
Fix sanitizeEmptyValues DOM warning

### DIFF
--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -55,6 +55,7 @@ const FormWithRedirect: FC<FormWithRedirectOwnProps & FormProps> = ({
     validateOnBlur,
     version,
     warnWhenUnsavedChanges,
+    sanitizeEmptyValues: shouldSanitizeEmptyValues = true,
     ...props
 }) => {
     let redirect = useRef(props.redirect);
@@ -98,11 +99,6 @@ const FormWithRedirect: FC<FormWithRedirectOwnProps & FormProps> = ({
             typeof redirect.current === undefined
                 ? props.redirect
                 : redirect.current;
-
-        const shouldSanitizeEmptyValues =
-            typeof props.sanitizeEmptyValues === 'undefined'
-                ? true
-                : props.sanitizeEmptyValues;
 
         if (shouldSanitizeEmptyValues) {
             const sanitizedValues = sanitizeEmptyValues(


### PR DESCRIPTION
The PR #5077 introduced a DOM warning when using `sanitizeEmptyValues` in a form.

![warning](https://user-images.githubusercontent.com/28799755/89978848-22b92780-dc77-11ea-869e-d29dfd327da3.png)

This PR just suppress the warning by destructuring the value from the props.