### PR TITLE
Ensure Guessers properly retrieve their contexts

### DIFF
--- a/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
@@ -14,7 +14,7 @@ import { EditView } from './EditView';
 import editFieldTypes from './editFieldTypes';
 
 const EditViewGuesser = props => {
-    const resource = useResourceContext();
+    const resource = useResourceContext(props);
     const { record } = useEditContext();
     const [inferredChild, setInferredChild] = useState(null);
     useEffect(() => {

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
@@ -6,13 +6,16 @@ import {
     InferredElement,
     getElementsFromRecords,
     ShowContextProvider,
+    useResourceContext,
+    useShowContext,
 } from 'ra-core';
 
 import { ShowView } from './ShowView';
 import showFieldTypes from './showFieldTypes';
 
 const ShowViewGuesser = props => {
-    const { record, resource } = props;
+    const resource = useResourceContext(props);
+    const { record } = useShowContext();
     const [inferredChild, setInferredChild] = useState(null);
     useEffect(() => {
         if (record && !inferredChild) {


### PR DESCRIPTION
Uniformize how guessers get their resource and record.
Properly get the resource from context.