### PR TITLE
Feature: Confirm Dialog's `content` prop can receive `React.ReactNode`

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -404,7 +404,7 @@ export default ResetViewsButton;
 
 **Tip**: `<Confirm>` leverages material-ui's `<Dialog>` component to implement a confirmation popup. Feel free to use it in your admins!
 
-**Tip**: `<Confirm>` text props such as `title` and `content` are translatable. You can pass use translation keys in these props.
+**Tip**: `<Confirm>` text props such as `title` and `content` are translatable. You can pass use translation keys in these props. Note: `content` is only translateable when value is `string`, otherwise it renders the content as a `ReactNode`.
 
 **Tip**: You can customize the text of the two `<Confirm>` component buttons using the `cancel` and `confirm` props which accept translation keys. You can customize the icons by setting the `ConfirmIcon` and `CancelIcon` props, which accept a SvgIcon type.
 

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -153,7 +153,7 @@ const sanitizeRestProps = ({
 export interface BulkDeleteWithConfirmButtonProps
     extends BulkActionProps,
         ButtonProps {
-    confirmContent?: string;
+    confirmContent?: React.ReactNode;
     confirmTitle?: string;
     icon?: ReactElement;
 }

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -125,7 +125,7 @@ interface Props {
     classes?: object;
     className?: string;
     confirmTitle?: string;
-    confirmContent?: string;
+    confirmContent?: React.ReactNode;
     icon?: ReactElement;
     label?: string;
     mutationMode?: MutationMode;

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -83,8 +83,6 @@ const Confirm: FC<ConfirmProps> = props => {
         e.stopPropagation();
     }, []);
 
-    const isContentString = typeof content === 'string';
-
     return (
         <Dialog
             open={isOpen}
@@ -96,7 +94,7 @@ const Confirm: FC<ConfirmProps> = props => {
                 {translate(title, { _: title, ...translateOptions })}
             </DialogTitle>
             <DialogContent>
-                {isContentString ? (
+                {typeof content === 'string' ? (
                     <DialogContentText>
                         {translate(content, {
                             _: content,

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -83,6 +83,8 @@ const Confirm: FC<ConfirmProps> = props => {
         e.stopPropagation();
     }, []);
 
+    const isContentString = typeof content === 'string';
+
     return (
         <Dialog
             open={isOpen}
@@ -94,12 +96,16 @@ const Confirm: FC<ConfirmProps> = props => {
                 {translate(title, { _: title, ...translateOptions })}
             </DialogTitle>
             <DialogContent>
-                <DialogContentText>
-                    {translate(content, {
-                        _: content,
-                        ...translateOptions,
-                    })}
-                </DialogContentText>
+                {isContentString ? (
+                    <DialogContentText>
+                        {translate(content, {
+                            _: content,
+                            ...translateOptions,
+                        })}
+                    </DialogContentText>
+                ) : (
+                    content
+                )}
             </DialogContent>
             <DialogActions>
                 <Button disabled={loading} onClick={onClose}>
@@ -130,7 +136,7 @@ export interface ConfirmProps {
     confirmColor?: string;
     ConfirmIcon?: ReactComponentLike;
     CancelIcon?: ReactComponentLike;
-    content: string;
+    content: React.ReactNode;
     isOpen?: boolean;
     loading?: boolean;
     onClose: MouseEventHandler;
@@ -146,7 +152,7 @@ Confirm.propTypes = {
     confirmColor: PropTypes.string,
     ConfirmIcon: PropTypes.elementType,
     CancelIcon: PropTypes.elementType,
-    content: PropTypes.string.isRequired,
+    content: PropTypes.node.isRequired,
     isOpen: PropTypes.bool,
     loading: PropTypes.bool,
     onClose: PropTypes.func.isRequired,


### PR DESCRIPTION
Makes the `Confirm` component more flexible while retaining existing behaviour, `i.e.` if a string is passed through, the content is translated, otherwise simply render the component.

The video demonstrates this behaviour in action.

https://user-images.githubusercontent.com/17087167/109144902-b1941a00-7759-11eb-82b1-562c3d262904.mov

Note: While I updated the all of the uses of `Content` within the React Admin codebase, please let me know if there's anything else I need to consider.

I'll also be happy adding a cypress test too.
