### PR TITLE
Add Initial Support For Creation in Choices Inputs

### DIFF
--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -36,3 +36,4 @@
 <li {% if page.path contains 'Ecosystem.md' %} class="active" {% endif %}><a href="./Ecosystem.html">Ecosystem</a></li>
 <li {% if page.path contains 'FAQ.md' %} class="active" {% endif %}><a href="./FAQ.html">FAQ</a></li>
 <li {% if page.path contains 'Reference.md' %} class="active" {% endif %}><a href="./Reference.html">Reference</a></li>
+<li><a href="https://github.com/marmelab/react-admin/releases" target="_blank">Changelog</a></li>

--- a/examples/simple/src/comments/CommentEdit.tsx
+++ b/examples/simple/src/comments/CommentEdit.tsx
@@ -77,7 +77,7 @@ const CreatePost = () => {
                 onSuccess: ({ data }) => {
                     setValue('');
                     const choice = data;
-                    onCreate(data.id, choice);
+                    onCreate(choice);
                 },
             }
         );

--- a/examples/simple/src/comments/CommentEdit.tsx
+++ b/examples/simple/src/comments/CommentEdit.tsx
@@ -22,7 +22,7 @@ import {
     Title,
     minLength,
     Record,
-    useCreateSuggestion,
+    useCreateSuggestionContext,
     useCreate,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
@@ -60,7 +60,7 @@ const inputText = record =>
         : `${record.title} - ${record.id}`;
 
 const CreatePost = () => {
-    const { filter, onCancel, onCreate } = useCreateSuggestion();
+    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
     const [value, setValue] = React.useState(filter || '');
     const [create] = useCreate('posts');
     const handleSubmit = (event: React.FormEvent) => {

--- a/examples/simple/src/comments/CommentEdit.tsx
+++ b/examples/simple/src/comments/CommentEdit.tsx
@@ -1,4 +1,12 @@
-import { Card, Typography } from '@material-ui/core';
+import {
+    Card,
+    Typography,
+    Dialog,
+    DialogContent,
+    TextField as MuiTextField,
+    DialogActions,
+    Button,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import * as React from 'react';
 import {
@@ -14,6 +22,8 @@ import {
     Title,
     minLength,
     Record,
+    useCreateSuggestion,
+    useCreate,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
 const LinkToRelatedPost = ({ record }: { record?: Record }) => (
@@ -34,13 +44,64 @@ const useEditStyles = makeStyles({
     },
 });
 
-const OptionRenderer = ({ record }: { record?: Record }) => (
-    <span>
-        {record?.title} - {record?.id}
-    </span>
-);
+const OptionRenderer = ({ record }: { record?: Record }) => {
+    return record.id === '@@ra-create' ? (
+        <span>{record.name}</span>
+    ) : (
+        <span>
+            {record?.title} - {record?.id}
+        </span>
+    );
+};
 
-const inputText = record => `${record.title} - ${record.id}`;
+const inputText = record =>
+    record.id === '@@ra-create'
+        ? record.name
+        : `${record.title} - ${record.id}`;
+
+const CreatePost = () => {
+    const { filter, onCancel, onCreate } = useCreateSuggestion();
+    const [value, setValue] = React.useState(filter || '');
+    const [create] = useCreate('posts');
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        create(
+            {
+                payload: {
+                    data: {
+                        title: value,
+                    },
+                },
+            },
+            {
+                onSuccess: ({ data }) => {
+                    setValue('');
+                    const choice = data;
+                    onCreate(value, choice);
+                },
+            }
+        );
+        return false;
+    };
+    return (
+        <Dialog open onClose={onCancel}>
+            <form onSubmit={handleSubmit}>
+                <DialogContent>
+                    <MuiTextField
+                        label="New post title"
+                        value={value}
+                        onChange={event => setValue(event.target.value)}
+                        autoFocus
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button type="submit">Save</Button>
+                    <Button onClick={onCancel}>Cancel</Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+};
 
 const CommentEdit = props => {
     const classes = useEditStyles();
@@ -86,6 +147,7 @@ const CommentEdit = props => {
                                 fullWidth
                             >
                                 <AutocompleteInput
+                                    create={<CreatePost />}
                                     matchSuggestion={(
                                         filterValue,
                                         suggestion

--- a/examples/simple/src/comments/CommentEdit.tsx
+++ b/examples/simple/src/comments/CommentEdit.tsx
@@ -77,7 +77,7 @@ const CreatePost = () => {
                 onSuccess: ({ data }) => {
                     setValue('');
                     const choice = data;
-                    onCreate(value, choice);
+                    onCreate(data.id, choice);
                 },
             }
         );

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -28,13 +28,58 @@ import {
     number,
     required,
     FormDataConsumer,
+    useCreateSuggestion,
+    EditActionsProps,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
-import { Box, BoxProps } from '@material-ui/core';
+import {
+    Box,
+    BoxProps,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    TextField as MuiTextField,
+} from '@material-ui/core';
 
 import PostTitle from './PostTitle';
 import TagReferenceInput from './TagReferenceInput';
 
-const EditActions = ({ basePath, data, hasShow }: any) => (
+const CreateCategory = ({
+    onAddChoice,
+}: {
+    onAddChoice: (record: any) => void;
+}) => {
+    const { filter, onCancel, onCreate } = useCreateSuggestion();
+    const [value, setValue] = React.useState(filter || '');
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        const choice = { name: value, id: value };
+        onAddChoice(choice);
+        onCreate(value, choice);
+        setValue('');
+        return false;
+    };
+    return (
+        <Dialog open onClose={onCancel}>
+            <form onSubmit={handleSubmit}>
+                <DialogContent>
+                    <MuiTextField
+                        label="New Category"
+                        value={value}
+                        onChange={event => setValue(event.target.value)}
+                        autoFocus
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button type="submit">Save</Button>
+                    <Button onClick={onCancel}>Cancel</Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+};
+
+const EditActions = ({ basePath, data, hasShow }: EditActionsProps) => (
     <TopToolbar>
         <CloneButton
             className="button-clone"
@@ -51,140 +96,159 @@ const SanitizedBox = ({
     ...props
 }: BoxProps & { fullWidth?: boolean; basePath?: string }) => <Box {...props} />;
 
-const PostEdit = ({ permissions, ...props }) => (
-    <Edit title={<PostTitle />} actions={<EditActions />} {...props}>
-        <TabbedForm initialValues={{ average_note: 0 }} warnWhenUnsavedChanges>
-            <FormTab label="post.form.summary">
-                <SanitizedBox
-                    display="flex"
-                    flexDirection="column"
-                    width="100%"
-                    justifyContent="space-between"
-                    fullWidth
-                >
-                    <TextInput disabled source="id" />
+const categories = [
+    { name: 'Tech', id: 'tech' },
+    { name: 'Lifestyle', id: 'lifestyle' },
+];
+
+const PostEdit = ({ permissions, ...props }) => {
+    return (
+        <Edit title={<PostTitle />} actions={<EditActions />} {...props}>
+            <TabbedForm
+                initialValues={{ average_note: 0 }}
+                warnWhenUnsavedChanges
+            >
+                <FormTab label="post.form.summary">
+                    <SanitizedBox
+                        display="flex"
+                        flexDirection="column"
+                        width="100%"
+                        justifyContent="space-between"
+                        fullWidth
+                    >
+                        <TextInput disabled source="id" />
+                        <TextInput
+                            source="title"
+                            validate={required()}
+                            resettable
+                        />
+                    </SanitizedBox>
                     <TextInput
-                        source="title"
+                        multiline={true}
+                        fullWidth={true}
+                        source="teaser"
                         validate={required()}
                         resettable
                     />
-                </SanitizedBox>
-                <TextInput
-                    multiline={true}
-                    fullWidth={true}
-                    source="teaser"
-                    validate={required()}
-                    resettable
-                />
-                <CheckboxGroupInput
-                    source="notifications"
-                    choices={[
-                        { id: 12, name: 'Ray Hakt' },
-                        { id: 31, name: 'Ann Gullar' },
-                        { id: 42, name: 'Sean Phonee' },
-                    ]}
-                />
-                <ImageInput multiple source="pictures" accept="image/*">
-                    <ImageField source="src" title="title" />
-                </ImageInput>
-                {permissions === 'admin' && (
-                    <ArrayInput source="authors">
+                    <CheckboxGroupInput
+                        source="notifications"
+                        choices={[
+                            { id: 12, name: 'Ray Hakt' },
+                            { id: 31, name: 'Ann Gullar' },
+                            { id: 42, name: 'Sean Phonee' },
+                        ]}
+                    />
+                    <ImageInput multiple source="pictures" accept="image/*">
+                        <ImageField source="src" title="title" />
+                    </ImageInput>
+                    {permissions === 'admin' && (
+                        <ArrayInput source="authors">
+                            <SimpleFormIterator>
+                                <ReferenceInput
+                                    label="User"
+                                    source="user_id"
+                                    reference="users"
+                                >
+                                    <AutocompleteInput />
+                                </ReferenceInput>
+                                <FormDataConsumer>
+                                    {({
+                                        formData,
+                                        scopedFormData,
+                                        getSource,
+                                        ...rest
+                                    }) =>
+                                        scopedFormData &&
+                                        scopedFormData.user_id ? (
+                                            <SelectInput
+                                                label="Role"
+                                                source={getSource('role')}
+                                                choices={[
+                                                    {
+                                                        id: 'headwriter',
+                                                        name: 'Head Writer',
+                                                    },
+                                                    {
+                                                        id: 'proofreader',
+                                                        name: 'Proof reader',
+                                                    },
+                                                    {
+                                                        id: 'cowriter',
+                                                        name: 'Co-Writer',
+                                                    },
+                                                ]}
+                                                {...rest}
+                                            />
+                                        ) : null
+                                    }
+                                </FormDataConsumer>
+                            </SimpleFormIterator>
+                        </ArrayInput>
+                    )}
+                </FormTab>
+                <FormTab label="post.form.body">
+                    <RichTextInput
+                        source="body"
+                        label=""
+                        validate={required()}
+                        addLabel={false}
+                    />
+                </FormTab>
+                <FormTab label="post.form.miscellaneous">
+                    <TagReferenceInput
+                        reference="tags"
+                        source="tags"
+                        label="Tags"
+                    />
+                    <ArrayInput source="backlinks">
                         <SimpleFormIterator>
-                            <ReferenceInput
-                                label="User"
-                                source="user_id"
-                                reference="users"
-                            >
-                                <AutocompleteInput />
-                            </ReferenceInput>
-                            <FormDataConsumer>
-                                {({
-                                    formData,
-                                    scopedFormData,
-                                    getSource,
-                                    ...rest
-                                }) =>
-                                    scopedFormData && scopedFormData.user_id ? (
-                                        <SelectInput
-                                            label="Role"
-                                            source={getSource('role')}
-                                            choices={[
-                                                {
-                                                    id: 'headwriter',
-                                                    name: 'Head Writer',
-                                                },
-                                                {
-                                                    id: 'proofreader',
-                                                    name: 'Proof reader',
-                                                },
-                                                {
-                                                    id: 'cowriter',
-                                                    name: 'Co-Writer',
-                                                },
-                                            ]}
-                                            {...rest}
-                                        />
-                                    ) : null
-                                }
-                            </FormDataConsumer>
+                            <DateInput source="date" />
+                            <TextInput source="url" validate={required()} />
                         </SimpleFormIterator>
                     </ArrayInput>
-                )}
-            </FormTab>
-            <FormTab label="post.form.body">
-                <RichTextInput
-                    source="body"
-                    label=""
-                    validate={required()}
-                    addLabel={false}
-                />
-            </FormTab>
-            <FormTab label="post.form.miscellaneous">
-                <TagReferenceInput
-                    reference="tags"
-                    source="tags"
-                    label="Tags"
-                />
-                <ArrayInput source="backlinks">
-                    <SimpleFormIterator>
-                        <DateInput source="date" />
-                        <TextInput source="url" validate={required()} />
-                    </SimpleFormIterator>
-                </ArrayInput>
-                <DateInput source="published_at" />
-                <SelectInput
-                    allowEmpty
-                    resettable
-                    source="category"
-                    choices={[
-                        { name: 'Tech', id: 'tech' },
-                        { name: 'Lifestyle', id: 'lifestyle' },
-                    ]}
-                />
-                <NumberInput
-                    source="average_note"
-                    validate={[required(), number(), minValue(0)]}
-                />
-                <BooleanInput source="commentable" defaultValue />
-                <TextInput disabled source="views" />
-            </FormTab>
-            <FormTab label="post.form.comments">
-                <ReferenceManyField
-                    reference="comments"
-                    target="post_id"
-                    addLabel={false}
-                    fullWidth
-                >
-                    <Datagrid>
-                        <DateField source="created_at" />
-                        <TextField source="author.name" />
-                        <TextField source="body" />
-                        <EditButton />
-                    </Datagrid>
-                </ReferenceManyField>
-            </FormTab>
-        </TabbedForm>
-    </Edit>
-);
+                    <DateInput
+                        source="published_at"
+                        options={{ locale: 'pt' }}
+                    />
+                    <SelectInput
+                        create={
+                            <CreateCategory
+                                // Ajouté sur le composant parce que je ne suis pas
+                                // dans un ReferenceInput donc faut que je mette
+                                // à jour ma liste de choix à donner à l'AutocompleteInput
+                                onAddChoice={choice => categories.push(choice)}
+                            />
+                        }
+                        allowEmpty
+                        resettable
+                        source="category"
+                        choices={categories}
+                    />
+                    <NumberInput
+                        source="average_note"
+                        validate={[required(), number(), minValue(0)]}
+                    />
+                    <BooleanInput source="commentable" defaultValue />
+                    <TextInput disabled source="views" />
+                </FormTab>
+                <FormTab label="post.form.comments">
+                    <ReferenceManyField
+                        reference="comments"
+                        target="post_id"
+                        addLabel={false}
+                        fullWidth
+                    >
+                        <Datagrid>
+                            <DateField source="created_at" />
+                            <TextField source="author.name" />
+                            <TextField source="body" />
+                            <EditButton />
+                        </Datagrid>
+                    </ReferenceManyField>
+                </FormTab>
+            </TabbedForm>
+        </Edit>
+    );
+};
 
 export default PostEdit;

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -53,7 +53,7 @@ const CreateCategory = ({
     const [value, setValue] = React.useState(filter || '');
     const handleSubmit = (event: React.FormEvent) => {
         event.preventDefault();
-        const choice = { name: value, id: value };
+        const choice = { name: value, id: value.toLowerCase() };
         onAddChoice(choice);
         onCreate(value, choice);
         setValue('');

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -28,7 +28,7 @@ import {
     number,
     required,
     FormDataConsumer,
-    useCreateSuggestion,
+    useCreateSuggestionContext,
     EditActionsProps,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import {
@@ -49,7 +49,7 @@ const CreateCategory = ({
 }: {
     onAddChoice: (record: any) => void;
 }) => {
-    const { filter, onCancel, onCreate } = useCreateSuggestion();
+    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
     const [value, setValue] = React.useState(filter || '');
     const handleSubmit = (event: React.FormEvent) => {
         event.preventDefault();

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -55,7 +55,7 @@ const CreateCategory = ({
         event.preventDefault();
         const choice = { name: value, id: value.toLowerCase() };
         onAddChoice(choice);
-        onCreate(value, choice);
+        onCreate(choice);
         setValue('');
         return false;
     };

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -213,9 +213,8 @@ const PostEdit = ({ permissions, ...props }) => {
                     <SelectInput
                         create={
                             <CreateCategory
-                                // Ajouté sur le composant parce que je ne suis pas
-                                // dans un ReferenceInput donc faut que je mette
-                                // à jour ma liste de choix à donner à l'AutocompleteInput
+                                // Added on the component because we have to update the choices
+                                // ourselves as we don't use a ReferenceInput
                                 onAddChoice={choice => categories.push(choice)}
                             />
                         }

--- a/examples/simple/src/posts/PostTitle.tsx
+++ b/examples/simple/src/posts/PostTitle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useTranslate, Record } from 'react-admin';
+import { TitleProps, useTranslate } from 'react-admin';
 
-export default ({ record }: { record?: Record }) => {
+export default ({ record }: TitleProps) => {
     const translate = useTranslate();
     return (
         <span>

--- a/examples/simple/src/posts/TagReferenceInput.tsx
+++ b/examples/simple/src/posts/TagReferenceInput.tsx
@@ -1,8 +1,19 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-final-form';
-import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin';
-import { Button } from '@material-ui/core';
+import {
+    AutocompleteArrayInput,
+    ReferenceArrayInput,
+    useCreate,
+    useCreateSuggestion,
+} from 'react-admin';
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogActions,
+    TextField as MuiTextField,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles({
@@ -37,7 +48,10 @@ const TagReferenceInput = ({
     return (
         <div className={classes.input}>
             <ReferenceArrayInput {...props} filter={{ published: filter }}>
-                <AutocompleteArrayInput optionText="name.en" />
+                <AutocompleteArrayInput
+                    create={<CreateTag />}
+                    optionText="name.en"
+                />
             </ReferenceArrayInput>
             <Button
                 name="change-filter"
@@ -47,6 +61,52 @@ const TagReferenceInput = ({
                 Filter {filter ? 'Unpublished' : 'Published'} Tags
             </Button>
         </div>
+    );
+};
+
+const CreateTag = () => {
+    const { filter, onCancel, onCreate } = useCreateSuggestion();
+    const [value, setValue] = React.useState(filter || '');
+    const [create] = useCreate('tags');
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        create(
+            {
+                payload: {
+                    data: {
+                        name: {
+                            en: value,
+                        },
+                    },
+                },
+            },
+            {
+                onSuccess: ({ data }) => {
+                    setValue('');
+                    const choice = data;
+                    onCreate(value, choice);
+                },
+            }
+        );
+        return false;
+    };
+    return (
+        <Dialog open onClose={onCancel}>
+            <form onSubmit={handleSubmit}>
+                <DialogContent>
+                    <MuiTextField
+                        label="New tag"
+                        value={value}
+                        onChange={event => setValue(event.target.value)}
+                        autoFocus
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button type="submit">Save</Button>
+                    <Button onClick={onCancel}>Cancel</Button>
+                </DialogActions>
+            </form>
+        </Dialog>
     );
 };
 

--- a/examples/simple/src/posts/TagReferenceInput.tsx
+++ b/examples/simple/src/posts/TagReferenceInput.tsx
@@ -84,7 +84,7 @@ const CreateTag = () => {
                 onSuccess: ({ data }) => {
                     setValue('');
                     const choice = data;
-                    onCreate(value, choice);
+                    onCreate(choice);
                 },
             }
         );

--- a/examples/simple/src/posts/TagReferenceInput.tsx
+++ b/examples/simple/src/posts/TagReferenceInput.tsx
@@ -5,7 +5,7 @@ import {
     AutocompleteArrayInput,
     ReferenceArrayInput,
     useCreate,
-    useCreateSuggestion,
+    useCreateSuggestionContext,
 } from 'react-admin';
 import {
     Button,
@@ -65,7 +65,7 @@ const TagReferenceInput = ({
 };
 
 const CreateTag = () => {
-    const { filter, onCancel, onCreate } = useCreateSuggestion();
+    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
     const [value, setValue] = React.useState(filter || '');
     const [create] = useCreate('tags');
     const handleSubmit = (event: React.FormEvent) => {

--- a/packages/ra-core/src/controller/field/ReferenceFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldController.spec.tsx
@@ -84,6 +84,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/posts/123',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -116,6 +117,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/prefix/posts/123',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -148,6 +150,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/edit/123',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -180,6 +183,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/show/123',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -205,6 +209,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/posts/123/show',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -238,6 +243,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/edit/123/show',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -271,6 +277,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: '/show/123/show',
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -296,6 +303,7 @@ describe('<ReferenceFieldController />', () => {
             referenceRecord: { id: 123, title: 'foo' },
             resourceLinkPath: false,
             error: null,
+            refetch: expect.any(Function),
         });
     });
 });

--- a/packages/ra-core/src/controller/input/ReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.spec.tsx
@@ -170,6 +170,7 @@ describe('<ReferenceInputController />', () => {
                     'possibleValues.showFilter',
                 ])
             ).toEqual({
+                refetch: expect.any(Function),
                 possibleValues: {
                     basePath: '/comments',
                     currentSort: {

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -17,6 +17,7 @@ import { useSortState } from '..';
 import useFilterState from '../useFilterState';
 import useSelectionState from '../useSelectionState';
 import { useResourceContext } from '../../core';
+import { Refetch } from '../../dataProvider';
 
 const defaultReferenceSource = (resource: string, source: string) =>
     `${resource}@${source}`;
@@ -126,6 +127,7 @@ export const useReferenceInputController = (
     // fetch current value
     const {
         referenceRecord,
+        refetch,
         error: referenceError,
         loading: referenceLoading,
         loaded: referenceLoaded,
@@ -202,6 +204,7 @@ export const useReferenceInputController = (
         loading: possibleValuesLoading || referenceLoading,
         loaded: possibleValuesLoaded && referenceLoaded,
         filter: filterValues,
+        refetch,
         setFilter,
         pagination,
         setPagination,
@@ -238,6 +241,7 @@ export interface ReferenceInputValue {
     setSort: (sort: SortPayload) => void;
     sort: SortPayload;
     warning?: string;
+    refetch: Refetch;
 }
 
 interface Option {

--- a/packages/ra-core/src/controller/useReference.spec.tsx
+++ b/packages/ra-core/src/controller/useReference.spec.tsx
@@ -143,6 +143,7 @@ describe('useReference', () => {
             loading: true,
             loaded: true,
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -171,6 +172,7 @@ describe('useReference', () => {
             loading: true,
             loaded: false,
             error: null,
+            refetch: expect.any(Function),
         });
     });
 });

--- a/packages/ra-core/src/controller/useReference.ts
+++ b/packages/ra-core/src/controller/useReference.ts
@@ -1,5 +1,5 @@
 import { Record } from '../types';
-import { useGetMany } from '../dataProvider';
+import { Refetch, useGetMany } from '../dataProvider';
 
 interface Option {
     id: string;
@@ -11,6 +11,7 @@ export interface UseReferenceProps {
     loaded: boolean;
     referenceRecord?: Record;
     error?: any;
+    refetch: Refetch;
 }
 
 /**
@@ -41,9 +42,12 @@ export interface UseReferenceProps {
  * @returns {ReferenceProps} The reference record
  */
 export const useReference = ({ reference, id }: Option): UseReferenceProps => {
-    const { data, error, loading, loaded } = useGetMany(reference, [id]);
+    const { data, error, loading, loaded, refetch } = useGetMany(reference, [
+        id,
+    ]);
     return {
         referenceRecord: error ? undefined : data[0],
+        refetch,
         error,
         loading,
         loaded,

--- a/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
@@ -217,6 +217,7 @@ describe('useGetMany', () => {
             loading: true,
             loaded: true,
             error: null,
+            refetch: expect.any(Function),
         });
     });
 
@@ -257,6 +258,7 @@ describe('useGetMany', () => {
                 loading: false,
                 loaded: true,
                 error: null,
+                refetch: expect.any(Function),
             });
         });
     });
@@ -310,6 +312,7 @@ describe('useGetMany', () => {
             loading: true,
             loaded: false,
             error: null,
+            refetch: expect.any(Function),
         });
     });
 

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -105,11 +105,12 @@ const useGetMany = (
     const version = useVersion(); // used to allow force reload
     // used to force a refetch without relying on version
     // which might trigger other queries as well
-    const [innerVersion, setInnerVersion] = useState(0);
+    const [innerVersion, setInnerVersion] = useSafeSetState(0);
 
     const refetch = useCallback(() => {
         setInnerVersion(prevInnerVersion => prevInnerVersion + 1);
-    }, []);
+    }, [setInnerVersion]);
+
     const [state, setState] = useSafeSetState({
         data,
         error: null,

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -215,7 +215,7 @@ const useMutation = (
 export interface Mutation {
     type: string;
     resource?: string;
-    payload: object;
+    payload?: object;
 }
 
 export interface MutationOptions {
@@ -281,7 +281,12 @@ const mergeDefinitionAndCallTimeParameters = (
     callTimeQuery?: Partial<Mutation> | Event,
     options?: MutationOptions,
     callTimeOptions?: MutationOptions
-) => {
+): {
+    type: string;
+    resource: string;
+    payload?: object;
+    options: MutationOptions;
+} => {
     if (!query && (!callTimeQuery || callTimeQuery instanceof Event)) {
         throw new Error('Missing query either at definition or at call time');
     }

--- a/packages/ra-core/src/dataProvider/useQuery.ts
+++ b/packages/ra-core/src/dataProvider/useQuery.ts
@@ -6,7 +6,7 @@ import useDataProvider from './useDataProvider';
 import useDataProviderWithDeclarativeSideEffects from './useDataProviderWithDeclarativeSideEffects';
 import { DeclarativeSideEffect } from './useDeclarativeSideEffects';
 import useVersion from '../controller/useVersion';
-import { DataProviderQuery } from './useQueryWithStore';
+import { DataProviderQuery, Refetch } from './useQueryWithStore';
 
 /**
  * Call the data provider on mount
@@ -165,5 +165,5 @@ export type UseQueryValue = {
     error?: any;
     loading: boolean;
     loaded: boolean;
-    refetch: () => void;
+    refetch: Refetch;
 };

--- a/packages/ra-core/src/dataProvider/useQueryWithStore.ts
+++ b/packages/ra-core/src/dataProvider/useQueryWithStore.ts
@@ -14,13 +14,15 @@ export interface DataProviderQuery {
     payload: object;
 }
 
+export type Refetch = () => void;
+
 export interface UseQueryWithStoreValue {
     data?: any;
     total?: number;
     error?: any;
     loading: boolean;
     loaded: boolean;
-    refetch: () => void;
+    refetch: Refetch;
 }
 
 export interface QueryOptions {

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -70,10 +70,13 @@ const FormWithRedirect = ({
     const redirect = useRef(props.redirect);
     const onSave = useRef(save);
     const formGroups = useRef<{ [key: string]: string[] }>({});
-    const finalMutators =
-        mutators === defaultMutators
-            ? mutators
-            : { ...defaultMutators, ...mutators };
+    const finalMutators = useMemo(
+        () =>
+            mutators === defaultMutators
+                ? mutators
+                : { ...defaultMutators, ...mutators },
+        [mutators]
+    );
 
     // We don't use state here for two reasons:
     // 1. There no way to execute code only after the state has been updated

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -73,7 +73,7 @@ const FormWithRedirect = ({
     const finalMutators =
         mutators === defaultMutators
             ? mutators
-            : { ...mutators, ...defaultMutators };
+            : { ...defaultMutators, ...mutators };
 
     // We don't use state here for two reasons:
     // 1. There no way to execute code only after the state has been updated

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -70,6 +70,10 @@ const FormWithRedirect = ({
     const redirect = useRef(props.redirect);
     const onSave = useRef(save);
     const formGroups = useRef<{ [key: string]: string[] }>({});
+    const finalMutators =
+        mutators === defaultMutators
+            ? mutators
+            : { ...mutators, ...defaultMutators };
 
     // We don't use state here for two reasons:
     // 1. There no way to execute code only after the state has been updated
@@ -162,7 +166,7 @@ const FormWithRedirect = ({
                 initialValues={finalInitialValues}
                 initialValuesEqual={initialValuesEqual}
                 keepDirtyOnReinitialize={keepDirtyOnReinitialize}
-                mutators={mutators} // necessary for ArrayInput
+                mutators={finalMutators} // necessary for ArrayInput
                 onSubmit={submit}
                 subscription={subscription} // don't redraw entire form each time one field changes
                 validate={validate}

--- a/packages/ra-core/src/form/useChoices.ts
+++ b/packages/ra-core/src/form/useChoices.ts
@@ -8,7 +8,8 @@ import { InputProps } from '.';
 export type OptionTextElement = ReactElement<{
     record: Record;
 }>;
-export type OptionText = (choice: object) => string | OptionTextElement;
+export type OptionTextFunc = (choice: object) => string | OptionTextElement;
+export type OptionText = OptionTextElement | OptionTextFunc | string;
 
 export interface ChoicesInputProps<T = any>
     extends Omit<InputProps<T>, 'source'> {
@@ -22,13 +23,13 @@ export interface ChoicesInputProps<T = any>
 export interface ChoicesProps {
     choices: object[];
     optionValue?: string;
-    optionText?: OptionTextElement | OptionText | string;
+    optionText?: OptionText;
     translateChoice?: boolean;
 }
 
 export interface UseChoicesOptions {
     optionValue?: string;
-    optionText?: OptionTextElement | OptionText | string;
+    optionText?: OptionText;
     disableValue?: string;
     translateChoice?: boolean;
 }
@@ -63,6 +64,12 @@ const useChoices = ({
                 typeof optionText === 'function'
                     ? optionText(choice)
                     : get(choice, optionText);
+
+            if (isValidElement<{ record: any }>(choiceName)) {
+                return cloneElement<{ record: any }>(choiceName, {
+                    record: choice,
+                });
+            }
 
             return translateChoice
                 ? translate(choiceName, { _: choiceName })

--- a/packages/ra-core/src/form/useChoices.ts
+++ b/packages/ra-core/src/form/useChoices.ts
@@ -65,12 +65,6 @@ const useChoices = ({
                     ? optionText(choice)
                     : get(choice, optionText);
 
-            if (isValidElement<{ record: any }>(choiceName)) {
-                return cloneElement<{ record: any }>(choiceName, {
-                    record: choice,
-                });
-            }
-
             return translateChoice
                 ? translate(choiceName, { _: choiceName })
                 : choiceName;

--- a/packages/ra-core/src/form/useSuggestions.spec.ts
+++ b/packages/ra-core/src/form/useSuggestions.spec.ts
@@ -10,15 +10,10 @@ describe('getSuggestions', () => {
 
     const defaultOptions = {
         choices,
-        allowEmpty: false,
-        emptyText: '',
-        emptyValue: null,
         getChoiceText: ({ value }) => value,
         getChoiceValue: ({ id }) => id,
-        limitChoicesToValue: false,
         matchSuggestion: undefined,
         optionText: 'value',
-        optionValue: 'id',
         selectedItem: undefined,
     };
 
@@ -86,6 +81,7 @@ describe('getSuggestions', () => {
             })('one')
         ).toEqual([choices[0]]);
     });
+
     it('should add emptySuggestion if allowEmpty is true', () => {
         expect(
             getSuggestions({
@@ -97,6 +93,20 @@ describe('getSuggestions', () => {
             { id: 1, value: 'one' },
             { id: 2, value: 'two' },
             { id: 3, value: 'three' },
+        ]);
+    });
+
+    it('should add createSuggestion if allowCreate is true', () => {
+        expect(
+            getSuggestions({
+                ...defaultOptions,
+                allowCreate: true,
+            })('')
+        ).toEqual([
+            { id: 1, value: 'one' },
+            { id: 2, value: 'two' },
+            { id: 3, value: 'three' },
+            { id: '@@create', value: 'ra.action.create' },
         ]);
     });
 

--- a/packages/ra-core/src/form/useSuggestions.ts
+++ b/packages/ra-core/src/form/useSuggestions.ts
@@ -1,6 +1,6 @@
 import { useCallback, isValidElement } from 'react';
 import set from 'lodash/set';
-import useChoices, { UseChoicesOptions } from './useChoices';
+import useChoices, { OptionText, UseChoicesOptions } from './useChoices';
 import { useTranslate } from '../i18n';
 
 /*
@@ -25,9 +25,12 @@ import { useTranslate } from '../i18n';
  * - getSuggestions: A function taking a filter value (string) and returning the matching suggestions
  */
 const useSuggestions = ({
+    allowCreate,
     allowDuplicates,
     allowEmpty,
     choices,
+    createText = 'ra.action.create',
+    createValue = '@@create',
     emptyText = '',
     emptyValue = null,
     limitChoicesToValue,
@@ -37,7 +40,7 @@ const useSuggestions = ({
     selectedItem,
     suggestionLimit = 0,
     translateChoice,
-}: Options) => {
+}: UseSuggestionsOptions) => {
     const translate = useTranslate();
     const { getChoiceText, getChoiceValue } = useChoices({
         optionText,
@@ -48,9 +51,12 @@ const useSuggestions = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const getSuggestions = useCallback(
         getSuggestionsFactory({
+            allowCreate,
             allowDuplicates,
             allowEmpty,
             choices,
+            createText,
+            createValue,
             emptyText: translate(emptyText, { _: emptyText }),
             emptyValue,
             getChoiceText,
@@ -63,9 +69,12 @@ const useSuggestions = ({
             suggestionLimit,
         }),
         [
+            allowCreate,
             allowDuplicates,
             allowEmpty,
             choices,
+            createText,
+            createValue,
             emptyText,
             emptyValue,
             getChoiceText,
@@ -92,14 +101,21 @@ export default useSuggestions;
 const escapeRegExp = value =>
     value ? value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; // $& means the whole matched string
 
-interface Options extends UseChoicesOptions {
-    choices: any[];
+export interface UseSuggestionsOptions extends UseChoicesOptions {
+    allowCreate?: boolean;
     allowDuplicates?: boolean;
     allowEmpty?: boolean;
+    choices: any[];
+    createText?: string;
+    createValue?: any;
     emptyText?: string;
     emptyValue?: any;
     limitChoicesToValue?: boolean;
-    matchSuggestion?: (filter: string, suggestion: any) => boolean;
+    matchSuggestion?: (
+        filter: string,
+        suggestion: any,
+        exact?: boolean
+    ) => boolean;
     suggestionLimit?: number;
     selectedItem?: any | any[];
 }
@@ -107,10 +123,15 @@ interface Options extends UseChoicesOptions {
 /**
  * Default matcher implementation which check whether the suggestion text matches the filter.
  */
-const defaultMatchSuggestion = getChoiceText => (filter, suggestion) => {
+const defaultMatchSuggestion = getChoiceText => (
+    filter,
+    suggestion,
+    exact = false
+) => {
     const suggestionText = getChoiceText(suggestion);
 
     const isReactElement = isValidElement(suggestionText);
+    const regex = escapeRegExp(filter);
 
     return isReactElement
         ? false
@@ -118,7 +139,7 @@ const defaultMatchSuggestion = getChoiceText => (filter, suggestion) => {
               suggestionText.match(
                   // We must escape any RegExp reserved characters to avoid errors
                   // For example, the filter might contains * which must be escaped as \*
-                  new RegExp(escapeRegExp(filter), 'i')
+                  new RegExp(exact ? `^${regex}$` : regex, 'i')
               );
 };
 
@@ -145,19 +166,25 @@ const defaultMatchSuggestion = getChoiceText => (filter, suggestion) => {
  * // Will return [{ id: 2, name: 'publisher' }]
  */
 export const getSuggestionsFactory = ({
+    allowCreate = false,
+    allowDuplicates = false,
+    allowEmpty = false,
     choices = [],
-    allowDuplicates,
-    allowEmpty,
-    emptyText,
-    emptyValue,
-    optionText,
-    optionValue,
+    createText = 'ra.action.create',
+    createValue = '@@create',
+    emptyText = '',
+    emptyValue = null,
+    optionText = 'name',
+    optionValue = 'id',
     getChoiceText,
     getChoiceValue,
     limitChoicesToValue = false,
     matchSuggestion = defaultMatchSuggestion(getChoiceText),
     selectedItem,
     suggestionLimit = 0,
+}: UseSuggestionsOptions & {
+    getChoiceText: (choice: any) => string;
+    getChoiceValue: (choice: any) => string;
 }) => filter => {
     let suggestions = [];
     // if an item is selected and matches the filter
@@ -195,15 +222,37 @@ export const getSuggestionsFactory = ({
 
     suggestions = limitSuggestions(suggestions, suggestionLimit);
 
-    if (allowEmpty) {
-        suggestions = addEmptySuggestion(suggestions, {
-            optionText,
-            optionValue,
-            emptyText,
-            emptyValue,
-        });
+    const hasExactMatch = suggestions.some(suggestion =>
+        matchSuggestion(filter, suggestion, true)
+    );
+
+    const filterIsSelectedItem = !!selectedItem
+        ? matchSuggestion(filter, selectedItem, true)
+        : false;
+
+    if (allowCreate) {
+        if (!hasExactMatch && !filterIsSelectedItem) {
+            suggestions.push(
+                getSuggestion({
+                    optionText,
+                    optionValue,
+                    text: createText,
+                    value: createValue,
+                })
+            );
+        }
     }
 
+    if (allowEmpty) {
+        suggestions.unshift(
+            getSuggestion({
+                optionText,
+                optionValue,
+                text: emptyText,
+                value: emptyValue,
+            })
+        );
+    }
     return suggestions;
 };
 
@@ -257,7 +306,7 @@ const limitSuggestions = (suggestions: any[], limit: any = 0) =>
         : suggestions;
 
 /**
- * addEmptySuggestion(
+ * addSuggestion(
  *  [{ id: 1, name: 'foo'}, { id: 2, name: 'bar' }],
  * );
  *
@@ -265,23 +314,24 @@ const limitSuggestions = (suggestions: any[], limit: any = 0) =>
  *
  * @param suggestions List of suggestions
  * @param options
+ * @param options.optionText
  */
-const addEmptySuggestion = (
-    suggestions: any[],
-    {
-        optionText = 'name',
-        optionValue = 'id',
-        emptyText = '',
-        emptyValue = null,
-    }
-) => {
-    let newSuggestions = suggestions;
-
-    const emptySuggestion = {};
-    set(emptySuggestion, optionValue, emptyValue);
+const getSuggestion = ({
+    optionText = 'name',
+    optionValue = 'id',
+    text = '',
+    value = null,
+}: {
+    optionText: OptionText;
+    optionValue: string;
+    text: string;
+    value: any;
+}) => {
+    const suggestion = {};
+    set(suggestion, optionValue, value);
     if (typeof optionText === 'string') {
-        set(emptySuggestion, optionText, emptyText);
+        set(suggestion, optionText, text);
     }
 
-    return [].concat(emptySuggestion, newSuggestions);
+    return suggestion;
 };

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -12,6 +12,7 @@ const englishMessages: TranslationMessages = {
             clone: 'Clone',
             confirm: 'Confirm',
             create: 'Create',
+            create_item: 'Create %{item}',
             delete: 'Delete',
             edit: 'Edit',
             export: 'Export',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -13,6 +13,7 @@ const frenchMessages: TranslationMessages = {
             clone: 'Dupliquer',
             confirm: 'Confirmer',
             create: 'Créer',
+            create_item: 'Créer %{item}',
             delete: 'Supprimer',
             edit: 'Éditer',
             export: 'Exporter',

--- a/packages/ra-ui-materialui/src/detail/editFieldTypes.tsx
+++ b/packages/ra-ui-materialui/src/detail/editFieldTypes.tsx
@@ -10,7 +10,7 @@ import ReferenceInput from '../input/ReferenceInput';
 import ReferenceArrayInput, {
     ReferenceArrayInputProps,
 } from '../input/ReferenceArrayInput';
-import SelectInput from '../input/SelectInput';
+import { SelectInput } from '../input/SelectInput';
 import TextInput from '../input/TextInput';
 import { InferredElement, InferredTypeMap, InputProps } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/field/UrlField.tsx
+++ b/packages/ra-ui-materialui/src/field/UrlField.tsx
@@ -11,7 +11,7 @@ const UrlField: FC<UrlFieldProps> = memo<UrlFieldProps>(props => {
     const record = useRecordContext(props);
     const value = get(record, source);
 
-    if (value == null && emptyText) {
+    if (value == null) {
         return (
             <Typography
                 component="span"

--- a/packages/ra-ui-materialui/src/field/sanitizeFieldRestProps.ts
+++ b/packages/ra-ui-materialui/src/field/sanitizeFieldRestProps.ts
@@ -13,6 +13,7 @@ const sanitizeFieldRestProps: (props: any) => any = ({
     link,
     locale,
     record,
+    refetch,
     resource,
     sortable,
     sortBy,

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -5,6 +5,7 @@ import expect from 'expect';
 
 import AutocompleteArrayInput from './AutocompleteArrayInput';
 import { TestTranslationProvider } from 'ra-core';
+import { useCreateSuggestion } from './useSupportCreateSuggestion';
 
 describe('<AutocompleteArrayInput />', () => {
     const defaultProps = {
@@ -749,5 +750,178 @@ describe('<AutocompleteArrayInput />', () => {
         );
 
         expect(queryByRole('progressbar')).toBeNull();
+    });
+
+    test('should support creation of a new choice through the onCreate event', async () => {
+        const choices = [
+            { id: 'ang', name: 'Angular' },
+            { id: 'rea', name: 'React' },
+        ];
+        const handleCreate = filter => {
+            const newChoice = {
+                id: 'js_fatigue',
+                name: filter,
+            };
+            choices.push(newChoice);
+            return newChoice;
+        };
+
+        const { getByLabelText, getByText, queryByText, rerender } = render(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteArrayInput
+                        source="language"
+                        resource="posts"
+                        choices={choices}
+                        onCreate={handleCreate}
+                    />
+                )}
+            />
+        );
+
+        const input = getByLabelText('resources.posts.fields.language', {
+            selector: 'input',
+        }) as HTMLInputElement;
+        input.focus();
+        fireEvent.change(input, { target: { value: 'New Kid On The Block' } });
+        fireEvent.click(getByText('ra.action.create_item'));
+        await new Promise(resolve => setImmediate(resolve));
+        rerender(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteArrayInput
+                        source="language"
+                        resource="posts"
+                        resettable
+                        choices={choices}
+                        onCreate={handleCreate}
+                    />
+                )}
+            />
+        );
+
+        expect(queryByText('New Kid On The Block')).not.toBeNull();
+    });
+
+    test('should support creation of a new choice through the onCreate event with a promise', async () => {
+        const choices = [
+            { id: 'ang', name: 'Angular' },
+            { id: 'rea', name: 'React' },
+        ];
+        const handleCreate = filter => {
+            return new Promise(resolve => {
+                const newChoice = {
+                    id: 'js_fatigue',
+                    name: filter,
+                };
+                choices.push(newChoice);
+                setImmediate(() => resolve(newChoice));
+            });
+        };
+
+        const { getByLabelText, getByText, queryByText, rerender } = render(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteArrayInput
+                        source="language"
+                        resource="posts"
+                        choices={choices}
+                        onCreate={handleCreate}
+                        resettable
+                    />
+                )}
+            />
+        );
+
+        const input = getByLabelText('resources.posts.fields.language', {
+            selector: 'input',
+        }) as HTMLInputElement;
+        input.focus();
+        fireEvent.change(input, { target: { value: 'New Kid On The Block' } });
+        fireEvent.click(getByText('ra.action.create_item'));
+        await new Promise(resolve => setImmediate(resolve));
+        rerender(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteArrayInput
+                        source="language"
+                        resource="posts"
+                        resettable
+                        choices={choices}
+                        onCreate={handleCreate}
+                    />
+                )}
+            />
+        );
+
+        expect(queryByText('New Kid On The Block')).not.toBeNull();
+    });
+
+    test('should support creation of a new choice through the create element', async () => {
+        const choices = [
+            { id: 'ang', name: 'Angular' },
+            { id: 'rea', name: 'React' },
+        ];
+        const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
+
+        const Create = () => {
+            const context = useCreateSuggestion();
+            const handleClick = () => {
+                choices.push(newChoice);
+                context.onCreate(newChoice.id, newChoice);
+            };
+
+            return <button onClick={handleClick}>Get the kid</button>;
+        };
+
+        const { getByLabelText, rerender, getByText, queryByText } = render(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteArrayInput
+                        source="language"
+                        resource="posts"
+                        choices={choices}
+                        create={<Create />}
+                        resettable
+                    />
+                )}
+            />
+        );
+
+        const input = getByLabelText('resources.posts.fields.language', {
+            selector: 'input',
+        }) as HTMLInputElement;
+        input.focus();
+        fireEvent.change(input, { target: { value: 'New Kid On The Block' } });
+        fireEvent.click(getByText('ra.action.create_item'));
+        fireEvent.click(getByText('Get the kid'));
+        await new Promise(resolve => setImmediate(resolve));
+        rerender(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <AutocompleteArrayInput
+                        source="language"
+                        resource="posts"
+                        resettable
+                        choices={choices}
+                        create={<Create />}
+                    />
+                )}
+            />
+        );
+
+        expect(queryByText('New Kid On The Block')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -876,7 +876,7 @@ describe('<AutocompleteArrayInput />', () => {
             const context = useCreateSuggestion();
             const handleClick = () => {
                 choices.push(newChoice);
-                context.onCreate(newChoice.id, newChoice);
+                context.onCreate(newChoice);
             };
 
             return <button onClick={handleClick}>Get the kid</button>;

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -5,7 +5,7 @@ import expect from 'expect';
 
 import AutocompleteArrayInput from './AutocompleteArrayInput';
 import { TestTranslationProvider } from 'ra-core';
-import { useCreateSuggestion } from './useSupportCreateSuggestion';
+import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 describe('<AutocompleteArrayInput />', () => {
     const defaultProps = {
@@ -873,7 +873,7 @@ describe('<AutocompleteArrayInput />', () => {
         const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
 
         const Create = () => {
-            const context = useCreateSuggestion();
+            const context = useCreateSuggestionContext();
             const handleClick = () => {
                 choices.push(newChoice);
                 context.onCreate(newChoice);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { AutocompleteInput } from './AutocompleteInput';
 import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
-import { useCreateSuggestion } from './useSupportCreateSuggestion';
+import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 describe('<AutocompleteInput />', () => {
     // Fix document.createRange is not a function error on fireEvent usage (Fixed in jsdom v16.0.0)
@@ -695,7 +695,7 @@ describe('<AutocompleteInput />', () => {
         expect(queryByRole('progressbar')).toBeNull();
     });
 
-    test('should support creation of a new choice through the onCreate event', async () => {
+    it('should support creation of a new choice through the onCreate event', async () => {
         const choices = [
             { id: 'ang', name: 'Angular' },
             { id: 'rea', name: 'React' },
@@ -751,7 +751,7 @@ describe('<AutocompleteInput />', () => {
         expect(queryByText('New Kid On The Block')).not.toBeNull();
     });
 
-    test('should support creation of a new choice through the onCreate event with a promise', async () => {
+    it('should support creation of a new choice through the onCreate event with a promise', async () => {
         const choices = [
             { id: 'ang', name: 'Angular' },
             { id: 'rea', name: 'React' },
@@ -810,7 +810,7 @@ describe('<AutocompleteInput />', () => {
         expect(queryByText('New Kid On The Block')).not.toBeNull();
     });
 
-    test('should support creation of a new choice through the create element', async () => {
+    it('should support creation of a new choice through the create element', async () => {
         const choices = [
             { id: 'ang', name: 'Angular' },
             { id: 'rea', name: 'React' },
@@ -818,7 +818,7 @@ describe('<AutocompleteInput />', () => {
         const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
 
         const Create = () => {
-            const context = useCreateSuggestion();
+            const context = useCreateSuggestionContext();
             const handleClick = () => {
                 choices.push(newChoice);
                 context.onCreate(newChoice);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -821,7 +821,7 @@ describe('<AutocompleteInput />', () => {
             const context = useCreateSuggestion();
             const handleClick = () => {
                 choices.push(newChoice);
-                context.onCreate(newChoice.id, newChoice);
+                context.onCreate(newChoice);
             };
 
             return <button onClick={handleClick}>Get the kid</button>;

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
-import AutocompleteInput from './AutocompleteInput';
+import { AutocompleteInput } from './AutocompleteInput';
 import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -748,10 +748,7 @@ describe('<AutocompleteInput />', () => {
         );
         fireEvent.click(getByLabelText('ra.action.clear_input_value'));
 
-        expect(
-            // The selector ensure we don't get the options from the menu but the select value
-            queryByText('New Kid On The Block')
-        ).not.toBeNull();
+        expect(queryByText('New Kid On The Block')).not.toBeNull();
     });
 
     test('should support creation of a new choice through the onCreate event with a promise', async () => {
@@ -780,6 +777,7 @@ describe('<AutocompleteInput />', () => {
                         resource="posts"
                         choices={choices}
                         onCreate={handleCreate}
+                        resettable
                     />
                 )}
             />
@@ -809,10 +807,7 @@ describe('<AutocompleteInput />', () => {
         );
         fireEvent.click(getByLabelText('ra.action.clear_input_value'));
 
-        expect(
-            // The selector ensure we don't get the options from the menu but the select value
-            queryByText('New Kid On The Block')
-        ).not.toBeNull();
+        expect(queryByText('New Kid On The Block')).not.toBeNull();
     });
 
     test('should support creation of a new choice through the create element', async () => {
@@ -842,6 +837,7 @@ describe('<AutocompleteInput />', () => {
                         resource="posts"
                         choices={choices}
                         create={<Create />}
+                        resettable
                     />
                 )}
             />
@@ -872,9 +868,6 @@ describe('<AutocompleteInput />', () => {
         );
         fireEvent.click(getByLabelText('ra.action.clear_input_value'));
 
-        expect(
-            // The selector ensure we don't get the options from the menu but the select value
-            queryByText('New Kid On The Block')
-        ).not.toBeNull();
+        expect(queryByText('New Kid On The Block')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteSuggestionItem.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteSuggestionItem.tsx
@@ -26,7 +26,8 @@ const useStyles = makeStyles(
     { name: 'RaAutocompleteSuggestionItem' }
 );
 
-interface Props {
+export interface AutocompleteSuggestionItemProps {
+    createValue?: any;
     suggestion: any;
     index: number;
     highlightedIndex: number;
@@ -37,9 +38,10 @@ interface Props {
 }
 
 const AutocompleteSuggestionItem: FunctionComponent<
-    Props & MenuItemProps<'li', { button?: true }>
+    AutocompleteSuggestionItemProps & MenuItemProps<'li', { button?: true }>
 > = props => {
     const {
+        createValue,
         suggestion,
         index,
         highlightedIndex,
@@ -51,7 +53,10 @@ const AutocompleteSuggestionItem: FunctionComponent<
     } = props;
     const classes = useStyles(props);
     const isHighlighted = highlightedIndex === index;
-    const suggestionText = getSuggestionText(suggestion);
+    const suggestionText =
+        suggestion?.id === createValue
+            ? suggestion.name
+            : getSuggestionText(suggestion);
     let matches;
     let parts;
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -316,13 +316,7 @@ describe('<SelectArrayInput />', () => {
         const choices = [...defaultProps.choices];
         const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
 
-        const {
-            debug,
-            getByLabelText,
-            getByRole,
-            getByText,
-            queryAllByText,
-        } = render(
+        const { getByLabelText, getByRole, getByText, queryAllByText } = render(
             <Form
                 validateOnBlur
                 onSubmit={jest.fn()}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -5,7 +5,7 @@ import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
 
 import SelectArrayInput from './SelectArrayInput';
-import { useCreateSuggestion } from './useSupportCreateSuggestion';
+import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 describe('<SelectArrayInput />', () => {
     const defaultProps = {
@@ -394,7 +394,7 @@ describe('<SelectArrayInput />', () => {
         const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
 
         const Create = () => {
-            const context = useCreateSuggestion();
+            const context = useCreateSuggestionContext();
             const handleClick = () => {
                 choices.push(newChoice);
                 context.onCreate(newChoice);

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -397,7 +397,7 @@ describe('<SelectArrayInput />', () => {
             const context = useCreateSuggestion();
             const handleClick = () => {
                 choices.push(newChoice);
-                context.onCreate(newChoice.id, newChoice);
+                context.onCreate(newChoice);
             };
 
             return <button onClick={handleClick}>Get the kid</button>;

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-    FunctionComponent,
-    useCallback,
-    useRef,
-    useState,
-    useEffect,
-} from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
     Select,
@@ -29,6 +23,294 @@ import { SelectProps } from '@material-ui/core/Select';
 import { FormControlProps } from '@material-ui/core/FormControl';
 import Labeled from './Labeled';
 import { LinearProgress } from '../layout';
+import {
+    SupportCreateSuggestionOptions,
+    useSupportCreateSuggestion,
+} from './useSupportCreateSuggestion';
+
+/**
+ * An Input component for a select box allowing multiple selections, using an array of objects for the options
+ *
+ * Pass possible options as an array of objects in the 'choices' attribute.
+ *
+ * By default, the options are built from:
+ *  - the 'id' property as the option value,
+ *  - the 'name' property as the option text
+ * @example
+ * const choices = [
+ *    { id: 'programming', name: 'Programming' },
+ *    { id: 'lifestyle', name: 'Lifestyle' },
+ *    { id: 'photography', name: 'Photography' },
+ * ];
+ * <SelectArrayInput source="tags" choices={choices} />
+ *
+ * You can also customize the properties to use for the option name and value,
+ * thanks to the 'optionText' and 'optionValue' attributes.
+ * @example
+ * const choices = [
+ *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
+ *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
+ * ];
+ * <SelectArrayInput source="authors" choices={choices} optionText="full_name" optionValue="_id" />
+ *
+ * `optionText` also accepts a function, so you can shape the option text at will:
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+ * <SelectArrayInput source="authors" choices={choices} optionText={optionRenderer} />
+ *
+ * `optionText` also accepts a React Element, that will be cloned and receive
+ * the related choice as the `record` prop. You can use Field components there.
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
+ * <SelectArrayInput source="authors" choices={choices} optionText={<FullNameField />}/>
+ *
+ * The choices are translated by default, so you can use translation identifiers as choices:
+ * @example
+ * const choices = [
+ *    { id: 'programming', name: 'myroot.tags.programming' },
+ *    { id: 'lifestyle', name: 'myroot.tags.lifestyle' },
+ *    { id: 'photography', name: 'myroot.tags.photography' },
+ * ];
+ */
+const SelectArrayInput = (props: SelectArrayInputProps) => {
+    const {
+        choices = [],
+        classes: classesOverride,
+        className,
+        create,
+        createLabel,
+        createValue,
+        disableValue,
+        format,
+        helperText,
+        label,
+        loaded,
+        loading,
+        margin = 'dense',
+        onBlur,
+        onChange,
+        onCreate,
+        onFocus,
+        options,
+        optionText,
+        optionValue,
+        parse,
+        resource,
+        source,
+        translateChoice,
+        validate,
+        variant = 'filled',
+        ...rest
+    } = props;
+
+    const classes = useStyles(props);
+    const inputLabel = useRef(null);
+    const [labelWidth, setLabelWidth] = useState(0);
+
+    useEffect(() => {
+        // Will be null while loading and we don't need this fix in that case
+        if (inputLabel.current) {
+            setLabelWidth(inputLabel.current.offsetWidth);
+        }
+    }, []);
+
+    const { getChoiceText, getChoiceValue, getDisableValue } = useChoices({
+        optionText,
+        optionValue,
+        disableValue,
+        translateChoice,
+    });
+    const {
+        input,
+        isRequired,
+        meta: { error, submitError, touched },
+    } = useInput({
+        format,
+        onBlur,
+        onChange,
+        onFocus,
+        parse,
+        resource,
+        source,
+        validate,
+        ...rest,
+    });
+
+    const handleChange = useCallback(
+        (event, newItem) => {
+            if (newItem) {
+                input.onChange([...input.value, getChoiceValue(newItem)]);
+                return;
+            }
+            input.onChange(event);
+        },
+        [input, getChoiceValue]
+    );
+
+    const {
+        getCreateItem,
+        handleChange: handleChangeWithCreateSupport,
+        createElement,
+    } = useSupportCreateSuggestion({
+        create,
+        createLabel,
+        createValue,
+        handleChange,
+        onCreate,
+    });
+
+    const createItem = getCreateItem();
+    const finalChoices =
+        create || onCreate ? [...choices, createItem] : choices;
+
+    const renderMenuItemOption = useCallback(choice => getChoiceText(choice), [
+        getChoiceText,
+    ]);
+
+    const renderMenuItem = useCallback(
+        choice => {
+            return choice ? (
+                <MenuItem
+                    key={getChoiceValue(choice)}
+                    value={getChoiceValue(choice)}
+                    disabled={getDisableValue(choice)}
+                >
+                    {choice?.id === createItem.id
+                        ? createItem.name
+                        : renderMenuItemOption(choice)}
+                </MenuItem>
+            ) : null;
+        },
+        [getChoiceValue, getDisableValue, renderMenuItemOption, createItem]
+    );
+
+    if (loading) {
+        return (
+            <Labeled
+                label={label}
+                source={source}
+                resource={resource}
+                className={className}
+                isRequired={isRequired}
+            >
+                <LinearProgress />
+            </Labeled>
+        );
+    }
+
+    return (
+        <>
+            <FormControl
+                margin={margin}
+                className={classnames(classes.root, className)}
+                error={touched && !!(error || submitError)}
+                variant={variant}
+                {...sanitizeRestProps(rest)}
+            >
+                <InputLabel
+                    ref={inputLabel}
+                    id={`${label}-outlined-label`}
+                    error={touched && !!(error || submitError)}
+                >
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                </InputLabel>
+                <Select
+                    autoWidth
+                    labelId={`${label}-outlined-label`}
+                    multiple
+                    error={!!(touched && (error || submitError))}
+                    renderValue={(selected: any[]) => (
+                        <div className={classes.chips}>
+                            {selected
+                                .map(item =>
+                                    choices.find(
+                                        choice =>
+                                            getChoiceValue(choice) === item
+                                    )
+                                )
+                                .filter(item => !!item)
+                                .map(item => (
+                                    <Chip
+                                        key={getChoiceValue(item)}
+                                        label={renderMenuItemOption(item)}
+                                        className={classes.chip}
+                                    />
+                                ))}
+                        </div>
+                    )}
+                    data-testid="selectArray"
+                    {...input}
+                    onChange={handleChangeWithCreateSupport}
+                    value={input.value || []}
+                    {...options}
+                    labelWidth={labelWidth}
+                >
+                    {finalChoices.map(renderMenuItem)}
+                </Select>
+                <FormHelperText error={touched && !!(error || submitError)}>
+                    <InputHelperText
+                        touched={touched}
+                        error={error || submitError}
+                        helperText={helperText}
+                    />
+                </FormHelperText>
+            </FormControl>
+            {createElement}
+        </>
+    );
+};
+
+export interface SelectArrayInputProps
+    extends Omit<ChoicesProps, 'choices'>,
+        Omit<SupportCreateSuggestionOptions, 'handleChange'>,
+        Omit<InputProps<SelectProps>, 'source'>,
+        Omit<
+            FormControlProps,
+            'defaultValue' | 'onBlur' | 'onChange' | 'onFocus'
+        > {
+    choices?: object[];
+    source?: string;
+}
+
+SelectArrayInput.propTypes = {
+    choices: PropTypes.arrayOf(PropTypes.object),
+    classes: PropTypes.object,
+    className: PropTypes.string,
+    children: PropTypes.node,
+    label: PropTypes.string,
+    options: PropTypes.object,
+    optionText: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.element,
+    ]).isRequired,
+    optionValue: PropTypes.string.isRequired,
+    disableValue: PropTypes.string,
+    resource: PropTypes.string,
+    source: PropTypes.string,
+    translateChoice: PropTypes.bool,
+};
+
+SelectArrayInput.defaultProps = {
+    options: {},
+    optionText: 'name',
+    optionValue: 'id',
+    disableValue: 'disabled',
+    translateChoice: true,
+};
 
 const sanitizeRestProps = ({
     addLabel,
@@ -86,247 +368,5 @@ const useStyles = makeStyles(
     }),
     { name: 'RaSelectArrayInput' }
 );
-
-/**
- * An Input component for a select box allowing multiple selections, using an array of objects for the options
- *
- * Pass possible options as an array of objects in the 'choices' attribute.
- *
- * By default, the options are built from:
- *  - the 'id' property as the option value,
- *  - the 'name' property as the option text
- * @example
- * const choices = [
- *    { id: 'programming', name: 'Programming' },
- *    { id: 'lifestyle', name: 'Lifestyle' },
- *    { id: 'photography', name: 'Photography' },
- * ];
- * <SelectArrayInput source="tags" choices={choices} />
- *
- * You can also customize the properties to use for the option name and value,
- * thanks to the 'optionText' and 'optionValue' attributes.
- * @example
- * const choices = [
- *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
- *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
- * ];
- * <SelectArrayInput source="authors" choices={choices} optionText="full_name" optionValue="_id" />
- *
- * `optionText` also accepts a function, so you can shape the option text at will:
- * @example
- * const choices = [
- *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
- *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
- * ];
- * const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
- * <SelectArrayInput source="authors" choices={choices} optionText={optionRenderer} />
- *
- * `optionText` also accepts a React Element, that will be cloned and receive
- * the related choice as the `record` prop. You can use Field components there.
- * @example
- * const choices = [
- *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
- *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
- * ];
- * const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
- * <SelectArrayInput source="authors" choices={choices} optionText={<FullNameField />}/>
- *
- * The choices are translated by default, so you can use translation identifiers as choices:
- * @example
- * const choices = [
- *    { id: 'programming', name: 'myroot.tags.programming' },
- *    { id: 'lifestyle', name: 'myroot.tags.lifestyle' },
- *    { id: 'photography', name: 'myroot.tags.photography' },
- * ];
- */
-const SelectArrayInput: FunctionComponent<SelectArrayInputProps> = props => {
-    const {
-        choices = [],
-        classes: classesOverride,
-        className,
-        disableValue,
-        format,
-        helperText,
-        label,
-        loaded,
-        loading,
-        margin = 'dense',
-        onBlur,
-        onChange,
-        onFocus,
-        options,
-        optionText,
-        optionValue,
-        parse,
-        resource,
-        source,
-        translateChoice,
-        validate,
-        variant = 'filled',
-        ...rest
-    } = props;
-    const classes = useStyles(props);
-    const inputLabel = useRef(null);
-    const [labelWidth, setLabelWidth] = useState(0);
-    useEffect(() => {
-        // Will be null while loading and we don't need this fix in that case
-        if (inputLabel.current) {
-            setLabelWidth(inputLabel.current.offsetWidth);
-        }
-    }, []);
-
-    const { getChoiceText, getChoiceValue, getDisableValue } = useChoices({
-        optionText,
-        optionValue,
-        disableValue,
-        translateChoice,
-    });
-    const {
-        input,
-        isRequired,
-        meta: { error, submitError, touched },
-    } = useInput({
-        format,
-        onBlur,
-        onChange,
-        onFocus,
-        parse,
-        resource,
-        source,
-        validate,
-        ...rest,
-    });
-
-    const renderMenuItemOption = useCallback(choice => getChoiceText(choice), [
-        getChoiceText,
-    ]);
-
-    const renderMenuItem = useCallback(
-        choice => {
-            return choice ? (
-                <MenuItem
-                    key={getChoiceValue(choice)}
-                    value={getChoiceValue(choice)}
-                    disabled={getDisableValue(choice)}
-                >
-                    {renderMenuItemOption(choice)}
-                </MenuItem>
-            ) : null;
-        },
-        [getChoiceValue, getDisableValue, renderMenuItemOption]
-    );
-
-    if (loading) {
-        return (
-            <Labeled
-                label={label}
-                source={source}
-                resource={resource}
-                className={className}
-                isRequired={isRequired}
-            >
-                <LinearProgress />
-            </Labeled>
-        );
-    }
-
-    return (
-        <FormControl
-            margin={margin}
-            className={classnames(classes.root, className)}
-            error={touched && !!(error || submitError)}
-            variant={variant}
-            {...sanitizeRestProps(rest)}
-        >
-            <InputLabel
-                ref={inputLabel}
-                id={`${label}-outlined-label`}
-                error={touched && !!(error || submitError)}
-            >
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
-            </InputLabel>
-            <Select
-                autoWidth
-                labelId={`${label}-outlined-label`}
-                multiple
-                error={!!(touched && (error || submitError))}
-                renderValue={(selected: any[]) => (
-                    <div className={classes.chips}>
-                        {selected
-                            .map(item =>
-                                choices.find(
-                                    choice => getChoiceValue(choice) === item
-                                )
-                            )
-                            .map(item => (
-                                <Chip
-                                    key={getChoiceValue(item)}
-                                    label={renderMenuItemOption(item)}
-                                    className={classes.chip}
-                                />
-                            ))}
-                    </div>
-                )}
-                data-testid="selectArray"
-                {...input}
-                value={input.value || []}
-                {...options}
-                labelWidth={labelWidth}
-            >
-                {choices.map(renderMenuItem)}
-            </Select>
-            <FormHelperText error={touched && !!(error || submitError)}>
-                <InputHelperText
-                    touched={touched}
-                    error={error || submitError}
-                    helperText={helperText}
-                />
-            </FormHelperText>
-        </FormControl>
-    );
-};
-
-export interface SelectArrayInputProps
-    extends Omit<ChoicesProps, 'choices'>,
-        Omit<InputProps<SelectProps>, 'source'>,
-        Omit<
-            FormControlProps,
-            'defaultValue' | 'onBlur' | 'onChange' | 'onFocus'
-        > {
-    choices?: object[];
-    source?: string;
-}
-
-SelectArrayInput.propTypes = {
-    choices: PropTypes.arrayOf(PropTypes.object),
-    classes: PropTypes.object,
-    className: PropTypes.string,
-    children: PropTypes.node,
-    label: PropTypes.string,
-    options: PropTypes.object,
-    optionText: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.func,
-        PropTypes.element,
-    ]).isRequired,
-    optionValue: PropTypes.string.isRequired,
-    disableValue: PropTypes.string,
-    resource: PropTypes.string,
-    source: PropTypes.string,
-    translateChoice: PropTypes.bool,
-};
-
-SelectArrayInput.defaultProps = {
-    options: {},
-    optionText: 'name',
-    optionValue: 'id',
-    disableValue: 'disabled',
-    translateChoice: true,
-};
 
 export default SelectArrayInput;

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -5,7 +5,7 @@ import { TestTranslationProvider } from 'ra-core';
 
 import { SelectInput } from './SelectInput';
 import { required } from 'ra-core';
-import { useCreateSuggestion } from './useSupportCreateSuggestion';
+import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 describe('<SelectInput />', () => {
     const defaultProps = {
@@ -590,7 +590,7 @@ describe('<SelectInput />', () => {
         const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
 
         const Create = () => {
-            const context = useCreateSuggestion();
+            const context = useCreateSuggestionContext();
             const handleClick = () => {
                 choices.push(newChoice);
                 context.onCreate(newChoice);

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -593,7 +593,7 @@ describe('<SelectInput />', () => {
             const context = useCreateSuggestion();
             const handleClick = () => {
                 choices.push(newChoice);
-                context.onCreate(newChoice.id, newChoice);
+                context.onCreate(newChoice);
             };
 
             return <button onClick={handleClick}>Get the kid</button>;

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
 
 import { SelectInput } from './SelectInput';
 import { required } from 'ra-core';
+import { useCreateSuggestion } from './useSupportCreateSuggestion';
 
 describe('<SelectInput />', () => {
     const defaultProps = {
@@ -495,16 +496,137 @@ describe('<SelectInput />', () => {
             <Form
                 validateOnBlur
                 onSubmit={jest.fn()}
+                render={() => <SelectInput {...defaultProps} />}
+            />
+        );
+
+        expect(queryByRole('progressbar')).toBeNull();
+    });
+
+    test('should support creation of a new choice through the onCreate event', async () => {
+        const choices = [...defaultProps.choices];
+        const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
+
+        const { getByLabelText, getByRole, getByText, queryByText } = render(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
                 render={() => (
                     <SelectInput
-                        {...{
-                            ...defaultProps,
+                        {...defaultProps}
+                        choices={choices}
+                        onCreate={() => {
+                            choices.push(newChoice);
+                            return newChoice;
                         }}
                     />
                 )}
             />
         );
 
-        expect(queryByRole('progressbar')).toBeNull();
+        const input = getByLabelText(
+            'resources.posts.fields.language'
+        ) as HTMLInputElement;
+        input.focus();
+        const select = getByRole('button');
+        fireEvent.mouseDown(select);
+
+        fireEvent.click(getByText('ra.action.create'));
+        await new Promise(resolve => setImmediate(resolve));
+        input.blur();
+
+        expect(
+            // The selector ensure we don't get the options from the menu but the select value
+            queryByText(newChoice.name, { selector: '[role=button]' })
+        ).not.toBeNull();
+    });
+
+    test('should support creation of a new choice through the onCreate event with a promise', async () => {
+        const choices = [...defaultProps.choices];
+        const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
+
+        const { getByLabelText, getByRole, getByText, queryByText } = render(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <SelectInput
+                        {...defaultProps}
+                        choices={choices}
+                        onCreate={() => {
+                            return new Promise(resolve => {
+                                setTimeout(() => {
+                                    choices.push(newChoice);
+                                    resolve(newChoice);
+                                }, 200);
+                            });
+                        }}
+                    />
+                )}
+            />
+        );
+
+        const input = getByLabelText(
+            'resources.posts.fields.language'
+        ) as HTMLInputElement;
+        input.focus();
+        const select = getByRole('button');
+        fireEvent.mouseDown(select);
+
+        fireEvent.click(getByText('ra.action.create'));
+        await new Promise(resolve => setImmediate(resolve));
+        input.blur();
+
+        await waitFor(() => {
+            expect(
+                // The selector ensure we don't get the options from the menu but the select value
+                queryByText(newChoice.name, { selector: '[role=button]' })
+            ).not.toBeNull();
+        });
+    });
+
+    test('should support creation of a new choice through the create element', async () => {
+        const choices = [...defaultProps.choices];
+        const newChoice = { id: 'js_fatigue', name: 'New Kid On The Block' };
+
+        const Create = () => {
+            const context = useCreateSuggestion();
+            const handleClick = () => {
+                choices.push(newChoice);
+                context.onCreate(newChoice.id, newChoice);
+            };
+
+            return <button onClick={handleClick}>Get the kid</button>;
+        };
+
+        const { getByLabelText, getByRole, getByText, queryByText } = render(
+            <Form
+                validateOnBlur
+                onSubmit={jest.fn()}
+                render={() => (
+                    <SelectInput
+                        {...defaultProps}
+                        choices={choices}
+                        create={<Create />}
+                    />
+                )}
+            />
+        );
+
+        const input = getByLabelText(
+            'resources.posts.fields.language'
+        ) as HTMLInputElement;
+        input.focus();
+        const select = getByRole('button');
+        fireEvent.mouseDown(select);
+
+        fireEvent.click(getByText('ra.action.create'));
+        fireEvent.click(getByText('Get the kid'));
+        input.blur();
+
+        expect(
+            // The selector ensure we don't get the options from the menu but the select value
+            queryByText(newChoice.name, { selector: '[role=button]' })
+        ).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { Form } from 'react-final-form';
 import { TestTranslationProvider } from 'ra-core';
 
-import SelectInput from './SelectInput';
+import { SelectInput } from './SelectInput';
 import { required } from 'ra-core';
 
 describe('<SelectInput />', () => {

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -23,7 +23,6 @@ import {
     useSupportCreateSuggestion,
     SupportCreateSuggestionOptions,
 } from './useSupportCreateSuggestion';
-import { useForm } from 'react-final-form';
 
 /**
  * An Input component for a select box, using an array of objects for the options
@@ -175,18 +174,17 @@ export const SelectInput = (props: SelectInputProps) => {
         getChoiceText,
     ]);
 
-    const form = useForm();
     const handleChange = useCallback(
         async (event: React.ChangeEvent<HTMLSelectElement>, newItem) => {
             if (newItem) {
                 const value = getChoiceValue(newItem);
-                form.change(source, value);
+                input.onChange(value);
                 return;
             }
 
             input.onChange(event);
         },
-        [input, form, getChoiceValue, source]
+        [input, getChoiceValue]
     );
 
     const {

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -24,7 +24,7 @@ import {
     SupportCreateSuggestionOptions,
 } from './useSupportCreateSuggestion';
 
-interface SelectInputProps
+export interface SelectInputProps
     extends ChoicesInputProps<TextFieldProps>,
         Omit<SupportCreateSuggestionOptions, 'source'>,
         Omit<TextFieldProps, 'label' | 'helperText'> {}
@@ -103,7 +103,7 @@ interface SelectInputProps
  * <SelectInput source="gender" choices={choices} disableValue="not_available" />
  *
  */
-const SelectInput = (props: SelectInputProps) => {
+export const SelectInput = (props: SelectInputProps) => {
     const {
         allowEmpty,
         choices = [],
@@ -351,5 +351,3 @@ const useStyles = makeStyles(
     }),
     { name: 'RaSelectInput' }
 );
-
-export default SelectInput;

--- a/packages/ra-ui-materialui/src/input/index.ts
+++ b/packages/ra-ui-materialui/src/input/index.ts
@@ -2,7 +2,6 @@ import ArrayInput, { ArrayInputProps } from './ArrayInput';
 import AutocompleteArrayInput, {
     AutocompleteArrayInputProps,
 } from './AutocompleteArrayInput';
-import AutocompleteInput, { AutocompleteInputProps } from './AutocompleteInput';
 import BooleanInput from './BooleanInput';
 import CheckboxGroupInput, {
     CheckboxGroupInputProps,
@@ -34,6 +33,8 @@ import SelectArrayInput, { SelectArrayInputProps } from './SelectArrayInput';
 import SelectInput, { SelectInputProps } from './SelectInput';
 import TextInput, { TextInputProps } from './TextInput';
 import sanitizeInputRestProps from './sanitizeInputRestProps';
+export * from './AutocompleteInput';
+export * from './useSupportCreateSuggestion';
 export * from './TranslatableInputs';
 export * from './TranslatableInputsTabContent';
 export * from './TranslatableInputsTabs';
@@ -42,7 +43,6 @@ export * from './TranslatableInputsTab';
 export {
     ArrayInput,
     AutocompleteArrayInput,
-    AutocompleteInput,
     BooleanInput,
     CheckboxGroupInput,
     DateInput,
@@ -68,7 +68,6 @@ export {
 
 export type {
     ArrayInputProps,
-    AutocompleteInputProps,
     AutocompleteArrayInputProps,
     CheckboxGroupInputProps,
     DateInputProps,

--- a/packages/ra-ui-materialui/src/input/index.ts
+++ b/packages/ra-ui-materialui/src/input/index.ts
@@ -30,10 +30,10 @@ import ResettableTextField, {
 } from './ResettableTextField';
 import SearchInput, { SearchInputProps } from './SearchInput';
 import SelectArrayInput, { SelectArrayInputProps } from './SelectArrayInput';
-import SelectInput, { SelectInputProps } from './SelectInput';
 import TextInput, { TextInputProps } from './TextInput';
 import sanitizeInputRestProps from './sanitizeInputRestProps';
 export * from './AutocompleteInput';
+export * from './SelectInput';
 export * from './useSupportCreateSuggestion';
 export * from './TranslatableInputs';
 export * from './TranslatableInputsTabContent';
@@ -61,7 +61,6 @@ export {
     ResettableTextField,
     SearchInput,
     SelectArrayInput,
-    SelectInput,
     TextInput,
     sanitizeInputRestProps,
 };
@@ -85,6 +84,5 @@ export type {
     ResettableTextFieldProps,
     SearchInputProps,
     SelectArrayInputProps,
-    SelectInputProps,
     TextInputProps,
 };

--- a/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
+++ b/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import {
+    ChangeEvent,
+    createContext,
+    isValidElement,
+    ReactElement,
+    useContext,
+    useState,
+} from 'react';
+import { useTranslate } from 'ra-core';
+import { useForm } from 'react-final-form';
+
+/**
+ * This hook provides support for suggestion creation in inputs which have choices.
+ *
+ * @param options The hook option
+ * @param {ReactElement} options.create A react element which will be rendered when users choose to create a new choice. This component must call the `useCreateSuggestion` hook which provides `onCancel`, `onCreate` and `filter`. See the examples.
+ * @param {String} options.createLabel Optional. The label for the choice item allowing users to create a new choice. Can be a translation key. Defaults to `ra.action.create`.
+ * @param {String} options.createItemLabel Optional. The label for the choice item allowing users to create a new choice when they already entered a filter. Can be a translation key. The translation will receive an `item` parameter. Defaults to `ra.action.create_item`.
+ * @param {any} options.createValue Optional. The value for the choice item allowing users to create a new choice. Defaults to `@@ra-create`.
+ * @param {String} options.filter Optional. The filter users may have already entered. Useful for autocomplete inputs for example.
+ * @param {OnCreateHandler} options.onCreate Optional. A function which will be called when users choose to create a new choice, if the `create` option wasn't provided.
+ * @param {String} options.source The input source. Used to trigger a form change upon successful creation.
+ * @returns {UseSupportCreateValue} An object with the following properties:
+ * - getCreateItemLabel: a function which will return the label of the choice for create a new choice.
+ * - handleChange: a function to pass to the input. Accept the event or the value selected and the original onChange handler of the input. This original handler will be called if users haven't asked to create a new choice.
+ * - createElement: a React element to render after the input. It will be rendered when users choose to create a new choice. It renders null otherwise.
+ */
+export const useSupportCreateSuggestion = (
+    options: SupportCreateSuggestionOptions
+): UseSupportCreateValue => {
+    const {
+        create,
+        createLabel = 'ra.action.create',
+        createItemLabel = 'ra.action.create_item',
+        createValue = '@@ra-create',
+        filter,
+        onCreate,
+        source,
+    } = options;
+    const translate = useTranslate();
+    const form = useForm();
+    const [renderOnCreate, setRenderOnCreate] = useState(false);
+
+    const context = {
+        filter,
+        onCancel: () => setRenderOnCreate(false),
+        onCreate: (value, item) => {
+            setRenderOnCreate(false);
+            form.change(source, value);
+        },
+    };
+
+    return {
+        getCreateItemLabel: () => {
+            return filter && createItemLabel
+                ? translate(createItemLabel, {
+                      item: filter,
+                      _: createItemLabel,
+                  })
+                : translate(createLabel, { _: createLabel });
+        },
+        handleChange: async (eventOrValue, handleChange) => {
+            const value = eventOrValue.target?.value || eventOrValue;
+
+            if (value === createValue) {
+                if (!isValidElement(create)) {
+                    const newSuggestion = await onCreate(filter);
+
+                    if (newSuggestion) {
+                        form.change(source, value);
+                        return;
+                    }
+                } else {
+                    setRenderOnCreate(true);
+                    return;
+                }
+            }
+            handleChange();
+        },
+        createElement:
+            renderOnCreate && isValidElement(create) ? (
+                <CreateSuggestionContext.Provider value={context}>
+                    {create}
+                </CreateSuggestionContext.Provider>
+            ) : null,
+    };
+};
+
+export interface SupportCreateSuggestionOptions {
+    create?: ReactElement;
+    createValue?: string;
+    createLabel?: string;
+    createItemLabel?: string;
+    filter?: string;
+    onCreate?: OnCreateHandler;
+    source: string;
+}
+
+export interface UseSupportCreateValue {
+    getCreateItemLabel: () => string;
+    handleChange: (
+        eventOrValue: ChangeEvent | any,
+        handleChange: (value?: any) => void
+    ) => Promise<void>;
+    createElement: ReactElement | null;
+}
+
+const CreateSuggestionContext = createContext<CreateSuggestionContextValue>(
+    undefined
+);
+
+interface CreateSuggestionContextValue {
+    filter?: string;
+    onCreate: (value: any, choice: any) => void;
+    onCancel: () => void;
+}
+export const useCreateSuggestion = () => useContext(CreateSuggestionContext);
+
+export type OnCreateHandler = (filter?: string) => any | Promise<any>;

--- a/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
+++ b/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
@@ -63,7 +63,13 @@ export const useSupportCreateSuggestion = (
         },
         handleChange: async eventOrValue => {
             const value = eventOrValue.target?.value || eventOrValue;
-            if (value?.id === createValue || value === createValue) {
+            const finalValue = Array.isArray(value) ? [...value].pop() : value;
+
+            if (eventOrValue?.preventDefault) {
+                eventOrValue.preventDefault();
+                eventOrValue.stopPropagation();
+            }
+            if (finalValue?.id === createValue || finalValue === createValue) {
                 if (!isValidElement(create)) {
                     const newSuggestion = await onCreate(filter);
 

--- a/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
+++ b/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
@@ -13,7 +13,7 @@ import { Identifier, useTranslate } from 'ra-core';
  * This hook provides support for suggestion creation in inputs which have choices.
  *
  * @param options The hook option
- * @param {ReactElement} options.create A react element which will be rendered when users choose to create a new choice. This component must call the `useCreateSuggestion` hook which provides `onCancel`, `onCreate` and `filter`. See the examples.
+ * @param {ReactElement} options.create A react element which will be rendered when users choose to create a new choice. This component must call the `useCreateSuggestionContext` hook which provides `onCancel`, `onCreate` and `filter`. See the examples.
  * @param {String} options.createLabel Optional. The label for the choice item allowing users to create a new choice. Can be a translation key. Defaults to `ra.action.create`.
  * @param {String} options.createItemLabel Optional. The label for the choice item allowing users to create a new choice when they already entered a filter. Can be a translation key. The translation will receive an `item` parameter. Defaults to `ra.action.create_item`.
  * @param {any} options.createValue Optional. The value for the choice item allowing users to create a new choice. Defaults to `@@ra-create`.
@@ -118,6 +118,7 @@ interface CreateSuggestionContextValue {
     onCreate: (choice: any) => void;
     onCancel: () => void;
 }
-export const useCreateSuggestion = () => useContext(CreateSuggestionContext);
+export const useCreateSuggestionContext = () =>
+    useContext(CreateSuggestionContext);
 
 export type OnCreateHandler = (filter?: string) => any | Promise<any>;

--- a/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
+++ b/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
@@ -42,7 +42,7 @@ export const useSupportCreateSuggestion = (
     const context = {
         filter,
         onCancel: () => setRenderOnCreate(false),
-        onCreate: (value, item) => {
+        onCreate: item => {
             setRenderOnCreate(false);
             handleChange(undefined, item);
         },
@@ -115,7 +115,7 @@ const CreateSuggestionContext = createContext<CreateSuggestionContextValue>(
 
 interface CreateSuggestionContextValue {
     filter?: string;
-    onCreate: (value: any, choice: any) => void;
+    onCreate: (choice: any) => void;
     onCancel: () => void;
 }
 export const useCreateSuggestion = () => useContext(CreateSuggestionContext);

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -5,7 +5,7 @@ import { renderWithRedux } from 'ra-test';
 
 import FilterForm, { mergeInitialValuesWithDefaultValues } from './FilterForm';
 import TextInput from '../../input/TextInput';
-import SelectInput from '../../input/SelectInput';
+import { SelectInput } from '../../input/SelectInput';
 
 describe('<FilterForm />', () => {
     const defaultProps = {


### PR DESCRIPTION
- [x] Add support for creation in `SelectInput`
- [x] Add support for creation in `AutocompleteInput`
- [x] Check support for creation in `ReferenceInput`
- [x] Add support for creation in `AutocompleteArrayInput`
- [x] Check support for creation in `ReferenceArrayInput`
- [x] Add support for creation in `SelectArrayInput`
- [x] Tests
- [x] Documentation

![ra-quick-create](https://user-images.githubusercontent.com/1122076/114988072-32d47700-9e96-11eb-9295-1f72617514db.gif)

![ra-quick-create-autocomplete-modal-reference](https://user-images.githubusercontent.com/1122076/114987994-1c2e2000-9e96-11eb-82a4-4639a454d863.gif)

![ra-quick-create-autocompletearray-modal-reference](https://user-images.githubusercontent.com/1122076/114988033-27814b80-9e96-11eb-8686-7bc797e22f15.gif)
