### PR TITLE
Fix the last testimonial which is not reachable

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@ export default App;</code></pre>
               <div class="carousel__controls">
                 <label
                   class="carousel__control carousel__control--backward"
-                  for="J"
+                  for="K"
                 ></label>
                 <label
                   class="carousel__control carousel__control--forward"
@@ -814,7 +814,7 @@ export default App;</code></pre>
                 <label class="carousel__indicator" for="H"></label>
                 <label class="carousel__indicator" for="I"></label>
                 <label class="carousel__indicator" for="J"></label>
-                <label class="carousel__indicator" for="F"></label>
+                <label class="carousel__indicator" for="K"></label>
               </div>
             </div>
           </div>


### PR DESCRIPTION
In the [react-admin public website](https://marmelab.com/react-admin), the last testimonial is not reachable.

## Todo

- [x] K is not J
- [x] F is not K

## Screenshot(s)

**Final testimonial is now reachable**

![Sélection_005](https://user-images.githubusercontent.com/5584839/94695374-1fb4ec00-0336-11eb-9c3c-858f967198a2.png)

**Looping on the testimonials**

![Peek 30-09-2020 15-43](https://user-images.githubusercontent.com/5584839/94695419-2d6a7180-0336-11eb-8ba1-62849da51ead.gif)
