### PR TITLE
[Doc] Fix sidebar size change resets the theme color

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -485,9 +485,11 @@ const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
 You can specify the `Sidebar` width by setting the `width` and `closedWidth` property on your custom material-ui theme:
 
 ```jsx
+import { defaultTheme } from "react-admin";
 import { createMuiTheme } from '@material-ui/core/styles';
 
 const theme = createMuiTheme({
+    ...defaultTheme,
     sidebar: {
         width: 300, // The default value is 240
         closedWidth: 70, // The default value is 55


### PR DESCRIPTION
Avoid all color changes when just changing sidebar size. See [this issue](https://github.com/marmelab/react-admin/issues/5426)