### PR TITLE
Add ability to call useGetList without pagination, sort, or filter params

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -12,6 +12,9 @@ import {
 } from '../types';
 import useQueryWithStore from './useQueryWithStore';
 
+const defautlPagination = { page: 1, perPage: 25 };
+const defaultSort = { field: 'id', order: 'DESC' };
+const defaultFilter = {};
 const defaultIds = [];
 const defaultData = {};
 
@@ -58,9 +61,9 @@ const defaultData = {};
  */
 const useGetList = <RecordType extends Record = Record>(
     resource: string,
-    pagination: PaginationPayload,
-    sort: SortPayload,
-    filter: object,
+    pagination: PaginationPayload = defautlPagination,
+    sort: SortPayload = defaultSort,
+    filter: object = defaultFilter,
     options?: UseDataProviderOptions
 ): {
     data?: RecordMap<RecordType>;


### PR DESCRIPTION
## Problem

`useGetList` requires that users pass sort, pagination, and filter params. It's cumbersome.

## Solution

Use sensible defaults

```diff
-const { ids, data, loaded } = useGetList('posts', { page: 1, perPage: 25 }, { field: 'id', order: 'DESC' }, {});
+const { ids, data, loaded } = useGetList('posts');
```