### PR TITLE
Feature: Update window title on page change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 3.14.1
+
+* Fix performance regression ([6096](https://github.com/marmelab/react-admin/pull/6096)) ([fzaninotto](https://github.com/fzaninotto))
+* [TypeScript] Fix `<SingleFieldList component>` doesn't accept string components ([6094](https://github.com/marmelab/react-admin/pull/6094)) ([fzaninotto](https://github.com/fzaninotto))
+
+## v3.14.0
+
+* Add ability to use `record` from context in `Field` components ([5995](https://github.com/marmelab/react-admin/pull/5995)) ([fzaninotto](https://github.com/fzaninotto))
+* Add `<Datagrid isRowExpandable` prop ([5941](https://github.com/marmelab/react-admin/pull/5941)) ([WiXSL](https://github.com/WiXSL))
+* Add `useResourceLabel` hook ([6016](https://github.com/marmelab/react-admin/pull/6016)) ([djhi](https://github.com/djhi))
+* Add ability to use an element as label in `<FormTab>` ([6061](https://github.com/marmelab/react-admin/pull/6061)) ([WiXSL](https://github.com/WiXSL))
+* Add ability to use an element as label in `<FilterListItem>` ([6034](https://github.com/marmelab/react-admin/pull/6034)) ([fzaninotto](https://github.com/fzaninotto))
+* Add ability to call `useGetList` without pagination, sort, or filter params ([6056](https://github.com/marmelab/react-admin/pull/6056)) ([fzaninotto](https://github.com/fzaninotto))
+* Add ability to omit `basePath` in buttons ([6041](https://github.com/marmelab/react-admin/pull/6041)) ([fzaninotto](https://github.com/fzaninotto))
+* Add ability to omit `basePath` in Reference fields ([6028](https://github.com/marmelab/react-admin/pull/6028)) ([fzaninotto](https://github.com/fzaninotto))
+* Add support for `<SingleFieldList component>` ([6036](https://github.com/marmelab/react-admin/pull/6036)) ([fzaninotto](https://github.com/fzaninotto))
+* Add support for `<Labeled fullWidth>` ([6089](https://github.com/marmelab/react-admin/pull/6089)) ([seniorquico](https://github.com/seniorquico))
+* Add support for `<ArrayInput helperText>` ([6062](https://github.com/marmelab/react-admin/pull/6062)) ([WiXSL](https://github.com/WiXSL))
+* Add debounce to `<AutocompleteArrayInput>` `setFilter` call ([6003](https://github.com/marmelab/react-admin/pull/6003)) ([djhi](https://github.com/djhi))
+* Add `success` notification type ([5961](https://github.com/marmelab/react-admin/pull/5961)) ([WiXSL](https://github.com/WiXSL))
+* Add support for a React element as `<Confirm content` prop value ([5954](https://github.com/marmelab/react-admin/pull/5954)) ([andrico1234](https://github.com/andrico1234))
+* Fix refresh strategy to avoid empty page while refreshing ([6054](https://github.com/marmelab/react-admin/pull/6054)) ([fzaninotto](https://github.com/fzaninotto))
+* Fix performance issue in forms with many validators ([6092](https://github.com/marmelab/react-admin/pull/6092)) ([djhi](https://github.com/djhi))
+* Fix `<ReferenceArrayField>` passes empty data to child when loaded ([6080](https://github.com/marmelab/react-admin/pull/6080)) ([fzaninotto](https://github.com/fzaninotto))
+* Fix typo in private variable name in `useGetList` code ([6069](https://github.com/marmelab/react-admin/pull/6069)) ([WiXSL](https://github.com/WiXSL))
+* [TypeScript] Fix `ra-input-rich-text` is missing types ([6093](https://github.com/marmelab/react-admin/pull/6093)) ([fzaninotto](https://github.com/fzaninotto))
+* [TypeScript] Fix `<SimpleList>` and other list components can't be used without context ([6090](https://github.com/marmelab/react-admin/pull/6090)) ([fzaninotto](https://github.com/fzaninotto))
+* [TypeScript] Export more types for `ra-ui-materialui` Input components props ([6086](https://github.com/marmelab/react-admin/pull/6086)) ([tdnl](https://github.com/tdnl))
+* [TypeScript] Fix typo in `<FormWithRedirect>` props types ([6085](https://github.com/marmelab/react-admin/pull/6085)) ([djhi](https://github.com/djhi))
+* [TypeScript] Fix type definition for `<Datagrid rowClick>` prop doesn't allow for functions that return a Promise ([6060](https://github.com/marmelab/react-admin/pull/6060)) ([jvert](https://github.com/jvert))
+* [Doc] Fix error in snippet for custom error page ([6091](https://github.com/marmelab/react-admin/pull/6091)) ([danangekal](https://github.com/danangekal))
+* [Doc] Fix installation snippet for `'ra-data-local-storage` ([6083](https://github.com/marmelab/react-admin/pull/6083)) ([luoxi](https://github.com/luoxi))
+
+## v3.13.5
+
+* Fix `<FilterLiveSearch>` looses its value upon navigation ([6066](https://github.com/marmelab/react-admin/pull/6066)) ([djhi](https://github.com/djhi))
+* Fix `<AutocompleteInput>` and `<AutocompletearrayInput>` options appear behind Dialog ([6065](https://github.com/marmelab/react-admin/pull/6065)) ([fzaninotto](https://github.com/fzaninotto))
+* Fix `<DeleteWithConfirmButton>` propagates click event down to `<DatagridRow>` ([6063](https://github.com/marmelab/react-admin/pull/6063)) ([WiXSL](https://github.com/WiXSL))
+* Fix `<ReferenceInput>` incorrectly sets the `total` value ([6058](https://github.com/marmelab/react-admin/pull/6058)) ([WiXSL](https://github.com/WiXSL))
+* [TypeScript] Fix `useGetList` return type assumes `data` and `ids` are possibly `undefined` ([6053](https://github.com/marmelab/react-admin/pull/6053)) ([fzaninotto](https://github.com/fzaninotto))
+* [TypeScript] Fix `useRecordContext` doesn't work without props ([6046](https://github.com/marmelab/react-admin/pull/6046)) ([fzaninotto](https://github.com/fzaninotto))
+* [Doc] Fix various typos and doc anchors ([6059](https://github.com/marmelab/react-admin/pull/6059)) ([WiXSL](https://github.com/WiXSL))
+* [Doc] Fix missing newline in Inputs chapter ([6064](https://github.com/marmelab/react-admin/pull/6064)) ([WiXSL](https://github.com/WiXSL))
+* [Doc] Fix `<Admin ready>` prop doesn't appear in the side navigation ([6048](https://github.com/marmelab/react-admin/pull/6048)) ([WiXSL](https://github.com/WiXSL))
+* [Doc] Fix typo in `bulkActionButtons` documentation ([6043](https://github.com/marmelab/react-admin/pull/6043)) ([WiXSL](https://github.com/WiXSL))
+* [Doc] Fix `react-admin` package README is out of date ([6042](https://github.com/marmelab/react-admin/pull/6042)) ([WiXSL](https://github.com/WiXSL))
+* [Doc] Fix outdated indonesian translation ([5937](https://github.com/marmelab/react-admin/pull/5937)) ([danangekal](https://github.com/danangekal))
+
 ## v3.13.4
 
 * Fix Go to definition goes to the compiled code in VSCode ([6039](https://github.com/marmelab/react-admin/pull/6039)) ([fzaninotto](https://github.com/fzaninotto))

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,7 +34,7 @@ Failing to upgrade one of the `ra-` packages will result in a duplication of the
 
 * `react` and `react-dom` are now required to be >= 16.9. This version is backward compatible with 16.3, which was the minimum requirement in react-admin, and it offers the support for Hooks, on which react-admin v3 relies heavily.
 * `react-redux` requires a minimum version of 7.1.0 (instead of 5.0). Check their upgrade guide for [6.0](https://github.com/reduxjs/react-redux/releases/tag/v6.0.0) and [7.0](https://github.com/reduxjs/react-redux/releases/tag/v7.0.0)
-* `redux-saga` requires a minimim version of 1.0.0 (instead of ~0.16.0). Check their [list of breaking changes for redux-saga 1.0](https://github.com/redux-saga/redux-saga/releases/tag/v1.0.0) on GitHub. 
+* `redux-saga` requires a minimum version of 1.0.0 (instead of ~0.16.0). Check their [list of breaking changes for redux-saga 1.0](https://github.com/redux-saga/redux-saga/releases/tag/v1.0.0) on GitHub. 
 * `material-ui` requires a minimum of 4.0.0 (instead of 1.5). Check their [Upgrade guide](https://next.material-ui.com/guides/migration-v3/).
 
 ## `react-router-redux` replaced by `connected-react-router`
@@ -1118,17 +1118,17 @@ We've described how to pre-fill some fields in the create form in an [Advanced T
 
 ```jsx
 const AddNewCommentButton = ({ record }) => (
-  <Button
-    component={Link}
-    to={{
-      pathname: "/comments/create",
--     search: `?post_id=${record.id}`,
-+     search: `?source=${JSON.stringify({ post_id: record.id })}`,
-    }}
-    label="Add a comment"
-  >
-    <ChatBubbleIcon />
-  </Button>
+    <Button
+        component={Link}
+        to={{
+            pathname: "/comments/create",
+-           search: `?post_id=${record.id}`,
++           search: `?source=${JSON.stringify({ post_id: record.id })}`,
+        }}
+        label="Add a comment"
+    >
+        <ChatBubbleIcon />
+    </Button>
 );
 ```
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -578,7 +578,7 @@ const App = () => (
 
 **Caution**: Do not use the 5.x version of the `history` package. It's currently incompatible with another dependency of react-admin, `connected-react-router`. `history@4.10.1` works fine. 
 
-### `ready`
+## `ready`
 
 When you run an `<Admin>` with no child `<Resource>`, react-admin displays a "ready" screen:
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -52,7 +52,7 @@ You can get more details about input params, response and error formats in the [
 
 ## Available Providers
 
-It's very common that your auth logic is so specific that so you'll need to write your own `authProvider`. However, the community has built a few open-source Auth Providers that may fit your need:
+It's very common that your auth logic is so specific that you'll need to write your own `authProvider`. However, the community has built a few open-source Auth Providers that may fit your need:
 
 - **[AWS Amplify](https://docs.amplify.aws)**: [MrHertal/react-admin-amplify](https://github.com/MrHertal/react-admin-amplify)
 - **[AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/setting-up-the-javascript-sdk.html)**: [thedistance/ra-cognito](https://github.com/thedistance/ra-cognito)

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -577,7 +577,7 @@ const PostList = props => (
 
 **Note**: `<CloneButton>` is designed to be used in a `<Datagrid>` and in an edit view `<Actions>` component, not inside the form `<Toolbar>`. The `Toolbar` is basically for submitting the form, not for going to another resource.
 
-Alternately, users need to prepopulate a record based on a *related* record. For instance, to create a comment related to an exising post. 
+Alternately, users need to prepopulate a record based on a *related* record. For instance, to create a comment related to an existing post. 
 
 By default, the `<Create>` view starts with an empty `record`. However, if the `location` object (injected by [react-router-dom](https://reacttraining.com/react-router/web/api/location)) contains a `record` in its `state`, the `<Create>` view uses that `record` instead of the empty object. That's how the `<CloneButton>` works under the hood.
 
@@ -938,7 +938,7 @@ You can also opt out the location synchronization by passing `false` to the `syn
 ```jsx
 export const PostEdit = (props) => (
     <Edit {...props}>
-        <TabbedForm syncWithLocation>
+        <TabbedForm syncWithLocation={false}>
             <FormTab label="summary">
                 <TextInput disabled label="Id" source="id" />
                 <TextInput source="title" validate={required()} />
@@ -969,6 +969,7 @@ export const PostEdit = (props) => (
 ```
 {% endraw %}
 **Tip**: When `syncWithLocation` is `false`, the `path` prop of the `<FormTab>` components is ignored.
+
 ### Label Decoration
 
 `<FormTab>` scans its children for the `addLabel` prop, and automatically wraps a child in a `<Labeled>` component when found. This displays a label on top of the child, based on the `label` prop. This is not necessary for `<Input>` components, as they already contain their label. Also, all the react-admin `<Field>` components have a default prop `addLabel: true`, which explains why react-admin shows a label on top of Fields when they are used as children of `<FormTab>`. 

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -466,16 +466,16 @@ import { NumberField }  from 'react-admin';
 
 | Prop      | Required | Type   | Default | Description                                                                                              |
 | --------- | -------- | ------ | ------- | -------------------------------------------------------------------------------------------------------- |
-| `locales` | Optional | string | ''      | Override the browser locale in the date formatting. Passed as first argument to `Intl.DateTimeFormat()`. |
+| `locales` | Optional | string | ''      | Override the browser locale in the date formatting. Passed as first argument to `Intl.NumberFormat()`.   |
 | `options` | Optional | Object | -       | Number formatting options. Passed as second argument to `Intl.NumberFormat()`.                           |
 
 `<NumberField>` also accepts the [common field props](./Fields.md#common-field-props).
 
 #### Usage
 
-`<NumberField>` uses `Intl.NumberFormat()` if available, passing the `locales` and `options` props as arguments. This allows a perfect display of decimals, currencies, percentages, etc.
+`<NumberField>` uses `Intl.NumberFormat()` if available, passing the `locales` and `options` props as arguments. This allows a perfect display of decimals, currencies, percentages, etc. See [Intl.NumberFormat documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) for the `options` prop syntax.
 
-If Intl is not available, it outputs numbers as is (and ignores the `locales` and `options` props).
+If Intl is not available, `<NumberField>` outputs numbers as is (and ignores the `locales` and `options` props).
 
 {% raw %}
 ```jsx
@@ -498,8 +498,6 @@ import { NumberField }  from 'react-admin';
 <span>25,99 $US</span>
 ```
 {% endraw %}
-
-See [Intl.NumberFormat documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) for the `options` prop syntax.
 
 **Tip**: If you need more formatting options than what `Intl.NumberFormat` can provide, build your own field component leveraging a third-party library like [numeral.js](http://numeraljs.com/).
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -544,26 +544,6 @@ import { AutocompleteInput } from 'react-admin';
 | `container`            | Applied to the root element          |
 | `suggestionsContainer` | Applied to the suggestions container |
 
-The suggestions container has a `z-index` of 2. When using `<AutocompleteInput>` in a `<Dialog>`, this will cause suggestions to appear beneath the Dialog. The solution is to override the `suggestionsContainer` class name, as follows:
-
-```diff
-import { AutocompleteInput } from 'react-admin';
--import { Dialog } from '@material-ui/core';
-+import { Dialog, withStyles } from '@material-ui/core';
-
-+const AutocompleteInputInDialog = withStyles({
-+    suggestionsContainer: { zIndex: 2000 },
-+})(AutocompleteInput);
-
-const EditForm = () => (
-    <Dialog open>
-        ...
--       <AutocompleteInput source="foo" choices={[...]}>
-+       <AutocompleteInputInDialog source="foo" choices={[...]}>
-    </Dialog>
-)
-```
-
 To override the style of all instances of `<AutocompleteInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaAutocompleteInput` key.
 
 #### Usage
@@ -1061,26 +1041,6 @@ import { AutocompleteArrayInput } from 'react-admin';
 | `inputRootFilled`       | Styles pass as the `root` class of the underlying Material UI's `TextField` component input when `variant` prop is `filled` |
 | `inputInput`            | Styles pass as the `input` class of the underlying Material UI's `TextField` component input                                |
 
-The suggestions container has a `z-index` of 2. When using `<AutocompleteArrayInput>` in a `<Dialog>`, this will cause suggestions to appear beneath the Dialog. The solution is to override the `suggestionsContainer` class name, as follows:
-
-```diff
-import { AutocompleteArrayInput } from 'react-admin';
--import { Dialog } from '@material-ui/core';
-+import { Dialog, withStyles } from '@material-ui/core';
-
-+const AutocompleteArrayInputInDialog = withStyles({
-+    suggestionsContainer: { zIndex: 2000 },
-+})(AutocompleteArrayInput);
-
-const EditForm = () => (
-    <Dialog open>
-        ...
--       <AutocompleteArrayInput source="foo" choices={[...]}>
-+       <AutocompleteArrayInputInDialog source="foo" choices={[...]}>
-    </Dialog>
-)
-```
-
 To override the style of all instances of `<AutocompleteArrayInput>` using the [material-ui style overrides](https://material-ui.com/customization/globals/#css), use the `RaAutocompleteArrayInput` key.
 
 #### Usage
@@ -1135,6 +1095,7 @@ Lastly, `<AutocompleteArrayInput>` renders a [material-ui `<TextField>` componen
 {% endraw %}
 
 **Tip**: Like many other inputs, `<AutocompleteArrayInput>` accept a `fullWidth` prop.
+
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<AutocompleteArrayInput>` with [`<ReferenceArrayInput>`](#referenceinput), and leave the `choices` empty:
 
 ```jsx
@@ -1500,7 +1461,7 @@ You can tweak how this component fetches the possible values using the `perPage`
 ```
 {% endraw %}
 
-In addition to the `ReferenceArrayInputContext`, `<ReferenceArrayInput>` also sets up a `ListContext` providing access to the records from the reference resource in a similar fashion to that of the `<List>` component. This `ListContext` value is accessible with the [`useListContext`](/List.md#uselistcontext) hook.
+In addition to the `ReferenceArrayInputContext`, `<ReferenceArrayInput>` also sets up a `ListContext` providing access to the records from the reference resource in a similar fashion to that of the `<List>` component. This `ListContext` value is accessible with the [`useListContext`](./List.md#uselistcontext) hook.
 
 `<ReferenceArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
@@ -1508,7 +1469,7 @@ In addition to the `ReferenceArrayInputContext`, `<ReferenceArrayInput>` also se
 
 The [`<ReferenceArrayInput>`](#referencearrayinput) component take care of fetching the data, and put that data in a context called `ReferenceArrayInputContext` so that it’s available for its descendants. This context also stores filters, pagination, sort state, and provides callbacks to update them.
 
-Any component decendent of `<ReferenceArryInput>` can grab information from the `ReferenceArrayInputContext` using the `useReferenceArrayInputContext` hook. Here is what it returns:
+Any component descendant of `<ReferenceArryInput>` can grab information from the `ReferenceArrayInputContext` using the `useReferenceArrayInputContext` hook. Here is what it returns:
 
 ```js
 const {

--- a/docs/List.md
+++ b/docs/List.md
@@ -404,7 +404,7 @@ export default ResetViewsButton;
 
 **Tip**: `<Confirm>` leverages material-ui's `<Dialog>` component to implement a confirmation popup. Feel free to use it in your admins!
 
-**Tip**: `<Confirm>` text props such as `title` and `content` are translatable. You can pass use translation keys in these props. Note: `content` is only translateable when value is `string`, otherwise it renders the content as a `ReactNode`.
+**Tip**: `<Confirm>` text props such as `title` and `content` are translatable. You can pass translation keys in these props. Note: `content` is only translateable when value is `string`, otherwise it renders the content as a `ReactNode`.
 
 **Tip**: You can customize the text of the two `<Confirm>` component buttons using the `cancel` and `confirm` props which accept translation keys. You can customize the icons by setting the `ConfirmIcon` and `CancelIcon` props, which accept a SvgIcon type.
 
@@ -2819,15 +2819,13 @@ export const UserList = ({ permissions, ...props }) => {
 
 ### Rendering `<Datagrid>` With A Custom Query
 
-You can use the `<Datagrid>` component with [custom queries](./Actions.md#usequery-hook), provided you pass the result to a `<ListContextProvider>`:
+You can use the `<Datagrid>` component with [custom queries](./Actions.md#usequery-hook):
 
 {% raw %}
 ```jsx
 import keyBy from 'lodash/keyBy'
 import {
     useQuery,
-    ResourceContextProvider,
-    ListContextProvider,
     Datagrid,
     TextField,
     Pagination,
@@ -2836,13 +2834,14 @@ import {
 
 const CustomList = () => {
     const [page, setPage] = useState(1);
-    const perPage = 50;
+    const [perPage, setPerPage] = useState(25);
+    const [sort, setSort] = useState({ field: 'id', order: 'ASC' })
     const { data, total, loading, error } = useQuery({
         type: 'getList',
         resource: 'posts',
         payload: {
             pagination: { page, perPage },
-            sort: { field: 'id', order: 'ASC' },
+            sort,
             filter: {},
         }
     });
@@ -2854,32 +2853,28 @@ const CustomList = () => {
         return <p>ERROR: {error}</p>
     }
     return (
-        <ResourceContextProvider value="posts">
-            <ListContextProvider
-                value={{
-                    basePath: '/posts',
-                    data: keyBy(data, 'id'),
-                    ids: data.map(({ id }) => id),
-                    currentSort: { field: 'id', order: 'ASC' },
-                    selectedIds: [],
-                }}
-            >
-                <Datagrid rowClick="edit">
-                    <TextField source="id" />
-                    <TextField source="title" />
-                </Datagrid>
-                <Pagination
-                    page={page}
-                    perPage={perPage}
-                    setPage={setPage}
-                    total={total}
-                />
-            </ListContextProvider>
-        </ResourceContextProvider>
+        <Datagrid 
+            data={keyBy(data, 'id')}
+            ids={data.map(({ id }) => id)}
+            currentSort={sort}
+            setSort={(field, order) => setSort({ field, order })}
+        >
+            <TextField source="id" />
+            <TextField source="title" />
+        </Datagrid>
+        <Pagination
+            page={page}
+            setPage={setPage}
+            perPage={perPage}
+            setPerPage={setPerPage}
+            total={total}
+        />
     );
 }
 ```
 {% endraw %}
+
+**Tip**: If you use the `<Datagrid rowClick>` prop in this case, you must also set the `basePath` prop to let the `<Datagrid>` compute the link to the record pages. 
 
 ## Third-Party Components
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1010,7 +1010,7 @@ const MyError = ({
             <div>
                 <Button
                     variant="contained"
-                    icon={<History />}
+                    startIcon={<History />}
                     onClick={() => history.go(-1)}
                 >
                     Back

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -181,7 +181,7 @@ You can find translation packages for the following languages:
 - Hebrew (`he`): [ak-il/ra-language-hebrew](https://github.com/ak-il/ra-language-hebrew)
 - Hindi (`hi`): [harshit-budhraja/ra-language-hindi](https://github.com/harshit-budhraja/ra-language-hindi)
 - Hungarian (`hu`): [phelion/ra-language-hungarian](https://github.com/phelion/ra-language-hungarian)
-- Indonesian (`id`): [ronadi/ra-language-indonesian](https://github.com/ronadi/ra-language-indonesian)
+- Indonesian (`id`): [danangekal/ra-language-indonesian-new](https://github.com/danangekal/ra-language-indonesian-new)
 - Italian (`it`): [stefsava/ra-italian](https://github.com/stefsava/ra-italian)
 - Japanese (`ja`): [bicstone/ra-language-japanese](https://github.com/bicstone/ra-language-japanese)
 - Korean (`ko`): [acidsound/ra-language-korean](https://github.com/acidsound/ra-language-korean)
@@ -669,8 +669,9 @@ resources: {
         fields: {
             id: 'Id',
             name: 'Bezeichnung',
-        },
-    },
+        }
+    }
+}
 ```
 
 ## Silencing Translation Warnings

--- a/examples/simple/src/customRouteLayout.tsx
+++ b/examples/simple/src/customRouteLayout.tsx
@@ -26,13 +26,13 @@ const CustomRouteLayout = () => {
                 Found <span className="total">{total}</span> posts !
             </p>
             <Datagrid
-                basePath=""
+                basePath="/posts"
                 currentSort={currentSort}
                 data={data}
                 ids={ids}
-                selectedIds={[]}
                 loaded={loaded}
                 total={total}
+                rowClick="edit"
             >
                 <TextField source="id" sortable={false} />
                 <TextField source="title" sortable={false} />

--- a/examples/simple/src/index.tsx
+++ b/examples/simple/src/index.tsx
@@ -1,6 +1,6 @@
 /* eslint react/jsx-key: off */
 import * as React from 'react';
-import { Admin, Resource } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { Admin, Resource, CustomRoute } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import { render } from 'react-dom';
 import { Route } from 'react-router-dom';
 
@@ -23,7 +23,7 @@ render(
         title="Example Admin"
         layout={Layout}
         customRoutes={[
-            <Route
+            <Route<CustomRoute>
                 exact
                 path="/custom"
                 component={props => <CustomRouteNoLayout {...props} />}

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "examples/data-generator",
     "packages/*"
   ],
-  "version": "3.13.4"
+  "version": "3.14.1"
 }

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-core",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "Core components of react-admin, a frontend Framework for building admin applications on top of REST services, using ES6, React",
     "files": [
         "*.md",
@@ -40,7 +40,7 @@
         "final-form": "^4.20.2",
         "history": "^4.7.2",
         "ignore-styles": "~5.0.1",
-        "ra-test": "^3.13.4",
+        "ra-test": "^3.14.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-final-form": "^6.5.2",

--- a/packages/ra-core/src/controller/RecordContext.tsx
+++ b/packages/ra-core/src/controller/RecordContext.tsx
@@ -71,7 +71,7 @@ export interface RecordContextOptions<RecordType> {
 export const useRecordContext = <
     RecordType extends Record | Omit<Record, 'id'> = Record
 >(
-    props: UseRecordContextParams<RecordType>
+    props?: UseRecordContextParams<RecordType>
 ): RecordType => {
     // Can't find a way to specify the RecordType when CreateContext is declared
     // @ts-ignore

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -133,6 +133,7 @@ const useDeleteWithConfirmController = (
 
     const handleDelete = useCallback(
         event => {
+            event.stopPropagation();
             deleteOne({
                 payload: { id: record.id, previousData: record },
             });

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -88,6 +88,9 @@ const useReferenceArrayFieldController = (
             ),
     });
 
+    const [loadingState, setLoadingState] = useSafeSetState<boolean>(loading);
+    const [loadedState, setLoadedState] = useSafeSetState<boolean>(loaded);
+
     const [finalData, setFinalData] = useSafeSetState<RecordMap>(
         indexById(data)
     );
@@ -211,6 +214,18 @@ const useReferenceArrayFieldController = (
         sort.order,
     ]);
 
+    useEffect(() => {
+        if (loaded !== loadedState) {
+            setLoadedState(loaded);
+        }
+    }, [loaded, loadedState, setLoadedState]);
+
+    useEffect(() => {
+        if (loading !== loadingState) {
+            setLoadingState(loading);
+        }
+    }, [loading, loadingState, setLoadingState]);
+
     return {
         basePath: basePath
             ? basePath.replace(resource, reference)
@@ -224,8 +239,8 @@ const useReferenceArrayFieldController = (
         hasCreate: false,
         hideFilter,
         ids: finalIds,
-        loaded,
-        loading,
+        loaded: loadedState,
+        loading: loadingState,
         onSelect,
         onToggleItem,
         onUnselectItems,

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -145,7 +145,7 @@ export const useReferenceInputController = (
     } else {
         finalIds = [input.value, ...possibleValuesIds];
         finalData = { [input.value]: referenceRecord, ...possibleValuesData };
-        finalTotal += 1;
+        finalTotal = possibleValuesTotal + 1;
     }
 
     // overall status

--- a/packages/ra-core/src/core/CoreAdminRouter.tsx
+++ b/packages/ra-core/src/core/CoreAdminRouter.tsx
@@ -107,33 +107,43 @@ const CoreAdminRouter: FunctionComponent<AdminRouterProps> = props => {
         loading: LoadingPage,
         logout,
         menu,
-        ready,
+        ready: Ready,
         theme,
         title,
     } = props;
 
-    if (
-        (typeof children !== 'function' && !children) ||
-        (Array.isArray(children) && children.length === 0)
-    ) {
-        return createElement(ready);
+    if (typeof children !== 'function' && !children) {
+        return <Ready />;
     }
 
     if (
-        typeof children === 'function' &&
-        (!computedChildren || computedChildren.length === 0)
+        (typeof children === 'function' &&
+            (!computedChildren || computedChildren.length === 0)) ||
+        (Array.isArray(children) && children.length === 0)
     ) {
-        if (oneSecondHasPassed) {
-            return (
-                <Route
-                    path="/"
-                    key="loading"
-                    render={() => <LoadingPage theme={theme} />}
-                />
-            );
-        } else {
-            return null;
-        }
+        return (
+            <Switch>
+                {customRoutes
+                    .filter(route => route.props.noLayout)
+                    .map((route, key) =>
+                        cloneElement(route, {
+                            key,
+                            render: routeProps =>
+                                renderCustomRoutesWithoutLayout(
+                                    route,
+                                    routeProps
+                                ),
+                            component: undefined,
+                        })
+                    )}
+                {oneSecondHasPassed && (
+                    <Route
+                        key="loading"
+                        render={() => <LoadingPage theme={theme} />}
+                    />
+                )}
+            </Switch>
+        );
     }
 
     const childrenToRender = (typeof children === 'function'
@@ -167,6 +177,7 @@ const CoreAdminRouter: FunctionComponent<AdminRouterProps> = props => {
                                     route,
                                     routeProps
                                 ),
+                            component: undefined,
                         })
                     )}
                 <Route

--- a/packages/ra-core/src/core/useGetResourceLabel.ts
+++ b/packages/ra-core/src/core/useGetResourceLabel.ts
@@ -1,5 +1,5 @@
 import inflection from 'inflection';
-import { useSelector } from 'react-redux';
+import { useStore } from 'react-redux';
 import { getResources } from '../reducer';
 import { useTranslate } from '../i18n';
 
@@ -24,11 +24,13 @@ import { useTranslate } from '../i18n';
  * }
  */
 export const useGetResourceLabel = (): GetResourceLabel => {
-    const resources = useSelector(getResources);
+    const store = useStore();
     const translate = useTranslate();
 
     return (resource: string, count = 2): string => {
-        const resourceDefinition = resources.find(r => r?.name === resource);
+        const resourceDefinition = getResources(store.getState()).find(
+            r => r?.name === resource
+        );
 
         const label = translate(`resources.${resource}.name`, {
             smart_count: count,

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -66,8 +66,8 @@ const useGetList = <RecordType extends Record = Record>(
     filter: object = defaultFilter,
     options?: UseDataProviderOptions
 ): {
-    data?: RecordMap<RecordType>;
-    ids?: Identifier[];
+    data: RecordMap<RecordType>;
+    ids: Identifier[];
     total?: number;
     error?: any;
     loading: boolean;

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -190,7 +190,7 @@ export type FormWithRedirectProps = FormWithRedirectOwnProps &
 
 export type FormWithRedirectRenderProps = Omit<
     FormViewProps,
-    'chilren' | 'render' | 'setRedirect'
+    'children' | 'render' | 'setRedirect'
 >;
 export type FormWithRedirectRender = (
     props: FormWithRedirectRenderProps

--- a/packages/ra-core/src/form/useFormGroup.ts
+++ b/packages/ra-core/src/form/useFormGroup.ts
@@ -52,7 +52,7 @@ type FormGroupState = {
  *     );
  * }
  *
- * @param {string] name The form group name
+ * @param {string} name The form group name
  * @returns {FormGroupState} The form group state
  */
 export const useFormGroup = (name: string): FormGroupState => {
@@ -104,7 +104,7 @@ export const useFormGroup = (name: string): FormGroupState => {
 /**
  * Get the state of a form group
  *
- * @param {FieldStates} fieldStates A map of field states from final-form where the key is the field name.
+ * @param {FieldState[]} fieldStates A map of field states from final-form where the key is the field name.
  * @returns {FormGroupState} The state of the group.
  */
 export const getFormGroupState = (

--- a/packages/ra-core/src/form/validate.spec.ts
+++ b/packages/ra-core/src/form/validate.spec.ts
@@ -30,7 +30,7 @@ describe('Validators', () => {
 
     describe('composeValidators', () => {
         const asyncSuccessfullValidator = async =>
-            new Promise(resolve => resolve());
+            new Promise(resolve => resolve(undefined));
         const asyncFailedValidator = async =>
             new Promise(resolve => resolve('async'));
 

--- a/packages/ra-core/src/form/validate.ts
+++ b/packages/ra-core/src/form/validate.ts
@@ -77,10 +77,18 @@ export const composeValidators = (...validators) => async (
     ).filter(isFunction);
 
     for (const validator of allValidators) {
-        const error = await validator(value, values, meta);
+        const errorPromise = validator(value, values, meta);
 
-        if (error) {
-            return error;
+        if (errorPromise) {
+            let error = errorPromise;
+
+            if (errorPromise.then) {
+                error = await errorPromise;
+            }
+
+            if (error) {
+                return error;
+            }
         }
     }
 };

--- a/packages/ra-core/src/i18n/useTranslatable.ts
+++ b/packages/ra-core/src/i18n/useTranslatable.ts
@@ -10,7 +10,7 @@ import useTranslate from './useTranslate';
  *
  * @param options The hook options
  * @param {string} options.defaultLocale The locale of the default selected locale. Defaults to 'en'.
- * @param {strong[]} options.locales An array of the supported locales. Each is an object with a locale and a name property. For example { locale: 'en', name: 'English' }.
+ * @param {string[]} options.locales An array of the supported locales. Each is an object with a locale and a name property. For example { locale: 'en', name: 'English' }.
  *
  * @returns
  * An object with following properties and methods:

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -389,6 +389,7 @@ export type AdminChildren = RenderResourcesFunction | ReactNode;
 
 export interface CustomRoute extends RouteProps {
     noLayout?: boolean;
+    [key: string]: any;
 }
 
 export type CustomRoutes = Array<ReactElement<CustomRoute>>;

--- a/packages/ra-core/src/util/hooks.ts
+++ b/packages/ra-core/src/util/hooks.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
 

--- a/packages/ra-core/src/util/hooks.ts
+++ b/packages/ra-core/src/util/hooks.ts
@@ -61,3 +61,11 @@ export function useTimeout(ms = 0) {
 
     return ready;
 }
+
+export function useDocumentTitle(title: string) {
+    React.useEffect(() => {
+        if (title) {
+            document.title = title;
+        }
+    }, [title]);
+}

--- a/packages/ra-core/src/util/index.ts
+++ b/packages/ra-core/src/util/index.ts
@@ -10,7 +10,7 @@ import Ready from './Ready';
 import resolveRedirectTo from './resolveRedirectTo';
 import warning from './warning';
 import useWhyDidYouUpdate from './useWhyDidYouUpdate';
-import { useSafeSetState, useTimeout } from './hooks';
+import { useSafeSetState, useTimeout, useDocumentTitle } from './hooks';
 export * from './indexById';
 
 export {
@@ -28,4 +28,5 @@ export {
     useWhyDidYouUpdate,
     useSafeSetState,
     useTimeout,
+    useDocumentTitle,
 };

--- a/packages/ra-data-fakerest/README.md
+++ b/packages/ra-data-fakerest/README.md
@@ -59,12 +59,12 @@ Here is an example input:
 ```json
 {
     "posts": [
-        { "id": 0, "title": 'Hello, world!' },
-        { "id": 1, "title": 'FooBar' }
+        { "id": 0, "title": "Hello, world!" },
+        { "id": 1, "title": "FooBar" }
     ],
     "comments": [
-        { "id": 0, "post_id": 0, "author": 'John Doe', "body": 'Sensational!' },
-        { "id": 1, "post_id": 0, "author": 'Jane Doe', "body": 'I agree' }
+        { "id": 0, "post_id": 0, "author": "John Doe", "body": "Sensational!" },
+        { "id": 1, "post_id": 0, "author": "Jane Doe", "body": "I agree" }
     ]
 }
 ```

--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-data-fakerest",
-    "version": "3.13.4",
+    "version": "3.13.5",
     "description": "JSON Server data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-data-json-server",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "JSON Server data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "query-string": "^5.1.1",
-        "ra-core": "^3.13.4"
+        "ra-core": "^3.14.1"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-data-localstorage/README.md
+++ b/packages/ra-data-localstorage/README.md
@@ -16,7 +16,7 @@ npm install --save ra-data-local-storage
 // in src/App.js
 import * as React from "react";
 import { Admin, Resource } from 'react-admin';
-import localStorageDataProvider from 'ra-data-localstorage';
+import localStorageDataProvider from 'ra-data-local-storage';
 
 const dataProvider = localStorageDataProvider();
 import { PostList } from './posts';

--- a/packages/ra-data-localstorage/package.json
+++ b/packages/ra-data-localstorage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-data-local-storage",
-    "version": "3.13.4",
+    "version": "3.14.0",
     "description": "Local storage data provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "lodash": "~4.17.5",
-        "ra-data-fakerest": "^3.13.4"
+        "ra-data-fakerest": "^3.13.5"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-i18n-polyglot/package.json
+++ b/packages/ra-i18n-polyglot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-i18n-polyglot",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "Polyglot i18n provider for react-admin",
     "main": "lib/index.js",
     "module": "esm/index.js",
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "node-polyglot": "^2.2.2",
-        "ra-core": "^3.13.4"
+        "ra-core": "^3.14.1"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-input-rich-text",
-    "version": "3.12.0",
+    "version": "3.14.0",
     "description": "<RichTextInput> component for react-admin, useful for editing HTML code in admin GUIs.",
     "main": "lib/index.js",
     "module": "esm/index.js",

--- a/packages/ra-input-rich-text/tsconfig.json
+++ b/packages/ra-input-rich-text/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "declaration": true,
+        "declarationMap": true,
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/ra-language-english/package.json
+++ b/packages/ra-language-english/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-language-english",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "English messages for react-admin, the frontend framework for building admin applications on top of REST/GraphQL services",
     "repository": {
         "type": "git",
@@ -22,7 +22,7 @@
         "watch": "tsc --outDir esm --module es2015 --watch"
     },
     "dependencies": {
-        "ra-core": "^3.13.4"
+        "ra-core": "^3.14.1"
     },
     "keywords": [
         "react",

--- a/packages/ra-language-french/package.json
+++ b/packages/ra-language-french/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-language-french",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "French messages for react-admin, the frontend framework for building admin applications on top of REST/GraphQL services",
     "repository": {
         "type": "git",
@@ -16,7 +16,7 @@
         "watch": "tsc --outDir esm --module es2015 --watch"
     },
     "dependencies": {
-        "ra-core": "^3.13.4"
+        "ra-core": "^3.14.1"
     },
     "keywords": [
         "react",

--- a/packages/ra-test/README.md
+++ b/packages/ra-test/README.md
@@ -88,7 +88,7 @@ it('should send the user to another url', () => {
 
 ### Testing Permissions
 
-As explained on the [Auth Provider chapter](./Authentication.md#authorization), it's possible to manage permissions via the `authProvider` in order to filter page and fields the users can see.
+As explained on the [Auth Provider chapter](https://marmelab.com/react-admin/Authentication.html#authorization), it's possible to manage permissions via the `authProvider` in order to filter page and fields the users can see.
 
 In order to avoid regressions and make the design explicit to your co-workers, it's better to unit test which fields are supposed to be displayed or hidden for each permission.
 

--- a/packages/ra-test/package.json
+++ b/packages/ra-test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-test",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "Test utilities for react-admin, a frontend Framework for building admin applications on top of REST services, using ES6, React",
     "files": [
         "*.md",
@@ -39,7 +39,7 @@
         "final-form": "^4.20.2",
         "history": "^4.7.2",
         "ignore-styles": "~5.0.1",
-        "ra-core": "^3.13.4",
+        "ra-core": "^3.14.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-redux": "^7.1.0",

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ra-ui-materialui",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "UI Components for react-admin with MaterialUI",
     "files": [
         "*.md",
@@ -36,7 +36,7 @@
         "final-form": "^4.20.2",
         "final-form-arrays": "^3.0.2",
         "ignore-styles": "~5.0.1",
-        "ra-core": "^3.13.4",
+        "ra-core": "^3.14.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-final-form": "^6.5.2",
@@ -54,7 +54,7 @@
         "@material-ui/styles": "^4.11.2",
         "final-form": "^4.20.2",
         "final-form-arrays": "^3.0.2",
-        "ra-core": "^3.9.0",
+        "ra-core": "^3.14.0",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",
         "react-final-form": "^6.5.2",

--- a/packages/ra-ui-materialui/src/button/RefreshIconButton.tsx
+++ b/packages/ra-ui-materialui/src/button/RefreshIconButton.tsx
@@ -7,7 +7,7 @@ import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
 import NavigationRefresh from '@material-ui/icons/Refresh';
 import { refreshView, useTranslate } from 'ra-core';
 
-const RefreshIconButton: FC<RefreshIconProps> = ({
+const RefreshIconButton: FC<RefreshIconButtonProps> = ({
     label = 'ra.action.refresh',
     icon = defaultIcon,
     onClick,
@@ -51,7 +51,7 @@ interface Props {
     onClick?: (e: MouseEvent) => void;
 }
 
-export type RefreshIconProps = Props & IconButtonProps;
+export type RefreshIconButtonProps = Props & IconButtonProps;
 
 RefreshIconButton.propTypes = {
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -217,7 +217,7 @@ interface Props {
     undoable?: boolean;
 }
 
-type SaveButtonProps = Props & ButtonProps;
+export type SaveButtonProps = Props & ButtonProps;
 
 SaveButton.propTypes = {
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/button/index.ts
+++ b/packages/ra-ui-materialui/src/button/index.ts
@@ -1,10 +1,14 @@
-import BulkDeleteButton from './BulkDeleteButton';
-import BulkDeleteWithConfirmButton from './BulkDeleteWithConfirmButton';
-import BulkDeleteWithUndoButton from './BulkDeleteWithUndoButton';
-import BulkExportButton from './BulkExportButton';
+import BulkDeleteButton, { BulkDeleteButtonProps } from './BulkDeleteButton';
+import BulkDeleteWithConfirmButton, {
+    BulkDeleteWithConfirmButtonProps,
+} from './BulkDeleteWithConfirmButton';
+import BulkDeleteWithUndoButton, {
+    BulkDeleteWithUndoButtonProps,
+} from './BulkDeleteWithUndoButton';
+import BulkExportButton, { BulkExportButtonProps } from './BulkExportButton';
 import Button, { ButtonProps } from './Button';
-import CloneButton from './CloneButton';
-import CreateButton from './CreateButton';
+import CloneButton, { CloneButtonProps } from './CloneButton';
+import CreateButton, { CreateButtonProps } from './CreateButton';
 import DeleteButton, { DeleteButtonProps } from './DeleteButton';
 import DeleteWithConfirmButton, {
     DeleteWithConfirmButtonProps,
@@ -12,20 +16,34 @@ import DeleteWithConfirmButton, {
 import DeleteWithUndoButton, {
     DeleteWithUndoButtonProps,
 } from './DeleteWithUndoButton';
-import EditButton from './EditButton';
-import ExportButton from './ExportButton';
-import ListButton from './ListButton';
-import SaveButton from './SaveButton';
-import ShowButton from './ShowButton';
-import SortButton from './SortButton';
-import RefreshButton from './RefreshButton';
-import RefreshIconButton from './RefreshIconButton';
+import EditButton, { EditButtonProps } from './EditButton';
+import ExportButton, { ExportButtonProps } from './ExportButton';
+import ListButton, { ListButtonProps } from './ListButton';
+import SaveButton, { SaveButtonProps } from './SaveButton';
+import ShowButton, { ShowButtonProps } from './ShowButton';
+import SortButton, { SortButtonProps } from './SortButton';
+import RefreshButton, { RefreshButtonProps } from './RefreshButton';
+import RefreshIconButton, { RefreshIconButtonProps } from './RefreshIconButton';
 
 export type {
+    BulkDeleteButtonProps,
+    BulkDeleteWithConfirmButtonProps,
+    BulkDeleteWithUndoButtonProps,
+    BulkExportButtonProps,
     ButtonProps,
+    CloneButtonProps,
+    CreateButtonProps,
     DeleteButtonProps,
     DeleteWithConfirmButtonProps,
     DeleteWithUndoButtonProps,
+    EditButtonProps,
+    ExportButtonProps,
+    ListButtonProps,
+    SaveButtonProps,
+    ShowButtonProps,
+    SortButtonProps,
+    RefreshButtonProps,
+    RefreshIconButtonProps,
 };
 
 export {

--- a/packages/ra-ui-materialui/src/form/SimpleFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Children, FC, ReactElement } from 'react';
+import { Children, ReactElement, ReactNode } from 'react';
 import classnames from 'classnames';
 import FormInput from './FormInput';
 import PropTypes from 'prop-types';
@@ -7,7 +7,7 @@ import { FormWithRedirectRenderProps, MutationMode, Record } from 'ra-core';
 import Toolbar from './Toolbar';
 import CardContentInner from '../layout/CardContentInner';
 
-export const SimpleFormView: FC<SimpleFormViewProps> = ({
+export const SimpleFormView = ({
     basePath,
     children,
     className,
@@ -27,7 +27,7 @@ export const SimpleFormView: FC<SimpleFormViewProps> = ({
     undoable,
     variant,
     ...rest
-}) => (
+}: SimpleFormViewProps): ReactElement => (
     <form
         className={classnames('simple-form', className)}
         {...sanitizeRestProps(rest)}
@@ -98,6 +98,7 @@ SimpleFormView.defaultProps = {
 
 export interface SimpleFormViewProps extends FormWithRedirectRenderProps {
     basePath?: string;
+    children?: ReactNode;
     className?: string;
     component?: React.ComponentType<any>;
     margin?: 'none' | 'normal' | 'dense';

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -5,6 +5,7 @@ import {
     cloneElement,
     isValidElement,
     ReactElement,
+    ReactNode,
     useState,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -22,7 +23,7 @@ import Toolbar from './Toolbar';
 import TabbedFormTabs, { getTabFullPath } from './TabbedFormTabs';
 import { ClassesOverride } from '../types';
 
-export const TabbedFormView = (props: TabbedFormViewProps) => {
+export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
     const {
         basePath,
         children,
@@ -183,6 +184,7 @@ TabbedFormView.defaultProps = {
 
 export interface TabbedFormViewProps extends FormWithRedirectRenderProps {
     basePath?: string;
+    children?: ReactNode;
     classes?: ClassesOverride<typeof useTabbedFormViewStyles>;
     className?: string;
     margin?: 'none' | 'normal' | 'dense';

--- a/packages/ra-ui-materialui/src/form/index.tsx
+++ b/packages/ra-ui-materialui/src/form/index.tsx
@@ -1,9 +1,9 @@
-import FormInput from './FormInput';
+import FormInput, { FormInputProps } from './FormInput';
 import SimpleForm, { SimpleFormProps } from './SimpleForm';
 import SimpleFormIterator, {
     SimpleFormIteratorProps,
 } from './SimpleFormIterator';
-import TabbedFormTabs from './TabbedFormTabs';
+import TabbedFormTabs, { TabbedFormTabsProps } from './TabbedFormTabs';
 import Toolbar, { ToolbarProps } from './Toolbar';
 import getFormInitialValues from './getFormInitialValues';
 import { SimpleFormView, SimpleFormViewProps } from './SimpleFormView';
@@ -14,8 +14,10 @@ export * from './FormTab';
 export * from './FormTabHeader';
 
 export type {
+    FormInputProps,
     SimpleFormProps,
     SimpleFormIteratorProps,
+    TabbedFormTabsProps,
     SimpleFormViewProps,
     TabbedFormViewProps,
     ToolbarProps,

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.tsx
@@ -502,42 +502,40 @@ const AutocompleteArrayInput = (props: AutocompleteArrayInputProps) => {
 const emptyArray = [];
 
 const useStyles = makeStyles(
-    theme => {
-        const chipBackgroundColor =
-            theme.palette.type === 'light'
-                ? 'rgba(0, 0, 0, 0.09)'
-                : 'rgba(255, 255, 255, 0.09)';
-
-        return {
-            container: {
-                flexGrow: 1,
-                position: 'relative',
+    theme => ({
+        container: {
+            flexGrow: 1,
+            position: 'relative',
+        },
+        suggestionsContainer: {
+            zIndex: theme.zIndex.modal,
+        },
+        chip: {
+            margin: theme.spacing(0.5, 0.5, 0.5, 0),
+        },
+        chipContainerFilled: {
+            margin: '27px 12px 10px 0',
+        },
+        chipContainerOutlined: {
+            margin: '12px 12px 10px 0',
+        },
+        inputRoot: {
+            flexWrap: 'wrap',
+        },
+        inputRootFilled: {
+            flexWrap: 'wrap',
+            '& $chip': {
+                backgroundColor:
+                    theme.palette.type === 'light'
+                        ? 'rgba(0, 0, 0, 0.09)'
+                        : 'rgba(255, 255, 255, 0.09)',
             },
-            suggestionsContainer: {},
-            chip: {
-                margin: theme.spacing(0.5, 0.5, 0.5, 0),
-            },
-            chipContainerFilled: {
-                margin: '27px 12px 10px 0',
-            },
-            chipContainerOutlined: {
-                margin: '12px 12px 10px 0',
-            },
-            inputRoot: {
-                flexWrap: 'wrap',
-            },
-            inputRootFilled: {
-                flexWrap: 'wrap',
-                '& $chip': {
-                    backgroundColor: chipBackgroundColor,
-                },
-            },
-            inputInput: {
-                width: 'auto',
-                flexGrow: 1,
-            },
-        };
-    },
+        },
+        inputInput: {
+            width: 'auto',
+            flexGrow: 1,
+        },
+    }),
     { name: 'RaAutocompleteArrayInput' }
 );
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -567,7 +567,7 @@ const handleMouseDownClearButton = event => {
 };
 
 const useStyles = makeStyles(
-    {
+    theme => ({
         container: {
             flexGrow: 1,
             position: 'relative',
@@ -591,8 +591,10 @@ const useStyles = makeStyles(
         inputAdornedEnd: {
             paddingRight: 0,
         },
-        suggestionsContainer: {},
-    },
+        suggestionsContainer: {
+            zIndex: theme.zIndex.modal,
+        },
+    }),
     { name: 'RaAutocompleteInput' }
 );
 

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -11,10 +11,7 @@ import sanitizeInputRestProps from './sanitizeInputRestProps';
 import InputHelperText from './InputHelperText';
 import InputPropTypes from './InputPropTypes';
 
-const BooleanInput: FunctionComponent<
-    InputProps<SwitchProps> &
-        Omit<FormGroupProps, 'defaultValue' | 'onChange' | 'onBlur' | 'onFocus'>
-> = ({
+const BooleanInput: FunctionComponent<BooleanInputProps> = ({
     format,
     label,
     fullWidth,
@@ -98,5 +95,8 @@ BooleanInput.propTypes = {
 BooleanInput.defaultProps = {
     options: {},
 };
+
+export type BooleanInputProps = InputProps<SwitchProps> &
+    Omit<FormGroupProps, 'defaultValue' | 'onChange' | 'onBlur' | 'onFocus'>;
 
 export default BooleanInput;

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -44,9 +44,7 @@ const getStringFromDate = (value: string | Date) => {
     return convertDateToString(new Date(value));
 };
 
-const DateInput: FunctionComponent<
-    InputProps<TextFieldProps> & Omit<TextFieldProps, 'helperText' | 'label'>
-> = ({
+const DateInput: FunctionComponent<DateInputProps> = ({
     format = getStringFromDate,
     label,
     options,
@@ -119,5 +117,8 @@ DateInput.propTypes = {
 DateInput.defaultProps = {
     options: {},
 };
+
+export type DateInputProps = InputProps<TextFieldProps> &
+    Omit<TextFieldProps, 'helperText' | 'label'>;
 
 export default DateInput;

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -65,9 +65,7 @@ const parseDateTime = (value: string) => new Date(value);
 /**
  * Input component for entering a date and a time with timezone, using the browser locale
  */
-const DateTimeInput: FunctionComponent<
-    InputProps<TextFieldProps> & Omit<TextFieldProps, 'helperText' | 'label'>
-> = ({
+const DateTimeInput: FunctionComponent<DateTimeInputProps> = ({
     format = formatDateTime,
     label,
     helperText,
@@ -140,5 +138,8 @@ DateTimeInput.propTypes = {
 DateTimeInput.defaultProps = {
     options: {},
 };
+
+export type DateTimeInputProps = InputProps<TextFieldProps> &
+    Omit<TextFieldProps, 'helperText' | 'label'>;
 
 export default DateTimeInput;

--- a/packages/ra-ui-materialui/src/input/ImageInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ImageInput.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles(
     { name: 'RaImageInput' }
 );
 
-const ImageInput = (props: FileInputProps & InputProps<FileInputOptions>) => {
+const ImageInput = (props: ImageInputProps) => {
     const classes = useStyles(props);
 
     return (
@@ -50,5 +50,7 @@ const ImageInput = (props: FileInputProps & InputProps<FileInputOptions>) => {
         />
     );
 };
+
+export type ImageInputProps = FileInputProps & InputProps<FileInputOptions>;
 
 export default ImageInput;

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { FunctionComponent } from 'react';
 import { useTranslate, ValidationError, ValidationErrorMessage } from 'ra-core';
 
-interface Props {
+export interface InputHelperTextProps {
     helperText?: string | boolean;
     error?: ValidationErrorMessage;
     touched: boolean;
 }
 
-const InputHelperText: FunctionComponent<Props> = ({
+const InputHelperText: FunctionComponent<InputHelperTextProps> = ({
     helperText,
     touched,
     error,

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -88,9 +88,7 @@ const useStyles = makeStyles(
  *
  * The object passed as `options` props is passed to the material-ui <RadioButtonGroup> component
  */
-const RadioButtonGroupInput: FunctionComponent<
-    ChoicesInputProps<RadioGroupProps> & FormControlProps
-> = props => {
+const RadioButtonGroupInput: FunctionComponent<RadioButtonGroupInputProps> = props => {
     const {
         choices = [],
         classes: classesOverride,
@@ -218,5 +216,8 @@ RadioButtonGroupInput.defaultProps = {
     row: true,
     translateChoice: true,
 };
+
+export type RadioButtonGroupInputProps = ChoicesInputProps<RadioGroupProps> &
+    FormControlProps;
 
 export default RadioButtonGroupInput;

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -16,9 +16,7 @@ import { ClassesOverride } from '../types';
 /**
  * An override of the default Material-UI TextField which is resettable
  */
-function ResettableTextField(
-    props: InputProps<ResettableTextFieldProps & TextFieldProps>
-) {
+function ResettableTextField(props: ResettableTextFieldProps) {
     const {
         classes: classesOverride,
         clearAlwaysVisible,
@@ -213,10 +211,12 @@ ResettableTextField.propTypes = {
     value: PropTypes.any.isRequired,
 };
 
-interface ResettableTextFieldProps {
+interface Props {
     classes?: ClassesOverride<typeof useStyles>;
     clearAlwaysVisible?: boolean;
     resettable?: boolean;
 }
+
+export type ResettableTextFieldProps = InputProps<Props & TextFieldProps>;
 
 export default ResettableTextField;

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -18,9 +18,7 @@ const useStyles = makeStyles(
     { name: 'RaSearchInput' }
 );
 
-const SearchInput: FunctionComponent<
-    InputProps<TextFieldProps> & Omit<TextFieldProps, 'label' | 'helperText'>
-> = props => {
+const SearchInput: FunctionComponent<SearchInputProps> = props => {
     const { classes: classesOverride, ...rest } = props;
     const translate = useTranslate();
     const classes = useStyles(props);
@@ -52,5 +50,8 @@ const SearchInput: FunctionComponent<
 SearchInput.propTypes = {
     classes: PropTypes.object,
 };
+
+export type SearchInputProps = InputProps<TextFieldProps> &
+    Omit<TextFieldProps, 'label' | 'helperText'>;
 
 export default SearchInput;

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -291,7 +291,7 @@ const SelectArrayInput: FunctionComponent<SelectArrayInputProps> = props => {
     );
 };
 
-interface SelectArrayInputProps
+export interface SelectArrayInputProps
     extends Omit<ChoicesProps, 'choices'>,
         Omit<InputProps<SelectProps>, 'source'>,
         Omit<

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -137,10 +137,7 @@ const useStyles = makeStyles(
  * <SelectInput source="gender" choices={choices} disableValue="not_available" />
  *
  */
-const SelectInput: FunctionComponent<
-    ChoicesInputProps<TextFieldProps> &
-        Omit<TextFieldProps, 'label' | 'helperText'>
-> = props => {
+const SelectInput: FunctionComponent<SelectInputProps> = props => {
     const {
         allowEmpty,
         choices = [],
@@ -312,5 +309,8 @@ SelectInput.defaultProps = {
     translateChoice: true,
     disableValue: 'disabled',
 };
+
+export type SelectInputProps = ChoicesInputProps<TextFieldProps> &
+    Omit<TextFieldProps, 'label' | 'helperText'>;
 
 export default SelectInput;

--- a/packages/ra-ui-materialui/src/input/index.ts
+++ b/packages/ra-ui-materialui/src/input/index.ts
@@ -1,4 +1,4 @@
-import ArrayInput from './ArrayInput';
+import ArrayInput, { ArrayInputProps } from './ArrayInput';
 import AutocompleteArrayInput, {
     AutocompleteArrayInputProps,
 } from './AutocompleteArrayInput';
@@ -7,24 +7,32 @@ import BooleanInput from './BooleanInput';
 import CheckboxGroupInput, {
     CheckboxGroupInputProps,
 } from './CheckboxGroupInput';
-import DateInput from './DateInput';
-import DateTimeInput from './DateTimeInput';
-import FileInput from './FileInput';
-import ImageInput from './ImageInput';
-import InputHelperText from './InputHelperText';
+import DateInput, { DateInputProps } from './DateInput';
+import DateTimeInput, { DateTimeInputProps } from './DateTimeInput';
+import FileInput, { FileInputProps } from './FileInput';
+import ImageInput, { ImageInputProps } from './ImageInput';
+import InputHelperText, { InputHelperTextProps } from './InputHelperText';
 import InputPropTypes from './InputPropTypes';
-import Labeled from './Labeled';
-import NullableBooleanInput from './NullableBooleanInput';
-import NumberInput from './NumberInput';
-import PasswordInput from './PasswordInput';
-import RadioButtonGroupInput from './RadioButtonGroupInput';
-import ReferenceArrayInput from './ReferenceArrayInput';
-import ReferenceInput from './ReferenceInput';
-import ResettableTextField from './ResettableTextField';
-import SearchInput from './SearchInput';
-import SelectArrayInput from './SelectArrayInput';
-import SelectInput from './SelectInput';
-import TextInput from './TextInput';
+import Labeled, { LabeledProps } from './Labeled';
+import NullableBooleanInput, {
+    NullableBooleanInputProps,
+} from './NullableBooleanInput';
+import NumberInput, { NumberInputProps } from './NumberInput';
+import PasswordInput, { PasswordInputProps } from './PasswordInput';
+import RadioButtonGroupInput, {
+    RadioButtonGroupInputProps,
+} from './RadioButtonGroupInput';
+import ReferenceArrayInput, {
+    ReferenceArrayInputProps,
+} from './ReferenceArrayInput';
+import ReferenceInput, { ReferenceInputProps } from './ReferenceInput';
+import ResettableTextField, {
+    ResettableTextFieldProps,
+} from './ResettableTextField';
+import SearchInput, { SearchInputProps } from './SearchInput';
+import SelectArrayInput, { SelectArrayInputProps } from './SelectArrayInput';
+import SelectInput, { SelectInputProps } from './SelectInput';
+import TextInput, { TextInputProps } from './TextInput';
 import sanitizeInputRestProps from './sanitizeInputRestProps';
 export * from './TranslatableInputs';
 export * from './TranslatableInputsTabContent';
@@ -59,7 +67,25 @@ export {
 };
 
 export type {
+    ArrayInputProps,
     AutocompleteInputProps,
     AutocompleteArrayInputProps,
     CheckboxGroupInputProps,
+    DateInputProps,
+    DateTimeInputProps,
+    FileInputProps,
+    ImageInputProps,
+    InputHelperTextProps,
+    LabeledProps,
+    NullableBooleanInputProps,
+    NumberInputProps,
+    PasswordInputProps,
+    RadioButtonGroupInputProps,
+    ReferenceArrayInputProps,
+    ReferenceInputProps,
+    ResettableTextFieldProps,
+    SearchInputProps,
+    SelectArrayInputProps,
+    SelectInputProps,
+    TextInputProps,
 };

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -3,9 +3,9 @@ import { Fragment, HtmlHTMLAttributes, ErrorInfo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '@material-ui/core/Button';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
 import { makeStyles } from '@material-ui/core/styles';
 import ErrorIcon from '@material-ui/icons/Report';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -75,17 +75,21 @@ const Error = (props: ErrorProps): JSX.Element => {
                 </h1>
                 <div>{translate('ra.message.error')}</div>
                 {process.env.NODE_ENV !== 'production' && (
-                    <ExpansionPanel className={classes.panel}>
-                        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                    <Accordion className={classes.panel}>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             {translate('ra.message.details')}
-                        </ExpansionPanelSummary>
-                        <ExpansionPanelDetails className={classes.panelDetails}>
+                        </AccordionSummary>
+                        <AccordionDetails className={classes.panelDetails}>
                             <div>
-                                <h2>{translate(error.toString())}</h2>
+                                <h2>
+                                    {translate(error.toString(), {
+                                        _: error.toString(),
+                                    })}
+                                </h2>
                                 {errorInfo && errorInfo.componentStack}
                             </div>
-                        </ExpansionPanelDetails>
-                    </ExpansionPanel>
+                        </AccordionDetails>
+                    </Accordion>
                 )}
                 <div className={classes.toolbar}>
                     <Button

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FC, cloneElement, ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
-import { useTranslate, Record, warning } from 'ra-core';
+import { useTranslate, Record, warning, useDocumentTitle } from 'ra-core';
 
 export interface TitleProps {
     className?: string;
@@ -23,6 +23,10 @@ const Title: FC<TitleProps> = ({
         typeof document !== 'undefined'
             ? document.getElementById('react-admin-title')
             : null;
+
+    const documentTitle = typeof title === 'string' ? title : defaultTitle;
+    useDocumentTitle(translate(documentTitle, { _: documentTitle }));
+
     if (!container) return null;
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -2,7 +2,14 @@ import * as React from 'react';
 import { Children, cloneElement, isValidElement, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslate, useGetIdentity } from 'ra-core';
-import { Tooltip, IconButton, Menu, Button, Avatar } from '@material-ui/core';
+import {
+    Tooltip,
+    IconButton,
+    Menu,
+    Button,
+    Avatar,
+    PopoverOrigin,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import AccountCircle from '@material-ui/icons/AccountCircle';
 
@@ -19,6 +26,16 @@ const useStyles = makeStyles(
     }),
     { name: 'RaUserMenu' }
 );
+
+const AnchorOrigin: PopoverOrigin = {
+    vertical: 'bottom',
+    horizontal: 'right',
+};
+
+const TransformOrigin: PopoverOrigin = {
+    vertical: 'top',
+    horizontal: 'right',
+};
 
 const UserMenu = props => {
     const [anchorEl, setAnchorEl] = useState(null);
@@ -70,15 +87,13 @@ const UserMenu = props => {
             )}
             <Menu
                 id="menu-appbar"
+                disableScrollLock
                 anchorEl={anchorEl}
-                anchorOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                }}
-                transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                }}
+                anchorOrigin={AnchorOrigin}
+                transformOrigin={TransformOrigin}
+                // Make sure the menu is display under the button and not over the appbar
+                // See https://material-ui.com/components/menus/#customized-menus
+                getContentAnchorEl={null}
                 open={open}
                 onClose={handleClose}
             >

--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -18,6 +18,7 @@ import {
     sanitizeListRestProps,
     useListContext,
     Record,
+    RecordMap,
     Identifier,
 } from 'ra-core';
 
@@ -186,7 +187,8 @@ export type FunctionToElement = (
     id: Identifier
 ) => ReactElement | string;
 
-export interface SimpleListProps extends Omit<ListProps, 'classes'> {
+export interface SimpleListProps<RecordType extends Record = Record>
+    extends Omit<ListProps, 'classes'> {
     className?: string;
     classes?: ClassesOverride<typeof useStyles>;
     hasBulkActions?: boolean;
@@ -199,6 +201,12 @@ export interface SimpleListProps extends Omit<ListProps, 'classes'> {
     secondaryText?: FunctionToElement;
     tertiaryText?: FunctionToElement;
     rowStyle?: (record: Record, index: number) => any;
+    // can be injected when using the component without context
+    basePath?: string;
+    data?: RecordMap<RecordType>;
+    ids?: Identifier[];
+    loaded?: boolean;
+    total?: number;
 }
 
 const useLinkOrNotStyles = makeStyles(

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -15,6 +15,9 @@ import {
     sanitizeListRestProps,
     useListContext,
     useResourceContext,
+    Record,
+    RecordMap,
+    Identifier,
     RecordContextProvider,
     ComponentPropType,
 } from 'ra-core';
@@ -146,20 +149,25 @@ SingleFieldList.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
     component: ComponentPropType,
-    data: PropTypes.object,
+    data: PropTypes.any,
     ids: PropTypes.array,
     // @ts-ignore
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     resource: PropTypes.string,
 };
 
-export interface SingleFieldListProps
+export interface SingleFieldListProps<RecordType extends Record = Record>
     extends HtmlHTMLAttributes<HTMLDivElement> {
     className?: string;
     classes?: ClassesOverride<typeof useStyles>;
-    component?: ComponentType<any>;
+    component?: string | ComponentType<any>;
     linkType?: string | false;
     children: React.ReactElement;
+    // can be injected when using the component without context
+    basePath?: string;
+    data?: RecordMap<RecordType>;
+    ids?: Identifier[];
+    loaded?: boolean;
 }
 
 export default SingleFieldList;

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -17,6 +17,8 @@ import {
     useVersion,
     Identifier,
     Record,
+    RecordMap,
+    SortPayload,
 } from 'ra-core';
 import {
     Checkbox,
@@ -35,6 +37,7 @@ import DatagridLoading from './DatagridLoading';
 import DatagridBody, { PureDatagridBody } from './DatagridBody';
 import useDatagridStyles from './useDatagridStyles';
 import { ClassesOverride } from '../../types';
+import { RowClickFunction } from './DatagridRow';
 import DatagridContextProvider from './DatagridContextProvider';
 
 /**
@@ -144,7 +147,7 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
         isRowExpandable,
     ]);
 
-    const updateSort = useCallback(
+    const updateSortCallback = useCallback(
         event => {
             event.stopPropagation();
             const newField = event.currentTarget.dataset.field;
@@ -159,6 +162,8 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
         },
         [currentSort.field, currentSort.order, setSort]
     );
+
+    const updateSort = setSort ? updateSortCallback : null;
 
     const handleSelectAll = useCallback(
         event => {
@@ -181,10 +186,10 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
     const lastSelected = useRef(null);
 
     useEffect(() => {
-        if (selectedIds.length === 0) {
+        if (!selectedIds || selectedIds.length === 0) {
             lastSelected.current = null;
         }
-    }, [selectedIds.length]);
+    }, [JSON.stringify(selectedIds)]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleToggleItem = useCallback(
         (id, event) => {
@@ -273,7 +278,7 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                                 )}
                             />
                         )}
-                        {hasBulkActions && (
+                        {hasBulkActions && selectedIds && (
                             <TableCell
                                 padding="checkbox"
                                 className={classes.headerCell}
@@ -343,11 +348,11 @@ Datagrid.propTypes = {
     children: PropTypes.node.isRequired,
     classes: PropTypes.object,
     className: PropTypes.string,
-    currentSort: PropTypes.shape({
-        field: PropTypes.string,
-        order: PropTypes.string,
+    currentSort: PropTypes.exact({
+        field: PropTypes.string.isRequired,
+        order: PropTypes.string.isRequired,
     }),
-    data: PropTypes.object,
+    data: PropTypes.any,
     // @ts-ignore
     expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
     hasBulkActions: PropTypes.bool,
@@ -367,13 +372,8 @@ Datagrid.propTypes = {
     isRowExpandable: PropTypes.func,
 };
 
-type RowClickFunction = (
-    id: Identifier,
-    basePath: string,
-    record: Record
-) => string;
-
-export interface DatagridProps extends Omit<TableProps, 'size' | 'classes'> {
+export interface DatagridProps<RecordType extends Record = Record>
+    extends Omit<TableProps, 'size' | 'classes' | 'onSelect'> {
     body?: ReactElement;
     classes?: ClassesOverride<typeof useDatagridStyles>;
     className?: string;
@@ -393,6 +393,19 @@ export interface DatagridProps extends Omit<TableProps, 'size' | 'classes'> {
     rowClick?: string | RowClickFunction;
     rowStyle?: (record: Record, index: number) => any;
     size?: 'medium' | 'small';
+    // can be injected when using the component without context
+    basePath?: string;
+    currentSort?: SortPayload;
+    data?: RecordMap<RecordType>;
+    ids?: Identifier[];
+    loaded?: boolean;
+    onSelect?: (ids: Identifier[]) => void;
+    onToggleItem?: (id: Identifier) => void;
+    setSort?: (sort: string, order?: string) => void;
+    selectedIds?: Identifier[];
+    total?: number;
 }
+
+Datagrid.displayName = 'Datagrid';
 
 export default Datagrid;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { shallowEqual } from 'react-redux';
 import { Identifier, Record, RecordMap } from 'ra-core';
 
-import DatagridRow, { PureDatagridRow } from './DatagridRow';
+import DatagridRow, { PureDatagridRow, RowClickFunction } from './DatagridRow';
 import useDatagridStyles from './useDatagridStyles';
 
 const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
@@ -49,7 +49,7 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
                             [classes.clickableRow]: rowClick,
                         }),
                         expand,
-                        hasBulkActions,
+                        hasBulkActions: hasBulkActions && selectedIds,
                         hover,
                         id,
                         key: id,
@@ -97,12 +97,6 @@ DatagridBody.defaultProps = {
     ids: [],
     row: <DatagridRow />,
 };
-
-type RowClickFunction = (
-    id: Identifier,
-    basePath: string,
-    record: Record
-) => string;
 
 export interface DatagridBodyProps extends Omit<TableBodyProps, 'classes'> {
     basePath?: string;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -52,7 +52,8 @@ export const DatagridHeaderCell = (
             variant="head"
             {...rest}
         >
-            {field.props.sortable !== false &&
+            {updateSort &&
+            field.props.sortable !== false &&
             (field.props.sortBy || field.props.source) ? (
                 <Tooltip
                     title={translate('ra.action.sort')}
@@ -103,7 +104,7 @@ DatagridHeaderCell.propTypes = {
     }).isRequired,
     isSorting: PropTypes.bool,
     resource: PropTypes.string,
-    updateSort: PropTypes.func.isRequired,
+    updateSort: PropTypes.func,
 };
 
 export interface DatagridHeaderCellProps
@@ -114,7 +115,7 @@ export interface DatagridHeaderCellProps
     isSorting?: boolean;
     resource: string;
     currentSort: SortPayload;
-    updateSort: (event: any) => void;
+    updateSort?: (event: any) => void;
 }
 
 export default memo(

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -110,14 +110,16 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
 
             const effect =
                 typeof rowClick === 'function'
-                    ? await rowClick(id, basePath, record)
+                    ? await rowClick(id, basePath || `/${resource}`, record)
                     : rowClick;
             switch (effect) {
                 case 'edit':
-                    history.push(linkToRecord(basePath, id));
+                    history.push(linkToRecord(basePath || `/${resource}`, id));
                     return;
                 case 'show':
-                    history.push(linkToRecord(basePath, id, 'show'));
+                    history.push(
+                        linkToRecord(basePath || `/${resource}`, id, 'show')
+                    );
                     return;
                 case 'expand':
                     handleToggleExpand(event);
@@ -137,6 +139,7 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
             handleToggleSelection,
             id,
             record,
+            resource,
             rowClick,
         ]
     );
@@ -279,7 +282,7 @@ export type RowClickFunction = (
     id: Identifier,
     basePath: string,
     record: Record
-) => string;
+) => string | Promise<string>;
 
 const areEqual = (prevProps, nextProps) => {
     const { children: _1, expand: _2, ...prevPropsWithoutChildren } = prevProps;

--- a/packages/ra-ui-materialui/src/list/datagrid/index.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/index.ts
@@ -8,7 +8,11 @@ import DatagridHeaderCell, {
     DatagridHeaderCellProps,
 } from './DatagridHeaderCell';
 import DatagridLoading, { DatagridLoadingProps } from './DatagridLoading';
-import DatagridRow, { DatagridRowProps, PureDatagridRow } from './DatagridRow';
+import DatagridRow, {
+    DatagridRowProps,
+    PureDatagridRow,
+    RowClickFunction,
+} from './DatagridRow';
 import ExpandRowButton, { ExpandRowButtonProps } from './ExpandRowButton';
 import useDatagridStyles from './useDatagridStyles';
 
@@ -33,4 +37,5 @@ export type {
     DatagridLoadingProps,
     DatagridRowProps,
     ExpandRowButtonProps,
+    RowClickFunction,
 };

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ChangeEvent, memo } from 'react';
+import { FC, ChangeEvent, memo, useMemo } from 'react';
 import { InputAdornment } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import { Form } from 'react-final-form';
@@ -36,11 +36,18 @@ const FilterLiveSearch: FC<{ source?: string }> = props => {
         }
     };
 
+    const initialValues = useMemo(
+        () => ({
+            [source]: filterValues[source],
+        }),
+        [filterValues, source]
+    );
+
     const onSubmit = () => undefined;
 
     return (
-        <Form onSubmit={onSubmit}>
-            {({ handleSubmit }) => (
+        <Form initialValues={initialValues} onSubmit={onSubmit}>
+            {() => (
                 <TextInput
                     resettable
                     helperText={false}

--- a/packages/react-admin/README.md
+++ b/packages/react-admin/README.md
@@ -1,43 +1,32 @@
-# react-admin
+# react-admin [![Build Status](https://travis-ci.org/marmelab/react-admin.svg?branch=master)](https://travis-ci.org/marmelab/react-admin) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmarmelab%2Freact-admin.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmarmelab%2Freact-admin?ref=badge_shield) [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/marmelab/react-admin)
 
-A frontend Framework for building admin applications running in the browser on top of REST/GraphQL services, using ES6, [React](https://facebook.github.io/react/) and [Material Design](https://material.io/). Open sourced and maintained by [marmelab](https://marmelab.com/).
+A frontend Framework for building data-driven applications running in the browser on top of REST/GraphQL APIs, using ES6, [React](https://facebook.github.io/react/) and [Material Design](https://material.io/). Previously named [admin-on-rest](https://github.com/marmelab/admin-on-rest). Open sourced and maintained by [marmelab](https://marmelab.com/).
 
-[Demo](https://marmelab.com/react-admin-demo/) - [Documentation](https://marmelab.com/react-admin/) - [Releases](https://github.com/marmelab/react-admin/releases) - [Support](https://stackoverflow.com/questions/tagged/react-admin)
+[Home page](https://marmelab.com/react-admin/) - [Documentation](https://marmelab.com/react-admin/Tutorial.html) - [Demo](https://marmelab.com/react-admin-demo/) - [Blog](https://marmelab.com/en/blog/#react-admin) - [Releases](https://github.com/marmelab/react-admin/releases) - [Support](https://stackoverflow.com/questions/tagged/react-admin)
 
-[![react-admin-demo](https://marmelab.com/react-admin/img/react-admin-demo-still.png)](https://vimeo.com/205118063)
+[![react-admin-demo](https://marmelab.com/react-admin/img/react-admin-demo-still.png)](https://vimeo.com/474999017)
 
 ## Features
 
 * Adapts to any backend (REST, GraphQL, SOAP, etc.)
-* Complete documentation
-* Optimistic rendering (renders before the server returns)
+* Powered by [material-ui](https://material-ui.com/), [redux](https://redux.js.org/), [react-final-form](https://final-form.org/react), [react-router](https://reacttraining.com/react-router/) and a few more
+* Super-fast UI thanks to optimistic rendering (renders before the server returns)
+* Undo updates and deletes for a few seconds
 * Relationships (many to one, one to many)
+* Data Validation
 * Internationalization (i18n)
-* Conditional formatting
-* Themeable
+* Themeable, Highly customizable interface
 * Supports any authentication provider (REST API, OAuth, Basic Auth, ...)
-* Full-featured Datagrid (sort, pagination, filters)
+* Full-featured datagrid (sort, pagination, filters)
+* Large library of components for various data types: boolean, number, rich text, etc.
+* Conditional formatting
 * Filter-as-you-type
 * Supports any form layout (simple, tabbed, etc.)
-* Data Validation
 * Custom actions
-* Large library of components for various data types: boolean, number, rich text, etc.
 * WYSIWYG editor
 * Customize dashboard, menu, layout
 * Super easy to extend and override (it's just React components)
-* Highly customizable interface
-* Can connect to multiple backends
-* Leverages the best libraries in the React ecosystem (Redux, redux-form, redux-saga, material-ui)
 * Can be included in another React app
-* Inspired by the popular [ng-admin](https://github.com/marmelab/ng-admin) library (also by marmelab)
-
-## Versions In This Repository
-
-* [master](https://github.com/marmelab/react-admin/commits/master) - commits that will be included in the next _patch_ release
-
-* [next](https://github.com/marmelab/react-admin/commits/next) - commits that will be included in the next _major_ or _minor_ release
-
-Bugfix PRs that don't break BC should be made against **master**. All other PRs (new features, bugfix with BC break) should be made against **next**.
 
 ## Installation
 
@@ -45,12 +34,14 @@ React-admin is available from npm. You can install it (and its required dependen
 using:
 
 ```sh
-npm install --save-dev react-admin
+npm install react-admin
+#or
+yarn add react-admin
 ```
 
 ## Documentation
 
-Read the [Tutorial](https://marmelab.com/react-admin/Tutorial.html) for a 15 minutes introduction. After that, head to the [Documentation](https://marmelab.com/react-admin/Readme.html), or checkout the [source code of the demo](https://github.com/marmelab/react-admin-demo) for an example usage.
+Read the [Tutorial](https://marmelab.com/react-admin/Tutorial.html) for a 30 minutes introduction. After that, head to the [Documentation](https://marmelab.com/react-admin/Readme.html), or checkout the [source code of the demo](https://github.com/marmelab/react-admin-demo) for an example usage.
 
 ## At a Glance
 
@@ -77,7 +68,8 @@ The `<Resource>` component is a configuration component that allows to define su
 // in posts.js
 import * as React from "react";
 import { List, Datagrid, Edit, Create, SimpleForm, DateField, TextField, EditButton, TextInput, DateInput } from 'react-admin';
-export PostIcon from '@material-ui/icons/Book';
+import BookIcon from '@material-ui/icons/Book';
+export const PostIcon = BookIcon;
 
 export const PostList = (props) => (
     <List {...props}>
@@ -123,7 +115,7 @@ export const PostCreate = (props) => (
 );
 ```
 
-## Does It Work With My API
+## Does It Work With My API?
 
 Yes.
 
@@ -135,29 +127,130 @@ See the [Data Providers documentation](https://marmelab.com/react-admin/DataProv
 
 ## Batteries Included But Removable
 
-React-admin is designed as a library of loosely coupled React components built on top of [material-ui](https://www.material-ui.com/#/), in addition to controller functions implemented the Redux way. It is very easy to replace one part of react-admin with your own, e.g. to use a custom datagrid, GraphQL instead of REST, or bootstrap instead of Material Design.
+React-admin is designed as a library of loosely coupled React components built on top of [material-ui](https://material-ui.com/), in addition to custom react hooks exposing reusable controller logic. It is very easy to replace one part of react-admin with your own, e.g. to use a custom datagrid, GraphQL instead of REST, or Bootstrap instead of Material Design.
 
-## Run the example
+## Examples
 
-You can run the example app by calling:
+There are several examples inside the `examples` folder:
+
+* `simple` ([CodeSandbox](https://codesandbox.io/s/github/marmelab/react-admin/tree/master/examples/simple)): a simple application with posts, comments and users that we use for our e2e tests.
+* `tutorial` ([CodeSandbox](https://codesandbox.io/s/github/marmelab/react-admin/tree/master/examples/tutorial)): the application built while following the tutorial.
+* `demo`: ([Live](https://marmelab.com/react-admin-demo/)) A fictional poster shop admin, serving as the official react-admin demo.
+
+You can run those example applications by calling:
 
 ```sh
-npm install
-make run
+# At the react-admin project root
+make install
+# or
+yarn install
+
+# Run the simple application
+make run-simple
+
+# Run the tutorial application
+make build
+make run-tutorial
+
+# Run the demo application
+make build
+make run-demo
 ```
 
-And then browse to [http://localhost:8080/](http://localhost:8080/).
-The credentials are **login/password**
+And then browse to the URL displayed in your console.
+
+## Support
+
+You can get professional support from Marmelab via [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise), or community support via [StackOverflow](https://stackoverflow.com/questions/tagged/react-admin). 
+
+## Versions In This Repository
+
+* [master](https://github.com/marmelab/react-admin/commits/master) - commits that will be included in the next _patch_ release
+
+* [next](https://github.com/marmelab/react-admin/commits/next) - commits that will be included in the next _major_ or _minor_ release
+
+Bugfix PRs that don't break BC should be made against **master**. All other PRs (new features, bugfix with BC break) should be made against **next**.
 
 ## Contributing
 
-Pull requests are welcome. You must follow the coding style of the existing files (based on [prettier](https://github.com/prettier/prettier)), and include unit tests and documentation. Be prepared for a thorough code review, and be patient for the merge - this is an open-source initiative.
+If you want to give a hand: Thank you! There are many things you can do to help making react-admin better. 
 
-You can run the tests (linting, unit and functional tests) by calling
+The easiest task is **bug triaging**. Check that new issues on GitHub follow the issue template and give a way to reproduce the issue. If not, comment on the issue to ask precisions. Then, try and reproduce the issue following the description. If you managed to reproduce the issue, add a comment to say it. Otherwise, add a comment to say that something is missing. 
+
+The second way to contribute is to **answer support questions on [StackOverflow](https://stackoverflow.com/questions/tagged/react-admin)**. There are many beginner questions there, so even if you're not super experienced with react-admin, there is someone you can help there. 
+
+Pull requests for **bug fixes** are welcome on the [GitHub repository](https://github.com/marmelab/react-admin). There is always a bunch of [issues labeled "Good First Issue"](https://github.com/marmelab/react-admin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) in the bug tracker - start with these. 
+
+If you want to **add a feature**, you can open a Pull request on the `next` branch. We don't accept all features - we try to keep the react-admin code small and manageable. Try and see if your feature can't be built as an additional `npm` package. If you're in doubt, open a "Feature Request" issue to see if the core team would accept your feature before developing it.
+
+For all Pull requests, you must follow the coding style of the existing files (based on [prettier](https://github.com/prettier/prettier)), and include unit tests and documentation. Be prepared for a thorough code review, and be patient for the merge - this is an open-source initiative.
+
+**Tip**: Most of the commands used by the react-admin developers are automated in the `makefile`. Feel free to type `make` without argument to see a list of the available commands. 
+
+### Setup
+
+Clone this repository and run `make install` to grab the dependencies, then `make build` to compile the sources from TypeScript to JS.
+
+### Online one-click Setup
+
+You can use Gitpod(An Online Open Source VS Code like IDE which is free for Open Source) for working on issues and making PRs. With a single click it will launch a workspace and automatically clone the repo, run `make install` and `make start` so that you can start straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
+### Testing Your Changes In The Example Apps
+
+When developing, most of the time we use the **simple example** to do visual check. It's the same application that we use in CodeSandbox to reproduce errors (see https://codesandbox.io/s/github/marmelab/react-admin/tree/master/examples/simple). The source is located under `examples/simple/`. Call `make run` to launch that example on port 8080 (http://localhost:8080). This command includes a `watch` on the react-admin source, so any of the changes you make to the react-admin packages triggers a live update of the simple example in your browser. 
+
+However, the simple example is sometimes too limited. You can use the **demo example** (the source for https://marmelab.com/react-admin-demo/), which is more complete. The source is located under `examples/demo/`. Call `make run-demo` to launch the demo example with a REST dataProvider, or `make run-graphql-demo` to run it with a GraphQL dataProvider. Unfortunately, due to the fact that we use Create React App for this demo, these commands don't watch the changes made in the packages. You'll have to rebuild the react-admin packages after a change (using `make build`, or the more targeted `make build-ra-core`, `make build-ra-ui-materialui`, etc) to see the effect in the demo app.
+
+Both of these examples work without server - the API is simulated on the client-side. 
+
+### Testing Your Changes In Your App
+
+Using `yarn link`, you can have your project use a local checkout of the react-admn package instead of npm. This allows you to test react-admin changes in your app: 
+
+```sh
+# Register your local react-admin as a linkable package
+$ cd /code/path/to/react-admin/packages/react-admin && yarn link
+
+# Replace the npm-installed version with a symlink to your local version 
+$ cd /code/path/to/myapp/ && yarn link react-admin
+
+# If you run into issues with React red-screen, then you need to register your app's version of React as a linkable package 
+
+$ cd /code/path/to/myapp/node_modules/react && yarn link
+# And then replace the npm-installed version of React with a symlink to your app's node_modules version
+$ cd /code/path/to/react-admin/ && yarn link react
+
+# Rebuild the packages with the same version of React
+$ cd /code/path/to/react-admin/ && make build
+
+# Return to your app and ensure all dependencies have resolved 
+$ cd /code/path/to/myapp/ && yarn install
+
+# Start your app
+$ yarn start
+```
+
+### Automated Tests
+
+Automated tests are also crucial in our development process. You can run all the tests (linting, unit and functional tests) by calling:
 
 ```sh
 make test
 ```
+
+Unit tests use `jest`, so you should be able to run a subset of tests, or run tests continuously on change, by passing options to 
+
+```sh
+yarn jest
+```
+
+Besides, tests related to the modified files are ran automatically at commit using a git pre-commit hook. This means you won't be able to commit your changes if they break the tests. 
+
+When working on the end to end tests, you can leverage [cypress](https://www.cypress.io/) runner by starting the simple example yourself (`make run-simple` or `yarn run-simple`) and starting cypress in another terminal (`make test-e2e-local` or `yarn test-e2e-local`).
+
+### Coding Standards
 
 If you have coding standards problems, you can fix them automatically using `prettier` by calling
 
@@ -165,7 +258,11 @@ If you have coding standards problems, you can fix them automatically using `pre
 make prettier
 ```
 
-If you want to contribute to the documentation, install jekyll, then call
+However, these commands are ran automatically at each commit so you shouldn't have to worry about them.
+
+### Documentation
+
+If you want to contribute to the documentation, install [jekyll](https://jekyllrb.com/docs/home/), then call
 
 ```sh
 make doc
@@ -173,32 +270,11 @@ make doc
 
 And then browse to [http://localhost:4000/](http://localhost:4000/)
 
-*Note*: if you have added a section with heading to the docs, you also have to add it to `docs/_layouts/default.html` (the links on the left) manually.
-
-If you are using react-admin as a dependency, and if you want to try and hack it, here is the advised process:
-
-```sh
-# in myapp
-# install react-admin from GitHub in another directory
-$ cd ..
-$ git clone git@github.com:marmelab/react-admin.git && cd react-admin && make install
-# replace your node_modules/react-admin by a symbolic link to the github checkout
-$ cd ../myapp
-$ npm link ../react-admin
-# go back to the checkout, and replace the version of react by the one in your app
-$ cd ../react-admin
-$ npm link ../myapp/node_modules/react
-$ make watch
-# in another terminal, go back to your app, and start it as usual
-$ cd ../myapp
-$ npm run
-```
-
-**Tip**: If you're on Windows and can't use `make`, try [this Gist](https://gist.github.com/mantis/bb5d9f7d492f86e94341816321500934).
-
 ## License
 
 React-admin is licensed under the [MIT License](https://github.com/marmelab/react-admin/blob/master/LICENSE.md), sponsored and supported by [marmelab](https://marmelab.com).
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmarmelab%2Freact-admin.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmarmelab%2Freact-admin?ref=badge_large)
 
 ## Donate
 

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-admin",
-    "version": "3.13.4",
+    "version": "3.14.1",
     "description": "A frontend Framework for building admin applications on top of REST services, using ES6, React and Material UI",
     "files": [
         "*.md",
@@ -41,10 +41,10 @@
         "final-form": "^4.20.2",
         "final-form-arrays": "^3.0.2",
         "final-form-submit-errors": "^0.1.2",
-        "ra-core": "^3.13.4",
-        "ra-i18n-polyglot": "^3.13.4",
-        "ra-language-english": "^3.13.4",
-        "ra-ui-materialui": "^3.13.4",
+        "ra-core": "^3.14.1",
+        "ra-i18n-polyglot": "^3.14.1",
+        "ra-language-english": "^3.14.1",
+        "ra-ui-materialui": "^3.14.1",
         "react-final-form": "^6.5.2",
         "react-final-form-arrays": "^3.1.3",
         "react-redux": "^7.1.0",


### PR DESCRIPTION
Closes: https://github.com/marmelab/react-admin/issues/5893

Updates the window title to match with the title of the current page. This solves an issue with the browser history simply displaying the same title for every single page.

Note: I created a new hook called `useDocumentTitle` this is a way to set the document title. I added it to the hooks folder in `ra-core` and exported it. To me it doesn't feel like it should live there. Practically it would only be used in this Title component, so I'm not sure if we should keep the function located in `ra-core`, but there aren't any hooks exported in ra-ui-materialui`. 

Saying that, if someone chooses to pass through their own Title component, they should be able to manage their document.title however they see fit, which means they should also be able to import `useDocumentTitle`.

tl;dr, `useDocumentTitle` lives in `ra-core` but i'll be happy to place it in `ra-ui-materialui` if you see it fit