### PR TITLE
Fix Go to definition goes to the compiled code in VSCode

### DIFF
--- a/packages/ra-core/tsconfig.json
+++ b/packages/ra-core/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-data-fakerest/tsconfig.json
+++ b/packages/ra-data-fakerest/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-data-json-server/tsconfig.json
+++ b/packages/ra-data-json-server/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-data-localstorage/tsconfig.json
+++ b/packages/ra-data-localstorage/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-data-simple-rest/tsconfig.json
+++ b/packages/ra-data-simple-rest/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-i18n-polyglot/tsconfig.json
+++ b/packages/ra-i18n-polyglot/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-language-english/tsconfig.json
+++ b/packages/ra-language-english/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-language-french/tsconfig.json
+++ b/packages/ra-language-french/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-test/tsconfig.json
+++ b/packages/ra-test/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],

--- a/packages/ra-ui-materialui/tsconfig.json
+++ b/packages/ra-ui-materialui/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "declaration": true
+        "declaration": true,
+        "declarationMap": true
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/react-admin/tsconfig.json
+++ b/packages/react-admin/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "lib",
         "rootDir": "src",
         "declaration": true,
+        "declarationMap": true,
         "allowJs": false
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],


### PR DESCRIPTION
## Problem 

Using Ctrl+click (or "Go to definition") in VSCode when hovering on a function name leads to the compiled Types file. It's really slowing us down when developing.

![go_to_definition_broken](https://user-images.githubusercontent.com/99944/111155728-1ee6de00-8595-11eb-9aa0-9b6e22e29175.gif)


## Solution

Output declarationMaps 

![go_to_definition_fixed](https://user-images.githubusercontent.com/99944/111155724-1e4e4780-8595-11eb-9375-c6ac4915b54c.gif)
