### PR TITLE
Add documentation of Data Provider

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -66,6 +66,7 @@ The react-admin project includes 4 Data Providers:
 Developers from the react-admin community have open-sourced Data Providers for many more backends:
 
 * **[AWS Amplify](https://docs.amplify.aws)**: [MrHertal/react-admin-amplify](https://github.com/MrHertal/react-admin-amplify)
+* **[Configurable Identity Property REST Client](https://github.com/zachrybaker/ra-data-rest-client)**: [zachrybaker/ra-data-rest-client](https://github.com/zachrybaker/ra-data-rest-client)
 * **[Django Rest Framework](https://www.django-rest-framework.org/)**: [synaptic-cl/ra-data-drf](https://github.com/synaptic-cl/ra-data-drf)
 * **[Express & Sequelize](https://github.com/lalalilo/express-sequelize-crud)**: [express-sequelize-crud](https://github.com/lalalilo/express-sequelize-crud)
 * **[Feathersjs](https://www.feathersjs.com/)**: [josx/ra-data-feathers](https://github.com/josx/ra-data-feathers)


### PR DESCRIPTION
Added a link to a data provider I added today, that is simply taking the ra-data-simple-rest provider and giving it a  configuration hash of resourceName:identityName values so that it can map between 'id' and the real identity property name in HTTP communication.  Simple.  And React-admin continues to work as it always has, but people get to avoid changing their server-side API.