### PR TITLE
Added ra-compact-ui to ecosystem docs

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -19,6 +19,10 @@ title: "Ecosystem"
 
 See the [List](./List.md#third-party-components) page.
 
+## Show Related Components
+
+See the [Show](./Show.md#third-party-components) page.
+
 ## Fields
 
 See the [Field](./Fields.md#third-party-components) page.

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -357,6 +357,12 @@ export default ScrollableTabbedShowLayout;
 
 ```
 
+## Third-Party Components
+
+You can find components for react-admin in third-party repositories.
+
+- [ra-compact-ui](https://github.com/ValentinnDimitroff/ra-compact-ui#layouts): plugin that allows to have custom styled show layouts.
+
 ## Displaying Fields depending on the user permissions
 
 You might want to display some fields only to users with specific permissions. 


### PR DESCRIPTION
This proposal PR is in regards with a little plugin I have started building for the react-admin as I have used it extensively over the past year and decided to share privately developed components. 

Hope you will find it a useful project to the community and if it is not following any guidelines I will be more than happy to  refactor it's current state.

Wasn't sure if I should include it only on the Miscellaneous list in Ecosystem page but decided to rather place it in the Show page instead. I have noticed this is still quite hot topic on stackoverflow and people keep searching for ways to easily customize show layout. 

I am planning on sharing some more fields and inputs components but my intention is to link them to documentation anchors to the relative pages' third party sections like I did with Layouts.