### PR TITLE
[Doc] Undoable is for edit only

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1947,7 +1947,7 @@ export const UserEdit = ({ permissions, ...props }) =>
 
 Once the `dataProvider` returns successfully after save, users see a generic notification ("Element created" / "Element updated"). You can customize this message by passing a custom success side effect function as [the `<Edit onSuccess>` prop](#onsuccess):
 
-By default, when saving with optimistic rendering, the `onSuccess` callback is called immediately. To change that, you need to pass `undoable={false}` to your `<Edit />` or `<Create />` component. The `onSuccess` callback will then be called at the end of the dataProvider call.
+By default, when saving with optimistic rendering (edit only), the `onSuccess` callback is called immediately. To change that, you need to pass `undoable={false}` to your `<Edit />` component. The `onSuccess` callback will then be called at the end of the dataProvider call.
 
 In addition, the saved object will not be available as an argument of the `onSuccess` callback method when `undoable` feature is enabled.
 


### PR DESCRIPTION
A reference to the `undoable` prop in the `Create` component was still present in the documentation.