### PR TITLE
Improve data provider types

### DIFF
--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -173,9 +173,9 @@ export interface GetManyReferenceResult<RecordType = Record> {
     validUntil?: ValidUntil;
 }
 
-export interface UpdateParams {
+export interface UpdateParams<T = any> {
     id: Identifier;
-    data: any;
+    data: T;
     previousData: Record;
 }
 export interface UpdateResult<RecordType = Record> {
@@ -183,17 +183,17 @@ export interface UpdateResult<RecordType = Record> {
     validUntil?: ValidUntil;
 }
 
-export interface UpdateManyParams {
+export interface UpdateManyParams<T = any> {
     ids: Identifier[];
-    data: any;
+    data: T;
 }
 export interface UpdateManyResult {
     data?: Identifier[];
     validUntil?: ValidUntil;
 }
 
-export interface CreateParams {
-    data: any;
+export interface CreateParams<T = any> {
+    data: T;
 }
 export interface CreateResult<RecordType = Record> {
     data: RecordType;


### PR DESCRIPTION
Only 3 param types required this

`UpdateParams`
`UpdateManyParams`
`CreateParams`

This small change allows us to pass through our data's types if we know what they'll be at this point, and defaulting to `any` if no type is passed through. The current types treat the `data` object as `any`.

As for naming, I'm not too keen on giving single letter names to the generic's arguments. I'll be happy to change `T` to `Data` or whatever you feel is most appropriate

