### PR TITLE
Use getFieldLabelTranslationArgs in ReferenceArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FC, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
+    getFieldLabelTranslationArgs,
     InputProps,
     useReferenceArrayInputController,
     useInput,
@@ -244,8 +245,11 @@ export const ReferenceArrayInputView = ({
     ...rest
 }: ReferenceArrayInputViewProps) => {
     const translatedLabel = translate(
-        label || `resources.${resource}.fields.${source}`,
-        { _: label }
+        ...getFieldLabelTranslationArgs({
+            label,
+            resource,
+            source,
+        })
     );
 
     if (loading) {


### PR DESCRIPTION
The `ReferenceArrayInput` component is not using the `getFieldLabelTranslationArgs` function like the `FieldTitle` component (used by the other inputs: `ReferenceInput`, `TextInput`, ...).

The difference is that, if no label is given and if there is no translation, the label is not humanized by default.

Before:
![image](https://user-images.githubusercontent.com/10920253/100632635-5e165980-332d-11eb-8d6e-6713c02ed3e5.png)

After:
![image](https://user-images.githubusercontent.com/10920253/100633247-2360f100-332e-11eb-8c56-6dbd0855e535.png)