### PR TITLE
[BC Break] Rename duplicate types to allow type emission from react-admin 

### DIFF
--- a/packages/ra-core/src/actions/accumulateActions.ts
+++ b/packages/ra-core/src/actions/accumulateActions.ts
@@ -1,5 +1,5 @@
 import { crudGetMany, crudGetMatching } from './dataActions';
-import { Pagination, Sort, Identifier } from '../types';
+import { PaginationPayload, SortPayload, Identifier } from '../types';
 
 export const CRUD_GET_MANY_ACCUMULATE = 'RA/CRUD_GET_MANY_ACCUMULATE';
 
@@ -37,8 +37,8 @@ export interface CrudGetMatchingAccumulateAction {
 export const crudGetMatchingAccumulate = (
     reference: string,
     relatedTo: string,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object
 ): CrudGetMatchingAccumulateAction => {
     const action = crudGetMatching(

--- a/packages/ra-core/src/actions/dataActions/crudGetAll.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetAll.ts
@@ -1,11 +1,11 @@
-import { Record, Pagination, Sort } from '../../types';
+import { Record, PaginationPayload, SortPayload } from '../../types';
 import { GET_LIST } from '../../core';
 import { FETCH_END, FETCH_ERROR } from '../fetchActions';
 import { NotificationSideEffect, CallbackSideEffect } from '../../sideEffect';
 
 export const crudGetAll = (
     resource: string,
-    sort: Sort,
+    sort: SortPayload,
     filter: object,
     maxResults: number,
     callback?: CallbackSideEffect
@@ -28,8 +28,8 @@ export const crudGetAll = (
 });
 
 interface RequestPayload {
-    pagination: Pagination;
-    sort: Sort;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     filter: object;
 }
 

--- a/packages/ra-core/src/actions/dataActions/crudGetList.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetList.ts
@@ -1,12 +1,12 @@
-import { Record, Pagination, Sort } from '../../types';
+import { Record, PaginationPayload, SortPayload } from '../../types';
 import { GET_LIST } from '../../core';
 import { FETCH_END, FETCH_ERROR } from '../fetchActions';
 import { NotificationSideEffect } from '../../sideEffect';
 
 export const crudGetList = (
     resource: string,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object
 ): CrudGetListAction => ({
     type: CRUD_GET_LIST,
@@ -24,8 +24,8 @@ export const crudGetList = (
 });
 
 interface RequestPayload {
-    pagination: Pagination;
-    sort: Sort;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     filter: object;
 }
 

--- a/packages/ra-core/src/actions/dataActions/crudGetManyReference.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetManyReference.ts
@@ -1,4 +1,9 @@
-import { Identifier, Record, Pagination, Sort } from '../../types';
+import {
+    Identifier,
+    Record,
+    PaginationPayload,
+    SortPayload,
+} from '../../types';
 import { GET_MANY_REFERENCE } from '../../core';
 import { FETCH_END, FETCH_ERROR } from '../fetchActions';
 import { NotificationSideEffect } from '../../sideEffect';
@@ -8,8 +13,8 @@ export const crudGetManyReference = (
     target: string,
     id: Identifier,
     relatedTo: string,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object,
     source: string
 ): CrudGetManyReferenceAction => ({
@@ -32,8 +37,8 @@ interface RequestPayload {
     source: string;
     target: string;
     id: Identifier;
-    pagination: Pagination;
-    sort: Sort;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     filter: object;
 }
 

--- a/packages/ra-core/src/actions/dataActions/crudGetMatching.ts
+++ b/packages/ra-core/src/actions/dataActions/crudGetMatching.ts
@@ -1,4 +1,4 @@
-import { Record, Pagination, Sort } from '../../types';
+import { Record, PaginationPayload, SortPayload } from '../../types';
 import { GET_LIST } from '../../core';
 import { FETCH_END, FETCH_ERROR } from '../fetchActions';
 import { NotificationSideEffect } from '../../sideEffect';
@@ -6,8 +6,8 @@ import { NotificationSideEffect } from '../../sideEffect';
 export const crudGetMatching = (
     reference: string,
     relatedTo: string,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object
 ): CrudGetMatchingAction => ({
     type: CRUD_GET_MATCHING,
@@ -26,8 +26,8 @@ export const crudGetMatching = (
 });
 
 interface RequestPayload {
-    pagination: Pagination;
-    sort: Sort;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     filter: object;
 }
 

--- a/packages/ra-core/src/actions/notificationActions.ts
+++ b/packages/ra-core/src/actions/notificationActions.ts
@@ -11,7 +11,7 @@ interface NotificationOptions {
     undoable?: boolean;
 }
 
-export interface Notification {
+export interface NotificationPayload {
     readonly message: string;
     readonly type: NotificationType;
     readonly notificationOptions?: NotificationOptions;
@@ -19,7 +19,7 @@ export interface Notification {
 
 export interface ShowNotificationAction {
     readonly type: typeof SHOW_NOTIFICATION;
-    readonly payload: Notification;
+    readonly payload: NotificationPayload;
 }
 
 /**

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldController.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactElement } from 'react';
 
 import useReferenceArrayFieldController from './useReferenceArrayFieldController';
 import { ListControllerProps } from '../useListController';
-import { Record, Sort } from '../../types';
+import { Record, SortPayload } from '../../types';
 
 interface Props {
     basePath: string;
@@ -12,7 +12,7 @@ interface Props {
     record?: Record;
     reference: string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
     children: (params: ListControllerProps) => ReactElement<any>;
 }

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, FunctionComponent } from 'react';
 
-import { Record, Sort } from '../../types';
+import { Record, SortPayload } from '../../types';
 import useReferenceManyFieldController from './useReferenceManyFieldController';
 import { ListControllerProps } from '../useListController';
 
@@ -13,7 +13,7 @@ interface Props {
     record?: Record;
     reference: string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
     target: string;
     total?: number;

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 
 import { useSafeSetState, removeEmpty } from '../../util';
-import { Record, RecordMap, Identifier, Sort } from '../../types';
+import { Record, RecordMap, Identifier, SortPayload } from '../../types';
 import { useGetMany } from '../../dataProvider';
 import { ListControllerProps } from '../useListController';
 import { useNotify } from '../../sideEffect';
@@ -19,7 +19,7 @@ interface Option {
     record?: Record;
     reference: string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
 }
 

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import { useSafeSetState, removeEmpty } from '../../util';
 import { useGetManyReference } from '../../dataProvider';
 import { useNotify } from '../../sideEffect';
-import { Record, Sort, RecordMap } from '../../types';
+import { Record, SortPayload, RecordMap } from '../../types';
 import { ListControllerProps } from '../useListController';
 import usePaginationState from '../usePaginationState';
 import useSelectionState from '../useSelectionState';
@@ -22,7 +22,7 @@ interface Options {
     record?: Record;
     reference: string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source?: string;
     target: string;
     total?: number;

--- a/packages/ra-core/src/controller/input/ReferenceArrayInputController.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceArrayInputController.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react';
 import debounce from 'lodash/debounce';
 
-import { Record, Sort, Pagination } from '../../types';
+import { Record, SortPayload, PaginationPayload } from '../../types';
 import useReferenceArrayInputController from './useReferenceArrayInputController';
 
 interface ChildrenFuncParams {
@@ -15,8 +15,8 @@ interface ChildrenFuncParams {
     loaded: boolean;
     loading: boolean;
     setFilter: (filter: any) => void;
-    setPagination: (pagination: Pagination) => void;
-    setSort: (sort: Sort) => void;
+    setPagination: (pagination: PaginationPayload) => void;
+    setSort: (sort: SortPayload) => void;
     warning?: string;
 }
 
@@ -32,7 +32,7 @@ interface Props {
     record?: Record;
     reference: string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
 }
 

--- a/packages/ra-core/src/controller/input/ReferenceInputController.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.tsx
@@ -5,7 +5,7 @@ import {
     ReactElement,
 } from 'react';
 
-import { Sort, Record } from '../../types';
+import { SortPayload, Record } from '../../types';
 import useReferenceInputController, {
     ReferenceInputValue,
 } from './useReferenceInputController';
@@ -22,7 +22,7 @@ interface Props {
     reference: string;
     referenceSource?: (resource: string, source: string) => string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
     onChange: () => void;
 }

--- a/packages/ra-core/src/controller/input/useGetMatchingReferences.ts
+++ b/packages/ra-core/src/controller/input/useGetMatchingReferences.ts
@@ -7,7 +7,12 @@ import {
     getPossibleReferenceValues,
     getReferenceResource,
 } from '../../reducer';
-import { Pagination, Sort, Record, Filter } from '../../types';
+import {
+    PaginationPayload,
+    SortPayload,
+    Record,
+    FilterPayload,
+} from '../../types';
 import { useDeepCompareEffect } from '../../util/hooks';
 
 interface UseMatchingReferencesOption {
@@ -15,9 +20,9 @@ interface UseMatchingReferencesOption {
     referenceSource: (resource: string, source: string) => string;
     resource: string;
     source: string;
-    filter: Filter;
-    pagination: Pagination;
-    sort: Sort;
+    filter: FilterPayload;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     id: string;
 }
 

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
@@ -2,7 +2,12 @@ import { useMemo, useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import difference from 'lodash/difference';
-import { Pagination, Record, Sort, ReduxState } from '../../types';
+import {
+    PaginationPayload,
+    Record,
+    SortPayload,
+    ReduxState,
+} from '../../types';
 import { useGetMany } from '../../dataProvider';
 import { FieldInputProps } from 'react-final-form';
 import useGetMatching from '../../dataProvider/useGetMatching';
@@ -206,8 +211,8 @@ interface ReferenceArrayInputProps {
     loading: boolean;
     loaded: boolean;
     setFilter: (filter: any) => void;
-    setPagination: (pagination: Pagination) => void;
-    setSort: (sort: Sort) => void;
+    setPagination: (pagination: PaginationPayload) => void;
+    setSort: (sort: SortPayload) => void;
 }
 
 interface Option {
@@ -220,7 +225,7 @@ interface Option {
     record?: Record;
     reference: string;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
 }
 

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -1,6 +1,6 @@
 import { getStatusForInput as getDataStatus } from './referenceDataStatus';
 import useTranslate from '../../i18n/useTranslate';
-import { Sort, Record, Pagination } from '../../types';
+import { SortPayload, Record, PaginationPayload } from '../../types';
 import useReference from '../useReference';
 import useGetMatchingReferences from './useGetMatchingReferences';
 import usePaginationState from '../usePaginationState';
@@ -15,12 +15,12 @@ export interface ReferenceInputValue {
     choices: Record[];
     error?: string;
     loading: boolean;
-    pagination: Pagination;
+    pagination: PaginationPayload;
     setFilter: (filter: string) => void;
     filter: any;
-    setPagination: (pagination: Pagination) => void;
-    setSort: (sort: Sort) => void;
-    sort: Sort;
+    setPagination: (pagination: PaginationPayload) => void;
+    setSort: (sort: SortPayload) => void;
+    sort: SortPayload;
     warning?: string;
 }
 
@@ -34,7 +34,7 @@ interface Option {
     reference: string;
     referenceSource?: typeof defaultReferenceSource;
     resource: string;
-    sort?: Sort;
+    sort?: SortPayload;
     source: string;
 }
 

--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
-import { Filter } from '../types';
+import { FilterPayload } from '../types';
 
 interface UseFilterStateOptions {
-    filterToQuery?: (v: string) => Filter;
-    permanentFilter?: Filter;
+    filterToQuery?: (v: string) => FilterPayload;
+    permanentFilter?: FilterPayload;
     debounceTime?: number;
 }
 
@@ -15,7 +15,7 @@ interface UseFilterStateOptions {
  * @property {setFilter} setFilter: Update the filter with the given string
  */
 interface UseFilterStateProps {
-    filter: Filter;
+    filter: FilterPayload;
     setFilter: (v: string) => void;
 }
 

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -15,8 +15,8 @@ import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
 import { CRUD_GET_LIST } from '../actions';
 import defaultExporter from '../export/defaultExporter';
 import {
-    Filter,
-    Sort,
+    FilterPayload,
+    SortPayload,
     RecordMap,
     Identifier,
     ReduxState,
@@ -26,11 +26,11 @@ import {
 
 export interface ListProps {
     // the props you can change
-    filter?: Filter;
+    filter?: FilterPayload;
     filters?: ReactElement<any>;
     filterDefaultValues?: object;
     perPage?: number;
-    sort?: Sort;
+    sort?: SortPayload;
     exporter?: Exporter | false;
     // the props managed by react-admin
     basePath?: string;
@@ -54,7 +54,7 @@ const defaultData = {};
 
 export interface ListControllerProps<RecordType = Record> {
     basePath: string;
-    currentSort: Sort;
+    currentSort: SortPayload;
     data: RecordMap<RecordType>;
     defaultTitle?: string;
     displayedFilters: any;

--- a/packages/ra-core/src/controller/useListParams.ts
+++ b/packages/ra-core/src/controller/useListParams.ts
@@ -15,7 +15,7 @@ import queryReducer, {
     SORT_ASC,
 } from '../reducer/admin/resource/list/queryReducer';
 import { changeListParams, ListParams } from '../actions/listActions';
-import { Sort, ReduxState, Filter } from '../types';
+import { SortPayload, ReduxState, FilterPayload } from '../types';
 import removeEmpty from '../util/removeEmpty';
 import removeKey from '../util/removeKey';
 
@@ -23,11 +23,11 @@ interface ListParamsOptions {
     resource: string;
     location: Location;
     perPage?: number;
-    sort?: Sort;
+    sort?: SortPayload;
     // default value for a filter when displayed but not yet set
-    filterDefaultValues?: Filter;
+    filterDefaultValues?: FilterPayload;
     // permanent filter which always overrides the user entry
-    filter?: Filter;
+    filter?: FilterPayload;
     debounce?: number;
 }
 

--- a/packages/ra-core/src/controller/usePaginationState.ts
+++ b/packages/ra-core/src/controller/usePaginationState.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useCallback, useRef } from 'react';
-import { Pagination } from '../types';
+import { PaginationPayload } from '../types';
 
 /**
  * @typedef PaginationProps
@@ -13,16 +13,16 @@ import { Pagination } from '../types';
 export interface PaginationProps {
     page: number;
     perPage: number;
-    pagination: Pagination;
+    pagination: PaginationPayload;
     setPage: (page: number) => void;
     setPerPage: (perPage: number) => void;
-    setPagination: (pagination: Pagination) => void;
+    setPagination: (pagination: PaginationPayload) => void;
 }
 
 const paginationReducer = (
-    prevState: Pagination,
-    nextState: Partial<Pagination>
-): Pagination => {
+    prevState: PaginationPayload,
+    nextState: Partial<PaginationPayload>
+): PaginationPayload => {
     return {
         ...prevState,
         ...nextState,

--- a/packages/ra-core/src/controller/useSortState.ts
+++ b/packages/ra-core/src/controller/useSortState.ts
@@ -4,25 +4,25 @@ import {
     SORT_ASC,
     SORT_DESC,
 } from '../reducer/admin/resource/list/queryReducer';
-import { Sort } from '../types';
+import { SortPayload } from '../types';
 
 export interface SortProps {
     setSortField: (field: string) => void;
     setSortOrder: (order: string) => void;
-    setSort: (sort: Sort, order?: string) => void;
-    sort: Sort;
+    setSort: (sort: SortPayload, order?: string) => void;
+    sort: SortPayload;
 }
 
 interface Action {
     type: 'SET_SORT' | 'SET_SORT_FIELD' | 'SET_SORT_ORDER';
     payload: {
-        sort?: Sort;
+        sort?: SortPayload;
         field?: string;
         order?: string;
     };
 }
 
-const sortReducer = (state: Sort, action: Action): Sort => {
+const sortReducer = (state: SortPayload, action: Action): SortPayload => {
     switch (action.type) {
         case 'SET_SORT':
             return action.payload.sort;
@@ -54,7 +54,7 @@ export const defaultSort = { field: 'id', order: 'DESC' };
  * set the sort { field, order }
  * @name setSort
  * @function
- * @param {Sort} sort the sort object
+ * @param {SortPayload} sort the sort object
  */
 
 /**
@@ -102,7 +102,7 @@ export const defaultSort = { field: 'id', order: 'DESC' };
  * @param {string} initialSort.order The initial sort order
  * @returns {SortProps} The sort props
  */
-const useSortState = (initialSort: Sort = defaultSort): SortProps => {
+const useSortState = (initialSort: SortPayload = defaultSort): SortProps => {
     const [sort, dispatch] = useReducer(sortReducer, initialSort);
     const isFirstRender = useRef(true);
     useEffect(() => {
@@ -115,7 +115,8 @@ const useSortState = (initialSort: Sort = defaultSort): SortProps => {
 
     return {
         setSort: useCallback(
-            (sort: Sort) => dispatch({ type: 'SET_SORT', payload: { sort } }),
+            (sort: SortPayload) =>
+                dispatch({ type: 'SET_SORT', payload: { sort } }),
             [dispatch]
         ),
         setSortField: useCallback(

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -2,8 +2,8 @@ import { useSelector, shallowEqual } from 'react-redux';
 import get from 'lodash/get';
 
 import {
-    Pagination,
-    Sort,
+    PaginationPayload,
+    SortPayload,
     ReduxState,
     Identifier,
     Record,
@@ -53,8 +53,8 @@ const defaultData = {};
  */
 const useGetList = <RecordType = Record>(
     resource: string,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object,
     options?: any
 ): {

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -1,6 +1,11 @@
 import { useSelector, shallowEqual } from 'react-redux';
 import { CRUD_GET_MANY_REFERENCE } from '../actions/dataActions/crudGetManyReference';
-import { Pagination, Sort, Identifier, ReduxState } from '../types';
+import {
+    PaginationPayload,
+    SortPayload,
+    Identifier,
+    ReduxState,
+} from '../types';
 import useQueryWithStore from './useQueryWithStore';
 import {
     getReferences,
@@ -59,8 +64,8 @@ const useGetManyReference = (
     resource: string,
     target: string,
     id: Identifier,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object,
     referencingResource: string,
     options?: any

--- a/packages/ra-core/src/dataProvider/useGetMatching.ts
+++ b/packages/ra-core/src/dataProvider/useGetMatching.ts
@@ -2,7 +2,13 @@ import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 
 import { CRUD_GET_MATCHING } from '../actions/dataActions/crudGetMatching';
-import { Identifier, Pagination, Sort, Record, ReduxState } from '../types';
+import {
+    Identifier,
+    PaginationPayload,
+    SortPayload,
+    Record,
+    ReduxState,
+} from '../types';
 import useQueryWithStore from './useQueryWithStore';
 import {
     getReferenceResource,
@@ -62,8 +68,8 @@ const referenceSource = (resource, source) => `${resource}@${source}`;
  */
 const useGetMatching = (
     resource: string,
-    pagination: Pagination,
-    sort: Sort,
+    pagination: PaginationPayload,
+    sort: SortPayload,
     filter: object,
     source: string,
     referencingResource: string,

--- a/packages/ra-core/src/reducer/admin/notifications.ts
+++ b/packages/ra-core/src/reducer/admin/notifications.ts
@@ -4,7 +4,7 @@ import {
     ShowNotificationAction,
     HIDE_NOTIFICATION,
     HideNotificationAction,
-    Notification,
+    NotificationPayload,
 } from '../../actions/notificationActions';
 import { UNDO, UndoAction } from '../../actions/undoActions';
 
@@ -14,7 +14,7 @@ type ActionTypes =
     | UndoAction
     | { type: 'OTHER_TYPE' };
 
-type State = Notification[];
+type State = NotificationPayload[];
 
 const notificationsReducer: Reducer<State> = (
     previousState = [],

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -4,6 +4,7 @@ import {
     RouteComponentProps,
     match as Match,
 } from 'react-router-dom';
+import { ThemeOptions } from '@material-ui/core';
 import { Location, History } from 'history';
 
 import { WithPermissionsChildrenParams } from './auth/WithPermissions';
@@ -371,9 +372,12 @@ export type DashboardComponent = ComponentType<WithPermissionsChildrenParams>;
 
 export interface LayoutProps {
     dashboard?: DashboardComponent;
-    logout: ReactNode;
-    menu: ComponentType;
-    theme: object;
+    logout?: ReactNode;
+    menu?: ComponentType<{
+        logout?: ReactNode;
+        hasDashboard?: boolean;
+    }>;
+    theme?: ThemeOptions;
     title?: TitleComponent;
 }
 
@@ -424,7 +428,7 @@ export interface AdminProps {
     loginPage?: LoginComponent | boolean;
     logoutButton?: ComponentType;
     menu?: ComponentType;
-    theme?: object;
+    theme?: ThemeOptions;
     title?: TitleComponent;
 }
 

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -25,14 +25,14 @@ export interface RecordMap<RecordType = Record> {
     [id: number]: RecordType;
 }
 
-export interface Sort {
+export interface SortPayload {
     field: string;
     order: string;
 }
-export interface Filter {
+export interface FilterPayload {
     [k: string]: any;
 }
-export interface Pagination {
+export interface PaginationPayload {
     page: number;
     perPage: number;
 }
@@ -120,8 +120,8 @@ export type DataProvider = {
 };
 
 export interface GetListParams {
-    pagination: Pagination;
-    sort: Sort;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     filter: any;
 }
 export interface GetListResult {
@@ -149,8 +149,8 @@ export interface GetManyResult {
 export interface GetManyReferenceParams {
     target: string;
     id: Identifier;
-    pagination: Pagination;
-    sort: Sort;
+    pagination: PaginationPayload;
+    sort: SortPayload;
     filter: any;
 }
 export interface GetManyReferenceResult {

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -13,19 +13,21 @@ import { ThemeProvider } from '@material-ui/styles';
 import LockIcon from '@material-ui/icons/Lock';
 import { StaticContext } from 'react-router';
 import { useHistory } from 'react-router-dom';
-import { useCheckAuth } from 'ra-core';
+import { useCheckAuth, TitleComponent } from 'ra-core';
 
 import defaultTheme from '../defaultTheme';
 import Notification from '../layout/Notification';
 import DefaultLoginForm from './LoginForm';
 
-interface Props {
+export interface LoginProps
+    extends Omit<HtmlHTMLAttributes<HTMLDivElement>, 'title'> {
     backgroundImage?: string;
-    children: ReactNode;
+    children?: ReactNode;
     classes?: object;
     className?: string;
     staticContext?: StaticContext;
-    theme: object;
+    theme?: object;
+    title?: TitleComponent;
 }
 
 const useStyles = makeStyles(
@@ -76,11 +78,10 @@ const useStyles = makeStyles(
  *        </Admin>
  *     );
  */
-const Login: React.FunctionComponent<
-    Props & HtmlHTMLAttributes<HTMLDivElement>
-> = props => {
+const Login: React.FunctionComponent<LoginProps> = props => {
     const {
         theme,
+        title,
         classes: classesOverride,
         className,
         children,

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -7,9 +7,9 @@ import {
     useDataProvider,
     useNotify,
     useListContext,
-    Sort,
+    SortPayload,
     Exporter,
-    Filter,
+    FilterPayload,
 } from 'ra-core';
 import Button, { ButtonProps } from './Button';
 
@@ -97,13 +97,13 @@ const sanitizeRestProps = ({
 interface Props {
     basePath?: string;
     exporter?: Exporter;
-    filterValues?: Filter;
+    filterValues?: FilterPayload;
     icon?: JSX.Element;
     label?: string;
     maxResults?: number;
     onClick?: (e: Event) => void;
     resource?: string;
-    sort?: Sort;
+    sort?: SortPayload;
 }
 
 export type ExportButtonProps = Props & ButtonProps;

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -7,8 +7,8 @@ import {
     ListContextProvider,
     ListControllerProps,
     useReferenceArrayFieldController,
-    Sort,
-    Filter,
+    SortPayload,
+    FilterPayload,
 } from 'ra-core';
 
 import { fieldPropTypes, FieldProps, InjectedFieldProps } from './types';
@@ -133,13 +133,13 @@ export interface ReferenceArrayFieldProps
         InjectedFieldProps {
     children: ReactElement;
     classes?: ClassesOverride<typeof useStyles>;
-    filter?: Filter;
+    filter?: FilterPayload;
     page?: number;
     pagination?: ReactElement;
     perPage?: number;
     reference: string;
     resource?: string;
-    sort?: Sort;
+    sort?: SortPayload;
 }
 
 const useStyles = makeStyles(

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -1,8 +1,8 @@
 import React, { FC, cloneElement, Children, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
-    Filter,
-    Sort,
+    FilterPayload,
+    SortPayload,
     useReferenceManyFieldController,
     ListContextProvider,
     ListControllerProps,
@@ -100,11 +100,11 @@ export const ReferenceManyField: FC<ReferenceManyFieldProps> = props => {
 
 interface ReferenceManyFieldProps extends FieldProps, InjectedFieldProps {
     children: ReactElement;
-    filter?: Filter;
+    filter?: FilterPayload;
     page?: number;
     perPage?: number;
     reference: string;
-    sort?: Sort;
+    sort?: SortPayload;
     target: string;
 }
 

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -10,8 +10,8 @@ import {
     useInput,
     useReferenceInputController,
     InputProps,
-    Pagination,
-    Sort,
+    PaginationPayload,
+    SortPayload,
     warning as warningLog,
 } from 'ra-core';
 
@@ -203,8 +203,8 @@ export interface ReferenceInputViewProps {
     reference: string;
     resource: string;
     setFilter: (v: string) => void;
-    setPagination: (pagination: Pagination) => void;
-    setSort: (sort: Sort, order?: string) => void;
+    setPagination: (pagination: PaginationPayload) => void;
+    setSort: (sort: SortPayload, order?: string) => void;
     source: string;
     warning?: string;
 }

--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -5,6 +5,8 @@ import React, {
     useRef,
     useState,
     ErrorInfo,
+    ReactElement,
+    ReactNode,
     ComponentType,
     HtmlHTMLAttributes,
 } from 'react';
@@ -19,7 +21,7 @@ import {
 } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import { ThemeOptions } from '@material-ui/core';
-import { ComponentPropType, CustomRoutes, DashboardComponent } from 'ra-core';
+import { ComponentPropType, CustomRoutes, LayoutProps } from 'ra-core';
 import compose from 'lodash/flowRight';
 
 import DefaultAppBar from './AppBar';
@@ -84,7 +86,7 @@ const sanitizeRestProps = ({
     ...props
 }: RestProps) => props;
 
-class Layout extends Component<LayoutProps, LayoutState> {
+class Layout extends Component<MuiLayoutProps, LayoutState> {
     state = { hasError: false, errorMessage: null, errorInfo: null };
 
     constructor(props) {
@@ -181,33 +183,30 @@ class Layout extends Component<LayoutProps, LayoutState> {
     };
 }
 
-export interface LayoutProps
-    extends RouteComponentProps,
-        HtmlHTMLAttributes<HTMLDivElement> {
+export interface MuiLayoutProps
+    extends LayoutProps,
+        RouteComponentProps,
+        Omit<HtmlHTMLAttributes<HTMLDivElement>, 'title'> {
     className?: string;
     classes?: any;
     customRoutes?: CustomRoutes;
     appBar?: ComponentType<{
-        title?: string;
+        title?: string | ReactElement<any>;
         open?: boolean;
-        logout?: JSX.Element;
+        logout?: ReactNode;
     }>;
     sidebar?: ComponentType<{ children: JSX.Element }>;
-    menu?: ComponentType<{ logout?: JSX.Element; hasDashboard?: boolean }>;
     error?: ComponentType<{
         error?: string;
         errorInfo?: React.ErrorInfo;
-        title?: string;
+        title?: string | ReactElement<any>;
     }>;
-    dashboard?: DashboardComponent;
     notification?: ComponentType;
-    logout?: JSX.Element;
-    title?: string;
     open?: boolean;
 }
 
 export type RestProps = Omit<
-    LayoutProps,
+    MuiLayoutProps,
     | 'appBar'
     | 'children'
     | 'classes'

--- a/packages/ra-ui-materialui/src/list/ListActions.tsx
+++ b/packages/ra-ui-materialui/src/list/ListActions.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {
     sanitizeListRestProps,
     Identifier,
-    Sort,
+    SortPayload,
     Exporter,
     useListContext,
 } from 'ra-core';
@@ -74,7 +74,7 @@ ListActions.defaultProps = {
 };
 
 interface ListActionsProps extends ToolbarProps {
-    currentSort?: Sort;
+    currentSort?: SortPayload;
     className?: string;
     resource?: string;
     filters?: ReactElement<any>;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { TableCell, TableSortLabel, Tooltip } from '@material-ui/core';
 import { TableCellProps } from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
-import { FieldTitle, useTranslate, Sort } from 'ra-core';
+import { FieldTitle, useTranslate, SortPayload } from 'ra-core';
 
 import { ClassesOverride } from '../../types';
 
@@ -108,7 +108,7 @@ export interface DatagridHeaderCellProps
     field?: JSX.Element;
     isSorting?: boolean;
     resource: string;
-    currentSort: Sort;
+    currentSort: SortPayload;
     updateSort: (event: any) => void;
 }
 

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -1,5 +1,5 @@
 import { FC, ReactElement, ReactNode } from 'react';
-import { usePermissions, Exporter, Sort } from 'ra-core';
+import { usePermissions, Exporter, SortPayload } from 'ra-core';
 import { RouteComponentProps } from 'react-router-dom';
 import { StaticContext } from 'react-router';
 import { LocationState } from 'history';
@@ -34,7 +34,7 @@ export interface ListProps extends ResourceComponentProps {
     filters?: ReactElement;
     pagination?: ReactElement | false;
     perPage?: number;
-    sort?: Sort;
+    sort?: SortPayload;
     title?: string | ReactElement;
 }
 

--- a/packages/ra-ui-materialui/tsconfig.json
+++ b/packages/ra-ui-materialui/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src"
-  },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
-  "include": ["src"]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "rootDir": "src",
+        "declaration": true
+    },
+    "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
+    "include": ["src"]
 }

--- a/packages/ra-ui-materialui/tsconfig.json
+++ b/packages/ra-ui-materialui/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "declaration": true
+        "declaration": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/react-admin/tsconfig.json
+++ b/packages/react-admin/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "declaration": true,
+        "declaration": false,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/react-admin/tsconfig.json
+++ b/packages/react-admin/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "declaration": false,
+        "declaration": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],


### PR DESCRIPTION
## Problem

We have name conflicts in `ra-core` and `ra-ui-materialui` (`Sort`, `Filter` and `Navigation` exist twice, once as types in `ra-core`, once as components in `ra-ui-material-ui`).

The `react-admin` packages reexports all the exports from both `ra-core` and `ra-ui-materialui`. The conflicts prevent the TypeScript compilation.

## Solution

We have no other solution but to rename one of the exports. As the TypeScript migration isn't finished, I think it's less painful to rename the types than the components. 

It's a slight BC break for developers who started importing types directly from `ra-core` - which is not documented. 

Besides, the current types are not well enough tested, as the `react-admin` package doesn't emit them. So they're probably false, and will need further changes. We should not worry about changing these types for now. 

Refs #4505