### PR TITLE
Docs: Fix wrong link in Fields documentation

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -261,7 +261,7 @@ This component accepts a `showTime` attribute (`false` by default) to force the 
 ```
 {% endraw %}
 
-See [Intl.DateTimeFormat documentation](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Date/toLocaleDateString) for the `options` prop syntax.
+See [Intl.DateTimeFormat documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for the `options` prop syntax.
 
 **Tip**: If you need more formatting options than what `Intl.DateTimeFormat` can provide, build your own field component leveraging a third-party library like [moment.js](https://momentjs.com/).
 


### PR DESCRIPTION
This PR fixes a link that points to the french version of the MDN.