### PR TITLE
fix BooleanInput parse/format

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -32,7 +32,7 @@ const BooleanInput: FunctionComponent<
 }) => {
     const {
         id,
-        input: { onChange: finalFormOnChange, type, value, ...inputProps },
+        input: { onChange: finalFormOnChange, value, ...inputProps },
         isRequired,
         meta: { error, touched },
     } = useInput({
@@ -43,7 +43,6 @@ const BooleanInput: FunctionComponent<
         parse,
         resource,
         source,
-        type: 'checkbox',
         validate,
         ...rest,
     });


### PR DESCRIPTION
## Problem
React-admin boolean input will be broken if parse/format function used.

### Description
I recently upgraded from 2.9 to the latest 3.8.2 and found my BooleanInputs was broken. My API takes on the string values "1" (if true) or "0" (if false) for these purposes I use parse `v => v ? "1" : "0"` and format `v => !!Number(v)`. On 2.9 its work, but on 3.X input freeze and dont changes value after a couple of switches.

### Step to reproduce
You can see live example here: https://codesandbox.io/s/ra-boolean-parse-format-example-yixdg
(Default final-form field with same params work, ra-boolean - does not)

### Solution
I tried to find the problem and saw the `BooleanInput` has a property `"type": "checkbox"`, in the [official documentation of final form](https://final-form.org/docs/react-final-form/types/FieldProps#type) this field is marked as optional. I think this parameter works fine inside the final form, but in react-admin context it breaks the parse/format functions, when I removed it - the problem was solved.
(P.S: since ra-boolean is based on MUI switch, DOM element will have `type="checkbox"` by default and accessibility will not be affected)