### PR TITLE
Fix unexpected List Page Change

### DIFF
--- a/examples/demo/src/reviews/BulkAcceptButton.tsx
+++ b/examples/demo/src/reviews/BulkAcceptButton.tsx
@@ -2,19 +2,21 @@ import * as React from 'react';
 import { FC } from 'react';
 import PropTypes from 'prop-types';
 import ThumbUp from '@material-ui/icons/ThumbUp';
+
 import {
     Button,
     useUpdateMany,
     useNotify,
-    useRedirect,
+    useRefresh,
     useUnselectAll,
     CRUD_UPDATE_MANY,
 } from 'react-admin';
+
 import { BulkActionProps } from '../types';
 
 const BulkAcceptButton: FC<BulkActionProps> = ({ selectedIds }) => {
     const notify = useNotify();
-    const redirectTo = useRedirect();
+    const refresh = useRefresh();
     const unselectAll = useUnselectAll('reviews');
 
     const [approve, { loading }] = useUpdateMany(
@@ -31,7 +33,7 @@ const BulkAcceptButton: FC<BulkActionProps> = ({ selectedIds }) => {
                     {},
                     true
                 );
-                redirectTo('/reviews');
+                refresh();
                 unselectAll();
             },
             onFailure: () => {

--- a/examples/demo/src/reviews/BulkRejectButton.tsx
+++ b/examples/demo/src/reviews/BulkRejectButton.tsx
@@ -2,19 +2,21 @@ import * as React from 'react';
 import { FC } from 'react';
 import PropTypes from 'prop-types';
 import ThumbDown from '@material-ui/icons/ThumbDown';
+
 import {
     Button,
     useUpdateMany,
     useNotify,
-    useRedirect,
+    useRefresh,
     useUnselectAll,
     CRUD_UPDATE_MANY,
 } from 'react-admin';
+
 import { BulkActionProps } from '../types';
 
 const BulkRejectButton: FC<BulkActionProps> = ({ selectedIds }) => {
     const notify = useNotify();
-    const redirectTo = useRedirect();
+    const refresh = useRefresh();
     const unselectAll = useUnselectAll('reviews');
 
     const [reject, { loading }] = useUpdateMany(
@@ -31,7 +33,7 @@ const BulkRejectButton: FC<BulkActionProps> = ({ selectedIds }) => {
                     {},
                     true
                 );
-                redirectTo('/reviews');
+                refresh();
                 unselectAll();
             },
             onFailure: () => {

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -180,11 +180,16 @@ const useListController = <RecordType = Record>(
         get(state.admin.resources, [resource, 'list', 'total'], 0)
     );
 
+    // Since the total can be empty during the loading phase
+    // We need to override that total with the latest loaded one
+    // This way, the useEffect bellow won't reset the page to 1
+    const finalTotal = typeof total === 'undefined' ? defaultTotal : total;
+
     const finalIds = typeof total === 'undefined' ? defaultIds : ids;
 
     const totalPages = useMemo(() => {
-        return Math.ceil(total / query.perPage) || 1;
-    }, [query.perPage, total]);
+        return Math.ceil(finalTotal / query.perPage) || 1;
+    }, [query.perPage, finalTotal]);
 
     useEffect(() => {
         if (


### PR DESCRIPTION
This fix avoid resetting current page (in a list) when the total is resetted (during loading phase).
This way, the demo "reviews" page don't go to the first page when we accept or reject a review.

I also removed the redirect to "/reviews" when we accept or reject reviews in bulk mode. This way we stay on the current page of reviews