### PR TITLE
[TypeScript] Add the ability to type SimpleList callbacks

### DIFF
--- a/examples/crm/src/dashboard/DealsPipeline.tsx
+++ b/examples/crm/src/dashboard/DealsPipeline.tsx
@@ -13,10 +13,11 @@ import {
 
 import { CompanyAvatar } from '../companies/CompanyAvatar';
 import { stages, stageNames } from '../deals/stages';
+import { Deal } from '../types';
 
 export const DealsPipeline = () => {
     const { identity } = useGetIdentity();
-    const { data, ids: unorderedIds, total, loaded } = useGetList(
+    const { data, ids: unorderedIds, total, loaded } = useGetList<Deal>(
         'deals',
         { page: 1, perPage: 10 },
         { field: 'last_seen', order: 'DESC' },
@@ -53,7 +54,7 @@ export const DealsPipeline = () => {
                 </Link>
             </Box>
             <Card>
-                <SimpleList
+                <SimpleList<Deal>
                     basePath="/deals"
                     linkType="show"
                     ids={ids}

--- a/examples/crm/src/dashboard/HotContacts.tsx
+++ b/examples/crm/src/dashboard/HotContacts.tsx
@@ -39,7 +39,7 @@ export const HotContacts = () => {
                 </Link>
             </Box>
             <Card>
-                <SimpleList
+                <SimpleList<Contact>
                     basePath="/contacts"
                     linkType="show"
                     ids={contactIds}
@@ -58,10 +58,7 @@ export const HotContacts = () => {
                             }
                         )
                     }
-                    /* @ts-ignore */
-                    leftAvatar={(contact: Contact) => (
-                        <Avatar record={contact} />
-                    )}
+                    leftAvatar={contact => <Avatar record={contact} />}
                 />
             </Card>
         </>

--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -66,7 +66,9 @@ const useStyles = makeStyles(
  *     </List>
  * );
  */
-const SimpleList: FC<SimpleListProps> = props => {
+const SimpleList = <RecordType extends Record = Record>(
+    props: SimpleListProps<RecordType>
+) => {
     const {
         className,
         classes: classesOverride,
@@ -82,7 +84,9 @@ const SimpleList: FC<SimpleListProps> = props => {
         rowStyle,
         ...rest
     } = props;
-    const { basePath, data, ids, loaded, total } = useListContext(props);
+    const { basePath, data, ids, loaded, total } = useListContext<RecordType>(
+        props
+    );
     const classes = useStyles(props);
 
     if (loaded === false) {
@@ -182,8 +186,8 @@ SimpleList.propTypes = {
     rowStyle: PropTypes.func,
 };
 
-export type FunctionToElement = (
-    record: Record,
+export type FunctionToElement<RecordType extends Record = Record> = (
+    record: RecordType,
     id: Identifier
 ) => ReactElement | string;
 
@@ -192,14 +196,14 @@ export interface SimpleListProps<RecordType extends Record = Record>
     className?: string;
     classes?: ClassesOverride<typeof useStyles>;
     hasBulkActions?: boolean;
-    leftAvatar?: FunctionToElement;
-    leftIcon?: FunctionToElement;
-    primaryText?: FunctionToElement;
+    leftAvatar?: FunctionToElement<RecordType>;
+    leftIcon?: FunctionToElement<RecordType>;
+    primaryText?: FunctionToElement<RecordType>;
     linkType?: string | FunctionLinkType | boolean;
-    rightAvatar?: FunctionToElement;
-    rightIcon?: FunctionToElement;
-    secondaryText?: FunctionToElement;
-    tertiaryText?: FunctionToElement;
+    rightAvatar?: FunctionToElement<RecordType>;
+    rightIcon?: FunctionToElement<RecordType>;
+    secondaryText?: FunctionToElement<RecordType>;
+    tertiaryText?: FunctionToElement<RecordType>;
     rowStyle?: (record: Record, index: number) => any;
     // can be injected when using the component without context
     basePath?: string;


### PR DESCRIPTION
## Problem

Many of the `<SimpleList>` props are callback that expect a `Record` argument. But TypeScript complains when accessing fields of these records, and that forces to add `// @ts-ignore` flags.

![image](https://user-images.githubusercontent.com/99944/117399912-de0aa600-af01-11eb-82df-f89c516bdadb.png)

## Solution

Make `<SimpleList>` generic to accept a Record type.