### PR TITLE
Export ui default state for custom apps to override some values of it

### DIFF
--- a/packages/ra-core/src/index.ts
+++ b/packages/ra-core/src/index.ts
@@ -30,5 +30,7 @@ export {
     nameRelatedTo,
 } from './reducer/admin/references/oneToMany';
 
+export { uiDefaultState } from './reducer/admin/ui';
+
 export * from './sideEffect';
 export * from './types';

--- a/packages/ra-core/src/reducer/admin/ui.ts
+++ b/packages/ra-core/src/reducer/admin/ui.ts
@@ -42,7 +42,7 @@ const isDesktop = (): boolean =>
         ? window.matchMedia('(min-width:960px)').matches
         : false;
 
-const defaultState: UIState = {
+export const uiDefaultState: UIState = {
     automaticRefreshEnabled: true,
     sidebarOpen: isDesktop(),
     optimistic: false,
@@ -50,7 +50,7 @@ const defaultState: UIState = {
 };
 
 const uiReducer: Reducer<UIState> = (
-    previousState = defaultState,
+    previousState = uiDefaultState,
     action: ActionTypes
 ) => {
     switch (action.type) {


### PR DESCRIPTION
When I want to make the sideBar default to closed by setting the `admin.ui` initialState of `<Admin/>`, some other properties are also get dropped in the redux.
e.g. initialState = { admin: { ui: { sideBarOpen: false } } } // missing the default automaticRefreshEnabled, etc...

It would be more convenient to export the default state as an object so I can override some of the values before passing it into the `<Admin/>` component.