### PR TITLE
Fix/redirect cant catch search params

### DIFF
--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -30,13 +30,13 @@ export type RedirectionSideEffect = string | boolean | RedirectToFunction;
  * redirect((redirectTo, basePath, is, data) => ...)
  */
 
-const useRedirect = ({ baseURL = '' }: { baseURL?: string }) => {
+const useRedirect = (baseURL?: string) => {
     const dispatch = useDispatch();
     const history = useHistory(); // Note: history is mutable. This prevents render loops in useCallback.
 
     const origin = useMemo(
         () =>
-            new URL(baseURL ?? process.env.PUBLIC_URL, window.location.origin),
+            new URL(baseURL ?? process.env.PUBLIC_URL ?? "", window.location.origin),
         []
     );
 

--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -29,11 +29,16 @@ export type RedirectionSideEffect = string | boolean | RedirectToFunction;
  * // redirect to the result of a function
  * redirect((redirectTo, basePath, is, data) => ...)
  */
+
 const useRedirect = ({ baseURL = '' }: { baseURL?: string }) => {
     const dispatch = useDispatch();
     const history = useHistory(); // Note: history is mutable. This prevents render loops in useCallback.
 
-    const origin = useMemo(() => window.location.origin || '' + baseURL, []);
+    const origin = useMemo(
+        () =>
+            new URL(baseURL ?? process.env.PUBLIC_URL, window.location.origin),
+        []
+    );
 
     return useCallback(
         (
@@ -57,8 +62,9 @@ const useRedirect = ({ baseURL = '' }: { baseURL?: string }) => {
 
             const redirectPath =
                 resolveRedirectTo(redirectTo, basePath, id, data) ?? '';
+            //because we manually add state: { _scrollToTop: true} to scroll to stop -> search params cannot catch
             //need create new URL to get search params
-            const url = new URL(origin + redirectPath);
+            const url = new URL(redirectPath, origin);
 
             history.push({
                 pathname: url.pathname,

--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -40,7 +40,7 @@ const useRedirect = (baseURL?: string) => {
                 baseURL ?? process.env.PUBLIC_URL ?? '',
                 window.location.origin
             ),
-        []
+        [baseURL]
     );
 
     return useCallback(
@@ -75,7 +75,7 @@ const useRedirect = (baseURL?: string) => {
                 state: { _scrollToTop: true },
             });
         },
-        [dispatch, history]
+        [dispatch, history, origin]
     );
 };
 

--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -36,7 +36,10 @@ const useRedirect = (baseURL?: string) => {
 
     const origin = useMemo(
         () =>
-            new URL(baseURL ?? process.env.PUBLIC_URL ?? "", window.location.origin),
+            new URL(
+                baseURL ?? process.env.PUBLIC_URL ?? '',
+                window.location.origin
+            ),
         []
     );
 


### PR DESCRIPTION
Since we manually add `state: { _scrollToTop: true }`. `history` cannot catch search params 