### PR TITLE
Add missing field in interface of <DeleteButton> props

### DIFF
--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -68,6 +68,8 @@ interface Props {
     basePath?: string;
     classes?: object;
     className?: string;
+    confirmTitle?: string;
+    confirmContent?: string;
     icon?: ReactElement;
     label?: string;
     mutationMode?: MutationMode;


### PR DESCRIPTION
`<DeleteButton>`, when passed `undoable={false}`, calls its child `<DeleteWithConfirmButton>` and passes it the props.

Problem: `<DeleteButton>` `Props` inferface is missing (at least) 2 props that `<DeleteWithConfirmButton>` accepts, namely `confirmTitle` and `confirmContent`. This prevents code from typechecking.

Please find an quick fix in this PR.