### PR TITLE
doc: update setFilter definitions for consistency

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -1891,7 +1891,7 @@ const {
     // filtering
     filterValues, // a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
     setFilters, // a callback to update the filters, e.g. setFilters(filters, displayedFilters)
-    displayedFilters, // a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+    displayedFilters, // the names of the filters displayed in the form, e.g. ['commentable','title']
     showFilter, // a callback to show one of the filters, e.g. showFilter('title', defaultValue)
     hideFilter, // a callback to hide one of the filters, e.g. hidefilter('title')
     // row selection

--- a/packages/ra-core/src/controller/ListContext.tsx
+++ b/packages/ra-core/src/controller/ListContext.tsx
@@ -21,7 +21,7 @@ import { ListControllerProps } from './useListController';
  * @prop {Function} setSort a callback to change the sort, e.g. setSort('name', 'ASC')
  * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
  * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @prop {Array}    displayedFilters the names of the filters displayed in the form, e.g. ['commentable','title']
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
  * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]

--- a/packages/ra-core/src/controller/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/ListFilterContext.tsx
@@ -11,7 +11,7 @@ import { ListControllerProps } from './useListController';
  * @typedef {Object} ListFilterContextValue
  * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
  * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @prop {Array}    displayedFilters the names of the filters displayed in the form, e.g. ['commentable','title']
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
  * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'

--- a/packages/ra-core/src/controller/useListContext.ts
+++ b/packages/ra-core/src/controller/useListContext.ts
@@ -24,7 +24,7 @@ import { Record } from '../types';
  * @prop {Function} setSort a callback to change the sort, e.g. setSort('name', 'ASC')
  * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
  * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @prop {Array}    displayedFilters the names of the filters displayed in the form, e.g. ['commentable','title']
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
  * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]

--- a/packages/ra-core/src/controller/useListFilterContext.ts
+++ b/packages/ra-core/src/controller/useListFilterContext.ts
@@ -11,7 +11,7 @@ import ListFilterContext, { ListFilterContextValue } from './ListFilterContext';
  * @typedef {Object} ListFilterContextValue
  * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
  * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @prop {Array}    displayedFilters the names of the filters displayed in the form, e.g. ['commentable','title']
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
  * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'


### PR DESCRIPTION
As describe in the #5635, the `displayedFilters` definition is inconsistent in the documentation. 