### PR TITLE
add open in Gitpod button + update config to open preview of port 8080 on workspace startup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
 tasks:
   - init: make install
     command: make run
+ports: 
+  - port: 8080
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ For all Pull requests, you must follow the coding style of the existing files (b
 
 Clone this repository and run `make install` to grab the dependencies, then `make build` to compile the sources from TypeScript to JS.
 
+### Online one-click Setup
+
+You can use Gitpod(An Online Open Source VS Code like IDE which is free for Open Source) for working on issues and making PRs. With a single click it will launch a workspace and automatically clone the repo, run `make install` and `make start` so that you can start straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Testing Your Changes In The Example Apps
 
 When developing, most of the time we use the **simple example** to do visual check. It's the same application that we use in CodeSandbox to reproduce errors (see https://codesandbox.io/s/github/marmelab/react-admin/tree/master/examples/simple). The source is located under `examples/simple/`. Call `make run` to launch that example on port 8080 (http://localhost:8080). This command includes a `watch` on the react-admin source, so any of the changes you make to the react-admin packages triggers a live update of the simple example in your browser. 


### PR DESCRIPTION
This Pr updates the config to open the preview of port 8080 on Gitpod workspace startup with this change in place a workspace once started will look like the following:

![image](https://user-images.githubusercontent.com/46004116/95371154-40131680-08f3-11eb-81c0-69cf3860e829.png)

Also I have added a Open in Gitpod button + a bit of description in the Readme so that more people can benefit from it.