### PR TITLE
Fix FilterListItem doesn't appear selected when more than one filter is applied

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.spec.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, cleanup } from '@testing-library/react';
+
+import { ListContextProvider } from 'ra-core';
+import FilterListItem from './FilterListItem';
+
+describe('<FilterListItem/>', () => {
+    afterEach(cleanup);
+
+    it('should not appear selected if filterValues is empty', () => {
+        const { getByText } = render(
+            <ListContextProvider value={{ hideFilter: true }}>
+                <FilterListItem label="Foo" value={{ foo: 'bar' }} />
+            </ListContextProvider>
+        );
+        expect(getByText('Foo').parentElement.dataset.selected).toBe('false');
+    });
+
+    it('should not appear selected if filterValues does not contain value', () => {
+        const { getByText } = render(
+            <ListContextProvider
+                value={{ hideFilter: true, filterValues: { bar: 'baz' } }}
+            >
+                <FilterListItem label="Foo" value={{ foo: 'bar' }} />
+            </ListContextProvider>
+        );
+        expect(getByText('Foo').parentElement.dataset.selected).toBe('false');
+    });
+
+    it('should appear selected if filterValues is equal to value', () => {
+        const { getByText } = render(
+            <ListContextProvider
+                value={{ hideFilter: true, filterValues: { foo: 'bar' } }}
+            >
+                <FilterListItem label="Foo" value={{ foo: 'bar' }} />
+            </ListContextProvider>
+        );
+        expect(getByText('Foo').parentElement.dataset.selected).toBe('true');
+    });
+
+    it('should appear selected if filterValues is equal to value for nested filters', () => {
+        const { getByText } = render(
+            <ListContextProvider
+                value={{
+                    hideFilter: true,
+                    filterValues: {
+                        $and: [
+                            {
+                                'marketData.IssrDsclsrDdln.Dt.Dt': {
+                                    $gte: { $date: 'yesterday' },
+                                },
+                            },
+                            {
+                                'marketData.IssrDsclsrDdln.Dt.Dt': {
+                                    $lte: { $date: 'today' },
+                                },
+                            },
+                        ],
+                    },
+                }}
+            >
+                <FilterListItem
+                    label="Foo"
+                    value={{
+                        $and: [
+                            {
+                                'marketData.IssrDsclsrDdln.Dt.Dt': {
+                                    $gte: { $date: 'yesterday' },
+                                },
+                            },
+                            {
+                                'marketData.IssrDsclsrDdln.Dt.Dt': {
+                                    $lte: { $date: 'today' },
+                                },
+                            },
+                        ],
+                    }}
+                />
+            </ListContextProvider>
+        );
+        expect(getByText('Foo').parentElement.dataset.selected).toBe('true');
+    });
+
+    it('should appear selected if filterValues contains value', () => {
+        const { getByText } = render(
+            <ListContextProvider
+                value={{
+                    hideFilter: true,
+                    filterValues: { foo: 'bar', bar: 'baz' },
+                }}
+            >
+                <FilterListItem label="Foo" value={{ foo: 'bar' }} />
+            </ListContextProvider>
+        );
+        expect(getByText('Foo').parentElement.dataset.selected).toBe('true');
+    });
+});

--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -10,7 +10,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import CancelIcon from '@material-ui/icons/CancelOutlined';
 import { useTranslate, useListFilterContext } from 'ra-core';
 import { shallowEqual } from 'react-redux';
-import isEqual from 'lodash/isEqual';
+import matches from 'lodash/matches';
+import pickBy from 'lodash/pickBy';
 
 const useStyles = makeStyles(theme => ({
     listItem: {
@@ -148,7 +149,9 @@ const FilterListItem: FC<{ label: string; value: any }> = props => {
     const translate = useTranslate();
     const classes = useStyles(props);
 
-    const isSelected = isEqual(value, filterValues);
+    const isSelected = matches(
+        pickBy(value, val => typeof val !== 'undefined')
+    )(filterValues);
 
     const addFilter = () => {
         setFilters({ ...filterValues, ...value }, null, false);
@@ -179,6 +182,7 @@ const FilterListItem: FC<{ label: string; value: any }> = props => {
             <ListItemText
                 primary={translate(label, { _: label })}
                 className={classes.listItemText}
+                data-selected={isSelected ? 'true' : 'false'}
             />
             {isSelected && (
                 <ListItemSecondaryAction>


### PR DESCRIPTION
Fixes a regression introduced by #5559 

Added unit tests to avoid regressions in the future

## Before

![filterlistitem_broken](https://user-images.githubusercontent.com/99944/101543168-29954400-39a4-11eb-9d44-0d2819074d5e.gif)


## After

![filterlistitem](https://user-images.githubusercontent.com/99944/101542878-b8ee2780-39a3-11eb-88ef-204977dd2d36.gif)
