### PR TITLE
Fix filter margin-top that create an invisible overlay

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -20,6 +20,7 @@ const useStyles = makeStyles(
             alignItems: 'flex-end',
             flexWrap: 'wrap',
             minHeight: theme.spacing(10),
+            pointerEvents: 'none',
         },
         clearFix: { clear: 'right' },
     }),

--- a/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
@@ -10,7 +10,11 @@ const emptyRecord = {};
 
 const useStyles = makeStyles(
     theme => ({
-        body: { display: 'flex', alignItems: 'flex-end' },
+        body: {
+            display: 'flex',
+            alignItems: 'flex-end',
+            pointerEvents: 'auto',
+        },
         spacer: { width: theme.spacing(2) },
         hideButton: {},
     }),


### PR DESCRIPTION
## Issue

In lists pages, the filter form have a top margin that makes it highter than the inputs looks.
When placing something upper than the filer form, it is covered by this margin, and very difficult to click on.

## Solution

Use css pointer properties to disable click on this invisible margin, and allow click on the components displayed under it.


![image](https://user-images.githubusercontent.com/39904906/92398797-7cebc200-f129-11ea-8e4a-e2905f11a60f.png)
