### PR TITLE
[TypeScript] Fix type mismatch error on title prop for page components

### DIFF
--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -43,7 +43,7 @@ export interface EditProps extends ResourceComponentPropsWithId {
     onSuccess?: OnSuccess;
     onFailure?: OnFailure;
     transform?: (data: RaRecord) => RaRecord | Promise<RaRecord>;
-    title?: string | ReactElement;
+    title?: string | ReactElement | false;
 }
 
 export interface CreateProps extends ResourceComponentProps {
@@ -56,7 +56,7 @@ export interface CreateProps extends ResourceComponentProps {
     onSuccess?: OnSuccess;
     onFailure?: OnFailure;
     transform?: (data: RaRecord) => RaRecord | Promise<RaRecord>;
-    title?: string | ReactElement;
+    title?: string | ReactElement | false;
 }
 
 export interface ShowProps extends ResourceComponentPropsWithId {
@@ -65,7 +65,7 @@ export interface ShowProps extends ResourceComponentPropsWithId {
     classes?: any;
     className?: string;
     component?: ElementType;
-    title?: string | ReactElement;
+    title?: string | ReactElement | false;
 }
 
 export interface BulkActionProps {


### PR DESCRIPTION
closes: https://github.com/marmelab/react-admin/issues/6350

adds `false` to `title` types for Create, Edit and Show components to match `title` type on List component (was added here: https://github.com/marmelab/react-admin/pull/6119)