### PR TITLE
Fix actions={false] in a View component throws a runtime warning

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -77,7 +77,7 @@ export const Edit = (
 };
 
 Edit.propTypes = {
-    actions: PropTypes.element,
+    actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     aside: PropTypes.element,
     children: PropTypes.node,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -125,7 +125,7 @@ interface EditViewProps
 }
 
 EditView.propTypes = {
-    actions: PropTypes.element,
+    actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     aside: PropTypes.element,
     basePath: PropTypes.string,
     children: PropTypes.element,

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -75,7 +75,7 @@ export const Show = (
 };
 
 Show.propTypes = {
-    actions: PropTypes.element,
+    actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     aside: PropTypes.element,
     children: PropTypes.element,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -101,7 +101,7 @@ interface ShowViewProps
 }
 
 ShowView.propTypes = {
-    actions: PropTypes.element,
+    actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     aside: PropTypes.element,
     basePath: PropTypes.string,
     children: PropTypes.element,


### PR DESCRIPTION
## Problem

In an `<Edit>` view, developers can disable the actions toolbar altogether by passing `actions={false}` as prop. However, this logs a runtime proptype warning. 