### PR TITLE
Fix stop propagation of click event on DeleteWithConfirmButton component

### DIFF
--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -133,6 +133,7 @@ const useDeleteWithConfirmController = (
 
     const handleDelete = useCallback(
         event => {
+            event.stopPropagation();
             deleteOne({
                 payload: { id: record.id, previousData: record },
             });


### PR DESCRIPTION
Fixes #5815

Note: `useDeleteWithUndoController` hook already runs `event.stopPropagation()`