### PR TITLE
Docs: Fix broken link in UnitTesting.md

### DIFF
--- a/docs/UnitTesting.md
+++ b/docs/UnitTesting.md
@@ -93,7 +93,7 @@ As explained on the [Auth Provider chapter](./Authentication.md#authorization), 
 
 In order to avoid regressions and make the design explicit to your co-workers, it's better to unit test which fields are supposed to be displayed or hidden for each permission.
 
-Here is an example with Jest and TestingLibrary, which is testing the [`UserShow` page of the simple example](https://github.com/marmelab/react-admin/blob/master/examples/simple/src/users/UserShow.js).
+Here is an example with Jest and TestingLibrary, which is testing the [`UserShow` page of the simple example](https://github.com/marmelab/react-admin/blob/master/examples/simple/src/users/UserShow.tsx).
 
 ```jsx
 // UserShow.spec.js


### PR DESCRIPTION
This PR fixes a broken link in the testing docs.