### PR TITLE
Fix usePermissions always triggers a re-render even though the permissions are unchanged

### DIFF
--- a/packages/ra-core/src/auth/WithPermissions.tsx
+++ b/packages/ra-core/src/auth/WithPermissions.tsx
@@ -9,7 +9,7 @@ import { Location } from 'history';
 
 import warning from '../util/warning';
 import useAuthenticated from './useAuthenticated';
-import usePermissions from './usePermissions';
+import usePermissionsOptimized from './usePermissionsOptimized';
 
 export interface WithPermissionsChildrenParams {
     permissions: any;
@@ -81,7 +81,7 @@ const WithPermissions: FunctionComponent<Props> = ({
     );
 
     useAuthenticated(authParams);
-    const { permissions } = usePermissions(authParams);
+    const { permissions } = usePermissionsOptimized(authParams);
     // render even though the usePermissions() call isn't finished (optimistic rendering)
     if (component) {
         return createElement(component, { permissions, ...props });

--- a/packages/ra-core/src/auth/index.ts
+++ b/packages/ra-core/src/auth/index.ts
@@ -3,6 +3,7 @@ import AuthContext from './AuthContext';
 import useAuthProvider from './useAuthProvider';
 import useAuthState from './useAuthState';
 import usePermissions from './usePermissions';
+import usePermissionsOptimized from './usePermissionsOptimized';
 import useAuthenticated from './useAuthenticated';
 import WithPermissions from './WithPermissions';
 import useLogin from './useLogin';
@@ -26,6 +27,7 @@ export {
     useGetPermissions,
     // hooks with state management
     usePermissions,
+    usePermissionsOptimized,
     useAuthState,
     // hook with immediate effect
     useAuthenticated,

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import isEqual from 'lodash/isEqual';
 
 import useGetPermissions from './useGetPermissions';
 import { useSafeSetState } from '../util/hooks';
@@ -13,14 +12,10 @@ interface State {
 
 const emptyParams = {};
 
-// keep a cache of already fetched permissions to initialize state for new
-// components and avoid a useless rerender if the permissions haven't changed
-const alreadyFetchedPermissions = { '{}': [] };
-
 /**
  * Hook for getting user permissions
  *
- * Calls the authProvider.getPrmissions() method asynchronously.
+ * Calls the authProvider.getPermissions() method asynchronously.
  * If the authProvider returns a rejected promise, returns empty permissions.
  *
  * The return value updates according to the request state:
@@ -51,17 +46,12 @@ const usePermissions = (params = emptyParams) => {
     const [state, setState] = useSafeSetState<State>({
         loading: true,
         loaded: false,
-        permissions: alreadyFetchedPermissions[JSON.stringify(params)],
     });
     const getPermissions = useGetPermissions();
     useEffect(() => {
         getPermissions(params)
             .then(permissions => {
-                const key = JSON.stringify(params);
-                if (!isEqual(permissions, alreadyFetchedPermissions[key])) {
-                    alreadyFetchedPermissions[key] = permissions;
-                    setState({ loading: false, loaded: true, permissions });
-                }
+                setState({ loading: false, loaded: true, permissions });
             })
             .catch(error => {
                 setState({

--- a/packages/ra-core/src/auth/usePermissionsOptimized.ts
+++ b/packages/ra-core/src/auth/usePermissionsOptimized.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+import isEqual from 'lodash/isEqual';
+
+import useGetPermissions from './useGetPermissions';
+import { useSafeSetState } from '../util/hooks';
+
+interface State {
+    permissions?: any;
+    error?: any;
+}
+
+const emptyParams = {};
+
+// keep a cache of already fetched permissions to initialize state for new
+// components and avoid a useless rerender if the permissions haven't changed
+const alreadyFetchedPermissions = { '{}': [] };
+
+/**
+ * Hook for getting user permissions without the loading state.
+ *
+ * When compared to usePermissions, this hook doesn't cause a re-render
+ * when the permissions haven't changed since the last call.
+ *
+ * This hook doesn't handle the loading state.
+ *
+ * @see usePermissions
+ *
+ * Calls the authProvider.getPermissions() method asynchronously.
+ * If the authProvider returns a rejected promise, returns empty permissions.
+ *
+ * The return value updates according to the request state:
+ *
+ * - start:   { permissions: [previously fetched permissions for these params] }
+ * - success: { permissions: [permissions returned by the authProvider (usually the same as on start)] }
+ * - error:   { error: [error from provider] }
+ *
+ * Useful to enable features based on user permissions
+ *
+ * @param {Object} params Any params you want to pass to the authProvider
+ *
+ * @returns The current auth check state. Destructure as { permissions, error }.
+ *
+ * @example
+ *     import { usePermissionsOptimized } from 'react-admin';
+ *
+ *     const PostDetail = props => {
+ *         const { permissions } = usePermissionsOptimized();
+ *         if (permissions !== 'editor') {
+ *             return <Redirect  to={`posts/${props.id}/show`} />
+ *         } else {
+ *             return <PostEdit {...props} />
+ *         }
+ *     };
+ */
+const usePermissionsOptimized = (params = emptyParams) => {
+    const [state, setState] = useSafeSetState<State>({
+        permissions: alreadyFetchedPermissions[JSON.stringify(params)],
+    });
+    const getPermissions = useGetPermissions();
+    useEffect(() => {
+        getPermissions(params)
+            .then(permissions => {
+                const key = JSON.stringify(params);
+                if (!isEqual(permissions, alreadyFetchedPermissions[key])) {
+                    alreadyFetchedPermissions[key] = permissions;
+                    setState({ permissions });
+                }
+            })
+            .catch(error => {
+                setState({
+                    error,
+                });
+            });
+    }, [getPermissions, params, setState]);
+
+    return state;
+};
+
+export default usePermissionsOptimized;


### PR DESCRIPTION
## Problem

All react-admin routes (list, edit, create, etc) are wrapped by `WithPermissions`. This component renders the page content optimistically with empty permissions, then calls `authProvider.getPermissions()`, and passes the result to the child.

In many cases, this means the routes will render twice: once with empty permissions, and once with the permissions returned by the `authProvider`. 

## Solution

`WithPermissions` calls `authProvider.getPermissions()` with empty params. In many cases, the result of this call is always the same.

`useGetPermissions` can cache the result from the first call, and initialize its state with it. 

that way, in most cases, the return from  `authProvider.getPermissions()` will be the same as the cached one, and we'll save a re-render.

This should git a short perf boost to all apps, whether they use permissions or not.

## Before

12 renders when coming back to the Post List page

![image](https://user-images.githubusercontent.com/99944/100642575-3927e380-3339-11eb-80aa-f64aab480a60.png)

## After

11 renders when coming back to the Post List page

![image](https://user-images.githubusercontent.com/99944/100642496-21505f80-3339-11eb-8f03-60ff7b912e62.png)
 