### PR TITLE
[TypeScript] Fix useRecordContext doesn't work without props

### DIFF
--- a/packages/ra-core/src/controller/RecordContext.tsx
+++ b/packages/ra-core/src/controller/RecordContext.tsx
@@ -71,7 +71,7 @@ export interface RecordContextOptions<RecordType> {
 export const useRecordContext = <
     RecordType extends Record | Omit<Record, 'id'> = Record
 >(
-    props: UseRecordContextParams<RecordType>
+    props?: UseRecordContextParams<RecordType>
 ): RecordType => {
     // Can't find a way to specify the RecordType when CreateContext is declared
     // @ts-ignore


### PR DESCRIPTION
## Problem

TypeScript doesn't compile code where `useRecordContext` is called with no argument.

```js
const record = useRecordContext();
               ------------------
                 expected 1 argument but got 0
```

But `useRecordContext` was designed to work even without props!

## Solution

Make params optional
                         