### PR TITLE
Fix useList pagination total

### DIFF
--- a/packages/ra-core/src/controller/useList.spec.tsx
+++ b/packages/ra-core/src/controller/useList.spec.tsx
@@ -51,6 +51,7 @@ describe('<useList />', () => {
                 },
                 ids: [2],
                 error: undefined,
+                total: 1,
             })
         );
     });
@@ -90,6 +91,7 @@ describe('<useList />', () => {
                     },
                     ids: [1, 3, 4],
                     error: undefined,
+                    total: 3,
                 })
             );
         });
@@ -138,6 +140,7 @@ describe('<useList />', () => {
                     },
                     ids: [2, 1],
                     error: undefined,
+                    total: 2,
                 })
             );
         });
@@ -155,6 +158,7 @@ describe('<useList />', () => {
                     },
                     ids: [1, 2],
                     error: undefined,
+                    total: 2,
                 })
             );
         });

--- a/packages/ra-core/src/controller/useList.spec.tsx
+++ b/packages/ra-core/src/controller/useList.spec.tsx
@@ -200,6 +200,7 @@ describe('<useList />', () => {
                     page: 2,
                     perPage: 5,
                     error: undefined,
+                    total: 7,
                 })
             );
         });

--- a/packages/ra-core/src/controller/useList.ts
+++ b/packages/ra-core/src/controller/useList.ts
@@ -73,9 +73,11 @@ export const useList = (props: UseListOptions): UseListValue => {
     const [finalItems, setFinalItems] = useSafeSetState<{
         data: RecordMap;
         ids: Identifier[];
+        total: number;
     }>(() => ({
         data: indexById(data),
         ids,
+        total: 0,
     }));
 
     // pagination logic
@@ -174,6 +176,9 @@ export const useList = (props: UseListOptions): UseListValue => {
                 return result;
             })
         );
+
+        const filteredLength = tempData.length;
+
         // 2. sort
         if (sort.field) {
             tempData = tempData.sort((a, b) => {
@@ -192,10 +197,10 @@ export const useList = (props: UseListOptions): UseListValue => {
         const finalIds = tempData
             .filter(data => typeof data !== 'undefined')
             .map(data => data.id);
-
         setFinalItems({
             data: finalData,
             ids: finalIds,
+            total: filteredLength,
         });
     }, [
         data,
@@ -241,7 +246,7 @@ export const useList = (props: UseListOptions): UseListValue => {
         setPerPage,
         setSort,
         showFilter,
-        total: ids.length,
+        total: finalItems.total,
     };
 };
 

--- a/packages/ra-core/src/controller/useList.ts
+++ b/packages/ra-core/src/controller/useList.ts
@@ -241,7 +241,7 @@ export const useList = (props: UseListOptions): UseListValue => {
         setPerPage,
         setSort,
         showFilter,
-        total: finalItems.ids.length,
+        total: ids.length,
     };
 };
 

--- a/packages/ra-core/src/controller/useList.ts
+++ b/packages/ra-core/src/controller/useList.ts
@@ -77,7 +77,7 @@ export const useList = (props: UseListOptions): UseListValue => {
     }>(() => ({
         data: indexById(data),
         ids,
-        total: 0,
+        total: ids.length,
     }));
 
     // pagination logic


### PR DESCRIPTION
The current implementation to calculate the total in useList is broken. `finalItems.ids.length` changes once pagination is rendered ([useList.ts#L192](https://github.com/marmelab/react-admin/blob/74606bf8d5c1c72ac3c54ba22be8c1fa7b592fd2/packages/ra-core/src/controller/useList.ts#L192)) . So the value of total equals perPage.
I think using the `ids.length` instead would be appropriate to fix this.