### PR TITLE
Strip down lodash footprint by loading only the required utility

### DIFF
--- a/packages/ra-core/src/form/useInitializeFormWithRecord.ts
+++ b/packages/ra-core/src/form/useInitializeFormWithRecord.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-final-form';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 /**
  * Restore the record values which should override any default values specified on the form.


### PR DESCRIPTION
Importing `lodash` instead of `lodash/merge` was having an impact in the `ra-core` import size for `examples/demo`.

This is `lodash` footprint before the change:

<img width="1674" alt="Screen Shot 2020-10-11 at 11 27 33" src="https://user-images.githubusercontent.com/165799/95681279-42a49300-0bb5-11eb-8742-79d872fa1a33.png">

And after:

<img width="1667" alt="Screen Shot 2020-10-11 at 11 30 02" src="https://user-images.githubusercontent.com/165799/95681253-256fc480-0bb5-11eb-8828-4306b7f36e51.png">
