### PR TITLE
Add better support for async validators

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1092,6 +1092,38 @@ export const UserCreate = (props) => (
 
 **Tip**: The props you pass to `<SimpleForm>` and `<TabbedForm>` are passed to the [<Form>](https://final-form.org/docs/react-final-form/api/Form) of `react-final-form`.
 
+**Tip**: The `validate` function can return a promise for asynchronous validation. For instance:
+
+```jsx
+const validateUserCreation = async (values) => {
+    const errors = {};
+    if (!values.firstName) {
+        errors.firstName = ['The firstName is required'];
+    }
+    if (!values.age) {
+        errors.age = ['The age is required'];
+    } else if (values.age < 18) {
+        errors.age = ['Must be over 18'];
+    }
+
+    const isEmailUnique = await checkEmailIsUnique(values.userName);
+    if (!isEmailUnique) {
+        errors.email = ['Email already used'];
+    }
+    return errors
+};
+
+export const UserCreate = (props) => (
+    <Create {...props}>
+        <SimpleForm validate={validateUserCreation}>
+            <TextInput label="First Name" source="firstName" />
+            <TextInput label="Email" source="email" />
+            <TextInput label="Age" source="age" />
+        </SimpleForm>
+    </Create>
+);
+```
+
 ### Per Input Validation: Built-in Field Validators
 
 Alternatively, you can specify a `validate` prop directly in `<Input>` components, taking either a function or an array of functions. React-admin already bundles a few validator functions, that you can just require, and use as input-level validators:
@@ -1257,6 +1289,39 @@ export const ProductEdit = ({ ...props }) => (
 
 **Tip**: You can use *both* Form validation and input validation.
 
+**Tip**: The custom validator function can return a promise for asynchronous validation. For instance:
+
+```jsx
+const validateEmailUnicity = async (value) => {
+    const isEmailUnique = await checkEmailIsUnique(value);
+    if (!isEmailUnique) {
+        return 'Email already used';
+
+        // You can return a translation key as well
+        return 'myroot.validation.email_already_used';
+
+        // Or even an object just like the other validators
+        return { message: 'myroot.validation.email_already_used', args: { email: value } }
+
+    }
+
+    return errors
+};
+
+const emailValidators = [required(), validateEmailUnicity];
+
+export const UserCreate = (props) => (
+    <Create {...props}>
+        <SimpleForm validate={validateUserCreation}>
+            ...
+            <TextInput label="Email" source="email" validate={emailValidators} />
+            ...
+        </SimpleForm>
+    </Create>
+);
+```
+
+**Important**: Note that asynchronous validators are not supported on the `ArrayInput` component due to a limitation of [react-final-form-arrays](https://github.com/final-form/react-final-form-arrays).
 ## Submit On Enter
 
 By default, pressing `ENTER` in any of the form fields submits the form - this is the expected behavior in most cases. However, some of your custom input components (e.g. Google Maps widget) may have special handlers for the `ENTER` key. In that case, to disable the automated form submission on enter, set the `submitOnEnter` prop of the form component to `false`:

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -1008,7 +1008,9 @@ import { ArrayInput, SimpleFormIterator, DateInput, TextInput, FormDataConsumer 
 </ArrayInput>
 ```
 
-`<ArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props) (except `format` and `parse`).
+`<ArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props) (except `format` and `parse`). 
+
+**Important**: Note that asynchronous validators are not supported on the `ArrayInput` component due to a limitation of [react-final-form-arrays](https://github.com/final-form/react-final-form-arrays).
 
 ### `<AutocompleteArrayInput>`
 

--- a/examples/simple/src/users/UserCreate.js
+++ b/examples/simple/src/users/UserCreate.js
@@ -38,6 +38,11 @@ const UserEditToolbar = ({
     </Toolbar>
 );
 
+const isValidName = async value =>
+    new Promise(resolve =>
+        setTimeout(resolve(value === 'Admin' ? "Can't be Admin" : undefined))
+    );
+
 const UserCreate = ({ permissions, ...props }) => (
     <Create {...props} aside={<Aside />}>
         <TabbedForm
@@ -48,7 +53,7 @@ const UserCreate = ({ permissions, ...props }) => (
                     source="name"
                     defaultValue="Slim Shady"
                     autoFocus
-                    validate={required()}
+                    validate={[required(), isValidName]}
                 />
             </FormTab>
             {permissions === 'admin' && (

--- a/packages/ra-core/src/form/validate.ts
+++ b/packages/ra-core/src/form/validate.ts
@@ -63,18 +63,26 @@ type Memoize = <T extends (...args: any[]) => any>(
 const memoize: Memoize = (fn: any) =>
     lodashMemoize(fn, (...args) => JSON.stringify(args));
 
-// Compose multiple validators into a single one for use with final-form
-export const composeValidators = (...validators) => (value, values, meta) => {
-    const allValidators = Array.isArray(validators[0])
-        ? validators[0]
-        : validators;
+const isFunction = value => typeof value === 'function';
 
-    return allValidators.reduce(
-        (error, validator) =>
-            error ||
-            (typeof validator === 'function' && validator(value, values, meta)),
-        undefined
-    );
+// Compose multiple validators into a single one for use with final-form
+export const composeValidators = (...validators) => async (
+    value,
+    values,
+    meta
+) => {
+    const allValidators = (Array.isArray(validators[0])
+        ? validators[0]
+        : validators
+    ).filter(isFunction);
+
+    for (const validator of allValidators) {
+        const error = await validator(value, values, meta);
+
+        if (error) {
+            return error;
+        }
+    }
 };
 
 /**

--- a/packages/ra-core/src/form/validate.ts
+++ b/packages/ra-core/src/form/validate.ts
@@ -85,6 +85,26 @@ export const composeValidators = (...validators) => async (
     }
 };
 
+// Compose multiple validators into a single one for use with final-form
+export const composeSyncValidators = (...validators) => (
+    value,
+    values,
+    meta
+) => {
+    const allValidators = (Array.isArray(validators[0])
+        ? validators[0]
+        : validators
+    ).filter(isFunction);
+
+    for (const validator of allValidators) {
+        const error = validator(value, values, meta);
+
+        if (error) {
+            return error;
+        }
+    }
+};
+
 /**
  * Required validator
  *

--- a/packages/ra-ui-materialui/src/input/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { cloneElement, Children, FC, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { isRequired, FieldTitle, composeValidators, InputProps } from 'ra-core';
+import {
+    isRequired,
+    FieldTitle,
+    composeSyncValidators,
+    InputProps,
+} from 'ra-core';
 import { useFieldArray } from 'react-final-form-arrays';
 import { InputLabel, FormControl } from '@material-ui/core';
 
@@ -62,7 +67,7 @@ const ArrayInput: FC<ArrayInputProps> = ({
     ...rest
 }) => {
     const sanitizedValidate = Array.isArray(validate)
-        ? composeValidators(validate)
+        ? composeSyncValidators(validate)
         : validate;
 
     const fieldProps = useFieldArray(source, {


### PR DESCRIPTION
It's currently possible to pass an async validation function if, and only if, this is either the only validator or the last one inside the validation functions array.

This PR aims at providing real support for async validation functions.

### TODO

- [x] Implementation
- [x] Tests
- [x] Documentation