### PR TITLE
Fix <Admin> with no i18nProvider logs warnings for missing translations

### DIFF
--- a/packages/react-admin/src/defaultI18nProvider.spec.ts
+++ b/packages/react-admin/src/defaultI18nProvider.spec.ts
@@ -1,0 +1,17 @@
+import expect from 'expect';
+import defaultI18nProvider from './defaultI18nProvider';
+
+describe('defaultI18nProvider', () => {
+    it('should use the English translations', () => {
+        expect(defaultI18nProvider.translate('ra.action.edit')).toBe('Edit');
+    });
+    it('should return the input when the translation is missing', () => {
+        expect(defaultI18nProvider.translate('bar')).toBe('bar');
+    });
+    it('should not log any warning for missing translations', () => {
+        const spy = jest.spyOn(console, 'error');
+        defaultI18nProvider.translate('foo');
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});

--- a/packages/react-admin/src/defaultI18nProvider.ts
+++ b/packages/react-admin/src/defaultI18nProvider.ts
@@ -1,4 +1,6 @@
 import defaultMessages from 'ra-language-english';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 
-export default polyglotI18nProvider(() => defaultMessages);
+export default polyglotI18nProvider(() => defaultMessages, 'en', {
+    allowMissing: true,
+});


### PR DESCRIPTION
## Problem 

When a developer only needs English, and relies on components that pass their label through the translation layer (e.g. `<FilterListItem>`), they should not see warnings for missing translation labels. 

## Solution

Disable translation warnings for default i18nProvider