### PR TITLE
Patch ra-realtime for 3.x

### DIFF
--- a/packages/ra-realtime/src/buildAction.js
+++ b/packages/ra-realtime/src/buildAction.js
@@ -1,11 +1,30 @@
-import { FETCH_END } from 'ra-core';
+import {
+  CRUD_GET_LIST,
+  CRUD_GET_ONE,
+  FETCH_END,
+  GET_LIST,
+  GET_ONE
+} from "ra-core";
+
+export const getFetchType = (actionType) => {
+  if (actionType === CRUD_GET_LIST) {
+    return GET_LIST;
+  } else if (actionType === CRUD_GET_ONE) {
+    return GET_ONE;
+  } else {
+    console.error(
+      `unexpected action type: ${actionType}, should be only ${CRUD_GET_LIST} or ${CRUD_GET_ONE}`
+    );
+    return undefined;
+  }
+};
 
 export default (
-    { type, payload: requestPayload, meta: { fetch: restType, ...meta } },
-    payload
+  { type, payload: requestPayload, meta: { fetch: restType, ...meta } },
+  payload
 ) => ({
-    type: `${type}_SUCCESS`,
-    payload,
-    requestPayload,
-    meta: { ...meta, fetchResponse: restType, fetchStatus: FETCH_END },
+  type: `${type}_SUCCESS`,
+  payload,
+  requestPayload,
+  meta: { ...meta, fetchResponse: getFetchType(type), fetchStatus: FETCH_END }
 });


### PR DESCRIPTION
Hi, this patch allow using ra-realtime on 3.x

The only 2 changes are: 

`import { LOCATION_CHANGE } from 'react-router-redux';` for  `import { LOCATION_CHANGE } from "connected-react-router";`

And get `fetchType` from the action type, and not action payload `meta.fetch`, because even if it exists on

https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/actions/dataActions/crudGetList.ts
https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/actions/dataActions/crudGetOne.ts

it is not present on the actual payload, as you can see on the console output on the example below.

I made this as a draft on 2.x because it was easier and didn't know if you want this on 3.x branch or prefer that i create a new repo for it. If you want this on 3.x, i create a new, non-draft pull request on it, and converted to TypeScript.

Commenting https://github.com/marmelab/react-admin/pull/3908, i agree that the actual approach is not optimal, one reason is that for example, with graphql subscriptions or firebase realtime db/firestore, it firsts asks a normal, non-realtime request, and right after asks a realtime one, which return the first result very fast and likely the same as the normal request, ending up with one unnecessary request. So, what do you think about allowing dataProviders to return observable requests, likely with a next function on the response object that awaits for new data and then returns it?

Working example (posts list only):

https://codesandbox.io/s/jovial-swirles-gn3un

Working live:

https://gn3un.sse.codesandbox.io/#/posts