### PR TITLE
Fix Create method API call URL example

### DIFF
--- a/packages/ra-data-json-server/README.md
+++ b/packages/ra-data-json-server/README.md
@@ -20,7 +20,7 @@ This Data Provider fits REST APIs powered by [JSON Server](https://github.com/ty
 | `getOne`           | `GET http://my.api.url/posts/123`                                                                       |
 | `getMany`          | `GET http://my.api.url/posts?id=123&id=456&id=789`     |
 | `getManyReference` | `GET http://my.api.url/posts?author_id=345`                                                             |
-| `create`           | `POST http://my.api.url/posts/123`                                                                      |
+| `create`           | `POST http://my.api.url/posts`                                                                      |
 | `update`           | `PUT http://my.api.url/posts/123`                                                                       |
 | `updateMany`       | `PUT http://my.api.url/posts/123`, `PUT http://my.api.url/posts/456`, `PUT http://my.api.url/posts/789` |
 | `delete`           | `DELETE http://my.api.url/posts/123`                                                                    |


### PR DESCRIPTION
The Create method API URL does not have an ID.  The resource is not
created yet.
Fixes #5792