### PR TITLE
Fix performance regression

### DIFF
--- a/packages/ra-core/src/core/useGetResourceLabel.ts
+++ b/packages/ra-core/src/core/useGetResourceLabel.ts
@@ -1,5 +1,5 @@
 import inflection from 'inflection';
-import { useSelector } from 'react-redux';
+import { useStore } from 'react-redux';
 import { getResources } from '../reducer';
 import { useTranslate } from '../i18n';
 
@@ -24,11 +24,13 @@ import { useTranslate } from '../i18n';
  * }
  */
 export const useGetResourceLabel = (): GetResourceLabel => {
-    const resources = useSelector(getResources);
+    const store = useStore();
     const translate = useTranslate();
 
     return (resource: string, count = 2): string => {
-        const resourceDefinition = resources.find(r => r?.name === resource);
+        const resourceDefinition = getResources(store.getState()).find(
+            r => r?.name === resource
+        );
 
         const label = translate(`resources.${resource}.name`, {
             smart_count: count,

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -404,4 +404,6 @@ export interface DatagridProps<RecordType extends Record = Record>
     total?: number;
 }
 
+Datagrid.displayName = 'Datagrid';
+
 export default Datagrid;


### PR DESCRIPTION
## Problem

Inner page components depending on the context render more often than before, and are significantly slower. 

## Root cause analysis

The introduction of `useResourceLabel` in #6016 forced a rerender of each view whenever an action is dispatched. That's because this new hook depends on a bad selector that *creates* a new result each time it is called:

https://github.com/marmelab/react-admin/blob/f8df1eb65556ec99085b6fee70c156546a0b632b/packages/ra-core/src/reducer/admin/resource/index.ts#L77-L78

Therefore, in each of the main page controller (`useListController`, etc.), any change in the Redux store forces a re-run of the controller, which returns a new object, which updates the page context, which forces a rerender of all the components depending on it. 

## Solution

Do not use `useSelector` with that bad selector. 

## Before

13 renders of the `<Datagrid>` component in the Post list view in the simple demo:

![image](https://user-images.githubusercontent.com/99944/112907532-4fc72700-90ee-11eb-8247-945a945b5991.png)

## After

7 renders of the `<Datagrid>` component in the Post list view in the simple demo:


![image](https://user-images.githubusercontent.com/99944/112907592-6ff6e600-90ee-11eb-9200-e0ff6aeae5a1.png)
