### PR TITLE
[Typescript] Add missing classes prop on SimpleFormIterator

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.tsx
@@ -21,6 +21,7 @@ import classNames from 'classnames';
 import { FieldArrayRenderProps } from 'react-final-form-arrays';
 
 import FormInput from './FormInput';
+import { ClassesOverride } from '../types';
 
 const useStyles = makeStyles(
     theme => ({
@@ -319,7 +320,7 @@ export interface SimpleFormIteratorProps
     extends Partial<Omit<FieldArrayRenderProps<any, HTMLElement>, 'meta'>> {
     addButton?: ReactElement;
     basePath?: string;
-    classes?: Partial<ReturnType<typeof useStyles>>;
+    classes?: ClassesOverride<typeof useStyles>;
     className?: string;
     defaultValue?: any;
     disabled?: boolean;

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.tsx
@@ -319,6 +319,7 @@ export interface SimpleFormIteratorProps
     extends Partial<Omit<FieldArrayRenderProps<any, HTMLElement>, 'meta'>> {
     addButton?: ReactElement;
     basePath?: string;
+    classes?: Partial<ReturnType<typeof useStyles>>;
     className?: string;
     defaultValue?: any;
     disabled?: boolean;


### PR DESCRIPTION
In order to customise the layout of a form in `SimpleFormIterator`, I need to use the `classes` props. It works but the TS definition was not allowing it.

This simply adds the `classes` prop.