### PR TITLE
Remove sanitizing __ types

### DIFF
--- a/packages/ra-data-graphql-simple/src/getResponseParser.js
+++ b/packages/ra-data-graphql-simple/src/getResponseParser.js
@@ -2,10 +2,7 @@ import { GET_LIST, GET_MANY, GET_MANY_REFERENCE } from 'ra-core';
 
 const sanitizeResource = data => {
     const result = Object.keys(data).reduce((acc, key) => {
-        if (key.startsWith('_')) {
-            return acc;
-        }
-
+        
         const dataKey = data[key];
 
         if (dataKey === null || dataKey === undefined) {


### PR DESCRIPTION
When using graphql, we rely on `__typename` for identifying the correct types in a `union` type.

imagine i have the following interface

```
interface Animal {
    id: ID!
}

type Crawler implements Animal {
    legs: Int
}

type Swimmer implements Animal {
    fins: Int
}
```

we would return a type of the form `union SomeAnimal = Crawler & Swimmer` where we rely on `__typename` to correctly display some information on the dashboard.

With this proposal I ask to not filter out `__` fields.