### PR TITLE
Graphql data simple data provider: handle if type can't be found

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildVariables.js
+++ b/packages/ra-data-graphql-simple/src/buildVariables.js
@@ -121,7 +121,7 @@ const buildGetListVariables = introspectionResults => (
                 const type = introspectionResults.types.find(
                     t => t.name === `${resource.type.name}Filter`
                 );
-                const filterSome = type.inputFields.find(
+                const filterSome = type?.inputFields?.find(
                     t => t.name === `${key}_some`
                 );
 
@@ -144,7 +144,7 @@ const buildGetListVariables = introspectionResults => (
                     const type = introspectionResults.types.find(
                         t => t.name === `${resource.type.name}Filter`
                     );
-                    const filterSome = type.inputFields.find(
+                    const filterSome = type?.inputFields?.find(
                         t => t.name === `${parts[0]}_some`
                     );
 


### PR DESCRIPTION
Right now, if the naming of your filter parameter doesn't match the expected naming (`resourceFilter`) the data provider errors out because `type` is `undefined`. In our case, our filters are named `resourceFilterInput` which seems like a fairly common pattern see [kotlin docs](https://expediagroup.github.io/graphql-kotlin/docs/3.x.x/schema-generator/writing-schemas/arguments/#input-types) and [graphql docs](https://graphql.org/graphql-js/mutations-and-input-types/). I think ideally, it would take in a parameter to adjust the naming convention the same way it does for query naming but this seems like a good temporary solution to at least make the filters usable for "nonstandard" naming practices. 