### PR TITLE
Menu icon aligned with the close sidebar icons

### DIFF
--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -29,8 +29,8 @@ const useStyles = makeStyles(
             paddingRight: 24,
         },
         menuButton: {
-            marginLeft: '0.5em',
-            marginRight: '0.5em',
+            marginLeft: '0.2em',
+            marginRight: '0.2em',
         },
         menuButtonIconClosed: {
             transition: theme.transitions.create(['transform'], {


### PR DESCRIPTION
Menu icons in the navbar have been aligned with the closed sidebar icons now, for which I had opened an issue a couple of hours earlier @fzaninotto 

Closes #6159 