### PR TITLE
Change RecordContext in Reference elements

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -216,7 +216,7 @@ const useReferenceArrayFieldController = (
         onUnselectItems,
         page,
         perPage,
-        resource,
+        resource: reference,
         selectedIds,
         setFilters,
         setPage,

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -10,6 +10,7 @@ import {
     useReferenceArrayFieldController,
     SortPayload,
     FilterPayload,
+    ResourceContextProvider,
 } from 'ra-core';
 
 import { fieldPropTypes, PublicFieldProps, InjectedFieldProps } from './types';
@@ -103,9 +104,11 @@ const ReferenceArrayField: FC<ReferenceArrayFieldProps> = props => {
         source,
     });
     return (
-        <ListContextProvider value={controllerProps}>
-            <PureReferenceArrayFieldView {...props} {...controllerProps} />
-        </ListContextProvider>
+        <ResourceContextProvider value={reference}>
+            <ListContextProvider value={controllerProps}>
+                <PureReferenceArrayFieldView {...props} {...controllerProps} />
+            </ListContextProvider>
+        </ResourceContextProvider>
     );
 };
 
@@ -160,7 +163,14 @@ export interface ReferenceArrayFieldViewProps
 }
 
 export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props => {
-    const { children, pagination, className, reference, ...rest } = props;
+    const {
+        children,
+        pagination,
+        className,
+        resource,
+        reference,
+        ...rest
+    } = props;
     const classes = useStyles(props);
     const { loaded } = useListContext(props);
 
@@ -173,7 +183,7 @@ export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props =
             {cloneElement(Children.only(children), {
                 ...sanitizeFieldRestProps(rest),
                 className,
-                resource: reference,
+                resource,
             })}{' '}
             {pagination &&
                 props.total !== undefined &&

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -10,6 +10,7 @@ import {
     UseReferenceProps,
     getResourceLinkPath,
     LinkToType,
+    ResourceContextProvider,
 } from 'ra-core';
 
 import LinearProgress from '../layout/LinearProgress';
@@ -82,16 +83,18 @@ const ReferenceField: FC<ReferenceFieldProps> = ({
     });
 
     return (
-        <PureReferenceFieldView
-            {...props}
-            {...useReference({
-                reference: props.reference,
-                id: get(record, source),
-            })}
-            resourceLinkPath={resourceLinkPath}
-        >
-            {children}
-        </PureReferenceFieldView>
+        <ResourceContextProvider value={props.reference}>
+            <PureReferenceFieldView
+                {...props}
+                {...useReference({
+                    reference: props.reference,
+                    id: get(record, source),
+                })}
+                resourceLinkPath={resourceLinkPath}
+            >
+                {children}
+            </PureReferenceFieldView>
+        </ResourceContextProvider>
     );
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -6,6 +6,7 @@ import {
     useReferenceManyFieldController,
     ListContextProvider,
     ListControllerProps,
+    ResourceContextProvider,
 } from 'ra-core';
 
 import { PublicFieldProps, fieldPropTypes, InjectedFieldProps } from './types';
@@ -92,9 +93,11 @@ export const ReferenceManyField: FC<ReferenceManyFieldProps> = props => {
     });
 
     return (
-        <ListContextProvider value={controllerProps}>
-            <ReferenceManyFieldView {...props} {...controllerProps} />
-        </ListContextProvider>
+        <ResourceContextProvider value={reference}>
+            <ListContextProvider value={controllerProps}>
+                <ReferenceManyFieldView {...props} {...controllerProps} />
+            </ListContextProvider>
+        </ResourceContextProvider>
     );
 };
 

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
@@ -9,6 +9,7 @@ import {
     SortPayload,
     PaginationPayload,
     Translate,
+    ResourceContextProvider,
 } from 'ra-core';
 
 import sanitizeInputRestProps from './sanitizeInputRestProps';
@@ -232,6 +233,7 @@ export const ReferenceArrayInputView = ({
     meta,
     onChange,
     options,
+    reference,
     resource,
     setFilter,
     setPagination,
@@ -264,31 +266,35 @@ export const ReferenceArrayInputView = ({
         return <ReferenceError label={translatedLabel} error={error} />;
     }
 
-    return React.cloneElement(children, {
-        allowEmpty,
-        basePath,
-        choices,
-        className,
-        error,
-        input,
-        isRequired,
-        label: translatedLabel,
-        meta: {
-            ...meta,
-            helperText: warning || false,
-        },
-        onChange,
-        options,
-        resource,
-        setFilter,
-        setPagination,
-        setSort,
-        source,
-        translateChoice: false,
-        limitChoicesToValue: true,
-        ...sanitizeRestProps(rest),
-        ...children.props,
-    });
+    return (
+        <ResourceContextProvider value={reference}>
+            {React.cloneElement(children, {
+                allowEmpty,
+                basePath,
+                choices,
+                className,
+                error,
+                input,
+                isRequired,
+                label: translatedLabel,
+                meta: {
+                    ...meta,
+                    helperText: warning || false,
+                },
+                onChange,
+                options,
+                resource,
+                setFilter,
+                setPagination,
+                setSort,
+                source,
+                translateChoice: false,
+                limitChoicesToValue: true,
+                ...sanitizeRestProps(rest),
+                ...children.props,
+            })}
+        </ResourceContextProvider>
+    );
 };
 
 ReferenceArrayInputView.propTypes = {

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -13,6 +13,7 @@ import {
     ListContextProvider,
     ReferenceInputValue,
     UseInputValue,
+    ResourceContextProvider,
 } from 'ra-core';
 
 import sanitizeInputRestProps from './sanitizeInputRestProps';
@@ -206,6 +207,7 @@ export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
     meta,
     possibleValues,
     resource,
+    reference,
     setFilter,
     setPagination,
     setSort,
@@ -260,27 +262,29 @@ export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
     const disabledHelperText = helperText === false ? { helperText } : {};
 
     return (
-        <ListContextProvider value={possibleValues}>
-            {cloneElement(children, {
-                allowEmpty,
-                classes,
-                className,
-                input,
-                isRequired,
-                label,
-                resource,
-                meta: finalMeta,
-                source,
-                choices,
-                basePath,
-                setFilter,
-                setPagination,
-                setSort,
-                translateChoice: false,
-                ...disabledHelperText,
-                ...sanitizeRestProps(rest),
-            })}
-        </ListContextProvider>
+        <ResourceContextProvider value={reference}>
+            <ListContextProvider value={possibleValues}>
+                {cloneElement(children, {
+                    allowEmpty,
+                    classes,
+                    className,
+                    input,
+                    isRequired,
+                    label,
+                    resource,
+                    meta: finalMeta,
+                    source,
+                    choices,
+                    basePath,
+                    setFilter,
+                    setPagination,
+                    setSort,
+                    translateChoice: false,
+                    ...disabledHelperText,
+                    ...sanitizeRestProps(rest),
+                })}
+            </ListContextProvider>
+        </ResourceContextProvider>
     );
 };
 

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -14,7 +14,6 @@ import {
     useVersion,
     Identifier,
     Record,
-    useResourceContext,
 } from 'ra-core';
 import {
     Checkbox,


### PR DESCRIPTION
As `<FieldTitle>` now uses `useRecordContext`, field and input titles in Reference element sis wrong unless we change the resource context.

Supersedes #5461