### PR TITLE
Fix hasBulkActions prop type passed to DatagridRow

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -49,7 +49,7 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
                             [classes.clickableRow]: rowClick,
                         }),
                         expand,
-                        hasBulkActions: hasBulkActions && selectedIds,
+                        hasBulkActions: hasBulkActions && !!selectedIds,
                         hover,
                         id,
                         key: id,


### PR DESCRIPTION
Prop hasBulkActions passed to DatagridBody was computed as "array" instead of boolean generating this console error:

`Warning: Failed prop type: Invalid prop hasBulkActions of type array supplied to ForwardRef, expected boolean.`
