### PR TITLE
fix Layout component type

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -270,7 +270,7 @@ LayoutWithTheme.defaultProps = {
     theme: defaultTheme,
 };
 
-interface LayoutWithThemeProps extends LayoutProps {
+interface LayoutWithThemeProps extends MuiLayoutProps {
     theme?: ThemeOptions;
 }
 


### PR DESCRIPTION
react-admin version: 3.9.3

I'm getting the following error when trying to use `sidebar` prop of `Layout`:

```ts
9:45 Type '{ appBar: FC<AppBarProps>; sidebar: { (props: any): Element; propTypes: { children: Validator<ReactNodeLike>; }; }; className?: string; ... 264 more ...; onTransitionEndCapture?: (event: TransitionEvent<...>) => void; }' is not assignable to type 'IntrinsicAttributes & Pick<Pick<LayoutWithThemeProps, "menu" | "title" | "children" | "theme" | "appBar" | "dashboard" | "logout" | "sideBar"> & Pick<...> & Pick<...>, "menu" | ... 5 more ... | "sideBar"> & Partial<...> & Partial<...>'.
  Property 'sidebar' does not exist on type 'IntrinsicAttributes & Pick<Pick<LayoutWithThemeProps, "menu" | "title" | "children" | "theme" | "appBar" | "dashboard" | "logout" | "sideBar"> & Pick<...> & Pick<...>, "menu" | ... 5 more ... | "sideBar"> & Partial<...> & Partial<...>'.
     7 | 
     8 | const MyLayout: React.FC<LayoutProps> = (props) => (
  >  9 |   <Layout {...props} appBar={AppBar} sidebar={Sidebar} />
       |                                             ^
    10 | )
```

This is my code:
```ts
import React from 'react'
import {Layout, LayoutProps} from 'react-admin'

import AppBar from './AppBar'
import Sidebar from './Sidebar'

export const MyLayout: React.FC<LayoutProps> = (props) => (
  <Layout {...props} appBar={AppBar} sidebar={Sidebar} />
)
```

(This is my custom Sidebar component, but it happens also when importing `Sidebar` directly from `react-admin`.)

By looking at the `Layout.tsx`, I found:
- `LayoutWithTheme` is passing props to `EnhancedLayout`, which is enhancing `Layout`
- `class Layout` is defined using `MuiLayoutProps`
- `LayoutWithTheme` is defined using `LayoutWithThemeProps`

this means `LayoutWithThemeProps` should be based on `MuiLayoutProps` instead of `LayoutProps`