### PR TITLE
Fix and improve onSuccess/onFailure typings

### DIFF
--- a/packages/ra-core/src/controller/saveModifiers.tsx
+++ b/packages/ra-core/src/controller/saveModifiers.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { createContext, useRef } from 'react';
+import { Record } from '../types';
 
 export const SideEffectContext = createContext<SideEffectContextValue>({});
 
@@ -67,7 +68,7 @@ export const useSaveModifiers = ({
     };
 };
 
-export type OnSuccess = (response: any) => void;
+export type OnSuccess = (response: { data: Record }) => void;
 export type SetOnSuccess = (onSuccess: OnSuccess) => void;
 export type OnFailure = (error: { message?: string }) => void;
 export type SetOnFailure = (onFailure: OnFailure) => void;

--- a/packages/ra-core/src/dataProvider/useDeclarativeSideEffects.ts
+++ b/packages/ra-core/src/dataProvider/useDeclarativeSideEffects.ts
@@ -3,6 +3,8 @@ import {
     useRedirect,
     useRefresh,
     useUnselectAll,
+    NotificationSideEffect,
+    RedirectionSideEffect,
 } from '../sideEffect';
 import { useMemo } from 'react';
 
@@ -15,12 +17,21 @@ const useDeclarativeSideEffects = () => {
     return useMemo(
         () => (
             resource,
-            { onSuccess, onFailure }: any = {
+            {
+                onSuccess,
+                onFailure,
+            }: {
+                onSuccess?: DeclarativeSideEffect;
+                onFailure?: DeclarativeSideEffect;
+            } = {
                 onSuccess: undefined,
                 onFailure: undefined,
             }
         ) => {
-            const convertToFunctionSideEffect = (resource, sideEffects) => {
+            const convertToFunctionSideEffect = (
+                resource: string | undefined,
+                sideEffects: DeclarativeSideEffect
+            ) => {
                 if (!sideEffects || typeof sideEffects === 'function') {
                     return sideEffects;
                 }
@@ -67,5 +78,12 @@ const useDeclarativeSideEffects = () => {
         [notify, redirect, refresh, unselectAll]
     );
 };
+
+export interface DeclarativeSideEffect {
+    notification?: NotificationSideEffect;
+    redirectTo?: RedirectionSideEffect;
+    refresh?: boolean;
+    unselectAll?: boolean;
+}
 
 export default useDeclarativeSideEffects;

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -4,6 +4,8 @@ import merge from 'lodash/merge';
 import { useSafeSetState } from '../util/hooks';
 import useDataProvider from './useDataProvider';
 import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDeclarativeSideEffects';
+import { OnSuccess, OnFailure } from '../controller';
+import { DeclarativeSideEffect } from './useDeclarativeSideEffects';
 
 /**
  * Get a callback to fetch the data provider through Redux, usually for mutations.
@@ -204,8 +206,8 @@ export interface Mutation {
 export interface MutationOptions {
     action?: string;
     undoable?: boolean;
-    onSuccess?: (response: any) => any | Object;
-    onFailure?: (error?: any) => any | Object;
+    onSuccess?: OnSuccess | DeclarativeSideEffect;
+    onFailure?: OnFailure | DeclarativeSideEffect;
     withDeclarativeSideEffectsSupport?: boolean;
 }
 

--- a/packages/ra-core/src/sideEffect/fetch.ts
+++ b/packages/ra-core/src/sideEffect/fetch.ts
@@ -15,6 +15,8 @@ import {
     fetchActionsWithTotalResponse,
     sanitizeFetchType,
 } from '../core';
+import { OnSuccess, OnFailure } from '../controller';
+import { DeclarativeSideEffect } from '../dataProvider/useDeclarativeSideEffects';
 
 function validateResponseFormat(
     response,
@@ -73,8 +75,8 @@ interface ActionWithSideEffect {
     meta: {
         fetch: string;
         resource: string;
-        onSuccess?: any;
-        onFailure?: any;
+        onSuccess?: OnSuccess | DeclarativeSideEffect;
+        onFailure?: OnFailure | DeclarativeSideEffect;
     };
 }
 

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -7,6 +7,8 @@ import {
     Record as RaRecord,
     ResourceComponentProps,
     ResourceComponentPropsWithId,
+    OnSuccess,
+    OnFailure,
 } from 'ra-core';
 
 export interface ListProps extends ResourceComponentProps {
@@ -34,8 +36,8 @@ export interface EditProps extends ResourceComponentPropsWithId {
     className?: string;
     component?: ElementType;
     undoable?: boolean;
-    onSuccess?: (data: RaRecord) => void;
-    onFailure?: (error: any) => void;
+    onSuccess?: OnSuccess;
+    onFailure?: OnFailure;
     transform?: (data: RaRecord) => RaRecord;
     title?: string | ReactElement;
 }
@@ -47,8 +49,8 @@ export interface CreateProps extends ResourceComponentProps {
     className?: string;
     component?: ElementType;
     record?: Partial<RaRecord>;
-    onSuccess?: (data: RaRecord) => void;
-    onFailure?: (error: any) => void;
+    onSuccess?: OnSuccess;
+    onFailure?: OnFailure;
     transform?: (data: RaRecord) => RaRecord;
     title?: string | ReactElement;
 }


### PR DESCRIPTION
The onSuccess type declaration was not consistent with the usage in useDataProvider. Additionally, there was an erroneus definition in the material-ui package.

There were several locations, where the typings were not defined yet for onSuccess and onFailure. useDeclarativeSideEffects and useDataProvider suggested the commited types.

Fixes #5761 