### PR TITLE
Revert "Fix for autocomplete off #5620"

### DIFF
--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -42,7 +42,6 @@ const SearchInput: FunctionComponent<
                         <SearchIcon color="disabled" />
                     </InputAdornment>
                 ),
-                autoComplete: 'off',
             }}
             className={classes.input}
             {...rest}


### PR DESCRIPTION
Reverts marmelab/react-admin#5684 because we may want the autocomplete activated for search. Besides, you can already override this by providing your own `InputProps`