### PR TITLE
Add ability to omit basePath in buttons

### DIFF
--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -165,7 +165,6 @@ const CommentGrid = () => {
                                 {translate('comment.list.about')}&nbsp;
                             </Typography>
                             <ReferenceField
-                                resource="comments"
                                 record={data[id]}
                                 source="post_id"
                                 reference="posts"
@@ -177,16 +176,8 @@ const CommentGrid = () => {
                             </ReferenceField>
                         </CardContent>
                         <CardActions className={classes.cardActions}>
-                            <EditButton
-                                resource="posts"
-                                basePath={basePath}
-                                record={data[id]}
-                            />
-                            <ShowButton
-                                resource="posts"
-                                basePath={basePath}
-                                record={data[id]}
-                            />
+                            <EditButton record={data[id]} />
+                            <ShowButton record={data[id]} />
                         </CardActions>
                     </Card>
                 </Grid>

--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -128,7 +128,7 @@ const useListStyles = makeStyles(theme => ({
 }));
 
 const CommentGrid = () => {
-    const { ids, data, basePath } = useListContext();
+    const { ids, data } = useListContext();
     const translate = useTranslate();
     const classes = useListStyles();
 

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -90,7 +90,7 @@ const useDeleteWithConfirmController = (
             setOpen(false);
             if (onSuccess === undefined) {
                 notify('ra.notification.deleted', 'info', { smart_count: 1 });
-                redirect(redirectTo, basePath);
+                redirect(redirectTo, basePath || `/${resource}`);
                 refresh();
             } else {
                 onSuccess(response);

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -75,7 +75,7 @@ const useDeleteWithUndoController = (
                           { smart_count: 1 },
                           true
                       );
-                      redirect(redirectTo, basePath);
+                      redirect(redirectTo, basePath || `/${resource}`);
                       refresh();
                   },
         onFailure:

--- a/packages/ra-core/src/controller/field/getResourceLinkPath.ts
+++ b/packages/ra-core/src/controller/field/getResourceLinkPath.ts
@@ -53,7 +53,7 @@ const getResourceLinkPath = ({
     reference,
     link = 'edit',
     record = { id: '' },
-    basePath = `/${resource}`,
+    basePath = '',
     linkType,
 }: Option): string | false => {
     if (linkType !== undefined) {
@@ -62,7 +62,9 @@ const getResourceLinkPath = ({
         );
     }
     const sourceId = get(record, source);
-    const rootPath = basePath.replace(resource, reference);
+    const rootPath = basePath
+        ? basePath.replace(resource, reference)
+        : `/${reference}`;
     const linkTo: LinkToType = linkType !== undefined ? linkType : link;
 
     // Backward compatibility: keep linkType but with warning

--- a/packages/ra-core/src/core/useResourceContext.ts
+++ b/packages/ra-core/src/core/useResourceContext.ts
@@ -10,7 +10,7 @@ import { ResourceContext, ResourceContextValue } from './ResourceContext';
  * @example
  *
  * const ResourceName = (props) => {
- *   const { resource } = useResourceContext(props);
+ *   const resource = useResourceContext(props);
  *   const resourceName = translate(`resources.${resource}.name`, {
  *      smart_count: 1,
  *      _: inflection.humanize(inflection.singularize(resource)),

--- a/packages/ra-ui-materialui/src/button/CloneButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/CloneButton.spec.tsx
@@ -12,7 +12,7 @@ import { TestContext } from 'ra-test';
 const theme = createMuiTheme();
 
 const invalidButtonDomProps = {
-    basePath: '',
+    basePath: '/posts',
     handleSubmit: jest.fn(),
     handleSubmitWithRedirect: jest.fn(),
     invalid: false,
@@ -32,14 +32,17 @@ describe('<CloneButton />', () => {
         const { getByRole } = render(
             <Router history={history}>
                 <ThemeProvider theme={theme}>
-                    <CloneButton record={{ id: 123, foo: 'bar' }} basePath="" />
+                    <CloneButton
+                        record={{ id: 123, foo: 'bar' }}
+                        basePath="/posts"
+                    />
                 </ThemeProvider>
             </Router>
         );
 
         const button = getByRole('button');
         expect(button.getAttribute('href')).toEqual(
-            '/create?source=%7B%22foo%22%3A%22bar%22%7D'
+            '/posts/create?source=%7B%22foo%22%3A%22bar%22%7D'
         );
     });
 
@@ -56,7 +59,7 @@ describe('<CloneButton />', () => {
 
         expect(spy).not.toHaveBeenCalled();
         expect(getByRole('button').getAttribute('href')).toEqual(
-            '/create?source=%7B%22foo%22%3A%22bar%22%7D'
+            '/posts/create?source=%7B%22foo%22%3A%22bar%22%7D'
         );
 
         spy.mockRestore();

--- a/packages/ra-ui-materialui/src/button/CloneButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CloneButton.tsx
@@ -4,36 +4,42 @@ import PropTypes from 'prop-types';
 import Queue from '@material-ui/icons/Queue';
 import { Link } from 'react-router-dom';
 import { stringify } from 'query-string';
-import { Record } from 'ra-core';
+import { Record, useResourceContext } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
 export const CloneButton: FC<CloneButtonProps> = ({
     basePath = '',
     label = 'ra.action.clone',
+    scrollToTop = true,
     record,
     icon = defaultIcon,
     ...rest
-}) => (
-    <Button
-        component={Link}
-        to={
-            record
-                ? {
-                      pathname: `${basePath}/create`,
-                      search: stringify({
-                          source: JSON.stringify(omitId(record)),
-                      }),
-                  }
-                : `${basePath}/create`
-        }
-        label={label}
-        onClick={stopPropagation}
-        {...rest}
-    >
-        {icon}
-    </Button>
-);
+}) => {
+    const resource = useResourceContext();
+    const pathname = basePath ? `${basePath}/create` : `/${resource}/create`;
+    return (
+        <Button
+            component={Link}
+            to={
+                record
+                    ? {
+                          pathname,
+                          search: stringify({
+                              source: JSON.stringify(omitId(record)),
+                          }),
+                          state: { _scrollToTop: scrollToTop },
+                      }
+                    : pathname
+            }
+            label={label}
+            onClick={stopPropagation}
+            {...rest}
+        >
+            {icon}
+        </Button>
+    );
+};
 
 const defaultIcon = <Queue />;
 
@@ -46,6 +52,7 @@ interface Props {
     basePath?: string;
     record?: Record;
     icon?: ReactElement;
+    scrollToTop?: boolean;
 }
 
 export type CloneButtonProps = Props & ButtonProps;

--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import ContentAdd from '@material-ui/icons/Add';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
-import { useTranslate } from 'ra-core';
+import { useTranslate, useResourceContext } from 'ra-core';
 
 import Button, { ButtonProps, sanitizeButtonRestProps } from './Button';
 
@@ -39,12 +39,13 @@ const CreateButton: FC<CreateButtonProps> = props => {
     const isSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('sm')
     );
+    const resource = useResourceContext();
     const location = useMemo(
         () => ({
-            pathname: `${basePath}/create`,
+            pathname: basePath ? `${basePath}/create` : `/${resource}/create`,
             state: { _scrollToTop: scrollToTop },
         }),
-        [basePath, scrollToTop]
+        [basePath, resource, scrollToTop]
     );
     return isSmall ? (
         <Fab

--- a/packages/ra-ui-materialui/src/button/EditButton.tsx
+++ b/packages/ra-ui-materialui/src/button/EditButton.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import ContentCreate from '@material-ui/icons/Create';
 import { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
 import { Link } from 'react-router-dom';
-import { linkToRecord, Record } from 'ra-core';
+import { linkToRecord, Record, useResourceContext } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
@@ -25,23 +25,28 @@ const EditButton: FC<EditButtonProps> = ({
     record,
     scrollToTop = true,
     ...rest
-}) => (
-    <Button
-        component={Link}
-        to={useMemo(
-            () => ({
-                pathname: record ? linkToRecord(basePath, record.id) : '',
-                state: { _scrollToTop: scrollToTop },
-            }),
-            [basePath, record, scrollToTop]
-        )}
-        label={label}
-        onClick={stopPropagation}
-        {...(rest as any)}
-    >
-        {icon}
-    </Button>
-);
+}) => {
+    const resource = useResourceContext();
+    return (
+        <Button
+            component={Link}
+            to={useMemo(
+                () => ({
+                    pathname: record
+                        ? linkToRecord(basePath || `/${resource}`, record.id)
+                        : '',
+                    state: { _scrollToTop: scrollToTop },
+                }),
+                [basePath, record, resource, scrollToTop]
+            )}
+            label={label}
+            onClick={stopPropagation}
+            {...(rest as any)}
+        >
+            {icon}
+        </Button>
+    );
+};
 
 const defaultIcon = <ContentCreate />;
 

--- a/packages/ra-ui-materialui/src/button/ListButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ListButton.tsx
@@ -3,6 +3,7 @@ import { FC, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ActionList from '@material-ui/icons/List';
 import { Link } from 'react-router-dom';
+import { useResourceContext } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
@@ -37,11 +38,19 @@ const ListButton: FC<ListButtonProps> = ({
     icon = defaultIcon,
     label = 'ra.action.list',
     ...rest
-}) => (
-    <Button component={Link} to={basePath} label={label} {...(rest as any)}>
-        {icon}
-    </Button>
-);
+}) => {
+    const resource = useResourceContext();
+    return (
+        <Button
+            component={Link}
+            to={basePath || `/${resource}`}
+            label={label}
+            {...(rest as any)}
+        >
+            {icon}
+        </Button>
+    );
+};
 
 const defaultIcon = <ActionList />;
 

--- a/packages/ra-ui-materialui/src/button/ShowButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ShowButton.tsx
@@ -3,7 +3,7 @@ import { FC, memo, useMemo, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ImageEye from '@material-ui/icons/RemoveRedEye';
 import { Link } from 'react-router-dom';
-import { linkToRecord, Record } from 'ra-core';
+import { linkToRecord, Record, useResourceContext } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
@@ -24,25 +24,31 @@ const ShowButton: FC<ShowButtonProps> = ({
     record,
     scrollToTop = true,
     ...rest
-}) => (
-    <Button
-        component={Link}
-        to={useMemo(
-            () => ({
-                pathname: record
-                    ? `${linkToRecord(basePath, record.id)}/show`
-                    : '',
-                state: { _scrollToTop: scrollToTop },
-            }),
-            [basePath, record, scrollToTop]
-        )}
-        label={label}
-        onClick={stopPropagation}
-        {...(rest as any)}
-    >
-        {icon}
-    </Button>
-);
+}) => {
+    const resource = useResourceContext();
+    return (
+        <Button
+            component={Link}
+            to={useMemo(
+                () => ({
+                    pathname: record
+                        ? `${linkToRecord(
+                              basePath || `/${resource}`,
+                              record.id
+                          )}/show`
+                        : '',
+                    state: { _scrollToTop: scrollToTop },
+                }),
+                [basePath, record, resource, scrollToTop]
+            )}
+            label={label}
+            onClick={stopPropagation}
+            {...(rest as any)}
+        >
+            {icon}
+        </Button>
+    );
+};
 
 const defaultIcon = <ImageEye />;
 


### PR DESCRIPTION
In the general case, we can infer the basePath from the resource, which is in the context. 

```diff
                        <CardActions className={classes.cardActions}>
-                           <EditButton
-                               resource="posts"
-                               basePath={basePath}
-                               record={data[id]}
-                           />
-                           <ShowButton
-                               resource="posts"
-                               basePath={basePath}
-                               record={data[id]}
-                           />
+                           <EditButton record={data[id]} />
+                           <ShowButton record={data[id]} />
                        </CardActions>
```