### PR TITLE
Fixed FieldTitle component label issue 

### DIFF
--- a/packages/ra-core/src/util/FieldTitle.spec.tsx
+++ b/packages/ra-core/src/util/FieldTitle.spec.tsx
@@ -82,4 +82,14 @@ describe('FieldTitle', () => {
         const { container } = render(<FieldTitle label="foo" isRequired />);
         expect(container.firstChild.textContent).toEqual('foo *');
     });
+
+    it('should return null if label is false', () => {
+        const { container } = render(<FieldTitle label={false} isRequired />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('should return null if label is empty string', () => {
+        const { container } = render(<FieldTitle label="hhh" isRequired />);
+        expect(container.firstChild).toBeNull();
+    });
 });

--- a/packages/ra-core/src/util/FieldTitle.tsx
+++ b/packages/ra-core/src/util/FieldTitle.tsx
@@ -8,7 +8,7 @@ interface Props {
     isRequired?: boolean;
     resource?: string;
     source?: string;
-    label?: string | ReactElement;
+    label?: string | ReactElement | false;
 }
 
 export const FieldTitle: FunctionComponent<Props> = ({
@@ -18,9 +18,15 @@ export const FieldTitle: FunctionComponent<Props> = ({
     isRequired,
 }) => {
     const translate = useTranslate();
+
+    if (label === false || label === '') {
+        return null;
+    }
+
     if (label && typeof label !== 'string') {
         return label;
     }
+
     return (
         <span>
             {translate(

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -95,7 +95,7 @@ const NumberInput: FunctionComponent<NumberInputProps> = ({
 };
 
 NumberInput.propTypes = {
-    label: PropTypes.string,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,


### PR DESCRIPTION
Closes #6352

Fixed label issue for `FieldTitle` component

**Before** - `NumberInput` with `label={false}`

<img width="1755" alt="Screenshot 2021-06-15 at 11 27 48 PM" src="https://user-images.githubusercontent.com/32485571/122120360-ec74a780-ce47-11eb-978b-03c5b28ab8e0.png">