### PR TITLE
Fix return type of Exporter

### DIFF
--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -498,7 +498,7 @@ export type Exporter = (
     ) => Promise<any>,
     dataProvider: DataProvider,
     resource?: string
-) => Promise<void>;
+) => void | Promise<void>;
 
 export type SetOnSave = (
     onSave?: (values: object, redirect: any) => void


### PR DESCRIPTION
ref https://github.com/marmelab/react-admin/pull/5771#issuecomment-760469318

The return type of `Exporter` has been wrong, this pull request fixes it.