### PR TITLE
Fix missing type for 'ra.navigation.skip_nav' translation message

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -105,6 +105,7 @@ export interface TranslationMessages extends StringMap {
             page_rows_per_page: string;
             next: string;
             prev: string;
+            skip_nav: string;
         };
         sort: {
             sort_by: string;


### PR DESCRIPTION
Fix missing type for 'ra.navigation.skip_nav' translation message.

https://github.com/marmelab/react-admin/commit/d5d4a47e3f713cc1335a7032ca7ff17f27db078a#diff-d55e636245f2994de4a9a74002cca1fec0a6a2e68d1805a5439a0c885f37263b