### PR TITLE
Fix UserMenu overlaps the user icon

### DIFF
--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -71,8 +71,9 @@ const UserMenu = props => {
             <Menu
                 id="menu-appbar"
                 anchorEl={anchorEl}
+                getContentAnchorEl={null}
                 anchorOrigin={{
-                    vertical: 'top',
+                    vertical: 'bottom',
                     horizontal: 'right',
                 }}
                 transformOrigin={{


### PR DESCRIPTION
Closes #6101

## Before

![image](https://user-images.githubusercontent.com/99944/113107441-3a442100-9204-11eb-8e16-e1861fcf80ea.png)


## After

![image](https://user-images.githubusercontent.com/99944/113107335-1680db00-9204-11eb-855e-e9cfe01af51f.png)
