### PR TITLE
Handle submission validation errors

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -710,7 +710,7 @@ export const PostCreate = (props) => (
 );
 ```
 
-**Tip**: `Create` and `Edit` inject more props to their child. So `SimpleForm` also expects these props to be set (but you shouldn't set them yourself):
+**Tip**: `Create` and `Edit` inject more props to their child. So `SimpleForm` also expects these props to be set (you should set them yourself only in particular cases like the [submission validation](#submission-validation)):
 
 * `save`: The function invoked when the form is submitted.
 * `saving`: A boolean indicating whether a save operation is ongoing.
@@ -1328,6 +1328,47 @@ export const UserCreate = (props) => (
 ```
 
 **Important**: Note that asynchronous validators are not supported on the `<ArrayInput>` component due to a limitation of [react-final-form-arrays](https://github.com/final-form/react-final-form-arrays).
+
+## Submission Validation
+
+The form can be validated by the server after its submission. In order to display the validation errors, a custom `save` function needs to be used:
+
+{% raw %}
+```jsx
+import { useMutation } from 'react-admin';
+
+export const UserCreate = (props) => {
+    const [mutate] = useMutation();
+    const save = useCallback(
+        async (values) => {
+            try {
+                await mutate({
+                    type: 'create',
+                    resource: 'users',
+                    payload: { data: values },
+                }, { returnPromise: true });
+            } catch (error) {
+                if (error.body.errors) {
+                    return error.body.errors;
+                }
+            }
+        },
+        [mutate],
+    );
+
+    return (
+        <Create undoable={false} {...props}>
+            <SimpleForm save={save}>
+                <TextInput label="First Name" source="firstName" />
+                <TextInput label="Age" source="age" />
+            </SimpleForm>
+        </Create>
+    );
+};
+```
+{% endraw %}
+
+**Tip**: The shape of the returned validation errors must correspond to the form: a key needs to match a `source` prop.
 
 ## Submit On Enter
 

--- a/packages/ra-core/src/dataProvider/Mutation.tsx
+++ b/packages/ra-core/src/dataProvider/Mutation.tsx
@@ -16,7 +16,7 @@ interface Props {
             event?: any,
             callTimePayload?: any,
             callTimeOptions?: any
-        ) => void,
+        ) => void | Promise<any>,
         params: ChildrenFuncParams
     ) => JSX.Element;
     type: string;
@@ -35,6 +35,7 @@ interface Props {
  * @param {Object} options
  * @param {string} options.action Redux action type
  * @param {boolean} options.undoable Set to true to run the mutation locally before calling the dataProvider
+ * @param {boolean} options.returnPromise Set to true to return the result promise of the mutation
  * @param {Function} options.onSuccess Side effect function to be executed upon success or failure, e.g. { onSuccess: response => refresh() }
  * @param {Function} options.onFailure Side effect function to be executed upon failure, e.g. { onFailure: error => notify(error.message) }
  *

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -31,6 +31,7 @@ import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDecl
  * @param {Object} options
  * @param {string} options.action Redux action type
  * @param {boolean} options.undoable Set to true to run the mutation locally before calling the dataProvider
+ * @param {boolean} options.returnPromise Set to true to return the result promise of the mutation
  * @param {Function} options.onSuccess Side effect function to be executed upon success or failure, e.g. { onSuccess: response => refresh() }
  * @param {Function} options.onFailure Side effect function to be executed upon failure, e.g. { onFailure: error => notify(error.message) }
  * @param {boolean} options.withDeclarativeSideEffectsSupport Set to true to support legacy side effects e.g. { onSuccess: { refresh: true } }
@@ -52,6 +53,7 @@ import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDecl
  * - {Object} options
  * - {string} options.action Redux action type
  * - {boolean} options.undoable Set to true to run the mutation locally before calling the dataProvider
+ * - {boolean} options.returnPromise Set to true to return the result promise of the mutation
  * - {Function} options.onSuccess Side effect function to be executed upon success or failure, e.g. { onSuccess: response => refresh() }
  * - {Function} options.onFailure Side effect function to be executed upon failure, e.g. { onFailure: error => notify(error.message) }
  * - {boolean} withDeclarativeSideEffectsSupport Set to true to support legacy side effects e.g. { onSuccess: { refresh: true } }
@@ -140,7 +142,7 @@ const useMutation = (
         (
             callTimeQuery?: Mutation | Event,
             callTimeOptions?: MutationOptions
-        ): void => {
+        ): void | Promise<any> => {
             const finalDataProvider = hasDeclarativeSideEffectsSupport(
                 options,
                 callTimeOptions
@@ -156,14 +158,17 @@ const useMutation = (
 
             setState(prevState => ({ ...prevState, loading: true }));
 
-            finalDataProvider[params.type]
+            const returnPromise = params.options.returnPromise;
+
+            const promise = finalDataProvider[params.type]
                 .apply(
                     finalDataProvider,
                     typeof params.resource !== 'undefined'
                         ? [params.resource, params.payload, params.options]
                         : [params.payload, params.options]
                 )
-                .then(({ data, total }) => {
+                .then(response => {
+                    const { data, total } = response;
                     setState({
                         data,
                         error: null,
@@ -171,6 +176,9 @@ const useMutation = (
                         loading: false,
                         total,
                     });
+                    if (returnPromise) {
+                        return response;
+                    }
                 })
                 .catch(errorFromResponse => {
                     setState({
@@ -180,7 +188,14 @@ const useMutation = (
                         loading: false,
                         total: null,
                     });
+                    if (returnPromise) {
+                        throw errorFromResponse;
+                    }
                 });
+
+            if (returnPromise) {
+                return promise;
+            }
         },
         [
             // deep equality, see https://github.com/facebook/react/issues/14476#issuecomment-471199055
@@ -204,13 +219,17 @@ export interface Mutation {
 export interface MutationOptions {
     action?: string;
     undoable?: boolean;
+    returnPromise?: boolean;
     onSuccess?: (response: any) => any | Object;
     onFailure?: (error?: any) => any | Object;
     withDeclarativeSideEffectsSupport?: boolean;
 }
 
 export type UseMutationValue = [
-    (query?: Partial<Mutation>, options?: Partial<MutationOptions>) => void,
+    (
+        query?: Partial<Mutation>,
+        options?: Partial<MutationOptions>
+    ) => void | Promise<any>,
     {
         data?: any;
         total?: number;

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -142,9 +142,9 @@ const FormWithRedirect: FC<FormWithRedirectProps> = ({
                 finalInitialValues,
                 values
             );
-            onSave.current(sanitizedValues, finalRedirect);
+            return onSave.current(sanitizedValues, finalRedirect);
         } else {
-            onSave.current(values, finalRedirect);
+            return onSave.current(values, finalRedirect);
         }
     };
 

--- a/packages/ra-core/src/form/useInitializeFormWithRecord.ts
+++ b/packages/ra-core/src/form/useInitializeFormWithRecord.ts
@@ -19,10 +19,14 @@ const useInitializeFormWithRecord = record => {
         // Disable this option when re-initializing the form because in this case, it should reset the dirty state of all fields
         // We do need to keep this option for dynamically added inputs though which is why it is kept at the form level
         form.setConfig('keepDirtyOnReinitialize', false);
-        // Ignored until next version of final-form is released. See https://github.com/final-form/final-form/pull/376
-        // @ts-ignore
-        form.restart(initialValuesMergedWithRecord);
-        form.setConfig('keepDirtyOnReinitialize', true);
+        // Since the submit function returns a promise, use setTimeout to prevent the error "Cannot reset() in onSubmit()" in final-form
+        // It will not be necessary anymore when the next version of final-form will be released (see https://github.com/final-form/final-form/pull/363)
+        setTimeout(() => {
+            // Ignored until next version of final-form is released. See https://github.com/final-form/final-form/pull/376
+            // @ts-ignore
+            form.restart(initialValuesMergedWithRecord);
+            form.setConfig('keepDirtyOnReinitialize', true);
+        });
     }, [form, JSON.stringify(record)]); // eslint-disable-line react-hooks/exhaustive-deps
 };
 

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -66,7 +66,10 @@ export const CreateView = (props: CreateViewProps) => {
                                 ? redirect
                                 : children.props.redirect,
                         resource,
-                        save,
+                        save:
+                            typeof children.props.save === 'undefined'
+                                ? save
+                                : children.props.save,
                         saving,
                         version,
                     })}
@@ -76,7 +79,10 @@ export const CreateView = (props: CreateViewProps) => {
                         basePath,
                         record,
                         resource,
-                        save,
+                        save:
+                            typeof children.props.save === 'undefined'
+                                ? save
+                                : children.props.save,
                         saving,
                         version,
                     })}

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -87,7 +87,10 @@ export const EditView = (props: EditViewProps) => {
                                     ? redirect
                                     : children.props.redirect,
                             resource,
-                            save,
+                            save:
+                                typeof children.props.save === 'undefined'
+                                    ? save
+                                    : children.props.save,
                             saving,
                             undoable,
                             version,
@@ -102,7 +105,10 @@ export const EditView = (props: EditViewProps) => {
                         record,
                         resource,
                         version,
-                        save,
+                        save:
+                            typeof children.props.save === 'undefined'
+                                ? save
+                                : children.props.save,
                         saving,
                     })}
             </div>

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -167,7 +167,7 @@ const AutocompleteArrayInput: FunctionComponent<
         id,
         input,
         isRequired,
-        meta: { touched, error },
+        meta: { touched, error, submitError },
     } = useInput({
         format,
         id: idOverride,
@@ -427,7 +427,7 @@ const AutocompleteArrayInput: FunctionComponent<
                                 },
                                 onFocus,
                             }}
-                            error={!!(touched && error)}
+                            error={!!(touched && (error || submitError))}
                             label={
                                 <FieldTitle
                                     label={label}
@@ -448,7 +448,7 @@ const AutocompleteArrayInput: FunctionComponent<
                             helperText={
                                 <InputHelperText
                                     touched={touched}
-                                    error={error}
+                                    error={error || submitError}
                                     helperText={helperText}
                                 />
                             }

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -184,7 +184,7 @@ const AutocompleteInput: FunctionComponent<AutocompleteInputProps> = props => {
         id,
         input,
         isRequired,
-        meta: { touched, error },
+        meta: { touched, error, submitError },
     } = useInput({
         format,
         id: idOverride,
@@ -488,7 +488,7 @@ const AutocompleteInput: FunctionComponent<AutocompleteInputProps> = props => {
                                 onFocus,
                                 ...InputPropsWithoutEndAdornment,
                             }}
-                            error={!!(touched && error)}
+                            error={!!(touched && (error || submitError))}
                             label={
                                 <FieldTitle
                                     label={label}
@@ -509,7 +509,7 @@ const AutocompleteInput: FunctionComponent<AutocompleteInputProps> = props => {
                             helperText={
                                 <InputHelperText
                                     touched={touched}
-                                    error={error}
+                                    error={error || submitError}
                                     helperText={helperText}
                                 />
                             }

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -34,7 +34,7 @@ const BooleanInput: FunctionComponent<
         id,
         input: { onChange: finalFormOnChange, type, value, ...inputProps },
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -77,10 +77,10 @@ const BooleanInput: FunctionComponent<
                     />
                 }
             />
-            <FormHelperText error={!!error}>
+            <FormHelperText error={!!(error || submitError)}>
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             </FormHelperText>

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -144,7 +144,7 @@ const CheckboxGroupInput: FunctionComponent<
         id,
         input: { onChange: finalFormOnChange, onBlur: finalFormOnBlur, value },
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -195,7 +195,7 @@ const CheckboxGroupInput: FunctionComponent<
         <FormControl
             component="fieldset"
             margin={margin}
-            error={touched && !!error}
+            error={touched && !!(error || submitError)}
             className={classnames(classes.root, className)}
             {...sanitizeRestProps(rest)}
         >
@@ -225,7 +225,7 @@ const CheckboxGroupInput: FunctionComponent<
             <FormHelperText>
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             </FormHelperText>

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -66,7 +66,7 @@ const DateInput: FunctionComponent<
         id,
         input,
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -86,11 +86,11 @@ const DateInput: FunctionComponent<
             variant={variant}
             margin={margin}
             type="date"
-            error={!!(touched && error)}
+            error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             }

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -87,7 +87,7 @@ const DateTimeInput: FunctionComponent<
         id,
         input,
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -107,11 +107,11 @@ const DateTimeInput: FunctionComponent<
             {...input}
             variant={variant}
             margin={margin}
-            error={!!(touched && error)}
+            error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             }

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -128,7 +128,7 @@ const FileInput: FunctionComponent<
         validate,
         ...rest,
     });
-    const { touched, error } = meta;
+    const { touched, error, submitError } = meta;
     const files = value ? (Array.isArray(value) ? value : [value]) : [];
 
     const onDrop = (newFiles, rejectedFiles, event) => {
@@ -209,7 +209,7 @@ const FileInput: FunctionComponent<
                 <FormHelperText>
                     <InputHelperText
                         touched={touched}
-                        error={error}
+                        error={error || submitError}
                         helperText={helperText}
                     />
                 </FormHelperText>

--- a/packages/ra-ui-materialui/src/input/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/input/Labeled.tsx
@@ -87,7 +87,7 @@ const Labeled: FunctionComponent<LabeledProps> = props => {
         <FormControl
             className={className}
             fullWidth={fullWidth}
-            error={meta && meta.touched && !!meta.error}
+            error={meta && meta.touched && !!(meta.error || meta.submitError)}
             margin={margin}
         >
             <InputLabel htmlFor={id} shrink className={classes.label}>

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -65,7 +65,7 @@ const NullableBooleanInput: FunctionComponent<NullableBooleanInputProps> = props
         id,
         input,
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -91,11 +91,11 @@ const NullableBooleanInput: FunctionComponent<NullableBooleanInputProps> = props
                     isRequired={isRequired}
                 />
             }
-            error={!!(touched && error)}
+            error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             }

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -49,7 +49,7 @@ const NumberInput: FunctionComponent<NumberInputProps> = ({
         id,
         input,
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -70,11 +70,11 @@ const NumberInput: FunctionComponent<NumberInputProps> = ({
             id={id}
             {...input}
             variant={variant}
-            error={!!(touched && error)}
+            error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             }

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -138,7 +138,7 @@ const RadioButtonGroupInput: FunctionComponent<
         ...rest,
     });
 
-    const { error, touched } = meta;
+    const { error, submitError, touched } = meta;
 
     if (loading) {
         return (
@@ -160,7 +160,7 @@ const RadioButtonGroupInput: FunctionComponent<
         <FormControl
             component="fieldset"
             margin={margin}
-            error={touched && !!error}
+            error={touched && !!(error || submitError)}
             {...sanitizeInputRestProps(rest)}
         >
             <FormLabel component="legend" className={classes.label}>
@@ -188,7 +188,7 @@ const RadioButtonGroupInput: FunctionComponent<
             <FormHelperText>
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             </FormHelperText>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -181,7 +181,7 @@ const SelectArrayInput: FunctionComponent<SelectArrayInputProps> = props => {
     const {
         input,
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -230,14 +230,14 @@ const SelectArrayInput: FunctionComponent<SelectArrayInputProps> = props => {
         <FormControl
             margin={margin}
             className={classnames(classes.root, className)}
-            error={touched && !!error}
+            error={touched && !!(error || submitError)}
             variant={variant}
             {...sanitizeRestProps(rest)}
         >
             <InputLabel
                 ref={inputLabel}
                 id={`${label}-outlined-label`}
-                error={touched && !!error}
+                error={touched && !!(error || submitError)}
             >
                 <FieldTitle
                     label={label}
@@ -250,7 +250,7 @@ const SelectArrayInput: FunctionComponent<SelectArrayInputProps> = props => {
                 autoWidth
                 labelId={`${label}-outlined-label`}
                 multiple
-                error={!!(touched && error)}
+                error={!!(touched && (error || submitError))}
                 renderValue={(selected: any[]) => (
                     <div className={classes.chips}>
                         {selected
@@ -276,10 +276,10 @@ const SelectArrayInput: FunctionComponent<SelectArrayInputProps> = props => {
             >
                 {choices.map(renderMenuItem)}
             </Select>
-            <FormHelperText error={touched && !!error}>
+            <FormHelperText error={touched && !!(error || submitError)}>
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             </FormHelperText>

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -198,7 +198,7 @@ const SelectInput: FunctionComponent<
         ...rest,
     });
 
-    const { touched, error } = meta;
+    const { touched, error, submitError } = meta;
 
     const renderEmptyItemOption = useCallback(() => {
         return React.isValidElement(emptyText)
@@ -247,11 +247,11 @@ const SelectInput: FunctionComponent<
             }
             className={`${classes.input} ${className}`}
             clearAlwaysVisible
-            error={!!(touched && error)}
+            error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             }

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -43,7 +43,7 @@ const TextInput: FunctionComponent<TextInputProps> = ({
         id,
         input,
         isRequired,
-        meta: { error, touched },
+        meta: { error, submitError, touched },
     } = useInput({
         format,
         onBlur,
@@ -72,11 +72,11 @@ const TextInput: FunctionComponent<TextInputProps> = ({
                     />
                 )
             }
-            error={!!(touched && error)}
+            error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
                     touched={touched}
-                    error={error}
+                    error={error || submitError}
                     helperText={helperText}
                 />
             }


### PR DESCRIPTION
Fixes #4703.
Fixes #4351.

Returning a promise in the `submit` function is essential for handling correctly submission errors: https://final-form.org/docs/react-final-form/types/FormProps#3-asynchronous-with-a-promise.

It has been discussed in this issue too: #4351.

`useCreateController` and `useEditController` hooks are already returning a promise resolving to `undefined` for the `save` function: it will not break anything.

To handle submission errors, the custom `save` function could be implemented by using the `useDataProvider` hook, like this: https://github.com/bmihelac/react-admin/commit/1a9f02b65f1342c695a10b5aad7a6a63603fb9ba.

In order to be able to use the `useMutation` hook too, a `returnPromise` option has been added, like asked in @fzaninotto's comment: https://github.com/marmelab/react-admin/issues/4703#issuecomment-616456129.

I hope it will be OK, it would be really nice to have a way to handle submission errors easily in React-Admin and API Platform Admin!