### PR TITLE
Add translateOptions as props in DeleteWthConfirmButton.tsx

### DIFF
--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import expect from 'expect';
 import { DataProvider, DataProviderContext } from 'ra-core';
@@ -200,5 +200,48 @@ describe('<DeleteWithConfirmButton />', () => {
                 message: 'not good',
             });
         });
+    });
+
+    it('should allow to override the translateOptions props', async () => {
+        const dataProvider = ({
+            getOne: () =>
+                Promise.resolve({
+                    data: { id: 123, title: 'lorem' },
+                }),
+            delete: () => Promise.resolve({ data: { id: 123 } }),
+        } as unknown) as DataProvider;
+
+        const translateOptions = {
+            id: '#20061703',
+        };
+        const EditToolbar = props => (
+            <Toolbar {...props}>
+                <DeleteWithConfirmButton translateOptions={translateOptions} />
+            </Toolbar>
+        );
+        const {
+            queryByDisplayValue,
+            getByLabelText,
+            getByText,
+        } = renderWithRedux(
+            <ThemeProvider theme={theme}>
+                <DataProviderContext.Provider value={dataProvider}>
+                    <Edit {...defaultEditProps}>
+                        <SimpleForm toolbar={<EditToolbar />}>
+                            <TextInput source="title" />
+                        </SimpleForm>
+                    </Edit>
+                </DataProviderContext.Provider>
+            </ThemeProvider>,
+            { admin: { resources: { posts: { data: {} } } } }
+        );
+
+        // waitFor for the dataProvider.getOne() return
+        await waitFor(() => {
+            expect(queryByDisplayValue('lorem')).toBeDefined();
+        });
+
+        fireEvent.click(getByLabelText('ra.action.delete'));
+        expect(queryByDisplayValue('#20061703')).toBeDefined();
     });
 });

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -40,6 +40,7 @@ const DeleteWithConfirmButton: FC<DeleteWithConfirmButtonProps> = props => {
         redirect = 'list',
         onSuccess,
         onFailure,
+        translateOptions = {},
         ...rest
     } = props;
     const translate = useTranslate();
@@ -94,6 +95,7 @@ const DeleteWithConfirmButton: FC<DeleteWithConfirmButtonProps> = props => {
                         ),
                     }),
                     id: record.id,
+                    ...translateOptions,
                 }}
                 onConfirm={handleDelete}
                 onClose={handleDialogClose}
@@ -143,6 +145,7 @@ interface Props {
     undoable?: boolean;
     onSuccess?: OnSuccess;
     onFailure?: OnFailure;
+    translateOptions?: object;
 }
 
 export type DeleteWithConfirmButtonProps = Props & ButtonProps;
@@ -162,6 +165,7 @@ DeleteWithConfirmButton.propTypes = {
     ]),
     resource: PropTypes.string,
     icon: PropTypes.element,
+    translateOptions: PropTypes.object,
 };
 
 export default DeleteWithConfirmButton;


### PR DESCRIPTION
Allow the creation of a custom message during deletion