### PR TITLE
Add skip navigation button

### DIFF
--- a/cypress/integration/navigation.js
+++ b/cypress/integration/navigation.js
@@ -9,12 +9,24 @@ describe('Navigation', () => {
 
             ListPage.waitUntilVisible();
 
-            cy.get('body').tab().tab().tab();
+            cy.get('body').tab().tab().tab().tab();
 
             cy.get(`${ListPage.elements.menuItems}:first-child`).should(
                 'have.class',
                 'Mui-focusVisible'
             );
+        });
+    });
+
+    describe('Skip Navigation Button', () => {
+        it('should appear when a user immediately tabs on the homepage', () => {
+            ListPage.navigate();
+
+            ListPage.waitUntilVisible();
+
+            cy.get('body').tab();
+
+            cy.get(ListPage.elements.skipNavButton).should('exist');
         });
     });
 });

--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -31,6 +31,7 @@ export default url => ({
         title: '#react-admin-title',
         headroomUnfixed: '.headroom--unfixed',
         headroomUnpinned: '.headroom--unpinned',
+        skipNavButton: '.skip-nav-button',
     },
 
     navigate() {

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -103,6 +103,7 @@ const englishMessages: TranslationMessages = {
             page_rows_per_page: 'Rows per page:',
             next: 'Next',
             prev: 'Prev',
+            skip_nav: 'Skip to content',
         },
         sort: {
             sort_by: 'Sort by %{field} %{order}',

--- a/packages/ra-ui-materialui/src/button/SkipNavigationButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SkipNavigationButton.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from './Button';
+import { useTranslate } from 'ra-core';
+import classnames from 'classnames';
+
+function skipToContent() {
+    const element = document.getElementById('main-content');
+
+    if (!element) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+                'No element with id "main-content" was found. Ensure the element that contains your main content has an id of "main-content".'
+            );
+        }
+
+        return;
+    }
+
+    element.setAttribute('tabIndex', '-1');
+    element.focus();
+    element.blur();
+    element.removeAttribute('tabIndex');
+}
+
+const useStyles = makeStyles(theme => ({
+    skipToContentButton: {
+        position: 'fixed',
+        padding: theme.spacing(1),
+        backgroundColor: theme.palette.background.default,
+        color: theme.palette.getContrastText(theme.palette.background.default),
+        transition: theme.transitions.create(['top', 'opacity'], {
+            easing: theme.transitions.easing.easeIn,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        left: theme.spacing(2),
+        top: theme.spacing(-10),
+        zIndex: 5000,
+        '&:hover': {
+            opacity: 0.8,
+            backgroundColor: theme.palette.background.default,
+        },
+        '&:focus': {
+            top: theme.spacing(2),
+            transition: theme.transitions.create(['top', 'opacity'], {
+                easing: theme.transitions.easing.easeOut,
+                duration: theme.transitions.duration.enteringScreen,
+            }),
+        },
+    },
+}));
+
+function SkipNavigationButton() {
+    const classes = useStyles();
+    const translate = useTranslate();
+
+    return (
+        <Button
+            onClick={skipToContent}
+            className={classnames(
+                classes.skipToContentButton,
+                'skip-nav-button'
+            )}
+            label={translate('ra.navigation.skip_nav')}
+            variant="contained"
+        />
+    );
+}
+
+export default SkipNavigationButton;

--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -30,6 +30,7 @@ import DefaultMenu, { MenuProps } from './Menu';
 import DefaultNotification from './Notification';
 import DefaultError from './Error';
 import defaultTheme from '../defaultTheme';
+import SkipNavigationButton from '../button/SkipNavigationButton';
 
 const styles = theme =>
     createStyles({
@@ -130,6 +131,7 @@ class LayoutWithoutTheme extends Component<
                     className={classnames('layout', classes.root, className)}
                     {...props}
                 >
+                    <SkipNavigationButton />
                     <div className={classes.appFrame}>
                         {createElement(appBar, { title, open, logout })}
                         <main className={classes.contentWithSidebar}>
@@ -139,7 +141,7 @@ class LayoutWithoutTheme extends Component<
                                     hasDashboard: !!dashboard,
                                 }),
                             })}
-                            <div className={classes.content}>
+                            <div id="main-content" className={classes.content}>
                                 {hasError
                                     ? createElement(error, {
                                           error: errorMessage,


### PR DESCRIPTION
## Notes

I messed up the rebase, and I'm just opening up a new PR with the same changes. 

## Description

I've added a button inside of `Layout.tsx` that only displays when the first action a user performs on a RA site is pressing the tab button.

This moves the focus into the main content of the website, avoiding having to tab through the top and side menus.

While the functionality is complete, I'm going to write Cypress tests for this functionality.

Notes:

Because navigating to anchors via the `#` didn't seem to work nicely with `HashRouter`, I had to install an node module that exports a custom link. [Here's a link to the discussion](https://github.com/ReactTraining/react-router/issues/394#issuecomment-220221604)

Fortunately the module has no dependencies, and it works out of the box.

I implementing this component similarly to how it's written inside of the Material-UI repo. You can view their implementation [here](https://github.com/mui-org/material-ui/blob/69eb1d66a7bab366bc6b270faff2baf3cad5b4cd/docs/src/modules/components/AppFrame.js#L194)

https://user-images.githubusercontent.com/17087167/104626969-5f59d680-568e-11eb-8999-ce665b37d484.mov

