### PR TITLE
Make cursor inherit pointer in ChipField when wrapped in <ReferenceField>

### DIFF
--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -11,7 +11,7 @@ import { FieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 
 const useStyles = makeStyles(
     {
-        chip: { margin: 4 },
+        chip: { margin: 4, cursor: 'inherit' },
     },
     { name: 'RaChipField' }
 );


### PR DESCRIPTION
Hi,

This pull request improves some of the user experience when using \<ChipField> as the child of \<ReferenceField>.

The original implementation of the ChipField uses \<div> to wrap around a \<span>. When the ChipField is used in Referencefield, only the margins of that \<div> will have cursor as pointer when moved to it, and the text in the ChipField will display default cursor. This is not very intuitive for user to click on that chip.

The patch will make \<div> in ChipField inherit the cursor and offer better user experience.