### PR TITLE
Improve the documentation of the SaveButton when customizing the Toolbar

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1226,7 +1226,7 @@ export const PostEdit = (props) => (
 );
 ```
 
-By default the `<SaveButton>` is disabled when the form is `pristine`. You can bypass this behavior and always enable it without recreating the whole `<Toolbar>`:
+In the default `<Toolbar>`, the `<SaveButton>` is disabled when the form is `pristine`. You can bypass this behavior and always enable it without customizing the `<Toolbar>` thanks to the prop `alwaysEnableSaveButton`:
 
 ```jsx
 import * as React from 'react';
@@ -1236,6 +1236,27 @@ export const PostEdit = (props) => (
     <Edit {...props}>
         <SimpleForm toolbar={<Toolbar alwaysEnableSaveButton />}>
             ...
+        </SimpleForm>
+    </Edit>
+);
+```
+
+But if you want to customize the `<Toolbar>` (to remove the `<DeleteButton>` for example), you have to manage the _disabled_ behaviour of the `<SaveButton>` by yourself:
+
+```jsx
+import * as React from "react";
+import { Edit, SimpleForm, SaveButton, Toolbar } from 'react-admin';
+
+const PostEditToolbar = props => (
+    <Toolbar {...props} >
+        <SaveButton disabled={!props.pristine} />
+    </Toolbar>
+);
+
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm toolbar={<PostEditToolbar />}>
+            // ...
         </SimpleForm>
     </Edit>
 );


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/5220

The documentation about the `<SaveButton>` disable mechanism is confusing when the `<Toolbar>` is customized. So I added an explanation and an example about how to restore this mechanism.

## Todo

- [x] Improve the documentation of the `<SaveButton>` when customizing the `<Toolbar>`