### PR TITLE
Fix `<Admin history>` prop injection documentation misses package version constraint

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -553,6 +553,8 @@ const App = () => (
 );
 ```
 
+**Caution**: Do not use the 5.x version of the `history` package. It's currently incompatible with another dependency of react-admin, `connected-react-router`. `history@4.10.1` works fine. 
+
 ### `ready`
 
 When you run an `<Admin>` with no child `<Resource>`, react-admin displays a "ready" screen:


### PR DESCRIPTION
This is the only way we can overcome the problem caused by a bug in one of our dependencies (`connected-react-router`). By the way, this dependency seems not to be actively maintained anymore, and this could cause further problems in the future. 

Closes #5450