### PR TITLE
[Doc] Group Inputs and Fields in documentation to allow better discoverability

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -110,95 +110,9 @@ Then you can display the author first name as follows:
 
 **Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.md#translating-resource-and-field-names) for details.
 
-## `<ArrayField>`
+## Basic Fields
 
-Display a collection using `<Field>` child components.
-
-Ideal for embedded arrays of objects, e.g. `tags` and `backlinks` in the following `post` object:
-
-```js
-{
-  id: 123,
-  tags: [
-        { name: 'foo' },
-        { name: 'bar' }
-  ],
-  backlinks: [
-        {
-            uuid: '34fdf393-f449-4b04-a423-38ad02ae159e',
-            date: '2012-08-10T00:00:00.000Z',
-            url: 'http://example.com/foo/bar.html',
-        },
-        {
-            uuid: 'd907743a-253d-4ec1-8329-404d4c5e6cf1',
-            date: '2012-08-14T00:00:00.000Z',
-            url: 'https://blog.johndoe.com/2012/08/12/foobar.html',
-        }
-   ]
-}
-```
-
-The child must be an iterator component (like `<Datagrid>` or `<SingleFieldList>`).
-
-Here is how to display all the backlinks of the current post as a `<Datagrid>`:
-
-```jsx
-<ArrayField source="backlinks">
-    <Datagrid>
-        <DateField source="date" />
-        <UrlField source="url" />
-    </Datagrid>
-</ArrayField>
-```
-
-And here is how to display all the tags of the current post as `<Chip>` components:
-
-```jsx
-<ArrayField source="tags">
-    <SingleFieldList>
-        <ChipField source="name" />
-    </SingleFieldList>
-</ArrayField>
-```
-
-### Properties
-
-| Prop       | Required | Type   | Default | Description                                                   |
-| ---------- | -------- | ------ | ------- | ------------------------------------------------------------- |
-| `fieldKey` | Optional | string | -       | Name for the field to be used as key when displaying children |
-
-`<ArrayField>` also accepts the [common field props](./Fields.md#common-field-props).
-
-### Usage
-
-If the array value contains a lot of items, you may experience slowdowns in the UI. In such cases, set the `fieldKey` prop to use one field as key, and reduce CPU and memory usage:
-
-```diff
--<ArrayField source="backlinks">
-+<ArrayField source="backlinks" fieldKey="uuid">
-    <Datagrid>
-        <DateField source="date" />
-        <UrlField source="url" />
-    </Datagrid>
-</ArrayField>
-```
-
-**Tip**: If you need to render a custom collection, it's often simpler to write your own component:
-
-```jsx
-const TagsField = ({ record }) => (
-    <ul>
-        {record.tags.map(item => (
-            <li key={item.name}>{item.name}</li>
-        ))}
-    </ul>
-)
-TagsField.defaultProps = {
-    addLabel: true
-};
-```
-
-## `<BooleanField>`
+### `<BooleanField>`
 
 Displays a boolean value as a check.
 
@@ -210,7 +124,7 @@ import { BooleanField } from 'react-admin';
 
 ![BooleanField](./img/boolean-field.png)
 
-### Properties
+#### Properties
 
 | Prop              | Required | Type             | Default                    | Description                       |
 | ----------------- | -------- | ---------------- | -------------------------- | --------------------------------- |
@@ -221,7 +135,7 @@ import { BooleanField } from 'react-admin';
 
 `<BooleanField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                 |
 | ---------- | --------------------------- |
@@ -229,7 +143,7 @@ import { BooleanField } from 'react-admin';
 
 To override the style of all instances of `<BooleanField>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaBooleanField` key.
 
-### Usage
+#### Usage
 
 The `<BooleanField>` includes a tooltip text for accessibility (or to query in "end to end" tests). By default, it is the translated value ('true' or 'false' in English).
 
@@ -252,11 +166,11 @@ import AlarmOffIcon from '@material-ui/icons/AlarmOff';
 <BooleanField source="alarm" TrueIcon={AlarmOnIcon} FalseIcon={AlarmOffIcon} />
 ``` 
 
-## `<ChipField>`
+### `<ChipField>`
 
 Displays a value inside a ["Chip"](https://material-ui.com/components/chips), which is Material UI's term for a label.
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                                              |
 | ---------- | -------------------------------------------------------- |
@@ -264,7 +178,7 @@ Displays a value inside a ["Chip"](https://material-ui.com/components/chips), wh
 
 To override the style of all instances of `<ChipField>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaChipField` key.
 
-### Usage
+#### Usage
 
 ```jsx
 import { ChipField } from 'react-admin';
@@ -288,7 +202,7 @@ import { ChipField, SingleFieldList, ReferenceManyField } from 'react-admin';
 
 Any additional props are passed to material-ui's `<Chip>` element. Check [The material-ui `<Chip>` documentation](https://material-ui.com/api/chip/) for details.
 
-## `<DateField>`
+### `<DateField>`
 
 Displays a date or datetime using the browser locale (thanks to `Date.toLocaleDateString()` and `Date.toLocaleString()`).
 
@@ -298,7 +212,7 @@ import { DateField } from 'react-admin';
 <DateField source="publication_date" />
 ```
 
-### Properties
+#### Properties
 
 | Prop       | Required | Type    | Default | Description                                                                                              |
 | ---------- | -------- | ------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -308,7 +222,7 @@ import { DateField } from 'react-admin';
 
 `<DateField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### Usage
+#### Usage
 
 This component accepts a `showTime` attribute (`false` by default) to force the display of time in addition to date. It uses `Intl.DateTimeFormat()` if available, passing the `locales` and `options` props as arguments. If Intl is not available, it ignores the `locales` and `options` props.
 
@@ -336,7 +250,7 @@ See [Intl.DateTimeFormat documentation](https://developer.mozilla.org/fr/docs/We
 
 **Tip**: If you need more formatting options than what `Intl.DateTimeFormat` can provide, build your own field component leveraging a third-party library like [moment.js](https://momentjs.com/).
 
-## `<EmailField>`
+### `<EmailField>`
 
 `<EmailField>` displays an email as a Material UI's `<Link href="mailto:" />` component.
 
@@ -346,7 +260,7 @@ import { EmailField } from 'react-admin';
 <EmailField source="personal_email" />
 ```
 
-## `<FunctionField>`
+### `<FunctionField>`
 
 If you need a special function to render a field, `<FunctionField>` is the perfect match. It passes the `record` to a `render` function supplied by the developer. For instance, to display the full name of a `user` record based on `first_name` and `last_name` properties:
 
@@ -356,7 +270,7 @@ import { FunctionField } from 'react-admin';
 <FunctionField label="Name" render={record => `${record.first_name} ${record.last_name}`} />
 ```
 
-### Properties
+#### Properties
 
 | Prop     | Required | Type     | Default | Description                                                                |
 | -------- | -------- | -------- | ------- | -------------------------------------------------------------------------- |
@@ -366,7 +280,7 @@ import { FunctionField } from 'react-admin';
 
 **Tip**: Technically, you can omit the `source` and `sortBy` properties for the `<FunctionField>` since you provide the render function. However, providing a `source` or a `sortBy` will allow the `Datagrid` to make the column sortable, since when a user clicks on a column, the `Datagrid` uses these properties to sort. Should you provide both, `sortBy` will override `source` for sorting the column.
 
-## `<ImageField>`
+### `<ImageField>`
 
 If you need to display an image based on a path contained in a record field, you can use the `<ImageField />` component:
 
@@ -383,7 +297,7 @@ import { ImageField } from 'react-admin';
 
 This field is also often used within the [<ImageInput />](./Inputs.md#imageinput) component to display a preview.
 
-### Properties
+#### Properties
 
 | Prop    | Required | Type   | Default      | Description                                                                              |
 | ------- | -------- | ------ | ------------ | ---------------------------------------------------------------------------------------- |
@@ -392,7 +306,7 @@ This field is also often used within the [<ImageInput />](./Inputs.md#imageinput
 
 `<ImageField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                                                                    |
 | ---------- | ------------------------------------------------------------------------------ |
@@ -401,7 +315,7 @@ This field is also often used within the [<ImageInput />](./Inputs.md#imageinput
 
 To override the style of all instances of `<ImageField>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaImageField` key.
 
-### Usage
+#### Usage
 
 The optional `title` prop points to the picture title property, used for both `alt` and `title` attributes. It can either be a hard-written string, or a path within your JSON object:
 
@@ -429,7 +343,7 @@ If the record actually contains an array of images in the property defined by th
 <ImageField source="pictures" src="url" title="desc" />
 ```
 
-## `<FileField>`
+### `<FileField>`
 
 If you need to render a link to a file based on a path contained in a record field, you can use the `<FileField />` component:
 
@@ -446,7 +360,7 @@ import { FileField } from 'react-admin';
 
 This field is also often used within an [<FileInput />](./Inputs.md#fileinput) component to display preview.
 
-### Properties
+#### Properties
 
 | Prop       | Required | Type                      | Default      | Description                                                                                                                                            |
 | ---------- | -------- | ------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -459,7 +373,7 @@ This field is also often used within an [<FileInput />](./Inputs.md#fileinput) c
 
 `<FileField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                 |
 | ---------- | --------------------------- |
@@ -467,7 +381,7 @@ This field is also often used within an [<FileInput />](./Inputs.md#fileinput) c
 
 To override the style of all instances of `<FileField>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaFileField` key.
 
-### Usage
+#### Usage
 
 The optional `title` prop points to the file title property, used for `title` attributes. It can either be a hard-written string, or a path within your JSON object:
 
@@ -502,7 +416,7 @@ You can optionally set the `target` prop to choose which window will the link tr
 <FileField source="file.url" target="_blank" />
 ```
 
-## `<MarkdownField>`
+### `<MarkdownField>`
 
 This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to render Markdown data as HTML.
 
@@ -522,7 +436,7 @@ const PostShow = props => (
 
 Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.
 
-## `<NumberField>`
+### `<NumberField>`
 
 Displays a number formatted according to the browser locale, right aligned.
 
@@ -534,7 +448,7 @@ import { NumberField }  from 'react-admin';
 <span>567</span>
 ```
 
-### Properties
+#### Properties
 
 | Prop      | Required | Type   | Default | Description                                                                                              |
 | --------- | -------- | ------ | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -543,7 +457,7 @@ import { NumberField }  from 'react-admin';
 
 `<NumberField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### Usage
+#### Usage
 
 `<NumberField>` uses `Intl.NumberFormat()` if available, passing the `locales` and `options` props as arguments. This allows a perfect display of decimals, currencies, percentages, etc.
 
@@ -583,7 +497,59 @@ import { NumberField }  from 'react-admin';
 <NumberField source="score" textAlign="left" />
 ```
 
-## `<SelectField>`
+### `<RichTextField>`
+
+This component displays some HTML content. The content is "rich" (i.e. unescaped) by default.
+
+```jsx
+import { RichTextField } from 'react-admin';
+
+<RichTextField source="body" />
+```
+
+![RichTextField](./img/rich-text-field.png)
+
+#### Properties
+
+| Prop        | Required | Type      | Default  | Description                                          |
+| ----------- | -------- | --------- | -------- | ---------------------------------------------------- |
+| `stripTags` | Optional | `boolean` | `false`  | If `true`, remove all HTML tags and render text only |
+
+`<RichTextField>` also accepts the [common field props](./Fields.md#common-field-props).
+
+#### Usage
+
+The `stripTags` prop allows to remove all HTML markup, preventing some display glitches (which is especially useful in list views, or when truncating the content).
+
+```jsx
+import { RichTextField } from 'react-admin';
+
+<RichTextField source="body" stripTags />
+```
+
+### `<TextField>`
+
+The simplest of all fields, `<TextField>` simply displays the record property as plain text.
+
+```jsx
+import { TextField } from 'react-admin';
+
+<TextField label="Author Name" source="name" />
+```
+
+### `<UrlField>`
+
+`<UrlField>` displays an url in a Material UI's `<Link href="" />` component.
+
+```jsx
+import { UrlField } from 'react-admin';
+
+<UrlField source="site_url" />
+```
+
+## Choice Fields
+
+### `<SelectField>`
 
 When you need to display an enumerated field, `<SelectField>` maps the value to a string.
 
@@ -598,7 +564,7 @@ import { SelectField } from 'react-admin';
 ]} />
 ```
 
-### Properties
+#### Properties
 
 | Prop              | Required | Type                          | Default | Description                                                                                                                                  |
 | ----------------- | -------- | ----------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -608,7 +574,7 @@ import { SelectField } from 'react-admin';
 
 `<SelectField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### Usage
+#### Usage
 
 By default, the text is built by:
 
@@ -664,7 +630,101 @@ However, in some cases (e.g. inside a `<ReferenceField>`), you may not want the 
 
 **Tip**: `<SelectField>` sets `translateChoice` to `true` by default.
 
-## `<ReferenceField>`
+## Array Fields
+
+### `<ArrayField>`
+
+Display a collection using `<Field>` child components.
+
+Ideal for embedded arrays of objects, e.g. `tags` and `backlinks` in the following `post` object:
+
+```js
+{
+  id: 123,
+  tags: [
+        { name: 'foo' },
+        { name: 'bar' }
+  ],
+  backlinks: [
+        {
+            uuid: '34fdf393-f449-4b04-a423-38ad02ae159e',
+            date: '2012-08-10T00:00:00.000Z',
+            url: 'http://example.com/foo/bar.html',
+        },
+        {
+            uuid: 'd907743a-253d-4ec1-8329-404d4c5e6cf1',
+            date: '2012-08-14T00:00:00.000Z',
+            url: 'https://blog.johndoe.com/2012/08/12/foobar.html',
+        }
+   ]
+}
+```
+
+The child must be an iterator component (like `<Datagrid>` or `<SingleFieldList>`).
+
+Here is how to display all the backlinks of the current post as a `<Datagrid>`:
+
+```jsx
+<ArrayField source="backlinks">
+    <Datagrid>
+        <DateField source="date" />
+        <UrlField source="url" />
+    </Datagrid>
+</ArrayField>
+```
+
+And here is how to display all the tags of the current post as `<Chip>` components:
+
+```jsx
+<ArrayField source="tags">
+    <SingleFieldList>
+        <ChipField source="name" />
+    </SingleFieldList>
+</ArrayField>
+```
+
+#### Properties
+
+| Prop       | Required | Type   | Default | Description                                                   |
+| ---------- | -------- | ------ | ------- | ------------------------------------------------------------- |
+| `fieldKey` | Optional | string | -       | Name for the field to be used as key when displaying children |
+
+`<ArrayField>` also accepts the [common field props](./Fields.md#common-field-props).
+
+#### Usage
+
+If the array value contains a lot of items, you may experience slowdowns in the UI. In such cases, set the `fieldKey` prop to use one field as key, and reduce CPU and memory usage:
+
+```diff
+-<ArrayField source="backlinks">
++<ArrayField source="backlinks" fieldKey="uuid">
+    <Datagrid>
+        <DateField source="date" />
+        <UrlField source="url" />
+    </Datagrid>
+</ArrayField>
+```
+
+**Tip**: If you need to render a custom collection, it's often simpler to write your own component:
+
+```jsx
+const TagsField = ({ record }) => (
+    <ul>
+        {record.tags.map(item => (
+            <li key={item.name}>{item.name}</li>
+        ))}
+    </ul>
+)
+TagsField.defaultProps = {
+    addLabel: true
+};
+```
+
+## Reference Fields
+
+
+
+### `<ReferenceField>`
 
 `<ReferenceField>` is useful for displaying many-to-one and one-to-one relationships. This component fetches a referenced record (using the `dataProvider.getMany()` method), and passes it to its child. A `<ReferenceField>` displays nothing on its own, it just fetches the data and expects its child to render it. Usual child components for `<ReferenceField>` are other `<Field>` components.
 
@@ -692,7 +752,7 @@ With this configuration, `<ReferenceField>` wraps the user's name in a link to t
 
 ![ReferenceField](./img/reference-field.png)
 
-### Properties
+#### Properties
 
 | Prop        | Required | Type                | Default  | Description                                                                                                         |
 | ----------- | -------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -703,7 +763,7 @@ With this configuration, `<ReferenceField>` wraps the user's name in a link to t
 
 `<ReferenceField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                   |
 | ---------- | ----------------------------- |
@@ -711,7 +771,7 @@ With this configuration, `<ReferenceField>` wraps the user's name in a link to t
 
 To override the style of all instances of `<ReferenceField>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaReferenceField` key.
 
-### Usage
+#### Usage
 
 `<ReferenceField>` accepts a `reference` attribute, which specifies the resource to fetch for the related record.
 
@@ -782,7 +842,7 @@ You can also use a custom `link` function to get a custom path for the children.
 
 Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField>`, fetches the API for the related users in one call (`GET http://path.to.my.api/users?ids=[789,735]`), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.
 
-## `<ReferenceManyField>`
+### `<ReferenceManyField>`
 
 `<ReferenceManyField>` is useful for displaying one-to-many relationships, when the foreign key is carried by the referenced resource. For instance, if a `user` has many `books` and the `books` resource exposes a `user_id` field, `<ReferenceManyField>` can fetch all the books authored by a given user.
 
@@ -812,7 +872,7 @@ export const PostList = (props) => (
 
 ![ReferenceManyFieldSingleFieldList](./img/reference-many-field-single-field-list.png)
 
-### Properties
+#### Properties
 
 | Prop         | Required | Type               | Default                          | Description                                                                         |
 | ------------ | -------- | ------------------ | -------------------------------- | ----------------------------------------------------------------------------------- |
@@ -826,7 +886,7 @@ export const PostList = (props) => (
 
 `<ReferenceManyField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### Usage
+#### Usage
 
 `<ReferenceManyField>` accepts a `reference` attribute, which specifies the resource to fetch for the related record. It also accepts a `source` attribute which defines the field containing the value to look for in the `target` field of the referenced resource. By default, this is the `id` of the resource (`post.id` in the previous example).
 
@@ -901,7 +961,7 @@ Also, you can filter the query used to populate the possible values. Use the `fi
 ```
 {% endraw %}
 
-## `<ReferenceManyToManyField>`
+### `<ReferenceManyToManyField>`
 
 This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component fetches a list of referenced records by lookup in an associative table, and passes the records down to its child component, which must be an iterator component.
 
@@ -955,7 +1015,7 @@ This example uses the following schema:
 
 Check [the `ra-relationships` documentation](https://marmelab.com/ra-enterprise/modules/ra-relationships) for more details.
 
-## `<ReferenceArrayField>`
+### `<ReferenceArrayField>`
 
 Use `<ReferenceArrayField>` to display a one-to-many relationship based on an array of foreign keys. This component fetches a list of referenced records (using the `dataProvider.getMany()` method), and passes them to its child. A `<ReferenceArrayField>` displays nothing on its own, it just fetches the data and expects its child to render it.
 
@@ -985,7 +1045,7 @@ export const PostList = (props) => (
 
 `<ReferenceArrayField>` fetches the `tag` resources related to each `post` resource by matching `post.tag_ids` to `tag.id`. Once it receives the related resources, `<ReferenceArrayField>` passes them to its child component using the `ids` and `data` props, so the child must be an iterator component (like `<SingleFieldList>` or `<Datagrid>`). The iterator component usually has one or more child `<Field>` components.
 
-### Properties
+#### Properties
 
 | Prop         | Required | Type                | Default                          | Description                                                                                                                                |
 | ------------ | -------- | ------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -999,7 +1059,7 @@ export const PostList = (props) => (
 
 `<ReferenceArrayField>` also accepts the [common field props](./Fields.md#common-field-props).
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                                                                            |
 | ---------- | -------------------------------------------------------------------------------------- |
@@ -1007,7 +1067,7 @@ export const PostList = (props) => (
 
 To override the style of all instances of `<ReferenceArrayField>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaReferenceArrayField` key.
 
-### Usage
+#### Usage
 
 `<ReferenceArrayField>` expects a `reference` attribute, which specifies the resource to fetch for the related records. It also expects a `source` attribute, which defines the field containing the list of ids to look for in the referenced resource.
 
@@ -1046,57 +1106,9 @@ export const PostShow = (props) => (
 );
 ```
 
-## `<RichTextField>`
+## Recipes
 
-This component displays some HTML content. The content is "rich" (i.e. unescaped) by default.
-
-```jsx
-import { RichTextField } from 'react-admin';
-
-<RichTextField source="body" />
-```
-
-![RichTextField](./img/rich-text-field.png)
-
-### Properties
-
-| Prop        | Required | Type      | Default  | Description                                          |
-| ----------- | -------- | --------- | -------- | ---------------------------------------------------- |
-| `stripTags` | Optional | `boolean` | `false`  | If `true`, remove all HTML tags and render text only |
-
-`<RichTextField>` also accepts the [common field props](./Fields.md#common-field-props).
-
-### Usage
-
-The `stripTags` prop allows to remove all HTML markup, preventing some display glitches (which is especially useful in list views, or when truncating the content).
-
-```jsx
-import { RichTextField } from 'react-admin';
-
-<RichTextField source="body" stripTags />
-```
-
-## `<TextField>`
-
-The simplest of all fields, `<TextField>` simply displays the record property as plain text.
-
-```jsx
-import { TextField } from 'react-admin';
-
-<TextField label="Author Name" source="name" />
-```
-
-## `<UrlField>`
-
-`<UrlField>` displays an url in a Material UI's `<Link href="" />` component.
-
-```jsx
-import { UrlField } from 'react-admin';
-
-<UrlField source="site_url" />
-```
-
-## Styling Fields
+### Styling Fields
 
 All field components accept a `className` prop, allowing you to customize their style to your liking. We advise you to use the Material UI styling solution, JSS, to generate those classes. See their [documentation](https://material-ui.com/customization/css-in-js/#api) about that.
 
@@ -1195,74 +1207,7 @@ PriceField.defaultProps = {
 ```
 {% endraw %}
 
-
-## Third-Party Components
-
-You can find components for react-admin in third-party repositories.
-
-- [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): a quick and customizable copy-to-clipboard field.
-
-## Writing Your Own Field Component
-
-If you don't find what you need in the list above, you can write your own Field component. It must be a regular React component, accepting not only a `source` attribute, but also a `record` attribute. React-admin will inject the `record` based on the API response data at render time. The field component only needs to find the `source` in the `record` and display it.
-
-For instance, here is an equivalent of react-admin's `<TextField>` component:
-
-```jsx
-import * as React from "react";
-import PropTypes from 'prop-types';
-
-const TextField = ({ source, record = {} }) => <span>{record[source]}</span>;
-
-TextField.propTypes = {
-    label: PropTypes.string,
-    record: PropTypes.object,
-    source: PropTypes.string.isRequired,
-};
-
-export default TextField;
-```
-
-**Tip**: The `label` attribute isn't used in the `render()` method, but react-admin uses it to display the table header.
-
-**Tip**: If you want to support deep field sources (e.g. source values like `author.name`), use [`lodash/get`](https://www.npmjs.com/package/lodash.get) to replace the simple object lookup:
-
-```jsx
-import get from 'lodash/get';
-const TextField = ({ source, record = {} }) => <span>{get(record, source)}</span>;
-```
-
-If you are not looking for reusability, you can create even simpler components, with no attributes. Let's say an API returns user records with `firstName` and `lastName` properties, and that you want to display a full name in a user list.
-
-```js
-{
-    id: 123,
-    firstName: 'John',
-    lastName: 'Doe'
-}
-```
-
-The component will be:
-
-```jsx
-import * as React from "react";
-import { List, Datagrid, TextField } from 'react-admin';
-
-const FullNameField = ({ record = {} }) => <span>{record.firstName} {record.lastName}</span>;
-FullNameField.defaultProps = { label: 'Name' };
-
-export const UserList = (props) => (
-    <List {...props}>
-        <Datagrid>
-            <FullNameField source="lastName" />
-        </Datagrid>
-    </List>
-);
-```
-
-**Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked. In case you use the `source` property for additional purposes, the sorting can be overridden by the `sortBy` property on any `Field` component.
-
-## Adding Label To Custom Field Components In The Show View
+### Adding Label To Custom Field Components In The Show View
 
 React-admin lets you use the same `Field` components in the `List` view and in the `Show` view. But if you use the `<FullNameField>` custom field component defined earlier in a `Show` view, something is missing: the `Field` label. Why do other fields have a label and not this custom `Field`? And how can you create a `Field` component that has a label in the `Show` view, but not in the `List` view?
 
@@ -1276,7 +1221,7 @@ FullNameField.defaultProps = {
 };
 ```
 
-## Hiding A Field Based On The Value Of Another
+### Hiding A Field Based On The Value Of Another
 
 In a Show view, you may want to display or hide fields based on the value of another field - for instance, show an `email` field only if the `hasEmail` boolean field is `true`.
 
@@ -1385,3 +1330,69 @@ const UserShow = props => (
 ```
 
 And now you can use a regular Field component, and the label displays correctly in the Show view.
+
+## Writing Your Own Field Component
+
+If you don't find what you need in the list above, you can write your own Field component. It must be a regular React component, accepting not only a `source` attribute, but also a `record` attribute. React-admin will inject the `record` based on the API response data at render time. The field component only needs to find the `source` in the `record` and display it.
+
+For instance, here is an equivalent of react-admin's `<TextField>` component:
+
+```jsx
+import * as React from "react";
+import PropTypes from 'prop-types';
+
+const TextField = ({ source, record = {} }) => <span>{record[source]}</span>;
+
+TextField.propTypes = {
+    label: PropTypes.string,
+    record: PropTypes.object,
+    source: PropTypes.string.isRequired,
+};
+
+export default TextField;
+```
+
+**Tip**: The `label` attribute isn't used in the `render()` method, but react-admin uses it to display the table header.
+
+**Tip**: If you want to support deep field sources (e.g. source values like `author.name`), use [`lodash/get`](https://www.npmjs.com/package/lodash.get) to replace the simple object lookup:
+
+```jsx
+import get from 'lodash/get';
+const TextField = ({ source, record = {} }) => <span>{get(record, source)}</span>;
+```
+
+If you are not looking for reusability, you can create even simpler components, with no attributes. Let's say an API returns user records with `firstName` and `lastName` properties, and that you want to display a full name in a user list.
+
+```js
+{
+    id: 123,
+    firstName: 'John',
+    lastName: 'Doe'
+}
+```
+
+The component will be:
+
+```jsx
+import * as React from "react";
+import { List, Datagrid, TextField } from 'react-admin';
+
+const FullNameField = ({ record = {} }) => <span>{record.firstName} {record.lastName}</span>;
+FullNameField.defaultProps = { label: 'Name' };
+
+export const UserList = (props) => (
+    <List {...props}>
+        <Datagrid>
+            <FullNameField source="lastName" />
+        </Datagrid>
+    </List>
+);
+```
+
+**Tip**: In such custom fields, the `source` is optional. React-admin uses it to determine which column to use for sorting when the column header is clicked. In case you use the `source` property for additional purposes, the sorting can be overridden by the `sortBy` property on any `Field` component.
+
+## Third-Party Components
+
+You can find components for react-admin in third-party repositories.
+
+- [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): a quick and customizable copy-to-clipboard field.

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -77,94 +77,431 @@ Then you can display a text input to edit the author first name as follows:
 
 **Tip**: For compatibility reasons, input components also accept the `defaultValue` prop - which is simply copied as the `initialValue` prop.
 
-## `<ArrayInput>`
+## Basic Inputs
 
-To edit arrays of data embedded inside a record, `<ArrayInput>` creates a list of sub-forms.
+### `<BooleanInput>` and `<NullableBooleanInput>`
+
+`<BooleanInput />` is a toggle button allowing you to attribute a `true` or `false` value to a record field.
 
 ```jsx
-import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+import { BooleanInput } from 'react-admin';
 
-<ArrayInput source="backlinks">
-    <SimpleFormIterator>
-        <DateInput source="date" />
-        <TextInput source="url" />
-    </SimpleFormIterator>
-</ArrayInput>
+<BooleanInput label="Commentable" source="commentable" />
 ```
 
-![ArrayInput](./img/array-input.png)
+![BooleanInput](./img/boolean-input.png)
 
- `<ArrayInput>` allows editing of embedded arrays, like the `backlinks` field in the following `post` record:
+This input does not handle `null` values. You would need the `<NullableBooleanInput />` component if you have to handle non-set booleans.
 
-```json
-{
-  "id": 123,
-  "backlinks": [
-        {
-            "date": "2012-08-10T00:00:00.000Z",
-            "url": "http://example.com/foo/bar.html",
+You can use the `options` prop to pass any option supported by the Material UI's `Switch` components. For example, here's how to set a custom checked icon:
+
+{% raw %}
+```jsx
+import { BooleanInput } from 'react-admin';
+import FavoriteIcon from '@material-ui/icons/Favorite';
+
+<BooleanInput
+    source="favorite"
+    options={{
+        checkedIcon: <FavoriteIcon />,
+    }}
+/>
+```
+{% endraw %}
+
+![CustomBooleanInputCheckIcon](./img/custom-switch-icon.png)
+
+Refer to [Material UI Switch documentation](https://material-ui.com/api/switch) for more details.
+
+`<NullableBooleanInput />` renders as a dropdown list, allowing choosing between `true`, `false`, and `null` values.
+
+#### CSS API
+
+| Rule name  | Description                                                   |
+| ---------- | ------------------------------------------------------------- |
+| `input`    | Applied to the underlying Material UI's `TextField` component |
+
+To override the style of all instances of `<NullableBooleanInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaNullableBooleanInput` key.
+
+```jsx
+import { NullableBooleanInput } from 'react-admin';
+
+<NullableBooleanInput label="Commentable" source="commentable" />
+```
+
+![NullableBooleanInput](./img/nullable-boolean-input.png)
+
+The labels of the options can be customized for the entire application by overriding the translation.
+
+```jsx
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
+
+englishMessages.ra.boolean.null = 'Null label';
+englishMessages.ra.boolean.false = 'False label';
+englishMessages.ra.boolean.true = 'True label';
+const i18nProvider = polyglotI18nProvider(() => englishMessages, 'en');
+
+<Admin i18nProvider={i18nProvider}></Admin>
+```
+
+Additionally, individual instances of `NullableBooleanInput` may be customized by setting the `nullLabel`, `falseLabel` and `trueLabel` properties. Values specified for those properties will be translated by react-admin.
+
+```jsx
+import { NullableBooleanInput } from 'react-admin';
+
+<NullableBooleanInput
+    label="Commentable"
+    source="commentable"
+    nullLabel="Either"
+    falseLabel="No"
+    trueLabel="Yes"
+/>
+```
+
+![NullableBooleanInput](./img/nullable-boolean-input-null-label.png)
+
+`<BooleanInput>` and `<NullableBooleanInput>` also accept the [common input props](./Inputs.md#common-input-props).
+
+### `<DateInput>`
+
+Ideal for editing dates, `<DateInput>` renders an HTML `<input type="date">` element, that most browsers display as a standard [Date Picker](https://material-ui.com/components/pickers/#date-pickers). That means the appearance of `<DateInput>` depends on the browser, and falls back to a text input on Safari. The date formatting in this input depends on the user's locale.
+
+```jsx
+import { DateInput } from 'react-admin';
+
+<DateInput source="published_at" />
+```
+
+![DateInput](./img/date-input.gif)
+
+`<DateInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+**Tip**: For a material-ui styled `<DateInput>` component, check out [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs).
+
+### `<DateTimeInput>`
+
+An input for editing dates with time. `<DateTimeInput>` renders a standard browser [Date and Time Picker](https://material-ui.com/components/pickers/#date-amp-time-pickers), so the appearance depends on the browser (and falls back to a text input on safari).
+
+```jsx
+import { DateTimeInput } from 'react-admin';
+
+<DateTimeInput source="published_at" />
+```
+
+`<DateTimeInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+**Tip**: For a material-ui styled `<DateTimeInput>` component, check out [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs).
+
+### `<ImageInput>`
+
+`<ImageInput>` allows to upload some pictures using [react-dropzone](https://github.com/okonet/react-dropzone).
+
+![ImageInput](./img/image-input.png)
+
+#### Properties
+
+| Prop            | Required | Type                        | Default                          | Description                                                                                                                                                                                                                                                         |
+| --------------- | -------- | --------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accept`        | Optional | `string | string[]`         | -                                | Accepted file type(s), e. g. 'image/*,.pdf'. If left empty, all file types are accepted. Equivalent of the `accept` attribute of an `<input type="file">`. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept for syntax and examples. |
+| `children`      | Optional | `ReactNode`                 | -                                | Element used to display the preview of an image (cloned several times if the select accepts multiple files).                                                                                                                                                        |
+| `minSize`       | Optional | `number`                    | 0                                | Minimum image size (in bytes), e.g. 5000 form 5KB                                                                                                                                                                                                                   |
+| `maxSize`       | Optional | `number`                    | `Infinity`                       | Maximum image size (in bytes), e.g. 5000000 for 5MB                                                                                                                                                                                                                 |
+| `multiple`      | Optional | `boolean`                   | `false`                          | Set to true if the input should accept a list of images, false if it should only accept one image                                                                                                                                                                   |
+| `labelSingle`   | Optional | `string`                    | 'ra.input.image. upload_single'  | Invite displayed in the drop zone if the input accepts one image                                                                                                                                                                                                    |
+| `labelMultiple` | Optional | `string`                    | 'ra.input.file. upload_multiple' | Invite displayed in the drop zone if the input accepts several images                                                                                                                                                                                               |
+| `placeholder`   | Optional | `string` &#124; `ReactNode` | -                                | Invite displayed in the drop zone, overrides `labelSingle` and `labelMultiple`                                                                                                                                                                                      |
+| `options`       | Optional | `Object`                    | `{}`                             | Additional options passed to react-dropzone's `useDropzone()` hook. See [the react-dropzone source](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js)  for details .                                                                       |
+
+`<ImageInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### CSS API
+
+| Rule name       | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `root`          | Styles pass to the underlying `FileInput` component  |
+| `dropZone`      | Styles pass to the underlying `FileInput` component  |
+| `preview`       | Styles pass to the underlying `FileInput` component  |
+| `removeButton`  | Styles pass to the underlying `FileInput` component  |
+
+To override the style of all instances of `<ImageInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaImageInput` key.
+
+#### Usage
+
+Files are accepted or rejected based on the `accept`, `multiple`, `minSize` and `maxSize` props. `accept` must be a valid [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file) or a valid file extension. If `multiple` is set to false and additional files are dropped, all files besides the first will be rejected. Any file which does not have a size in the [`minSize`, `maxSize`] range, will be rejected as well.
+
+`<ImageInput>` delegates the preview of currently selected images to its child. `<ImageInput>` clones its child as many times as there are selected images, passing the image as the `record` prop. To preview a simple list of image thumbnails, you can use `<ImageField>` as child, as follows:
+
+```jsx
+<ImageInput source="pictures" label="Related pictures" accept="image/*">
+    <ImageField source="src" title="title" />
+</ImageInput>
+```
+
+Writing a custom preview component is quite straightforward: it's a standard [field](./Fields.md#writing-your-own-field-component).
+
+When receiving **new** images, `ImageInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display information about size or mimetype inside a custom field.
+
+The `ImageInput` component accepts an `options` prop, allowing to set the [react-dropzone properties](https://react-dropzone.netlify.com/#proptypes).
+
+If the default Dropzone label doesn't fit with your need, you can pass a `placeholder` prop to overwrite it. The value can be anything React can render (`PropTypes.node`):
+
+```jsx
+<ImageInput source="pictures" label="Related pictures" accept="image/*" placeholder={<p>Drop your file here</p>}>
+    <ImageField source="src" title="title" />
+</ImageInput>
+```
+
+Note that the image upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#extending-a-data-provider-example-of-file-upload) for base64 encoding data by extending the REST Client.
+
+### `<FileInput>`
+
+`<FileInput>` allows uploading files using [react-dropzone](https://github.com/okonet/react-dropzone).
+
+![FileInput](./img/file-input.png)
+
+#### Properties
+
+| Prop            | Required | Type                 | Default                         | Description                                                                                                                                                                                                                                                                                                                                            |
+| --------------- | -------- | -------------------- | ------------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
+| `accept`        | Optional | `string | string[]`  | -                               | Accepted file type(s), e. g. 'application/json,video/*' or 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'. If left empty, all file types are accepted. Equivalent of the `accept` attribute of an `<input type="file">`. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept for syntax and examples. |
+| `children`      | Optional | `ReactNode`          | -                               | Element used to display the preview of a file (cloned several times if the select accepts multiple files).                                                                                                                                                                                                                                             |
+| `minSize`       | Optional | `number`             | 0                               | Minimum file size (in bytes), e.g. 5000 form 5KB                                                                                                                                                                                                                                                                                                       |
+| `maxSize`       | Optional | `number`             | `Infinity`                      | Maximum file size (in bytes), e.g. 5000000 for 5MB                                                                                                                                                                                                                                                                                                     |
+| `multiple`      | Optional | `boolean`            | `false`                         | Set to true if the input should accept a list of files, false if it should only accept one file                                                                                                                                                                                                                                                        |
+| `labelSingle`   | Optional | `string`             | 'ra.input.file. upload_single'  | Invite displayed in the drop zone if the input accepts one file                                                                                                                                                                                                                                                                                        |
+| `labelMultiple` | Optional | `string`             | 'ra.input.file. upload_several' | Invite displayed in the drop zone if the input accepts several files                                                                                                                                                                                                                                                                                   |
+| `placeholder`   | Optional | `string | ReactNode` | -                               | Invite displayed in the drop zone, overrides `labelSingle` and `labelMultiple`                                                                                                                                                                                                                                                                         |
+| `options`       | Optional | `Object`             | `{}`                            | Additional options passed to react-dropzone's `useDropzone()` hook. See [the react-dropzone source](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js)  for details .                                                                                                                                                          |
+
+`<FileInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### CSS API
+
+| Rule name       | Description                                                                       |
+| --------------- | --------------------------------------------------------------------------------- |
+| `root`          | Applied to the underlying `Labeled` component                                     |
+| `dropZone`      | Applied to the main container of the component                                    |
+| `preview`       | Applied to each children                                                          |
+| `removeButton`  | Applied to each of the Material UI's `IconButton` component used as remove button |
+
+To override the style of all instances of `<FileInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaFileInput` key.
+
+#### Usage
+
+Files are accepted or rejected based on the `accept`, `multiple`, `minSize` and `maxSize` props. `accept` must be a valid [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file) or a valid file extension. If `multiple` is set to false and additional files are dropped, all files besides the first will be rejected. Any file which does not have a size in the [`minSize`, `maxSize`] range, will be rejected as well.
+
+`FileInput` delegates the preview of currently selected files to its child. `FileInput` clones its child as many times as there are selected files, passing the file as the `record` prop. To preview a simple list of files names, you can use `<FileField>` as child, as follows:
+
+```jsx
+<FileInput source="files" label="Related files" accept="application/pdf">
+    <FileField source="src" title="title" />
+</FileInput>
+```
+
+Writing a custom preview component is quite straightforward: it's a standard [field](./Fields.md#writing-your-own-field-component).
+
+When receiving **new** files, `FileInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display information about size or mimetype inside a custom field.
+
+The `FileInput` component accepts an `options` prop into which you can pass all the [react-dropzone properties](https://react-dropzone.netlify.com/#proptypes). 
+
+If the default Dropzone label doesn't fit with your need, you can pass a `placeholder` prop to overwrite it. The value can be anything React can render (`PropTypes.node`):
+
+```jsx
+<FileInput source="files" label="Related files" accept="application/pdf" placeholder={<p>Drop your file here</p>}>
+    <ImageField source="src" title="title" />
+</FileInput>
+```
+
+Note that the file upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#extending-a-data-provider-example-of-file-upload) for base64 encoding data by extending the REST Client.
+
+### `<MarkdownInput>`
+
+This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit and preview Markdown data, based on [the Toast UI editor](https://nhn.github.io/tui.editor/latest/ToastUIEditor).
+
+```jsx
+import { Edit, SimpleForm, TextInput } from 'react-admin';
+import { MarkdownInput } from '@react-admin/ra-markdown';
+
+const PostEdit = props => (
+    <Edit {...props}>
+        <SimpleForm>
+            <TextInput source="title" />
+            <MarkdownInput source="description" />
+        </SimpleForm>
+    </Edit>
+);
+```
+
+Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.
+
+### `<NumberInput>`
+
+`<NumberInput>` translates to an HTML `<input type="number">`. It is necessary for numeric values because of a [known React bug](https://github.com/facebook/react/issues/1425), which prevents using the more generic [`<TextInput>`](#textinput) in that case.
+
+```jsx
+import { NumberInput } from 'react-admin';
+
+<NumberInput source="nb_views" />
+```
+
+#### Properties
+
+| Prop   | Required | Type     | Default | Description                                                                                             |
+| ------ | -------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `max`  | Optional | `number` | ''      | The maximum value to accept for this input                                                              |
+| `min`  | Optional | `number` | ''      | The minimum value to accept for this input                                                              |
+| `step` | Optional | `number` | `any`   | A stepping interval to use when using up and down arrows to adjust the value, as well as for validation |
+
+`<NumberInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### Usage
+
+You can customize the `step` props (which defaults to "any"). For instance, to restrict the value to integers, ise a value of 1 for the `step`:
+
+```jsx
+<NumberInput source="nb_views" step={1} />
+```
+
+### `<PasswordInput>`
+
+`<PasswordInput>` works like the [`<TextInput>`](#textinput) but overwrites its `type` prop to `password` or `text` in accordance with a visibility button, hidden by default.
+
+```jsx
+import { PasswordInput } from 'react-admin';
+<PasswordInput source="password" />
+```
+
+![Password Input](./img/password-input.png)
+
+It is possible to change the default behavior and display the value by default via the `initiallyVisible` prop:
+
+```jsx
+import { PasswordInput } from 'react-admin';
+<PasswordInput source="password" initiallyVisible />
+```
+
+![Password Input (visible)](./img/password-input-visible.png)
+
+**Tip**: It is possible to set the [`autocomplete` attribute](https://developer.mozilla.org/fr/docs/Web/HTML/Attributs/autocomplete) by injecting an input props:
+
+{% raw %}
+```jsx
+<PasswordInput source="password" inputProps={{ autocomplete: 'current-password' }} />
+```
+{% endraw %}
+
+### `<RichTextInput>`
+
+`<RichTextInput>` is the ideal component if you want to allow your users to edit some HTML contents. It
+is powered by [Quill](https://quilljs.com/).
+
+**Note**: Due to its size, `<RichTextInput>` is not bundled by default with react-admin. You must install it first, using npm:
+
+```sh
+npm install ra-input-rich-text
+```
+
+Then use it as a normal input component:
+
+```jsx
+import RichTextInput from 'ra-input-rich-text';
+
+<RichTextInput source="body" />
+```
+
+![RichTextInput](./img/rich-text-input.png)
+
+You can customize the rich text editor toolbar using the `toolbar` attribute, as described on the [Quill official toolbar documentation](https://quilljs.com/docs/modules/toolbar/).
+
+```jsx
+<RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
+```
+
+If you need to add Quill `modules` or `themes`, you can do so by passsing them in the `options` prop.
+
+{% raw %}
+```jsx
+<RichTextInput
+    source="body"
+    options={{
+        modules: {
+            history: { // History module
+                delay: 2000,
+                maxStack: 500,
+                userOnly: true
+            }
         },
-        {
-            "date": "2012-08-14T00:00:00.000Z",
-            "url": "https://blog.johndoe.com/2012/08/12/foobar.html",
-        }
-   ]
-}
+        theme: "snow"
+    }}
+/>
 ```
+{% endraw %}
 
-`<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component accepting a `fields` object as passed by [react-final-form-array](https://github.com/final-form/react-final-form-arrays#fieldarrayrenderprops), and defining a layout for an array of fields. For instance, the `<SimpleFormIterator>` component displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record (a backlink in this example).
-
-You can pass `disableAdd` and `disableRemove` as props of `SimpleFormIterator`, to disable `ADD` and `REMOVE` button respectively. Default value of both is `false`.
+If you need more customization, you can access the quill object through the `configureQuill` callback that will be called just after its initialization.
 
 ```jsx
-import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+const configureQuill = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
+    this.quill.format('bold', value)
+});
 
-<ArrayInput source="backlinks">
-    <SimpleFormIterator disableRemove >
-        <DateInput source="date" />
-        <TextInput source="url" />
-    </SimpleFormIterator>
-</ArrayInput>
+// ...
+
+<RichTextInput source="text" configureQuill={configureQuill}/>
 ```
 
-You can also use `addButton` and `removeButton` props to pass your custom add and remove buttons to `SimpleFormIterator`.
+`<RichTextInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+### `<TextInput>`
+
+`<TextInput>` is the most common input. It is used for texts, emails, URL or passwords. In translates to an HTML `<input>` tag.
 
 ```jsx
-import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+import { TextInput } from 'react-admin';
 
-<ArrayInput source="backlinks">
-    <SimpleFormIterator addButton={<CustomAddButton />} removeButton={<CustomRemoveButton />}>
-        <DateInput source="date" />
-        <TextInput source="url" />
-    </SimpleFormIterator>
-</ArrayInput>
+<TextInput source="title" />
 ```
 
-**Note**: `SimpleFormIterator` only accepts `Input` components as children. If you want to use some `Fields` instead, you have to use a `<FormDataConsumer>` to get the correct source, as follows:
+![TextInput](./img/text-input.png)
+
+#### Properties
+
+| Prop         | Required | Type      | Default | Description                                                          |
+| ------------ | -------- | --------- | ------- | -------------------------------------------------------------------- |
+| `resettable` | Optional | `boolean` | `false` | If `true`, display a button to reset the changes in this input value |
+| `type`       | Optional | `string`  | `text`  | Type attribute passed to the `<input>` element                       |
+
+`<TextInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### Usage
+
+You can choose a specific input type using the `type` attribute, for instance `text` (the default), `email`, `url`, or `password`:
 
 ```jsx
-import { ArrayInput, SimpleFormIterator, DateInput, TextInput, FormDataConsumer } from 'react-admin';
-
-<ArrayInput source="backlinks">
-    <SimpleFormIterator disableRemove >
-        <DateInput source="date" />
-        <FormDataConsumer>
-            {({ getSource, scopedFormData }) => {
-                return (
-                    <TextField
-                        source={getSource('url')}
-                        record={scopedFormData}
-                    />
-                );
-            }}
-        </FormDataConsumer>
-    </SimpleFormIterator>
-</ArrayInput>
+<TextInput label="Email Address" source="email" type="email" />
 ```
 
-`<ArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props) (except `format` and `parse`).
+You can make the `TextInput` expandable using the `multiline` prop for multiline text values. It renders as an auto expandable textarea.
 
-## `<AutocompleteInput>`
+```jsx
+<TextInput multiline source="body" />
+```
+
+You can make the `TextInput` component resettable using the `resettable` prop. This will add a reset button which will be displayed only when the field has a value and is focused.
+
+```jsx
+import { TextInput } from 'react-admin';
+
+<TextInput source="title" resettable />
+```
+
+![resettable TextInput](./img/resettable-text-input.png)
+
+**Warning**: Do not use `type="number"`, or you'll receive a string as value (this is a [known React bug](https://github.com/facebook/react/issues/1425)). Instead, use [`<NumberInput>`](#numberinput).
+
+## Choice Inputs
+
+### `<AutocompleteInput>`
 
 To let users choose a value in a list using a dropdown with autocompletion, use `<AutocompleteInput>`.
 It renders using [downshift](https://github.com/downshift-js/downshift) and a `fuzzySearch` filter.
@@ -180,7 +517,7 @@ import { AutocompleteInput } from 'react-admin';
 ]} />
 ```
 
-### Properties
+#### Properties
 
 | Prop                      | Required | Type           | Default      | Description                          |
 | ------------------------- | -------- | -------------- | ------------ | ------------------------------------ |
@@ -198,7 +535,7 @@ import { AutocompleteInput } from 'react-admin';
 
 `<AutocompleteInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
-### CSS API
+#### CSS API
 
 | Rule name              | Description                          |
 | ---------------------- | ------------------------------------ |
@@ -227,7 +564,7 @@ const EditForm = () => (
 
 To override the style of all instances of `<AutocompleteInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaAutocompleteInput` key.
 
-### Usage
+#### Usage
 
 You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
 
@@ -326,582 +663,7 @@ Lastly, would you need to override the props of the suggestion's container (a `P
 
 **Tip**: `<AutocompleteInput>` is a stateless component, so it only allows to *filter* the list of choices, not to *extend* it. If you need to populate the list of choices based on the result from a `fetch` call (and if [`<ReferenceInput>`](#referenceinput) doesn't cover your need), you'll have to [write your own Input component](#writing-your-own-input-component) based on material-ui `<AutoComplete>` component.
 
-## `<AutocompleteArrayInput>`
-
-To let users choose multiple values in a list using a dropdown with autocompletion, use `<AutocompleteArrayInput>`.
-It renders using [downshift](https://github.com/downshift-js/downshift) and a `fuzzySearch` filter.
-Set the `choices` attribute to determine the options list (with `id`, `name` tuples).
-
-```jsx
-import { AutocompleteArrayInput } from 'react-admin';
-
-<AutocompleteArrayInput source="category" choices={[
-    { id: 'programming', name: 'Programming' },
-    { id: 'lifestyle', name: 'Lifestyle' },
-    { id: 'photography', name: 'Photography' },
-]} />
-```
-
-### Properties
-
-| Prop                      | Required | Type                       | Default      | Description                                                                                                                                                                                                                                                                                          |
-| ------------------------- | -------- | -------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `allowEmpty`              | Optional | `boolean`                  | `false`      | If `true`, the first option is an empty one                                                                                                                                                                                                                                                          |
-| `allowDuplicates`         | Optional | `boolean`                  | `false`      | If `true`, the options can be selected several times                                                                                                                                                                                                                                                 |
-| `choices`                 | Required | `Object[]`                 | -            | List of items to autosuggest                                                                                                                                                                                                                                                                         |
-| `matchSuggestion`         | Optional | `Function`                 | -            | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                                                                                                              |
-| `optionValue`             | Optional | `string`                   | `id`         | Fieldname of record containing the value to use as input value                                                                                                                                                                                                                                       |
-| `optionText`              | Optional | `string` &#124; `Function` | `name`       | Fieldname of record to display in the suggestion item or function which accepts the current record as argument (`(record)=> {string}`)                                                                                                                                                               |
-| `setFilter`               | Optional | `Function`                 | `null`       | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.                                                                                   |
-| `shouldRenderSuggestions` | Optional | `Function`                 | `() => true` | A function that returns a `boolean` to determine whether or not suggestions are rendered. Use this when working with large collections of data to improve performance and user experience. This function is passed into the underlying react-autosuggest component. Ex.`(value) => value.trim() > 2` |
-| `source`                  | Required | `string`                   | -            | Name of field to edit, its type should match the type retrieved from `optionValue`                                                                                                                                                                                                                   |
-| `suggestionLimit`         | Optional | `number`                   | `null`       | Limits the numbers of suggestions that are shown in the dropdown list                                                                                                                                                                                                                                |
-
-`<AutocompleteArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### CSS API
-
-| Rule name               | Description                                                                                                                 |
-| ----------------------  | --------------------------------------------------------------------------------------------------------------------------- |
-| `container`             | Applied to the container of the underlying Material UI's `TextField` component input                                        |
-| `suggestionsContainer`  | Applied to the suggestions container |
-| `chip`                  | Applied to each Material UI's `Chip` component used as selected item                                                        |
-| `chipContainerFilled`   | Applied to each container of each Material UI's `Chip` component used as selected item when `variant` prop is `filled`      |
-| `chipContainerOutlined` | Applied to each container of each `Chip` component used as selected item when `variant` prop is `outlined`                  |
-| `inputRoot`             | Styles pass as the `root` class of the underlying Material UI's `TextField` component input                                 |
-| `inputRootFilled`       | Styles pass as the `root` class of the underlying Material UI's `TextField` component input when `variant` prop is `filled` |
-| `inputInput`            | Styles pass as the `input` class of the underlying Material UI's `TextField` component input                                |
-
-The suggestions container has a `z-index` of 2. When using `<AutocompleteArrayInput>` in a `<Dialog>`, this will cause suggestions to appear beneath the Dialog. The solution is to override the `suggestionsContainer` class name, as follows:
-
-```diff
-import { AutocompleteArrayInput } from 'react-admin';
--import { Dialog } from '@material-ui/core';
-+import { Dialog, withStyles } from '@material-ui/core';
-
-+const AutocompleteArrayInputInDialog = withStyles({
-+    suggestionsContainer: { zIndex: 2000 },
-+})(AutocompleteArrayInput);
-
-const EditForm = () => (
-    <Dialog open>
-        ...
--       <AutocompleteArrayInput source="foo" choices={[...]}>
-+       <AutocompleteArrayInputInDialog source="foo" choices={[...]}>
-    </Dialog>
-)
-```
-
-To override the style of all instances of `<AutocompleteArrayInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaAutocompleteArrayInput` key.
-
-### Usage
-
-You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
-
-```jsx
-const choices = [
-    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
-    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
-];
-<AutocompleteArrayInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
-```
-
-`optionText` also accepts a function, so you can shape the option text at will:
-
-```jsx
-const choices = [
-   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
-   { id: 456, first_name: 'Jane', last_name: 'Austen' },
-];
-const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
-<AutocompleteArrayInput source="author_id" choices={choices} optionText={optionRenderer} />
-```
-
-The choices are translated by default, so you can use translation identifiers as choices:
-
-```jsx
-const choices = [
-   { id: 'M', name: 'myroot.gender.male' },
-   { id: 'F', name: 'myroot.gender.female' },
-];
-```
-
-However, in some cases (e.g. inside a `<ReferenceInput>`), you may not want the choice to be translated. In that case, set the `translateChoice` prop to `false`.
-
-```jsx
-<AutocompleteArrayInput source="gender" choices={choices} translateChoice={false}/>
-```
-
-When dealing with a large amount of `choices` you may need to limit the number of suggestions that are rendered in order to maintain usable performance. The `shouldRenderSuggestions` is an optional prop that allows you to set conditions on when to render suggestions. An easy way to improve performance would be to skip rendering until the user has entered 2 or 3 characters in the search box. This lowers the result set significantly, and might be all you need (depending on your data set).
-Ex. `<AutocompleteArrayInput shouldRenderSuggestions={(val) => { return val.trim().length > 2 }} />` would not render any suggestions until the 3rd character has been entered. This prop is passed to the underlying `react-autosuggest` component and is documented [here](https://github.com/moroshko/react-autosuggest#should-render-suggestions-prop).
-
-Lastly, `<AutocompleteArrayInput>` renders a [material-ui `<TextField>` component](https://material-ui.com/api/text-field/). Use the `options` attribute to override any of the `<TextField>` attributes:
-
-{% raw %}
-```jsx
-<AutocompleteArrayInput source="category" options={{
-    color: 'secondary',
-}} />
-```
-{% endraw %}
-
-**Tip**: Like many other inputs, `<AutocompleteArrayInput>` accept a `fullWidth` prop.
-**Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<AutocompleteArrayInput>` with [`<ReferenceArrayInput>`](#referenceinput), and leave the `choices` empty:
-
-```jsx
-import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin';
-
-<ReferenceArrayInput label="Tags" reference="tags" source="tags">
-    <AutocompleteArrayInput />
-</ReferenceArrayInput>
-```
-
-If you need to override the props of the suggestion's container (a `Popper` element), you can specify them using the `options.suggestionsContainerProps`. For example:
-
-{% raw %}
-```jsx
-<AutocompleteArrayInput source="category" options={{
-    suggestionsContainerProps: {
-        disablePortal: true,
-}}} />
-```
-{% endraw %}
-
-**Tip**: `<ReferenceArrayInput>` is a stateless component, so it only allows to *filter* the list of choices, not to *extend* it. If you need to populate the list of choices based on the result from a `fetch` call (and if [`<ReferenceArrayInput>`](#referencearrayinput) doesn't cover your need), you'll have to [write your own Input component](#writing-your-own-input-component) based on [material-ui-chip-input](https://github.com/TeamWertarbyte/material-ui-chip-input).
-
-**Tip**: React-admin's `<AutocompleteInput>` has only a capital A, while material-ui's `<AutoComplete>` has a capital A and a capital C. Don't mix up the components!
-
-## `<BooleanInput>` and `<NullableBooleanInput>`
-
-`<BooleanInput />` is a toggle button allowing you to attribute a `true` or `false` value to a record field.
-
-```jsx
-import { BooleanInput } from 'react-admin';
-
-<BooleanInput label="Commentable" source="commentable" />
-```
-
-![BooleanInput](./img/boolean-input.png)
-
-This input does not handle `null` values. You would need the `<NullableBooleanInput />` component if you have to handle non-set booleans.
-
-You can use the `options` prop to pass any option supported by the Material UI's `Switch` components. For example, here's how to set a custom checked icon:
-
-{% raw %}
-```jsx
-import { BooleanInput } from 'react-admin';
-import FavoriteIcon from '@material-ui/icons/Favorite';
-
-<BooleanInput
-    source="favorite"
-    options={{
-        checkedIcon: <FavoriteIcon />,
-    }}
-/>
-```
-{% endraw %}
-
-![CustomBooleanInputCheckIcon](./img/custom-switch-icon.png)
-
-Refer to [Material UI Switch documentation](https://material-ui.com/api/switch) for more details.
-
-`<NullableBooleanInput />` renders as a dropdown list, allowing choosing between `true`, `false`, and `null` values.
-
-### CSS API
-
-| Rule name  | Description                                                   |
-| ---------- | ------------------------------------------------------------- |
-| `input`    | Applied to the underlying Material UI's `TextField` component |
-
-To override the style of all instances of `<NullableBooleanInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaNullableBooleanInput` key.
-
-```jsx
-import { NullableBooleanInput } from 'react-admin';
-
-<NullableBooleanInput label="Commentable" source="commentable" />
-```
-
-![NullableBooleanInput](./img/nullable-boolean-input.png)
-
-The labels of the options can be customized for the entire application by overriding the translation.
-
-```jsx
-import polyglotI18nProvider from 'ra-i18n-polyglot';
-import englishMessages from 'ra-language-english';
-
-englishMessages.ra.boolean.null = 'Null label';
-englishMessages.ra.boolean.false = 'False label';
-englishMessages.ra.boolean.true = 'True label';
-const i18nProvider = polyglotI18nProvider(() => englishMessages, 'en');
-
-<Admin i18nProvider={i18nProvider}></Admin>
-```
-
-Additionally, individual instances of `NullableBooleanInput` may be customized by setting the `nullLabel`, `falseLabel` and `trueLabel` properties. Values specified for those properties will be translated by react-admin.
-
-```jsx
-import { NullableBooleanInput } from 'react-admin';
-
-<NullableBooleanInput
-    label="Commentable"
-    source="commentable"
-    nullLabel="Either"
-    falseLabel="No"
-    trueLabel="Yes"
-/>
-```
-
-![NullableBooleanInput](./img/nullable-boolean-input-null-label.png)
-
-`<BooleanInput>` and `<NullableBooleanInput>` also accept the [common input props](./Inputs.md#common-input-props).
-
-## `<CheckboxGroupInput>`
-
-If you want to let the user choose multiple values among a list of possible values by showing them all, `<CheckboxGroupInput>` is the right component. Set the `choices` attribute to determine the options (with `id`, `name` tuples):
-
-```jsx
-import { CheckboxGroupInput } from 'react-admin';
-
-<CheckboxGroupInput source="category" choices={[
-    { id: 'programming', name: 'Programming' },
-    { id: 'lifestyle', name: 'Lifestyle' },
-    { id: 'photography', name: 'Photography' },
-]} />
-```
-
-![CheckboxGroupInput](./img/checkbox-group-input.png)
-
-### Properties
-
-| Prop          | Required | Type                       | Default | Description                                                                                                                            |
-| ------------- | -------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------  |
-| `choices`     | Required | `Object[]`                 | -       | List of choices                                                                                                                        |
-| `optionText`  | Optional | `string` &#124; `Function` | `name`  | Fieldname of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`) |
-| `optionValue` | Optional | `string`                   | `id`    | Fieldname of record containing the value to use as input value                                                                         |
-| `row`         | Optional | `boolean`                  | `true`  | Display group of elements in a compact row.                                                                                            |
-
-Refer to [Material UI Checkbox documentation](https://material-ui.com/api/checkbox/) for more details.
-
-`<CheckboxGroupInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### CSS API
-
-| Rule name  | Description                                                   |
-| ---------- | ------------------------------------------------------------- |
-| `root`     | Applied to the root element                                   |
-| `label`    | Applied to the underlying Material UI's `FormLabel` component |
-
-To override the style of all instances of `<CheckboxGroupInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaCheckboxGroupInput` key.
-
-### Usage
-
-You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
-
-```jsx
-const choices = [
-    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
-    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
-];
-<CheckboxGroupInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
-```
-
-`optionText` also accepts a function, so you can shape the option text at will:
-
-```jsx
-const choices = [
-   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
-   { id: 456, first_name: 'Jane', last_name: 'Austen' },
-];
-const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
-<CheckboxGroupInput source="author_id" choices={choices} optionText={optionRenderer} />
-```
-
-`optionText` also accepts a React Element, that will be cloned and receive the related choice as the `record` prop. You can use Field components there.
-
-```jsx
-const choices = [
-   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
-   { id: 456, first_name: 'Jane', last_name: 'Austen' },
-];
-const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
-<CheckboxGroupInput source="gender" choices={choices} optionText={<FullNameField />}/>
-```
-
-The choices are translated by default, so you can use translation identifiers as choices:
-
-```jsx
-const choices = [
-    { id: 'programming', name: 'myroot.category.programming' },
-    { id: 'lifestyle', name: 'myroot.category.lifestyle' },
-    { id: 'photography', name: 'myroot.category.photography' },
-];
-```
-
-However, in some cases (e.g. inside a `<ReferenceInput>`), you may not want the choice to be translated. In that case, set the `translateChoice` prop to `false`.
-
-```jsx
-<CheckboxGroupInput source="gender" choices={choices} translateChoice={false}/>
-```
-
-Lastly, use the `options` attribute if you want to override any of Material UI's `<Checkbox>` attributes:
-
-{% raw %}
-```jsx
-import { FavoriteBorder, Favorite } from '@material-ui/icons';
-
-<CheckboxGroupInput source="category" options={{
-    icon: <FavoriteBorder />,
-    checkedIcon: <Favorite />
-}} />
-```
-{% endraw %}
-
-## `<DateInput>`
-
-Ideal for editing dates, `<DateInput>` renders an HTML `<input type="date">` element, that most browsers display as a standard [Date Picker](https://material-ui.com/components/pickers/#date-pickers). That means the appearance of `<DateInput>` depends on the browser, and falls back to a text input on Safari. The date formatting in this input depends on the user's locale.
-
-```jsx
-import { DateInput } from 'react-admin';
-
-<DateInput source="published_at" />
-```
-
-![DateInput](./img/date-input.gif)
-
-`<DateInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-**Tip**: For a material-ui styled `<DateInput>` component, check out [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs).
-
-## `<DateTimeInput>`
-
-An input for editing dates with time. `<DateTimeInput>` renders a standard browser [Date and Time Picker](https://material-ui.com/components/pickers/#date-amp-time-pickers), so the appearance depends on the browser (and falls back to a text input on safari).
-
-```jsx
-import { DateTimeInput } from 'react-admin';
-
-<DateTimeInput source="published_at" />
-```
-
-`<DateTimeInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-**Tip**: For a material-ui styled `<DateTimeInput>` component, check out [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs).
-
-## `<DualListInput>`
-
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit array values, one-to-many or many-to-many relationships by moving items from one list to another. It's a good alternative to `<SelectInput>` for a small number of choices.
-
-![DualListInput](https://marmelab.com/ra-enterprise/modules/assets/ra-relationships-duallistinput.gif)
-
-```jsx
-import { ReferenceInput } from 'react-admin';
-import { DualListInput } from '@react-admin/ra-relationships';
-
-<ReferenceInput label="Author" source="author_id" reference="authors">
-    <DualListInput optionText="last_name" />
-</ReferenceInput>
-```
-
-Check [the `ra-relationships` documentation](https://marmelab.com/ra-enterprise/modules/ra-relationships) for more details.
-
-## `<ImageInput>`
-
-`<ImageInput>` allows to upload some pictures using [react-dropzone](https://github.com/okonet/react-dropzone).
-
-![ImageInput](./img/image-input.png)
-
-### Properties
-
-| Prop            | Required | Type                        | Default                          | Description                                                                                                                                                                                                                                                         |
-| --------------- | -------- | --------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accept`        | Optional | `string | string[]`         | -                                | Accepted file type(s), e. g. 'image/*,.pdf'. If left empty, all file types are accepted. Equivalent of the `accept` attribute of an `<input type="file">`. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept for syntax and examples. |
-| `children`      | Optional | `ReactNode`                 | -                                | Element used to display the preview of an image (cloned several times if the select accepts multiple files).                                                                                                                                                        |
-| `minSize`       | Optional | `number`                    | 0                                | Minimum image size (in bytes), e.g. 5000 form 5KB                                                                                                                                                                                                                   |
-| `maxSize`       | Optional | `number`                    | `Infinity`                       | Maximum image size (in bytes), e.g. 5000000 for 5MB                                                                                                                                                                                                                 |
-| `multiple`      | Optional | `boolean`                   | `false`                          | Set to true if the input should accept a list of images, false if it should only accept one image                                                                                                                                                                   |
-| `labelSingle`   | Optional | `string`                    | 'ra.input.image. upload_single'  | Invite displayed in the drop zone if the input accepts one image                                                                                                                                                                                                    |
-| `labelMultiple` | Optional | `string`                    | 'ra.input.file. upload_multiple' | Invite displayed in the drop zone if the input accepts several images                                                                                                                                                                                               |
-| `placeholder`   | Optional | `string` &#124; `ReactNode` | -                                | Invite displayed in the drop zone, overrides `labelSingle` and `labelMultiple`                                                                                                                                                                                      |
-| `options`       | Optional | `Object`                    | `{}`                             | Additional options passed to react-dropzone's `useDropzone()` hook. See [the react-dropzone source](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js)  for details .                                                                       |
-
-`<ImageInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### CSS API
-
-| Rule name       | Description                                          |
-| --------------- | ---------------------------------------------------- |
-| `root`          | Styles pass to the underlying `FileInput` component  |
-| `dropZone`      | Styles pass to the underlying `FileInput` component  |
-| `preview`       | Styles pass to the underlying `FileInput` component  |
-| `removeButton`  | Styles pass to the underlying `FileInput` component  |
-
-To override the style of all instances of `<ImageInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaImageInput` key.
-
-### Usage
-
-Files are accepted or rejected based on the `accept`, `multiple`, `minSize` and `maxSize` props. `accept` must be a valid [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file) or a valid file extension. If `multiple` is set to false and additional files are dropped, all files besides the first will be rejected. Any file which does not have a size in the [`minSize`, `maxSize`] range, will be rejected as well.
-
-`<ImageInput>` delegates the preview of currently selected images to its child. `<ImageInput>` clones its child as many times as there are selected images, passing the image as the `record` prop. To preview a simple list of image thumbnails, you can use `<ImageField>` as child, as follows:
-
-```jsx
-<ImageInput source="pictures" label="Related pictures" accept="image/*">
-    <ImageField source="src" title="title" />
-</ImageInput>
-```
-
-Writing a custom preview component is quite straightforward: it's a standard [field](./Fields.md#writing-your-own-field-component).
-
-When receiving **new** images, `ImageInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display information about size or mimetype inside a custom field.
-
-The `ImageInput` component accepts an `options` prop, allowing to set the [react-dropzone properties](https://react-dropzone.netlify.com/#proptypes).
-
-If the default Dropzone label doesn't fit with your need, you can pass a `placeholder` prop to overwrite it. The value can be anything React can render (`PropTypes.node`):
-
-```jsx
-<ImageInput source="pictures" label="Related pictures" accept="image/*" placeholder={<p>Drop your file here</p>}>
-    <ImageField source="src" title="title" />
-</ImageInput>
-```
-
-Note that the image upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#extending-a-data-provider-example-of-file-upload) for base64 encoding data by extending the REST Client.
-
-## `<FileInput>`
-
-`<FileInput>` allows uploading files using [react-dropzone](https://github.com/okonet/react-dropzone).
-
-![FileInput](./img/file-input.png)
-
-### Properties
-
-| Prop            | Required | Type                 | Default                         | Description                                                                                                                                                                                                                                                                                                                                            |
-| --------------- | -------- | -------------------- | ------------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
-| `accept`        | Optional | `string | string[]`  | -                               | Accepted file type(s), e. g. 'application/json,video/*' or 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'. If left empty, all file types are accepted. Equivalent of the `accept` attribute of an `<input type="file">`. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept for syntax and examples. |
-| `children`      | Optional | `ReactNode`          | -                               | Element used to display the preview of a file (cloned several times if the select accepts multiple files).                                                                                                                                                                                                                                             |
-| `minSize`       | Optional | `number`             | 0                               | Minimum file size (in bytes), e.g. 5000 form 5KB                                                                                                                                                                                                                                                                                                       |
-| `maxSize`       | Optional | `number`             | `Infinity`                      | Maximum file size (in bytes), e.g. 5000000 for 5MB                                                                                                                                                                                                                                                                                                     |
-| `multiple`      | Optional | `boolean`            | `false`                         | Set to true if the input should accept a list of files, false if it should only accept one file                                                                                                                                                                                                                                                        |
-| `labelSingle`   | Optional | `string`             | 'ra.input.file. upload_single'  | Invite displayed in the drop zone if the input accepts one file                                                                                                                                                                                                                                                                                        |
-| `labelMultiple` | Optional | `string`             | 'ra.input.file. upload_several' | Invite displayed in the drop zone if the input accepts several files                                                                                                                                                                                                                                                                                   |
-| `placeholder`   | Optional | `string | ReactNode` | -                               | Invite displayed in the drop zone, overrides `labelSingle` and `labelMultiple`                                                                                                                                                                                                                                                                         |
-| `options`       | Optional | `Object`             | `{}`                            | Additional options passed to react-dropzone's `useDropzone()` hook. See [the react-dropzone source](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js)  for details .                                                                                                                                                          |
-
-`<FileInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### CSS API
-
-| Rule name       | Description                                                                       |
-| --------------- | --------------------------------------------------------------------------------- |
-| `root`          | Applied to the underlying `Labeled` component                                     |
-| `dropZone`      | Applied to the main container of the component                                    |
-| `preview`       | Applied to each children                                                          |
-| `removeButton`  | Applied to each of the Material UI's `IconButton` component used as remove button |
-
-To override the style of all instances of `<FileInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaFileInput` key.
-
-### Usage
-
-Files are accepted or rejected based on the `accept`, `multiple`, `minSize` and `maxSize` props. `accept` must be a valid [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file) or a valid file extension. If `multiple` is set to false and additional files are dropped, all files besides the first will be rejected. Any file which does not have a size in the [`minSize`, `maxSize`] range, will be rejected as well.
-
-`FileInput` delegates the preview of currently selected files to its child. `FileInput` clones its child as many times as there are selected files, passing the file as the `record` prop. To preview a simple list of files names, you can use `<FileField>` as child, as follows:
-
-```jsx
-<FileInput source="files" label="Related files" accept="application/pdf">
-    <FileField source="src" title="title" />
-</FileInput>
-```
-
-Writing a custom preview component is quite straightforward: it's a standard [field](./Fields.md#writing-your-own-field-component).
-
-When receiving **new** files, `FileInput` will add a `rawFile` property to the object passed as the `record` prop of children. This `rawFile` is the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) instance of the newly added file. This can be useful to display information about size or mimetype inside a custom field.
-
-The `FileInput` component accepts an `options` prop into which you can pass all the [react-dropzone properties](https://react-dropzone.netlify.com/#proptypes). 
-
-If the default Dropzone label doesn't fit with your need, you can pass a `placeholder` prop to overwrite it. The value can be anything React can render (`PropTypes.node`):
-
-```jsx
-<FileInput source="files" label="Related files" accept="application/pdf" placeholder={<p>Drop your file here</p>}>
-    <ImageField source="src" title="title" />
-</FileInput>
-```
-
-Note that the file upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#extending-a-data-provider-example-of-file-upload) for base64 encoding data by extending the REST Client.
-
-## `<MarkdownInput>`
-
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit and preview Markdown data, based on [the Toast UI editor](https://nhn.github.io/tui.editor/latest/ToastUIEditor).
-
-```jsx
-import { Edit, SimpleForm, TextInput } from 'react-admin';
-import { MarkdownInput } from '@react-admin/ra-markdown';
-
-const PostEdit = props => (
-    <Edit {...props}>
-        <SimpleForm>
-            <TextInput source="title" />
-            <MarkdownInput source="description" />
-        </SimpleForm>
-    </Edit>
-);
-```
-
-Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.
-
-## `<NumberInput>`
-
-`<NumberInput>` translates to an HTML `<input type="number">`. It is necessary for numeric values because of a [known React bug](https://github.com/facebook/react/issues/1425), which prevents using the more generic [`<TextInput>`](#textinput) in that case.
-
-```jsx
-import { NumberInput } from 'react-admin';
-
-<NumberInput source="nb_views" />
-```
-
-### Properties
-
-| Prop   | Required | Type     | Default | Description                                                                                             |
-| ------ | -------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `max`  | Optional | `number` | ''      | The maximum value to accept for this input                                                              |
-| `min`  | Optional | `number` | ''      | The minimum value to accept for this input                                                              |
-| `step` | Optional | `number` | `any`   | A stepping interval to use when using up and down arrows to adjust the value, as well as for validation |
-
-`<NumberInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### Usage
-
-You can customize the `step` props (which defaults to "any"). For instance, to restrict the value to integers, ise a value of 1 for the `step`:
-
-```jsx
-<NumberInput source="nb_views" step={1} />
-```
-
-## `<PasswordInput>`
-
-`<PasswordInput>` works like the [`<TextInput>`](#textinput) but overwrites its `type` prop to `password` or `text` in accordance with a visibility button, hidden by default.
-
-```jsx
-import { PasswordInput } from 'react-admin';
-<PasswordInput source="password" />
-```
-
-![Password Input](./img/password-input.png)
-
-It is possible to change the default behavior and display the value by default via the `initiallyVisible` prop:
-
-```jsx
-import { PasswordInput } from 'react-admin';
-<PasswordInput source="password" initiallyVisible />
-```
-
-![Password Input (visible)](./img/password-input-visible.png)
-
-**Tip**: It is possible to set the [`autocomplete` attribute](https://developer.mozilla.org/fr/docs/Web/HTML/Attributs/autocomplete) by injecting an input props:
-
-{% raw %}
-```jsx
-<PasswordInput source="password" inputProps={{ autocomplete: 'current-password' }} />
-```
-{% endraw %}
-
-## `<RadioButtonGroupInput>`
+### `<RadioButtonGroupInput>`
 
 If you want to let the user choose a value among a list of possible values that are always shown (instead of hiding them behind a dropdown list, as in [`<SelectInput>`](#selectinput)), `<RadioButtonGroupInput>` is the right component. Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
@@ -917,7 +679,7 @@ import { RadioButtonGroupInput } from 'react-admin';
 
 ![RadioButtonGroupInput](./img/radio-button-group-input.png)
 
-### Properties
+#### Properties
 
 | Prop              | Required | Type                       | Default | Description                                                                                                                            |
 | ----------------- | -------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -930,7 +692,7 @@ import { RadioButtonGroupInput } from 'react-admin';
 
 `<RadioButtonGroupInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                                                   |
 | ---------- | ------------------------------------------------------------- |
@@ -938,7 +700,7 @@ import { RadioButtonGroupInput } from 'react-admin';
 
 To override the style of all instances of `<RadioButtonGroupInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaRadioButtonGroupInput` key.
 
-### Usage
+#### Usage
 
 You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
 
@@ -1009,357 +771,7 @@ import { RadioButtonGroupInput, ReferenceInput } from 'react-admin';
 </ReferenceInput>
 ```
 
-## `<ReferenceArrayInput>`
-
-Use `<ReferenceArrayInput>` to edit an array of reference values, i.e. to let users choose a list of values (usually foreign keys) from another REST endpoint.
-
-`<ReferenceArrayInput>` fetches the related resources (using `dataProvider.getMany()`) as well as possible resources (using `dataProvider.getList()`) in the reference endpoint.
-
-For instance, if the post object has many tags, a post resource may look like:
-
-```json
-{
-    "id": 1234,
-    "tag_ids": [1, 23, 4]
-}
-```
-
-Then `<ReferenceArrayInput>` would fetch a list of tag resources from these two calls:
-
-```
-http://myapi.com/tags?id=[1,23,4]
-http://myapi.com/tags?page=1&perPage=25
-```
-
-Once it receives the deduplicated reference resources, this component delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
-
-This means you can use `<ReferenceArrayInput>` with [`<SelectArrayInput>`](#selectarrayinput), or with the component of your choice, provided it supports the `choices` attribute.
-
-The component expects a `source` and a `reference` attributes. For instance, to make the `tag_ids` for a `post` editable:
-
-```jsx
-import { ReferenceArrayInput, SelectArrayInput } from 'react-admin';
-
-<ReferenceArrayInput source="tag_ids" reference="tags">
-    <SelectArrayInput optionText="name" />
-</ReferenceArrayInput>
-```
-
-![SelectArrayInput](./img/select-array-input.gif)
-
-**Note**: You **must** add a `<Resource>` for the reference resource - react-admin needs it to fetch the reference data. You can omit the list prop in this reference if you want to hide it in the sidebar menu.
-
-```jsx
-<Admin dataProvider={myDataProvider}>
-    <Resource name="posts" list={PostList} edit={PostEdit} />
-    <Resource name="tags" />
-</Admin>
-```
-
-Set the `allowEmpty` prop when you want to add an empty choice with a value of `null` in the choices list.
-Disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.md#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
-
-```jsx
-import { ReferenceArrayInput, SelectArrayInput } from 'react-admin';
-
-<ReferenceArrayInput source="tag_ids" reference="tags" allowEmpty>
-    <SelectArrayInput optionText="name" />
-</ReferenceArrayInput>
-```
-
-**Tip**: `allowEmpty` is set by default for all Input components children of the `<Filter>` component
-
-You can tweak how this component fetches the possible values using the `perPage`, `sort`, and `filter` props.
-
-{% raw %}
-```jsx
-// by default, fetches only the first 25 values. You can extend this limit
-// by setting the `perPage` prop.
-<ReferenceArrayInput
-     source="tag_ids"
-     reference="tags"
-     perPage={100}>
-    <SelectArrayInput optionText="name" />
-</ReferenceArrayInput>
-
-// by default, orders the possible values by id desc. You can change this order
-// by setting the `sort` prop (an object with `field` and `order` properties).
-<ReferenceArrayInput
-     source="tag_ids"
-     reference="tags"
-     sort={{ field: 'title', order: 'ASC' }}>
-    <SelectArrayInput optionText="name" />
-</ReferenceArrayInput>
-
-// you can filter the query used to populate the possible values. Use the
-// `filter` prop for that.
-<ReferenceArrayInput
-     source="tag_ids"
-     reference="tags"
-     filter={{ is_published: true }}>
-    <SelectArrayInput optionText="name" />
-</ReferenceArrayInput>
-```
-{% endraw %}
-
-`<ReferenceArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-## `<ReferenceInput>`
-
-Use `<ReferenceInput>` for foreign-key values, for instance, to edit the `post_id` of a `comment` resource. This component fetches the related record (using `dataProvider.getMany()`) as well as possible choices (using `dataProvider.getList()` in the reference resource), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
-
-This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selectinput), [`<AutocompleteInput>`](#autocompleteinput), or [`<RadioButtonGroupInput>`](#radiobuttongroupinput), or even with the component of your choice, provided it supports the `choices` attribute.
-
-The component expects a `source` and a `reference` attributes. For instance, to make the `post_id` for a `comment` editable:
-
-```jsx
-import { ReferenceInput, SelectInput } from 'react-admin';
-
-<ReferenceInput label="Post" source="post_id" reference="posts">
-    <SelectInput optionText="title" />
-</ReferenceInput>
-```
-
-![ReferenceInput](./img/reference-input.gif)
-
-**Note**: You **must** add a `<Resource>` for the reference resource - react-admin needs it to fetch the reference data. You *can* omit the `list` prop in this reference if you want to hide it in the sidebar menu.
-
-```jsx
-<Admin dataProvider={myDataProvider}>
-    <Resource name="comments" list={CommentList} />
-    <Resource name="posts" />
-</Admin>
-```
-
-### Properties
-
-| Prop            | Required | Type                                        | Default                               | Description                                                                                                           |
-| --------------- | -------- | ------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `allowEmpty`    | Optional | `boolean`                                   | `false`                               | If true, add an empty item to the list of choices to allow for empty value                                            |
-| `filter`        | Optional | `Object`                                    | `{}`                                  | Permanent filters to use for getting the suggestion list                                                              |
-| `filterToQuery` | Optional | `string` => `Object`                        | `searchText => ({ q: [searchText] })` | How to transform the searchText (passed e.g. by an `<AutocompleteArrayInput>`) into a parameter for the data provider |
-| `perPage`       | Optional | `number`                                    | 25                                    | Number of suggestions to show                                                                                         |
-| `reference`     | Required | `string`                                    | ''                                    | Name of the reference resource, e.g. 'posts'.                                                                         |
-| `sort`          | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }`      | How to order the list of suggestions                                                                                  |
-
-`<ReferenceInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### Usage
-
-Set the `allowEmpty` prop when you want to add an empty choice with a value of `null` in the choices list.
-Disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.md#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
-
-```jsx
-import { ReferenceInput, SelectInput } from 'react-admin';
-
-<ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
-    <SelectInput optionText="title" />
-</ReferenceInput>
-```
-
-**Tip**: `allowEmpty` is set by default for all Input components children of the `<Filter>` component:
-
-```jsx
-const CommentFilter = (props) => (
-    <Filter {...props}>
-        <ReferenceInput label="Post" source="post_id" reference="posts"> // no need for allowEmpty
-            <SelectInput optionText="title" />
-        </ReferenceInput>
-    </Filter>
-);
-```
-
-You can tweak how this component fetches the possible values using the `perPage`, `sort`, and `filter` props.
-
-{% raw %}
-```jsx
-// by default, fetches only the first 25 values. You can extend this limit
-// by setting the `perPage` prop.
-<ReferenceInput
-     source="post_id"
-     reference="posts"
-     perPage={100}>
-    <SelectInput optionText="title" />
-</ReferenceInput>
-
-// by default, orders the possible values by id desc. You can change this order
-// by setting the `sort` prop (an object with `field` and `order` properties).
-<ReferenceInput
-     source="post_id"
-     reference="posts"
-     sort={{ field: 'title', order: 'ASC' }}>
-    <SelectInput optionText="title" />
-</ReferenceInput>
-
-// you can filter the query used to populate the possible values. Use the
-// `filter` prop for that.
-<ReferenceInput
-     source="post_id"
-     reference="posts"
-     filter={{ is_published: true }}>
-    <SelectInput optionText="title" />
-</ReferenceInput>
-```
-{% endraw %}
-
-The child component may further filter results (that's the case, for instance, for `<AutocompleteInput>`). ReferenceInput passes a `setFilter` function as prop to its child component. It uses the value to create a filter for the query - by default `{ q: [searchText] }`. You can customize the mapping
-`searchText => searchQuery` by setting a custom `filterToQuery` function prop:
-
-```jsx
-<ReferenceInput
-     source="post_id"
-     reference="posts"
-     filterToQuery={searchText => ({ title: searchText })}>
-    <AutocompleteInput optionText="title" />
-</ReferenceInput>
-```
-
-The child component receives the following props from `<ReferenceInput>`:
-
-- `loading`: whether the request for possible values is loading or not
-- `filter`: the current filter of the request for possible values. Defaults to `{}`.
-- `pagination`: the current pagination of the request for possible values. Defaults to `{ page: 1, perPage: 25 }`.
-- `sort`: the current sorting of the request for possible values. Defaults to `{ field: 'id', order: 'DESC' }`.
-- `error`: the error message if the form validation failed for that input
-- `warning`: the warning message if the form validation failed for that input
-- `onChange`: function to call when the value changes
-- `setFilter`: function to call to update the filter of the request for possible values
-- `setPagination`: : function to call to update the pagination of the request for possible values
-- `setSort`: function to call to update the sorting of the request for possible values
-
-**Tip**: Why does `<ReferenceInput>` use the `dataProvider.getMany()` method with a single value `[id]` instead of `dataProvider.getOne()` to fetch the record for the current value? Because when there are many `<ReferenceInput>` for the same resource in a form (for instance when inside an `<ArrayInput>`), react-admin *aggregates* the calls to `dataProvider.getMany()` into a single one with `[id1, id2, ...)]`. This speeds up the UI and avoids hitting the API too much.
-
-## `<ReferenceManyToManyInput>`
-
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to create, edit or remove relationships between two resources sharing an associative table. The changes in the associative table are sent to the dataProvider when the user submits the form, so that they can cancel the changes before submission.
-
-In this example, `artists.id` matches `performances.artist_id`, and `performances.event_id` matches `events.id`:
-
-```
-┌────────────┐       ┌──────────────┐      ┌────────┐
-│ artists    │       │ performances │      │ events │
-│------------│       │--------------│      │--------│
-│ id         │───┐   │ id           │      │ id     │
-│ first_name │   └──╼│ artist_id    │   ┌──│ name   │
-│ last_name  │       │ event_id     │╾──┘  │        │
-└────────────┘       └──────────────┘      └────────┘
-```
-
-The form displays the events name in a `<SelectArrayInput>`:
-
-```jsx
-import * as React from 'react';
-import { Edit, SelectArrayInput, SimpleForm, TextInput } from 'react-admin';
-import { ReferenceManyToManyInput, useReferenceManyToManyUpdate } from '@react-admin/ra-many-to-many';
-
-/**
- * Decorate <SimpleForm> to override the default save function.
- * This is necessary to save changes in the associative table
- * only on submission.
- */
-const ArtistEditForm = props => {
-    const save = useReferenceManyToManyUpdate({
-        basePath: props.basePath,
-        record: props.record,
-        redirect: props.redirect || 'list',
-        reference: 'events',
-        resource: props.resource,
-        source: 'id',
-        through: 'performances',
-        undoable: props.undoable,
-        using: 'artist_id,event_id',
-    });
-
-    return <SimpleForm {...props} save={save} />;
-};
-
-const ArtistEdit = props => (
-    <Edit {...props}>
-        <ArtistEditForm>
-            <TextInput disabled source="id" />
-            <TextInput source="first_name" />
-            <TextInput source="last_name" />
-            <ReferenceManyToManyInput
-                source="id"
-                reference="events"
-                through="performances"
-                using="artist_id,event_id"
-                fullWidth
-                label="Performances"
-            >
-                <SelectArrayInput optionText="name" />
-            </ReferenceManyToManyInput>
-        </ArtistEditForm>
-    </Edit>
-);
-
-export default ArtistEdit;
-```
-
-Check [the `ra-relationships` documentation](https://marmelab.com/ra-enterprise/modules/ra-relationships#referencemanytomanyinput) for more details.
-
-## `<RichTextInput>`
-
-`<RichTextInput>` is the ideal component if you want to allow your users to edit some HTML contents. It
-is powered by [Quill](https://quilljs.com/).
-
-**Note**: Due to its size, `<RichTextInput>` is not bundled by default with react-admin. You must install it first, using npm:
-
-```sh
-npm install ra-input-rich-text
-```
-
-Then use it as a normal input component:
-
-```jsx
-import RichTextInput from 'ra-input-rich-text';
-
-<RichTextInput source="body" />
-```
-
-![RichTextInput](./img/rich-text-input.png)
-
-You can customize the rich text editor toolbar using the `toolbar` attribute, as described on the [Quill official toolbar documentation](https://quilljs.com/docs/modules/toolbar/).
-
-```jsx
-<RichTextInput source="body" toolbar={[ ['bold', 'italic', 'underline', 'link'] ]} />
-```
-
-If you need to add Quill `modules` or `themes`, you can do so by passsing them in the `options` prop.
-
-{% raw %}
-```jsx
-<RichTextInput
-    source="body"
-    options={{
-        modules: {
-            history: { // History module
-                delay: 2000,
-                maxStack: 500,
-                userOnly: true
-            }
-        },
-        theme: "snow"
-    }}
-/>
-```
-{% endraw %}
-
-If you need more customization, you can access the quill object through the `configureQuill` callback that will be called just after its initialization.
-
-```jsx
-const configureQuill = quill => quill.getModule('toolbar').addHandler('bold', function (value) {
-    this.quill.format('bold', value)
-});
-
-// ...
-
-<RichTextInput source="text" configureQuill={configureQuill}/>
-```
-
-`<RichTextInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-## `<SelectInput>`
+### `<SelectInput>`
 
 To let users choose a value in a list using a dropdown, use `<SelectInput>`. It renders using [Material ui's `<Select>`](https://material-ui.com/api/select). Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
@@ -1375,7 +787,7 @@ import { SelectInput } from 'react-admin';
 
 ![SelectInput](./img/select-input.gif)
 
-### Properties
+#### Properties
 
 | Prop              | Required | Type                       | Default | Description                                                                                                                            |
 | ----------------- | -------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1390,7 +802,7 @@ import { SelectInput } from 'react-admin';
 
 `<SelectInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
-### CSS API
+#### CSS API
 
 | Rule name       | Description                                               |
 | --------------- | --------------------------------------------------------- |
@@ -1398,7 +810,7 @@ import { SelectInput } from 'react-admin';
 
 To override the style of all instances of `<SelectInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaSelectInput` key.
 
-### Usage
+#### Usage
 
 You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
 
@@ -1509,11 +921,363 @@ const choices = [
 <SelectInput source="contact_id" choices={choices} optionText="full_name" optionValue="_id" disableValue="not_available" />
 ```
 
-## `<SelectArrayInput>`
+## Array Inputs
+
+### `<ArrayInput>`
+
+To edit arrays of data embedded inside a record, `<ArrayInput>` creates a list of sub-forms.
+
+```jsx
+import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+
+<ArrayInput source="backlinks">
+    <SimpleFormIterator>
+        <DateInput source="date" />
+        <TextInput source="url" />
+    </SimpleFormIterator>
+</ArrayInput>
+```
+
+![ArrayInput](./img/array-input.png)
+
+ `<ArrayInput>` allows editing of embedded arrays, like the `backlinks` field in the following `post` record:
+
+```json
+{
+  "id": 123,
+  "backlinks": [
+        {
+            "date": "2012-08-10T00:00:00.000Z",
+            "url": "http://example.com/foo/bar.html",
+        },
+        {
+            "date": "2012-08-14T00:00:00.000Z",
+            "url": "https://blog.johndoe.com/2012/08/12/foobar.html",
+        }
+   ]
+}
+```
+
+`<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component accepting a `fields` object as passed by [react-final-form-array](https://github.com/final-form/react-final-form-arrays#fieldarrayrenderprops), and defining a layout for an array of fields. For instance, the `<SimpleFormIterator>` component displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record (a backlink in this example).
+
+You can pass `disableAdd` and `disableRemove` as props of `SimpleFormIterator`, to disable `ADD` and `REMOVE` button respectively. Default value of both is `false`.
+
+```jsx
+import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+
+<ArrayInput source="backlinks">
+    <SimpleFormIterator disableRemove >
+        <DateInput source="date" />
+        <TextInput source="url" />
+    </SimpleFormIterator>
+</ArrayInput>
+```
+
+You can also use `addButton` and `removeButton` props to pass your custom add and remove buttons to `SimpleFormIterator`.
+
+```jsx
+import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
+
+<ArrayInput source="backlinks">
+    <SimpleFormIterator addButton={<CustomAddButton />} removeButton={<CustomRemoveButton />}>
+        <DateInput source="date" />
+        <TextInput source="url" />
+    </SimpleFormIterator>
+</ArrayInput>
+```
+
+**Note**: `SimpleFormIterator` only accepts `Input` components as children. If you want to use some `Fields` instead, you have to use a `<FormDataConsumer>` to get the correct source, as follows:
+
+```jsx
+import { ArrayInput, SimpleFormIterator, DateInput, TextInput, FormDataConsumer } from 'react-admin';
+
+<ArrayInput source="backlinks">
+    <SimpleFormIterator disableRemove >
+        <DateInput source="date" />
+        <FormDataConsumer>
+            {({ getSource, scopedFormData }) => {
+                return (
+                    <TextField
+                        source={getSource('url')}
+                        record={scopedFormData}
+                    />
+                );
+            }}
+        </FormDataConsumer>
+    </SimpleFormIterator>
+</ArrayInput>
+```
+
+`<ArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props) (except `format` and `parse`).
+
+### `<AutocompleteArrayInput>`
+
+To let users choose multiple values in a list using a dropdown with autocompletion, use `<AutocompleteArrayInput>`.
+It renders using [downshift](https://github.com/downshift-js/downshift) and a `fuzzySearch` filter.
+Set the `choices` attribute to determine the options list (with `id`, `name` tuples).
+
+```jsx
+import { AutocompleteArrayInput } from 'react-admin';
+
+<AutocompleteArrayInput source="category" choices={[
+    { id: 'programming', name: 'Programming' },
+    { id: 'lifestyle', name: 'Lifestyle' },
+    { id: 'photography', name: 'Photography' },
+]} />
+```
+
+#### Properties
+
+| Prop                      | Required | Type                       | Default      | Description                                                                                                                                                                                                                                                                                          |
+| ------------------------- | -------- | -------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowEmpty`              | Optional | `boolean`                  | `false`      | If `true`, the first option is an empty one                                                                                                                                                                                                                                                          |
+| `allowDuplicates`         | Optional | `boolean`                  | `false`      | If `true`, the options can be selected several times                                                                                                                                                                                                                                                 |
+| `choices`                 | Required | `Object[]`                 | -            | List of items to autosuggest                                                                                                                                                                                                                                                                         |
+| `matchSuggestion`         | Optional | `Function`                 | -            | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                                                                                                              |
+| `optionValue`             | Optional | `string`                   | `id`         | Fieldname of record containing the value to use as input value                                                                                                                                                                                                                                       |
+| `optionText`              | Optional | `string` &#124; `Function` | `name`       | Fieldname of record to display in the suggestion item or function which accepts the current record as argument (`(record)=> {string}`)                                                                                                                                                               |
+| `setFilter`               | Optional | `Function`                 | `null`       | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically setup when using `ReferenceInput`.                                                                                   |
+| `shouldRenderSuggestions` | Optional | `Function`                 | `() => true` | A function that returns a `boolean` to determine whether or not suggestions are rendered. Use this when working with large collections of data to improve performance and user experience. This function is passed into the underlying react-autosuggest component. Ex.`(value) => value.trim() > 2` |
+| `source`                  | Required | `string`                   | -            | Name of field to edit, its type should match the type retrieved from `optionValue`                                                                                                                                                                                                                   |
+| `suggestionLimit`         | Optional | `number`                   | `null`       | Limits the numbers of suggestions that are shown in the dropdown list                                                                                                                                                                                                                                |
+
+`<AutocompleteArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### CSS API
+
+| Rule name               | Description                                                                                                                 |
+| ----------------------  | --------------------------------------------------------------------------------------------------------------------------- |
+| `container`             | Applied to the container of the underlying Material UI's `TextField` component input                                        |
+| `suggestionsContainer`  | Applied to the suggestions container |
+| `chip`                  | Applied to each Material UI's `Chip` component used as selected item                                                        |
+| `chipContainerFilled`   | Applied to each container of each Material UI's `Chip` component used as selected item when `variant` prop is `filled`      |
+| `chipContainerOutlined` | Applied to each container of each `Chip` component used as selected item when `variant` prop is `outlined`                  |
+| `inputRoot`             | Styles pass as the `root` class of the underlying Material UI's `TextField` component input                                 |
+| `inputRootFilled`       | Styles pass as the `root` class of the underlying Material UI's `TextField` component input when `variant` prop is `filled` |
+| `inputInput`            | Styles pass as the `input` class of the underlying Material UI's `TextField` component input                                |
+
+The suggestions container has a `z-index` of 2. When using `<AutocompleteArrayInput>` in a `<Dialog>`, this will cause suggestions to appear beneath the Dialog. The solution is to override the `suggestionsContainer` class name, as follows:
+
+```diff
+import { AutocompleteArrayInput } from 'react-admin';
+-import { Dialog } from '@material-ui/core';
++import { Dialog, withStyles } from '@material-ui/core';
+
++const AutocompleteArrayInputInDialog = withStyles({
++    suggestionsContainer: { zIndex: 2000 },
++})(AutocompleteArrayInput);
+
+const EditForm = () => (
+    <Dialog open>
+        ...
+-       <AutocompleteArrayInput source="foo" choices={[...]}>
++       <AutocompleteArrayInputInDialog source="foo" choices={[...]}>
+    </Dialog>
+)
+```
+
+To override the style of all instances of `<AutocompleteArrayInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaAutocompleteArrayInput` key.
+
+#### Usage
+
+You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
+
+```jsx
+const choices = [
+    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
+    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
+];
+<AutocompleteArrayInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+```
+
+`optionText` also accepts a function, so you can shape the option text at will:
+
+```jsx
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+<AutocompleteArrayInput source="author_id" choices={choices} optionText={optionRenderer} />
+```
+
+The choices are translated by default, so you can use translation identifiers as choices:
+
+```jsx
+const choices = [
+   { id: 'M', name: 'myroot.gender.male' },
+   { id: 'F', name: 'myroot.gender.female' },
+];
+```
+
+However, in some cases (e.g. inside a `<ReferenceInput>`), you may not want the choice to be translated. In that case, set the `translateChoice` prop to `false`.
+
+```jsx
+<AutocompleteArrayInput source="gender" choices={choices} translateChoice={false}/>
+```
+
+When dealing with a large amount of `choices` you may need to limit the number of suggestions that are rendered in order to maintain usable performance. The `shouldRenderSuggestions` is an optional prop that allows you to set conditions on when to render suggestions. An easy way to improve performance would be to skip rendering until the user has entered 2 or 3 characters in the search box. This lowers the result set significantly, and might be all you need (depending on your data set).
+Ex. `<AutocompleteArrayInput shouldRenderSuggestions={(val) => { return val.trim().length > 2 }} />` would not render any suggestions until the 3rd character has been entered. This prop is passed to the underlying `react-autosuggest` component and is documented [here](https://github.com/moroshko/react-autosuggest#should-render-suggestions-prop).
+
+Lastly, `<AutocompleteArrayInput>` renders a [material-ui `<TextField>` component](https://material-ui.com/api/text-field/). Use the `options` attribute to override any of the `<TextField>` attributes:
+
+{% raw %}
+```jsx
+<AutocompleteArrayInput source="category" options={{
+    color: 'secondary',
+}} />
+```
+{% endraw %}
+
+**Tip**: Like many other inputs, `<AutocompleteArrayInput>` accept a `fullWidth` prop.
+**Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<AutocompleteArrayInput>` with [`<ReferenceArrayInput>`](#referenceinput), and leave the `choices` empty:
+
+```jsx
+import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin';
+
+<ReferenceArrayInput label="Tags" reference="tags" source="tags">
+    <AutocompleteArrayInput />
+</ReferenceArrayInput>
+```
+
+If you need to override the props of the suggestion's container (a `Popper` element), you can specify them using the `options.suggestionsContainerProps`. For example:
+
+{% raw %}
+```jsx
+<AutocompleteArrayInput source="category" options={{
+    suggestionsContainerProps: {
+        disablePortal: true,
+}}} />
+```
+{% endraw %}
+
+**Tip**: `<ReferenceArrayInput>` is a stateless component, so it only allows to *filter* the list of choices, not to *extend* it. If you need to populate the list of choices based on the result from a `fetch` call (and if [`<ReferenceArrayInput>`](#referencearrayinput) doesn't cover your need), you'll have to [write your own Input component](#writing-your-own-input-component) based on [material-ui-chip-input](https://github.com/TeamWertarbyte/material-ui-chip-input).
+
+**Tip**: React-admin's `<AutocompleteInput>` has only a capital A, while material-ui's `<AutoComplete>` has a capital A and a capital C. Don't mix up the components!
+
+### `<CheckboxGroupInput>`
+
+If you want to let the user choose multiple values among a list of possible values by showing them all, `<CheckboxGroupInput>` is the right component. Set the `choices` attribute to determine the options (with `id`, `name` tuples):
+
+```jsx
+import { CheckboxGroupInput } from 'react-admin';
+
+<CheckboxGroupInput source="category" choices={[
+    { id: 'programming', name: 'Programming' },
+    { id: 'lifestyle', name: 'Lifestyle' },
+    { id: 'photography', name: 'Photography' },
+]} />
+```
+
+![CheckboxGroupInput](./img/checkbox-group-input.png)
+
+#### Properties
+
+| Prop          | Required | Type                       | Default | Description                                                                                                                            |
+| ------------- | -------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------  |
+| `choices`     | Required | `Object[]`                 | -       | List of choices                                                                                                                        |
+| `optionText`  | Optional | `string` &#124; `Function` | `name`  | Fieldname of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`) |
+| `optionValue` | Optional | `string`                   | `id`    | Fieldname of record containing the value to use as input value                                                                         |
+| `row`         | Optional | `boolean`                  | `true`  | Display group of elements in a compact row.                                                                                            |
+
+Refer to [Material UI Checkbox documentation](https://material-ui.com/api/checkbox/) for more details.
+
+`<CheckboxGroupInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### CSS API
+
+| Rule name  | Description                                                   |
+| ---------- | ------------------------------------------------------------- |
+| `root`     | Applied to the root element                                   |
+| `label`    | Applied to the underlying Material UI's `FormLabel` component |
+
+To override the style of all instances of `<CheckboxGroupInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaCheckboxGroupInput` key.
+
+#### Usage
+
+You can customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
+
+```jsx
+const choices = [
+    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
+    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
+];
+<CheckboxGroupInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+```
+
+`optionText` also accepts a function, so you can shape the option text at will:
+
+```jsx
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+<CheckboxGroupInput source="author_id" choices={choices} optionText={optionRenderer} />
+```
+
+`optionText` also accepts a React Element, that will be cloned and receive the related choice as the `record` prop. You can use Field components there.
+
+```jsx
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
+<CheckboxGroupInput source="gender" choices={choices} optionText={<FullNameField />}/>
+```
+
+The choices are translated by default, so you can use translation identifiers as choices:
+
+```jsx
+const choices = [
+    { id: 'programming', name: 'myroot.category.programming' },
+    { id: 'lifestyle', name: 'myroot.category.lifestyle' },
+    { id: 'photography', name: 'myroot.category.photography' },
+];
+```
+
+However, in some cases (e.g. inside a `<ReferenceInput>`), you may not want the choice to be translated. In that case, set the `translateChoice` prop to `false`.
+
+```jsx
+<CheckboxGroupInput source="gender" choices={choices} translateChoice={false}/>
+```
+
+Lastly, use the `options` attribute if you want to override any of Material UI's `<Checkbox>` attributes:
+
+{% raw %}
+```jsx
+import { FavoriteBorder, Favorite } from '@material-ui/icons';
+
+<CheckboxGroupInput source="category" options={{
+    icon: <FavoriteBorder />,
+    checkedIcon: <Favorite />
+}} />
+```
+{% endraw %}
+
+### `<DualListInput>`
+
+This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit array values, one-to-many or many-to-many relationships by moving items from one list to another. It's a good alternative to `<SelectInput>` for a small number of choices.
+
+![DualListInput](https://marmelab.com/ra-enterprise/modules/assets/ra-relationships-duallistinput.gif)
+
+```jsx
+import { ReferenceInput } from 'react-admin';
+import { DualListInput } from '@react-admin/ra-relationships';
+
+<ReferenceInput label="Author" source="author_id" reference="authors">
+    <DualListInput optionText="last_name" />
+</ReferenceInput>
+```
+
+Check [the `ra-relationships` documentation](https://marmelab.com/ra-enterprise/modules/ra-relationships) for more details.
+
+### `<SelectArrayInput>`
 
 To let users choose several values in a list using a dropdown, use `<SelectArrayInput>`. It renders using [Material ui's `<Select>`](https://material-ui.com/api/select). Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
-### CSS API
+#### CSS API
 
 | Rule name  | Description                                                                        |
 | ---------- | ---------------------------------------------------------------------------------- |
@@ -1614,54 +1378,300 @@ export const PostCreate = props => (
 
 `<SelectArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
-## `<TextInput>`
+## Reference Inputs 
 
-`<TextInput>` is the most common input. It is used for texts, emails, URL or passwords. In translates to an HTML `<input>` tag.
+### `<ReferenceArrayInput>`
 
-```jsx
-import { TextInput } from 'react-admin';
+Use `<ReferenceArrayInput>` to edit an array of reference values, i.e. to let users choose a list of values (usually foreign keys) from another REST endpoint.
 
-<TextInput source="title" />
+`<ReferenceArrayInput>` fetches the related resources (using `dataProvider.getMany()`) as well as possible resources (using `dataProvider.getList()`) in the reference endpoint.
+
+For instance, if the post object has many tags, a post resource may look like:
+
+```json
+{
+    "id": 1234,
+    "tag_ids": [1, 23, 4]
+}
 ```
 
-![TextInput](./img/text-input.png)
+Then `<ReferenceArrayInput>` would fetch a list of tag resources from these two calls:
 
-### Properties
-
-| Prop         | Required | Type      | Default | Description                                                          |
-| ------------ | -------- | --------- | ------- | -------------------------------------------------------------------- |
-| `resettable` | Optional | `boolean` | `false` | If `true`, display a button to reset the changes in this input value |
-| `type`       | Optional | `string`  | `text`  | Type attribute passed to the `<input>` element                       |
-
-`<TextInput>` also accepts the [common input props](./Inputs.md#common-input-props).
-
-### Usage
-
-You can choose a specific input type using the `type` attribute, for instance `text` (the default), `email`, `url`, or `password`:
-
-```jsx
-<TextInput label="Email Address" source="email" type="email" />
+```
+http://myapi.com/tags?id=[1,23,4]
+http://myapi.com/tags?page=1&perPage=25
 ```
 
-You can make the `TextInput` expandable using the `multiline` prop for multiline text values. It renders as an auto expandable textarea.
+Once it receives the deduplicated reference resources, this component delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
+
+This means you can use `<ReferenceArrayInput>` with [`<SelectArrayInput>`](#selectarrayinput), or with the component of your choice, provided it supports the `choices` attribute.
+
+The component expects a `source` and a `reference` attributes. For instance, to make the `tag_ids` for a `post` editable:
 
 ```jsx
-<TextInput multiline source="body" />
+import { ReferenceArrayInput, SelectArrayInput } from 'react-admin';
+
+<ReferenceArrayInput source="tag_ids" reference="tags">
+    <SelectArrayInput optionText="name" />
+</ReferenceArrayInput>
 ```
 
-You can make the `TextInput` component resettable using the `resettable` prop. This will add a reset button which will be displayed only when the field has a value and is focused.
+![SelectArrayInput](./img/select-array-input.gif)
+
+**Note**: You **must** add a `<Resource>` for the reference resource - react-admin needs it to fetch the reference data. You can omit the list prop in this reference if you want to hide it in the sidebar menu.
 
 ```jsx
-import { TextInput } from 'react-admin';
-
-<TextInput source="title" resettable />
+<Admin dataProvider={myDataProvider}>
+    <Resource name="posts" list={PostList} edit={PostEdit} />
+    <Resource name="tags" />
+</Admin>
 ```
 
-![resettable TextInput](./img/resettable-text-input.png)
+Set the `allowEmpty` prop when you want to add an empty choice with a value of `null` in the choices list.
+Disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.md#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
 
-**Warning**: Do not use `type="number"`, or you'll receive a string as value (this is a [known React bug](https://github.com/facebook/react/issues/1425)). Instead, use [`<NumberInput>`](#numberinput).
+```jsx
+import { ReferenceArrayInput, SelectArrayInput } from 'react-admin';
 
-## Transforming Input Value to/from Record
+<ReferenceArrayInput source="tag_ids" reference="tags" allowEmpty>
+    <SelectArrayInput optionText="name" />
+</ReferenceArrayInput>
+```
+
+**Tip**: `allowEmpty` is set by default for all Input components children of the `<Filter>` component
+
+You can tweak how this component fetches the possible values using the `perPage`, `sort`, and `filter` props.
+
+{% raw %}
+```jsx
+// by default, fetches only the first 25 values. You can extend this limit
+// by setting the `perPage` prop.
+<ReferenceArrayInput
+     source="tag_ids"
+     reference="tags"
+     perPage={100}>
+    <SelectArrayInput optionText="name" />
+</ReferenceArrayInput>
+
+// by default, orders the possible values by id desc. You can change this order
+// by setting the `sort` prop (an object with `field` and `order` properties).
+<ReferenceArrayInput
+     source="tag_ids"
+     reference="tags"
+     sort={{ field: 'title', order: 'ASC' }}>
+    <SelectArrayInput optionText="name" />
+</ReferenceArrayInput>
+
+// you can filter the query used to populate the possible values. Use the
+// `filter` prop for that.
+<ReferenceArrayInput
+     source="tag_ids"
+     reference="tags"
+     filter={{ is_published: true }}>
+    <SelectArrayInput optionText="name" />
+</ReferenceArrayInput>
+```
+{% endraw %}
+
+`<ReferenceArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+### `<ReferenceInput>`
+
+Use `<ReferenceInput>` for foreign-key values, for instance, to edit the `post_id` of a `comment` resource. This component fetches the related record (using `dataProvider.getMany()`) as well as possible choices (using `dataProvider.getList()` in the reference resource), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
+
+This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selectinput), [`<AutocompleteInput>`](#autocompleteinput), or [`<RadioButtonGroupInput>`](#radiobuttongroupinput), or even with the component of your choice, provided it supports the `choices` attribute.
+
+The component expects a `source` and a `reference` attributes. For instance, to make the `post_id` for a `comment` editable:
+
+```jsx
+import { ReferenceInput, SelectInput } from 'react-admin';
+
+<ReferenceInput label="Post" source="post_id" reference="posts">
+    <SelectInput optionText="title" />
+</ReferenceInput>
+```
+
+![ReferenceInput](./img/reference-input.gif)
+
+**Note**: You **must** add a `<Resource>` for the reference resource - react-admin needs it to fetch the reference data. You *can* omit the `list` prop in this reference if you want to hide it in the sidebar menu.
+
+```jsx
+<Admin dataProvider={myDataProvider}>
+    <Resource name="comments" list={CommentList} />
+    <Resource name="posts" />
+</Admin>
+```
+
+#### Properties
+
+| Prop            | Required | Type                                        | Default                               | Description                                                                                                           |
+| --------------- | -------- | ------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `allowEmpty`    | Optional | `boolean`                                   | `false`                               | If true, add an empty item to the list of choices to allow for empty value                                            |
+| `filter`        | Optional | `Object`                                    | `{}`                                  | Permanent filters to use for getting the suggestion list                                                              |
+| `filterToQuery` | Optional | `string` => `Object`                        | `searchText => ({ q: [searchText] })` | How to transform the searchText (passed e.g. by an `<AutocompleteArrayInput>`) into a parameter for the data provider |
+| `perPage`       | Optional | `number`                                    | 25                                    | Number of suggestions to show                                                                                         |
+| `reference`     | Required | `string`                                    | ''                                    | Name of the reference resource, e.g. 'posts'.                                                                         |
+| `sort`          | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }`      | How to order the list of suggestions                                                                                  |
+
+`<ReferenceInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+
+#### Usage
+
+Set the `allowEmpty` prop when you want to add an empty choice with a value of `null` in the choices list.
+Disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.md#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
+
+```jsx
+import { ReferenceInput, SelectInput } from 'react-admin';
+
+<ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
+    <SelectInput optionText="title" />
+</ReferenceInput>
+```
+
+**Tip**: `allowEmpty` is set by default for all Input components children of the `<Filter>` component:
+
+```jsx
+const CommentFilter = (props) => (
+    <Filter {...props}>
+        <ReferenceInput label="Post" source="post_id" reference="posts"> // no need for allowEmpty
+            <SelectInput optionText="title" />
+        </ReferenceInput>
+    </Filter>
+);
+```
+
+You can tweak how this component fetches the possible values using the `perPage`, `sort`, and `filter` props.
+
+{% raw %}
+```jsx
+// by default, fetches only the first 25 values. You can extend this limit
+// by setting the `perPage` prop.
+<ReferenceInput
+     source="post_id"
+     reference="posts"
+     perPage={100}>
+    <SelectInput optionText="title" />
+</ReferenceInput>
+
+// by default, orders the possible values by id desc. You can change this order
+// by setting the `sort` prop (an object with `field` and `order` properties).
+<ReferenceInput
+     source="post_id"
+     reference="posts"
+     sort={{ field: 'title', order: 'ASC' }}>
+    <SelectInput optionText="title" />
+</ReferenceInput>
+
+// you can filter the query used to populate the possible values. Use the
+// `filter` prop for that.
+<ReferenceInput
+     source="post_id"
+     reference="posts"
+     filter={{ is_published: true }}>
+    <SelectInput optionText="title" />
+</ReferenceInput>
+```
+{% endraw %}
+
+The child component may further filter results (that's the case, for instance, for `<AutocompleteInput>`). ReferenceInput passes a `setFilter` function as prop to its child component. It uses the value to create a filter for the query - by default `{ q: [searchText] }`. You can customize the mapping
+`searchText => searchQuery` by setting a custom `filterToQuery` function prop:
+
+```jsx
+<ReferenceInput
+     source="post_id"
+     reference="posts"
+     filterToQuery={searchText => ({ title: searchText })}>
+    <AutocompleteInput optionText="title" />
+</ReferenceInput>
+```
+
+The child component receives the following props from `<ReferenceInput>`:
+
+- `loading`: whether the request for possible values is loading or not
+- `filter`: the current filter of the request for possible values. Defaults to `{}`.
+- `pagination`: the current pagination of the request for possible values. Defaults to `{ page: 1, perPage: 25 }`.
+- `sort`: the current sorting of the request for possible values. Defaults to `{ field: 'id', order: 'DESC' }`.
+- `error`: the error message if the form validation failed for that input
+- `warning`: the warning message if the form validation failed for that input
+- `onChange`: function to call when the value changes
+- `setFilter`: function to call to update the filter of the request for possible values
+- `setPagination`: : function to call to update the pagination of the request for possible values
+- `setSort`: function to call to update the sorting of the request for possible values
+
+**Tip**: Why does `<ReferenceInput>` use the `dataProvider.getMany()` method with a single value `[id]` instead of `dataProvider.getOne()` to fetch the record for the current value? Because when there are many `<ReferenceInput>` for the same resource in a form (for instance when inside an `<ArrayInput>`), react-admin *aggregates* the calls to `dataProvider.getMany()` into a single one with `[id1, id2, ...)]`. This speeds up the UI and avoids hitting the API too much.
+
+### `<ReferenceManyToManyInput>`
+
+This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to create, edit or remove relationships between two resources sharing an associative table. The changes in the associative table are sent to the dataProvider when the user submits the form, so that they can cancel the changes before submission.
+
+In this example, `artists.id` matches `performances.artist_id`, and `performances.event_id` matches `events.id`:
+
+```
+┌────────────┐       ┌──────────────┐      ┌────────┐
+│ artists    │       │ performances │      │ events │
+│------------│       │--------------│      │--------│
+│ id         │───┐   │ id           │      │ id     │
+│ first_name │   └──╼│ artist_id    │   ┌──│ name   │
+│ last_name  │       │ event_id     │╾──┘  │        │
+└────────────┘       └──────────────┘      └────────┘
+```
+
+The form displays the events name in a `<SelectArrayInput>`:
+
+```jsx
+import * as React from 'react';
+import { Edit, SelectArrayInput, SimpleForm, TextInput } from 'react-admin';
+import { ReferenceManyToManyInput, useReferenceManyToManyUpdate } from '@react-admin/ra-many-to-many';
+
+/**
+ * Decorate <SimpleForm> to override the default save function.
+ * This is necessary to save changes in the associative table
+ * only on submission.
+ */
+const ArtistEditForm = props => {
+    const save = useReferenceManyToManyUpdate({
+        basePath: props.basePath,
+        record: props.record,
+        redirect: props.redirect || 'list',
+        reference: 'events',
+        resource: props.resource,
+        source: 'id',
+        through: 'performances',
+        undoable: props.undoable,
+        using: 'artist_id,event_id',
+    });
+
+    return <SimpleForm {...props} save={save} />;
+};
+
+const ArtistEdit = props => (
+    <Edit {...props}>
+        <ArtistEditForm>
+            <TextInput disabled source="id" />
+            <TextInput source="first_name" />
+            <TextInput source="last_name" />
+            <ReferenceManyToManyInput
+                source="id"
+                reference="events"
+                through="performances"
+                using="artist_id,event_id"
+                fullWidth
+                label="Performances"
+            >
+                <SelectArrayInput optionText="name" />
+            </ReferenceManyToManyInput>
+        </ArtistEditForm>
+    </Edit>
+);
+
+export default ArtistEdit;
+```
+
+Check [the `ra-relationships` documentation](https://marmelab.com/ra-enterprise/modules/ra-relationships#referencemanytomanyinput) for more details.
+
+## Recipes 
+
+### Transforming Input Value to/from Record
 
 The data format returned by the input component may not be what your API desires. Since React-admin uses react-final-form, we can use its [`parse`](https://final-form.org/docs/react-final-form/types/FieldProps#parse) and [`format`](https://final-form.org/docs/react-final-form/types/FieldProps#format) functions to transform the input value when saving to and loading from the record.
 
@@ -1701,237 +1711,7 @@ const dateParser = v => {
 <DateInput source="isodate" format={dateFormatter} parse={dateParser} />
 ```
 
-## Third-Party Components
-
-You can find components for react-admin in third-party repositories.
-
-- [vascofg/react-admin-color-input](https://github.com/vascofg/react-admin-color-input): a color input using [React Color](https://casesandberg.github.io/react-color/), a collection of color pickers.
-- [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs): a collection of Date Inputs, based on [material-ui-pickers](https://material-ui-pickers.firebaseapp.com/)
-
-- **DEPRECATED V3** [LoicMahieu/aor-tinymce-input](https://github.com/LoicMahieu/aor-tinymce-input): a TinyMCE component, useful for editing HTML
-
-## Writing Your Own Input Component
-
-If you need a more specific input type, you can write it directly in React. You'll have to rely on react-final-form's [`<Field>`](https://final-form.org/docs/react-final-form/api/Field) component, or its [`useField`](https://final-form.org/docs/react-final-form/api/useField) hook, to handle the value update cycle.
-
-For instance, let's write a component to edit the latitude and longitude of the current record:
-
-```jsx
-// in LatLongInput.js
-import { Field } from 'react-final-form';
-const LatLngInput = () => (
-    <span>
-        <Field name="lat" component="input" type="number" placeholder="latitude" />
-        &nbsp;
-        <Field name="lng" component="input" type="number" placeholder="longitude" />
-    </span>
-);
-export default LatLngInput;
-
-// in ItemEdit.js
-const ItemEdit = (props) => (
-    <Edit {...props}>
-        <SimpleForm>
-            <LatLngInput />
-        </SimpleForm>
-    </Edit>
-);
-```
-
-`LatLngInput` takes no props, because the `<Field>` component can access the current record via the form context. The `name` prop serves as a selector for the record property to edit. All the props passed to `Field` except `name` and `component` are passed to the child component (an `<input>` in that example). Executing this component will render roughly the following code:
-
-```html
-<span>
-    <input type="number" placeholder="latitude" value={record.lat} />
-    <input type="number" placeholder="longitude" value={record.lng} />
-</span>
-```
-
-**Tip**: React-final-form's `<Field>` component supports dot notation in the `name` prop, to allow binding to nested values:
-
-```jsx
-const LatLongInput = () => (
-    <span>
-        <Field name="position.lat" component="input" type="number" placeholder="latitude" />
-        &nbsp;
-        <Field name="position.lng" component="input" type="number" placeholder="longitude" />
-    </span>
-);
-```
-
-This component lacks a label. React-admin provides the `<Labeled>` component for that:
-
-```jsx
-// in LatLongInput.js
-import { Field } from 'react-final-form';
-import { Labeled } from 'react-admin';
-
-const LatLngInput = () => (
-    <Labeled label="position">
-        <span>
-            <Field name="lat" component="input" type="number" placeholder="latitude" />
-            &nbsp;
-            <Field name="lng" component="input" type="number" placeholder="longitude" />
-        </span>
-    </Labeled>
-);
-export default LatLngInput;
-```
-
-Now the component will render with a label:
-
-```html
-<label>Position</label>
-<span>
-    <input type="number" placeholder="longitude" value={record.lat} />
-    <input type="number" placeholder="longitude" value={record.lng} />
-</span>
-```
-
-Instead of HTML `input` elements, you can use a material-ui component like `TextField`. To bind material-ui components to the form values, use the `useField()` hook:
-
-```jsx
-// in LatLongInput.js
-import TextField from '@material-ui/core/TextField';
-import { useField } from 'react-final-form';
-
-const BoundedTextField = ({ name, label }) => {
-    const {
-        input: { onChange },
-        meta: { touched, error }
-    } = useField(name);
-    return (
-        <TextField
-            name={name}
-            label={label}
-            onChange={onChange}
-            error={!!(touched && error)}
-            helperText={touched && error}
-        />
-    );
-};
-const LatLngInput = () => (
-    <span>
-        <BoundedTextField name="lat" label="latitude" />
-        &nbsp;
-        <BoundedTextField name="lng" label="longitude" />
-    </span>
-);
-```
-
-**Tip**: Material-ui's `<TextField>` component already includes a label, so you don't need to use `<Labeled>` in this case.
-
-`useField()` returns two values: `input` and `meta`. To learn more about these props, please refer to the [`useField`](https://final-form.org/docs/react-final-form/api/useField) hook documentation in the react-final-form website.
-
-Instead of HTML `input` elements or material-ui components, you can use react-admin input components, like `<NumberInput>` for instance. React-admin components already use `useField()`, and already include a label, so you don't need either `useField()` or `<Labeled>` when using them:
-
-```jsx
-// in LatLongInput.js
-import { NumberInput } from 'react-admin';
-const LatLngInput = () => (
-    <span>
-        <NumberInput source="lat" label="latitude" />
-        &nbsp;
-        <NumberInput source="lng" label="longitude" />
-    </span>
-);
-export default LatLngInput;
-```
-
-## `useInput()` Hook
-
-React-admin adds functionality to react-final-form:
-
-- handling of custom event emitters like `onChange`,
-- support for an array of validators,
-- detection of required fields to add an asterisk to the field label.
-
-So internally, react-admin components use another hook, which wraps react-final-form's `useField()` hook. It's called `useInput()` ; use it instead of `useField()` to create form inputs that have the exact same API as react-admin Input components:
-
-```jsx
-// in LatLongInput.js
-import TextField from '@material-ui/core/TextField';
-import { useInput, required } from 'react-admin';
-
-const BoundedTextField = props => {
-    const {
-        input: { name, onChange, ...rest },
-        meta: { touched, error },
-        isRequired
-    } = useInput(props);
-
-    return (
-        <TextField
-            name={name}
-            label={props.label}
-            onChange={onChange}
-            error={!!(touched && error)}
-            helperText={touched && error}
-            required={isRequired}
-            {...rest}
-        />
-    );
-};
-const LatLngInput = props => {
-    const {source, ...rest} = props;
-
-    return (
-        <span>
-            <BoundedTextField source="lat" label="Latitude" validate={required()} {...rest} />
-            &nbsp;
-            <BoundedTextField source="lng" label="Longitude" validate={required()} {...rest} />
-        </span>
-    );
-};
-```
-
-Here is another example, this time using a material-ui `Select` component:
-
-```jsx
-// in SexInput.js
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
-import { useInput } from 'react-admin';
-
-const SexInput = props => {
-    const {
-        input,
-        meta: { touched, error }
-    } = useInput(props);
-
-    return (
-        <Select
-            label="Sex"
-            {...input}
-        >
-            <MenuItem value="M">Male</MenuItem>
-            <MenuItem value="F">Female</MenuItem>
-        </Select>
-    );
-};
-export default SexInput;
-```
-
-**Tip**: `useInput` accepts all arguments that you can pass to `useField`. That means that components using `useInput` accept props like [`format`](https://final-form.org/docs/react-final-form/types/FieldProps#format) and [`parse`](https://final-form.org/docs/react-final-form/types/FieldProps#parse), to convert values from the form to the input, and vice-versa:
-
-```jsx
-const parse = value => {/* ... */};
-const format = value => {/* ... */};
-
-const PersonEdit = props => (
-    <Edit {...props}>
-        <SimpleForm>
-            <SexInput
-                source="sex"
-                format={formValue => formValue === 0 ? 'M' : 'F'}
-                parse={inputValue => inputValue === 'M' ? 0 : 1}
-            />
-        </SimpleForm>
-    </Edit>
-);
-```
-
-## Linking Two Inputs
+### Linking Two Inputs
 
 Edition forms often contain linked inputs, e.g. country and city (the choices of the latter depending on the value of the former).
 
@@ -2039,7 +1819,7 @@ const PostEdit = (props) => (
 );
 ```
 
-## Hiding Inputs Based On Other Inputs
+### Hiding Inputs Based On Other Inputs
 
 You may want to display or hide inputs base on the value of another input - for instance, show an `email` input only if the `hasEmail` boolean input has been ticked to `true`.
 
@@ -2082,3 +1862,239 @@ import { FormDataConsumer } from 'react-admin';
  );
 ```
 {% endraw %}
+
+## Writing Your Own Input Component
+
+If you need a more specific input type, you can write it directly in React. You'll have to rely on react-final-form's [`<Field>`](https://final-form.org/docs/react-final-form/api/Field) component, or its [`useField`](https://final-form.org/docs/react-final-form/api/useField) hook, to handle the value update cycle.
+
+### Using `<Field>`
+
+For instance, let's write a component to edit the latitude and longitude of the current record:
+
+```jsx
+// in LatLongInput.js
+import { Field } from 'react-final-form';
+const LatLngInput = () => (
+    <span>
+        <Field name="lat" component="input" type="number" placeholder="latitude" />
+        &nbsp;
+        <Field name="lng" component="input" type="number" placeholder="longitude" />
+    </span>
+);
+export default LatLngInput;
+
+// in ItemEdit.js
+const ItemEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm>
+            <LatLngInput />
+        </SimpleForm>
+    </Edit>
+);
+```
+
+`LatLngInput` takes no props, because the `<Field>` component can access the current record via the form context. The `name` prop serves as a selector for the record property to edit. All the props passed to `Field` except `name` and `component` are passed to the child component (an `<input>` in that example). Executing this component will render roughly the following code:
+
+```html
+<span>
+    <input type="number" placeholder="latitude" value={record.lat} />
+    <input type="number" placeholder="longitude" value={record.lng} />
+</span>
+```
+
+**Tip**: React-final-form's `<Field>` component supports dot notation in the `name` prop, to allow binding to nested values:
+
+```jsx
+const LatLongInput = () => (
+    <span>
+        <Field name="position.lat" component="input" type="number" placeholder="latitude" />
+        &nbsp;
+        <Field name="position.lng" component="input" type="number" placeholder="longitude" />
+    </span>
+);
+```
+
+### Using `<Labeled>`
+
+This component lacks a label. React-admin provides the `<Labeled>` component for that:
+
+```jsx
+// in LatLongInput.js
+import { Field } from 'react-final-form';
+import { Labeled } from 'react-admin';
+
+const LatLngInput = () => (
+    <Labeled label="position">
+        <span>
+            <Field name="lat" component="input" type="number" placeholder="latitude" />
+            &nbsp;
+            <Field name="lng" component="input" type="number" placeholder="longitude" />
+        </span>
+    </Labeled>
+);
+export default LatLngInput;
+```
+
+Now the component will render with a label:
+
+```html
+<label>Position</label>
+<span>
+    <input type="number" placeholder="longitude" value={record.lat} />
+    <input type="number" placeholder="longitude" value={record.lng} />
+</span>
+```
+
+### Using Material-ui Field Components
+
+Instead of HTML `input` elements, you can use a material-ui component like `TextField`. To bind material-ui components to the form values, use the `useField()` hook:
+
+```jsx
+// in LatLongInput.js
+import TextField from '@material-ui/core/TextField';
+import { useField } from 'react-final-form';
+
+const BoundedTextField = ({ name, label }) => {
+    const {
+        input: { onChange },
+        meta: { touched, error }
+    } = useField(name);
+    return (
+        <TextField
+            name={name}
+            label={label}
+            onChange={onChange}
+            error={!!(touched && error)}
+            helperText={touched && error}
+        />
+    );
+};
+const LatLngInput = () => (
+    <span>
+        <BoundedTextField name="lat" label="latitude" />
+        &nbsp;
+        <BoundedTextField name="lng" label="longitude" />
+    </span>
+);
+```
+
+**Tip**: Material-ui's `<TextField>` component already includes a label, so you don't need to use `<Labeled>` in this case.
+
+`useField()` returns two values: `input` and `meta`. To learn more about these props, please refer to the [`useField`](https://final-form.org/docs/react-final-form/api/useField) hook documentation in the react-final-form website.
+
+Instead of HTML `input` elements or material-ui components, you can use react-admin input components, like `<NumberInput>` for instance. React-admin components already use `useField()`, and already include a label, so you don't need either `useField()` or `<Labeled>` when using them:
+
+```jsx
+// in LatLongInput.js
+import { NumberInput } from 'react-admin';
+const LatLngInput = () => (
+    <span>
+        <NumberInput source="lat" label="latitude" />
+        &nbsp;
+        <NumberInput source="lng" label="longitude" />
+    </span>
+);
+export default LatLngInput;
+```
+
+### The `useInput()` Hook
+
+React-admin adds functionality to react-final-form:
+
+- handling of custom event emitters like `onChange`,
+- support for an array of validators,
+- detection of required fields to add an asterisk to the field label.
+
+So internally, react-admin components use another hook, which wraps react-final-form's `useField()` hook. It's called `useInput()` ; use it instead of `useField()` to create form inputs that have the exact same API as react-admin Input components:
+
+```jsx
+// in LatLongInput.js
+import TextField from '@material-ui/core/TextField';
+import { useInput, required } from 'react-admin';
+
+const BoundedTextField = props => {
+    const {
+        input: { name, onChange, ...rest },
+        meta: { touched, error },
+        isRequired
+    } = useInput(props);
+
+    return (
+        <TextField
+            name={name}
+            label={props.label}
+            onChange={onChange}
+            error={!!(touched && error)}
+            helperText={touched && error}
+            required={isRequired}
+            {...rest}
+        />
+    );
+};
+const LatLngInput = props => {
+    const {source, ...rest} = props;
+
+    return (
+        <span>
+            <BoundedTextField source="lat" label="Latitude" validate={required()} {...rest} />
+            &nbsp;
+            <BoundedTextField source="lng" label="Longitude" validate={required()} {...rest} />
+        </span>
+    );
+};
+```
+
+Here is another example, this time using a material-ui `Select` component:
+
+```jsx
+// in SexInput.js
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import { useInput } from 'react-admin';
+
+const SexInput = props => {
+    const {
+        input,
+        meta: { touched, error }
+    } = useInput(props);
+
+    return (
+        <Select
+            label="Sex"
+            {...input}
+        >
+            <MenuItem value="M">Male</MenuItem>
+            <MenuItem value="F">Female</MenuItem>
+        </Select>
+    );
+};
+export default SexInput;
+```
+
+**Tip**: `useInput` accepts all arguments that you can pass to `useField`. That means that components using `useInput` accept props like [`format`](https://final-form.org/docs/react-final-form/types/FieldProps#format) and [`parse`](https://final-form.org/docs/react-final-form/types/FieldProps#parse), to convert values from the form to the input, and vice-versa:
+
+```jsx
+const parse = value => {/* ... */};
+const format = value => {/* ... */};
+
+const PersonEdit = props => (
+    <Edit {...props}>
+        <SimpleForm>
+            <SexInput
+                source="sex"
+                format={formValue => formValue === 0 ? 'M' : 'F'}
+                parse={inputValue => inputValue === 'M' ? 0 : 1}
+            />
+        </SimpleForm>
+    </Edit>
+);
+```
+
+## Third-Party Components
+
+You can find components for react-admin in third-party repositories.
+
+- [vascofg/react-admin-color-input](https://github.com/vascofg/react-admin-color-input): a color input using [React Color](https://casesandberg.github.io/react-color/), a collection of color pickers.
+- [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs): a collection of Date Inputs, based on [material-ui-pickers](https://material-ui-pickers.firebaseapp.com/)
+
+- **DEPRECATED V3** [LoicMahieu/aor-tinymce-input](https://github.com/LoicMahieu/aor-tinymce-input): a TinyMCE component, useful for editing HTML

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,132 +1,210 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en-US">
+    <head>
+        <title>React-admin - {{ page.title }}</title>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+        <meta name="description" content="{{ page.description }}" />
+        <meta name="HandheldFriendly" content="true" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+        <link
+            rel="stylesheet"
+            href="{{ '/css/materialize.min.css' | relative_url }}"
+        />
+        <link
+            rel="stylesheet"
+            href="{{ '/css/style-v7.css' | relative_url }}"
+        />
+        <link rel="stylesheet" href="{{ '/css/syntax.css' | relative_url }}" />
+        <link rel="stylesheet" href="{{ '/css/prism.css' | relative_url }}" />
+        <link rel="stylesheet" href="{{ '/css/tocbot.css' | relative_url }}" />
+        <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/icon?family=Material+Icons"
+        />
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+        />
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css"
+        />
+    </head>
 
-<head>
-    <title>React-admin - {{ page.title }}</title>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-    <meta name="description" content="{{ page.description }}">
-    <meta name="HandheldFriendly" content="true" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <link rel="stylesheet" href="{{ '/css/materialize.min.css' | relative_url }}">
-    <link rel="stylesheet" href="{{ '/css/style-v6.css' | relative_url }}">
-    <link rel="stylesheet" href="{{ '/css/syntax.css' | relative_url }}">
-    <link rel="stylesheet" href="{{ '/css/prism.css' | relative_url }}">
-    <link rel="stylesheet" href="{{ '/css/tocbot.css' | relative_url }}">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css">
-</head>
-
-<body>
-
-    <header>
-        <nav>
-            <a href="#" data-target="slide-out" class="sidenav-trigger"><i class="material-icons">menu</i></a>
-            <div class="nav-wrapper" style="background: linear-gradient(145deg,#027be3 11%,#1a237e 75%)">
-                <div class="left">
-                    <form action="#" onsubmit="return false;">
-                        <div class="input-field" style="position:absolute">
-                            <input type="search" name="q" id="query" size="31" maxlength="255" value=""
-                                style="vertical-align:inherit!important" />
-                            <label class="label-icon" for="test"><i class="material-icons">search</i></label>
-                            <i class="material-icons">close</i>
-                        </div>
-                        <span id="search"></span>
-                    </form>
+    <body>
+        <header>
+            <nav>
+                <a href="#" data-target="slide-out" class="sidenav-trigger"
+                    ><i class="material-icons">menu</i></a
+                >
+                <div
+                    class="nav-wrapper"
+                    style="
+                        background: linear-gradient(
+                            145deg,
+                            #027be3 11%,
+                            #1a237e 75%
+                        );
+                    "
+                >
+                    <div class="left">
+                        <form action="#" onsubmit="return false;">
+                            <div class="input-field" style="position: absolute">
+                                <input
+                                    type="search"
+                                    name="q"
+                                    id="query"
+                                    size="31"
+                                    maxlength="255"
+                                    value=""
+                                    style="vertical-align: inherit !important"
+                                />
+                                <label class="label-icon" for="test"
+                                    ><i class="material-icons">search</i></label
+                                >
+                                <i class="material-icons">close</i>
+                            </div>
+                            <span id="search"></span>
+                        </form>
+                    </div>
+                    <ul id="nav-mobile" class="right hide-on-med-and-down">
+                        <li class="active">
+                            <a
+                                href="https://marmelab.com/react-admin/Readme.html"
+                                >Documentation</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://marmelab.com/react-admin-demo"
+                                >Demo</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://marmelab.com/en/blog/#react-admin"
+                                >Blog</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://marmelab.com/ra-enterprise/"
+                                style="color: #f0c070"
+                                >Enterprise Edition</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://github.com/marmelab/react-admin">
+                                <svg
+                                    viewBox="0 0 256 250"
+                                    preserveAspectRatio="xMidYMid"
+                                    style="
+                                        height: 20px;
+                                        vertical-align: middle;
+                                        margin-right: 5px;
+                                        fill: #ffffff;
+                                    "
+                                >
+                                    <path
+                                        d="M128.001 0C57.317 0 0 57.307 0 128.001c0 56.554 36.676 104.535 87.535 121.46 6.397 1.185 8.746-2.777 8.746-6.158 0-3.052-.12-13.135-.174-23.83-35.61 7.742-43.124-15.103-43.124-15.103-5.823-14.795-14.213-18.73-14.213-18.73-11.613-7.944.876-7.78.876-7.78 12.853.902 19.621 13.19 19.621 13.19 11.417 19.568 29.945 13.911 37.249 10.64 1.149-8.272 4.466-13.92 8.127-17.116-28.431-3.236-58.318-14.212-58.318-63.258 0-13.975 5-25.394 13.188-34.358-1.329-3.224-5.71-16.242 1.24-33.874 0 0 10.749-3.44 35.21 13.121 10.21-2.836 21.16-4.258 32.038-4.307 10.878.049 21.837 1.47 32.066 4.307 24.431-16.56 35.165-13.12 35.165-13.12 6.967 17.63 2.584 30.65 1.255 33.873 8.207 8.964 13.173 20.383 13.173 34.358 0 49.163-29.944 59.988-58.447 63.157 4.591 3.972 8.682 11.762 8.682 23.704 0 17.126-.148 30.91-.148 35.126 0 3.407 2.304 7.398 8.792 6.14C219.37 232.5 256 184.537 256 128.002 256 57.307 198.691 0 128.001 0zm-80.06 182.34c-.282.636-1.283.827-2.194.39-.929-.417-1.45-1.284-1.15-1.922.276-.655 1.279-.838 2.205-.399.93.418 1.46 1.293 1.139 1.931zm6.296 5.618c-.61.566-1.804.303-2.614-.591-.837-.892-.994-2.086-.375-2.66.63-.566 1.787-.301 2.626.591.838.903 1 2.088.363 2.66zm4.32 7.188c-.785.545-2.067.034-2.86-1.104-.784-1.138-.784-2.503.017-3.05.795-.547 2.058-.055 2.861 1.075.782 1.157.782 2.522-.019 3.08zm7.304 8.325c-.701.774-2.196.566-3.29-.49-1.119-1.032-1.43-2.496-.726-3.27.71-.776 2.213-.558 3.315.49 1.11 1.03 1.45 2.505.701 3.27zm9.442 2.81c-.31 1.003-1.75 1.459-3.199 1.033-1.448-.439-2.395-1.613-2.103-2.626.301-1.01 1.747-1.484 3.207-1.028 1.446.436 2.396 1.602 2.095 2.622zm10.744 1.193c.036 1.055-1.193 1.93-2.715 1.95-1.53.034-2.769-.82-2.786-1.86 0-1.065 1.202-1.932 2.733-1.958 1.522-.03 2.768.818 2.768 1.868zm10.555-.405c.182 1.03-.875 2.088-2.387 2.37-1.485.271-2.861-.365-3.05-1.386-.184-1.056.893-2.114 2.376-2.387 1.514-.263 2.868.356 3.061 1.403z"
+                                    ></path>
+                                </svg>
+                                GitHub
+                            </a>
+                        </li>
+                    </ul>
                 </div>
-                <ul id="nav-mobile" class="right hide-on-med-and-down">
-                    <li class="active"><a href="https://marmelab.com/react-admin/Readme.html">Documentation</a></li>
-                    <li><a href="https://marmelab.com/react-admin-demo">Demo</a></li>
-                    <li><a href="https://marmelab.com/en/blog/#react-admin">Blog</a></li>
-                    <li><a href="https://marmelab.com/ra-enterprise/" style="color: #f0c070">Enterprise Edition</a></li>
-                    <li><a href="https://github.com/marmelab/react-admin">
-                        <svg viewBox="0 0 256 250" preserveAspectRatio="xMidYMid" style="height: 20px;vertical-align: middle;margin-right: 5px;fill:#ffffff">
-                            <path d="M128.001 0C57.317 0 0 57.307 0 128.001c0 56.554 36.676 104.535 87.535 121.46 6.397 1.185 8.746-2.777 8.746-6.158 0-3.052-.12-13.135-.174-23.83-35.61 7.742-43.124-15.103-43.124-15.103-5.823-14.795-14.213-18.73-14.213-18.73-11.613-7.944.876-7.78.876-7.78 12.853.902 19.621 13.19 19.621 13.19 11.417 19.568 29.945 13.911 37.249 10.64 1.149-8.272 4.466-13.92 8.127-17.116-28.431-3.236-58.318-14.212-58.318-63.258 0-13.975 5-25.394 13.188-34.358-1.329-3.224-5.71-16.242 1.24-33.874 0 0 10.749-3.44 35.21 13.121 10.21-2.836 21.16-4.258 32.038-4.307 10.878.049 21.837 1.47 32.066 4.307 24.431-16.56 35.165-13.12 35.165-13.12 6.967 17.63 2.584 30.65 1.255 33.873 8.207 8.964 13.173 20.383 13.173 34.358 0 49.163-29.944 59.988-58.447 63.157 4.591 3.972 8.682 11.762 8.682 23.704 0 17.126-.148 30.91-.148 35.126 0 3.407 2.304 7.398 8.792 6.14C219.37 232.5 256 184.537 256 128.002 256 57.307 198.691 0 128.001 0zm-80.06 182.34c-.282.636-1.283.827-2.194.39-.929-.417-1.45-1.284-1.15-1.922.276-.655 1.279-.838 2.205-.399.93.418 1.46 1.293 1.139 1.931zm6.296 5.618c-.61.566-1.804.303-2.614-.591-.837-.892-.994-2.086-.375-2.66.63-.566 1.787-.301 2.626.591.838.903 1 2.088.363 2.66zm4.32 7.188c-.785.545-2.067.034-2.86-1.104-.784-1.138-.784-2.503.017-3.05.795-.547 2.058-.055 2.861 1.075.782 1.157.782 2.522-.019 3.08zm7.304 8.325c-.701.774-2.196.566-3.29-.49-1.119-1.032-1.43-2.496-.726-3.27.71-.776 2.213-.558 3.315.49 1.11 1.03 1.45 2.505.701 3.27zm9.442 2.81c-.31 1.003-1.75 1.459-3.199 1.033-1.448-.439-2.395-1.613-2.103-2.626.301-1.01 1.747-1.484 3.207-1.028 1.446.436 2.396 1.602 2.095 2.622zm10.744 1.193c.036 1.055-1.193 1.93-2.715 1.95-1.53.034-2.769-.82-2.786-1.86 0-1.065 1.202-1.932 2.733-1.958 1.522-.03 2.768.818 2.768 1.868zm10.555-.405c.182 1.03-.875 2.088-2.387 2.37-1.485.271-2.861-.365-3.05-1.386-.184-1.056.893-2.114 2.376-2.387 1.514-.263 2.868.356 3.061 1.403z"></path>
-                        </svg>
-                        GitHub
-                    </a></li>
-                </ul>
+            </nav>
+            <ul id="slide-out" class="sidenav sidenav-fixed">
+                <li class="logo">
+                    <a href="{{ site.url }}"
+                        ><img src="{{ site.url }}/assets/logo_white.png"
+                    /></a>
+                </li>
+                <li class="version">{% include versions.html %}</li>
+                {% include_relative navigation.html %}
+            </ul>
+        </header>
+
+        <main>
+            <div class="container">
+                <div class="row">
+                    <div
+                        class="col s12 m8 offset-m1 xl7 offset-xl1 markdown-section DocSearch-content toc-content"
+                    >
+                        {{ content }}
+                    </div>
+                    <div class="col hide-on-small-only m3 xl3 offset-xl1">
+                        <div class="toc"></div>
+                    </div>
+                </div>
             </div>
-        </nav>
-        <ul id="slide-out" class="sidenav sidenav-fixed">
-            <li class="logo">
-                <a href="{{ site.url }}"><img src="{{ site.url }}/assets/logo_white.png" /></a>
-            </li>
-            <li class="version">
-                {% include versions.html %}
-            </li>
-            {% include_relative navigation.html %}
-        </ul>
+        </main>
 
-    </header>
-
-    <main>
-        <div class="container">
-            <div class="row">
-                <div class="col s12 m8 offset-m1 xl7 offset-xl1 markdown-section DocSearch-content toc-content">
-                    {{ content }}
-                </div>
-                <div class="col hide-on-small-only m3 xl3 offset-xl1">
-                    <div class="toc"></div>
-                </div>
-            </div>
-        </div>
-    </main>
-
-    <script src="{{ '/js/materialize.min.js' | relative_url }}"></script>
-    <script src="{{ 'js/prism.js' | relative_url }}"></script>
-    <script>
-        function slugify(text) {
-            return text.toString().toLowerCase()
-                .replace(/\s+/g, '-')           // Replace spaces with -
-                .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-                .replace(/\-\-+/g, '-')         // Replace multiple - with single -
-                .replace(/^-+/, '')             // Trim - from start of text
-                .replace(/-+$/, '');            // Trim - from end of text
-        }
-        document.addEventListener('DOMContentLoaded', function () {
-            // Initialize version selector
-            M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'));
-            /* Generate table of contents */
-            tocbot.init({
-                // Where to render the table of contents
-                tocSelector: '.toc',
-                positionFixedSelector: '.toc',
-                // Where to grab the headings to build the table of contents
-                contentSelector: '.toc-content',
-                // More options
-                headingSelector: 'h2, h3',
-                includeHtml: true,
-                collapseDepth: 2,
-                hasInnerContainers: true,
-            });
-        });
-    </script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-    <script type="text/javascript">
-        docsearch({
-            apiKey: '32f254b1de6a25a96665d1229b6eb8f7',
-            indexName: 'marmelab-react-admin',
-            inputSelector: '#query',
-            debug: false, // Set debug to true if you want to inspect the dropdown
-            autocompleteOptions: {
-                appendTo: '#search',
-                hint: false,
+        <script src="{{ '/js/materialize.min.js' | relative_url }}"></script>
+        <script src="{{ 'js/prism.js' | relative_url }}"></script>
+        <script>
+            function slugify(text) {
+                return text
+                    .toString()
+                    .toLowerCase()
+                    .replace(/\s+/g, '-') // Replace spaces with -
+                    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+                    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+                    .replace(/^-+/, '') // Trim - from start of text
+                    .replace(/-+$/, ''); // Trim - from end of text
             }
-        });
-    </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js" defer></script>
-    <!--
+            document.addEventListener('DOMContentLoaded', function () {
+                // Initialize version selector
+                M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'));
+                /* Generate table of contents */
+                tocbot.init({
+                    // Where to render the table of contents
+                    tocSelector: '.toc',
+                    positionFixedSelector: '.toc',
+                    // Where to grab the headings to build the table of contents
+                    contentSelector: '.toc-content',
+                    // More options
+                    headingSelector: 'h2, h3, h4',
+                    includeHtml: true,
+                    collapseDepth: 2,
+                    hasInnerContainers: true,
+                });
+            });
+        </script>
+        <script
+            type="text/javascript"
+            src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+        ></script>
+        <script type="text/javascript">
+            docsearch({
+                apiKey: '32f254b1de6a25a96665d1229b6eb8f7',
+                indexName: 'marmelab-react-admin',
+                inputSelector: '#query',
+                debug: false, // Set debug to true if you want to inspect the dropdown
+                autocompleteOptions: {
+                    appendTo: '#search',
+                    hint: false,
+                },
+            });
+        </script>
+        <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.min.js"
+            defer
+        ></script>
+        <!--
         React-admin protects your privacy!
         We use our own self-hosted tracking solution to collect some raw metrics,
         like page views, device type (mobile, desktop, etc.) or country.
         We don't track any personal information about our visitors.
     -->
-    <script async defer data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd" src="https://analytics.marmelab.com/umami.js"></script>
-</body>
-
+        <script
+            async
+            defer
+            data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd"
+            src="https://analytics.marmelab.com/umami.js"
+        ></script>
+    </body>
 </html>

--- a/docs/css/style-v7.css
+++ b/docs/css/style-v7.css
@@ -262,7 +262,12 @@ ul.sidenav code {
 }
 .markdown-section h3 {
     margin-top: 1.5em;
+    font-size: 1.25em;
+}
+.markdown-section h4 {
+    margin-top: 1.25em;
     font-size: 1em;
+    font-weight: bold;
 }
 .markdown-section code,
 .markdown-section pre {


### PR DESCRIPTION
## Problem

The fields and Inputs doc table of content are intimidating because they show too much content. Besides, the toc is too long and doesn't show the last elements on small screens

## Solution

Users use the reference and full-text search to get to a given input doc anyway, so let's use heading levels for discoverability.

Add a new heading level and group Inputs and Fields by category

## Before

![image](https://user-images.githubusercontent.com/99944/97166691-f6954900-1785-11eb-94f6-0f138142f972.png)

 ## After

![image](https://user-images.githubusercontent.com/99944/97166646-e4b3a600-1785-11eb-9771-277487fa64c5.png)

## Demo

![input-toc](https://user-images.githubusercontent.com/99944/97167113-8f2bc900-1786-11eb-9d68-71afb06522ff.gif)
