### PR TITLE
Fix npm package name in installation

### DIFF
--- a/packages/ra-data-localstorage/README.md
+++ b/packages/ra-data-localstorage/README.md
@@ -7,7 +7,7 @@ The provider issues no HTTP requests, every operation happens locally in the bro
 ## Installation
 
 ```sh
-npm install --save ra-data-localstorage
+npm install --save ra-data-local-storage
 ```
 
 ## Usage


### PR DESCRIPTION
As stated on the [npm package page](https://www.npmjs.com/package/ra-data-local-storage) the correct name of the package is ra-data-local-storage not ra-data-localstorage as stated in Installation. Current command makes the installation fail.

