### PR TITLE
[Doc] Update exporter usage

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -199,10 +199,12 @@ const exporter = posts => {
         postForExport.author_name = post.author.name; // add a field
         return postForExport;
     });
-    jsonExport(postsForExport, {
-        headers: ['id', 'title', 'author_name', 'body'] // order fields in the export
-    }, (err, csv) => {
-        downloadCSV(csv, 'posts'); // download as 'posts.csv` file
+    return new Promise(() => {
+        jsonExport(postsForExport, {
+            headers: ['id', 'title', 'author_name', 'body'] // order fields in the export
+        }, (err, csv) => {
+            downloadCSV(csv, 'posts'); // download as 'posts.csv` file
+        });
     });
 };
 


### PR DESCRIPTION
For https://marmelab.com/react-admin/doc/3.10/List.html#exporter

According to the type definition, `Exporter` is a function that returns `Promise<void>`.

```ts
# https://github.com/marmelab/react-admin/blob/9cc5e83252455b5e3e172306419431716f17a057/packages/ra-core/src/types.ts#L492-L501
export type Exporter = (
    data: any,
    fetchRelatedRecords: (
        data: any,
        field: string,
        resource: string
    ) => Promise<any>,
    dataProvider: DataProvider,
    resource?: string
) => Promise<void>;
```

And `jsonexport` that used in the example is a function that returns `void`.
So the example's return value does not match `Exporter` type without wrapping with `Promise`.

```ts
# https://github.com/DefinitelyTyped/DefinitelyTyped/blob/40e88087e9ec5898250644da6e4653888905bd85/types/jsonexport/index.d.ts#L112-L116
declare function jsonexport(
    json: object | object[],
    userOptions: jsonexport.UserOptionsWithHandlers,
    cb: (err: Error, csv: string) => void,
): void;
```