### PR TITLE
Fix performance regression causing unnecessary redraws

### DIFF
--- a/packages/ra-core/src/controller/details/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/details/useCreateContext.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 
 import { Record } from '../../types';
 import { CreateContext } from './CreateContext';
@@ -35,7 +35,7 @@ export const useCreateContext = <
     // Props take precedence over the context
     return useMemo(
         () =>
-            merge(
+            extend(
                 {},
                 context,
                 props != null ? extractCreateContextProps(props) : {}

--- a/packages/ra-core/src/controller/details/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/details/useCreateContext.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 
 import { Record } from '../../types';
 import { CreateContext } from './CreateContext';
@@ -35,10 +35,10 @@ export const useCreateContext = <
     // Props take precedence over the context
     return useMemo(
         () =>
-            extend(
+            defaults(
                 {},
-                context,
-                props != null ? extractCreateContextProps(props) : {}
+                props != null ? extractCreateContextProps(props) : {},
+                context
             ),
         [context, props]
     );

--- a/packages/ra-core/src/controller/details/useEditContext.tsx
+++ b/packages/ra-core/src/controller/details/useEditContext.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 
 import { Record } from '../../types';
 import { EditContext } from './EditContext';
@@ -32,10 +32,10 @@ export const useEditContext = <RecordType extends Record = Record>(
     // Props take precedence over the context
     return useMemo(
         () =>
-            extend(
+            defaults(
                 {},
-                context,
-                props != null ? extractEditContextProps(props) : {}
+                props != null ? extractEditContextProps(props) : {},
+                context
             ),
         [context, props]
     );

--- a/packages/ra-core/src/controller/details/useEditContext.tsx
+++ b/packages/ra-core/src/controller/details/useEditContext.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 
 import { Record } from '../../types';
 import { EditContext } from './EditContext';
@@ -32,7 +32,7 @@ export const useEditContext = <RecordType extends Record = Record>(
     // Props take precedence over the context
     return useMemo(
         () =>
-            merge(
+            extend(
                 {},
                 context,
                 props != null ? extractEditContextProps(props) : {}

--- a/packages/ra-core/src/controller/details/useShowContext.tsx
+++ b/packages/ra-core/src/controller/details/useShowContext.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 
 import { Record } from '../../types';
 import { ShowContext } from './ShowContext';
@@ -32,10 +32,10 @@ export const useShowContext = <RecordType extends Record = Record>(
     // Props take precedence over the context
     return useMemo(
         () =>
-            extend(
+            defaults(
                 {},
-                context,
-                props != null ? extractShowContextProps(props) : {}
+                props != null ? extractShowContextProps(props) : {},
+                context
             ),
         [context, props]
     );

--- a/packages/ra-core/src/controller/details/useShowContext.tsx
+++ b/packages/ra-core/src/controller/details/useShowContext.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 
 import { Record } from '../../types';
 import { ShowContext } from './ShowContext';
@@ -32,7 +32,7 @@ export const useShowContext = <RecordType extends Record = Record>(
     // Props take precedence over the context
     return useMemo(
         () =>
-            merge(
+            extend(
                 {},
                 context,
                 props != null ? extractShowContextProps(props) : {}

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputContext.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputContext.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 import {
     ReferenceArrayInputContext,
     ReferenceArrayInputContextValue,
@@ -17,12 +17,12 @@ export const useReferenceArrayInputContext = <
     // Props take precedence over the context
     return useMemo(
         () =>
-            extend(
+            defaults(
                 {},
-                context,
                 props != null
                     ? extractReferenceArrayInputContextProps(props)
-                    : {}
+                    : {},
+                context
             ),
         [context, props]
     );

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputContext.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputContext.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 import {
     ReferenceArrayInputContext,
     ReferenceArrayInputContextValue,
@@ -17,7 +17,7 @@ export const useReferenceArrayInputContext = <
     // Props take precedence over the context
     return useMemo(
         () =>
-            merge(
+            extend(
                 {},
                 context,
                 props != null

--- a/packages/ra-core/src/controller/useListContext.ts
+++ b/packages/ra-core/src/controller/useListContext.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 
 import ListContext from './ListContext';
 import { ListControllerProps } from './useListController';
@@ -101,10 +101,10 @@ const useListContext = <RecordType extends Record = Record>(
     // @ts-ignore
     return useMemo(
         () =>
-            extend(
+            defaults(
                 {},
-                context,
-                props != null ? extractListContextProps(props) : {}
+                props != null ? extractListContextProps(props) : {},
+                context
             ),
         [context, props]
     );

--- a/packages/ra-core/src/controller/useListContext.ts
+++ b/packages/ra-core/src/controller/useListContext.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 
 import ListContext from './ListContext';
 import { ListControllerProps } from './useListController';
@@ -101,7 +101,7 @@ const useListContext = <RecordType extends Record = Record>(
     // @ts-ignore
     return useMemo(
         () =>
-            merge(
+            extend(
                 {},
                 context,
                 props != null ? extractListContextProps(props) : {}

--- a/packages/ra-core/src/controller/useRecordSelection.ts
+++ b/packages/ra-core/src/controller/useRecordSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { setListSelectedIds, toggleListItem } from '../actions/listActions';
 import { Identifier, ReduxState } from '../types';
@@ -30,23 +30,20 @@ const useRecordSelection = (
                 : defaultRecords,
         shallowEqual
     );
-    const selectionModifiers = {
-        select: useCallback(
-            (newIds: Identifier[]) => {
+    const selectionModifiers = useMemo(
+        () => ({
+            select: (newIds: Identifier[]) => {
                 dispatch(setListSelectedIds(resource, newIds));
             },
-            [resource] // eslint-disable-line react-hooks/exhaustive-deps
-        ),
-        toggle: useCallback(
-            (id: Identifier) => {
+            toggle: (id: Identifier) => {
                 dispatch(toggleListItem(resource, id));
             },
-            [resource] // eslint-disable-line react-hooks/exhaustive-deps
-        ),
-        clearSelection: useCallback(() => {
-            dispatch(setListSelectedIds(resource, []));
-        }, [resource]), // eslint-disable-line react-hooks/exhaustive-deps
-    };
+            clearSelection: () => {
+                dispatch(setListSelectedIds(resource, []));
+            },
+        }),
+        [dispatch, resource]
+    );
 
     return [selectedIds, selectionModifiers];
 };

--- a/packages/ra-core/src/core/useResourceDefinition.ts
+++ b/packages/ra-core/src/core/useResourceDefinition.ts
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 import { getResources } from '../reducer';
 import { ResourceDefinition } from '../types';
 import { useResourceContext } from './useResourceContext';
@@ -17,7 +17,7 @@ export const useResourceDefinition = (
 
     const definition = useMemo(() => {
         const definitionFromRedux = resources.find(r => r?.name === resource);
-        return merge({}, definitionFromRedux, {
+        return extend({}, definitionFromRedux, {
             hasCreate,
             hasEdit,
             hasList,

--- a/packages/ra-core/src/core/useResourceDefinition.ts
+++ b/packages/ra-core/src/core/useResourceDefinition.ts
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 import { getResources } from '../reducer';
 import { ResourceDefinition } from '../types';
 import { useResourceContext } from './useResourceContext';
@@ -17,12 +17,16 @@ export const useResourceDefinition = (
 
     const definition = useMemo(() => {
         const definitionFromRedux = resources.find(r => r?.name === resource);
-        return extend({}, definitionFromRedux, {
-            hasCreate,
-            hasEdit,
-            hasList,
-            hasShow,
-        });
+        return defaults(
+            {},
+            {
+                hasCreate,
+                hasEdit,
+                hasList,
+                hasShow,
+            },
+            definitionFromRedux
+        );
     }, [resource, resources, hasCreate, hasEdit, hasList, hasShow]);
 
     return definition;

--- a/packages/ra-core/src/dataProvider/useDataProvider.spec.js
+++ b/packages/ra-core/src/dataProvider/useDataProvider.spec.js
@@ -422,7 +422,7 @@ describe('useDataProvider', () => {
                 expect(update).toBeCalledTimes(1);
                 // make sure the side effect hasn't been applied yet
                 expect(queryByText('(updated)')).toBeNull();
-                await act(() => {
+                await act(async () => {
                     resolveUpdate();
                 });
                 // side effects should be applied now
@@ -473,7 +473,7 @@ describe('useDataProvider', () => {
                 // side effects should be applied now
                 expect(queryByText('(updated)')).not.toBeNull();
                 expect(update).toBeCalledTimes(1);
-                await act(() => {
+                act(() => {
                     resolveUpdate();
                 });
             });
@@ -521,7 +521,7 @@ describe('useDataProvider', () => {
                 expect(queryByText('(updated)')).not.toBeNull();
                 // update shouldn't be called at all
                 expect(update).toBeCalledTimes(0);
-                await act(() => {
+                act(() => {
                     undoableEventEmitter.emit('end', {});
                 });
                 expect(update).toBeCalledTimes(1);

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 
 import { useSafeSetState } from '../util/hooks';
 import { MutationMode, OnSuccess, OnFailure } from '../types';
@@ -302,13 +302,13 @@ const mergeDefinitionAndCallTimeParameters = (
             type: query.type || callTimeQuery.type,
             resource: query.resource || callTimeQuery.resource,
             payload: callTimeQuery
-                ? extend({}, query.payload, callTimeQuery.payload)
+                ? defaults({}, callTimeQuery.payload, query.payload)
                 : query.payload,
             options: callTimeOptions
-                ? extend(
+                ? defaults(
                       {},
-                      sanitizeOptions(options),
-                      sanitizeOptions(callTimeOptions)
+                      sanitizeOptions(callTimeOptions),
+                      sanitizeOptions(options)
                   )
                 : sanitizeOptions(options),
         };

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 
 import { useSafeSetState } from '../util/hooks';
 import { MutationMode, OnSuccess, OnFailure } from '../types';
@@ -302,10 +302,10 @@ const mergeDefinitionAndCallTimeParameters = (
             type: query.type || callTimeQuery.type,
             resource: query.resource || callTimeQuery.resource,
             payload: callTimeQuery
-                ? merge({}, query.payload, callTimeQuery.payload)
+                ? extend({}, query.payload, callTimeQuery.payload)
                 : query.payload,
             options: callTimeOptions
-                ? merge(
+                ? extend(
                       {},
                       sanitizeOptions(options),
                       sanitizeOptions(callTimeOptions)

--- a/packages/ra-core/src/dataProvider/useMutation.ts
+++ b/packages/ra-core/src/dataProvider/useMutation.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import defaults from 'lodash/defaults';
+import merge from 'lodash/merge';
 
 import { useSafeSetState } from '../util/hooks';
 import { MutationMode, OnSuccess, OnFailure } from '../types';
@@ -302,13 +302,13 @@ const mergeDefinitionAndCallTimeParameters = (
             type: query.type || callTimeQuery.type,
             resource: query.resource || callTimeQuery.resource,
             payload: callTimeQuery
-                ? defaults({}, callTimeQuery.payload, query.payload)
+                ? merge({}, query.payload, callTimeQuery.payload)
                 : query.payload,
             options: callTimeOptions
-                ? defaults(
+                ? merge(
                       {},
-                      sanitizeOptions(callTimeOptions),
-                      sanitizeOptions(options)
+                      sanitizeOptions(options),
+                      sanitizeOptions(callTimeOptions)
                   )
                 : sanitizeOptions(options),
         };

--- a/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormIterator.spec.tsx
@@ -500,7 +500,7 @@ describe('<SimpleFormIterator />', () => {
     });
 
     it('should call the onClick method when the custom add button is clicked', async () => {
-        const onClick = jest.fn();
+        const onClick = jest.fn().mockImplementation(e => e.preventDefault());
         const { getByText } = renderWithRedux(
             <ThemeProvider theme={theme}>
                 <SaveContextProvider value={saveContextValue}>
@@ -527,7 +527,7 @@ describe('<SimpleFormIterator />', () => {
     });
 
     it('should call the onClick method when the custom remove button is clicked', async () => {
-        const onClick = jest.fn();
+        const onClick = jest.fn().mockImplementation(e => e.preventDefault());
         const { getByText } = renderWithRedux(
             <ThemeProvider theme={theme}>
                 <SaveContextProvider value={saveContextValue}>

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridContext.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridContext.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 import { DatagridProps } from './Datagrid';
 import DatagridContext, { DatagridContextValue } from './DatagridContext';
-import merge from 'lodash/merge';
+import extend from 'lodash/extend';
 
 export const useDatagridContext = (
     props?: DatagridProps
@@ -10,7 +10,7 @@ export const useDatagridContext = (
 
     return useMemo(
         () =>
-            merge(
+            extend(
                 {},
                 context,
                 props != null ? { isRowExpandable: props.isRowExpandable } : {}

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridContext.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridContext.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 import { DatagridProps } from './Datagrid';
 import DatagridContext, { DatagridContextValue } from './DatagridContext';
-import extend from 'lodash/extend';
+import defaults from 'lodash/defaults';
 
 export const useDatagridContext = (
     props?: DatagridProps
@@ -10,10 +10,10 @@ export const useDatagridContext = (
 
     return useMemo(
         () =>
-            extend(
+            defaults(
                 {},
-                context,
-                props != null ? { isRowExpandable: props.isRowExpandable } : {}
+                props != null ? { isRowExpandable: props.isRowExpandable } : {},
+                context
             ),
         [context, props]
     );


### PR DESCRIPTION
## Problem

Our context hooks (e.g. `useListContext`) always return new items, even though nothing has changed. 

The problem is that they use lodash/merge, which is recursive. When merging complex objects, the result is almost always a new object.

## Solution

~~Use lodash/extend instead~~. 
Use lodash/defaults instead (because extend considers undefined values as an override, see https://stackoverflow.com/a/33247597/1333479)

## Before

![image](https://user-images.githubusercontent.com/99944/118528733-fae57b80-b742-11eb-8460-123299859cf2.png)


## After

![image](https://user-images.githubusercontent.com/99944/118528635-d8536280-b742-11eb-8ebd-40ac54350f45.png)
