### PR TITLE
useQuery does not work with GET_LIST

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -2366,7 +2366,7 @@ const CustomList = () => {
     const [page, setPage] = useState(1);
     const perPage = 50;
     const { data, total, loading, error } = useQuery({
-        type: 'GET_LIST',
+        type: 'getList',
         resource: 'posts',
         payload: {
             pagination: { page, perPage },


### PR DESCRIPTION
Using `GET_LIST` as `type` for `useQuery` does not work. It needs `getList`