### PR TITLE
allow to end undoable mutation directly in onSuccess callback

### DIFF
--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -296,7 +296,6 @@ const performUndoableQuery = ({
             optimistic: true,
         },
     });
-    onSuccess && onSuccess({});
     undoableEventEmitter.once('end', ({ isUndo }) => {
         dispatch(stopOptimisticMode());
         if (isUndo) {
@@ -389,6 +388,8 @@ const performUndoableQuery = ({
             );
         }
     });
+    onSuccess && onSuccess({});
+
     return Promise.resolve({});
 };
 


### PR DESCRIPTION
This allows to have optimistic behavior while sending the query immediately.
fix #5133 