### PR TITLE
Ensure form children can override props

### DIFF
--- a/packages/ra-ui-materialui/src/form/FormInput.tsx
+++ b/packages/ra-ui-materialui/src/form/FormInput.tsx
@@ -29,7 +29,9 @@ const FormInput = <RecordType extends Record | Omit<Record, 'id'> = Record>(
 ) => {
     const { input, classes: classesOverride, ...rest } = props;
     const classes = useStyles(props);
-    const { id, ...inputProps } = input ? input.props : { id: undefined };
+    const { id, className, ...inputProps } = input
+        ? input.props
+        : { id: undefined, className: undefined };
     return input ? (
         <div
             className={classnames(
@@ -49,10 +51,11 @@ const FormInput = <RecordType extends Record | Omit<Record, 'id'> = Record>(
                             {
                                 [classes.input]: !input.props.fullWidth,
                             },
-                            input.props.className
+                            className
                         ),
                         id: input.props.id || input.props.source,
                         ...rest,
+                        ...inputProps,
                     })}
                 </Labeled>
             ) : (
@@ -61,10 +64,11 @@ const FormInput = <RecordType extends Record | Omit<Record, 'id'> = Record>(
                         {
                             [classes.input]: !input.props.fullWidth,
                         },
-                        input.props.className
+                        className
                     ),
                     id: input.props.id || input.props.source,
                     ...rest,
+                    ...inputProps,
                 })
             )}
         </div>

--- a/packages/ra-ui-materialui/src/form/SimpleForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.spec.tsx
@@ -59,7 +59,7 @@ describe('<SimpleForm />', () => {
             <SaveContextProvider value={saveContextValue}>
                 <SideEffectContextProvider value={sideEffects}>
                     <SimpleForm submitOnEnter={false} toolbar={<Toolbar />}>
-                        <div />
+                        <TextInput source="name" />
                     </SimpleForm>
                 </SideEffectContextProvider>
             </SaveContextProvider>
@@ -71,7 +71,7 @@ describe('<SimpleForm />', () => {
             <SaveContextProvider value={saveContextValue}>
                 <SideEffectContextProvider value={sideEffects}>
                     <SimpleForm submitOnEnter toolbar={<Toolbar />}>
-                        <div />
+                        <TextInput source="name" />
                     </SimpleForm>
                 </SideEffectContextProvider>
             </SaveContextProvider>


### PR DESCRIPTION
This can be useful when you want to display a component using a different resource in the form.

- [x] Implementation
- [ ] Example use case