### PR TITLE
Fix theming docs UserMenu example

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -435,7 +435,7 @@ const MyUserMenu = props => (
 
 const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
 
-const MyLayout = props => <Layout {...props} appBar={<MyAppBar />} />;
+const MyLayout = props => <Layout {...props} appBar={MyAppBar} />;
 ```
 
 You can also customize the default icon by setting the `icon` prop to the `<UserMenu />` component.


### PR DESCRIPTION
I was getting this error when trying UserMenu customizaton:

`Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`

I changed how MyAppBar is passed to Layout. From `{<MyAppBar />}` to `{MyAppBar}` Seems ok now. It looks like Layout is not expecting component that way.