### PR TITLE
Fix console warnings from Error component

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -3,9 +3,9 @@ import { Fragment, HtmlHTMLAttributes, ErrorInfo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '@material-ui/core/Button';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
 import { makeStyles } from '@material-ui/core/styles';
 import ErrorIcon from '@material-ui/icons/Report';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -75,17 +75,21 @@ const Error = (props: ErrorProps): JSX.Element => {
                 </h1>
                 <div>{translate('ra.message.error')}</div>
                 {process.env.NODE_ENV !== 'production' && (
-                    <ExpansionPanel className={classes.panel}>
-                        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                    <Accordion className={classes.panel}>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             {translate('ra.message.details')}
-                        </ExpansionPanelSummary>
-                        <ExpansionPanelDetails className={classes.panelDetails}>
+                        </AccordionSummary>
+                        <AccordionDetails className={classes.panelDetails}>
                             <div>
-                                <h2>{translate(error.toString())}</h2>
+                                <h2>
+                                    {translate(error.toString(), {
+                                        _: error.toString(),
+                                    })}
+                                </h2>
                                 {errorInfo && errorInfo.componentStack}
                             </div>
-                        </ExpansionPanelDetails>
-                    </ExpansionPanel>
+                        </AccordionDetails>
+                    </Accordion>
                 )}
                 <div className={classes.toolbar}>
                     <Button


### PR DESCRIPTION
## Problem

When an error occurs, the "Something went wrong" screen displays too many warnings:

- MUI deprecation warnings about `ExpansionPanel` being renamed to `Accordion` (long before our current `peerDependency` of 4.11.2, see https://github.com/mui-org/material-ui/releases/tag/v4.11.0
- i18N warnings about missing translation for error message.  

## Before

![image](https://user-images.githubusercontent.com/99944/113356633-da07c900-9342-11eb-9ec8-f97328f37381.png)

## After

![image](https://user-images.githubusercontent.com/99944/113356713-028fc300-9343-11eb-91d1-7679a79c5f6d.png)
