### PR TITLE
fix: add default value for hasShow in Show.tsx

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -193,6 +193,7 @@ const useStyles = makeStyles(
 const sanitizeRestProps = ({
     hasCreate = null,
     hasEdit = null,
+    hasShow = null,
     history = null,
     id = null,
     loaded = null,


### PR DESCRIPTION
Prevents having `hasShow` on a `div` element, because `React` complains about this

```
Warning: React does not recognize the `hasShow` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `hasshow` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by ShowView)
    in ShowView (created by Show)
```