### PR TITLE
Manage the table of contents of the documentation using tocbot

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="{{ '/css/prism.css' | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css">
 </head>
 
 <body>
@@ -114,14 +115,14 @@
             apiKey: '32f254b1de6a25a96665d1229b6eb8f7',
             indexName: 'marmelab-react-admin',
             inputSelector: '#query',
-            debug: false, // Set debug to true if you want to inspect the dropdown 
+            debug: false, // Set debug to true if you want to inspect the dropdown
             autocompleteOptions: {
                 appendTo: '#search',
                 hint: false,
             }
-        }); 
+        });
     </script>
-
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
     <!--
         React-admin protects your privacy!
         We use our own self-hosted tracking solution to collect some raw metrics,

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,16 +66,11 @@
     <main>
         <div class="container">
             <div class="row">
-                <div class="col s12 m8 offset-m1 xl7 offset-xl1 markdown-section DocSearch-content">
+                <div class="col s12 m8 offset-m1 xl7 offset-xl1 markdown-section DocSearch-content toc-content">
                     {{ content }}
                 </div>
                 <div class="col hide-on-small-only m3 xl3 offset-xl1">
-                    <div class="toc-wrapper">
-                        <div style="height: 1px;">
-                            <ul class="section table-of-contents pushpin">
-                            </ul>
-                        </div>
-                    </div>
+                    <div class="toc"></div>
                 </div>
             </div>
         </div>
@@ -93,20 +88,18 @@
                 .replace(/-+$/, '');            // Trim - from end of text
         }
         document.addEventListener('DOMContentLoaded', function () {
-            /* Generate table of contents */
-            document.querySelectorAll('.markdown-section h2').forEach(element => {
-                element.classList.add('scrollspy');
-                var a = document.createElement('a');
-                a.href = "#" + slugify(element.innerText);
-                a.innerText = element.innerText;
-                var li = document.createElement('li');
-                li.appendChild(a);
-                document.querySelector('.table-of-contents').appendChild(li)
-            })
-            M.Sidenav.init(document.querySelectorAll('.sidenav'));
-            M.Pushpin.init(document.querySelector('.pushpin'), { offset: 75, top: 75 });
-            M.ScrollSpy.init(document.querySelectorAll('.scrollspy'));
-            M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'));
+            tocbot.init({
+                // Where to render the table of contents
+                tocSelector: '.toc',
+                positionFixedSelector: '.toc',
+                // Where to grab the headings to build the table of contents
+                contentSelector: '.toc-content',
+                // More options
+                headingSelector: 'h2, h3',
+                includeHtml: true,
+                collapseDepth: 2,
+                hasInnerContainers: true,
+            });
         });
     </script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -121,6 +121,13 @@
             }
         }); 
     </script>
+
+    <!--
+        React-admin protects your privacy!
+        We use our own self-hosted tracking solution to collect some raw metrics,
+        like page views, device type (mobile, desktop, etc.) or country.
+        We don't track any personal information about our visitors.
+    -->
     <script async defer data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd" src="https://analytics.marmelab.com/umami.js"></script>
 </body>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{{ '/css/style-v6.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/css/syntax.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/css/prism.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/css/tocbot.css' | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css">

--- a/css/tocbot.css
+++ b/css/tocbot.css
@@ -1,0 +1,42 @@
+:root {
+  --lightgrey: #e8e8e8;
+  --black: #000;
+  --deepblue: #00023b;
+  --white: white;
+  --magenta: #313264;
+  --yellowkindof: #f0c070;
+}
+
+.toc-list-item {
+  padding: 4px 0;
+}
+
+.toc-link {
+  color: var(--black) !important;
+}
+
+.toc-link::before {
+  margin-top: -3px !important;
+}
+
+.toc-link:hover {
+  color: var(--deepblue) !important;
+  font-weight: 700;
+}
+
+.toc-link:hover::before {
+  color: var(--deepblue) !important;
+  background-color: var(--deepblue);
+}
+
+.is-active-link {
+  color: var(--deepblue) !important;
+}
+
+.is-active-link::before {
+  background-color: var(--deepblue) !important;
+}
+
+.is-position-fixed {
+  margin-top: 32px;
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <link href="assets/styles.css" rel="stylesheet" />
     <link href="assets/prism.css" rel="stylesheet" />
     <link href="assets/carousel.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,700|Source+Sans+Pro:400,600,700&display=swap" rel="stylesheet" />
     <link rel="shortcut icon" href="./assets/favicon.ico" />
     <meta name="description" content="A Web Framework for B2B applications" />

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
     <link href="assets/styles.css" rel="stylesheet" />
     <link href="assets/prism.css" rel="stylesheet" />
     <link href="assets/carousel.css" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,700|Source+Sans+Pro:400,600,700&display=swap" rel="stylesheet" />
     <link rel="shortcut icon" href="./assets/favicon.ico" />
     <meta name="description" content="A Web Framework for B2B applications" />
@@ -954,7 +953,6 @@ export default App;</code></pre>
     <script src="assets/prism.js" async></script>
     <script src="assets/githubstars.js" defer></script>
     <script src="assets/generate-copyright-date.js" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
     <!--
         React-admin protects your privacy!
         We use our own self-hosted tracking solution to collect some raw metrics,

--- a/index.html
+++ b/index.html
@@ -955,6 +955,12 @@ export default App;</code></pre>
     <script src="assets/githubstars.js" defer></script>
     <script src="assets/generate-copyright-date.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
+    <!--
+        React-admin protects your privacy!
+        We use our own self-hosted tracking solution to collect some raw metrics,
+        like page views, device type (mobile, desktop, etc.) or country.
+        We don't track any personal information about our visitors.
+    -->
     <script async defer data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd" src="https://analytics.marmelab.com/umami.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -953,6 +953,7 @@ export default App;</code></pre>
     <script src="assets/prism.js" async></script>
     <script src="assets/githubstars.js" defer></script>
     <script src="assets/generate-copyright-date.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
     <script async defer data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd" src="https://analytics.marmelab.com/umami.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Use [Tocbot](https://github.com/tscanlin/tocbot) to manage the table of contents of the documentation

As François said:
> It's so much better

## Todo

- [x] Add tocbot.js to page dependencies
- [x] Adapt the default design to match the react-admin design

## Screenshot(s)

**Basic view**

![Sélection_004](https://user-images.githubusercontent.com/5584839/96150524-bd014a00-0f0a-11eb-83d7-0348714171e7.png)

**Basic view when hovering an item**

![Sélection_005](https://user-images.githubusercontent.com/5584839/96150547-c4285800-0f0a-11eb-8ca1-7759c39d8c2a.png)

**Scrolled view**

![Sélection_006](https://user-images.githubusercontent.com/5584839/96150696-ecb05200-0f0a-11eb-8391-2295c089b2aa.png)
