### PR TITLE
Fix SortButton labels must have a valid translation message

### DIFF
--- a/packages/ra-core/src/util/getFieldLabelTranslationArgs.ts
+++ b/packages/ra-core/src/util/getFieldLabelTranslationArgs.ts
@@ -1,9 +1,9 @@
 import inflection from 'inflection';
 
 interface Args {
-    label: string;
-    resource: string;
-    source: string;
+    label?: string;
+    resource?: string;
+    source?: string;
 }
 
 type TranslationArguments = [string, any?];
@@ -17,7 +17,7 @@ type TranslationArguments = [string, any?];
  *      {translate(...getFieldLabelTranslationArgs({ label, resource, source }))}
  *  </span>
  */
-export default (options: Args): TranslationArguments => {
+export default (options?: Args): TranslationArguments => {
     if (!options) {
         return [''];
     }

--- a/packages/ra-ui-materialui/src/button/SortButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SortButton.tsx
@@ -12,7 +12,11 @@ import {
 import SortIcon from '@material-ui/icons/Sort';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import { shallowEqual } from 'react-redux';
-import { useListSortContext, useTranslate } from 'ra-core';
+import {
+    useListSortContext,
+    useTranslate,
+    getFieldLabelTranslationArgs,
+} from 'ra-core';
 
 /**
  * A button allowing to change the sort field and order.
@@ -72,7 +76,12 @@ const SortButton: FC<SortButtonProps> = ({
     };
 
     const buttonLabel = translate(label, {
-        field: translate(`resources.${resource}.fields.${currentSort.field}`),
+        field: translate(
+            ...getFieldLabelTranslationArgs({
+                resource,
+                source: currentSort.field,
+            })
+        ),
         order: translate(`ra.sort.${currentSort.order}`),
         _: label,
     });
@@ -115,7 +124,12 @@ const SortButton: FC<SortButtonProps> = ({
                         data-sort={field}
                         key={field}
                     >
-                        {translate(`resources.${resource}.fields.${field}`)}{' '}
+                        {translate(
+                            ...getFieldLabelTranslationArgs({
+                                resource,
+                                source: field,
+                            })
+                        )}{' '}
                         {translate(
                             `ra.sort.${
                                 currentSort.field === field


### PR DESCRIPTION
## Problem

With no translation messages, `<SortButton>` label and choices look ugly

![image](https://user-images.githubusercontent.com/99944/110946968-d8e50c80-833f-11eb-9cca-a0e1c2e0997e.png)

## Solution

Use the same fallback to humanized field name as for the datagrid headers

![image](https://user-images.githubusercontent.com/99944/110947095-016d0680-8340-11eb-9eb6-28aefa95a44d.png)