### PR TITLE
docs: add lb4, processmaker3, mixer provider links

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -99,7 +99,7 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[Sails.js](https://sailsjs.com/)**: [mpampin/ra-data-json-sails](https://github.com/mpampin/ra-data-json-sails)
 * **[Spring Boot](https://spring.io/projects/spring-boot)**: [vishpat/ra-data-springboot-rest](https://github.com/vishpat/ra-data-springboot-rest) 
 * **[Strapi](https://strapi.io/)**: [nazirov91/ra-strapi-rest](https://github.com/nazirov91/ra-strapi-rest)
-* **[Loopback4 CRUD](https://loopback.io/)**: [ckoliber/ra-data-lb4](https://github.com/ckoliber/ra-data-lb4)
+* **[Loopback4 CRUD](https://loopback.io/)**: [loopback4/ra-data-lb4](https://github.com/loopback4/ra-data-lb4)
 * **[ProcessMaker3](https://github.com/ckoliber/ra-data-processmaker3)**: [ckoliber/ra-data-processmaker3](https://github.com/ckoliber/ra-data-processmaker3)
 * **[Mixer](https://github.com/ckoliber/ra-data-mixer)**: [ckoliber/ra-data-mixer](https://github.com/ckoliber/ra-data-mixer)
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -87,6 +87,8 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[LocalStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)**: [marmelab/ra-data-localstorage](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-localstorage)
 * **[Loopback3](https://loopback.io/lb3)**: [darthwesker/react-admin-loopback](https://github.com/darthwesker/react-admin-loopback)
 * **[Loopback4](https://loopback.io/)**: [elmaistrenko/react-admin-lb4](https://github.com/elmaistrenko/react-admin-lb4)
+* **[Loopback4 CRUD](https://loopback.io/)**: [loopback4/ra-data-lb4](https://github.com/loopback4/ra-data-lb4)
+* **[Mixer](https://github.com/ckoliber/ra-data-mixer)**: [ckoliber/ra-data-mixer](https://github.com/ckoliber/ra-data-mixer)
 * **[Moleculer Microservices](https://github.com/RancaguaInnova/moleculer-data-provider)**: [RancaguaInnova/moleculer-data-provider](https://github.com/RancaguaInnova/moleculer-data-provider)
 * **[NestJS CRUD](https://github.com/nestjsx/crud)**: [rayman1104/ra-data-nestjsx-crud](https://github.com/rayman1104/ra-data-nestjsx-crud)
 * **[Parse](https://parseplatform.org/)**: [almahdi/ra-data-parse](https://github.com/almahdi/ra-data-parse)
@@ -94,14 +96,12 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[PostgREST](https://postgrest.org/)**: [raphiniert-com/ra-data-postgrest](https://github.com/raphiniert-com/ra-data-postgrest)
 * **[Prisma](https://github.com/weakky/ra-data-prisma)**: [weakky/ra-data-prisma](https://github.com/weakky/ra-data-prisma)
 * **[Prisma Version 2](https://www.prisma.io/)**: [panter/ra-data-prisma](https://github.com/panter/ra-data-prisma)
+* **[ProcessMaker3](https://www.processmaker.com/)**: [ckoliber/ra-data-processmaker3](https://github.com/ckoliber/ra-data-processmaker3)
 * **[OpenCRUD](https://www.opencrud.org/)**: [weakky/ra-data-opencrud](https://github.com/Weakky/ra-data-opencrud)
 * **[REST-HAPI](https://github.com/JKHeadley/rest-hapi)**: [ra-data-rest-hapi](https://github.com/mkg20001/ra-data-rest-hapi)
 * **[Sails.js](https://sailsjs.com/)**: [mpampin/ra-data-json-sails](https://github.com/mpampin/ra-data-json-sails)
 * **[Spring Boot](https://spring.io/projects/spring-boot)**: [vishpat/ra-data-springboot-rest](https://github.com/vishpat/ra-data-springboot-rest) 
 * **[Strapi](https://strapi.io/)**: [nazirov91/ra-strapi-rest](https://github.com/nazirov91/ra-strapi-rest)
-* **[Loopback4 CRUD](https://loopback.io/)**: [loopback4/ra-data-lb4](https://github.com/loopback4/ra-data-lb4)
-* **[ProcessMaker3](https://github.com/ckoliber/ra-data-processmaker3)**: [ckoliber/ra-data-processmaker3](https://github.com/ckoliber/ra-data-processmaker3)
-* **[Mixer](https://github.com/ckoliber/ra-data-mixer)**: [ckoliber/ra-data-mixer](https://github.com/ckoliber/ra-data-mixer)
 
 If you've written a Data Provider for another backend, and open-sourced it, please help complete this list with your package.
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -99,6 +99,9 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[Sails.js](https://sailsjs.com/)**: [mpampin/ra-data-json-sails](https://github.com/mpampin/ra-data-json-sails)
 * **[Spring Boot](https://spring.io/projects/spring-boot)**: [vishpat/ra-data-springboot-rest](https://github.com/vishpat/ra-data-springboot-rest) 
 * **[Strapi](https://strapi.io/)**: [nazirov91/ra-strapi-rest](https://github.com/nazirov91/ra-strapi-rest)
+* **[Loopback4 CRUD](https://loopback.io/)**: [ckoliber/ra-data-lb4](https://github.com/ckoliber/ra-data-lb4)
+* **[ProcessMaker3](https://github.com/ckoliber/ra-data-processmaker3)**: [ckoliber/ra-data-processmaker3](https://github.com/ckoliber/ra-data-processmaker3)
+* **[Mixer](https://github.com/ckoliber/ra-data-mixer)**: [ckoliber/ra-data-mixer](https://github.com/ckoliber/ra-data-mixer)
 
 If you've written a Data Provider for another backend, and open-sourced it, please help complete this list with your package.
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -87,7 +87,7 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[LocalStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)**: [marmelab/ra-data-localstorage](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-localstorage)
 * **[Loopback3](https://loopback.io/lb3)**: [darthwesker/react-admin-loopback](https://github.com/darthwesker/react-admin-loopback)
 * **[Loopback4](https://loopback.io/)**: [elmaistrenko/react-admin-lb4](https://github.com/elmaistrenko/react-admin-lb4)
-* **[Loopback4 CRUD](https://loopback.io/)**: [loopback4/ra-data-lb4](https://github.com/loopback4/ra-data-lb4)
+* **[Loopback4 CRUD](https://github.com/loopback4/loopback-component-crud)**: [loopback4/ra-data-lb4](https://github.com/loopback4/ra-data-lb4)
 * **[Mixer](https://github.com/ckoliber/ra-data-mixer)**: [ckoliber/ra-data-mixer](https://github.com/ckoliber/ra-data-mixer)
 * **[Moleculer Microservices](https://github.com/RancaguaInnova/moleculer-data-provider)**: [RancaguaInnova/moleculer-data-provider](https://github.com/RancaguaInnova/moleculer-data-provider)
 * **[NestJS CRUD](https://github.com/nestjsx/crud)**: [rayman1104/ra-data-nestjsx-crud](https://github.com/rayman1104/ra-data-nestjsx-crud)


### PR DESCRIPTION
I've created some provider plugins, this pull request will add their links:

1. **Loopback4 CRUD**: a provider fully compatible with [Loopback4 CRUD](https://github.com/loopback4/loopback-component-crud) component, supports `nested create`, `nested update`, `authentication`, `authorization`
2. **ProcessMaker3**: a provider for ProcessMaker3 BPMS
3. **Mixer**: a plugin for combining and merging other providers