### PR TITLE
Add the posibility to pass false to the toolbar prop

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1684,6 +1684,21 @@ export const PostEdit = (props) => (
 );
 ```
 
+In case you don't want to have a toolbar to be displayed, you can set `false` to the `toolbar` prop:
+
+```jsx
+import * as React from "react";
+import { Edit, SimpleForm } from 'react-admin';
+
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm toolbar={false}>
+            // ...
+        </SimpleForm>
+    </Edit>
+);
+```
+
 Here are the props received by the `Toolbar` component when passed as the `toolbar` prop of the `SimpleForm` or `TabbedForm` components:
 
 * `alwaysEnableSaveButton`: Force enabling the `<SaveButton>`. If it's not defined, the `<SaveButton>` will be enabled using the `pristine` prop (disabled if pristine, enabled otherwise).

--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -60,7 +60,8 @@ SimpleForm.propTypes = {
     save: PropTypes.func,
     saving: PropTypes.bool,
     submitOnEnter: PropTypes.bool,
-    toolbar: PropTypes.element,
+    // @ts-ignore-line
+    toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     undoable: PropTypes.bool,
     validate: PropTypes.func,
     version: PropTypes.number,
@@ -82,7 +83,7 @@ export interface SimpleFormProps
     mutationMode?: MutationMode;
     resource?: string;
     submitOnEnter?: boolean;
-    toolbar?: ReactElement;
+    toolbar?: ReactElement | false;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';

--- a/packages/ra-ui-materialui/src/form/SimpleFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormView.tsx
@@ -85,7 +85,8 @@ SimpleFormView.propTypes = {
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     saving: PropTypes.bool,
     submitOnEnter: PropTypes.bool,
-    toolbar: PropTypes.element,
+    // @ts-ignore-line
+    toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     undoable: PropTypes.bool,
     validate: PropTypes.func,
 };
@@ -105,7 +106,7 @@ export interface SimpleFormViewProps extends FormWithRedirectRenderProps {
     mutationMode?: MutationMode;
     record?: Record;
     resource?: string;
-    toolbar?: ReactElement;
+    toolbar?: ReactElement | false;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -110,6 +110,8 @@ TabbedForm.propTypes = {
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     saving: PropTypes.bool,
     submitOnEnter: PropTypes.bool,
+    // @ts-ignore-line
+    toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     undoable: PropTypes.bool,
     validate: PropTypes.func,
     sanitizeEmptyValues: PropTypes.bool,
@@ -143,7 +145,7 @@ export interface TabbedFormProps
     submitOnEnter?: boolean;
     syncWithLocation?: boolean;
     tabs?: ReactElement;
-    toolbar?: ReactElement;
+    toolbar?: ReactElement | false;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -168,7 +168,8 @@ TabbedFormView.propTypes = {
     saving: PropTypes.bool,
     submitOnEnter: PropTypes.bool,
     tabs: PropTypes.element.isRequired,
-    toolbar: PropTypes.element,
+    // @ts-ignore-line
+    toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     translate: PropTypes.func,
     undoable: PropTypes.bool,
     validate: PropTypes.func,
@@ -193,7 +194,7 @@ export interface TabbedFormViewProps extends FormWithRedirectRenderProps {
     resource?: string;
     syncWithLocation?: boolean;
     tabs?: ReactElement;
-    toolbar?: ReactElement;
+    toolbar?: ReactElement | false;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';


### PR DESCRIPTION
This is not really possible to remove the toolbar from a form component unless by passing an empty component.
I added the possibility to pass false to be able to not display the toolbar:

```jsx
import * as React from "react";
import { Edit, SimpleForm } from 'react-admin';

export const PostEdit = (props) => (
    <Edit {...props}>
        <SimpleForm toolbar={false}>
            // ...
        </SimpleForm>
    </Edit>
);
```