### PR TITLE
docs(Input): add link to ReactPage Integration

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -2753,5 +2753,6 @@ You can find components for react-admin in third-party repositories.
 - [vascofg/react-admin-color-input](https://github.com/vascofg/react-admin-color-input): a color input using [React Color](https://casesandberg.github.io/react-color/), a collection of color pickers.
 - [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs): a collection of Date Inputs, based on [material-ui-pickers](https://material-ui-pickers.firebaseapp.com/)
 - [MrHertal/react-admin-json-view](https://github.com/MrHertal/react-admin-json-view): JSON field and input for react-admin.
+- [@react-page/react-admin](https://react-page.github.io/docs/#/integration-react-admin): ReactPage is a rich content editor and can comes with a ready-to-use React-admin input component. [check out the demo](https://react-page.github.io/examples/reactadmin)
 
 - **DEPRECATED V3** [LoicMahieu/aor-tinymce-input](https://github.com/LoicMahieu/aor-tinymce-input): a TinyMCE component, useful for editing HTML


### PR DESCRIPTION
ReactPage is a rich content editor and works nicely with React-admin. It provides a ready-to-use Input component for react-admin. You can further use react-admin's resources in ReactPage's form controls. We added a documentation and demo how this can look like (see commit)

Disclaimer: i am (main) contributor to ReactPage. 