### PR TITLE
Docs: Add ref to ra-acl

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -42,6 +42,7 @@ See the [Auth Provider](./Authentication.md#available-providers) page. Here is a
 ## Authorization Management
 
 - **[Access Control List (ACL) for Resources](https://github.com/marmelab/ra-auth-acl)**: [marmelab/ra-auth-acl](https://github.com/marmelab/ra-auth-acl)
+- **[Access Control List (ACL) utilities and components](https://github.com/andrico1234/ra-acl)**: Easily manage role-based permissions with hooks and ready-to-use components
 
 ## Data Providers
 


### PR DESCRIPTION
I open sourced a utility module, [ra-acl](https://github.com/andrico1234/ra-acl), to expand on the work done in ra-auth-acl, by adding a `useAcl` hook, as well as a handful of declarative components to abstract out the permission logic and keep the code clean 

Even though this module was added to GitHub recently, I've been using it internally for a month on a production RA application