### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -756,7 +756,7 @@ const TagsEdit = (props) => (
         <Edit {...props}>
             // ...
         </Edit>
-        <ResourceContextProvider resource="posts">
+        <ResourceContextProvider value="posts">
             <List syncWithLocation basePath="/posts" filter={{ tags: [id]}}>
                 <Datagrid>
                     <TextField source="title" />

--- a/examples/simple/src/tags/TagEdit.js
+++ b/examples/simple/src/tags/TagEdit.js
@@ -23,7 +23,7 @@ const TagEdit = props => (
                 </TranslatableInputs>
             </SimpleForm>
         </Edit>
-        <ResourceContextProvider resource="posts">
+        <ResourceContextProvider value="posts">
             <List
                 hasCreate={false}
                 hasShow


### PR DESCRIPTION
`ResourceContextProvider` should take a `value` prop, not `resource`