### PR TITLE
Export `PublicFieldProps` and `InjectedFieldProps` types (so devs can use them to define their own field components)

### DIFF
--- a/packages/ra-ui-materialui/src/field/index.ts
+++ b/packages/ra-ui-materialui/src/field/index.ts
@@ -19,7 +19,7 @@ import SelectField, { SelectFieldProps } from './SelectField';
 import TextField, { TextFieldProps } from './TextField';
 import UrlField, { UrlFieldProps } from './UrlField';
 import sanitizeFieldRestProps from './sanitizeFieldRestProps';
-import { FieldProps } from './types';
+import { FieldProps, InjectedFieldProps, PublicFieldProps } from './types';
 
 export * from './TranslatableFields';
 export * from './TranslatableFieldsTabContent';
@@ -45,6 +45,8 @@ export {
 };
 
 export type {
+    PublicFieldProps,
+    InjectedFieldProps,
     ArrayFieldProps,
     BooleanFieldProps,
     ChipFieldProps,


### PR DESCRIPTION
In our admin app, we create a lot of our own custom `*Field` components. When defining them, we need to add typescript definitions for props like `addLabel?: boolean`, which aren't used directly by the field component, but by the components wrapping it (e.g. `Labeled`).

All props like that are currently nicely defined in `react-admin` as `PublicFieldProps` or `InjectedFieldProps`, but unfortunately we can't import them, as they aren't exported by the library.

This PR exports them, so they can be used.