### PR TITLE
Allow formClassName in SimpleFormIterator

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.tsx
@@ -100,6 +100,7 @@ const SimpleFormIterator: FC<SimpleFormIteratorProps> = props => {
         basePath,
         children,
         className,
+        formClassName,
         fields,
         meta: { error, submitFailed },
         record,
@@ -195,7 +196,12 @@ const SimpleFormIterator: FC<SimpleFormIteratorProps> = props => {
                             >
                                 {index + 1}
                             </Typography>
-                            <section className={classes.form}>
+                            <section
+                                className={classNames(
+                                    classes.form,
+                                    formClassName
+                                )}
+                            >
                                 {Children.map(
                                     children,
                                     (input: ReactElement, index2) =>
@@ -286,6 +292,7 @@ SimpleFormIterator.propTypes = {
     children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
+    formClassName: PropTypes.string,
     // @ts-ignore
     fields: PropTypes.object,
     meta: PropTypes.object,
@@ -306,6 +313,7 @@ export interface SimpleFormIteratorProps
     addButton?: ReactElement;
     basePath?: string;
     className?: string;
+    formClassName?: string;
     defaultValue?: any;
     disableAdd?: boolean;
     disableRemove?: boolean | DisableRemoveFunction;


### PR DESCRIPTION
I saw that the `className` property had recently beed added to SimpleFormIterator, but it didn't do exactly what I was hoping for. As `className` is for the "exterior" div, I wanted a way to control the "interior" div that directly holds the inputs.

On the name of the property:
* `formClassName` is used throughout the codebase (though I'm not sure if this falls into the same pattern)
* SimpleFormIterator already uses the `form` style internally for this div.