### PR TITLE
Fix Appbar custom content flickers when loading

### DIFF
--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useSelector } from 'react-redux';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useRefreshWhenVisible } from 'ra-core';
 
@@ -23,11 +23,12 @@ const LoadingIndicator = props => {
     useRefreshWhenVisible();
     const loading = useSelector(state => state.admin.loading > 0);
     const classes = useStyles(props);
+    const theme = useTheme();
     return loading ? (
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
             color="inherit"
-            size="1em"
+            size={theme.spacing(2)}
             thickness={6}
             {...rest}
         />

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -9,12 +9,12 @@ import { useRefreshWhenVisible } from 'ra-core';
 import RefreshIconButton from '../button/RefreshIconButton';
 
 const useStyles = makeStyles(
-    {
+    theme => ({
         loader: {
-            margin: 16,
+            margin: theme.spacing(2),
         },
         loadedIcon: {},
-    },
+    }),
     { name: 'RaLoadingIndicator' }
 );
 
@@ -27,7 +27,7 @@ const LoadingIndicator = props => {
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
             color="inherit"
-            size={16}
+            size="1em"
             thickness={6}
             {...rest}
         />

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -11,7 +11,7 @@ import RefreshIconButton from '../button/RefreshIconButton';
 const useStyles = makeStyles(
     {
         loader: {
-            margin: 14,
+            margin: 16,
         },
         loadedIcon: {},
     },
@@ -27,8 +27,8 @@ const LoadingIndicator = props => {
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
             color="inherit"
-            size={18}
-            thickness={5}
+            size={16}
+            thickness={6}
             {...rest}
         />
     ) : (


### PR DESCRIPTION
The size of the spinner isn't exactly the same as the size of the refresh button. As a consequence, if the AppBar has a custom content, this content moves a bit when the app loads data.

Making the size of the two components match exactly fixes the bug.

## Before

![spinner2](https://user-images.githubusercontent.com/99944/96875005-086da800-1477-11eb-9278-e353fa28dcc3.gif)

## After

![spinner1](https://user-images.githubusercontent.com/99944/96874884-e5db8f00-1476-11eb-9e40-51282034dcf1.gif)
