### PR TITLE
Fix ReferenceInput does not show loader while possible values and reference record are loading

### DIFF
--- a/packages/ra-core/src/controller/input/ReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.spec.tsx
@@ -216,7 +216,7 @@ describe('<ReferenceInputController />', () => {
             choices: [{ id: 1 }],
             error: null,
             filter: { q: '' },
-            loading: false,
+            loading: true,
             pagination: { page: 1, perPage: 25 },
             sort: { field: 'title', order: 'ASC' },
             warning: null,

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -199,7 +199,7 @@ export const useReferenceInputController = (
         // kept for backwards compatibility
         // @deprecated to be removed in 4.0
         error: dataStatus.error,
-        loading: dataStatus.waiting,
+        loading: !possibleValuesLoaded || !referenceLoaded,
         filter: filterValues,
         setFilter,
         pagination,


### PR DESCRIPTION
To test this, I forced a `dataProvider` waiting longer for `getList` and `getMany`, and loaded the `CommentEdit` page in the simple example. I saw that no loader was shown. 

This is also mentioned as a gotcha in StackOverflow (https://stackoverflow.com/questions/65488613/react-admin-referenceinput-doesnt-show-loading-linearprogress-while-loading).

The fix uses the `loaded` state from the two `dataProvider` calls rather than the convoluted logic from `getDataStatus`.