### PR TITLE
Fix dataProvider: rm HTTP req body from deleteMany

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -950,7 +950,6 @@ export default {
         };
         return httpClient(`${apiUrl}/${resource}?${stringify(query)}`, {
             method: 'DELETE',
-            body: JSON.stringify(params.data),
         }).then(({ json }) => ({ data: json }));
     }
 };


### PR DESCRIPTION
Remove unnecessary body from request. It even raises a TS error: `Property 'data' does not exist on type 'DeleteManyParams'.ts(2339)`