### PR TITLE
Add ability to override the Datagrid header row

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -2016,6 +2016,7 @@ The `Datagrid` component renders a list of records as a table. It is usually use
 Here are all the props accepted by the component:
 
 * [`body`](#body-element)
+* [`header`](#header-element)
 * [`rowStyle`](#row-style-function)
 * [`rowClick`](#rowclick)
 * [`expand`](#expand)
@@ -2100,6 +2101,39 @@ const PostList = props => (
 
 export default PostList;
 ```
+
+### Header Element
+
+By default, `<Datagrid>` renders its header using `<DatagridHeader>`, an internal react-admin component. You can pass a custom component as the `header` prop to override that default. This can be useful e.g. to add a second header row, or to create headers spanning multiple columns.
+
+For instance, here is a simple datagrid header that displays column names with no sort and no "select all" button:
+
+```jsx
+import { TableHead, TableRow, TableCell } from '@material-ui/core';
+
+const DatagridHeader = ({ children }) => (
+    <TableHead>
+        <TableRow>
+            <TableCell></TableCell> {/* empty cell to account for the select row checkbox in the body */}
+            {Children.map(children, child => (
+                <TableCell key={child.props.source}>
+                    {child.props.source}
+                </TableCell>
+            ))}
+        </TableRow>
+    </TableHead>
+);
+
+const PostList = props => (
+    <List {...props}>
+        <Datagrid header={<DatagridHeader />}>
+            {/* ... */}
+        </Datagrid>
+    </List>
+);
+```
+
+**Tip**: To handle sorting in your custom Datagrid header component, check out the [Building a custom sort control](#building-a-custom-sort-control) section.
 
 ### Row Style Function
 

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -127,12 +127,14 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
 
     const {
         basePath,
+        currentSort,
         data,
         ids,
         loaded,
         onSelect,
         onToggleItem,
         selectedIds,
+        setSort,
         total,
     } = useListContext(props);
     const version = useVersion();
@@ -229,10 +231,16 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                         children,
                         classes,
                         className,
+                        currentSort,
+                        data,
                         hasExpand: !!expand,
                         hasBulkActions,
+                        ids,
                         isRowSelectable,
+                        onSelect,
                         resource,
+                        selectedIds,
+                        setSort,
                     },
                     children
                 )}

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -232,6 +232,7 @@ const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                         hasExpand: !!expand,
                         hasBulkActions,
                         isRowSelectable,
+                        resource,
                     },
                     children
                 )}

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { Children, isValidElement, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import {
+    useListContext,
+    useResourceContext,
+    Identifier,
+    Record,
+    RecordMap,
+    SortPayload,
+} from 'ra-core';
+import { Checkbox, TableCell, TableHead, TableRow } from '@material-ui/core';
+import classnames from 'classnames';
+
+import DatagridHeaderCell from './DatagridHeaderCell';
+import useDatagridStyles from './useDatagridStyles';
+import { ClassesOverride } from '../../types';
+
+/**
+ * The default Datagrid Header component.
+ *
+ * Renders select all checkbox as well as column header buttons used for sorting.
+ */
+export const DatagridHeader = (props: DatagridHeaderProps) => {
+    const {
+        children,
+        classes,
+        className,
+        hasExpand = false,
+        hasBulkActions = false,
+        isRowSelectable,
+    } = props;
+    const resource = useResourceContext(props);
+    const {
+        currentSort,
+        data,
+        ids,
+        onSelect,
+        selectedIds,
+        setSort,
+    } = useListContext(props);
+
+    const updateSortCallback = useCallback(
+        event => {
+            event.stopPropagation();
+            const newField = event.currentTarget.dataset.field;
+            const newOrder =
+                currentSort.field === newField
+                    ? currentSort.order === 'ASC'
+                        ? 'DESC'
+                        : 'ASC'
+                    : event.currentTarget.dataset.order;
+
+            setSort(newField, newOrder);
+        },
+        [currentSort.field, currentSort.order, setSort]
+    );
+
+    const updateSort = setSort ? updateSortCallback : null;
+
+    const handleSelectAll = useCallback(
+        event => {
+            if (event.target.checked) {
+                const all = ids.concat(
+                    selectedIds.filter(id => !ids.includes(id))
+                );
+                onSelect(
+                    isRowSelectable
+                        ? all.filter(id => isRowSelectable(data[id]))
+                        : all
+                );
+            } else {
+                onSelect([]);
+            }
+        },
+        [data, ids, onSelect, isRowSelectable, selectedIds]
+    );
+
+    const selectableIds = isRowSelectable
+        ? ids.filter(id => isRowSelectable(data[id]))
+        : ids;
+
+    return (
+        <TableHead className={classnames(className, classes.thead)}>
+            <TableRow className={classnames(classes.row, classes.headerRow)}>
+                {hasExpand && (
+                    <TableCell
+                        padding="none"
+                        className={classnames(
+                            classes.headerCell,
+                            classes.expandHeader
+                        )}
+                    />
+                )}
+                {hasBulkActions && selectedIds && (
+                    <TableCell
+                        padding="checkbox"
+                        className={classes.headerCell}
+                    >
+                        <Checkbox
+                            className="select-all"
+                            color="primary"
+                            checked={
+                                selectedIds.length > 0 &&
+                                selectableIds.length > 0 &&
+                                selectableIds.every(id =>
+                                    selectedIds.includes(id)
+                                )
+                            }
+                            onChange={handleSelectAll}
+                        />
+                    </TableCell>
+                )}
+                {Children.map(children, (field, index) =>
+                    isValidElement(field) ? (
+                        <DatagridHeaderCell
+                            className={classes.headerCell}
+                            currentSort={currentSort}
+                            field={field}
+                            isSorting={
+                                currentSort.field ===
+                                ((field.props as any).sortBy ||
+                                    (field.props as any).source)
+                            }
+                            key={(field.props as any).source || index}
+                            resource={resource}
+                            updateSort={updateSort}
+                        />
+                    ) : null
+                )}
+            </TableRow>
+        </TableHead>
+    );
+};
+
+DatagridHeader.propTypes = {
+    children: PropTypes.node,
+    classes: PropTypes.object,
+    className: PropTypes.string,
+    currentSort: PropTypes.exact({
+        field: PropTypes.string,
+        order: PropTypes.string,
+    }),
+    data: PropTypes.any,
+    hasExpand: PropTypes.bool,
+    hasBulkActions: PropTypes.bool,
+    ids: PropTypes.arrayOf(PropTypes.any),
+    isRowSelectable: PropTypes.func,
+    isRowExpandable: PropTypes.func,
+    onSelect: PropTypes.func,
+    onToggleItem: PropTypes.func,
+    resource: PropTypes.string,
+    selectedIds: PropTypes.arrayOf(PropTypes.any),
+    setSort: PropTypes.func,
+};
+
+export interface DatagridHeaderProps<RecordType extends Record = Record> {
+    children?: React.ReactNode;
+    classes?: ClassesOverride<typeof useDatagridStyles>;
+    className?: string;
+    hasExpand?: boolean;
+    hasBulkActions?: boolean;
+    isRowSelectable?: (record: Record) => boolean;
+    isRowExpandable?: (record: Record) => boolean;
+    size?: 'medium' | 'small';
+    // can be injected when using the component without context
+    currentSort?: SortPayload;
+    data?: RecordMap<RecordType>;
+    ids?: Identifier[];
+    onSelect?: (ids: Identifier[]) => void;
+    onToggleItem?: (id: Identifier) => void;
+    resource?: string;
+    selectedIds?: Identifier[];
+    setSort?: (sort: string, order?: string) => void;
+}
+
+DatagridHeader.displayName = 'DatagridHeader';

--- a/packages/ra-ui-materialui/src/list/datagrid/index.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/index.ts
@@ -16,6 +16,8 @@ import DatagridRow, {
 import ExpandRowButton, { ExpandRowButtonProps } from './ExpandRowButton';
 import useDatagridStyles from './useDatagridStyles';
 
+export * from './DatagridHeader';
+
 export {
     Datagrid,
     DatagridLoading,


### PR DESCRIPTION
## Problem

To override the datagrid headers (e.g. to have a header span over 2 columns), one has to copy the entire Datagrid code. 

## Solution

By default, `<Datagrid>` renders its header using `<DatagridHeader>`, an internal react-admin component. You can pass a custom component as the `header` prop to override that default. This can be useful e.g. to add a second header row, or to create headers spanning multiple columns.

For instance, here is a simple datagrid header that displays column names with no sort and no "select all" button:

```jsx
import { TableHead, TableRow, TableCell } from '@material-ui/core';

const DatagridHeader = ({ children }) => (
    <TableHead>
        <TableRow>
            <TableCell></TableCell> {/* empty cell to account for the select row checkbox in the body */}
            {Children.map(children, child => (
                <TableCell key={child.props.source}>
                    {child.props.source}
                </TableCell>
            ))}
        </TableRow>
    </TableHead>
);

const PostList = props => (
    <List {...props}>
        <Datagrid header={<DatagridHeader />}>
            {/* ... */}
        </Datagrid>
    </List>
);
```

Bonus: Easier maintenance due to smaller files
