### PR TITLE
Add should to ra-test docs test case's explanation

### DIFF
--- a/packages/ra-test/README.md
+++ b/packages/ra-test/README.md
@@ -122,7 +122,7 @@ it('should initilize store', () => {
     expect(storeState).toEqual({...defaultStore, ...initialState});
 });
 
-it('send the user to another url', () => {
+it('should send the user to another url', () => {
     fireEvent.click(testUtils.getByText('Go to next'));
     expect(dispatch).toHaveBeenCalledWith(`/next-url`);
 });


### PR DESCRIPTION
Just added a 'should' to the case's explanation for consistency and better reading