### PR TITLE
Extended downloadCSV helper with type paramater

### DIFF
--- a/packages/ra-core/src/export/downloadCSV.ts
+++ b/packages/ra-core/src/export/downloadCSV.ts
@@ -1,4 +1,4 @@
-export default (csv, filename, blobType = 'text/csv') => {
+export default (csv, filename, blobType = 'text/csv;charset=utf-8') => {
     const fakeLink = document.createElement('a');
     fakeLink.style.display = 'none';
     document.body.appendChild(fakeLink);

--- a/packages/ra-core/src/export/downloadCSV.ts
+++ b/packages/ra-core/src/export/downloadCSV.ts
@@ -1,8 +1,8 @@
-export default (csv, filename, outputType) => {
+export default (csv, filename, blobType = 'text/csv') => {
     const fakeLink = document.createElement('a');
     fakeLink.style.display = 'none';
     document.body.appendChild(fakeLink);
-    const blob = new Blob([csv], { type: outputType ? outputType : 'text/csv' });
+    const blob = new Blob([csv], { type: blobType });
     if (window.navigator && window.navigator.msSaveOrOpenBlob) {
         // Manage IE11+ & Edge
         window.navigator.msSaveOrOpenBlob(blob, `${filename}.csv`);

--- a/packages/ra-core/src/export/downloadCSV.ts
+++ b/packages/ra-core/src/export/downloadCSV.ts
@@ -1,8 +1,8 @@
-export default (csv, filename) => {
+export default (csv, filename, outputType) => {
     const fakeLink = document.createElement('a');
     fakeLink.style.display = 'none';
     document.body.appendChild(fakeLink);
-    const blob = new Blob([csv], { type: 'text/csv' });
+    const blob = new Blob([csv], { type: outputType ? outputType : 'text/csv' });
     if (window.navigator && window.navigator.msSaveOrOpenBlob) {
         // Manage IE11+ & Edge
         window.navigator.msSaveOrOpenBlob(blob, `${filename}.csv`);

--- a/packages/ra-core/src/export/downloadCSV.ts
+++ b/packages/ra-core/src/export/downloadCSV.ts
@@ -1,8 +1,8 @@
-export default (csv, filename, blobType = 'text/csv;charset=utf-8') => {
+export default (csv, filename) => {
     const fakeLink = document.createElement('a');
     fakeLink.style.display = 'none';
     document.body.appendChild(fakeLink);
-    const blob = new Blob([csv], { type: blobType });
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
     if (window.navigator && window.navigator.msSaveOrOpenBlob) {
         // Manage IE11+ & Edge
         window.navigator.msSaveOrOpenBlob(blob, `${filename}.csv`);


### PR DESCRIPTION
Recently I needed to change the output encoding (text/csv;charset=utf-8) of the csv file. I had to reimplement it at my side because currently there is no way to  plug in at the type sport and customize the output. 

That's why I am proposing this extended parameter with default value if nothing is passed in.