### PR TITLE
Revert "Fix ReferenceInput does not show loader while possible values and reference record are loading"

### DIFF
--- a/packages/ra-core/src/controller/input/ReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.spec.tsx
@@ -216,7 +216,7 @@ describe('<ReferenceInputController />', () => {
             choices: [{ id: 1 }],
             error: null,
             filter: { q: '' },
-            loading: true,
+            loading: false,
             pagination: { page: 1, perPage: 25 },
             sort: { field: 'title', order: 'ASC' },
             warning: null,

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -199,7 +199,7 @@ export const useReferenceInputController = (
         // kept for backwards compatibility
         // @deprecated to be removed in 4.0
         error: dataStatus.error,
-        loading: !possibleValuesLoaded || !referenceLoaded,
+        loading: dataStatus.waiting,
         filter: filterValues,
         setFilter,
         pagination,


### PR DESCRIPTION
Reverts marmelab/react-admin#5731 as it bring another bug: #5757

The solution will be to give the loading status handling responsability to the ReferenceInput child