### PR TITLE
fix #6050 - type definition for Datagrid rowClick property doesn't allow for functions that return Promise<string>

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -34,6 +34,7 @@ import DatagridLoading from './DatagridLoading';
 import DatagridBody, { PureDatagridBody } from './DatagridBody';
 import useDatagridStyles from './useDatagridStyles';
 import { ClassesOverride } from '../../types';
+import { RowClickFunction } from './DatagridRow';
 
 /**
  * The Datagrid component renders a list of records as a table.
@@ -354,12 +355,6 @@ Datagrid.propTypes = {
     version: PropTypes.number,
     isRowSelectable: PropTypes.func,
 };
-
-type RowClickFunction = (
-    id: Identifier,
-    basePath: string,
-    record: Record
-) => string;
 
 export interface DatagridProps extends Omit<TableProps, 'size' | 'classes'> {
     body?: ReactElement;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { shallowEqual } from 'react-redux';
 import { Identifier, Record, RecordMap } from 'ra-core';
 
-import DatagridRow, { PureDatagridRow } from './DatagridRow';
+import DatagridRow, { PureDatagridRow, RowClickFunction } from './DatagridRow';
 import useDatagridStyles from './useDatagridStyles';
 
 const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
@@ -97,12 +97,6 @@ DatagridBody.defaultProps = {
     ids: [],
     row: <DatagridRow />,
 };
-
-type RowClickFunction = (
-    id: Identifier,
-    basePath: string,
-    record: Record
-) => string;
 
 export interface DatagridBodyProps extends Omit<TableBodyProps, 'classes'> {
     basePath?: string;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -265,7 +265,7 @@ export type RowClickFunction = (
     id: Identifier,
     basePath: string,
     record: Record
-) => string;
+) => string | Promise<string>;
 
 const areEqual = (prevProps, nextProps) => {
     const { children: _1, expand: _2, ...prevPropsWithoutChildren } = prevProps;


### PR DESCRIPTION
I wasn't sure why there were three separate definitions of RowTypeFunction so I removed two of the duplicates and fixed the remaining one to allow returning Promise<string>