### PR TITLE
Allow filters to have `null` value

### DIFF
--- a/packages/ra-core/src/util/removeEmpty.spec.ts
+++ b/packages/ra-core/src/util/removeEmpty.spec.ts
@@ -8,7 +8,7 @@ describe('removeEmpty', () => {
     });
 
     it('should remove the empty values with empty values', () => {
-        const input = { foo: '', bar: null };
+        const input = { foo: '', bar: undefined };
         expect(removeEmpty(input)).toEqual({});
     });
 

--- a/packages/ra-core/src/util/removeEmpty.ts
+++ b/packages/ra-core/src/util/removeEmpty.ts
@@ -6,10 +6,7 @@ const isObject = obj =>
 const isEmpty = obj =>
     obj instanceof Date
         ? false
-        : obj === '' ||
-          obj === null ||
-          obj === undefined ||
-          shallowEqual(obj, {});
+        : obj === '' || obj === undefined || shallowEqual(obj, {});
 
 const removeEmpty = object =>
     Object.keys(object).reduce((acc, key) => {


### PR DESCRIPTION
### Use Case

Our API allows to filter a list based on an `archived` attribute. By default (no `archived` filter), it returns only the non-archived entities.

Hence, we've implemented the following filter:

```js
    <Filter {...props}>
        <SelectInput
            source="archived"
            choices={[
                { id: null, name: 'All' },
                { id: false, name: 'Non-archived only' },
                { id: true, name: 'Archived only' },
            ]}
        />
    </Filter>
```
If we want to display all our entities, we need to pass the `null` value to the filter.

Before this fix, the `null` would be removed, hence replaced by an `undefined`. We would then have the non-archived only records.

### Workaround

We are using a workaround for now, setting the id to `"null"`, and replacing it in our custom `buildQuery` function. But that's sounds hack-ish, and this change may benefit to others. 