### PR TITLE
Fix several eslint warnings

### DIFF
--- a/packages/ra-core/src/dataProvider/Query.spec.tsx
+++ b/packages/ra-core/src/dataProvider/Query.spec.tsx
@@ -571,10 +571,10 @@ describe('Query', () => {
         };
 
         const myPayload = {};
-        const { getByText, dispatch } = renderWithRedux(
+        const { dispatch } = renderWithRedux(
             <DataProviderContext.Provider value={dataProvider}>
                 <Query type="mytype" payload={myPayload}>
-                    {({}) => <div />}
+                    {() => <div />}
                 </Query>
             </DataProviderContext.Provider>
         );

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -182,7 +182,6 @@ export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
                 aria-errormessage={error.message ? error.message : error}
                 color="error"
                 fontSize="small"
-                role="presentation"
             />
         );
     }

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -178,11 +178,14 @@ export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
     }
     if (error) {
         return (
+            /* eslint-disable jsx-a11y/role-supports-aria-props */
             <ErrorIcon
                 aria-errormessage={error.message ? error.message : error}
+                role="presentation"
                 color="error"
                 fontSize="small"
             />
+            /* eslint-enable */
         );
     }
     if (!referenceRecord) {


### PR DESCRIPTION
By reading Travis's logs, I saw some warnings. So I'm correcting them.

```
/home/travis/build/marmelab/react-admin/packages/ra-ui-materialui/src/field/ReferenceField.tsx
  181:13  warning  The attribute aria-errormessage is not supported by the role presentation  jsx-a11y/role-supports-aria-props
```

## Todo

- [x] Fix warnings in `ReferenceField.tsx`
- [x] Fix warnings in `Query.spec.tsx`