### PR TITLE
ReferenceField: fix label proptype

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -89,7 +89,7 @@ ReferenceField.propTypes = {
     className: PropTypes.string,
     cellClassName: PropTypes.string,
     headerClassName: PropTypes.string,
-    label: PropTypes.string,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     record: PropTypes.any,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,


### PR DESCRIPTION
Passing a React element is totally fine and is already allowed by the TS types.