### PR TITLE
Fix wrong link in shop demo's README

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -6,7 +6,7 @@ This is a demo of the [react-admin](https://github.com/marmelab/react-admin) lib
 
 React-admin usually requires a REST/GraphQL server to provide data. In this demo however, the API is simulated by the browser (using [FakeRest](https://github.com/marmelab/FakeRest)). The source data is generated at runtime by a package called [data-generator](https://github.com/marmelab/react-admin/tree/master/examples/data-generator).
 
-To explore the source code, start with [src/App.js](https://github.com/marmelab/react-admin/blob/master/examples/demo/src/App.js).
+To explore the source code, start with [src/App.tsx](https://github.com/marmelab/react-admin/blob/master/examples/demo/src/App.tsx).
 
 **Note**: This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 


### PR DESCRIPTION
src/App.js doesn't exist, src/App.tsx does.