### PR TITLE
identity.fullName text node

### DIFF
--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -80,7 +80,7 @@ const UserMenu = (props: UserMenuProps) => {
                     }
                     onClick={handleMenu}
                 >
-                    {identity.fullName}
+                    <span>{identity.fullName}</span>
                 </Button>
             ) : (
                 <Tooltip title={label && translate(label, { _: label })}>


### PR DESCRIPTION
I tried changing the style of identity.fullName in the UserMenu and found it very difficult, since it's just a text node and not an element.
I ended up having to create a custom UserMenu, which is basically identical to the original one.
While this solution works, I think it's a shame. A much easier fix exists - to wrap the existing identity.fullName in a tag.
In this change I used a span for convenience and simplicity, however it could also be MaterialUI's Typography tag which could accept typography props for even further customization.