### PR TITLE
Fix useGetIdentity fails when there is no authProvider

### DIFF
--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -45,7 +45,7 @@ const useGetIdentity = () => {
     });
     const authProvider = useAuthProvider();
     useEffect(() => {
-        if (typeof authProvider.getIdentity === 'function') {
+        if (authProvider && typeof authProvider.getIdentity === 'function') {
             const callAuthProvider = async () => {
                 try {
                     const identity = await authProvider.getIdentity();


### PR DESCRIPTION
closes #5201