### PR TITLE
Manage the table of contents of the documentation using tocbot

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -118,6 +118,12 @@
         });
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
+    <!--
+        React-admin protects your privacy!
+        We use our own self-hosted tracking solution to collect some raw metrics,
+        like page views, device type (mobile, desktop, etc.) or country.
+        We don't track any personal information about our visitors.
+    -->
     <script async defer data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd" src="https://analytics.marmelab.com/umami.js"></script>
 </body>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -15,9 +15,10 @@
     <link rel="stylesheet" href="{{ '/css/style-v6.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/css/syntax.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/css/prism.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/css/tocbot.css' | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-    <!-- You won't find analytics tags in this page. React-admin protects your privacy! -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css">
 </head>
 
 <body>
@@ -66,16 +67,11 @@
     <main>
         <div class="container">
             <div class="row">
-                <div class="col s12 m8 offset-m1 xl7 offset-xl1 markdown-section DocSearch-content">
+                <div class="col s12 m8 offset-m1 xl7 offset-xl1 markdown-section DocSearch-content toc-content">
                     {{ content }}
                 </div>
                 <div class="col hide-on-small-only m3 xl3 offset-xl1">
-                    <div class="toc-wrapper">
-                        <div style="height: 1px;">
-                            <ul class="section table-of-contents pushpin">
-                            </ul>
-                        </div>
-                    </div>
+                    <div class="toc"></div>
                 </div>
             </div>
         </div>
@@ -94,19 +90,18 @@
         }
         document.addEventListener('DOMContentLoaded', function () {
             /* Generate table of contents */
-            document.querySelectorAll('.markdown-section h2').forEach(element => {
-                element.classList.add('scrollspy');
-                var a = document.createElement('a');
-                a.href = "#" + slugify(element.innerText);
-                a.innerText = element.innerText;
-                var li = document.createElement('li');
-                li.appendChild(a);
-                document.querySelector('.table-of-contents').appendChild(li)
-            })
-            M.Sidenav.init(document.querySelectorAll('.sidenav'));
-            M.Pushpin.init(document.querySelector('.pushpin'), { offset: 75, top: 75 });
-            M.ScrollSpy.init(document.querySelectorAll('.scrollspy'));
-            M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'));
+            tocbot.init({
+                // Where to render the table of contents
+                tocSelector: '.toc',
+                positionFixedSelector: '.toc',
+                // Where to grab the headings to build the table of contents
+                contentSelector: '.toc-content',
+                // More options
+                headingSelector: 'h2, h3',
+                includeHtml: true,
+                collapseDepth: 2,
+                hasInnerContainers: true,
+            });
         });
     </script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
@@ -115,13 +110,14 @@
             apiKey: '32f254b1de6a25a96665d1229b6eb8f7',
             indexName: 'marmelab-react-admin',
             inputSelector: '#query',
-            debug: false, // Set debug to true if you want to inspect the dropdown 
+            debug: false, // Set debug to true if you want to inspect the dropdown
             autocompleteOptions: {
                 appendTo: '#search',
                 hint: false,
             }
-        }); 
+        });
     </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
     <script async defer data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd" src="https://analytics.marmelab.com/umami.js"></script>
 </body>
 

--- a/docs/css/tocbot.css
+++ b/docs/css/tocbot.css
@@ -1,0 +1,38 @@
+:root {
+    --black: #000;
+    --deepblue: #00023b;
+}
+
+.toc-list-item {
+    padding: 4px 0;
+}
+
+.toc-link {
+    color: var(--black) !important;
+}
+
+.toc-link::before {
+    margin-top: -3px !important;
+}
+
+.toc-link:hover {
+    color: var(--deepblue) !important;
+    font-weight: 700;
+}
+
+.toc-link:hover::before {
+    color: var(--deepblue) !important;
+    background-color: var(--deepblue);
+}
+
+.is-active-link {
+    color: var(--deepblue) !important;
+}
+
+.is-active-link::before {
+    background-color: var(--deepblue) !important;
+}
+
+.is-position-fixed {
+    margin-top: 32px;
+}


### PR DESCRIPTION
Use [Tocbot](https://github.com/tscanlin/tocbot) to manage the table of contents of the documentation.

__Same as https://github.com/marmelab/react-admin/pull/5404 but on master__

As François said:
> It's so much better

## Todo

- [x] Add tocbot.js to page dependencies
- [x] Adapt the default design to match the react-admin design

## Screenshot(s)

**Basic view**

![Sélection_004](https://user-images.githubusercontent.com/5584839/96150524-bd014a00-0f0a-11eb-83d7-0348714171e7.png)

**Basic view when hovering an item**

![Sélection_005](https://user-images.githubusercontent.com/5584839/96150547-c4285800-0f0a-11eb-8ca1-7759c39d8c2a.png)

**Scrolled view**

![Sélection_006](https://user-images.githubusercontent.com/5584839/96150696-ecb05200-0f0a-11eb-8391-2295c089b2aa.png)
