### PR TITLE
fix(RaThemeOptions): Make sidebar width options optional

### DIFF
--- a/packages/ra-ui-materialui/src/defaultTheme.ts
+++ b/packages/ra-ui-materialui/src/defaultTheme.ts
@@ -65,8 +65,8 @@ export interface RaThemeOverrides extends Overrides {
 
 export interface RaThemeOptions extends ThemeOptions {
     sidebar?: {
-        width: number;
-        closedWidth: number;
+        width?: number;
+        closedWidth?: number;
     };
     overrides?: RaThemeOverrides;
 }


### PR DESCRIPTION
This just fixes TS type definition. The width options are already optional ( https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/layout/Sidebar.tsx ).