### PR TITLE
Add ability to omit basePath in Reference fields

### DIFF
--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -11,6 +11,7 @@ import {
     CardHeader,
     Grid,
     Toolbar,
+    Typography,
     useMediaQuery,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -160,13 +161,14 @@ const CommentGrid = () => {
                             <TextField record={data[id]} source="body" />
                         </CardContent>
                         <CardContent className={classes.cardLink}>
-                            {translate('comment.list.about')}&nbsp;
+                            <Typography component="span" variant="body2">
+                                {translate('comment.list.about')}&nbsp;
+                            </Typography>
                             <ReferenceField
                                 resource="comments"
                                 record={data[id]}
                                 source="post_id"
                                 reference="posts"
-                                basePath={basePath}
                             >
                                 <TextField
                                     source="title"

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldController.spec.tsx
@@ -13,7 +13,6 @@ describe('<ReferenceArrayFieldController />', () => {
             <ReferenceArrayFieldController
                 resource="foo"
                 reference="bar"
-                basePath=""
                 record={{ id: 1, barIds: [1, 2] }}
                 source="barIds"
             >
@@ -30,7 +29,7 @@ describe('<ReferenceArrayFieldController />', () => {
             }
         );
         expect(children.mock.calls[0][0]).toMatchObject({
-            basePath: '',
+            basePath: '/bar',
             currentSort: { field: 'id', order: 'ASC' },
             loaded: false,
             loading: true,
@@ -49,7 +48,6 @@ describe('<ReferenceArrayFieldController />', () => {
                 resource="foo"
                 reference="bar"
                 source="barIds"
-                basePath=""
             >
                 {children}
             </ReferenceArrayFieldController>,
@@ -70,7 +68,7 @@ describe('<ReferenceArrayFieldController />', () => {
         );
 
         expect(children.mock.calls[0][0]).toMatchObject({
-            basePath: '',
+            basePath: '/bar',
             currentSort: { field: 'id', order: 'ASC' },
             loaded: false,
             loading: true,
@@ -93,7 +91,6 @@ describe('<ReferenceArrayFieldController />', () => {
                 resource="foo"
                 reference="bar"
                 source="barIds"
-                basePath=""
             >
                 {children}
             </ReferenceArrayFieldController>,
@@ -111,7 +108,7 @@ describe('<ReferenceArrayFieldController />', () => {
             }
         );
         expect(children.mock.calls[0][0]).toMatchObject({
-            basePath: '',
+            basePath: '/bar',
             currentSort: { field: 'id', order: 'ASC' },
             loaded: true,
             loading: true,
@@ -132,7 +129,6 @@ describe('<ReferenceArrayFieldController />', () => {
                 resource="foo"
                 reference="bar"
                 source="barIds"
-                basePath=""
             >
                 {children}
             </ReferenceArrayFieldController>,
@@ -150,7 +146,7 @@ describe('<ReferenceArrayFieldController />', () => {
             }
         );
         expect(children.mock.calls[0][0]).toMatchObject({
-            basePath: '',
+            basePath: '/bar',
             currentSort: { field: 'id', order: 'ASC' },
             loaded: true,
             loading: true,
@@ -182,7 +178,6 @@ describe('<ReferenceArrayFieldController />', () => {
                     resource="foo"
                     reference="bar"
                     source="barIds"
-                    basePath=""
                 >
                     {children}
                 </ReferenceArrayFieldController>
@@ -212,7 +207,6 @@ describe('<ReferenceArrayFieldController />', () => {
                 resource="foo"
                 reference="bar"
                 source="barIds"
-                basePath=""
             >
                 {children}
             </ReferenceArrayFieldController>,
@@ -230,7 +224,7 @@ describe('<ReferenceArrayFieldController />', () => {
             }
         );
         expect(children.mock.calls[0][0]).toMatchObject({
-            basePath: '',
+            basePath: '/bar',
             currentSort: { field: 'id', order: 'ASC' },
             loaded: true,
             loading: true,
@@ -251,7 +245,6 @@ describe('<ReferenceArrayFieldController />', () => {
                 resource="foo"
                 reference="bar"
                 source="barIds"
-                basePath=""
             >
                 {children}
             </ReferenceArrayFieldController>,
@@ -271,7 +264,7 @@ describe('<ReferenceArrayFieldController />', () => {
             }
         );
         expect(children.mock.calls[0][0]).toMatchObject({
-            basePath: '',
+            basePath: '/bar',
             currentSort: { field: 'id', order: 'ASC' },
             loaded: true,
             loading: true,

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldController.tsx
@@ -5,7 +5,7 @@ import { ListControllerProps } from '../useListController';
 import { Record, SortPayload } from '../../types';
 
 interface Props {
-    basePath: string;
+    basePath?: string;
     filter?: any;
     page?: number;
     perPage?: number;

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -14,7 +14,7 @@ import { useResourceContext } from '../../core';
 import { indexById } from '../../util/indexById';
 
 interface Option {
-    basePath: string;
+    basePath?: string;
     filter?: any;
     page?: number;
     perPage?: number;
@@ -212,7 +212,9 @@ const useReferenceArrayFieldController = (
     ]);
 
     return {
-        basePath: basePath.replace(resource, reference),
+        basePath: basePath
+            ? basePath.replace(resource, reference)
+            : `/${reference}`,
         currentSort: sort,
         data: finalData,
         defaultTitle: null,

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -13,7 +13,7 @@ import useSortState from '../useSortState';
 import { useResourceContext } from '../../core';
 
 interface Options {
-    basePath: string;
+    basePath?: string;
     data?: RecordMap;
     filter?: any;
     ids?: any[];
@@ -186,7 +186,9 @@ const useReferenceManyFieldController = (
     );
 
     return {
-        basePath: basePath.replace(resource, reference),
+        basePath: basePath
+            ? basePath.replace(resource, reference)
+            : `/${reference}`,
         currentSort: sort,
         data,
         defaultTitle: null,

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -335,5 +335,27 @@ describe('<ReferenceField />', () => {
             const links = container.getElementsByTagName('a');
             expect(links).toHaveLength(0);
         });
+
+        it('should work without basePath', () => {
+            const { container } = render(
+                <MemoryRouter>
+                    <ReferenceFieldView
+                        record={record}
+                        source="postId"
+                        referenceRecord={{ id: 123, title: 'foo' }}
+                        reference="posts"
+                        resource="comments"
+                        resourceLinkPath="/posts/123"
+                        loaded={true}
+                        loading={false}
+                    >
+                        <TextField source="title" />
+                    </ReferenceFieldView>
+                </MemoryRouter>
+            );
+            const links = container.getElementsByTagName('a');
+            expect(links).toHaveLength(1);
+            expect(links.item(0).href).toBe('http://localhost/posts/123');
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -170,7 +170,7 @@ export interface ReferenceManyFieldViewProps
 }
 
 ReferenceManyFieldView.propTypes = {
-    basePath: PropTypes.string,
+    basePath: PropTypes.string.isRequired,
     children: PropTypes.element,
     className: PropTypes.string,
     currentSort: PropTypes.exact({


### PR DESCRIPTION
## Problem

When using a Field component outside of a Datagrid or a Form, users have to inject props manually. They can understand that they must inject `record` and `resource`, but they often forget to inject `basePath`. It is not a problem, except for Reference fields, where the `basePath` is used to build the links to the related records. Using these Fields without a `basePath` leads to a cryptic error:

> TypeError: Cannot read property 'replace' of undefined

![image](https://user-images.githubusercontent.com/99944/110907236-5fccc180-830d-11eb-8c6b-d42f797d3e5e.png)

The `basePath` property isn't well documented, and to be honest, it isn't very useful. In the most common case, the `basePath` equals `/${resource}`. 

## Solution

If the `basePath` isn't set, use the resource name instead. That way, users can omit the `basePath` when using `ReferenceField`, `ReferenceArrayField`, and `ReferenceManyField` manually.

```diff
    <ReferenceField
        resource="comments"
        record={data[id]}
        source="post_id"
        reference="posts"
-       basePath="/comments"
    >
        <TextField source="title" />
    </ReferenceField>
```