### PR TITLE
Fix List view error after delete when using a field with no record test

### DIFF
--- a/packages/ra-core/src/controller/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/useListController.spec.tsx
@@ -153,7 +153,6 @@ describe('useListController', () => {
             const props = {
                 ...defaultProps,
                 debounce: 200,
-                crudGetList: jest.fn(),
                 children,
             };
 
@@ -171,6 +170,7 @@ describe('useListController', () => {
                                     params: {},
                                     cachedRequests: {},
                                     ids: [],
+                                    selectedIds: [],
                                 },
                             },
                         },

--- a/packages/ra-core/src/controller/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/useListController.spec.tsx
@@ -171,6 +171,7 @@ describe('useListController', () => {
                                     cachedRequests: {},
                                     ids: [],
                                     selectedIds: [],
+                                    total: null,
                                 },
                             },
                         },

--- a/packages/ra-core/src/controller/useListController.ts
+++ b/packages/ra-core/src/controller/useListController.ts
@@ -1,15 +1,13 @@
 import { isValidElement, ReactElement, useEffect, useMemo } from 'react';
 import inflection from 'inflection';
 import { Location } from 'history';
-import { useSelector } from 'react-redux';
-import get from 'lodash/get';
 
 import { useCheckMinimumRequiredProps } from './checkMinimumRequiredProps';
 import useListParams from './useListParams';
 import useRecordSelection from './useRecordSelection';
 import useTranslate from '../i18n/useTranslate';
 import useNotify from '../sideEffect/useNotify';
-import useGetList from '../dataProvider/useGetList';
+import { useGetMainList } from '../dataProvider/useGetMainList';
 import { SORT_ASC } from '../reducer/admin/resource/list/queryReducer';
 import { CRUD_GET_LIST } from '../actions';
 import defaultExporter from '../export/defaultExporter';
@@ -18,7 +16,6 @@ import {
     SortPayload,
     RecordMap,
     Identifier,
-    ReduxState,
     Record,
     Exporter,
 } from '../types';
@@ -52,8 +49,6 @@ const defaultSort = {
     field: 'id',
     order: SORT_ASC,
 };
-
-const defaultData = {};
 
 export interface ListControllerProps<RecordType extends Record = Record> {
     basePath: string;
@@ -153,7 +148,9 @@ const useListController = <RecordType extends Record = Record>(
      * We want the list of ids to be always available for optimistic rendering,
      * and therefore we need a custom action (CRUD_GET_LIST) that will be used.
      */
-    const { ids, total, error, loading, loaded } = useGetList<RecordType>(
+    const { ids, data, total, error, loading, loaded } = useGetMainList<
+        RecordType
+    >(
         resource,
         {
             page: query.page,
@@ -181,41 +178,12 @@ const useListController = <RecordType extends Record = Record>(
         }
     );
 
-    const data = useSelector(
-        (state: ReduxState): RecordMap<RecordType> =>
-            get(
-                state.admin.resources,
-                [resource, 'data'],
-                defaultData
-            ) as RecordMap<RecordType>
-    );
-
-    // When the user changes the page/sort/filter, this controller runs the
-    // useGetList hook again. While the result of this new call is loading,
-    // the ids and total are empty. To avoid rendering an empty list at that
-    // moment, we override the ids and total with the latest loaded ones.
-    const defaultIds = useSelector((state: ReduxState): Identifier[] =>
-        get(state.admin.resources, [resource, 'list', 'ids'], [])
-    );
-    const defaultTotal = useSelector((state: ReduxState): number =>
-        get(state.admin.resources, [resource, 'list', 'total'])
-    );
-
-    // Since the total can be empty during the loading phase
-    // We need to override that total with the latest loaded one
-    // This way, the useEffect bellow won't reset the page to 1
-    const finalTotal = typeof total === 'undefined' ? defaultTotal : total;
-
-    const finalIds = typeof total === 'undefined' ? defaultIds : ids;
-
-    const totalPages = useMemo(() => {
-        return Math.ceil(finalTotal / query.perPage) || 1;
-    }, [query.perPage, finalTotal]);
+    const totalPages = Math.ceil(total / query.perPage) || 1;
 
     useEffect(() => {
         if (
             query.page <= 0 ||
-            (!loading && query.page > 1 && (finalIds || []).length === 0)
+            (!loading && query.page > 1 && ids.length === 0)
         ) {
             // Query for a page that doesn't exist, set page to 1
             queryModifiers.setPage(1);
@@ -224,15 +192,7 @@ const useListController = <RecordType extends Record = Record>(
             // It occurs when deleting the last element of the last page
             queryModifiers.setPage(totalPages);
         }
-    }, [
-        loading,
-        query.page,
-        finalIds,
-        queryModifiers,
-        total,
-        totalPages,
-        defaultIds,
-    ]);
+    }, [loading, query.page, ids, queryModifiers, total, totalPages]);
 
     const currentSort = useMemo(
         () => ({
@@ -262,8 +222,8 @@ const useListController = <RecordType extends Record = Record>(
         filterValues: query.filterValues,
         hasCreate,
         hideFilter: queryModifiers.hideFilter,
-        ids: finalIds,
-        loaded: loaded || defaultIds.length > 0,
+        ids,
+        loaded: loaded || ids.length > 0,
         loading,
         onSelect: selectionModifiers.select,
         onToggleItem: selectionModifiers.toggle,
@@ -277,7 +237,7 @@ const useListController = <RecordType extends Record = Record>(
         setPerPage: queryModifiers.setPerPage,
         setSort: queryModifiers.setSort,
         showFilter: queryModifiers.showFilter,
-        total: finalTotal,
+        total: total,
     };
 };
 

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -13,6 +13,7 @@ import useQueryWithStore, { QueryOptions } from './useQueryWithStore';
 import withDataProvider from './withDataProvider';
 import useGetOne, { UseGetOneHookValue } from './useGetOne';
 import useGetList from './useGetList';
+import { useGetMainList } from './useGetMainList';
 import useGetMany from './useGetMany';
 import useGetManyReference from './useGetManyReference';
 import useGetMatching from './useGetMatching';
@@ -45,6 +46,7 @@ export {
     useQuery,
     useGetOne,
     useGetList,
+    useGetMainList,
     useGetMany,
     useGetManyReference,
     useGetMatching,

--- a/packages/ra-core/src/dataProvider/useGetMainList.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMainList.tsx
@@ -180,4 +180,4 @@ interface Memo<RecordType extends Record = Record> {
     result?: DataSelectorResult<RecordType>;
 }
 
-const isDataLoaded = (data: DataSelectorResult) => data.finalTotal == null; // null or undefined
+const isDataLoaded = (data: DataSelectorResult) => data.finalTotal != null; // null or undefined

--- a/packages/ra-core/src/dataProvider/useGetMainList.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMainList.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useRef } from 'react';
+import get from 'lodash/get';
+
+import {
+    PaginationPayload,
+    SortPayload,
+    ReduxState,
+    Identifier,
+    Record,
+    RecordMap,
+} from '../types';
+import useQueryWithStore from './useQueryWithStore';
+
+const defaultIds = [];
+const defaultData = {};
+
+/**
+ * Call the dataProvider.getList() method and return the resolved result
+ * as well as the loading state.
+ *
+ * Uses a special cache to avoid showing an empty list while re-fetching the
+ * list after changing params.
+ *
+ * The return value updates according to the request state:
+ *
+ * - start: { loading: true, loaded: false }
+ * - success: { data: [data from store], ids: [ids from response], total: [total from response], loading: false, loaded: true }
+ * - error: { error: [error from response], loading: false, loaded: true }
+ *
+ * This hook will return the cached result when called a second time
+ * with the same parameters, until the response arrives.
+ *
+ * @param {string} resource The resource name, e.g. 'posts'
+ * @param {Object} pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
+ * @param {Object} sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
+ * @param {Object} filter The request filters, e.g. { title: 'hello, world' }
+ * @param {Object} options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ *
+ * @returns The current request state. Destructure as { data, total, ids, error, loading, loaded }.
+ *
+ * @example
+ *
+ * import { useGetMainList } from 'react-admin';
+ *
+ * const LatestNews = () => {
+ *     const { data, ids, loading, error } = useGetMainList(
+ *         'posts',
+ *         { page: 1, perPage: 10 },
+ *         { field: 'published_at', order: 'DESC' }
+ *     );
+ *     if (loading) { return <Loading />; }
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <ul>{ids.map(id =>
+ *         <li key={id}>{data[id].title}</li>
+ *     )}</ul>;
+ * };
+ */
+export const useGetMainList = <RecordType extends Record = Record>(
+    resource: string,
+    pagination: PaginationPayload,
+    sort: SortPayload,
+    filter: object,
+    options?: any
+): {
+    data?: RecordMap<RecordType>;
+    ids?: Identifier[];
+    total?: number;
+    error?: any;
+    loading: boolean;
+    loaded: boolean;
+} => {
+    const requestSignature = JSON.stringify({ pagination, sort, filter });
+    const memo = useRef<Memo<RecordType>>({});
+    const {
+        data: { finalIds, finalTotal, allRecords },
+        error,
+        loading,
+        loaded,
+    } = useQueryWithStore(
+        { type: 'getList', resource, payload: { pagination, sort, filter } },
+        options,
+        // ids and data selector
+        (state: ReduxState): DataSelectorResult<RecordType> => {
+            const ids = get(state.admin.resources, [
+                resource,
+                'list',
+                'cachedRequests',
+                requestSignature,
+                'ids',
+            ]);
+            const total = get(state.admin.resources, [
+                resource,
+                'list',
+                'cachedRequests',
+                requestSignature,
+                'total',
+            ]);
+            // When the user changes the page/sort/filter, the list of ids from
+            // the cached requests is empty. To avoid rendering an empty list
+            // at that moment, we override the ids and total with the latest
+            // loaded ones.
+            const mainIds = get(state.admin.resources, [
+                resource,
+                'list',
+                'ids',
+            ]);
+            // Since the total can be empty during the loading phase
+            // We need to override that total with the latest loaded one
+            const mainTotal = get(state.admin.resources, [
+                resource,
+                'list',
+                'total',
+            ]);
+            // can be null for a page that was never loaded. Useful for the isDataLoaded callback
+            const finalIds = typeof ids === 'undefined' ? mainIds : ids;
+            // can be null for a page that was never loaded.
+            const finalTotal = typeof total === 'undefined' ? mainTotal : total;
+            const allRecords = get(
+                state.admin.resources,
+                [resource, 'data'],
+                defaultData
+            );
+            // poor man's useMemo inside a hook using a ref
+            if (
+                memo.current.finalIds !== finalIds ||
+                memo.current.finalTotal !== finalTotal ||
+                memo.current.allRecords !== allRecords
+            ) {
+                const result = {
+                    finalIds,
+                    finalTotal,
+                    allRecords,
+                };
+                memo.current = { finalIds, finalTotal, allRecords, result };
+            }
+            return memo.current.result;
+        },
+        () => null,
+        isDataLoaded
+    );
+
+    const data = useMemo(
+        () =>
+            typeof finalIds === 'undefined'
+                ? defaultData
+                : finalIds
+                      .map(id => allRecords[id])
+                      .reduce((acc, record) => {
+                          if (!record) return acc;
+                          acc[record.id] = record;
+                          return acc;
+                      }, {}),
+        [finalIds, allRecords]
+    );
+
+    return {
+        data,
+        ids: typeof finalIds === 'undefined' ? defaultIds : finalIds,
+        total: finalTotal,
+        error,
+        loading,
+        loaded,
+    };
+};
+
+interface DataSelectorResult<RecordType extends Record = Record> {
+    finalIds?: Identifier[];
+    finalTotal: number;
+    allRecords: RecordMap<RecordType>;
+}
+
+interface Memo<RecordType extends Record = Record> {
+    finalIds?: Identifier[];
+    finalTotal?: number;
+    allRecords?: RecordMap<RecordType>;
+    result?: DataSelectorResult<RecordType>;
+}
+
+const isDataLoaded = (data: DataSelectorResult) =>
+    typeof data.finalIds !== 'undefined';

--- a/packages/ra-core/src/dataProvider/useGetMainList.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMainList.tsx
@@ -87,14 +87,15 @@ export const useGetMainList = <RecordType extends Record = Record>(
                 'cachedRequests',
                 requestSignature,
                 'ids',
-            ]);
+            ]); // default value undefined
             const total = get(state.admin.resources, [
                 resource,
                 'list',
                 'cachedRequests',
                 requestSignature,
                 'total',
-            ]);
+            ]); // default value undefined
+
             // When the user changes the page/sort/filter, the list of ids from
             // the cached requests is empty. To avoid rendering an empty list
             // at that moment, we override the ids and total with the latest
@@ -103,18 +104,21 @@ export const useGetMainList = <RecordType extends Record = Record>(
                 resource,
                 'list',
                 'ids',
-            ]);
+            ]); // default value [] (see list.ids reducer)
+
             // Since the total can be empty during the loading phase
             // We need to override that total with the latest loaded one
             const mainTotal = get(state.admin.resources, [
                 resource,
                 'list',
                 'total',
-            ]);
-            // can be null for a page that was never loaded. Useful for the isDataLoaded callback
+            ]); // default value null (see list.total reducer)
+
+            // Is [] for a page that was never loaded
             const finalIds = typeof ids === 'undefined' ? mainIds : ids;
-            // can be null for a page that was never loaded.
+            // Is null for a page that was never loaded.
             const finalTotal = typeof total === 'undefined' ? mainTotal : total;
+
             const allRecords = get(
                 state.admin.resources,
                 [resource, 'data'],
@@ -176,5 +180,4 @@ interface Memo<RecordType extends Record = Record> {
     result?: DataSelectorResult<RecordType>;
 }
 
-const isDataLoaded = (data: DataSelectorResult) =>
-    typeof data.finalIds !== 'undefined';
+const isDataLoaded = (data: DataSelectorResult) => data.finalTotal == null; // null or undefined

--- a/packages/ra-core/src/dataProvider/useGetMainList.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMainList.tsx
@@ -153,7 +153,7 @@ export const useGetMainList = <RecordType extends Record = Record>(
                           if (!record) return acc;
                           acc[record.id] = record;
                           return acc;
-                      }, {}),
+                      }, defaultData),
         [finalIds, allRecords]
     );
 

--- a/packages/ra-core/src/dataProvider/useGetMainList.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMainList.tsx
@@ -153,7 +153,7 @@ export const useGetMainList = <RecordType extends Record = Record>(
                           if (!record) return acc;
                           acc[record.id] = record;
                           return acc;
-                      }, defaultData),
+                      }, {}),
         [finalIds, allRecords]
     );
 

--- a/packages/ra-core/src/reducer/admin/resource/list/cachedRequests.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/cachedRequests.ts
@@ -35,6 +35,19 @@ const cachedRequestsReducer: Reducer<State> = (
         // force refresh
         return initialState;
     }
+    if (action.meta && action.meta.optimistic) {
+        if (
+            action.meta.fetch === CREATE ||
+            action.meta.fetch === DELETE ||
+            action.meta.fetch === DELETE_MANY ||
+            action.meta.fetch === UPDATE ||
+            action.meta.fetch === UPDATE_MANY
+        ) {
+            // force refresh of all lists because we don't know where the
+            // new/deleted/updated record(s) will appear in the list
+            return initialState;
+        }
+    }
     if (!action.meta || action.meta.fetchStatus !== FETCH_END) {
         // not a return from the dataProvider
         return previousState;

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.ts
@@ -22,6 +22,8 @@ type ActionTypes =
           meta: any;
       };
 
+const initialState = [];
+
 /**
  * List of the ids of the latest loaded page, regardless of params
  *
@@ -35,7 +37,7 @@ type ActionTypes =
  *
  */
 const idsReducer: Reducer<IdentifierArray> = (
-    previousState = [],
+    previousState = initialState,
     action: ActionTypes
 ) => {
     if (action.meta && action.meta.optimistic) {


### PR DESCRIPTION
This fixes a nasty bug that occurs when:

- A list contains a Field that doesn't check if the record is defined before rendering it (e.g. `FooField = ({ record }) => <>{record.foo}</>` instead of `FooField = ({ record }) => <>{record ? record.foo : null}</>`
- The user deletes a record from the list using bulk actions

![image](https://user-images.githubusercontent.com/99944/107703225-a8b43a80-6cbb-11eb-9ed4-b0cca9cfcd58.png)

In addition, this bug caused an additional List rerender, so this should also speed up lists a bit.

Note to self: never use both a dataProvider hook and a useSelector in the same function. Because dataProvider hooks rely on useEffect, they will return one tick later than useSelector, resulting in data inconsistencies (in this case: a list of `ids` containing the id of a record already removed from the `data` key).