### PR TITLE
Fix SearchInput border style when variant is outlined

### DIFF
--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -3,6 +3,8 @@ import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
 import { TextFieldProps } from '@material-ui/core/TextField';
+import { Theme } from '@material-ui/core';
+import { makeStyles, Styles } from '@material-ui/styles';
 
 import ResettableTextField from './ResettableTextField';
 import InputHelperText from './InputHelperText';
@@ -25,20 +27,37 @@ export type TextInputProps = InputProps<TextFieldProps> &
  *
  * The object passed as `options` props is passed to the <ResettableTextField> component
  */
-const TextInput: FunctionComponent<TextInputProps> = ({
-    label,
-    format,
-    helperText,
-    onBlur,
-    onFocus,
-    onChange,
-    options,
-    parse,
-    resource,
-    source,
-    validate,
-    ...rest
-}) => {
+
+const textInputStyles: Styles<Theme, TextInputProps> = {
+    root: {
+        '& .MuiOutlinedInput-notchedOutline': {
+            '& legend': {
+                width: ({ label }) =>
+                    label === false || label === '' ? '0.01px' : 'auto',
+            },
+        },
+    },
+};
+
+const useStyles = makeStyles(textInputStyles, { name: 'RaTextInput' });
+
+const TextInput: FunctionComponent<TextInputProps> = props => {
+    const {
+        label,
+        format,
+        helperText,
+        onBlur,
+        onFocus,
+        onChange,
+        options,
+        parse,
+        resource,
+        source,
+        validate,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
+
     const {
         id,
         input,
@@ -58,30 +77,30 @@ const TextInput: FunctionComponent<TextInputProps> = ({
     });
 
     return (
-        <ResettableTextField
-            id={id}
-            {...input}
-            label={
-                label ? (
+        <div className={classes.root}>
+            <ResettableTextField
+                id={id}
+                {...input}
+                label={
                     <FieldTitle
                         label={label}
                         source={source}
                         resource={resource}
                         isRequired={isRequired}
                     />
-                ) : null
-            }
-            error={!!(touched && (error || submitError))}
-            helperText={
-                <InputHelperText
-                    touched={touched}
-                    error={error || submitError}
-                    helperText={helperText}
-                />
-            }
-            {...options}
-            {...sanitizeInputRestProps(rest)}
-        />
+                }
+                error={!!(touched && (error || submitError))}
+                helperText={
+                    <InputHelperText
+                        touched={touched}
+                        error={error || submitError}
+                        helperText={helperText}
+                    />
+                }
+                {...options}
+                {...sanitizeInputRestProps(rest)}
+            />
+        </div>
     );
 };
 

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -91,6 +91,11 @@ const TextInput: FunctionComponent<TextInputProps> = props => {
     );
 };
 
+/*
+ * The left top border is weird when variant  property is outlined.
+ * Following styles fix it temporarily.
+ * > https://github.com/marmelab/react-admin/issues/6468
+ */
 const useStyles = makeStyles<Theme, TextInputProps>(
     {
         root: {

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import { Theme } from '@material-ui/core';
-import { makeStyles, Styles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 
 import ResettableTextField from './ResettableTextField';
 import InputHelperText from './InputHelperText';
@@ -27,19 +27,6 @@ export type TextInputProps = InputProps<TextFieldProps> &
  *
  * The object passed as `options` props is passed to the <ResettableTextField> component
  */
-
-const textInputStyles: Styles<Theme, TextInputProps> = {
-    root: {
-        '& .MuiOutlinedInput-notchedOutline': {
-            '& legend': {
-                width: ({ label }) =>
-                    label === false || label === '' ? '0.01px' : 'auto',
-            },
-        },
-    },
-};
-
-const useStyles = makeStyles(textInputStyles, { name: 'RaTextInput' });
 
 const TextInput: FunctionComponent<TextInputProps> = props => {
     const {
@@ -103,6 +90,21 @@ const TextInput: FunctionComponent<TextInputProps> = props => {
         </div>
     );
 };
+
+const useStyles = makeStyles<Theme, TextInputProps>(
+    {
+        root: {
+            '& .MuiOutlinedInput-notchedOutline': {
+                '& legend': {
+                    width: ({ label }) =>
+                        label === false || label === '' ? '0.01px' : 'auto',
+                },
+            },
+        },
+    },
+
+    { name: 'RaTextInput' }
+);
 
 TextInput.propTypes = {
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -62,12 +62,14 @@ const TextInput: FunctionComponent<TextInputProps> = ({
             id={id}
             {...input}
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label ? (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                ) : null
             }
             error={!!(touched && (error || submitError))}
             helperText={


### PR DESCRIPTION
Close #6468 

![Screenshot from 2021-07-28 01-15-46](https://user-images.githubusercontent.com/39510845/127189980-7ed77c16-4100-4919-914b-aab94beef708.png)

## Causes

If label is falsy value, FieldTitle component returned null value. But it isn't string value, it's react element. So MuiTextField don't interpret label is empty.

## Resolve

In TextInput component, pass null value when label is falsy value.