### PR TITLE
Add domain telemetry on app mount

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -32,6 +32,7 @@ Here are all the props accepted by the component:
 - [`i18nProvider`](#i18nprovider)
 - [`title`](#title)
 - [`dashboard`](#dashboard)
+- [`disableTelemetry`](#disableTelemetry)
 - [`catchAll`](#catchall)
 - [`menu`](#menu)
 - [`theme`](#theme)
@@ -137,6 +138,24 @@ const App = () => (
 ```
 
 ![Custom home page](./img/dashboard.png)
+
+## `disableTelemetry`
+
+Telemetry is enabled by default on production environments. It's an anonymous metric only logging the domain name and allowing us to know who uses react-admin in production.
+
+You can disable it by settings the `disableTelemetry` prop:
+
+```jsx
+// in src/App.js
+import * as React from "react";
+import { Admin } from 'react-admin';
+
+const App = () => (
+    <Admin disableTelemetry>
+        // ...
+    </Admin>
+);
+```
 
 ## `catchAll`
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -141,9 +141,13 @@ const App = () => (
 
 ## `disableTelemetry`
 
-Telemetry is enabled by default on production environments. It's an anonymous metric only logging the domain name and allowing us to know who uses react-admin in production.
+In production, react-admin applications send an anonymous request on mount to a telemetry server operated by marmelab. You can see this request by looking at the Network tab of your browser DevTools:
 
-You can disable it by settings the `disableTelemetry` prop:
+`https://react-admin-telemetry.marmelab.com/react-admin-telemetry`
+
+The only data sent to the telemetry server is the admin domain (e.g. "example.com") - no personal data is ever sent, and no cookie is included in the response. The react-admin team uses these domains to track the usage of the framework.
+
+You can opt out of telemetry by simply adding `disableTelemetry` to the `<Admin>` component:
 
 ```jsx
 // in src/App.js

--- a/examples/demo/src/App.tsx
+++ b/examples/demo/src/App.tsx
@@ -74,6 +74,7 @@ const App = () => {
             loginPage={Login}
             layout={Layout}
             i18nProvider={i18nProvider}
+            disableTelemetry
         >
             <Resource name="customers" {...visitors} />
             <Resource

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, ComponentType, useEffect } from 'react';
+import { FunctionComponent, ComponentType } from 'react';
 
 import CoreAdminContext from './CoreAdminContext';
 import CoreAdminUI from './CoreAdminUI';

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -108,7 +108,6 @@ const CoreAdmin: FunctionComponent<AdminProps> = ({
     title = 'React Admin',
     disableTelemetry,
 }) => {
-    console.log(process.env.NODE_ENV);
     return (
         <CoreAdminContext
             authProvider={authProvider}

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -55,7 +55,7 @@ export type ChildrenFunction = () => ComponentType[];
  * // it's relatively straightforward to replace it:
  *
  * import * as React from 'react';
-import { useEffect, useState } from 'react';
+ * import { useEffect, useState } from 'react';
  * import {
  *     CoreAdminContext,
  *     CoreAdminUI,
@@ -96,6 +96,7 @@ const CoreAdmin: FunctionComponent<AdminProps> = ({
     customSagas,
     dashboard,
     dataProvider,
+    disableTelemetry,
     history,
     i18nProvider,
     initialState,
@@ -106,7 +107,6 @@ const CoreAdmin: FunctionComponent<AdminProps> = ({
     menu, // deprecated, use a custom layout instead
     theme,
     title = 'React Admin',
-    disableTelemetry,
 }) => {
     return (
         <CoreAdminContext

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, ComponentType } from 'react';
+import { FunctionComponent, ComponentType, useEffect } from 'react';
 
 import CoreAdminContext from './CoreAdminContext';
 import CoreAdminUI from './CoreAdminUI';
@@ -106,7 +106,9 @@ const CoreAdmin: FunctionComponent<AdminProps> = ({
     menu, // deprecated, use a custom layout instead
     theme,
     title = 'React Admin',
+    disableTelemetry,
 }) => {
+    console.log(process.env.NODE_ENV);
     return (
         <CoreAdminContext
             authProvider={authProvider}
@@ -121,6 +123,7 @@ const CoreAdmin: FunctionComponent<AdminProps> = ({
                 layout={appLayout || layout}
                 customRoutes={customRoutes}
                 dashboard={dashboard}
+                disableTelemetry={disableTelemetry}
                 menu={menu}
                 catchAll={catchAll}
                 theme={theme}

--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -66,11 +66,11 @@ const CoreAdminUI: FunctionComponent<AdminUIProps> = ({
     ]);
     return (
         <>
-            {process.env.NODE_ENV === 'production' &&
+            {process.env.NODE_ENV === 'development' &&
             disableTelemetry !== true &&
             typeof window !== 'undefined' ? (
                 <img
-                    src={`https://imfoxncoya.execute-api.eu-west-3.amazonaws.com/prod?domain=${window.location.hostname}`}
+                    src={`https://react-admin-telemetry.marmelab.com/react-admin-telemetry?domain=${window.location.hostname}`}
                     width="0"
                     height=""
                     alt=""

--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -66,7 +66,7 @@ const CoreAdminUI: FunctionComponent<AdminUIProps> = ({
     ]);
     return (
         <>
-            {process.env.NODE_ENV === 'development' &&
+            {process.env.NODE_ENV === 'production' &&
             disableTelemetry !== true &&
             typeof window !== 'undefined' ? (
                 <img

--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -32,6 +32,7 @@ export interface AdminUIProps {
     children?: AdminChildren;
     customRoutes?: CustomRoutes;
     dashboard?: DashboardComponent;
+    disableTelemetry?: boolean;
     layout?: LayoutComponent;
     loading?: LoadingComponent;
     loginPage?: LoginComponent | boolean;
@@ -50,6 +51,7 @@ const CoreAdminUI: FunctionComponent<AdminUIProps> = ({
     children,
     customRoutes = [],
     dashboard,
+    disableTelemetry = false,
     layout = DefaultLayout,
     loading = Noop,
     loginPage = false,
@@ -63,41 +65,53 @@ const CoreAdminUI: FunctionComponent<AdminUIProps> = ({
         logout,
     ]);
     return (
-        <Switch>
-            {loginPage !== false && loginPage !== true ? (
-                <Route
-                    exact
-                    path="/login"
-                    render={props =>
-                        createElement(loginPage, {
-                            ...props,
-                            title,
-                            theme,
-                        })
-                    }
+        <>
+            {process.env.NODE_ENV === 'development' &&
+            disableTelemetry !== true &&
+            typeof window !== 'undefined' ? (
+                <img
+                    src={`https://imfoxncoya.execute-api.eu-west-3.amazonaws.com/prod?domain=${window.location.hostname}`}
+                    width="0"
+                    height=""
+                    alt=""
                 />
             ) : null}
-            <Route
-                path="/"
-                render={props => (
-                    <CoreAdminRouter
-                        catchAll={catchAll}
-                        customRoutes={customRoutes}
-                        dashboard={dashboard}
-                        layout={layout}
-                        loading={loading}
-                        logout={logoutElement}
-                        menu={menu}
-                        ready={ready}
-                        theme={theme}
-                        title={title}
-                        {...props}
-                    >
-                        {children}
-                    </CoreAdminRouter>
-                )}
-            />
-        </Switch>
+            <Switch>
+                {loginPage !== false && loginPage !== true ? (
+                    <Route
+                        exact
+                        path="/login"
+                        render={props =>
+                            createElement(loginPage, {
+                                ...props,
+                                title,
+                                theme,
+                            })
+                        }
+                    />
+                ) : null}
+                <Route
+                    path="/"
+                    render={props => (
+                        <CoreAdminRouter
+                            catchAll={catchAll}
+                            customRoutes={customRoutes}
+                            dashboard={dashboard}
+                            layout={layout}
+                            loading={loading}
+                            logout={logoutElement}
+                            menu={menu}
+                            ready={ready}
+                            theme={theme}
+                            title={title}
+                            {...props}
+                        >
+                            {children}
+                        </CoreAdminRouter>
+                    )}
+                />
+            </Switch>
+        </>
     );
 };
 

--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -4,6 +4,7 @@ import {
     FunctionComponent,
     ComponentType,
     useMemo,
+    useEffect,
 } from 'react';
 import { Switch, Route } from 'react-router-dom';
 
@@ -64,54 +65,57 @@ const CoreAdminUI: FunctionComponent<AdminUIProps> = ({
     const logoutElement = useMemo(() => logout && createElement(logout), [
         logout,
     ]);
+
+    useEffect(() => {
+        if (
+            disableTelemetry ||
+            process.env.NODE_ENV !== 'production' ||
+            typeof window === 'undefined' ||
+            typeof window.location === 'undefined' ||
+            typeof Image === 'undefined'
+        ) {
+            return;
+        }
+        const img = new Image();
+        img.src = `https://react-admin-telemetry.marmelab.com/react-admin-telemetry?domain=${window.location.hostname}`;
+    }, [disableTelemetry]);
+
     return (
-        <>
-            {process.env.NODE_ENV === 'production' &&
-            disableTelemetry !== true &&
-            typeof window !== 'undefined' ? (
-                <img
-                    src={`https://react-admin-telemetry.marmelab.com/react-admin-telemetry?domain=${window.location.hostname}`}
-                    width="0"
-                    height=""
-                    alt=""
+        <Switch>
+            {loginPage !== false && loginPage !== true ? (
+                <Route
+                    exact
+                    path="/login"
+                    render={props =>
+                        createElement(loginPage, {
+                            ...props,
+                            title,
+                            theme,
+                        })
+                    }
                 />
             ) : null}
-            <Switch>
-                {loginPage !== false && loginPage !== true ? (
-                    <Route
-                        exact
-                        path="/login"
-                        render={props =>
-                            createElement(loginPage, {
-                                ...props,
-                                title,
-                                theme,
-                            })
-                        }
-                    />
-                ) : null}
-                <Route
-                    path="/"
-                    render={props => (
-                        <CoreAdminRouter
-                            catchAll={catchAll}
-                            customRoutes={customRoutes}
-                            dashboard={dashboard}
-                            layout={layout}
-                            loading={loading}
-                            logout={logoutElement}
-                            menu={menu}
-                            ready={ready}
-                            theme={theme}
-                            title={title}
-                            {...props}
-                        >
-                            {children}
-                        </CoreAdminRouter>
-                    )}
-                />
-            </Switch>
-        </>
+            <Route
+                path="/"
+                render={props => (
+                    <CoreAdminRouter
+                        catchAll={catchAll}
+                        customRoutes={customRoutes}
+                        dashboard={dashboard}
+                        layout={layout}
+                        loading={loading}
+                        logout={logoutElement}
+                        menu={menu}
+                        ready={ready}
+                        theme={theme}
+                        title={title}
+                        {...props}
+                    >
+                        {children}
+                    </CoreAdminRouter>
+                )}
+            />
+        </Switch>
     );
 };
 

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -474,6 +474,7 @@ export interface AdminProps {
     customSagas?: any[];
     dashboard?: DashboardComponent;
     dataProvider: DataProvider | LegacyDataProvider;
+    disableTelemetry?: boolean;
     history?: History;
     i18nProvider?: I18nProvider;
     initialState?: InitialState;

--- a/packages/react-admin/src/Admin.tsx
+++ b/packages/react-admin/src/Admin.tsx
@@ -94,6 +94,7 @@ const Admin: FunctionComponent<AdminProps> = ({
     customSagas,
     dashboard,
     dataProvider,
+    disableTelemetry,
     history,
     i18nProvider,
     initialState,
@@ -137,6 +138,7 @@ const Admin: FunctionComponent<AdminProps> = ({
                 layout={appLayout || layout}
                 customRoutes={customRoutes}
                 dashboard={dashboard}
+                disableTelemetry={disableTelemetry}
                 menu={menu}
                 catchAll={catchAll}
                 theme={theme}


### PR DESCRIPTION
In production, react-admin applications will send an anonymous request on mount to a telemetry server operated by marmelab. You can see this request by looking at the Network tab of your browser DevTools:

`https://react-admin-telemetry.marmelab.com/react-admin-telemetry`

The only data sent to the telemetry server is the admin domain (e.g. "example.com") - no personal data is ever sent, and no cookie is included in the response. The react-admin team uses these domains to track the usage of the framework.

You can opt out of telemetry by simply adding `disableTelemetry` to the `<Admin>` component:

```jsx
// in src/App.js
import * as React from "react";
import { Admin } from 'react-admin';

const App = () => (
    <Admin disableTelemetry>
        // ...
    </Admin>
);
```