### PR TITLE
fix: identity can be undefined on error and must be checked

### DIFF
--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -32,7 +32,7 @@ const UserMenu = props => {
 
     return (
         <div className={classes.user}>
-            {loaded && identity.fullName ? (
+            {loaded && identity?.fullName ? (
                 <Button
                     aria-label={label && translate(label, { _: label })}
                     className={classes.userButton}


### PR DESCRIPTION
On login error or when cleaning the local storage, `identity` becomes `undefined`. As the `UserMenu` rendering occurred before the logout via `checkError` something else, we must check for `identity` existence before rendering the `UserMenu` to prevent the 

> Cannot read property 'fullName' of undefined