### PR TITLE
allow common input prop textAlign=center

### DIFF
--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import { Record } from 'ra-core';
 import PropTypes from 'prop-types';
 
-type TextAlign = 'right' | 'left';
+type TextAlign = 'right' | 'left' | 'center';
 type SortOrder = 'ASC' | 'DESC';
 
 export interface FieldProps<RecordType extends Record = Record>
@@ -42,6 +42,6 @@ export const fieldPropTypes = {
     className: PropTypes.string,
     cellClassName: PropTypes.string,
     headerClassName: PropTypes.string,
-    textAlign: PropTypes.oneOf<TextAlign>(['right', 'left']),
+    textAlign: PropTypes.oneOf<TextAlign>(['right', 'left', 'center']),
     emptyText: PropTypes.string,
 };


### PR DESCRIPTION
Even though textAlign="center" is a perfectly valid option in MaterialUI, and also documented as an option for react-admin, it causes a warning when used as it is excluded from the permitted values in the PropTypes.  This simple PR is to extend the permitted values to include "center" and thus remove the unwarranted warning:

```
Warning: Failed prop type: Invalid prop `textAlign` of value `center` supplied to `TextField`, expected one of ["right","left"].
    at TextField