### PR TITLE
Fix uncaught error when dataProvider fails on undoable forms

### DIFF
--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -406,7 +406,6 @@ const performUndoableQuery = ({
                         });
                         dispatch({ type: FETCH_ERROR, error });
                         onFailure && onFailure(error);
-                        throw error;
                     });
                 });
         } catch (e) {


### PR DESCRIPTION
Closes #5685

This was introduced in #4291, where I used the same code for optimistic and non-optimistic calls. If it make sense to re-throw the error in non-optimistic mode (so that the dataProvider promise rejects), it doesn't make sense in optimistic mode, as the dataProvider promise already resolved. So the error mustn't be rethrown in optimistic mode.