### PR TITLE
Fix EditGuesser is broken

### DIFF
--- a/packages/ra-core/src/core/useResourceContext.ts
+++ b/packages/ra-core/src/core/useResourceContext.ts
@@ -12,7 +12,7 @@ import { ResourceContext, ResourceContextValue } from './ResourceContext';
 export const useResourceContext = <
     ResourceInformationsType extends Partial<{ resource: string }>
 >(
-    props: ResourceInformationsType
+    props?: ResourceInformationsType
 ): ResourceContextValue => {
     const context = useContext(ResourceContext);
 
@@ -29,7 +29,7 @@ export const useResourceContext = <
             // );
         }
         // Ignored because resource is often optional (as it is injected) in components which passes the props to this hook
-        return props.resource;
+        return props && props.resource;
     }
 
     return context;

--- a/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 import inflection from 'inflection';
 import {
     useEditController,
+    EditContextProvider,
     InferredElement,
+    useResourceContext,
+    useEditContext,
     getElementsFromRecords,
 } from 'ra-core';
 
@@ -11,7 +14,8 @@ import { EditView } from './EditView';
 import editFieldTypes from './editFieldTypes';
 
 const EditViewGuesser = props => {
-    const { record, resource } = props;
+    const resource = useResourceContext();
+    const { record } = useEditContext();
     const [inferredChild, setInferredChild] = useState(null);
     useEffect(() => {
         if (record && !inferredChild) {
@@ -47,8 +51,13 @@ ${inferredChild.getRepresentation()}
 
 EditViewGuesser.propTypes = EditView.propTypes;
 
-const EditGuesser = props => (
-    <EditViewGuesser {...props} {...useEditController(props)} />
-);
+const EditGuesser = props => {
+    const controllerProps = useEditController(props);
+    return (
+        <EditContextProvider value={controllerProps}>
+            <EditViewGuesser {...props} />
+        </EditContextProvider>
+    );
+};
 
 export default EditGuesser;


### PR DESCRIPTION
Using EditGuesser as explained in the Tutorial throws the following error:

> TypeError: Cannot read property 'save' of undefined. 