### PR TITLE
Fix useInput resetting NumberInput when value = 0

### DIFF
--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -115,17 +115,17 @@ const useInput = ({
     const form = useForm();
     const recordId = record?.id;
     useEffect(() => {
-        if (!!input.value) {
+        if (!!input.value || input.value === 0) {
             return;
         }
         // Apply the default value if provided
         // We use a change here which will make the form dirty but this is expected
         // and identical to what FinalForm does (https://final-form.org/docs/final-form/types/FieldConfig#defaultvalue)
-        if (!!defaultValue) {
+        if (!!defaultValue || defaultValue === 0) {
             form.change(source, defaultValue);
         }
 
-        if (!!initialValue) {
+        if (!!initialValue || initialValue === 0) {
             form.batch(() => {
                 form.change(source, initialValue);
                 form.resetFieldState(source);


### PR DESCRIPTION
This issue was making every NumberInput change its value to its defaultValue or initialValue when it reaches zero. 

If you try to do this: `<NumberInput source="test" min={-10} max={10} defaultValue={6} />`

It will go back to 6 when it reaches 0, like this

![l6tTZFrzAg](https://user-images.githubusercontent.com/20295/122731578-ba19de80-d27b-11eb-81dc-5d48384f3283.gif)


I don't know if there are more side-effects not considered, but this fixes the said issue.