### PR TITLE
fix: warning proptypes in ListToolBar component

### DIFF
--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -58,7 +58,8 @@ const ListToolbar: FC<ListToolbarProps> = props => {
 ListToolbar.propTypes = {
     classes: PropTypes.object,
     filters: PropTypes.element,
-    actions: PropTypes.element,
+    // @ts-ignore
+    actions: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
     // @ts-ignore
     exporter: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 };


### PR DESCRIPTION
When you define `actions={false}` in `<List />`, you have warning about ListToolBar proptypes. 

`<ListToolBar />` is create by `<ListView />`, I define the same props as [ListView propttypes](https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/list/ListView.tsx#L112) and [List proptypes](https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/list/List.tsx#L73).