### PR TITLE
simpleRestProvider: using a custom http header to count items in a collection

### DIFF
--- a/packages/ra-data-simple-rest/README.md
+++ b/packages/ra-data-simple-rest/README.md
@@ -105,7 +105,7 @@ Now all the requests to the REST API will contain the `Authorization: SRTRDFVESG
 
 Historically, Simple REST Data Provider uses the http `Content-Range` header to retrieve the number of items in a collection. But this is a *hack* of the [primary role of this header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range).
 
-And this can be problematic, for example within an infrastructure using a Varnish that may use, modify or delete this header. We also have feedback indicating that using this header is problematic when you host your application on [Versel](https://vercel.com/).
+However this can be problematic, for example within an infrastructure using a Varnish that may use, modify or delete this header. We also have feedback indicating that using this header is problematic when you host your application on [Vercel](https://vercel.com/).
 
 The solution is to use another http header to return the number of collection's items, the other header commonly used for this is `X-Total-Count`. So if you use `X-Total-Count`, you will have to :
 

--- a/packages/ra-data-simple-rest/README.md
+++ b/packages/ra-data-simple-rest/README.md
@@ -101,6 +101,40 @@ const httpClient = (url, options = {}) => {
 
 Now all the requests to the REST API will contain the `Authorization: SRTRDFVESGNJYTUKTYTHRG` header.
 
+## Note about Content-Range
+
+Historically, Simple REST Data Provider uses the http `Content-Range` header to retrieve the number of items in a collection. But this is a *hack* of the [primary role of this header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range).
+
+And this can be problematic, for example within an infrastructure using a Varnish that may use, modify or delete this header. We also have feedback indicating that using this header is problematic when you host your application on [Versel](https://vercel.com/).
+
+The solution is to use another http header to return the number of collection's items, the other header commonly used for this is `X-Total-Count`. So if you use `X-Total-Count`, you will have to :
+
+* Whitelist this header with an `Access-Control-Expose-Headers` [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) header.
+
+```
+Access-Control-Expose-Headers: X-Total-Count
+```
+
+* Use the third parameter of `simpleRestProvider` to specify the name of the header to use :
+  
+```jsx
+// in src/App.js
+import * as React from "react";
+import { Admin, Resource } from 'react-admin';
+import { fetchUtils } from 'ra-core';
+import simpleRestProvider from 'ra-data-simple-rest';
+
+import { PostList } from './posts';
+
+const App = () => (
+    <Admin dataProvider={simpleRestProvider('http://path.to.my.api/', fetchUtils.fetchJson, 'X-Total-Count')}>
+        <Resource name="posts" list={PostList} />
+    </Admin>
+);
+
+export default App;
+```
+
 ## License
 
 This data provider is licensed under the MIT License, and sponsored by [marmelab](http://marmelab.com).

--- a/packages/ra-data-simple-rest/README.md
+++ b/packages/ra-data-simple-rest/README.md
@@ -107,7 +107,7 @@ Historically, Simple REST Data Provider uses the http `Content-Range` header to 
 
 However this can be problematic, for example within an infrastructure using a Varnish that may use, modify or delete this header. We also have feedback indicating that using this header is problematic when you host your application on [Vercel](https://vercel.com/).
 
-The solution is to use another http header to return the number of collection's items, the other header commonly used for this is `X-Total-Count`. So if you use `X-Total-Count`, you will have to :
+The solution is to use another http header to return the number of collection's items. The other header commonly used for this is `X-Total-Count`. So if you use `X-Total-Count`, you will have to :
 
 * Whitelist this header with an `Access-Control-Expose-Headers` [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) header.
 

--- a/packages/ra-data-simple-rest/src/index.spec.ts
+++ b/packages/ra-data-simple-rest/src/index.spec.ts
@@ -35,5 +35,37 @@ describe('Data Simple REST Client', () => {
                 }
             );
         });
+
+        it('should use a custom http header to retrieve the number of items in the collection', async () => {
+            const httpClient = jest.fn(() =>
+                Promise.resolve({
+                    headers: new Headers({
+                        'x-total-count': '42',
+                    }),
+                    json: [{ id: 1 }],
+                    status: 200,
+                    body: '',
+                })
+            );
+            const client = simpleClient(
+                'http://localhost:3000',
+                httpClient,
+                'X-Total-Count'
+            );
+
+            const result = await client.getList('posts', {
+                filter: {},
+                pagination: {
+                    page: 1,
+                    perPage: 10,
+                },
+                sort: {
+                    field: 'title',
+                    order: 'desc',
+                },
+            });
+
+            expect(result.total).toEqual(42);
+        });
     });
 });


### PR DESCRIPTION
Historically, Simple REST Data Provider uses the http `Content-Range` header to retrieve the number of items in a collection. But this is a *hack* of the [primary role of this header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range).

And this can be problematic, for example within an infrastructure using a Varnish that may use, modify or delete this header. We also have feedback indicating that using this header is problematic when you host your application on [Versel](https://vercel.com/).

The solution is to use another http header to return the number of collection's items.

**This PR introduces a third optional parameter to the `simpleRestProvider` allowing to define this header.**