### PR TITLE
Fix "Please login to continue" notification remains after login

### DIFF
--- a/packages/ra-core/src/actions/notificationActions.ts
+++ b/packages/ra-core/src/actions/notificationActions.ts
@@ -53,3 +53,13 @@ export interface HideNotificationAction {
 export const hideNotification = (): HideNotificationAction => ({
     type: HIDE_NOTIFICATION,
 });
+
+export const RESET_NOTIFICATION = 'RA/RESET_NOTIFICATION';
+
+export interface ResetNotificationAction {
+    readonly type: typeof RESET_NOTIFICATION;
+}
+
+export const resetNotification = (): ResetNotificationAction => ({
+    type: RESET_NOTIFICATION,
+});

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -1,7 +1,9 @@
 import { useCallback } from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
-import { useLocation, useHistory } from 'react-router-dom';
+import { resetNotification } from '../actions/notificationActions';
 
 /**
  * Get a callback for calling the authProvider.login() method
@@ -31,26 +33,29 @@ const useLogin = (): Login => {
     const location = useLocation();
     const locationState = location.state as any;
     const history = useHistory();
+    const dispatch = useDispatch();
     const nextPathName = locationState && locationState.nextPathname;
 
     const login = useCallback(
         (params: any = {}, pathName) =>
             authProvider.login(params).then(ret => {
+                dispatch(resetNotification());
                 const redirectUrl = pathName
                     ? pathName
                     : nextPathName || defaultAuthParams.afterLoginUrl;
                 history.push(redirectUrl);
                 return ret;
             }),
-        [authProvider, history, nextPathName]
+        [authProvider, history, nextPathName, dispatch]
     );
 
     const loginWithoutProvider = useCallback(
         (_, __) => {
+            dispatch(resetNotification());
             history.push(defaultAuthParams.afterLoginUrl);
             return Promise.resolve();
         },
-        [history]
+        [history, dispatch]
     );
 
     return authProvider ? login : loginWithoutProvider;

--- a/packages/ra-core/src/reducer/admin/notifications.ts
+++ b/packages/ra-core/src/reducer/admin/notifications.ts
@@ -4,6 +4,8 @@ import {
     ShowNotificationAction,
     HIDE_NOTIFICATION,
     HideNotificationAction,
+    RESET_NOTIFICATION,
+    ResetNotificationAction,
     NotificationPayload,
 } from '../../actions/notificationActions';
 import { UNDO, UndoAction } from '../../actions/undoActions';
@@ -11,13 +13,16 @@ import { UNDO, UndoAction } from '../../actions/undoActions';
 type ActionTypes =
     | ShowNotificationAction
     | HideNotificationAction
+    | ResetNotificationAction
     | UndoAction
     | { type: 'OTHER_TYPE' };
 
 type State = NotificationPayload[];
 
+const initialState = [];
+
 const notificationsReducer: Reducer<State> = (
-    previousState = [],
+    previousState = initialState,
     action: ActionTypes
 ) => {
     switch (action.type) {
@@ -26,6 +31,8 @@ const notificationsReducer: Reducer<State> = (
         case HIDE_NOTIFICATION:
         case UNDO:
             return previousState.slice(1);
+        case RESET_NOTIFICATION:
+            return initialState;
         default:
             return previousState;
     }


### PR DESCRIPTION
## Problem

When an unlogged user tries to access a restricted page, the page calls the dataProvider, which returns a 403 response. This redirects the user to the login page with a "please login to continue" notification. This is correct, but:

- Users may enter and submit credentials faster than the notification hide delay
- The restricted page may make several calls to the dataProvider, each returning with a 403, and each pushing a new "please login to continue" notification to be displayed once the previous has hidden. 

In both cases, once the user has logged in, they still see the "Please login to continue" notification *while the page displays restricted data*, which is confusing.

![image](https://user-images.githubusercontent.com/99944/104844209-1e043980-58cf-11eb-89f5-ff31bd4a1c2f.png)


## Solution 

Reset notifications upon login