### PR TITLE
Add scroll to top on navigation

### DIFF
--- a/examples/demo/src/products/ProductList.tsx
+++ b/examples/demo/src/products/ProductList.tsx
@@ -20,6 +20,7 @@ import {
     TopToolbar,
     useListContext,
     useTranslate,
+    useScrollRestoration,
 } from 'react-admin';
 
 import GridList from './GridList';
@@ -69,6 +70,7 @@ const ListActions: FC<any> = ({ isSmall }) => (
 );
 
 const ProductList: FC<ListProps> = props => {
+    useScrollRestoration();
     const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('sm'));
     return (
         <ListBase

--- a/examples/demo/src/products/ProductList.tsx
+++ b/examples/demo/src/products/ProductList.tsx
@@ -20,7 +20,7 @@ import {
     TopToolbar,
     useListContext,
     useTranslate,
-    useScrollRestoration,
+    useScrollToTop,
 } from 'react-admin';
 
 import GridList from './GridList';
@@ -70,7 +70,7 @@ const ListActions: FC<any> = ({ isSmall }) => (
 );
 
 const ProductList: FC<ListProps> = props => {
-    useScrollRestoration();
+    useScrollToTop();
     const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('sm'));
     return (
         <ListBase

--- a/examples/demo/src/reviews/ReviewList.tsx
+++ b/examples/demo/src/reviews/ReviewList.tsx
@@ -77,7 +77,7 @@ const ReviewList: FC<ListProps> = props => {
                                 filters={<ReviewFilter />}
                                 perPage={25}
                                 sort={{ field: 'date', order: 'DESC' }}
-                                disableScrollRestoration
+                                disableScrollToTop
                             >
                                 {isXSmall ? (
                                     <ReviewListMobile />

--- a/examples/demo/src/reviews/ReviewList.tsx
+++ b/examples/demo/src/reviews/ReviewList.tsx
@@ -77,6 +77,7 @@ const ReviewList: FC<ListProps> = props => {
                                 filters={<ReviewFilter />}
                                 perPage={25}
                                 sort={{ field: 'date', order: 'DESC' }}
+                                disableScrollRestoration
                             >
                                 {isXSmall ? (
                                     <ReviewListMobile />

--- a/packages/ra-core/src/core/index.ts
+++ b/packages/ra-core/src/core/index.ts
@@ -6,4 +6,4 @@ export * from './useResourceContext';
 export * from './useResourceDefinition';
 // there seems to be a bug in TypeScript: this only works if the exports are in this order.
 // Swapping the two exports leads to the core module missing the dataFetchActions constants
-export * from './useScrollRestoration';
+export * from './useScrollToTop';

--- a/packages/ra-core/src/core/index.ts
+++ b/packages/ra-core/src/core/index.ts
@@ -6,3 +6,4 @@ export * from './useResourceContext';
 export * from './useResourceDefinition';
 // there seems to be a bug in TypeScript: this only works if the exports are in this order.
 // Swapping the two exports leads to the core module missing the dataFetchActions constants
+export * from './useScrollRestoration';

--- a/packages/ra-core/src/core/useScrollRestoration.tsx
+++ b/packages/ra-core/src/core/useScrollRestoration.tsx
@@ -1,5 +1,5 @@
 import { useHistory } from 'react-router-dom';
-import { useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 
 /**
  * Scroll the page to top when the route changes.
@@ -27,7 +27,7 @@ import { useLayoutEffect } from 'react';
  */
 export const useScrollRestoration = (disabled?: boolean): void => {
     const history = useHistory();
-    useLayoutEffect(() => {
+    useEffect(() => {
         if (
             history.action !== 'POP' &&
             typeof window != 'undefined' &&

--- a/packages/ra-core/src/core/useScrollRestoration.tsx
+++ b/packages/ra-core/src/core/useScrollRestoration.tsx
@@ -1,0 +1,44 @@
+import { useHistory } from 'react-router-dom';
+import { useLayoutEffect } from 'react';
+
+/**
+ * Scroll the page to top when the route changes.
+ *
+ * Used by default in react-admin <List>, <Edit>, <Create> and <Show>
+ * components. Not used anywhere else by default (so e.g. <ListBase> does not
+ * use it).
+ *
+ * @see https://reactrouter.com/web/guides/scroll-restoration
+ *
+ * @example
+ *
+ * import { ListBase, useScrollRestoration } from 'react-admin';
+ *
+ * const MyList = props => {
+ *     useScrollRestoration();
+ *     return (
+ *         <ListBase {...props}>
+ *             ...
+ *         </ListBase>
+ *     )
+ * };
+ *
+ * @param disabled Set to true to disable scroll to top. Required by the rules of hooks.
+ */
+export const useScrollRestoration = (disabled?: boolean): void => {
+    const history = useHistory();
+    useLayoutEffect(() => {
+        if (
+            history.action !== 'POP' &&
+            typeof window != 'undefined' &&
+            !disabled
+        ) {
+            window.scrollTo(0, 0);
+        }
+    }, [
+        history.action,
+        history.location.pathname,
+        history.location.search,
+        disabled,
+    ]);
+};

--- a/packages/ra-core/src/core/useScrollToTop.tsx
+++ b/packages/ra-core/src/core/useScrollToTop.tsx
@@ -12,10 +12,10 @@ import { useEffect } from 'react';
  *
  * @example
  *
- * import { ListBase, useScrollRestoration } from 'react-admin';
+ * import { ListBase, useScrollToTop } from 'react-admin';
  *
  * const MyList = props => {
- *     useScrollRestoration();
+ *     useScrollToTop();
  *     return (
  *         <ListBase {...props}>
  *             ...
@@ -25,7 +25,7 @@ import { useEffect } from 'react';
  *
  * @param disabled Set to true to disable scroll to top. Required by the rules of hooks.
  */
-export const useScrollRestoration = (disabled?: boolean): void => {
+export const useScrollToTop = (disabled?: boolean): void => {
     const history = useHistory();
     useEffect(() => {
         if (

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -80,7 +80,7 @@ Create.propTypes = {
     children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,
-    disableScrollRestoration: PropTypes.bool,
+    disableScrollToTop: PropTypes.bool,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasShow: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -80,6 +80,7 @@ Create.propTypes = {
     children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,
+    disableScrollRestoration: PropTypes.bool,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasShow: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {
     CreateControllerProps,
     useCreateContext,
-    useScrollRestoration,
+    useScrollToTop,
 } from 'ra-core';
 import { Card } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -20,12 +20,12 @@ export const CreateView = (props: CreateViewProps) => {
         classes: classesOverride,
         className,
         component: Content,
-        disableScrollRestoration,
+        disableScrollToTop,
         title,
         ...rest
     } = props;
 
-    useScrollRestoration(disableScrollRestoration);
+    useScrollToTop(disableScrollToTop);
     const classes = useStyles(props);
 
     const {

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { Children, cloneElement, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { CreateControllerProps, useCreateContext } from 'ra-core';
+import {
+    CreateControllerProps,
+    useCreateContext,
+    useScrollRestoration,
+} from 'ra-core';
 import { Card } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
@@ -16,10 +20,12 @@ export const CreateView = (props: CreateViewProps) => {
         classes: classesOverride,
         className,
         component: Content,
+        disableScrollRestoration,
         title,
         ...rest
     } = props;
 
+    useScrollRestoration(disableScrollRestoration);
     const classes = useStyles(props);
 
     const {

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -82,7 +82,7 @@ Edit.propTypes = {
     children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
-    disableScrollRestoration: PropTypes.bool,
+    disableScrollToTop: PropTypes.bool,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasShow: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -82,6 +82,7 @@ Edit.propTypes = {
     children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
+    disableScrollRestoration: PropTypes.bool,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasShow: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -9,6 +9,7 @@ import {
     EditControllerProps,
     ComponentPropType,
     useEditContext,
+    useScrollRestoration,
 } from 'ra-core';
 
 import DefaultActions from './EditActions';
@@ -23,12 +24,14 @@ export const EditView = (props: EditViewProps) => {
         classes: classesOverride,
         className,
         component: Content,
+        disableScrollRestoration,
         title,
         undoable,
         mutationMode,
         ...rest
     } = props;
 
+    useScrollRestoration(disableScrollRestoration);
     const classes = useStyles(props);
 
     const {

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -9,7 +9,7 @@ import {
     EditControllerProps,
     ComponentPropType,
     useEditContext,
-    useScrollRestoration,
+    useScrollToTop,
 } from 'ra-core';
 
 import DefaultActions from './EditActions';
@@ -24,14 +24,14 @@ export const EditView = (props: EditViewProps) => {
         classes: classesOverride,
         className,
         component: Content,
-        disableScrollRestoration,
+        disableScrollToTop,
         title,
         undoable,
         mutationMode,
         ...rest
     } = props;
 
-    useScrollRestoration(disableScrollRestoration);
+    useScrollToTop(disableScrollToTop);
     const classes = useStyles(props);
 
     const {

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -80,7 +80,7 @@ Show.propTypes = {
     children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,
-    disableScrollRestoration: PropTypes.bool,
+    disableScrollToTop: PropTypes.bool,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasList: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -80,6 +80,7 @@ Show.propTypes = {
     children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,
+    disableScrollRestoration: PropTypes.bool,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasList: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -8,6 +8,7 @@ import {
     ShowControllerProps,
     useResourceDefinition,
     useShowContext,
+    useScrollRestoration,
 } from 'ra-core';
 
 import DefaultActions from './ShowActions';
@@ -22,10 +23,12 @@ export const ShowView = (props: ShowViewProps) => {
         classes: classesOverride,
         className,
         component: Content,
+        disableScrollRestoration,
         title,
         ...rest
     } = props;
 
+    useScrollRestoration(disableScrollRestoration);
     const classes = useStyles(props);
 
     const {

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -8,7 +8,7 @@ import {
     ShowControllerProps,
     useResourceDefinition,
     useShowContext,
-    useScrollRestoration,
+    useScrollToTop,
 } from 'ra-core';
 
 import DefaultActions from './ShowActions';
@@ -23,12 +23,12 @@ export const ShowView = (props: ShowViewProps) => {
         classes: classesOverride,
         className,
         component: Content,
-        disableScrollRestoration,
+        disableScrollToTop,
         title,
         ...rest
     } = props;
 
-    useScrollRestoration(disableScrollRestoration);
+    useScrollToTop(disableScrollToTop);
     const classes = useStyles(props);
 
     const {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -76,7 +76,7 @@ interface Options {
  * ];
  * const matchSuggestion = (filterValue, choice) => choice.first_name.match(filterValue) || choice.last_name.match(filterValue);
  * const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
- * <SelectInput source="gender" choices={choices} optionText={<FullNameField />} matchSuggestion={matchSuggestion} />
+ * <AutocompleteInput source="gender" choices={choices} optionText={<FullNameField />} matchSuggestion={matchSuggestion} />
  *
  * The choices are translated by default, so you can use translation identifiers as choices:
  * @example

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -74,7 +74,7 @@ List.propTypes = {
     aside: PropTypes.element,
     // @ts-ignore-line
     bulkActionButtons: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
-    disableScrollRestoration: PropTypes.bool,
+    disableScrollToTop: PropTypes.bool,
     children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -74,6 +74,7 @@ List.propTypes = {
     aside: PropTypes.element,
     // @ts-ignore-line
     bulkActionButtons: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
+    disableScrollRestoration: PropTypes.bool,
     children: PropTypes.element,
     classes: PropTypes.object,
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -10,7 +10,7 @@ import {
     ListControllerProps,
     useListContext,
     getListControllerProps,
-    useScrollRestoration,
+    useScrollToTop,
     useVersion,
 } from 'ra-core';
 
@@ -37,10 +37,10 @@ export const ListView = (props: ListViewProps) => {
         exporter = defaultExporter,
         title,
         empty,
-        disableScrollRestoration,
+        disableScrollToTop,
         ...rest
     } = props;
-    useScrollRestoration(disableScrollRestoration);
+    useScrollToTop(disableScrollToTop);
     const controllerProps = getListControllerProps(props); // deprecated, to be removed in v4
     const listContext = useListContext(props);
     const classes = useStyles(props);

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -10,6 +10,7 @@ import {
     ListControllerProps,
     useListContext,
     getListControllerProps,
+    useScrollRestoration,
     useVersion,
 } from 'ra-core';
 
@@ -36,8 +37,10 @@ export const ListView = (props: ListViewProps) => {
         exporter = defaultExporter,
         title,
         empty,
+        disableScrollRestoration,
         ...rest
     } = props;
+    useScrollRestoration(disableScrollRestoration);
     const controllerProps = getListControllerProps(props); // deprecated, to be removed in v4
     const listContext = useListContext(props);
     const classes = useStyles(props);

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -17,7 +17,7 @@ export interface ListProps extends ResourceComponentProps {
     classes?: any;
     className?: string;
     component?: ElementType;
-    disableScrollRestoration?: boolean;
+    disableScrollToTop?: boolean;
     empty?: ReactElement | false;
     exporter?: Exporter | false;
     filter?: FilterPayload;
@@ -36,7 +36,7 @@ export interface EditProps extends ResourceComponentPropsWithId {
     classes?: any;
     className?: string;
     component?: ElementType;
-    disableScrollRestoration?: boolean;
+    disableScrollToTop?: boolean;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     mutationMode?: MutationMode;
@@ -52,7 +52,7 @@ export interface CreateProps extends ResourceComponentProps {
     classes?: any;
     className?: string;
     component?: ElementType;
-    disableScrollRestoration?: boolean;
+    disableScrollToTop?: boolean;
     record?: Partial<RaRecord>;
     onSuccess?: (data: RaRecord) => void;
     onFailure?: (error: any) => void;
@@ -66,7 +66,7 @@ export interface ShowProps extends ResourceComponentPropsWithId {
     classes?: any;
     className?: string;
     component?: ElementType;
-    disableScrollRestoration?: boolean;
+    disableScrollToTop?: boolean;
     title?: string | ReactElement;
 }
 

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -17,6 +17,7 @@ export interface ListProps extends ResourceComponentProps {
     classes?: any;
     className?: string;
     component?: ElementType;
+    disableScrollRestoration?: boolean;
     empty?: ReactElement | false;
     exporter?: Exporter | false;
     filter?: FilterPayload;
@@ -35,6 +36,7 @@ export interface EditProps extends ResourceComponentPropsWithId {
     classes?: any;
     className?: string;
     component?: ElementType;
+    disableScrollRestoration?: boolean;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     mutationMode?: MutationMode;
@@ -50,6 +52,7 @@ export interface CreateProps extends ResourceComponentProps {
     classes?: any;
     className?: string;
     component?: ElementType;
+    disableScrollRestoration?: boolean;
     record?: Partial<RaRecord>;
     onSuccess?: (data: RaRecord) => void;
     onFailure?: (error: any) => void;
@@ -63,6 +66,7 @@ export interface ShowProps extends ResourceComponentPropsWithId {
     classes?: any;
     className?: string;
     component?: ElementType;
+    disableScrollRestoration?: boolean;
     title?: string | ReactElement;
 }
 


### PR DESCRIPTION
## Problem

React-router [doesn't manage scroll changes on navigation](https://reactrouter.com/web/guides/scroll-restoration). As a consequence, when users click on an item low in the menu, or on the pagination controls, the new content may reveal up hidden in the non-visible area of the page. This is disturbing for end users.

![scrollToTop](https://user-images.githubusercontent.com/99944/107429178-f302b380-6b23-11eb-886a-4dd04d6b5f04.gif)

On the other hand, the page should not scroll to top everywhere, and especially not when using the back button.

## Solution

- [x] Enable scroll to top by default in `<List>`, `<Create>`, `<Edit>` and `<Show>`
- [x] Allow users to disable it using the `disableScrollToTop` prop
- [ ] Add documentation  

![scrollToTop2](https://user-images.githubusercontent.com/99944/107429614-699fb100-6b24-11eb-92db-fc08b7970ff0.gif)
