### PR TITLE
Publish data-generator typings

### DIFF
--- a/examples/data-generator/tsconfig.json
+++ b/examples/data-generator/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "declaration": true,
+        "declarationMap": true,
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]


### PR DESCRIPTION
Publish `data-generator` typings so that it can be used directly within typescript without having to add own typings.

Worth adding `declarationMap` too?