### PR TITLE
Remove hr tag under  tabbedshowlayout component 

### DIFF
--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
@@ -7,7 +7,6 @@ import {
     ReactNode,
 } from 'react';
 import PropTypes from 'prop-types';
-import Divider from '@material-ui/core/Divider';
 import { Route } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import { useRouteMatch } from 'react-router-dom';
@@ -103,7 +102,6 @@ const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
         <div className={className} key={version} {...sanitizeRestProps(rest)}>
             {cloneElement(tabs, {}, nonNullChildren)}
 
-            <Divider />
             <div className={classes.content}>
                 {Children.map(nonNullChildren, (tab, index) =>
                     tab && isValidElement(tab) ? (


### PR DESCRIPTION
With Tabbedshowlayout component has Divider will make fail UI.

Example: https://marmelab.com/react-admin-demo/#/commands?displayedFilters=%7B%7D&filter=%7B%22status%22%3A%22delivered%22%7D&order=DESC&page=1&perPage=25&sort=date

I think we shouldn't make add Divider under the tab. User will add it when they need.