### PR TITLE
Add support for image path value in <SimpleList leftAvatar>

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -107,7 +107,10 @@ const SimpleList = <RecordType extends Record = Record>(
         avatarCallback: FunctionToElement<RecordType>
     ) => {
         const avatarValue = avatarCallback(data[id], id);
-        if (typeof avatarValue === 'string' && avatarValue.startsWith('http')) {
+        if (
+            typeof avatarValue === 'string' &&
+            (avatarValue.startsWith('http') || avatarValue.startsWith('data:'))
+        ) {
             return <Avatar src={avatarValue} />;
         } else {
             return <Avatar>{avatarValue}</Avatar>;

--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -102,6 +102,18 @@ const SimpleList = <RecordType extends Record = Record>(
         );
     }
 
+    const renderAvatar = (
+        id: Identifier,
+        avatarCallback: FunctionToElement<RecordType>
+    ) => {
+        const avatarValue = avatarCallback(data[id], id);
+        if (typeof avatarValue === 'string' && avatarValue.startsWith('http')) {
+            return <Avatar src={avatarValue} />;
+        } else {
+            return <Avatar>{avatarValue}</Avatar>;
+        }
+    };
+
     return (
         total > 0 && (
             <List className={className} {...sanitizeListRestProps(rest)}>
@@ -128,7 +140,7 @@ const SimpleList = <RecordType extends Record = Record>(
                             )}
                             {leftAvatar && (
                                 <ListItemAvatar>
-                                    <Avatar>{leftAvatar(data[id], id)}</Avatar>
+                                    {renderAvatar(id, leftAvatar)}
                                 </ListItemAvatar>
                             )}
                             <ListItemText
@@ -150,7 +162,7 @@ const SimpleList = <RecordType extends Record = Record>(
                                 <ListItemSecondaryAction>
                                     {rightAvatar && (
                                         <Avatar>
-                                            {rightAvatar(data[id], id)}
+                                            {renderAvatar(id, rightAvatar)}
                                         </Avatar>
                                     )}
                                     {rightIcon && (


### PR DESCRIPTION
## Problem

By default, SimpleList expect avatar values to be initials. When passing a avatar URL, the avatar shows the end of the URL instead of the image. 

```jsx
const UserList = (props) => (
    <List {...props}>
        <SimpleList
            primaryText={record => record.name}
            secondaryText={record => record.role}
            leftAvatar={record => record.avatar}
        />
    </List>
);
```

![image](https://user-images.githubusercontent.com/99944/124674155-7ef1ef00-deba-11eb-833e-3ff6d021a941.png)

To set an image as avatar in SimpleList, developers must return an `<img>` element. This isn't super intuitive.

```diff
const UserList = (props) => (
    <List {...props}>
        <SimpleList
            primaryText={record => record.name}
            secondaryText={record => record.role}
-           leftAvatar={record => record.avatar}
+           leftAvatar={record => <img alt="" src={record.avatar} />}
        />
    </List>
);
```


Note: `user` records look like:

```
    [
        {
            id: 1,
            name: 'Logan Schowalter',
            role: 'admin',
            avatar: 'https://marmelab.com/posters/avatar-1.jpeg',
        },
        {
            id: 2,
            name: 'Breanna Gibson',
            role: 'user',
            avatar: 'https://marmelab.com/posters/avatar-2.jpeg',
        },
        {
            id: 3,
            name: 'Annamarie Mayer',
            role: 'user',
            avatar: 'https://marmelab.com/posters/avatar-3.jpeg',
        },
    ],
```

## Solution

Avatar accepts both text (displays initials) or image paths (displays image)

![image](https://user-images.githubusercontent.com/99944/124674245-a648bc00-deba-11eb-89b8-2ab5a61030c9.png)



