### PR TITLE
Reduce TranslatableInputs margin

### DIFF
--- a/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
@@ -4,6 +4,7 @@ import {
     TranslatableContextProvider,
     useTranslatable,
     UseTranslatableOptions,
+    InputProps,
 } from 'ra-core';
 import { TranslatableInputsTabs } from './TranslatableInputsTabs';
 import { TranslatableInputsTabContent } from './TranslatableInputsTabContent';
@@ -69,6 +70,8 @@ export const TranslatableInputs = (props: TranslatableProps): ReactElement => {
         groupKey = '',
         selector = <TranslatableInputsTabs groupKey={groupKey} />,
         children,
+        variant,
+        margin,
     } = props;
     const context = useTranslatable({ defaultLocale, locales });
     const classes = useStyles(props);
@@ -82,6 +85,8 @@ export const TranslatableInputs = (props: TranslatableProps): ReactElement => {
                         key={locale}
                         locale={locale}
                         groupKey={groupKey}
+                        variant={variant}
+                        margin={margin}
                     >
                         {children}
                     </TranslatableInputsTabContent>
@@ -91,7 +96,7 @@ export const TranslatableInputs = (props: TranslatableProps): ReactElement => {
     );
 };
 
-export interface TranslatableProps extends UseTranslatableOptions {
+export interface TranslatableProps extends UseTranslatableOptions, InputProps {
     selector?: ReactElement;
     children: ReactNode;
     groupKey?: string;

--- a/packages/ra-ui-materialui/src/input/TranslatableInputsTab.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputsTab.tsx
@@ -24,7 +24,9 @@ export const TranslatableInputsTab = (
             label={translate(`ra.locales.${locale}`, {
                 _: capitalize(locale),
             })}
-            className={invalid && touched ? classes.error : undefined}
+            className={`${classes.root} ${
+                invalid && touched ? classes.error : ''
+            }`}
             {...rest}
         />
     );
@@ -32,6 +34,11 @@ export const TranslatableInputsTab = (
 
 const useStyles = makeStyles(
     theme => ({
+        root: {
+            fontSize: '0.8em',
+            minHeight: theme.spacing(3),
+            minWidth: theme.spacing(6),
+        },
         error: { color: theme.palette.error.main },
     }),
     { name: 'RaTranslatableInputsTab' }

--- a/packages/ra-ui-materialui/src/input/TranslatableInputsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputsTabContent.tsx
@@ -90,7 +90,10 @@ const useStyles = makeStyles(
     theme => ({
         root: {
             flexGrow: 1,
-            padding: theme.spacing(2),
+            paddingLeft: theme.spacing(2),
+            paddingRight: theme.spacing(2),
+            paddingTop: theme.spacing(1),
+            paddingBottom: theme.spacing(1),
             borderRadius: 0,
             borderBottomLeftRadius: theme.shape.borderRadius,
             borderBottomRightRadius: theme.shape.borderRadius,

--- a/packages/ra-ui-materialui/src/input/TranslatableInputsTabs.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputsTabs.tsx
@@ -28,6 +28,7 @@ export const TranslatableInputsTabs = (
                 onChange={handleChange}
                 indicatorColor="primary"
                 textColor="primary"
+                className={classes.tabs}
                 {...tabsProps}
             >
                 {locales.map(locale => (
@@ -56,6 +57,9 @@ const useStyles = makeStyles(
             borderTopLeftRadius: theme.shape.borderRadius,
             borderTopRightRadius: theme.shape.borderRadius,
             border: `1px solid ${theme.palette.divider}`,
+        },
+        tabs: {
+            minHeight: theme.spacing(3),
         },
     }),
     { name: 'RaTranslatableInputsTabs' }


### PR DESCRIPTION
## Problem

The translatable input tabs take too much space for low information

![image](https://user-images.githubusercontent.com/99944/127881237-4cfa3b46-8d56-407c-94f8-866288429556.png)

## Solution

Reduce the margins

![image](https://user-images.githubusercontent.com/99944/127881096-b0d83317-65c6-466a-9f3d-fe635f3c2fd1.png)
