### PR TITLE
Add type for theme

### DIFF
--- a/packages/ra-ui-materialui/src/defaultTheme.ts
+++ b/packages/ra-ui-materialui/src/defaultTheme.ts
@@ -1,3 +1,6 @@
+import { ThemeOptions } from '@material-ui/core';
+import { Overrides } from '@material-ui/core/styles/overrides';
+
 export default {
     palette: {
         secondary: {
@@ -27,3 +30,17 @@ export default {
         },
     },
 };
+
+// Temporary solution until we specify our components in it like MUI does
+// See https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/styles/overrides.d.ts#L103
+export interface RaThemeOverrides extends Overrides {
+    [key: string]: any;
+}
+
+export interface RaThemeOptions extends ThemeOptions {
+    sidebar: {
+        width: number;
+        closedWidth: number;
+    };
+    overrides: RaThemeOverrides;
+}

--- a/packages/ra-ui-materialui/src/index.ts
+++ b/packages/ra-ui-materialui/src/index.ts
@@ -1,5 +1,5 @@
 import Link from './Link';
-import defaultTheme from './defaultTheme';
+import defaultTheme, { RaThemeOptions, RaThemeOverrides } from './defaultTheme';
 
 export * from './auth';
 export * from './button';
@@ -10,5 +10,6 @@ export * from './input';
 export * from './layout';
 export * from './list';
 export { Link, defaultTheme };
+export type { RaThemeOptions, RaThemeOverrides };
 
 export * from './types';


### PR DESCRIPTION
Fixes #5426

This is only the beginning. Indeed there is a lot of work in order to provide type safe overrides.
See how MUI does it:  https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/styles/overrides.d.ts#L103

I also wonder if our approach for the Sidebar `size` and `closedSize` configuration is correct. Maybe we should just rely on props with defaults (which can be overridden through the theme as well (https://material-ui.com/customization/globals/#default-props). This would lead to a single entry to customize the sidebar instead of two (`sidebar` at the theme root and `RaSidebar` in the `overrides`)

We would have to export the class keys for every component like this:
```ts
export type SidebarClassKey = keyof ReturnType<typeof useStyles>;
```

This could be a very good opportunity for first time contributors