### PR TITLE
Add a GET_COUNT fetch action for graphql dataProvider

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.test.js
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.test.js
@@ -8,6 +8,7 @@ import {
     CREATE,
     DELETE,
 } from 'ra-core';
+import { GET_COUNT } from 'ra-data-graphql';
 import buildGqlQuery, {
     buildApolloArgs,
     buildArgs,
@@ -293,6 +294,18 @@ describe('buildGqlQuery', () => {
     };
 
     const resource = {
+        [GET_COUNT]: {
+            name: '_allCommandMeta',
+            args: [
+                {
+                    name: 'foo',
+                    type: {
+                        kind: TypeKind.NON_NULL,
+                        ofType: { kind: TypeKind.SCALAR, name: 'Int' },
+                    },
+                },
+            ],
+        },
         type: {
             fields: [
                 { type: { kind: TypeKind.SCALAR, name: '' }, name: 'foo' },

--- a/packages/ra-data-graphql-simple/src/index.js
+++ b/packages/ra-data-graphql-simple/src/index.js
@@ -1,11 +1,15 @@
 import merge from 'lodash/merge';
-import buildDataProvider from 'ra-data-graphql';
+import buildDataProvider, {
+    GET_COUNT as INNER_GET_COUNT,
+} from 'ra-data-graphql';
 import { DELETE, DELETE_MANY, UPDATE, UPDATE_MANY } from 'ra-core';
 
 import defaultBuildQuery from './buildQuery';
 const defaultOptions = {
     buildQuery: defaultBuildQuery,
 };
+
+export const GET_COUNT = INNER_GET_COUNT;
 
 export const buildQuery = defaultBuildQuery;
 

--- a/packages/ra-data-graphql/src/constants.js
+++ b/packages/ra-data-graphql/src/constants.js
@@ -10,7 +10,14 @@ import {
     DELETE_MANY,
 } from 'ra-core';
 
-export const QUERY_TYPES = [GET_LIST, GET_MANY, GET_MANY_REFERENCE, GET_ONE];
+export const GET_COUNT = 'GET_COUNT';
+export const QUERY_TYPES = [
+    GET_LIST,
+    GET_MANY,
+    GET_MANY_REFERENCE,
+    GET_ONE,
+    GET_COUNT,
+];
 export const MUTATION_TYPES = [
     CREATE,
     UPDATE,

--- a/packages/ra-data-graphql/src/index.js
+++ b/packages/ra-data-graphql/src/index.js
@@ -16,17 +16,20 @@ import {
     QUERY_TYPES as INNER_QUERY_TYPES,
     MUTATION_TYPES as INNER_MUTATION_TYPES,
     ALL_TYPES as INNER_ALL_TYPES,
+    GET_COUNT as INNER_GET_COUNT,
 } from './constants';
 import defaultResolveIntrospection from './introspection';
 export const QUERY_TYPES = INNER_QUERY_TYPES;
 export const MUTATION_TYPES = INNER_MUTATION_TYPES;
 export const ALL_TYPES = INNER_ALL_TYPES;
+export const GET_COUNT = INNER_GET_COUNT;
 
 const defaultOptions = {
     resolveIntrospection: defaultResolveIntrospection,
     introspection: {
         operationNames: {
             [GET_LIST]: resource => `all${pluralize(resource.name)}`,
+            [GET_COUNT]: resource => `_all${pluralize(resource.name)}Meta`,
             [GET_ONE]: resource => `${resource.name}`,
             [GET_MANY]: resource => `all${pluralize(resource.name)}`,
             [GET_MANY_REFERENCE]: resource => `all${pluralize(resource.name)}`,


### PR DESCRIPTION
In the graphql provider, we have to define a query to fetch the total count of entity for a given resource. Previously, the name of this query was hardcoded.

This PR aims to allow the customization of this query name, such as every other query names.

I'm not sure about where to put the new `GET_COUNT` constant, tell me if you think there is a better place.

I have exported `GET_COUNT` from `ra-data-graphql-simple` to allow an easier use for developers, allowing to import this simbol directly from `ra-data-graphql-simple` instead of having an explicit dependence on `ra-data-graphql` in the application code.

Closes #4566