### PR TITLE
More TS fixes

### DIFF
--- a/packages/ra-core/src/controller/useCreateController.ts
+++ b/packages/ra-core/src/controller/useCreateController.ts
@@ -23,7 +23,7 @@ import { CRUD_CREATE } from '../actions';
 import { Record } from '../types';
 
 export interface CreateProps {
-    basePath: string;
+    basePath?: string;
     hasCreate?: boolean;
     hasEdit?: boolean;
     hasList?: boolean;
@@ -56,7 +56,7 @@ export interface CreateControllerProps {
     setOnFailure: SetOnFailure;
     setTransform: SetTransformData;
     resource: string;
-    basePath: string;
+    basePath?: string;
     record?: Partial<Record>;
     redirect: RedirectionSideEffect;
     version: number;

--- a/packages/ra-core/src/controller/useEditController.ts
+++ b/packages/ra-core/src/controller/useEditController.ts
@@ -24,12 +24,12 @@ import { useTranslate } from '../i18n';
 import { CRUD_GET_ONE, CRUD_UPDATE } from '../actions';
 
 export interface EditProps {
-    basePath: string;
+    basePath?: string;
     hasCreate?: boolean;
     hasEdit?: boolean;
     hasShow?: boolean;
     hasList?: boolean;
-    id: Identifier;
+    id?: Identifier;
     resource?: string;
     undoable?: boolean;
     onSuccess?: OnSuccess;
@@ -56,7 +56,7 @@ export interface EditControllerProps<RecordType extends Record = Record> {
     setOnFailure: SetOnFailure;
     setTransform: SetTransformData;
     resource: string;
-    basePath: string;
+    basePath?: string;
     record?: RecordType;
     redirect: RedirectionSideEffect;
     version: number;

--- a/packages/ra-core/src/controller/useShowController.ts
+++ b/packages/ra-core/src/controller/useShowController.ts
@@ -9,12 +9,12 @@ import { useNotify, useRedirect, useRefresh } from '../sideEffect';
 import { CRUD_GET_ONE } from '../actions';
 
 export interface ShowProps {
-    basePath: string;
+    basePath?: string;
     hasCreate?: boolean;
     hasedit?: boolean;
     hasShow?: boolean;
     hasList?: boolean;
-    id: Identifier;
+    id?: Identifier;
     resource?: string;
     [key: string]: any;
 }
@@ -24,7 +24,7 @@ export interface ShowControllerProps<RecordType extends Record = Record> {
     loaded: boolean;
     defaultTitle: string;
     resource: string;
-    basePath: string;
+    basePath?: string;
     record?: RecordType;
     version: number;
 }

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -388,6 +388,7 @@ export type DashboardComponent = ComponentType<WithPermissionsChildrenParams>;
 
 export interface LayoutProps {
     appBar?: ComponentType;
+    children?: ReactNode;
     dashboard?: DashboardComponent;
     logout?: ReactNode;
     menu?: ComponentType<{
@@ -402,7 +403,7 @@ export interface LayoutProps {
 export type LayoutComponent = ComponentType<LayoutProps>;
 
 export interface ResourceComponentInjectedProps {
-    basePath: string;
+    basePath?: string;
     permissions?: any;
     resource?: string;
     options?: any;
@@ -416,7 +417,7 @@ export interface ResourceComponentProps<
     Params extends { [K in keyof Params]?: string } = {},
     C extends StaticContext = StaticContext,
     S = LocationState
-> extends RouteComponentProps<Params, C, S>,
+> extends Partial<RouteComponentProps<Params, C, S>>,
         ResourceComponentInjectedProps {}
 
 // deprecated name, use ResourceComponentProps instead
@@ -426,9 +427,9 @@ export interface ResourceComponentPropsWithId<
     Params extends { id?: string } = {},
     C extends StaticContext = StaticContext,
     S = LocationState
-> extends RouteComponentProps<Params, C, S>,
+> extends Partial<RouteComponentProps<Params, C, S>>,
         ResourceComponentInjectedProps {
-    id: string;
+    id?: string;
 }
 
 // deprecated name, use ResourceComponentPropsWithId instead

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -215,17 +215,17 @@ const useStyles = makeStyles(
 const sanitizeRestProps = ({
     hasCreate = null,
     hasEdit = null,
-    history,
-    loaded,
-    loading,
-    location,
-    match,
+    history = null,
+    loaded = null,
+    loading = null,
+    location = null,
+    match = null,
     onFailure = null,
     onSuccess = null,
     options = null,
     permissions = null,
     transform = null,
     ...rest
-}: any) => rest;
+}) => rest;
 
 export default Create;

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -226,6 +226,6 @@ const sanitizeRestProps = ({
     permissions = null,
     transform = null,
     ...rest
-}) => rest;
+}: any) => rest;
 
 export default Create;

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -237,18 +237,18 @@ const useStyles = makeStyles(
 const sanitizeRestProps = ({
     hasCreate = null,
     hasEdit = null,
-    history,
-    id,
-    loaded,
-    loading,
-    location,
-    match,
+    history = null,
+    id = null,
+    loaded = null,
+    loading = null,
+    location = null,
+    match = null,
     onFailure = null,
     onSuccess = null,
     options = null,
     permissions = null,
     successMessage = null,
     ...rest
-}: any) => rest;
+}) => rest;
 
 export default Edit;

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -249,6 +249,6 @@ const sanitizeRestProps = ({
     permissions = null,
     successMessage = null,
     ...rest
-}) => rest;
+}: any) => rest;
 
 export default Edit;

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -191,29 +191,17 @@ const useStyles = makeStyles(
 );
 
 const sanitizeRestProps = ({
-    actions,
-    aside,
-    title,
-    children,
-    className,
-    id,
-    data,
-    loading,
-    loaded,
-    resource,
-    hasCreate,
-    hasEdit,
-    hasList,
-    hasShow,
-    version,
-    match,
-    location,
-    history,
-    options,
-    locale,
-    permissions,
-    translate,
+    hasCreate = null,
+    hasEdit = null,
+    history = null,
+    id = null,
+    loaded = null,
+    loading = null,
+    location = null,
+    match = null,
+    options = null,
+    permissions = null,
     ...rest
-}: any) => rest;
+}) => rest;
 
 export default Show;

--- a/packages/ra-ui-materialui/src/layout/index.ts
+++ b/packages/ra-ui-materialui/src/layout/index.ts
@@ -15,7 +15,7 @@ import MenuItemLink, { MenuItemLinkProps } from './MenuItemLink';
 import NotFound from './NotFound';
 import Notification from './Notification';
 import Responsive from './Responsive';
-import Sidebar from './Sidebar';
+import Sidebar, { SidebarProps } from './Sidebar';
 import Title, { TitlePropType } from './Title';
 import TitleForRecord from './TitleForRecord';
 import TopToolbar from './TopToolbar';
@@ -42,6 +42,7 @@ export {
     Notification,
     Responsive,
     Sidebar,
+    SidebarProps,
     Title,
     TitleForRecord,
     TitlePropType,


### PR DESCRIPTION
Many of the props are now optional because they are injected by react-admin. This was preventing usage such as passing a `Show` view inside an `expand`  