### PR TITLE
Fix ReferenceManyField renders too often

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 import debounce from 'lodash/debounce';
 import union from 'lodash/union';
 import isEqual from 'lodash/isEqual';
+import get from 'lodash/get';
 
 import { CRUD_GET_MANY } from '../actions/dataActions/crudGetMany';
 import { Identifier, Record, ReduxState, DataProviderProxy } from '../types';
@@ -143,12 +144,14 @@ const useGetMany = (
  */
 const makeGetManySelector = () =>
     createSelector(
-        (state: ReduxState) => state.admin.resources,
-        (_, resource) => resource,
-        (_, __, ids) => ids,
-        (resources, resource, ids) =>
-            resources[resource]
-                ? ids.map(id => resources[resource].data[id])
+        [
+            (state: ReduxState, resource) =>
+                get(state, ['admin', 'resources', resource, 'data']),
+            (_, __, ids) => ids,
+        ],
+        (resourceData, ids) =>
+            resourceData
+                ? ids.map(id => resourceData[id])
                 : ids.map(id => undefined)
     );
 


### PR DESCRIPTION
## Problem

`ReferenceManyField` rerenders whenever something in the resource changes. even unrelated changes like selected ids. This wastes CPU time and slows down List page interactions (a bit).

## Solution

Fix the data selector in `useGetMany`, which uses `reselect` to memoize the result... But has a too broad dependency  array.

## Before

Check the Tags column: all rows rerender when only one row is selected

![getmany_not_optimized](https://user-images.githubusercontent.com/99944/100843328-7c3da000-347a-11eb-8dce-110405c418ff.gif)

## After

Now only the selected row rerenders

![getmany_optimized](https://user-images.githubusercontent.com/99944/100843541-ccb4fd80-347a-11eb-96dd-fe6b1d6c08ce.gif)

