### PR TITLE
Provide correct resource in referencearrayfields

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -212,7 +212,7 @@ const useReferenceArrayFieldController = ({
         onUnselectItems,
         page,
         perPage,
-        resource,
+        resource: reference,
         selectedIds,
         setFilters,
         setPage,


### PR DESCRIPTION
so fields within ListContextProvider can use the correct resource for translation lookup