### PR TITLE
Fix non null id types handling

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -25,7 +25,8 @@ const sanitizeValue = (type, value) => {
 };
 
 const castType = (value, type) => {
-    switch (`${type.kind}:${type.name}`) {
+    const realType = type.kind === 'NON_NULL' ? type.ofType : type;
+    switch (`${realType.kind}:${realType.name}`) {
         case 'SCALAR:Int':
             return Number(value);
 


### PR DESCRIPTION
If the `id` field of an entity has a non null type like `Int!`, it cannot be edited with the `Edit` screen.

The problem was the `castType` function not handling types with `NON_NULL` kind which wraps the real type under a `ofType` property.

closes #5400
