### PR TITLE
Fix clicking on the documentation link on small screens

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -632,3 +632,9 @@ nav {
     height: calc(100vh - 120px);
   }
 }
+
+@media (max-width: 1280px) {
+  #lego {
+    display: none;
+  }
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -43,10 +43,10 @@ header {
 
 #lego {
   position: absolute;
-  z-index: 1;
+  z-index: 0;
   bottom: 120px;
   left: 0;
-  height: 70%;
+  height: 60%;
 }
 
 #logo {


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/5166

## Todo

- [x] Change the z-index of the lego logo
- [x] Hide the lego logo on small screens to make the title readable

## Screenshots

**Before**

![Sélection_005](https://user-images.githubusercontent.com/5584839/90532893-10a81f00-e178-11ea-8107-a04cc3e8e8c9.png)

**After**

![Sélection_006](https://user-images.githubusercontent.com/5584839/90533123-59f86e80-e178-11ea-9cd7-76899887b535.png)

![Sélection_007](https://user-images.githubusercontent.com/5584839/90533233-7eece180-e178-11ea-9678-8fe38b7fab1a.png)
