### PR TITLE
docs (List): clarifies accepted List props

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -17,20 +17,6 @@ The `<List>` component fetches the list of records from the data provider, and r
 
 Here is the minimal code necessary to display a list of posts using a `<Datagrid>`:
 
-* [`title`](#title)
-* [`actions`](#actions)
-* [`exporter`](#exporter)
-* [`bulkActionButtons`](#bulkactionbuttons)
-* [`filters`](#filters-filter-inputs) (a React element used to display the filter form)
-* [`filterDefaultValues`](#filterdefaultvalues) (the default values for `alwaysOn` filters)
-* [`perPage`](#perpage-pagination-size)
-* [`sort`](#sort-default-sort-field--order)
-* [`filter`](#filter-permanent-filter) (the permanent filter used in the REST request)
-* [`pagination`](#pagination-pagination-component)
-* [`aside`](#aside-aside-component)
-* [`empty`](#empty-empty-page-component)
-* [`syncWithLocation`](#synchronize-with-url)
-
 ```jsx
 // in src/posts.js
 import * as React from "react";
@@ -70,18 +56,20 @@ That's enough to display a basic post list, with functional sort and pagination:
 
 Here are all the props accepted by the `<List>` component:
 
-* [`title`](#title)
 * [`actions`](#actions)
-* [`exporter`](#exporter)
+* [`aside`](#aside-aside-component)
 * [`bulkActionButtons`](#bulkactionbuttons)
-* [`filters`](#filters-filter-inputs) (a React element used to display the filter form)
+* [`component`](#component)
+* [`empty`](#empty-empty-page-component)
+* [`exporter`](#exporter)
 * [`filter`](#filter-permanent-filter) (the permanent filter used in the REST request)
 * [`filterDefaultValues`](#filterdefaultvalues) (the default values for `alwaysOn` filters)
+* [`filters`](#filters-filter-inputs) (a React element used to display the filter form)
+* [`pagination`](#pagination-pagination-component)
 * [`perPage`](#perpage-pagination-size)
 * [`sort`](#sort-default-sort-field--order)
-* [`pagination`](#pagination-pagination-component)
-* [`aside`](#aside-aside-component)
-* [`empty`](#empty-empty-page-component)
+* [`title`](#title)
+* [`syncWithLocation`](#synchronize-with-url)
 
 ### `title`
 

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -26,13 +26,18 @@ import { ListProps } from '../types';
  *
  * - actions
  * - aside
+ * - bulkActionButtons
  * - component
+ * - empty
+ * - exporter
  * - filter (the permanent filter to apply to the query)
+ * - filterDefaultValues (the default values for `alwaysOn` filters)
  * - filters (a React component used to display the filter form)
  * - pagination
  * - perPage
  * - sort
  * - title
+ * - syncWithLocation
  *
  * @example
  *


### PR DESCRIPTION
Hi, it's confusing to have two list of props defined in the docs, I think only one List props is sufficient under the l57 `Here are all the props accepted by the `<List>` component`.
Moreover in the second list it was missing `syncWithLocation` and `component` (that was missing in the two lists)