### PR TITLE
Fix warning in UrlField when value is nullish and emptyText is empty

### DIFF
--- a/packages/ra-ui-materialui/src/field/UrlField.tsx
+++ b/packages/ra-ui-materialui/src/field/UrlField.tsx
@@ -11,7 +11,7 @@ const UrlField: FC<UrlFieldProps> = memo<UrlFieldProps>(props => {
     const record = useRecordContext(props);
     const value = get(record, source);
 
-    if (value == null && emptyText) {
+    if (value == null) {
         return (
             <Typography
                 component="span"


### PR DESCRIPTION
Choosing between 
- displaying a link or a static text, 
- showing the value or the default,
are two distinct orthogonal decisions.

In my base my `value` was `undefined` and I didnt provide an `emptyText`.
Because of that `UrlField` tried to create a `Link` leading to an annoying console warning, because it doesnt like that `children` is undefined.

In the case the value is null, it is better to display an empty static text than an empty link.