### PR TITLE
Fix ShowButton does not update on 'to' prop change

### DIFF
--- a/packages/ra-ui-materialui/src/button/ShowButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ShowButton.tsx
@@ -47,11 +47,12 @@ ShowButton.propTypes = {
 
 const PureShowButton = memo(
     ShowButton,
-    (props: Props, nextProps: Props) =>
+    (props: ShowButtonProps, nextProps: ShowButtonProps) =>
         (props.record && nextProps.record
             ? props.record.id === nextProps.record.id
             : props.record == nextProps.record) && // eslint-disable-line eqeqeq
-        props.basePath === nextProps.basePath
+        props.basePath === nextProps.basePath &&
+        props.to === nextProps.to
 );
 
 export default PureShowButton;


### PR DESCRIPTION
Identical to #5014, ShowButton doesn't update if 'to' prop changes. My goal was to make the edit and show buttons work consistently with tabbed layouts, when a tab is opened in the show view the edit button should open the same tab in the edit view. Due to memoizing it didn't always work and now it does.