### PR TITLE
[Docs] Add data example for ra-simple-rest

### DIFF
--- a/packages/ra-data-simple-rest/README.md
+++ b/packages/ra-data-simple-rest/README.md
@@ -26,6 +26,20 @@ This Data Provider fits REST APIs using simple GET parameters for filters and so
 | `delete`           | `DELETE http://my.api.url/posts/123`                                                    |
 | `deleteMany`       | Multiple calls to `DELETE http://my.api.url/posts/123`                                  |
 
+An example of `getList` data is:
+
+```json
+[
+  { "id": 0, "author_id": 0, "title": "Anna Karenina" },
+  { "id": 1, "author_id": 0, "title": "War and Peace" },
+  { "id": 2, "author_id": 1, "title": "Pride and Prejudice" },
+  { "id": 2, "author_id": 1, "title": "Pride and Prejudice" },
+  { "id": 3, "author_id": 1, "title": "Sense and Sensibility" }
+]
+```
+
+An `id` field is requied. You can also set [custom identifier or primary key for your resources](https://marmelab.com/react-admin/FAQ.html#can-i-have-custom-identifiersprimary-keys-for-my-resources)
+
 **Note**: The simple REST data provider expects the API to include a `Content-Range` header in the response to `getList` calls. The value must be the total number of resources in the collection. This allows react-admin to know how many pages of resources there are in total, and build the pagination controls.
 
 ```txt

--- a/packages/ra-data-simple-rest/README.md
+++ b/packages/ra-data-simple-rest/README.md
@@ -26,7 +26,7 @@ This Data Provider fits REST APIs using simple GET parameters for filters and so
 | `delete`           | `DELETE http://my.api.url/posts/123`                                                    |
 | `deleteMany`       | Multiple calls to `DELETE http://my.api.url/posts/123`                                  |
 
-An example of `getList` data is:
+The API response when called by `getList` should look like this:
 
 ```json
 [


### PR DESCRIPTION
This PR adds a small data example to help to get up and running with `ra-data-simple-rest`

I had trouble figuring out the correct data format, and it looks like [other people have too](https://stackoverflow.com/questions/60622649/ra-data-simple-rest-is-not-working-error-total-is-not-a-number-and-newrecords).