### PR TITLE
[DOC] Improve design on search modal 

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -37,6 +37,10 @@
             rel="stylesheet"
             href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.0/tocbot.css"
         />
+        <link
+            rel="stylesheet"
+            href="{{ '/css/docsearch.css' | relative_url }}"
+        />
     </head>
 
     <body>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -31,7 +31,7 @@
         />
         <link
             rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+            href="https://cdn.jsdelivr.net/npm/@docsearch/css@1.0.0-alpha.28"
         />
         <link
             rel="stylesheet"
@@ -56,25 +56,7 @@
                     "
                 >
                     <div class="left">
-                        <form action="#" onsubmit="return false;">
-                            <div class="input-field" style="position: absolute">
-                                <input
-                                    type="search"
-                                    name="q"
-                                    id="query"
-                                    size="31"
-                                    maxlength="255"
-                                    value=""
-                                    style="vertical-align: inherit !important"
-                                    placeholder="Search..."
-                                />
-                                <label class="label-icon" for="test"
-                                    ><i class="material-icons">search</i></label
-                                >
-                                <i class="material-icons">close</i>
-                            </div>
-                            <span id="search"></span>
-                        </form>
+                        <div id="docsearch" class="center"></div>
                     </div>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li class="active">
@@ -182,18 +164,13 @@
         </script>
         <script
             type="text/javascript"
-            src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+            src="https://cdn.jsdelivr.net/npm/@docsearch/js@1.0.0-alpha.28"
         ></script>
         <script type="text/javascript">
             docsearch({
                 apiKey: '32f254b1de6a25a96665d1229b6eb8f7',
                 indexName: 'marmelab-react-admin',
-                inputSelector: '#query',
-                debug: false, // Set debug to true if you want to inspect the dropdown
-                autocompleteOptions: {
-                    appendTo: '#search',
-                    hint: false,
-                },
+                container: '#docsearch',
             });
         </script>
         <script

--- a/docs/css/docsearch.css
+++ b/docs/css/docsearch.css
@@ -1,0 +1,55 @@
+:root {
+    --docsearch-highlight-color: #368fe7;
+    --docsearch-primary-color: #368fe7;
+}
+
+#docsearch .DocSearch-Button {
+    position: absolute;
+    margin-top: 1rem;
+    width: 400px;
+    border-radius: 4px;
+
+    --docsearch-searchbox-background: #368fe7;
+    --docsearch-muted-color: white;
+    --docsearch-text-color: white;
+    --docsearch-searchbox-focus-background: #5fa2e6;
+}
+
+#docsearch .DocSearch-Button-Key {
+    border: 1px solid #5fa2e6;
+    background: transparent;
+    box-shadow: none;
+}
+
+div.DocSearch-Container {
+    z-index: 1000; /* navbar materialize is z-index: 999; */
+}
+
+/* Start override materialize input color */
+input[type='search']:not(.browser-default) {
+    border: none;
+    margin: 0px;
+    padding: 0 0 0 8px;
+}
+input[type='search']:not(.browser-default):focus:not([readonly]) {
+    box-shadow: none;
+    border-bottom: none;
+}
+/* End override materialize input color */
+
+@media only screen and (max-width: 1300px) {
+    #docsearch .DocSearch-Button {
+        width: 250px;
+    }
+}
+
+@media only screen and (max-width: 992px) {
+    #docsearch .DocSearch-Button {
+        width: 200px;
+    }
+}
+
+#docsearch .DocSearch-Button-Placeholder {
+    display: block; /* display on mobile  */
+    margin-right: auto;
+}

--- a/docs/css/style-v9.css
+++ b/docs/css/style-v9.css
@@ -36,61 +36,32 @@ nav ul#nav-mobile a {
     font-size: 16px;
 }
 
-.input-field .label-icon {
-    -webkit-transform: none;
-    transform: none;
-    left: 2rem;
-}
-
-nav .input-field label.active i {
-    color: #8dbbe9;
-}
-
-.nav-wrapper .input-field input[type='search'] {
-    height: 2em;
-    margin-top: 1em;
-    margin-left: 1em;
-    background-color: #368fe7;
+#docsearch .DocSearch-Button {
+    position: absolute;
+    margin-top: 1rem;
+    width: 400px;
     border-radius: 4px;
-    color: #8dbbe9;
-    width: calc(100% - 6rem);
 }
 
-.nav-wrapper .input-field input[type='search']::placeholder {
-    color: #8dbbe9;
+div.DocSearch-Container {
+    z-index: 1000; /* navbar materialize is z-index: 999; */
 }
 
-.input-field input[type='search'] ~ .material-icons {
-    font-size: 1.5rem;
-    right: 1.5rem;
-}
-
-.nav-wrapper .input-field input[type='search']:hover,
-.nav-wrapper .input-field input[type='search']:active,
-.nav-wrapper .input-field input[type='search']:focus {
-    background-color: #5fa2e6;
-    color: white;
-}
-
-.input-field input[type='search']:focus:not(.browser-default) ~ label i,
-.input-field
-    input[type='search']:focus:not(.browser-default)
-    ~ .material-icons {
-    color: white;
-}
-
-.input-field input[type='search'] {
-    color: #1976d2;
-}
-
-@media only screen and (max-width: 600px) {
-    .nav-wrapper .input-field input[type='search'] {
-        margin-top: 0.7em;
+@media only screen and (max-width: 1300px) {
+    #docsearch .DocSearch-Button {
+        width: 250px;
     }
 }
 
-.algolia-docsearch-suggestion--wrapper {
-    line-height: initial;
+@media only screen and (max-width: 992px) {
+    #docsearch .DocSearch-Button {
+        width: 200px;
+    }
+}
+
+#docsearch .DocSearch-Button-Placeholder {
+    display: block; /* display on mobile  */
+    margin-right: auto;
 }
 
 .sidenav {
@@ -443,29 +414,6 @@ ul.sidenav code {
 .markdown-section .glossary-term {
     cursor: help;
     text-decoration: underline;
-}
-
-.search input[type='text'] {
-    font: inherit;
-    width: 100%;
-    color: inherit;
-    border: none;
-    margin: 10px;
-    cursor: inherit;
-    resize: none;
-    height: 38px;
-    outline: none;
-    padding: 0 8px 0 0;
-    background: transparent;
-    text-align: inherit;
-    box-sizing: border-box;
-    line-height: inherit;
-    border-radius: 3px;
-    font-size: 16px;
-}
-.search .octicon {
-    margin: 10px 0 10px 20px;
-    font-size: 16px;
 }
 
 .markdown-section .icon {

--- a/docs/css/style-v9.css
+++ b/docs/css/style-v9.css
@@ -36,34 +36,6 @@ nav ul#nav-mobile a {
     font-size: 16px;
 }
 
-#docsearch .DocSearch-Button {
-    position: absolute;
-    margin-top: 1rem;
-    width: 400px;
-    border-radius: 4px;
-}
-
-div.DocSearch-Container {
-    z-index: 1000; /* navbar materialize is z-index: 999; */
-}
-
-@media only screen and (max-width: 1300px) {
-    #docsearch .DocSearch-Button {
-        width: 250px;
-    }
-}
-
-@media only screen and (max-width: 992px) {
-    #docsearch .DocSearch-Button {
-        width: 200px;
-    }
-}
-
-#docsearch .DocSearch-Button-Placeholder {
-    display: block; /* display on mobile  */
-    margin-right: auto;
-}
-
 .sidenav {
     height: 100%;
     padding-bottom: 1em;


### PR DESCRIPTION
With the last version of Algolia ([docsearch package](https://github.com/algolia/DocSearch/tree/next)), we can easily improve the search experience.

We can use the modal component that allows us to bookmark a search and see the history of your searches. The modal can be open with shortcut (`ctrl+l` or `/`), no need to go back to the top of the page to do a search.


## Before

Empty search: ![image](https://user-images.githubusercontent.com/2212144/109831807-1232c380-7c40-11eb-945f-0aad19f5a007.png)

"react context" search:
![image](https://user-images.githubusercontent.com/2212144/109831902-270f5700-7c40-11eb-91d0-e3195a212fa7.png)

## After

The text color is white now, the contrast note is higher. Empty search:
 ![image](https://user-images.githubusercontent.com/2212144/109831945-32628280-7c40-11eb-8047-34b2d326271d.png)

When I click on search button, the algolia modal appears:
![image](https://user-images.githubusercontent.com/2212144/109832011-40b09e80-7c40-11eb-94bc-ac078e5de706.png)

When I search "react context": 
![image](https://user-images.githubusercontent.com/2212144/109832036-4908d980-7c40-11eb-9f05-5cb43f347061.png)
