### PR TITLE
Fix List subcontext lack resource data

### DIFF
--- a/packages/ra-core/src/controller/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/ListFilterContext.tsx
@@ -14,6 +14,7 @@ import { ListControllerProps } from './useListController';
  * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hidefilter('title')
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @typedef Props
  * @prop {ListFilterContextValue} value
@@ -42,6 +43,7 @@ const ListFilterContext = createContext<ListFilterContextValue>({
     hideFilter: null,
     setFilters: null,
     showFilter: null,
+    resource: null,
 });
 
 export type ListFilterContextValue = Pick<
@@ -51,6 +53,7 @@ export type ListFilterContextValue = Pick<
     | 'hideFilter'
     | 'setFilters'
     | 'showFilter'
+    | 'resource'
 >;
 
 export const usePickFilterContext = (
@@ -64,6 +67,7 @@ export const usePickFilterContext = (
                 'hideFilter',
                 'setFilters',
                 'showFilter',
+                'resource',
             ]),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [

--- a/packages/ra-core/src/controller/ListPaginationContext.tsx
+++ b/packages/ra-core/src/controller/ListPaginationContext.tsx
@@ -15,6 +15,7 @@ import { ListControllerProps } from './useListController';
  * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
  * @prop {integer}  perPage the number of results per page. Defaults to 25
  * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @typedef Props
  * @prop {ListPaginationContextValue} value
@@ -44,13 +45,20 @@ const ListPaginationContext = createContext<ListPaginationContextValue>({
     setPage: null,
     setPerPage: null,
     total: null,
+    resource: null,
 });
 
 ListPaginationContext.displayName = 'ListPaginationContext';
 
 export type ListPaginationContextValue = Pick<
     ListControllerProps,
-    'loading' | 'page' | 'perPage' | 'setPage' | 'setPerPage' | 'total'
+    | 'loading'
+    | 'page'
+    | 'perPage'
+    | 'setPage'
+    | 'setPerPage'
+    | 'total'
+    | 'resource'
 >;
 
 export const usePickPaginationContext = (
@@ -65,6 +73,7 @@ export const usePickPaginationContext = (
                 'setPage',
                 'setPerPage',
                 'total',
+                'resource',
             ]),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [

--- a/packages/ra-core/src/controller/ListSortContext.tsx
+++ b/packages/ra-core/src/controller/ListSortContext.tsx
@@ -11,6 +11,7 @@ import { ListControllerProps } from './useListController';
  * @typedef {Object} ListSortContextValue
  * @prop {Object}   currentSort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
  * @prop {Function} setSort a callback to change the sort, e.g. setSort('name', 'ASC')
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @typedef Props
  * @prop {ListSortContextValue} value
@@ -36,18 +37,19 @@ import { ListControllerProps } from './useListController';
 const ListSortContext = createContext<ListSortContextValue>({
     currentSort: null,
     setSort: null,
+    resource: null,
 });
 
 export type ListSortContextValue = Pick<
     ListControllerProps,
-    'currentSort' | 'setSort'
+    'currentSort' | 'setSort' | 'resource'
 >;
 
 export const usePickSortContext = (
     context: ListControllerProps
 ): ListSortContextValue =>
     useMemo(
-        () => pick(context, ['currentSort', 'setSort']),
+        () => pick(context, ['currentSort', 'setSort', 'resource']),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [context.currentSort, context.setSort]
     );

--- a/packages/ra-core/src/controller/useListFilterContext.ts
+++ b/packages/ra-core/src/controller/useListFilterContext.ts
@@ -14,6 +14,7 @@ import ListFilterContext, { ListFilterContextValue } from './ListFilterContext';
  * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hidefilter('title')
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListFilterContextValue} list controller props
  *

--- a/packages/ra-core/src/controller/useListPaginationContext.ts
+++ b/packages/ra-core/src/controller/useListPaginationContext.ts
@@ -16,6 +16,7 @@ import ListPaginationContext, {
  * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
  * @prop {integer}  perPage the number of results per page. Defaults to 25
  * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListPaginationContextValue} list controller props
  *

--- a/packages/ra-core/src/controller/useListSortContext.ts
+++ b/packages/ra-core/src/controller/useListSortContext.ts
@@ -11,6 +11,7 @@ import ListSortContext, { ListSortContextValue } from './ListSortContext';
  * @typedef {Object} ListSortContextValue
  * @prop {Object}   currentSort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
  * @prop {Function} setSort a callback to change the sort, e.g. setSort('name', 'ASC')
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListSortContextValue} list controller props
  *

--- a/packages/ra-ui-materialui/src/button/SortButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SortButton.tsx
@@ -12,7 +12,7 @@ import {
 import SortIcon from '@material-ui/icons/Sort';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import { shallowEqual } from 'react-redux';
-import { useListContext, useTranslate } from 'ra-core';
+import { useListSortContext, useTranslate } from 'ra-core';
 
 /**
  * A button allowing to change the sort field and order.
@@ -43,7 +43,7 @@ const SortButton: FC<{ fields: string[]; label?: string }> = ({
     fields,
     label = 'ra.sort.sort_by',
 }) => {
-    const { resource, currentSort, setSort } = useListContext();
+    const { resource, currentSort, setSort } = useListSortContext();
     const translate = useTranslate();
     const isXSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('xs')


### PR DESCRIPTION
The subcontexts of ListContext are made to avoid depending on the entire ListContext. Yet they are too tiny. the `resource`, for instance, is necessary for buttons. Adding a bit more data makes subcontexts enough for more cases, without adding more rerenders. 