### PR TITLE
Remove min width in confirmation dialog

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -16,9 +16,6 @@ import { useTranslate } from 'ra-core';
 
 const useStyles = makeStyles(
     theme => ({
-        contentText: {
-            minWidth: 400,
-        },
         confirmPrimary: {
             color: theme.palette.primary.main,
         },
@@ -97,7 +94,7 @@ const Confirm: FC<ConfirmProps> = props => {
                 {translate(title, { _: title, ...translateOptions })}
             </DialogTitle>
             <DialogContent>
-                <DialogContentText className={classes.contentText}>
+                <DialogContentText>
                     {translate(content, {
                         _: content,
                         ...translateOptions,


### PR DESCRIPTION
The `minWidth` style attribute in `<Confirm>` dialog should be removed. It doesn't make the dialog look much better and it adds a scroll bar for the contents on mobile.
Vanilla:
![Screenshot_20201215-143843](https://user-images.githubusercontent.com/184066/102211006-00187300-3ee4-11eb-8948-d02d1e1a07dd.png)
Fixed:
![Screenshot_20201215-143727](https://user-images.githubusercontent.com/184066/102211015-0149a000-3ee4-11eb-9d83-353cd9b3c2f1.png)

I use this component in my own code too and it's even worse when the confirmation text is long enough.