### PR TITLE
Fix useRedirect does not handle query strings

### DIFF
--- a/packages/ra-core/src/sideEffect/useRedirect.spec.tsx
+++ b/packages/ra-core/src/sideEffect/useRedirect.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { useEffect } from 'react';
+import expect from 'expect';
+import { renderWithRedux } from 'ra-test';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+
+import useRedirect from './useRedirect';
+
+const Redirect = ({ redirectTo, basePath = '', id = null, data = null }) => {
+    const redirect = useRedirect();
+    useEffect(() => {
+        redirect(redirectTo, basePath, id, data);
+    }, []);
+    return null;
+};
+
+describe('useRedirect', () => {
+    it('should redirect to the path with query string', () => {
+        const history = createMemoryHistory();
+        renderWithRedux(
+            <Router history={history}>
+                <Redirect redirectTo="/foo?bar=baz" />
+            </Router>
+        );
+        expect(history.location).toMatchObject({
+            pathname: '/foo',
+            search: '?bar=baz',
+            state: { _scrollToTop: true },
+        });
+    });
+});

--- a/packages/ra-core/src/sideEffect/useRedirect.spec.tsx
+++ b/packages/ra-core/src/sideEffect/useRedirect.spec.tsx
@@ -11,7 +11,7 @@ const Redirect = ({ redirectTo, basePath = '', id = null, data = null }) => {
     const redirect = useRedirect();
     useEffect(() => {
         redirect(redirectTo, basePath, id, data);
-    }, []);
+    }, [basePath, data, id, redirect, redirectTo]);
     return null;
 };
 

--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { parsePath } from 'history';
 
 import { Identifier, Record } from '../types';
 import resolveRedirectTo from '../util/resolveRedirectTo';
 import { refreshView } from '../actions/uiActions';
-import { useHistory } from 'react-router-dom';
 
 type RedirectToFunction = (
     basePath?: string,
@@ -53,7 +54,7 @@ const useRedirect = () => {
             }
 
             history.push({
-                pathname: resolveRedirectTo(redirectTo, basePath, id, data),
+                ...parsePath(resolveRedirectTo(redirectTo, basePath, id, data)),
                 state: { _scrollToTop: true },
             });
         },


### PR DESCRIPTION
## Problem

PR #5905 broke `useRedirect` when using a query string:

```jsx
const redirect = useRedirect();
// ...
redirect('/foo?bar=baz');
```

Because of the following change:

```diff
-           history.push(resolveRedirectTo(redirectTo, basePath, id, data));
+           history.push({
+               pathname: resolveRedirectTo(redirectTo, basePath, id, data),
+               state: { _scrollToTop: true },
+           });
```

## Solution

Transform the redirection target to a react-router `location` object.

Closes #6141
Supersedes #6009