### PR TITLE
Add docs translation for new indonesian translation

### DIFF
--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -181,7 +181,7 @@ You can find translation packages for the following languages:
 - Hebrew (`he`): [ak-il/ra-language-hebrew](https://github.com/ak-il/ra-language-hebrew)
 - Hindi (`hi`): [harshit-budhraja/ra-language-hindi](https://github.com/harshit-budhraja/ra-language-hindi)
 - Hungarian (`hu`): [phelion/ra-language-hungarian](https://github.com/phelion/ra-language-hungarian)
-- Indonesian (`id`): [ronadi/ra-language-indonesian](https://github.com/ronadi/ra-language-indonesian) (new translation: [danangekal/ra-language-indonesian-new](https://github.com/danangekal/ra-language-indonesian-new))
+- Indonesian (`id`): [danangekal/ra-language-indonesian-new](https://github.com/danangekal/ra-language-indonesian-new)
 - Italian (`it`): [stefsava/ra-italian](https://github.com/stefsava/ra-italian)
 - Japanese (`ja`): [bicstone/ra-language-japanese](https://github.com/bicstone/ra-language-japanese)
 - Korean (`ko`): [acidsound/ra-language-korean](https://github.com/acidsound/ra-language-korean)

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -181,7 +181,7 @@ You can find translation packages for the following languages:
 - Hebrew (`he`): [ak-il/ra-language-hebrew](https://github.com/ak-il/ra-language-hebrew)
 - Hindi (`hi`): [harshit-budhraja/ra-language-hindi](https://github.com/harshit-budhraja/ra-language-hindi)
 - Hungarian (`hu`): [phelion/ra-language-hungarian](https://github.com/phelion/ra-language-hungarian)
-- Indonesian (`id`): [ronadi/ra-language-indonesian](https://github.com/ronadi/ra-language-indonesian)
+- Indonesian (`id`): [ronadi/ra-language-indonesian](https://github.com/ronadi/ra-language-indonesian) (new translation: [danangekal/ra-language-indonesian-new](https://github.com/danangekal/ra-language-indonesian-new))
 - Italian (`it`): [stefsava/ra-italian](https://github.com/stefsava/ra-italian)
 - Japanese (`ja`): [bicstone/ra-language-japanese](https://github.com/bicstone/ra-language-japanese)
 - Korean (`ko`): [acidsound/ra-language-korean](https://github.com/acidsound/ra-language-korean)


### PR DESCRIPTION
Hi Creators, Mainteners & Contributors,

I added document translation to rebuild a new Indonesian translation. I rebuilt with a typescript & fixed a missing type for the translated message 'ra.navigation.skip_nav'. I hope to merge & publish them.

Thanks. 