### PR TITLE
Add ability to call specialized dataProvider hooks with specialized parameters

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -442,13 +442,33 @@ const BulkResetViewsButton = ({ selectedIds }) => {
 ```jsx
 // syntax
 const [deleteOne, { data, loading, loaded, error }] = useDelete(resource, id, previousData, options);
+```
 
-// example
+The `deleteOne()` function can be called in 3 different ways:
+ - with the same parameters as the `useDelete()` hook: `deleteOne(resource, id, previousData, options)`
+ - with the same syntax as `useMutation`: `deleteOne({ resource, payload: { id, previousData } }, options)`
+ - with no parameter (if they were already passed to `useDelete()`): `deleteOne()`
+
+```jsx
+// set params when calling the deleteOne callback
 import { useDelete } from 'react-admin';
+
 const DeleteButton = ({ record }) => {
-    const [deleteOne, { loading, error }] = useDelete('likes', record.id);
+    const [deleteOne, { loading, error }] = useDelete();
+    const handleClick = () => {
+        deleteOne('likes', record.id, record)
+    }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={deleteOne}>Delete</button>;
+    return <button disabled={loading} onClick={handleClick}>Delete</div>;
+};
+
+// set params when calling the hook
+import { useDelete } from 'react-admin';
+
+const DeleteButton = ({ record }) => {
+    const [deleteOne, { loading, error }] = useDelete('likes', record.id, record);
+    if (error) { return <p>ERROR</p>; }
+    return <button disabled={loading} onClick={deleteOne}>Delete</div>;
 };
 ```
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -517,10 +517,30 @@ const DeleteButton = ({ record }) => {
 
 ```jsx
 // syntax
-const [deleteOne, { data, loading, loaded, error }] = useDeleteMany(resource, ids, options);
+const [deleteMany, { data, loading, loaded, error }] = useDeleteMany(resource, ids, options);
+```
 
-// example
+The `deleteMany()` function can be called in 3 different ways:
+ - with the same parameters as the `useDeleteMany()` hook: `deleteMany(resource, ids, options)`
+ - with the same syntax as `useMutation`: `deleteMany({ resource, payload: { ids } }, options)`
+ - with no parameter (if they were already passed to `useDeleteMany()`): `deleteMany()`
+
+```jsx
+// set params when calling the dleteMany callback
 import { useDeleteMany } from 'react-admin';
+
+const BulkDeletePostsButton = ({ selectedIds }) => {
+    const [deleteMany, { loading, error }] = useDeleteMany();
+    const handleClick = () => {
+        deleteMany('posts', selectedIds)
+    }
+    if (error) { return <p>ERROR</p>; }
+    return <button disabled={loading} onClick={deleteMany}>Delete selected posts</button>;
+};
+
+// set params when calling the hook
+import { useDeleteMany } from 'react-admin';
+
 const BulkDeletePostsButton = ({ selectedIds }) => {
     const [deleteMany, { loading, error }] = useDeleteMany('posts', selectedIds);
     if (error) { return <p>ERROR</p>; }

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -390,14 +390,35 @@ const LikeButton = ({ record }) => {
 ```jsx
 // syntax
 const [update, { data, loading, loaded, error }] = useUpdate(resource, id, data, previousData, options);
+```
 
-// example
+The `update()` method can be called in 3 different ways:
+ - with the same parameters as the `useUpdate()` hook: `update(resource, id, data, previousData, options)`
+ - with the same syntax as `useMutation`: `update({ resource, payload: { id, data, previousData } }, options)`
+ - with no parameter (if they were already passed to useUpdate()): `update()`
+
+```jsx
+// set params when calling the update callback
 import { useUpdate } from 'react-admin';
+
+const IncreaseLikeButton = ({ record }) => {
+    const diff = { likes: record.likes + 1 };
+    const [update, { loading, error }] = useUpdate();
+    const handleClick = () => {
+        update('likes', record.id, diff, record)
+    }
+    if (error) { return <p>ERROR</p>; }
+    return <button disabled={loading} onClick={handleClick}>Like</div>;
+};
+
+// or set params when calling the hook
+import { useUpdate } from 'react-admin';
+
 const IncreaseLikeButton = ({ record }) => {
     const diff = { likes: record.likes + 1 };
     const [update, { loading, error }] = useUpdate('likes', record.id, diff, record);
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={update}>Like</button>;
+    return <button disabled={loading} onClick={update}>Like</div>;
 };
 ```
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -374,9 +374,30 @@ const PostComments = ({ post_id }) => {
 ```jsx
 // syntax
 const [create, { data, loading, loaded, error }] = useCreate(resource, data, options);
+```
 
-// example
+The `create()` function can be called in 3 different ways:
+ - with the same parameters as the `useCreate()` hook: `create(resource, data, options)`
+ - with the same syntax as `useMutation`: `create({ resource, payload: { data } }, options)`
+ - with no parameter (if they were already passed to `useCreate()`): `create()`
+
+```jsx
+// set params when calling the update callback
 import { useCreate } from 'react-admin';
+
+const LikeButton = ({ record }) => {
+    const like = { postId: record.id };
+    const [create, { loading, error }] = useCreate();
+    const handleClick = () => {
+        create('likes', like)
+    }
+    if (error) { return <p>ERROR</p>; }
+    return <button disabled={loading} onClick={handleClick}>Like</button>;
+};
+
+// set params when calling the hook
+import { useCreate } from 'react-admin';
+
 const LikeButton = ({ record }) => {
     const like = { postId: record.id };
     const [create, { loading, error }] = useCreate('likes', like);

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -448,9 +448,29 @@ const IncreaseLikeButton = ({ record }) => {
 ```jsx
 // syntax
 const [updateMany, { data, loading, loaded, error }] = useUpdateMany(resource, ids, data, options);
+```
 
-// example
+The `updateMany()` function can be called in 3 different ways:
+ - with the same parameters as the `useUpdateMany()` hook: `update(resource, ids, data, options)`
+ - with the same syntax as `useMutation`: `update({ resource, payload: { ids, data } }, options)`
+ - with no parameter (if they were already passed to `useUpdateMany()`): `updateMany()`
+
+```jsx
+// set params when calling the updateMany callback
 import { useUpdateMany } from 'react-admin';
+
+const BulkResetViewsButton = ({ selectedIds }) => {
+    const [updateMany, { loading, error }] = useUpdateMany();
+    const handleClick = () => {
+        updateMany('posts', selectedIds, { views: 0 });
+    }
+    if (error) { return <p>ERROR</p>; }
+    return <button disabled={loading} onClick={handleClick}>Reset views</button>;
+};
+
+// set params when calling the hook
+import { useUpdateMany } from 'react-admin';
+
 const BulkResetViewsButton = ({ selectedIds }) => {
     const [updateMany, { loading, error }] = useUpdateMany('posts', selectedIds, { views: 0 });
     if (error) { return <p>ERROR</p>; }

--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { renderWithRedux } from 'ra-test';
+import { waitFor } from '@testing-library/react';
+import expect from 'expect';
+
+import { DataProvider, Record } from '../types';
+import DataProviderContext from './DataProviderContext';
+import useCreate from './useCreate';
+
+describe('useCreate', () => {
+    it('returns a callback that can be used with create arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localCreate;
+        const Dummy = () => {
+            const [create] = useCreate();
+            localCreate = create;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localCreate('foo', { bar: 'baz' });
+        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+            data: { bar: 'baz' },
+        });
+    });
+
+    it('returns a callback that can be used with mutation payload', () => {
+        const dataProvider: Partial<DataProvider> = {
+            create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localCreate;
+        const Dummy = () => {
+            const [create] = useCreate();
+            localCreate = create;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localCreate({
+            type: 'update',
+            resource: 'foo',
+            payload: {
+                data: { bar: 'baz' },
+            },
+        });
+        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+            data: { bar: 'baz' },
+        });
+    });
+
+    it('returns a callback that can be used with no arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localCreate;
+        const Dummy = () => {
+            const [create] = useCreate('foo', { bar: 'baz' });
+            localCreate = create;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localCreate();
+        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+            data: { bar: 'baz' },
+        });
+    });
+
+    it('merges hook call time and callback call time queries', () => {
+        const dataProvider: Partial<DataProvider> = {
+            create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localCreate;
+        const Dummy = () => {
+            const [create] = useCreate('foo', { bar: 'baz' });
+            localCreate = create;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localCreate({ payload: { data: { foo: 456 } } });
+        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+            data: { bar: 'baz', foo: 456 },
+        });
+    });
+
+    it('returns a state typed based on the parametric type', async () => {
+        interface Product extends Record {
+            sku: string;
+        }
+        const dataProvider: Partial<DataProvider> = {
+            create: jest.fn(() =>
+                Promise.resolve({ data: { id: 1, sku: 'abc' } } as any)
+            ),
+        };
+        let localCreate;
+        let sku;
+        const Dummy = () => {
+            const [create, { data }] = useCreate<Product>();
+            localCreate = create;
+            sku = data && data.sku;
+            return <span />;
+        };
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        expect(sku).toBeNull();
+        localCreate('products', { sku: 'abc' });
+        await waitFor(() => {
+            expect(sku).toEqual('abc');
+        });
+    });
+});

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -1,13 +1,16 @@
-import useMutation, { MutationOptions } from './useMutation';
+import { useCallback } from 'react';
+import { Record } from '../types';
+import useMutation, { MutationOptions, Mutation } from './useMutation';
 
 /**
  * Get a callback to call the dataProvider.create() method, the result and the loading state.
  *
  * The return value updates according to the request state:
  *
- * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
- * - error: [callback, { error: [error from response], loading: false, loaded: true }]
+ * - initial: [create, { loading: false, loaded: false }]
+ * - start:   [create, { loading: true, loaded: false }]
+ * - success: [create, { data: [data from response], loading: false, loaded: true }]
+ * - error:   [create, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param data The data to initialize the new record with, e.g. { title: 'hello, world' }
@@ -15,7 +18,26 @@ import useMutation, { MutationOptions } from './useMutation';
  *
  * @returns The current request state. Destructure as [create, { data, error, loading, loaded }].
  *
- * @example
+ * The create() function can be called in 3 different ways:
+ *  - with the same parameters as the useCreate() hook: create(resource, data, options)
+ *  - with the same syntax as useMutation: create({ resource, payload: { data } }, options)
+ *  - with no parameter (if they were already passed to useCreate()): create()
+ *
+ * @example // set params when calling the update callback
+ *
+ * import { useCreate } from 'react-admin';
+ *
+ * const LikeButton = ({ record }) => {
+ *     const like = { postId: record.id };
+ *     const [create, { loading, error }] = useCreate();
+ *     const handleClick = () => {
+ *         create('likes', like)
+ *     }
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <button disabled={loading} onClick={handleClick}>Like</button>;
+ * };
+ *
+ * @example // set params when calling the hook
  *
  * import { useCreate } from 'react-admin';
  *
@@ -26,10 +48,57 @@ import useMutation, { MutationOptions } from './useMutation';
  *     return <button disabled={loading} onClick={create}>Like</button>;
  * };
  */
-const useCreate = (
-    resource: string,
-    data: any = {},
+const useCreate = <RecordType extends Record = Record>(
+    resource?: string,
+    data?: Partial<RecordType>,
     options?: MutationOptions
-) => useMutation({ type: 'create', resource, payload: { data } }, options);
+): UseCreateHookValue<RecordType> => {
+    const [mutate, state] = useMutation(
+        { type: 'create', resource, payload: { data } },
+        options
+    );
+
+    const create = useCallback(
+        (
+            resource?: string | Partial<Mutation> | Event,
+            data?: Partial<RecordType>,
+            options?: MutationOptions
+        ) => {
+            if (typeof resource === 'string') {
+                const query = {
+                    type: 'create',
+                    resource,
+                    payload: {
+                        data,
+                    },
+                };
+                return mutate(query, options);
+            } else {
+                return mutate(
+                    resource as Mutation | Event,
+                    data as MutationOptions
+                );
+            }
+        },
+        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    return [create, state];
+};
+
+type UseCreateHookValue<RecordType extends Record = Record> = [
+    (
+        resource?: string | Partial<Mutation> | Event,
+        data?: Partial<RecordType>,
+        options?: MutationOptions
+    ) => void | Promise<any>,
+    {
+        data?: RecordType;
+        total?: number;
+        error?: any;
+        loading: boolean;
+        loaded: boolean;
+    }
+];
 
 export default useCreate;

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { renderWithRedux } from 'ra-test';
+import { waitFor } from '@testing-library/react';
+import expect from 'expect';
+
+import { DataProvider, Record } from '../types';
+import DataProviderContext from './DataProviderContext';
+import useDelete from './useDelete';
+
+describe('useDelete', () => {
+    it('returns a callback that can be used with deleteOne arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            delete: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localDeleteOne;
+        const Dummy = () => {
+            const [deleteOne] = useDelete();
+            localDeleteOne = deleteOne;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localDeleteOne('foo', 1, { id: 1, bar: 'bar' });
+        expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+            id: 1,
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('returns a callback that can be used with mutation payload', () => {
+        const dataProvider: Partial<DataProvider> = {
+            delete: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localDeleteOne;
+        const Dummy = () => {
+            const [deleteOne] = useDelete();
+            localDeleteOne = deleteOne;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localDeleteOne({
+            type: 'delete',
+            resource: 'foo',
+            payload: {
+                id: 1,
+                previousData: { id: 1, bar: 'bar' },
+            },
+        });
+        expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+            id: 1,
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('returns a callback that can be used with no arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            delete: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localDeleteOne;
+        const Dummy = () => {
+            const [deleteOne] = useDelete('foo', 1, { id: 1, bar: 'bar' });
+            localDeleteOne = deleteOne;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localDeleteOne();
+        expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+            id: 1,
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('merges hook call time and callback call time queries', () => {
+        const dataProvider: Partial<DataProvider> = {
+            delete: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localDeleteOne;
+        const Dummy = () => {
+            const [deleteOne] = useDelete('foo', 1, { id: 1, bar: 'bar' });
+            localDeleteOne = deleteOne;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localDeleteOne({ payload: { previousData: { foo: 456 } } });
+        expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+            id: 1,
+            previousData: { id: 1, bar: 'bar', foo: 456 },
+        });
+    });
+
+    it('returns a state typed based on the parametric type', async () => {
+        interface Product extends Record {
+            sku: string;
+        }
+        const dataProvider: Partial<DataProvider> = {
+            delete: jest.fn(() =>
+                Promise.resolve({ data: { id: 1, sku: 'abc' } } as any)
+            ),
+        };
+        let localDeleteOne;
+        let sku;
+        const Dummy = () => {
+            const [deleteOne, { data }] = useDelete<Product>();
+            localDeleteOne = deleteOne;
+            sku = data && data.sku;
+            return <span />;
+        };
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        expect(sku).toBeNull();
+        localDeleteOne('products', 1, { id: 1, sku: 'bcd' });
+        await waitFor(() => {
+            expect(sku).toEqual('abc');
+        });
+    });
+});

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -1,5 +1,6 @@
-import useMutation, { MutationOptions } from './useMutation';
-import { Identifier } from '../types';
+import { useCallback } from 'react';
+import { Identifier, Record } from '../types';
+import useMutation, { MutationOptions, Mutation } from './useMutation';
 
 /**
  * Get a callback to call the dataProvider.delete() method, the result
@@ -7,36 +8,101 @@ import { Identifier } from '../types';
  *
  * The return value updates according to the request state:
  *
- * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
- * - error: [callback, { error: [error from response], loading: false, loaded: true }]
+ * - initial: [deleteOne, { loading: false, loaded: false }]
+ * - start:   [deleteOne, { loading: true, loaded: false }]
+ * - success: [deleteOne, { data: [data from response], loading: false, loaded: true }]
+ * - error:   [deleteOne, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param id The resource identifier, e.g. 123
  * @param previousData The record before the delete is applied
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [delete, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [delteOne, { data, error, loading, loaded }].
  *
- * @example
+ * The deleteOne() function can be called in 3 different ways:
+ *  - with the same parameters as the useDelete() hook: deleteOne(resource, id, previousData, options)
+ *  - with the same syntax as useMutation: deleteOne({ resource, payload: { id, previousData } }, options)
+ *  - with no parameter (if they were already passed to useDelete()): deleteOne()
+ *
+ * @example // set params when calling the deleteOne callback
  *
  * import { useDelete } from 'react-admin';
  *
  * const DeleteButton = ({ record }) => {
- *     const [deleteOne, { loading, error }] = useDelete('likes', record.id);
+ *     const [deleteOne, { loading, error }] = useDelete();
+ *     const handleClick = () => {
+ *         deleteOne('likes', record.id, record)
+ *     }
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <button disabled={loading} onClick={handleClick}>Delete</div>;
+ * };
+ *
+ * @example // set params when calling the hook
+ *
+ * import { useDelete } from 'react-admin';
+ *
+ * const DeleteButton = ({ record }) => {
+ *     const [deleteOne, { loading, error }] = useDelete('likes', record.id, record);
  *     if (error) { return <p>ERROR</p>; }
  *     return <button disabled={loading} onClick={deleteOne}>Delete</div>;
  * };
  */
-const useDelete = (
-    resource: string,
-    id: Identifier,
+const useDelete = <RecordType extends Record = Record>(
+    resource?: string,
+    id?: Identifier,
     previousData: any = {},
     options?: MutationOptions
-) =>
-    useMutation(
+): UseDeleteHookValue<RecordType> => {
+    const [mutate, state] = useMutation(
         { type: 'delete', resource, payload: { id, previousData } },
         options
     );
+
+    const deleteOne = useCallback(
+        (
+            resource?: string | Partial<Mutation> | Event,
+            id?: Identifier | Partial<MutationOptions>,
+            previousData?: any,
+            options?: MutationOptions
+        ) => {
+            if (typeof resource === 'string') {
+                const query = {
+                    type: 'delete',
+                    resource,
+                    payload: {
+                        id: id as Identifier,
+                        previousData,
+                    },
+                };
+                return mutate(query, options);
+            } else {
+                return mutate(
+                    resource as Mutation | Event,
+                    id as MutationOptions
+                );
+            }
+        },
+        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    return [deleteOne, state];
+};
+
+type UseDeleteHookValue<RecordType extends Record = Record> = [
+    (
+        resource?: string | Partial<Mutation> | Event,
+        id?: Identifier | Partial<MutationOptions>,
+        previousData?: RecordType,
+        options?: MutationOptions
+    ) => void | Promise<any>,
+    {
+        data?: RecordType;
+        total?: number;
+        error?: any;
+        loading: boolean;
+        loaded: boolean;
+    }
+];
 
 export default useDelete;

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -4,17 +4,17 @@ import expect from 'expect';
 
 import { DataProvider } from '../types';
 import DataProviderContext from './DataProviderContext';
-import useUpdateMany from './useUpdateMany';
+import useDeleteMany from './useDeleteMany';
 
-describe('useUpdateMany', () => {
+describe('useDeleteMany', () => {
     it('returns a callback that can be used with update arguments', () => {
         const dataProvider: Partial<DataProvider> = {
-            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+            deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
         };
-        let localUpdateMany;
+        let localDeleteMany;
         const Dummy = () => {
-            const [updateMany] = useUpdateMany();
-            localUpdateMany = updateMany;
+            const [deleteMany] = useDeleteMany();
+            localDeleteMany = deleteMany;
             return <span />;
         };
 
@@ -24,21 +24,20 @@ describe('useUpdateMany', () => {
                 <Dummy />
             </DataProviderContext.Provider>
         );
-        localUpdateMany('foo', [1, 2], { bar: 'baz' });
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+        localDeleteMany('foo', [1, 2]);
+        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
             ids: [1, 2],
-            data: { bar: 'baz' },
         });
     });
 
     it('returns a callback that can be used with mutation payload', () => {
         const dataProvider: Partial<DataProvider> = {
-            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+            deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
         };
-        let localUpdateMany;
+        let localDeleteMany;
         const Dummy = () => {
-            const [updateMany] = useUpdateMany();
-            localUpdateMany = updateMany;
+            const [deleteMany] = useDeleteMany();
+            localDeleteMany = deleteMany;
             return <span />;
         };
 
@@ -48,28 +47,26 @@ describe('useUpdateMany', () => {
                 <Dummy />
             </DataProviderContext.Provider>
         );
-        localUpdateMany({
-            type: 'updateMany',
+        localDeleteMany({
+            type: 'deleteMany',
             resource: 'foo',
             payload: {
                 ids: [1, 2],
-                data: { bar: 'baz' },
             },
         });
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
             ids: [1, 2],
-            data: { bar: 'baz' },
         });
     });
 
     it('returns a callback that can be used with no arguments', () => {
         const dataProvider: Partial<DataProvider> = {
-            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+            deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
         };
-        let localUpdateMany;
+        let localDeleteMany;
         const Dummy = () => {
-            const [updateMany] = useUpdateMany('foo', [1, 2], { bar: 'baz' });
-            localUpdateMany = updateMany;
+            const [deleteMany] = useDeleteMany('foo', [1, 2]);
+            localDeleteMany = deleteMany;
             return <span />;
         };
 
@@ -79,21 +76,20 @@ describe('useUpdateMany', () => {
                 <Dummy />
             </DataProviderContext.Provider>
         );
-        localUpdateMany();
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+        localDeleteMany();
+        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
             ids: [1, 2],
-            data: { bar: 'baz' },
         });
     });
 
     it('merges hook call time and callback call time queries', () => {
         const dataProvider: Partial<DataProvider> = {
-            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+            deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
         };
-        let localUpdateMany;
+        let localDeleteMany;
         const Dummy = () => {
-            const [updateMany] = useUpdateMany('foo', [1, 2], { bar: 'baz' });
-            localUpdateMany = updateMany;
+            const [deleteMany] = useDeleteMany('foo', [1, 2]);
+            localDeleteMany = deleteMany;
             return <span />;
         };
 
@@ -103,10 +99,9 @@ describe('useUpdateMany', () => {
                 <Dummy />
             </DataProviderContext.Provider>
         );
-        localUpdateMany({ payload: { data: { foo: 456 } } });
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
-            data: { bar: 'baz', foo: 456 },
+        localDeleteMany({ payload: { ids: [3, 4] } });
+        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
+            ids: [3, 4],
         });
     });
 });

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -1,5 +1,6 @@
-import useMutation, { MutationOptions } from './useMutation';
+import { useCallback } from 'react';
 import { Identifier } from '../types';
+import useMutation, { MutationOptions, Mutation } from './useMutation';
 
 /**
  * Get a callback to call the dataProvider.deleteMany() method, the result
@@ -7,17 +8,36 @@ import { Identifier } from '../types';
  *
  * The return value updates according to the request state:
  *
- * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
- * - error: [callback, { error: [error from response], loading: false, loaded: true }]
+ * - initial: [deleteMany, { loading: false, loaded: false }]
+ * - start:   [deleteMany, { loading: true, loaded: false }]
+ * - success: [deleteMany, { data: [data from response], loading: false, loaded: true }]
+ * - error:   [deleteMany, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param ids The resource identifiers, e.g. [123, 456]
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [delete, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [deleteMany, { data, error, loading, loaded }].
  *
- * @example
+ * The deleteMany() function can be called in 3 different ways:
+ *  - with the same parameters as the useDeleteMany() hook: deleteMany(resource, ids, options)
+ *  - with the same syntax as useMutation: deleteMany({ resource, payload: { ids } }, options)
+ *  - with no parameter (if they were already passed to useDeleteMany()): deleteMany()
+ *
+ * @example // set params when calling the dleteMany callback
+ *
+ * import { useDeleteMany } from 'react-admin';
+ *
+ * const BulkDeletePostsButton = ({ selectedIds }) => {
+ *     const [deleteMany, { loading, error }] = useDeleteMany();
+ *     const handleClick = () => {
+ *         deleteMany('posts', selectedIds)
+ *     }
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <button disabled={loading} onClick={deleteMany}>Delete selected posts</button>;
+ * };
+ *
+ * @example // set params when calling the hook
  *
  * import { useDeleteMany } from 'react-admin';
  *
@@ -28,9 +48,55 @@ import { Identifier } from '../types';
  * };
  */
 const useDeleteMany = (
-    resource: string,
-    ids: Identifier[],
+    resource?: string,
+    ids?: Identifier[],
     options?: MutationOptions
-) => useMutation({ type: 'deleteMany', resource, payload: { ids } }, options);
+): UseDeleteManyHookValue => {
+    const [mutate, state] = useMutation(
+        { type: 'deleteMany', resource, payload: { ids } },
+        options
+    );
 
+    const deleteMany = useCallback(
+        (
+            resource?: string | Partial<Mutation> | Event,
+            ids?: Identifier[] | Partial<MutationOptions>,
+            options?: MutationOptions
+        ) => {
+            if (typeof resource === 'string') {
+                const query = {
+                    type: 'deleteMany',
+                    resource,
+                    payload: {
+                        ids: ids as Identifier[],
+                    },
+                };
+                return mutate(query, options);
+            } else {
+                return mutate(
+                    resource as Mutation | Event,
+                    ids as MutationOptions
+                );
+            }
+        },
+        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    return [deleteMany, state];
+};
+
+type UseDeleteManyHookValue = [
+    (
+        resource?: string | Partial<Mutation> | Event,
+        ids?: Identifier[] | Partial<MutationOptions>,
+        options?: MutationOptions
+    ) => void | Promise<any>,
+    {
+        data?: Identifier[];
+        total?: number;
+        error?: any;
+        loading: boolean;
+        loaded: boolean;
+    }
+];
 export default useDeleteMany;

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -142,7 +142,7 @@ const useMutation = (
     /* eslint-disable react-hooks/exhaustive-deps */
     const mutate = useCallback(
         (
-            callTimeQuery?: Mutation | Event,
+            callTimeQuery?: Partial<Mutation> | Event,
             callTimeOptions?: MutationOptions
         ): void | Promise<any> => {
             const finalDataProvider = hasDeclarativeSideEffectsSupport(
@@ -231,7 +231,7 @@ export interface MutationOptions {
 
 export type UseMutationValue = [
     (
-        query?: Partial<Mutation>,
+        query?: Partial<Mutation> | Event,
         options?: Partial<MutationOptions>
     ) => void | Promise<any>,
     {
@@ -278,7 +278,7 @@ export type UseMutationValue = [
  */
 const mergeDefinitionAndCallTimeParameters = (
     query?: Mutation,
-    callTimeQuery?: Mutation | Event,
+    callTimeQuery?: Partial<Mutation> | Event,
     options?: MutationOptions,
     callTimeOptions?: MutationOptions
 ) => {

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { renderWithRedux } from 'ra-test';
+import { waitFor } from '@testing-library/react';
+import expect from 'expect';
+
+import { DataProvider, Record } from '../types';
+import DataProviderContext from './DataProviderContext';
+import useUpdate from './useUpdate';
+
+describe('useUpdate', () => {
+    it('returns a callback that can be used with update arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            update: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localUpdate;
+        const Dummy = () => {
+            const [update] = useUpdate();
+            localUpdate = update;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdate('foo', 1, { bar: 'baz' }, { id: 1, bar: 'bar' });
+        expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+            id: 1,
+            data: { bar: 'baz' },
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('returns a callback that can be used with mutation payload', () => {
+        const dataProvider: Partial<DataProvider> = {
+            update: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localUpdate;
+        const Dummy = () => {
+            const [update] = useUpdate();
+            localUpdate = update;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdate({
+            type: 'update',
+            resource: 'foo',
+            payload: {
+                id: 1,
+                data: { bar: 'baz' },
+                previousData: { id: 1, bar: 'bar' },
+            },
+        });
+        expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+            id: 1,
+            data: { bar: 'baz' },
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('returns a callback that can be used with no arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            update: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localUpdate;
+        const Dummy = () => {
+            const [update] = useUpdate(
+                'foo',
+                1,
+                { bar: 'baz' },
+                { id: 1, bar: 'bar' }
+            );
+            localUpdate = update;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdate();
+        expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+            id: 1,
+            data: { bar: 'baz' },
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('merges hook call time and callback call time queries', () => {
+        const dataProvider: Partial<DataProvider> = {
+            update: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        };
+        let localUpdate;
+        const Dummy = () => {
+            const [update] = useUpdate(
+                'foo',
+                1,
+                { bar: 'baz' },
+                { id: 1, bar: 'bar' }
+            );
+            localUpdate = update;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdate({ payload: { data: { foo: 456 } } });
+        expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+            id: 1,
+            data: { bar: 'baz', foo: 456 },
+            previousData: { id: 1, bar: 'bar' },
+        });
+    });
+
+    it('returns a state typed based on the parametric type', async () => {
+        interface Product extends Record {
+            sku: string;
+        }
+        const dataProvider: Partial<DataProvider> = {
+            update: jest.fn(() =>
+                Promise.resolve({ data: { id: 1, sku: 'abc' } } as any)
+            ),
+        };
+        let localUpdate;
+        let sku;
+        const Dummy = () => {
+            const [update, { data }] = useUpdate<Product>();
+            localUpdate = update;
+            sku = data && data.sku;
+            return <span />;
+        };
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        expect(sku).toBeNull();
+        localUpdate('products', 1, { sku: 'abc' }, { id: 1, sku: 'bcd' });
+        await waitFor(() => {
+            expect(sku).toEqual('abc');
+        });
+    });
+});

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -20,7 +20,7 @@ import useMutation, { MutationOptions, Mutation } from './useMutation';
  *
  * @returns The current request state. Destructure as [update, { data, error, loading, loaded }].
  *
- * The update() method can be called in 3 different ways:
+ * The update() function can be called in 3 different ways:
  *  - with the same parameters as the useUpdate() hook: update(resource, id, data, previousData, options)
  *  - with the same syntax as useMutation: update({ resource, payload: { id, data, previousData } }, options)
  *  - with no parameter (if they were already passed to useUpdate()): update()

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -1,14 +1,16 @@
-import { Identifier } from '../types';
-import useMutation, { MutationOptions } from './useMutation';
+import { useCallback } from 'react';
+import { Identifier, Record } from '../types';
+import useMutation, { MutationOptions, Mutation } from './useMutation';
 
 /**
  * Get a callback to call the dataProvider.update() method, the result and the loading state.
  *
  * The return value updates according to the request state:
  *
- * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
- * - error: [callback, { error: [error from response], loading: false, loaded: true }]
+ * - initial: [update, { loading: false, loaded: false }]
+ * - start:   [update, { loading: true, loaded: false }]
+ * - success: [update, { data: [data from response], loading: false, loaded: true }]
+ * - error:   [update, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param id The resource identifier, e.g. 123
@@ -18,7 +20,26 @@ import useMutation, { MutationOptions } from './useMutation';
  *
  * @returns The current request state. Destructure as [update, { data, error, loading, loaded }].
  *
- * @example
+ * The update() method can be called in 3 different ways:
+ *  - with the same parameters as the useUpdate() hook: update(resource, id, data, previousData, options)
+ *  - with the same syntax as useMutation: update({ resource, payload: { id, data, previousData } }, options)
+ *  - with no parameter (if they were already passed to useUpdate()): update()
+ *
+ * @example // set params when calling the update callback
+ *
+ * import { useUpdate } from 'react-admin';
+ *
+ * const IncreaseLikeButton = ({ record }) => {
+ *     const diff = { likes: record.likes + 1 };
+ *     const [update, { loading, error }] = useUpdate();
+ *     const handleClick = () => {
+ *         update('likes', record.id, diff, record)
+ *     }
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <button disabled={loading} onClick={handleClick}>Like</div>;
+ * };
+ *
+ * @example // set params when calling the hook
  *
  * import { useUpdate } from 'react-admin';
  *
@@ -28,17 +49,70 @@ import useMutation, { MutationOptions } from './useMutation';
  *     if (error) { return <p>ERROR</p>; }
  *     return <button disabled={loading} onClick={update}>Like</div>;
  * };
+ *
+ * @example // TypeScript
+ * const [update, { data }] = useUpdate<Product>('products', id, changes, product);
+ *                    \-- data is Product
  */
-const useUpdate = (
-    resource: string,
-    id: Identifier,
-    data?: any,
+const useUpdate = <RecordType extends Record = Record>(
+    resource?: string,
+    id?: Identifier,
+    data?: Partial<RecordType>,
     previousData?: any,
     options?: MutationOptions
-) =>
-    useMutation(
+): UseUpdateHookValue<RecordType> => {
+    const [mutate, state] = useMutation(
         { type: 'update', resource, payload: { id, data, previousData } },
         options
     );
+
+    const update = useCallback(
+        (
+            resource?: string | Partial<Mutation> | Event,
+            id?: Identifier | Partial<MutationOptions>,
+            data?: Partial<RecordType>,
+            previousData?: any,
+            options?: MutationOptions
+        ) => {
+            if (typeof resource === 'string') {
+                const query = {
+                    type: 'update',
+                    resource,
+                    payload: {
+                        id: id as Identifier,
+                        data,
+                        previousData,
+                    },
+                };
+                return mutate(query, options);
+            } else {
+                return mutate(
+                    resource as Mutation | Event,
+                    id as MutationOptions
+                );
+            }
+        },
+        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    return [update, state];
+};
+
+type UseUpdateHookValue<RecordType extends Record = Record> = [
+    (
+        resource?: string | Partial<Mutation> | Event,
+        id?: Identifier | Partial<MutationOptions>,
+        data?: Partial<RecordType>,
+        previousData?: any,
+        options?: MutationOptions
+    ) => void | Promise<any>,
+    {
+        data?: RecordType;
+        total?: number;
+        error?: any;
+        loading: boolean;
+        loaded: boolean;
+    }
+];
 
 export default useUpdate;

--- a/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { renderWithRedux } from 'ra-test';
+import { waitFor } from '@testing-library/react';
+import expect from 'expect';
+
+import { DataProvider, Record } from '../types';
+import DataProviderContext from './DataProviderContext';
+import useUpdateMany from './useUpdateMany';
+
+describe('useUpdateMany', () => {
+    it('returns a callback that can be used with update arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+        };
+        let localUpdateMany;
+        const Dummy = () => {
+            const [updateMany] = useUpdateMany();
+            localUpdateMany = updateMany;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdateMany('foo', [1, 2], { bar: 'baz' });
+        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+            ids: [1, 2],
+            data: { bar: 'baz' },
+        });
+    });
+
+    it('returns a callback that can be used with mutation payload', () => {
+        const dataProvider: Partial<DataProvider> = {
+            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+        };
+        let localUpdateMany;
+        const Dummy = () => {
+            const [updateMany] = useUpdateMany();
+            localUpdateMany = updateMany;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdateMany({
+            type: 'updateMany',
+            resource: 'foo',
+            payload: {
+                ids: [1, 2],
+                data: { bar: 'baz' },
+            },
+        });
+        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+            ids: [1, 2],
+            data: { bar: 'baz' },
+        });
+    });
+
+    it('returns a callback that can be used with no arguments', () => {
+        const dataProvider: Partial<DataProvider> = {
+            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+        };
+        let localUpdateMany;
+        const Dummy = () => {
+            const [updateMany] = useUpdateMany('foo', [1, 2], { bar: 'baz' });
+            localUpdateMany = updateMany;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdateMany();
+        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+            ids: [1, 2],
+            data: { bar: 'baz' },
+        });
+    });
+
+    it('merges hook call time and callback call time queries', () => {
+        const dataProvider: Partial<DataProvider> = {
+            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
+        };
+        let localUpdateMany;
+        const Dummy = () => {
+            const [updateMany] = useUpdateMany('foo', [1, 2], { bar: 'baz' });
+            localUpdateMany = updateMany;
+            return <span />;
+        };
+
+        renderWithRedux(
+            // @ts-expect-error
+            <DataProviderContext.Provider value={dataProvider}>
+                <Dummy />
+            </DataProviderContext.Provider>
+        );
+        localUpdateMany({ payload: { data: { foo: 456 } } });
+        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+            ids: [1, 2],
+            data: { bar: 'baz', foo: 456 },
+        });
+    });
+});

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -1,5 +1,6 @@
-import useMutation, { MutationOptions } from './useMutation';
-import { Identifier } from '../types';
+import { useCallback } from 'react';
+import { Identifier, Record } from '../types';
+import useMutation, { MutationOptions, Mutation } from './useMutation';
 
 /**
  * Get a callback to call the dataProvider.updateMany() method, the result
@@ -7,18 +8,37 @@ import { Identifier } from '../types';
  *
  * The return value updates according to the request state:
  *
- * - start: [callback, { loading: true, loaded: false }]
- * - success: [callback, { data: [data from response], loading: false, loaded: true }]
- * - error: [callback, { error: [error from response], loading: false, loaded: true }]
+ * - initial: [updateMany, { loading: false, loaded: false }]
+ * - start:   [updateMany, { loading: true, loaded: false }]
+ * - success: [updateMany, { data: [data from response], loading: false, loaded: true }]
+ * - error:   [updateMany, { error: [error from response], loading: false, loaded: true }]
  *
  * @param resource The resource name, e.g. 'posts'
  * @param ids The resource identifiers, e.g. [123, 456]
  * @param data The updates to merge into all records, e.g. { views: 10 }
  * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
  *
- * @returns The current request state. Destructure as [update, { data, error, loading, loaded }].
+ * @returns The current request state. Destructure as [updateMany, { data, error, loading, loaded }].
  *
- * @example
+ * The updateMany() function can be called in 3 different ways:
+ *  - with the same parameters as the useUpdateMany() hook: update(resource, ids, data, options)
+ *  - with the same syntax as useMutation: update({ resource, payload: { ids, data } }, options)
+ *  - with no parameter (if they were already passed to useUpdateMany()): updateMany()
+ *
+ * @example // set params when calling the updateMany callback
+ *
+ * import { useUpdateMany } from 'react-admin';
+ *
+ * const BulkResetViewsButton = ({ selectedIds }) => {
+ *     const [updateMany, { loading, error }] = useUpdateMany();
+ *     const handleClick = () => {
+ *         updateMany('posts', selectedIds, { views: 0 });
+ *     }
+ *     if (error) { return <p>ERROR</p>; }
+ *     return <button disabled={loading} onClick={handleClick}>Reset views</button>;
+ * };
+ *
+ * @example // set params when calling the hook
  *
  * import { useUpdateMany } from 'react-admin';
  *
@@ -28,15 +48,60 @@ import { Identifier } from '../types';
  *     return <button disabled={loading} onClick={updateMany}>Reset views</button>;
  * };
  */
-const useUpdateMany = (
-    resource: string,
-    ids: Identifier[],
-    data: any,
+const useUpdateMany = <RecordType extends Record = Record>(
+    resource?: string,
+    ids?: Identifier[],
+    data?: Partial<RecordType>,
     options?: MutationOptions
-) =>
-    useMutation(
+): UseUpdateManyHookValue<RecordType> => {
+    const [mutate, state] = useMutation(
         { type: 'updateMany', resource, payload: { ids, data } },
         options
     );
+
+    const updateMany = useCallback(
+        (
+            resource?: string | Partial<Mutation> | Event,
+            ids?: Identifier[] | Partial<MutationOptions>,
+            data?: Partial<RecordType>
+        ) => {
+            if (typeof resource === 'string') {
+                const query = {
+                    type: 'updateMany',
+                    resource,
+                    payload: {
+                        ids: ids as Identifier[],
+                        data,
+                    },
+                };
+                return mutate(query, options);
+            } else {
+                return mutate(
+                    resource as Mutation | Event,
+                    ids as MutationOptions
+                );
+            }
+        },
+        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    return [updateMany, state];
+};
+
+type UseUpdateManyHookValue<RecordType extends Record = Record> = [
+    (
+        resource?: string | Partial<Mutation> | Event,
+        ids?: Identifier[] | Partial<MutationOptions>,
+        data?: Partial<RecordType>,
+        options?: MutationOptions
+    ) => void | Promise<any>,
+    {
+        data?: RecordType;
+        total?: number;
+        error?: any;
+        loading: boolean;
+        loaded: boolean;
+    }
+];
 
 export default useUpdateMany;

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -63,7 +63,8 @@ const useUpdateMany = <RecordType extends Record = Record>(
         (
             resource?: string | Partial<Mutation> | Event,
             ids?: Identifier[] | Partial<MutationOptions>,
-            data?: Partial<RecordType>
+            data?: Partial<RecordType>,
+            options?: MutationOptions
         ) => {
             if (typeof resource === 'string') {
                 const query = {
@@ -96,7 +97,7 @@ type UseUpdateManyHookValue<RecordType extends Record = Record> = [
         options?: MutationOptions
     ) => void | Promise<any>,
     {
-        data?: RecordType;
+        data?: Identifier[];
         total?: number;
         error?: any;
         loading: boolean;


### PR DESCRIPTION
```jsx
// build-time query
const [update] = useUpdate()
// call-time query
update('likes', record.id, diff, record)
```

Also, made all specialized mutation hooks generic:

```jsx
const [update, { data }] = useUpdate<Product>('products', record.id, diff, record)
                   \- data is Product
```

Closes #6047 
Refs #6143