### PR TITLE
Remove usage of `FunctionComponent` from components definitions

### DIFF
--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, ReactElement, FunctionComponent } from 'react';
+import { cloneElement, ReactElement } from 'react';
 
 import useAuthenticated from './useAuthenticated';
 
@@ -36,12 +36,13 @@ interface Props {
  *         </Admin>
  *     );
  */
-const Authenticated: FunctionComponent<Props> = ({
-    authParams,
-    children,
-    location, // kept for backwards compatibility, unused
-    ...rest
-}) => {
+const Authenticated = (props: Props) => {
+    const {
+        authParams,
+        children,
+        location, // kept for backwards compatibility, unused
+        ...rest
+    } = props;
     useAuthenticated(authParams);
     // render the child even though the useAuthenticated() call isn't finished (optimistic rendering)
     // the above hook will log out if the authProvider doesn't validate that the user is authenticated

--- a/packages/ra-core/src/auth/WithPermissions.tsx
+++ b/packages/ra-core/src/auth/WithPermissions.tsx
@@ -1,10 +1,4 @@
-import {
-    Children,
-    FunctionComponent,
-    ReactElement,
-    ComponentType,
-    createElement,
-} from 'react';
+import { Children, ReactElement, ComponentType, createElement } from 'react';
 import { Location } from 'history';
 
 import warning from '../util/warning';
@@ -65,14 +59,15 @@ const isEmptyChildren = children => Children.count(children) === 0;
  *         </Admin>
  *     );
  */
-const WithPermissions: FunctionComponent<Props> = ({
-    authParams,
-    children,
-    render,
-    component,
-    staticContext,
-    ...props
-}) => {
+const WithPermissions = (props: Props) => {
+    const {
+        authParams,
+        children,
+        render,
+        component,
+        staticContext,
+        ...rest
+    } = props;
     warning(
         (render && children && !isEmptyChildren(children)) ||
             (render && component) ||
@@ -84,15 +79,15 @@ const WithPermissions: FunctionComponent<Props> = ({
     const { permissions } = usePermissionsOptimized(authParams);
     // render even though the usePermissions() call isn't finished (optimistic rendering)
     if (component) {
-        return createElement(component, { permissions, ...props });
+        return createElement(component, { permissions, ...rest });
     }
     // @deprecated
     if (render) {
-        return render({ permissions, ...props });
+        return render({ permissions, ...rest });
     }
     // @deprecated
     if (children) {
-        return children({ permissions, ...props });
+        return children({ permissions, ...rest });
     }
 };
 

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldController.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import useReferenceArrayFieldController from './useReferenceArrayFieldController';
 import { ListControllerProps } from '../useListController';
@@ -22,7 +22,7 @@ interface Props {
  *
  * @see useReferenceArrayFieldController
  */
-const ReferenceArrayFieldController: FunctionComponent<Props> = props => {
+const ReferenceArrayFieldController = (props: Props) => {
     const { children, ...rest } = props;
     const controllerProps = useReferenceArrayFieldController({
         sort: {

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, FunctionComponent } from 'react';
+import { ReactElement } from 'react';
 
 import { Record, SortPayload } from '../../types';
 import useReferenceManyFieldController from './useReferenceManyFieldController';
@@ -24,7 +24,7 @@ interface Props {
  *
  * @see useReferenceManyFieldController
  */
-export const ReferenceManyFieldController: FunctionComponent<Props> = props => {
+export const ReferenceManyFieldController = (props: Props) => {
     const { children, page = 1, perPage = 25, ...rest } = props;
     const controllerProps = useReferenceManyFieldController({
         page,

--- a/packages/ra-core/src/controller/input/ReferenceInputController.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.tsx
@@ -1,9 +1,4 @@
-import {
-    ReactNode,
-    ComponentType,
-    FunctionComponent,
-    ReactElement,
-} from 'react';
+import { ReactNode, ComponentType, ReactElement } from 'react';
 
 import { SortPayload, Record } from '../../types';
 import {
@@ -33,11 +28,9 @@ interface Props {
  *
  * @see useReferenceInputController
  */
-export const ReferenceInputController: FunctionComponent<Props> = ({
-    children,
-    ...props
-}) => {
-    return children(useReferenceInputController(props)) as ReactElement;
+export const ReferenceInputController = (props: Props) => {
+    const { children, ...rest } = props;
+    return children(useReferenceInputController(rest)) as ReactElement;
 };
 
 export default ReferenceInputController as ComponentType<Props>;

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, ComponentType } from 'react';
+import { ComponentType } from 'react';
 
 import CoreAdminContext from './CoreAdminContext';
 import CoreAdminUI from './CoreAdminUI';
@@ -86,28 +86,29 @@ export type ChildrenFunction = () => ComponentType[];
  *     );
  * };
  */
-const CoreAdmin: FunctionComponent<AdminProps> = ({
-    appLayout,
-    authProvider,
-    catchAll,
-    children,
-    customReducers,
-    customRoutes = [],
-    customSagas,
-    dashboard,
-    dataProvider,
-    disableTelemetry,
-    history,
-    i18nProvider,
-    initialState,
-    layout,
-    loading,
-    loginPage,
-    logoutButton,
-    menu, // deprecated, use a custom layout instead
-    theme,
-    title = 'React Admin',
-}) => {
+const CoreAdmin = (props: AdminProps) => {
+    const {
+        appLayout,
+        authProvider,
+        catchAll,
+        children,
+        customReducers,
+        customRoutes = [],
+        customSagas,
+        dashboard,
+        dataProvider,
+        disableTelemetry,
+        history,
+        i18nProvider,
+        initialState,
+        layout,
+        loading,
+        loginPage,
+        logoutButton,
+        menu, // deprecated, use a custom layout instead
+        theme,
+        title = 'React Admin',
+    } = props;
     return (
         <CoreAdminContext
             authProvider={authProvider}

--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, ComponentType, useContext, useState } from 'react';
+import { ComponentType, useContext, useState } from 'react';
 import { Provider, ReactReduxContext } from 'react-redux';
 import { History } from 'history';
 import { createHashHistory } from 'history';
@@ -40,16 +40,17 @@ export interface AdminContextProps {
     theme?: object;
 }
 
-const CoreAdminContext: FunctionComponent<AdminContextProps> = ({
-    authProvider,
-    dataProvider,
-    i18nProvider,
-    children,
-    history,
-    customReducers,
-    customSagas,
-    initialState,
-}) => {
+const CoreAdminContext = (props: AdminContextProps) => {
+    const {
+        authProvider,
+        dataProvider,
+        i18nProvider,
+        children,
+        history,
+        customReducers,
+        customSagas,
+        initialState,
+    } = props;
     const reduxIsAlreadyInitialized = !!useContext(ReactReduxContext);
 
     if (!dataProvider) {

--- a/packages/ra-core/src/core/CoreAdminRouter.tsx
+++ b/packages/ra-core/src/core/CoreAdminRouter.tsx
@@ -5,7 +5,6 @@ import React, {
     createElement,
     ComponentType,
     ReactElement,
-    FunctionComponent,
 } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
@@ -36,7 +35,7 @@ export interface AdminRouterProps extends CoreLayoutProps {
 
 type State = ResourceElement[];
 
-const CoreAdminRouter: FunctionComponent<AdminRouterProps> = props => {
+const CoreAdminRouter = (props: AdminRouterProps) => {
     const getPermissions = useGetPermissions();
     const doLogout = useLogout();
     const { authenticated } = useAuthState();

--- a/packages/ra-core/src/core/Resource.tsx
+++ b/packages/ra-core/src/core/Resource.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 
@@ -10,15 +10,16 @@ import { ResourceContextProvider } from './ResourceContextProvider';
 
 const defaultOptions = {};
 
-const ResourceRegister: FunctionComponent<ResourceProps> = ({
-    name,
-    list,
-    create,
-    edit,
-    show,
-    icon,
-    options = defaultOptions,
-}) => {
+const ResourceRegister = (props: ResourceProps) => {
+    const {
+        name,
+        list,
+        create,
+        edit,
+        show,
+        icon,
+        options = defaultOptions,
+    } = props;
     const dispatch = useDispatch();
     useEffect(() => {
         dispatch(
@@ -37,15 +38,16 @@ const ResourceRegister: FunctionComponent<ResourceProps> = ({
     return null;
 };
 
-const ResourceRoutes: FunctionComponent<ResourceProps> = ({
-    name,
-    match,
-    list,
-    create,
-    edit,
-    show,
-    options = defaultOptions,
-}) => {
+const ResourceRoutes = (props: ResourceProps) => {
+    const {
+        name,
+        match,
+        list,
+        create,
+        edit,
+        show,
+        options = defaultOptions,
+    } = props;
     const isRegistered = useSelector(
         (state: ReduxState) => !!state.admin.resources[name]
     );
@@ -141,14 +143,13 @@ const ResourceRoutes: FunctionComponent<ResourceProps> = ({
     }, [basePath, name, create, edit, list, show, options, isRegistered]); // eslint-disable-line react-hooks/exhaustive-deps
 };
 
-const Resource: FunctionComponent<ResourceProps> = ({
-    intent = 'route',
-    ...props
-}) =>
-    intent === 'registration' ? (
-        <ResourceRegister {...props} />
+const Resource = (props: ResourceProps) => {
+    const { intent = 'route', ...rest } = props;
+    return intent === 'registration' ? (
+        <ResourceRegister {...rest} />
     ) : (
-        <ResourceRoutes {...props} />
+        <ResourceRoutes {...rest} />
     );
+};
 
 export default Resource;

--- a/packages/ra-core/src/core/RoutesWithLayout.tsx
+++ b/packages/ra-core/src/core/RoutesWithLayout.tsx
@@ -1,9 +1,4 @@
-import React, {
-    Children,
-    cloneElement,
-    createElement,
-    FunctionComponent,
-} from 'react';
+import React, { Children, cloneElement, createElement } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import WithPermissions from '../auth/WithPermissions';
@@ -25,13 +20,8 @@ interface Props {
 
 const defaultAuthParams = { route: 'dashboard' };
 
-const RoutesWithLayout: FunctionComponent<Props> = ({
-    catchAll,
-    children,
-    customRoutes,
-    dashboard,
-    title,
-}) => {
+const RoutesWithLayout = (props: Props) => {
+    const { catchAll, children, customRoutes, dashboard, title } = props;
     const childrenAsArray = React.Children.toArray(children);
     const firstChild: React.ReactElement<any> | null =
         childrenAsArray.length > 0

--- a/packages/ra-core/src/form/FormDataConsumer.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactNode, FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import { useFormState } from 'react-final-form';
 import { FormSubscription } from 'final-form';
 import get from 'lodash/get';
@@ -74,14 +74,8 @@ const FormDataConsumer = ({ subscription, ...props }: ConnectedProps) => {
     return <FormDataConsumerView formData={formState.values} {...props} />;
 };
 
-export const FormDataConsumerView: FunctionComponent<Props> = ({
-    children,
-    form,
-    formData,
-    source,
-    index,
-    ...rest
-}) => {
+export const FormDataConsumerView = (props: Props) => {
+    const { children, form, formData, source, index, ...rest } = props;
     let scopedFormData = formData;
     let getSource;
     let getSourceHasBeenCalled = false;

--- a/packages/ra-core/src/form/FormField.tsx
+++ b/packages/ra-core/src/form/FormField.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 import { Validator, composeValidators } from './validate';
@@ -25,12 +24,8 @@ interface Props
     validate?: Validator | Validator[];
 }
 
-const FormField: FunctionComponent<Props> = ({
-    id,
-    input,
-    validate,
-    ...props
-}) => {
+const FormField = (props: Props) => {
+    const { id, input, validate, ...rest } = props;
     if (process.env.NODE_ENV !== 'production') {
         console.log('FormField is deprecated, use the useInput hook instead.');
     }
@@ -39,15 +34,15 @@ const FormField: FunctionComponent<Props> = ({
         ? composeValidators(validate)
         : validate;
 
-    const finalId = id || props.source;
+    const finalId = id || rest.source;
 
     return input ? ( // An ancestor is already decorated by Field
-        React.createElement(props.component, { input, id: finalId, ...props })
+        React.createElement(rest.component, { input, id: finalId, ...rest })
     ) : (
         <Field
-            {...props}
+            {...rest}
             id={finalId}
-            name={props.source}
+            name={rest.source}
             isRequired={isRequired(validate)}
             validate={sanitizedValidate}
         />

--- a/packages/ra-core/src/form/ValidationError.tsx
+++ b/packages/ra-core/src/form/ValidationError.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import {
     ValidationErrorMessage,
     ValidationErrorMessageWithArgs,
@@ -10,7 +9,8 @@ interface Props {
     error: ValidationErrorMessage;
 }
 
-const ValidationError: FunctionComponent<Props> = ({ error }) => {
+const ValidationError = (props: Props) => {
+    const { error } = props;
     const translate = useTranslate();
     if ((error as ValidationErrorMessageWithArgs).message) {
         const { message, args } = error as ValidationErrorMessageWithArgs;

--- a/packages/ra-core/src/i18n/TranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TranslationProvider.tsx
@@ -1,9 +1,4 @@
-import React, {
-    useCallback,
-    useMemo,
-    Children,
-    FunctionComponent,
-} from 'react';
+import React, { useCallback, useMemo, Children, ReactNode } from 'react';
 
 import { useSafeSetState } from '../util/hooks';
 import { TranslationContext } from './TranslationContext';
@@ -12,6 +7,7 @@ import { I18nProvider } from '../types';
 interface Props {
     locale?: string;
     i18nProvider: I18nProvider;
+    children: ReactNode;
 }
 
 interface State {
@@ -31,7 +27,7 @@ interface State {
  *         </Provider>
  *     );
  */
-const TranslationProvider: FunctionComponent<Props> = props => {
+const TranslationProvider = (props: Props) => {
     const { i18nProvider, children } = props;
 
     const [state, setState] = useSafeSetState<State>({

--- a/packages/ra-core/src/util/FieldTitle.tsx
+++ b/packages/ra-core/src/util/FieldTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, ReactElement, memo } from 'react';
+import { ReactElement, memo } from 'react';
 
 import useTranslate from '../i18n/useTranslate';
 import getFieldLabelTranslationArgs from './getFieldLabelTranslationArgs';
@@ -11,12 +11,8 @@ interface Props {
     label?: string | ReactElement | false;
 }
 
-export const FieldTitle: FunctionComponent<Props> = ({
-    resource,
-    source,
-    label,
-    isRequired,
-}) => {
+export const FieldTitle = (props: Props) => {
+    const { resource, source, label, isRequired } = props;
     const translate = useTranslate();
 
     if (label === false || label === '') {

--- a/packages/ra-ui-materialui/src/Link.tsx
+++ b/packages/ra-ui-materialui/src/Link.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link as RRLink, LinkProps as RRLinkProps } from 'react-router-dom';
@@ -23,7 +22,7 @@ export interface LinkProps extends RRLinkProps {
     className?: string;
 }
 
-const Link: FC<LinkProps> = props => {
+const Link = (props: LinkProps) => {
     const {
         to,
         children,

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Field, Form } from 'react-final-form';
 import {
@@ -52,7 +51,7 @@ const Input = ({
     />
 );
 
-const LoginForm: FunctionComponent<Props> = props => {
+const LoginForm = (props: Props) => {
     const { redirectTo } = props;
     const [loading, setLoading] = useSafeSetState(false);
     const login = useLogin();

--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import BulkDeleteWithConfirmButton, {
     BulkDeleteWithConfirmButtonProps,
@@ -31,12 +30,15 @@ import BulkDeleteWithUndoButton, {
  *     </List>
  * );
  */
-const BulkDeleteButton: FC<BulkDeleteButtonProps> = ({ undoable, ...props }) =>
-    undoable ? (
-        <BulkDeleteWithUndoButton {...props} />
+const BulkDeleteButton = (props: BulkDeleteButtonProps) => {
+    const { undoable, ...rest } = props;
+
+    return undoable ? (
+        <BulkDeleteWithUndoButton {...rest} />
     ) : (
-        <BulkDeleteWithConfirmButton {...props} />
+        <BulkDeleteWithConfirmButton {...rest} />
     );
+};
 
 interface Props {
     undoable?: boolean;

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, Fragment, useState, ReactElement } from 'react';
+import { Fragment, useState, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ActionDelete from '@material-ui/icons/Delete';
 import { fade } from '@material-ui/core/styles/colorManipulator';
@@ -37,7 +37,9 @@ const useStyles = makeStyles(
 
 const defaultIcon = <ActionDelete />;
 
-const BulkDeleteWithConfirmButton: FC<BulkDeleteWithConfirmButtonProps> = props => {
+const BulkDeleteWithConfirmButton = (
+    props: BulkDeleteWithConfirmButtonProps
+) => {
     const {
         basePath,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ActionDelete from '@material-ui/icons/Delete';
 import { fade } from '@material-ui/core/styles/colorManipulator';
@@ -33,7 +33,7 @@ const useStyles = makeStyles(
     { name: 'RaBulkDeleteWithUndoButton' }
 );
 
-const BulkDeleteWithUndoButton: FC<BulkDeleteWithUndoButtonProps> = props => {
+const BulkDeleteWithUndoButton = (props: BulkDeleteWithUndoButtonProps) => {
     const {
         basePath,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, FunctionComponent } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import {
@@ -36,7 +36,7 @@ import Button, { ButtonProps } from './Button';
  *     </List>
  * );
  */
-const BulkExportButton: FunctionComponent<BulkExportButtonProps> = props => {
+const BulkExportButton = (props: BulkExportButtonProps) => {
     const {
         onClick,
         label = 'ra.action.export',

--- a/packages/ra-ui-materialui/src/button/BulkUpdateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateButton.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import BulkUpdateWithConfirmButton, {
     BulkUpdateWithConfirmButtonProps,
@@ -32,15 +31,15 @@ import { MutationMode } from 'ra-core';
  *     </List>
  * );
  */
-const BulkUpdateButton: FC<BulkUpdateButtonProps> = ({
-    mutationMode,
-    ...props
-}) =>
-    mutationMode === 'undoable' ? (
-        <BulkUpdateWithUndoButton {...props} />
+const BulkUpdateButton = (props: BulkUpdateButtonProps) => {
+    const { mutationMode, ...rest } = props;
+
+    return mutationMode === 'undoable' ? (
+        <BulkUpdateWithUndoButton {...rest} />
     ) : (
-        <BulkUpdateWithConfirmButton mutationMode={mutationMode} {...props} />
+        <BulkUpdateWithConfirmButton mutationMode={mutationMode} {...rest} />
     );
+};
 
 interface Props {
     mutationMode?: MutationMode;

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, Fragment, useState, ReactElement } from 'react';
+import { Fragment, useState, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ActionUpdate from '@material-ui/icons/Update';
 import { fade } from '@material-ui/core/styles/colorManipulator';
@@ -38,7 +38,9 @@ const useStyles = makeStyles(
 
 const defaultIcon = <ActionUpdate />;
 
-const BulkUpdateWithConfirmButton: FC<BulkUpdateWithConfirmButtonProps> = props => {
+const BulkUpdateWithConfirmButton = (
+    props: BulkUpdateWithConfirmButtonProps
+) => {
     const notify = useNotify();
     const refresh = useRefresh();
     const translate = useTranslate();

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ActionUpdate from '@material-ui/icons/Update';
 import { fade } from '@material-ui/core/styles/colorManipulator';
@@ -33,7 +33,7 @@ const useStyles = makeStyles(
     { name: 'RaBulkUpdateWithUndoButton' }
 );
 
-const BulkUpdateWithUndoButton: FC<BulkUpdateWithUndoButtonProps> = props => {
+const BulkUpdateWithUndoButton = (props: BulkUpdateWithUndoButtonProps) => {
     const { selectedIds } = useListContext(props);
     const classes = useStyles(props);
     const notify = useNotify();

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, SyntheticEvent, ReactNode } from 'react';
+import { ReactElement, SyntheticEvent, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import {
     Button as MuiButton,
@@ -28,7 +28,7 @@ import { LocationDescriptor } from 'history';
  * </Button>
  *
  */
-const Button: FC<ButtonProps> = props => {
+const Button = (props: ButtonProps) => {
     const {
         alignIcon = 'left',
         children,

--- a/packages/ra-ui-materialui/src/button/CloneButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CloneButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo, ReactElement } from 'react';
+import { memo, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import Queue from '@material-ui/icons/Queue';
 import { Link } from 'react-router-dom';
@@ -8,14 +8,16 @@ import { Record, useResourceContext } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
-export const CloneButton: FC<CloneButtonProps> = ({
-    basePath = '',
-    label = 'ra.action.clone',
-    scrollToTop = true,
-    record,
-    icon = defaultIcon,
-    ...rest
-}) => {
+export const CloneButton = (props: CloneButtonProps) => {
+    const {
+        basePath = '',
+        label = 'ra.action.clone',
+        scrollToTop = true,
+        record,
+        icon = defaultIcon,
+        ...rest
+    } = props;
+
     const resource = useResourceContext();
     const pathname = basePath ? `${basePath}/create` : `/${resource}/create`;
     return (

--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, memo, useMemo } from 'react';
+import { ReactElement, memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Fab, useMediaQuery, Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -23,7 +23,7 @@ import Button, { ButtonProps, sanitizeButtonRestProps } from './Button';
  *     <CreateButton basePath="/comments" label="Create comment" />
  * );
  */
-const CreateButton: FC<CreateButtonProps> = props => {
+const CreateButton = (props: CreateButtonProps) => {
     const {
         basePath = '',
         className,

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, SyntheticEvent } from 'react';
+import { ReactElement, SyntheticEvent } from 'react';
 import PropTypes from 'prop-types';
 import {
     Record,
@@ -49,24 +49,20 @@ import DeleteWithConfirmButton from './DeleteWithConfirmButton';
  *     return <Edit actions={<EditActions />} {...props} />;
  * };
  */
-const DeleteButton: FC<DeleteButtonProps> = ({
-    undoable,
-    mutationMode,
-    record,
-    ...props
-}) => {
+const DeleteButton = (props: DeleteButtonProps) => {
+    const { undoable, mutationMode, record, ...rest } = props;
     const mode = getMutationMode(mutationMode, undoable);
     if (!record || record.id == null) {
         return null;
     }
 
     return mode === 'undoable' ? (
-        <DeleteWithUndoButton record={record} {...props} />
+        <DeleteWithUndoButton record={record} {...rest} />
     ) : (
         <DeleteWithConfirmButton
             mutationMode={mode}
             record={record}
-            {...props}
+            {...rest}
         />
     );
 };

--- a/packages/ra-ui-materialui/src/button/EditButton.tsx
+++ b/packages/ra-ui-materialui/src/button/EditButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, useMemo } from 'react';
+import { ReactElement, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import ContentCreate from '@material-ui/icons/Create';
 import { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
@@ -18,14 +18,15 @@ import Button, { ButtonProps } from './Button';
  *     <EditButton basePath="/comments" label="Edit comment" record={record} />
  * );
  */
-const EditButton: FC<EditButtonProps> = ({
-    basePath = '',
-    icon = defaultIcon,
-    label = 'ra.action.edit',
-    record,
-    scrollToTop = true,
-    ...rest
-}) => {
+const EditButton = (props: EditButtonProps) => {
+    const {
+        basePath = '',
+        icon = defaultIcon,
+        label = 'ra.action.edit',
+        record,
+        scrollToTop = true,
+        ...rest
+    } = props;
     const resource = useResourceContext();
     return (
         <Button

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, FunctionComponent } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import {
@@ -14,7 +14,7 @@ import {
 } from 'ra-core';
 import Button, { ButtonProps } from './Button';
 
-const ExportButton: FunctionComponent<ExportButtonProps> = props => {
+const ExportButton = (props: ExportButtonProps) => {
     const {
         maxResults = 1000,
         onClick,

--- a/packages/ra-ui-materialui/src/button/ListButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ListButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ActionList from '@material-ui/icons/List';
 import { Link } from 'react-router-dom';
@@ -33,12 +33,13 @@ import Button, { ButtonProps } from './Button';
  *     </Edit>
  * );
  */
-const ListButton: FC<ListButtonProps> = ({
-    basePath = '',
-    icon = defaultIcon,
-    label = 'ra.action.list',
-    ...rest
-}) => {
+const ListButton = (props: ListButtonProps) => {
+    const {
+        basePath = '',
+        icon = defaultIcon,
+        label = 'ra.action.list',
+        ...rest
+    } = props;
     const resource = useResourceContext();
     return (
         <Button

--- a/packages/ra-ui-materialui/src/button/RefreshButton.tsx
+++ b/packages/ra-ui-materialui/src/button/RefreshButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, MouseEvent, useCallback } from 'react';
+import { ReactElement, MouseEvent, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import NavigationRefresh from '@material-ui/icons/Refresh';
@@ -7,12 +7,13 @@ import { refreshView } from 'ra-core';
 
 import Button, { ButtonProps } from './Button';
 
-const RefreshButton: FC<RefreshButtonProps> = ({
-    label = 'ra.action.refresh',
-    icon = defaultIcon,
-    onClick,
-    ...rest
-}) => {
+const RefreshButton = (props: RefreshButtonProps) => {
+    const {
+        label = 'ra.action.refresh',
+        icon = defaultIcon,
+        onClick,
+        ...rest
+    } = props;
     const dispatch = useDispatch();
     const handleClick = useCallback(
         event => {

--- a/packages/ra-ui-materialui/src/button/RefreshIconButton.tsx
+++ b/packages/ra-ui-materialui/src/button/RefreshIconButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, FC, ReactElement } from 'react';
+import { useCallback, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -7,13 +7,14 @@ import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
 import NavigationRefresh from '@material-ui/icons/Refresh';
 import { refreshView, useTranslate } from 'ra-core';
 
-const RefreshIconButton: FC<RefreshIconButtonProps> = ({
-    label = 'ra.action.refresh',
-    icon = defaultIcon,
-    onClick,
-    className,
-    ...rest
-}) => {
+const RefreshIconButton = (props: RefreshIconButtonProps) => {
+    const {
+        label = 'ra.action.refresh',
+        icon = defaultIcon,
+        onClick,
+        className,
+        ...rest
+    } = props;
     const dispatch = useDispatch();
     const translate = useTranslate();
     const handleClick = useCallback(

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, FC, ReactElement, SyntheticEvent } from 'react';
+import React, { cloneElement, ReactElement, SyntheticEvent } from 'react';
 import PropTypes from 'prop-types';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -58,7 +58,7 @@ import { FormRenderProps } from 'react-final-form';
  *     return <SaveButton {...props} onSuccess={onSuccess} />;
  * }
  */
-const SaveButton: FC<SaveButtonProps> = props => {
+const SaveButton = (props: SaveButtonProps) => {
     const {
         className,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/button/ShowButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ShowButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo, useMemo, ReactElement } from 'react';
+import { memo, useMemo, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import ImageEye from '@material-ui/icons/RemoveRedEye';
 import { Link } from 'react-router-dom';
@@ -17,14 +17,15 @@ import Button, { ButtonProps } from './Button';
  *     <ShowButton basePath="/comments" label="Show comment" record={record} />
  * );
  */
-const ShowButton: FC<ShowButtonProps> = ({
-    basePath = '',
-    icon = defaultIcon,
-    label = 'ra.action.show',
-    record,
-    scrollToTop = true,
-    ...rest
-}) => {
+const ShowButton = (props: ShowButtonProps) => {
+    const {
+        basePath = '',
+        icon = defaultIcon,
+        label = 'ra.action.show',
+        record,
+        scrollToTop = true,
+        ...rest
+    } = props;
     const resource = useResourceContext();
     return (
         <Button

--- a/packages/ra-ui-materialui/src/button/SortButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SortButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, memo } from 'react';
+import { ReactElement, memo } from 'react';
 import {
     Button,
     Menu,
@@ -43,11 +43,8 @@ import {
  *     </TopToolbar>
  * );
  */
-const SortButton: FC<SortButtonProps> = ({
-    fields,
-    label = 'ra.sort.sort_by',
-    icon = defaultIcon,
-}) => {
+const SortButton = (props: SortButtonProps) => {
+    const { fields, label = 'ra.sort.sort_by', icon = defaultIcon } = props;
     const { resource, currentSort, setSort } = useListSortContext();
     const translate = useTranslate();
     const isXSmall = useMediaQuery((theme: Theme) =>

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-    FC,
     cloneElement,
     Children,
     useEffect,
@@ -118,7 +117,7 @@ const getDataAndIds = (
  *     );
  *     TagsField.defaultProps = { addLabel: true };
  */
-export const ArrayField: FC<ArrayFieldProps> = memo<ArrayFieldProps>(props => {
+const ArrayField = (props: ArrayFieldProps) => {
     const {
         addLabel,
         basePath,
@@ -179,7 +178,7 @@ export const ArrayField: FC<ArrayFieldProps> = memo<ArrayFieldProps>(props => {
             })}
         </ListContextProvider>
     );
-});
+};
 
 ArrayField.defaultProps = {
     addLabel: true,
@@ -202,4 +201,4 @@ interface State {
 
 ArrayField.displayName = 'ArrayField';
 
-export default ArrayField;
+export default memo<ArrayFieldProps>(ArrayField);

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo } from 'react';
+import { memo } from 'react';
 import { SvgIconComponent } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
@@ -25,69 +25,64 @@ const useStyles = makeStyles(
     }
 );
 
-export const BooleanField: FC<BooleanFieldProps> = memo<BooleanFieldProps>(
-    props => {
-        const {
-            className,
-            classes: classesOverride,
-            emptyText,
-            source,
-            valueLabelTrue,
-            valueLabelFalse,
-            TrueIcon,
-            FalseIcon,
-            looseValue,
-            ...rest
-        } = props;
-        const record = useRecordContext(props);
-        const translate = useTranslate();
-        const classes = useStyles(props);
-        const value = get(record, source);
-        const isTruthyValue = value === true || (looseValue && value);
-        let ariaLabel = value ? valueLabelTrue : valueLabelFalse;
+const BooleanField = (props: BooleanFieldProps) => {
+    const {
+        className,
+        classes: classesOverride,
+        emptyText,
+        source,
+        valueLabelTrue,
+        valueLabelFalse,
+        TrueIcon,
+        FalseIcon,
+        looseValue,
+        ...rest
+    } = props;
+    const record = useRecordContext(props);
+    const translate = useTranslate();
+    const classes = useStyles(props);
+    const value = get(record, source);
+    const isTruthyValue = value === true || (looseValue && value);
+    let ariaLabel = value ? valueLabelTrue : valueLabelFalse;
 
-        if (!ariaLabel) {
-            ariaLabel = isTruthyValue ? 'ra.boolean.true' : 'ra.boolean.false';
-        }
+    if (!ariaLabel) {
+        ariaLabel = isTruthyValue ? 'ra.boolean.true' : 'ra.boolean.false';
+    }
 
-        if (looseValue || value === false || value === true) {
-            return (
-                <Typography
-                    component="span"
-                    variant="body2"
-                    className={classnames(classes.root, className)}
-                    {...sanitizeFieldRestProps(rest)}
-                >
-                    <Tooltip title={translate(ariaLabel, { _: ariaLabel })}>
-                        {isTruthyValue ? (
-                            <span>
-                                <TrueIcon data-testid="true" fontSize="small" />
-                            </span>
-                        ) : (
-                            <span>
-                                <FalseIcon
-                                    data-testid="false"
-                                    fontSize="small"
-                                />
-                            </span>
-                        )}
-                    </Tooltip>
-                </Typography>
-            );
-        }
-
+    if (looseValue || value === false || value === true) {
         return (
             <Typography
                 component="span"
                 variant="body2"
-                className={className}
+                className={classnames(classes.root, className)}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                <Tooltip title={translate(ariaLabel, { _: ariaLabel })}>
+                    {isTruthyValue ? (
+                        <span>
+                            <TrueIcon data-testid="true" fontSize="small" />
+                        </span>
+                    ) : (
+                        <span>
+                            <FalseIcon data-testid="false" fontSize="small" />
+                        </span>
+                    )}
+                </Tooltip>
             </Typography>
         );
     }
-);
+
+    return (
+        <Typography
+            component="span"
+            variant="body2"
+            className={className}
+            {...sanitizeFieldRestProps(rest)}
+        >
+            {emptyText}
+        </Typography>
+    );
+};
 
 BooleanField.defaultProps = {
     addLabel: true,
@@ -118,4 +113,4 @@ export interface BooleanFieldProps
     looseValue?: boolean;
 }
 
-export default BooleanField;
+export default memo<BooleanFieldProps>(BooleanField);

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo } from 'react';
+import { memo } from 'react';
 import get from 'lodash/get';
 import Chip, { ChipProps } from '@material-ui/core/Chip';
 import Typography from '@material-ui/core/Typography';
@@ -17,7 +17,7 @@ const useStyles = makeStyles(
     { name: 'RaChipField' }
 );
 
-export const ChipField: FC<ChipFieldProps> = memo<ChipFieldProps>(props => {
+const ChipField = (props: ChipFieldProps) => {
     const {
         className,
         classes: classesOverride,
@@ -49,7 +49,7 @@ export const ChipField: FC<ChipFieldProps> = memo<ChipFieldProps>(props => {
             {...sanitizeFieldRestProps(rest)}
         />
     );
-});
+};
 
 ChipField.defaultProps = {
     addLabel: true,
@@ -65,4 +65,4 @@ export interface ChipFieldProps
         InjectedFieldProps,
         Omit<ChipProps, 'label'> {}
 
-export default ChipField;
+export default memo<ChipFieldProps>(ChipField);

--- a/packages/ra-ui-materialui/src/field/DateField.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo } from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Typography, { TypographyProps } from '@material-ui/core/Typography';
@@ -42,7 +42,7 @@ const toLocaleStringSupportsLocales = (() => {
  * // renders the record { id: 1234, new Date('2012-11-07') } as
  * <span>mercredi 7 novembre 2012</span>
  */
-export const DateField: FC<DateFieldProps> = memo<DateFieldProps>(props => {
+const DateField = (props: DateFieldProps) => {
     const {
         className,
         emptyText,
@@ -89,7 +89,7 @@ export const DateField: FC<DateFieldProps> = memo<DateFieldProps>(props => {
             {dateString}
         </Typography>
     );
-});
+};
 
 DateField.defaultProps = {
     addLabel: true,
@@ -116,4 +116,4 @@ export interface DateFieldProps
     showTime?: boolean;
 }
 
-export default DateField;
+export default memo<DateFieldProps>(DateField);

--- a/packages/ra-ui-materialui/src/field/EmailField.tsx
+++ b/packages/ra-ui-materialui/src/field/EmailField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, AnchorHTMLAttributes, memo } from 'react';
+import { AnchorHTMLAttributes, memo } from 'react';
 import get from 'lodash/get';
 import Typography from '@material-ui/core/Typography';
 import { Link } from '@material-ui/core';
@@ -11,7 +11,7 @@ import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 // useful to prevent click bubbling in a datagrid with rowClick
 const stopPropagation = e => e.stopPropagation();
 
-const EmailField: FC<EmailFieldProps> = memo<EmailFieldProps>(props => {
+const EmailField = (props: EmailFieldProps) => {
     const { className, source, emptyText, ...rest } = props;
     const record = useRecordContext(props);
     const value = get(record, source);
@@ -39,7 +39,7 @@ const EmailField: FC<EmailFieldProps> = memo<EmailFieldProps>(props => {
             {value}
         </Link>
     );
-});
+};
 
 EmailField.defaultProps = {
     addLabel: true,
@@ -52,4 +52,4 @@ export interface EmailFieldProps
         InjectedFieldProps,
         AnchorHTMLAttributes<HTMLAnchorElement> {}
 
-export default EmailField;
+export default memo<EmailFieldProps>(EmailField);

--- a/packages/ra-ui-materialui/src/field/FileField.tsx
+++ b/packages/ra-ui-materialui/src/field/FileField.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { makeStyles } from '@material-ui/core/styles';
@@ -23,7 +22,7 @@ import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
  *     <a href="doc.pdf" title="Presentation">Presentation</a>
  * </div>
  */
-const FileField: FC<FileFieldProps> = props => {
+const FileField = (props: FileFieldProps) => {
     const {
         className,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { makeStyles } from '@material-ui/core/styles';
@@ -30,7 +29,7 @@ export interface ImageFieldProps extends PublicFieldProps, InjectedFieldProps {
     classes?: object;
 }
 
-const ImageField: FC<ImageFieldProps> = props => {
+const ImageField = (props: ImageFieldProps) => {
     const {
         className,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Children, cloneElement, FC, memo, ReactElement } from 'react';
+import { Children, cloneElement, memo, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { useSelector } from 'react-redux';
@@ -76,7 +76,7 @@ import { LinearProgress } from '../layout';
  *    ...
  * </ReferenceArrayField>
  */
-const ReferenceArrayField: FC<ReferenceArrayFieldProps> = props => {
+const ReferenceArrayField = (props: ReferenceArrayFieldProps) => {
     const {
         basePath,
         children,
@@ -176,7 +176,9 @@ export interface ReferenceArrayFieldViewProps
     classes?: ClassesOverride<typeof useStyles>;
 }
 
-export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props => {
+export const ReferenceArrayFieldView = (
+    props: ReferenceArrayFieldViewProps
+) => {
     const {
         children,
         pagination,
@@ -217,6 +219,8 @@ ReferenceArrayFieldView.propTypes = {
     reference: PropTypes.string.isRequired,
 };
 
-const PureReferenceArrayFieldView = memo(ReferenceArrayFieldView);
+const PureReferenceArrayFieldView = memo<ReferenceArrayFieldViewProps>(
+    ReferenceArrayFieldView
+);
 
 export default ReferenceArrayField;

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -69,7 +69,7 @@ import { ClassesOverride } from '../types';
  * In previous versions of React-Admin, the prop `linkType` was used. It is now deprecated and replaced with `link`. However
  * backward-compatibility is still kept
  */
-const ReferenceField: FC<ReferenceFieldProps> = props => {
+const ReferenceField = (props: ReferenceFieldProps) => {
     const { source, emptyText, ...rest } = props;
     const record = useRecordContext(props);
     const isReferenceDeclared = useSelector<ReduxState, boolean>(

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, cloneElement, Children, ReactElement } from 'react';
+import React, { cloneElement, Children, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     FilterPayload,
@@ -61,7 +61,7 @@ import sanitizeFieldRestProps from './sanitizeFieldRestProps';
  *    ...
  * </ReferenceManyField>
  */
-export const ReferenceManyField: FC<ReferenceManyFieldProps> = props => {
+const ReferenceManyField = (props: ReferenceManyFieldProps) => {
     const {
         basePath,
         children,
@@ -156,7 +156,7 @@ ReferenceManyField.defaultProps = {
     addLabel: true,
 };
 
-export const ReferenceManyFieldView: FC<ReferenceManyFieldViewProps> = props => {
+export const ReferenceManyFieldView = (props: ReferenceManyFieldViewProps) => {
     const { basePath, children, pagination, reference, ...rest } = props;
     return (
         <>

--- a/packages/ra-ui-materialui/src/field/RichTextField.tsx
+++ b/packages/ra-ui-materialui/src/field/RichTextField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo } from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Typography, { TypographyProps } from '@material-ui/core/Typography';
@@ -11,30 +11,28 @@ import { InjectedFieldProps, PublicFieldProps, fieldPropTypes } from './types';
 export const removeTags = (input: string) =>
     input ? input.replace(/<[^>]+>/gm, '') : '';
 
-const RichTextField: FC<RichTextFieldProps> = memo<RichTextFieldProps>(
-    props => {
-        const { className, emptyText, source, stripTags, ...rest } = props;
-        const record = useRecordContext(props);
-        const value = get(record, source);
+const RichTextField = (props: RichTextFieldProps) => {
+    const { className, emptyText, source, stripTags, ...rest } = props;
+    const record = useRecordContext(props);
+    const value = get(record, source);
 
-        return (
-            <Typography
-                className={className}
-                variant="body2"
-                component="span"
-                {...sanitizeFieldRestProps(rest)}
-            >
-                {value == null && emptyText ? (
-                    emptyText
-                ) : stripTags ? (
-                    removeTags(value)
-                ) : (
-                    <span dangerouslySetInnerHTML={{ __html: value }} />
-                )}
-            </Typography>
-        );
-    }
-);
+    return (
+        <Typography
+            className={className}
+            variant="body2"
+            component="span"
+            {...sanitizeFieldRestProps(rest)}
+        >
+            {value == null && emptyText ? (
+                emptyText
+            ) : stripTags ? (
+                removeTags(value)
+            ) : (
+                <span dangerouslySetInnerHTML={{ __html: value }} />
+            )}
+        </Typography>
+    );
+};
 
 RichTextField.defaultProps = {
     addLabel: true,
@@ -57,4 +55,4 @@ export interface RichTextFieldProps
 
 RichTextField.displayName = 'RichTextField';
 
-export default RichTextField;
+export default memo<RichTextFieldProps>(RichTextField);

--- a/packages/ra-ui-materialui/src/field/SelectField.tsx
+++ b/packages/ra-ui-materialui/src/field/SelectField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo } from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { ChoicesProps, useChoices, useRecordContext } from 'ra-core';
@@ -67,55 +67,53 @@ import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
  *
  * **Tip**: <ReferenceField> sets `translateChoice` to false by default.
  */
-export const SelectField: FC<SelectFieldProps> = memo<SelectFieldProps>(
-    props => {
-        const {
-            className,
-            emptyText,
-            source,
-            choices,
-            optionValue,
-            optionText,
-            translateChoice,
-            ...rest
-        } = props;
-        const record = useRecordContext(props);
-        const value = get(record, source);
-        const { getChoiceText, getChoiceValue } = useChoices({
-            optionText,
-            optionValue,
-            translateChoice,
-        });
+export const SelectField = (props: SelectFieldProps) => {
+    const {
+        className,
+        emptyText,
+        source,
+        choices,
+        optionValue,
+        optionText,
+        translateChoice,
+        ...rest
+    } = props;
+    const record = useRecordContext(props);
+    const value = get(record, source);
+    const { getChoiceText, getChoiceValue } = useChoices({
+        optionText,
+        optionValue,
+        translateChoice,
+    });
 
-        const choice = choices.find(choice => getChoiceValue(choice) === value);
+    const choice = choices.find(choice => getChoiceValue(choice) === value);
 
-        if (!choice) {
-            return emptyText ? (
-                <Typography
-                    component="span"
-                    variant="body2"
-                    className={className}
-                    {...sanitizeFieldRestProps(rest)}
-                >
-                    {emptyText}
-                </Typography>
-            ) : null;
-        }
-
-        let choiceText = getChoiceText(choice);
-
-        return (
+    if (!choice) {
+        return emptyText ? (
             <Typography
                 component="span"
                 variant="body2"
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {choiceText}
+                {emptyText}
             </Typography>
-        );
+        ) : null;
     }
-);
+
+    let choiceText = getChoiceText(choice);
+
+    return (
+        <Typography
+            component="span"
+            variant="body2"
+            className={className}
+            {...sanitizeFieldRestProps(rest)}
+        >
+            {choiceText}
+        </Typography>
+    );
+};
 
 SelectField.defaultProps = {
     optionText: 'name',
@@ -149,4 +147,4 @@ export interface SelectFieldProps
 
 SelectField.displayName = 'SelectField';
 
-export default SelectField;
+export default memo<SelectFieldProps>(SelectField);

--- a/packages/ra-ui-materialui/src/field/TextField.tsx
+++ b/packages/ra-ui-materialui/src/field/TextField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, memo, ElementType } from 'react';
+import { memo, ElementType } from 'react';
 import get from 'lodash/get';
 import Typography, { TypographyProps } from '@material-ui/core/Typography';
 import { useRecordContext } from 'ra-core';
@@ -7,7 +7,7 @@ import { useRecordContext } from 'ra-core';
 import sanitizeFieldRestProps from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 
-const TextField: FC<TextFieldProps> = memo<TextFieldProps>(props => {
+const TextField = (props: TextFieldProps) => {
     const { className, source, emptyText, ...rest } = props;
     const record = useRecordContext(props);
     const value = get(record, source);
@@ -24,7 +24,7 @@ const TextField: FC<TextFieldProps> = memo<TextFieldProps>(props => {
                 : value || emptyText}
         </Typography>
     );
-});
+};
 
 // what? TypeScript loses the displayName if we don't set it explicitly
 TextField.displayName = 'TextField';
@@ -47,4 +47,4 @@ export interface TextFieldProps
     component?: ElementType<any>;
 }
 
-export default TextField;
+export default memo<TextFieldProps>(TextField);

--- a/packages/ra-ui-materialui/src/field/UrlField.tsx
+++ b/packages/ra-ui-materialui/src/field/UrlField.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { FC, AnchorHTMLAttributes, memo } from 'react';
+import { AnchorHTMLAttributes, memo } from 'react';
 import get from 'lodash/get';
 import sanitizeFieldRestProps from './sanitizeFieldRestProps';
 import { Typography, Link } from '@material-ui/core';
 import { useRecordContext } from 'ra-core';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 
-const UrlField: FC<UrlFieldProps> = memo<UrlFieldProps>(props => {
+const UrlField = (props: UrlFieldProps) => {
     const { className, emptyText, source, ...rest } = props;
     const record = useRecordContext(props);
     const value = get(record, source);
@@ -33,7 +33,7 @@ const UrlField: FC<UrlFieldProps> = memo<UrlFieldProps>(props => {
             {value}
         </Link>
     );
-});
+};
 
 UrlField.defaultProps = {
     addLabel: true,
@@ -47,4 +47,4 @@ export interface UrlFieldProps
         InjectedFieldProps,
         AnchorHTMLAttributes<HTMLAnchorElement> {}
 
-export default UrlField;
+export default memo<UrlFieldProps>(UrlField);

--- a/packages/ra-ui-materialui/src/form/FormTab.tsx
+++ b/packages/ra-ui-materialui/src/form/FormTab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroupContextProvider, Record } from 'ra-core';
 
@@ -8,24 +8,25 @@ import { FormTabHeader } from './FormTabHeader';
 
 const hiddenStyle = { display: 'none' };
 
-export const FormTab: FC<FormTabProps> = ({
-    basePath,
-    className,
-    classes,
-    contentClassName,
-    children,
-    hidden,
-    icon,
-    intent,
-    label,
-    margin,
-    path,
-    record,
-    resource,
-    variant,
-    value,
-    ...rest
-}) => {
+export const FormTab = (props: FormTabProps) => {
+    const {
+        basePath,
+        className,
+        classes,
+        contentClassName,
+        children,
+        hidden,
+        icon,
+        intent,
+        label,
+        margin,
+        path,
+        record,
+        resource,
+        variant,
+        value,
+        ...rest
+    } = props;
     const renderHeader = () => (
         <FormTabHeader
             label={label}

--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement, ReactNode, HtmlHTMLAttributes } from 'react';
+import { ReactElement, ReactNode, HtmlHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { FormWithRedirect, FormWithRedirectProps, MutationMode } from 'ra-core';
 import { SimpleFormView } from './SimpleFormView';
@@ -39,7 +39,7 @@ import { SimpleFormView } from './SimpleFormView';
  *
  * @param {Props} props
  */
-const SimpleForm: FC<SimpleFormProps> = props => (
+const SimpleForm = (props: SimpleFormProps) => (
     <FormWithRedirect
         {...props}
         render={formProps => <SimpleFormView {...formProps} />}

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
     Children,
     isValidElement,
-    FC,
     ReactElement,
     ReactNode,
     HtmlHTMLAttributes,
@@ -89,7 +88,7 @@ import { TabbedFormView, useTabbedFormViewStyles } from './TabbedFormView';
  *
  * @param {Props} props
  */
-export const TabbedForm: FC<TabbedFormProps> = props => (
+export const TabbedForm = (props: TabbedFormProps) => (
     <FormWithRedirect
         {...props}
         render={formProps => <TabbedFormView {...formProps} />}

--- a/packages/ra-ui-materialui/src/form/TabbedFormTabs.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormTabs.tsx
@@ -1,23 +1,11 @@
 import * as React from 'react';
-import {
-    Children,
-    cloneElement,
-    isValidElement,
-    FC,
-    ReactElement,
-} from 'react';
+import { Children, cloneElement, isValidElement, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import Tabs, { TabsProps } from '@material-ui/core/Tabs';
 import { useLocation } from 'react-router-dom';
 
-const TabbedFormTabs: FC<TabbedFormTabsProps> = ({
-    children,
-    classes,
-    url,
-    syncWithLocation,
-    value,
-    ...rest
-}) => {
+const TabbedFormTabs = (props: TabbedFormTabsProps) => {
+    const { children, classes, url, syncWithLocation, value, ...rest } = props;
     const location = useLocation();
 
     const validTabPaths = Children.map(children, (tab, index) => {

--- a/packages/ra-ui-materialui/src/input/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { cloneElement, Children, FC, ReactElement } from 'react';
+import { cloneElement, Children, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     isRequired,
@@ -56,23 +56,24 @@ import { LinearProgress } from '../layout';
  *
  * @see https://github.com/final-form/react-final-form-arrays
  */
-const ArrayInput: FC<ArrayInputProps> = ({
-    className,
-    defaultValue,
-    label,
-    loaded,
-    loading,
-    children,
-    helperText,
-    record,
-    resource,
-    source,
-    validate,
-    variant,
-    disabled,
-    margin = 'dense',
-    ...rest
-}) => {
+const ArrayInput = (props: ArrayInputProps) => {
+    const {
+        className,
+        defaultValue,
+        label,
+        loaded,
+        loading,
+        children,
+        helperText,
+        record,
+        resource,
+        source,
+        validate,
+        variant,
+        disabled,
+        margin = 'dense',
+        ...rest
+    } = props;
     const sanitizedValidate = Array.isArray(validate)
         ? composeSyncValidators(validate)
         : validate;

--- a/packages/ra-ui-materialui/src/input/AutocompleteSuggestionItem.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteSuggestionItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, isValidElement, cloneElement } from 'react';
+import { isValidElement, cloneElement } from 'react';
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
 import { MenuItem } from '@material-ui/core';
@@ -37,9 +37,10 @@ export interface AutocompleteSuggestionItemProps {
     getSuggestionText: (suggestion: any) => string;
 }
 
-const AutocompleteSuggestionItem: FunctionComponent<
-    AutocompleteSuggestionItemProps & MenuItemProps<'li', { button?: true }>
-> = props => {
+const AutocompleteSuggestionItem = (
+    props: AutocompleteSuggestionItemProps &
+        MenuItemProps<'li', { button?: true }>
+) => {
     const {
         createValue,
         suggestion,

--- a/packages/ra-ui-materialui/src/input/AutocompleteSuggestionList.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteSuggestionList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactNode, FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import classnames from 'classnames';
 import { Paper, Popper } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -27,7 +27,7 @@ interface Props {
     suggestionsContainerProps?: any;
 }
 
-const AutocompleteSuggestionList: FunctionComponent<Props> = props => {
+const AutocompleteSuggestionList = (props: Props) => {
     const {
         children,
         className,

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, useCallback } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -11,22 +11,23 @@ import sanitizeInputRestProps from './sanitizeInputRestProps';
 import InputHelperText from './InputHelperText';
 import InputPropTypes from './InputPropTypes';
 
-const BooleanInput: FunctionComponent<BooleanInputProps> = ({
-    format,
-    label,
-    fullWidth,
-    helperText,
-    onBlur,
-    onChange,
-    onFocus,
-    options,
-    disabled,
-    parse,
-    resource,
-    source,
-    validate,
-    ...rest
-}) => {
+const BooleanInput = (props: BooleanInputProps) => {
+    const {
+        format,
+        label,
+        fullWidth,
+        helperText,
+        onBlur,
+        onChange,
+        onFocus,
+        options,
+        disabled,
+        parse,
+        resource,
+        source,
+        validate,
+        ...rest
+    } = props;
     const {
         id,
         input: { onChange: finalFormOnChange, type, value, ...inputProps },

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, FunctionComponent } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import FormLabel from '@material-ui/core/FormLabel';
@@ -80,7 +80,7 @@ import { ClassesOverride } from '../types';
  *
  * The object passed as `options` props is passed to the material-ui <Checkbox> components
  */
-const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = props => {
+const CheckboxGroupInput = (props: CheckboxGroupInputProps) => {
     const {
         choices = [],
         className,

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -1,5 +1,4 @@
 import React, {
-    FunctionComponent,
     Children,
     cloneElement,
     isValidElement,
@@ -50,9 +49,7 @@ export interface FileInputOptions extends DropzoneOptions {
     onRemove?: Function;
 }
 
-const FileInput: FunctionComponent<
-    FileInputProps & InputProps<FileInputOptions>
-> = props => {
+const FileInput = (props: FileInputProps & InputProps<FileInputOptions>) => {
     const {
         accept,
         children,

--- a/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect, ReactNode, FunctionComponent } from 'react';
+import { useEffect, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import RemoveCircle from '@material-ui/icons/RemoveCircle';
@@ -24,7 +24,7 @@ interface Props {
     file: any;
 }
 
-const FileInputPreview: FunctionComponent<Props> = props => {
+const FileInputPreview = (props: Props) => {
     const {
         children,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import { useTranslate, ValidationError, ValidationErrorMessage } from 'ra-core';
 
 export interface InputHelperTextProps {
@@ -8,11 +7,8 @@ export interface InputHelperTextProps {
     touched: boolean;
 }
 
-const InputHelperText: FunctionComponent<InputHelperTextProps> = ({
-    helperText,
-    touched,
-    error,
-}) => {
+const InputHelperText = (props: InputHelperTextProps) => {
+    const { helperText, touched, error } = props;
     const translate = useTranslate();
 
     return touched && error ? (

--- a/packages/ra-ui-materialui/src/input/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/input/Labeled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
@@ -56,7 +56,7 @@ export interface LabeledProps {
  *     <FooComponent source="title" />
  * </Labeled>
  */
-const Labeled: FunctionComponent<LabeledProps> = props => {
+const Labeled = (props: LabeledProps) => {
     const {
         children,
         className,

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -36,7 +35,7 @@ export type NullableBooleanInputProps = InputProps<TextFieldProps> &
         trueLabel?: string;
     };
 
-const NullableBooleanInput: FunctionComponent<NullableBooleanInputProps> = props => {
+const NullableBooleanInput = (props: NullableBooleanInputProps) => {
     const {
         className,
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
@@ -25,26 +24,27 @@ const convertStringToNumber = value => {
  *
  * The object passed as `options` props is passed to the material-ui <TextField> component
  */
-const NumberInput: FunctionComponent<NumberInputProps> = ({
-    format,
-    helperText,
-    label,
-    margin = 'dense',
-    onBlur,
-    onFocus,
-    onChange,
-    options,
-    parse = convertStringToNumber,
-    resource,
-    source,
-    step,
-    min,
-    max,
-    validate,
-    variant = 'filled',
-    inputProps: overrideInputProps,
-    ...rest
-}) => {
+const NumberInput = (props: NumberInputProps) => {
+    const {
+        format,
+        helperText,
+        label,
+        margin = 'dense',
+        onBlur,
+        onFocus,
+        onChange,
+        options,
+        parse = convertStringToNumber,
+        resource,
+        source,
+        step,
+        min,
+        max,
+        validate,
+        variant = 'filled',
+        inputProps: overrideInputProps,
+        ...rest
+    } = props;
     const {
         id,
         input,

--- a/packages/ra-ui-materialui/src/input/PasswordInput.tsx
+++ b/packages/ra-ui-materialui/src/input/PasswordInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, useState } from 'react';
+import { useState } from 'react';
 import { useTranslate } from 'ra-core';
 import { InputAdornment, IconButton } from '@material-ui/core';
 import Visibility from '@material-ui/icons/Visibility';
@@ -11,10 +11,8 @@ export interface PasswordInputProps extends TextInputProps {
     initiallyVisible?: boolean;
 }
 
-const PasswordInput: FC<PasswordInputProps> = ({
-    initiallyVisible = false,
-    ...props
-}) => {
+const PasswordInput = (props: PasswordInputProps) => {
+    const { initiallyVisible = false, ...rest } = props;
     const [visible, setVisible] = useState(initiallyVisible);
     const translate = useTranslate();
 
@@ -24,7 +22,7 @@ const PasswordInput: FC<PasswordInputProps> = ({
 
     return (
         <TextInput
-            {...props}
+            {...rest}
             type={visible ? 'text' : 'password'}
             InputProps={{
                 endAdornment: (

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import {
     FormControl,
@@ -88,7 +87,7 @@ const useStyles = makeStyles(
  *
  * The object passed as `options` props is passed to the material-ui <RadioButtonGroup> component
  */
-const RadioButtonGroupInput: FunctionComponent<RadioButtonGroupInputProps> = props => {
+const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
     const {
         choices = [],
         classes: classesOverride,

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -1,9 +1,4 @@
-import React, {
-    Children,
-    cloneElement,
-    FunctionComponent,
-    ReactElement,
-} from 'react';
+import React, { Children, cloneElement, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     useInput,
@@ -98,15 +93,16 @@ import ReferenceError from './ReferenceError';
  *     <AutocompleteInput optionText="title" />
  * </ReferenceInput>
  */
-const ReferenceInput: FunctionComponent<ReferenceInputProps> = ({
-    format,
-    onBlur,
-    onChange,
-    onFocus,
-    parse,
-    validate,
-    ...props
-}) => {
+const ReferenceInput = (props: ReferenceInputProps) => {
+    const {
+        format,
+        onBlur,
+        onChange,
+        onFocus,
+        parse,
+        validate,
+        ...rest
+    } = props;
     const inputProps = useInput({
         format,
         onBlur,
@@ -114,13 +110,13 @@ const ReferenceInput: FunctionComponent<ReferenceInputProps> = ({
         onFocus,
         parse,
         validate,
-        ...props,
+        ...rest,
     });
     return (
         <ReferenceInputView
             {...inputProps}
-            {...props}
-            {...useReferenceInputController({ ...props, ...inputProps })}
+            {...rest}
+            {...useReferenceInputController({ ...rest, ...inputProps })}
         />
     );
 };
@@ -188,30 +184,31 @@ export interface ReferenceInputViewProps
         ReferenceInputProps,
         Omit<UseInputValue, 'id'> {}
 
-export const ReferenceInputView: FunctionComponent<ReferenceInputViewProps> = ({
-    allowEmpty,
-    basePath,
-    children,
-    choices,
-    classes,
-    className,
-    error,
-    helperText,
-    id,
-    input,
-    isRequired,
-    label,
-    meta,
-    possibleValues,
-    resource,
-    reference,
-    setFilter,
-    setPagination,
-    setSort,
-    source,
-    warning,
-    ...rest
-}) => {
+export const ReferenceInputView = (props: ReferenceInputViewProps) => {
+    const {
+        allowEmpty,
+        basePath,
+        children,
+        choices,
+        classes,
+        className,
+        error,
+        helperText,
+        id,
+        input,
+        isRequired,
+        label,
+        meta,
+        possibleValues,
+        resource,
+        reference,
+        setFilter,
+        setPagination,
+        setSort,
+        source,
+        warning,
+        ...rest
+    } = props;
     if (Children.count(children) !== 1) {
         throw new Error('<ReferenceInput> only accepts a single child');
     }

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -18,7 +18,7 @@ import { Styles } from '@material-ui/styles';
 /**
  * An override of the default Material-UI TextField which is resettable
  */
-function ResettableTextField(props: ResettableTextFieldProps) {
+const ResettableTextField = (props: ResettableTextFieldProps) => {
     const {
         classes: classesOverride,
         clearAlwaysVisible,
@@ -170,7 +170,7 @@ function ResettableTextField(props: ResettableTextFieldProps) {
             onBlur={handleBlur}
         />
     );
-}
+};
 
 export const resettableStyles: Styles<Theme, ResettableTextFieldProps> = {
     clearIcon: {

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import SearchIcon from '@material-ui/icons/Search';
 import { InputAdornment } from '@material-ui/core';
@@ -18,7 +17,7 @@ const useStyles = makeStyles(
     { name: 'RaSearchInput' }
 );
 
-const SearchInput: FunctionComponent<SearchInputProps> = props => {
+const SearchInput = (props: SearchInputProps) => {
     const { classes: classesOverride, ...rest } = props;
     const translate = useTranslate();
     const classes = useStyles(props);

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
 import { TextFieldProps } from '@material-ui/core/TextField';
@@ -25,20 +24,21 @@ export type TextInputProps = InputProps<TextFieldProps> &
  *
  * The object passed as `options` props is passed to the <ResettableTextField> component
  */
-const TextInput: FunctionComponent<TextInputProps> = ({
-    label,
-    format,
-    helperText,
-    onBlur,
-    onFocus,
-    onChange,
-    options,
-    parse,
-    resource,
-    source,
-    validate,
-    ...rest
-}) => {
+const TextInput = (props: TextInputProps) => {
+    const {
+        label,
+        format,
+        helperText,
+        onBlur,
+        onFocus,
+        onChange,
+        options,
+        parse,
+        resource,
+        source,
+        validate,
+        ...rest
+    } = props;
     const {
         id,
         input,

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, useCallback, MouseEventHandler } from 'react';
+import { useCallback, MouseEventHandler } from 'react';
 import PropTypes, { ReactComponentLike } from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -53,7 +53,7 @@ const useStyles = makeStyles(
  *     onClose={() => { // do something }}
  * />
  */
-const Confirm: FC<ConfirmProps> = props => {
+const Confirm = (props: ConfirmProps) => {
     const {
         isOpen,
         loading,

--- a/packages/ra-ui-materialui/src/layout/DashboardMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/DashboardMenuItem.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import { useTranslate } from 'ra-core';
 
 import MenuItemLink from './MenuItemLink';
 
-const DashboardMenuItem: FC<DashboardMenuItemProps> = ({
-    locale,
-    ...props
-}) => {
+const DashboardMenuItem = (props: DashboardMenuItemProps) => {
+    const { locale, ...rest } = props;
     const translate = useTranslate();
     return (
         <MenuItemLink
@@ -17,7 +14,7 @@ const DashboardMenuItem: FC<DashboardMenuItemProps> = ({
             primaryText={translate('ra.page.dashboard')}
             leftIcon={<DashboardIcon />}
             exact
-            {...props}
+            {...rest}
         />
     );
 };
@@ -28,7 +25,7 @@ export interface DashboardMenuItemProps {
     onClick?: () => void;
     dense?: boolean;
     /**
-     * @deprcated
+     * @deprecated
      */
     sidebarIsOpen?: boolean;
 }

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -2,7 +2,6 @@ import React, {
     forwardRef,
     cloneElement,
     useCallback,
-    FC,
     ReactElement,
     ReactNode,
 } from 'react';
@@ -89,7 +88,7 @@ const useStyles = makeStyles(
  *     </Admin>
  * );
  */
-const MenuItemLink: FC<MenuItemLinkProps> = forwardRef((props, ref) => {
+const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
     const {
         classes: classesOverride,
         className,

--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -44,9 +44,7 @@ const useStyles = makeStyles(
     { name: 'RaNotification' }
 );
 
-const Notification: React.FunctionComponent<
-    Props & Omit<SnackbarProps, 'open'>
-> = props => {
+const Notification = (props: Props & Omit<SnackbarProps, 'open'>) => {
     const {
         classes: classesOverride,
         type,

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import { Children, ReactNode, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -54,7 +53,7 @@ const useStyles = makeStyles(
     { name: 'RaBulkActionsToolbar' }
 );
 
-const BulkActionsToolbar: FC<BulkActionsToolbarProps> = props => {
+const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
     const {
         classes: classesOverride,
         label = 'ra.action.bulk_actions',

--- a/packages/ra-ui-materialui/src/list/ListActions.tsx
+++ b/packages/ra-ui-materialui/src/list/ListActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { cloneElement, useMemo, useContext, FC, ReactElement } from 'react';
+import { cloneElement, useMemo, useContext, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     sanitizeListRestProps,
@@ -45,7 +45,7 @@ import FilterButton from './filter/FilterButton';
  *         </List>
  *     );
  */
-const ListActions: FC<ListActionsProps> = props => {
+const ListActions = (props: ListActionsProps) => {
     const { className, exporter, filters: filtersProp, ...rest } = props;
     const {
         currentSort,

--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { Toolbar, ToolbarProps } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -35,7 +35,7 @@ const useStyles = makeStyles(
     { name: 'RaListToolbar' }
 );
 
-const ListToolbar: FC<ListToolbarProps> = props => {
+const ListToolbar = (props: ListToolbarProps) => {
     const { classes: classesOverride, filters, actions, ...rest } = props;
     const classes = useStyles(props);
 

--- a/packages/ra-ui-materialui/src/list/Placeholder.tsx
+++ b/packages/ra-ui-materialui/src/list/Placeholder.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 
@@ -18,7 +17,7 @@ interface Props {
     classes?: Record<'root', string>;
 }
 
-const Placeholder: FC<Props> = props => {
+const Placeholder = (props: Props) => {
     const classes = useStyles(props);
     return (
         <span className={classnames(classes.root, props.className)}>

--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactNode, ReactElement } from 'react';
+import { ReactNode, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     Avatar,
@@ -238,14 +238,15 @@ const useLinkOrNotStyles = makeStyles(
     { name: 'RaLinkOrNot' }
 );
 
-const LinkOrNot: FC<LinkOrNotProps> = ({
-    classes: classesOverride,
-    linkType,
-    basePath,
-    id,
-    children,
-    record,
-}) => {
+const LinkOrNot = (props: LinkOrNotProps) => {
+    const {
+        classes: classesOverride,
+        linkType,
+        basePath,
+        id,
+        children,
+        record,
+    } = props;
     const classes = useLinkOrNotStyles({ classes: classesOverride });
     const link =
         typeof linkType === 'function' ? linkType(record, id) : linkType;

--- a/packages/ra-ui-materialui/src/list/SimpleListLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleListLoading.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FC } from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '@material-ui/core/Avatar';
 import List, { ListProps } from '@material-ui/core/List';
@@ -36,7 +35,7 @@ interface Props {
     nbFakeLines?: number;
 }
 
-const SimpleListLoading: FC<Props & ListProps> = props => {
+const SimpleListLoading = (props: Props & ListProps) => {
     const {
         classes: classesOverride,
         className,

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -3,7 +3,6 @@ import {
     cloneElement,
     Children,
     HtmlHTMLAttributes,
-    FC,
     ComponentType,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -78,7 +77,7 @@ const handleClick = () => {};
  *     </SingleFieldList>
  * </ReferenceManyField>
  */
-const SingleFieldList: FC<SingleFieldListProps> = props => {
+const SingleFieldList = (props: SingleFieldListProps) => {
     const {
         classes: classesOverride,
         className,

--- a/packages/ra-ui-materialui/src/list/filter/Filter.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/Filter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { sanitizeListRestProps, useListContext } from 'ra-core';
@@ -42,7 +42,7 @@ export interface FilterProps {
  * );
  *
  */
-const Filter: FC<FilterProps> = props => {
+const Filter = (props: FilterProps) => {
     const classes = useStyles(props);
     const {
         resource,

--- a/packages/ra-ui-materialui/src/list/filter/FilterList.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC } from 'react';
+import { ReactNode } from 'react';
 import { Box, Typography, List } from '@material-ui/core';
 import { useTranslate } from 'ra-core';
 
@@ -40,11 +40,12 @@ import { useTranslate } from 'ra-core';
  *     </Card>
  * );
  */
-const FilterList: FC<{ label: string; icon: React.ReactNode }> = ({
-    label,
-    icon,
-    children,
+const FilterList = (props: {
+    label: string;
+    icon: ReactNode;
+    children: ReactNode;
 }) => {
+    const { label, icon, children } = props;
     const translate = useTranslate();
     return (
         <>

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, ChangeEvent, memo, useMemo } from 'react';
+import { ChangeEvent, memo, useMemo } from 'react';
 import { InputAdornment } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import { Form } from 'react-final-form';
@@ -22,7 +22,7 @@ import TextInput from '../../input/TextInput';
  *     </Card>
  * );
  */
-const FilterLiveSearch: FC<{ source?: string }> = props => {
+const FilterLiveSearch = (props: { source?: string }) => {
     const { source = 'q', ...rest } = props;
     const { filterValues, setFilters } = useListFilterContext();
     const translate = useTranslate();

--- a/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
@@ -20,7 +20,7 @@ import DefaultPaginationLimit from './PaginationLimit';
 
 const emptyArray = [];
 
-const Pagination: FC<PaginationProps> = props => {
+const Pagination = (props: PaginationProps) => {
     const { rowsPerPageOptions, actions, limit, ...rest } = props;
     const {
         loading,
@@ -129,4 +129,4 @@ export interface PaginationProps extends TablePaginationBaseProps {
     limit?: ReactElement;
 }
 
-export default React.memo(Pagination);
+export default React.memo<PaginationProps>(Pagination);

--- a/packages/ra-ui-materialui/src/list/pagination/PaginationActions.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/PaginationActions.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(
     { name: 'RaPaginationActions' }
 );
 
-function PaginationActions(props) {
+const PaginationActions = props => {
     const { page, rowsPerPage, count, onChangePage, color, size } = props;
     const classes = useStyles(props);
     const translate = useTranslate();
@@ -159,7 +159,7 @@ function PaginationActions(props) {
             )}
         </div>
     );
-}
+};
 
 /**
  * PaginationActions propTypes are copied over from material-ui’s

--- a/packages/react-admin/src/Admin.tsx
+++ b/packages/react-admin/src/Admin.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FunctionComponent } from 'react';
 import { AdminProps } from 'ra-core';
 
 import AdminContext from './AdminContext';
@@ -84,30 +83,32 @@ import { useEffect, useState } from 'react';
  *     );
  * };
  */
-const Admin: FunctionComponent<AdminProps> = ({
-    appLayout,
-    authProvider,
-    catchAll,
-    children,
-    customReducers,
-    customRoutes = [],
-    customSagas,
-    dashboard,
-    dataProvider,
-    disableTelemetry,
-    history,
-    i18nProvider,
-    initialState,
-    layout,
-    loading,
-    locale,
-    loginPage,
-    logoutButton,
-    menu, // deprecated, use a custom layout instead
-    ready,
-    theme,
-    title = 'React Admin',
-}) => {
+const Admin = (props: AdminProps) => {
+    const {
+        appLayout,
+        authProvider,
+        catchAll,
+        children,
+        customReducers,
+        customRoutes = [],
+        customSagas,
+        dashboard,
+        dataProvider,
+        disableTelemetry,
+        history,
+        i18nProvider,
+        initialState,
+        layout,
+        loading,
+        locale,
+        loginPage,
+        logoutButton,
+        menu, // deprecated, use a custom layout instead
+        ready,
+        theme,
+        title = 'React Admin',
+    } = props;
+
     if (appLayout && process.env.NODE_ENV !== 'production') {
         console.warn(
             'You are using deprecated prop "appLayout", it was replaced by "layout", see https://github.com/marmelab/react-admin/issues/2918'

--- a/packages/react-admin/src/AdminContext.tsx
+++ b/packages/react-admin/src/AdminContext.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { FC } from 'react';
 import { CoreAdminContext, AdminContextProps } from 'ra-core';
 
 import defaultI18nProvider from './defaultI18nProvider';
 
-const AdminContext: FC<AdminContextProps> = props => (
+const AdminContext = (props: AdminContextProps) => (
     <CoreAdminContext {...props} />
 );
 

--- a/packages/react-admin/src/AdminRouter.tsx
+++ b/packages/react-admin/src/AdminRouter.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import { FC } from 'react';
 import { CoreAdminRouter, AdminRouterProps } from 'ra-core';
 import { LoadingPage } from 'ra-ui-materialui';
 
-const AdminRouter: FC<AdminRouterProps> = props => (
-    <CoreAdminRouter {...props} />
-);
+const AdminRouter = (props: AdminRouterProps) => <CoreAdminRouter {...props} />;
 
 AdminRouter.defaultProps = {
     loading: LoadingPage,


### PR DESCRIPTION
Notes on changes:

* Remove export of `ArrayField`, `BooleanField`, `ChipField` and `ReferenceManyField` components, since react-admin only uses and exports their default exports.
* `PaginationActions` definition changed to variable holding arrow to solve error: `Default export of the module has or is using private name 'PaginationActions'` in `Pagination` component default export.
* `TranslationProvider` missed children definition in `Props` interface