### PR TITLE
Improve Notification component colors definitions

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -21,22 +21,26 @@ interface Props {
 }
 
 const useStyles = makeStyles(
-    (theme: Theme) => ({
+    theme => ({
         success: {
             backgroundColor: theme.palette.success.main,
             color: theme.palette.success.contrastText,
         },
         error: {
-            backgroundColor: theme.palette.error.dark,
+            backgroundColor: theme.palette.error.main,
             color: theme.palette.error.contrastText,
+        },
+        info: {
+            backgroundColor: theme.palette.info.main,
+            color: theme.palette.info.contrastText,
         },
         warning: {
-            backgroundColor: theme.palette.error.light,
-            color: theme.palette.error.contrastText,
+            backgroundColor: theme.palette.warning.main,
+            color: theme.palette.warning.contrastText,
         },
-        undo: {
-            color: theme.palette.primary.light,
-        },
+        undo: (props: Props & Omit<SnackbarProps, 'open'>) => ({
+            color: theme.palette[props.type].contrastText,
+        }),
     }),
     { name: 'RaNotification' }
 );

--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const useStyles = makeStyles(
-    theme => ({
+    (theme: Theme) => ({
         success: {
             backgroundColor: theme.palette.success.main,
             color: theme.palette.success.contrastText,


### PR DESCRIPTION
This change matches `info`, `error` and `warning` CSS rules with material-ui's for the `Notification` component.

![notification-colors](https://user-images.githubusercontent.com/8268610/115253014-5e5b9980-a102-11eb-9c79-331adfd57f69.png)
