### PR TITLE
Pass `fullWidth` to `Labeled`

### DIFF
--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -82,6 +82,7 @@ const SimpleShowLayout = ({
                             label={field.props.label}
                             source={field.props.source}
                             disabled={false}
+                            fullWidth={field.props.fullWidth}
                         >
                             {field}
                         </Labeled>


### PR DESCRIPTION
I think this is how it should be, otherwise the `fullWidth` prop isn't really being passed through to the underlying Material UI  components. However, we're looking at it to specifically help fix the visual layout on some more advanced show pages where we do something like the following:

```ts
<Show {...props}>
  <SimpleShowLayout>
    <ArrayField source="transactions" fullWidth label="Transactions">
      <Datagrid>
        <TextField source="id" label="Transaction ID" />
```

`fullWidth` ensures the container takes up 100%, which the data grid happily uses. Without passing it through, the data grid only takes up about 1/3 of the horizontal screen real estate.