### PR TITLE
Fix ReferenceArrayInputView propTypes

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
@@ -302,7 +302,7 @@ ReferenceArrayInputView.propTypes = {
     meta: PropTypes.object,
     onChange: PropTypes.func,
     options: PropTypes.object,
-    resource: PropTypes.string.isRequired,
+    resource: PropTypes.string,
     setFilter: PropTypes.func,
     setPagination: PropTypes.func,
     setSort: PropTypes.func,


### PR DESCRIPTION
The propTypes for `resource` was marked as required while the TS definition was marked as optional.

I'm getting a warning in my application when using `ReferenceArrayInput` without a `resource` because of this.