### PR TITLE
Fix NullableBooleanInput empty value isn't selectable

### DIFF
--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -33,7 +33,7 @@ const englishMessages: TranslationMessages = {
         boolean: {
             true: 'Yes',
             false: 'No',
-            null: '',
+            null: ' ',
         },
         page: {
             create: 'Create %{name}',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -34,7 +34,7 @@ const frenchMessages: TranslationMessages = {
         boolean: {
             true: 'Oui',
             false: 'Non',
-            null: '',
+            null: ' ',
         },
         page: {
             create: 'Créer %{name}',


### PR DESCRIPTION
No code change necessary, I just used [an UTF8 Em Space character](https://www.compart.com/en/unicode/U+2003) in the translations. The fix will have to be done in each translation.

Refs #5311 

## Before

![image](https://user-images.githubusercontent.com/99944/94673115-8a562f80-0316-11eb-86b2-9be0919ede6a.png)

## After

![image](https://user-images.githubusercontent.com/99944/94673061-714d7e80-0316-11eb-9944-5f992cbc9ce4.png)
