### PR TITLE
[TypeScript] Fix ra-input-rich-text is missing types

### DIFF
--- a/packages/ra-input-rich-text/tsconfig.json
+++ b/packages/ra-input-rich-text/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "declaration": true,
+        "declarationMap": true,
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]


### PR DESCRIPTION
Closes #6088