### PR TITLE
Update Sidebar to remain fixed 

### DIFF
--- a/examples/demo/src/layout/Layout.tsx
+++ b/examples/demo/src/layout/Layout.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import { useSelector } from 'react-redux';
-import { Layout, LayoutProps, Sidebar } from 'react-admin';
+import { Layout, LayoutProps } from 'react-admin';
 import AppBar from './AppBar';
 import Menu from './Menu';
 import { darkTheme, lightTheme } from './themes';
 import { AppState } from '../types';
 
-const CustomSidebar = (props: any) => <Sidebar {...props} size={200} />;
-
 export default (props: LayoutProps) => {
     const theme = useSelector((state: AppState) =>
         state.theme === 'dark' ? darkTheme : lightTheme
     );
-    return (
-        <Layout
-            {...props}
-            appBar={AppBar}
-            sidebar={CustomSidebar}
-            menu={Menu}
-            theme={theme}
-        />
-    );
+    return <Layout {...props} appBar={AppBar} menu={Menu} theme={theme} />;
 };

--- a/examples/demo/src/layout/Menu.tsx
+++ b/examples/demo/src/layout/Menu.tsx
@@ -3,11 +3,13 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import LabelIcon from '@material-ui/icons/Label';
 import { makeStyles } from '@material-ui/core/styles';
+import classnames from 'classnames';
 import {
     useTranslate,
     DashboardMenuItem,
     MenuItemLink,
     MenuProps,
+    ReduxState,
 } from 'react-admin';
 
 import visitors from '../visitors';
@@ -28,6 +30,7 @@ const Menu = ({ dense = false }: MenuProps) => {
         menuCustomers: true,
     });
     const translate = useTranslate();
+    const open = useSelector((state: ReduxState) => state.admin.ui.sidebarOpen);
     useSelector((state: AppState) => state.theme); // force rerender on theme change
     const classes = useStyles();
 
@@ -36,7 +39,12 @@ const Menu = ({ dense = false }: MenuProps) => {
     };
 
     return (
-        <div className={classes.root}>
+        <div
+            className={classnames(classes.root, {
+                [classes.open]: open,
+                [classes.closed]: !open,
+            })}
+        >
             {' '}
             <DashboardMenuItem />
             <SubMenu
@@ -47,7 +55,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                 dense={dense}
             >
                 <MenuItemLink
-                    to={`/commands`}
+                    to={{
+                        pathname: '/commands',
+                        state: { _scrollToTop: true },
+                    }}
                     primaryText={translate(`resources.commands.name`, {
                         smart_count: 2,
                     })}
@@ -55,7 +66,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                     dense={dense}
                 />
                 <MenuItemLink
-                    to={`/invoices`}
+                    to={{
+                        pathname: '/invoices',
+                        state: { _scrollToTop: true },
+                    }}
                     primaryText={translate(`resources.invoices.name`, {
                         smart_count: 2,
                     })}
@@ -71,7 +85,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                 dense={dense}
             >
                 <MenuItemLink
-                    to={`/products`}
+                    to={{
+                        pathname: '/products',
+                        state: { _scrollToTop: true },
+                    }}
                     primaryText={translate(`resources.products.name`, {
                         smart_count: 2,
                     })}
@@ -79,7 +96,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                     dense={dense}
                 />
                 <MenuItemLink
-                    to={`/categories`}
+                    to={{
+                        pathname: '/categories',
+                        state: { _scrollToTop: true },
+                    }}
                     primaryText={translate(`resources.categories.name`, {
                         smart_count: 2,
                     })}
@@ -95,7 +115,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                 dense={dense}
             >
                 <MenuItemLink
-                    to={`/customers`}
+                    to={{
+                        pathname: '/customers',
+                        state: { _scrollToTop: true },
+                    }}
                     primaryText={translate(`resources.customers.name`, {
                         smart_count: 2,
                     })}
@@ -103,7 +126,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                     dense={dense}
                 />
                 <MenuItemLink
-                    to={`/segments`}
+                    to={{
+                        pathname: '/segments',
+                        state: { _scrollToTop: true },
+                    }}
                     primaryText={translate(`resources.segments.name`, {
                         smart_count: 2,
                     })}
@@ -112,7 +138,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                 />
             </SubMenu>
             <MenuItemLink
-                to={`/reviews`}
+                to={{
+                    pathname: '/reviews',
+                    state: { _scrollToTop: true },
+                }}
                 primaryText={translate(`resources.reviews.name`, {
                     smart_count: 2,
                 })}
@@ -126,6 +155,16 @@ const Menu = ({ dense = false }: MenuProps) => {
 const useStyles = makeStyles(theme => ({
     root: {
         marginTop: theme.spacing(1),
+        transition: theme.transitions.create('width', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+    },
+    open: {
+        width: 200,
+    },
+    closed: {
+        width: 55,
     },
 }));
 

--- a/examples/demo/src/layout/Menu.tsx
+++ b/examples/demo/src/layout/Menu.tsx
@@ -155,6 +155,7 @@ const Menu = ({ dense = false }: MenuProps) => {
 const useStyles = makeStyles(theme => ({
     root: {
         marginTop: theme.spacing(1),
+        marginBottom: theme.spacing(1),
         transition: theme.transitions.create('width', {
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,

--- a/examples/demo/src/layout/SubMenu.tsx
+++ b/examples/demo/src/layout/SubMenu.tsx
@@ -17,14 +17,14 @@ const useStyles = makeStyles(theme => ({
     icon: { minWidth: theme.spacing(5) },
     sidebarIsOpen: {
         '& a': {
-            paddingLeft: theme.spacing(4),
             transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+            paddingLeft: theme.spacing(4),
         },
     },
     sidebarIsClosed: {
         '& a': {
-            paddingLeft: theme.spacing(2),
             transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+            paddingLeft: theme.spacing(2),
         },
     },
 }));

--- a/examples/demo/src/layout/themes.ts
+++ b/examples/demo/src/layout/themes.ts
@@ -8,6 +8,9 @@ export const darkTheme = {
         },
         type: 'dark' as 'dark', // Switching the dark mode on is a single property value change.
     },
+    sidebar: {
+        width: 200,
+    },
     overrides: {
         MuiAppBar: {
             colorSecondary: {
@@ -62,6 +65,9 @@ export const lightTheme = {
     },
     shape: {
         borderRadius: 10,
+    },
+    sidebar: {
+        width: 200,
     },
     overrides: {
         RaMenuItemLink: {

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -25,9 +25,10 @@ const useStyles = makeStyles(
             [theme.breakpoints.only('xs')]: {
                 marginTop: 0,
             },
-            [theme.breakpoints.up('md')]: {
-                marginTop: '1.5em',
-            },
+            transition: theme.transitions.create('width', {
+                easing: theme.transitions.easing.sharp,
+                duration: theme.transitions.duration.leavingScreen,
+            }),
         },
         open: {
             width: lodashGet(theme, 'menu.width', MENU_WIDTH),

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles(
             flexDirection: 'column',
             justifyContent: 'flex-start',
             marginTop: '0.5em',
+            marginBottom: '1em',
             [theme.breakpoints.only('xs')]: {
                 marginTop: 0,
             },

--- a/packages/ra-ui-materialui/src/layout/Sidebar.tsx
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.tsx
@@ -29,7 +29,10 @@ const Sidebar = (props: SidebarProps) => {
     );
     useLocale(); // force redraw on locale change
     const toggleSidebar = () => dispatch(setSidebarVisibility(!open));
-    const { drawerPaper, ...classes } = useStyles({ ...props, open });
+    const { drawerPaper, fixed, ...classes } = useStyles({
+        ...props,
+        open,
+    });
 
     return isXSmall ? (
         <Drawer
@@ -55,7 +58,7 @@ const Sidebar = (props: SidebarProps) => {
             classes={classes}
             {...rest}
         >
-            {children}
+            <div className={fixed}>{children}</div>
         </Drawer>
     ) : (
         <Drawer
@@ -68,7 +71,7 @@ const Sidebar = (props: SidebarProps) => {
             classes={classes}
             {...rest}
         >
-            {children}
+            <div className={fixed}>{children}</div>
         </Drawer>
     );
 };
@@ -79,7 +82,9 @@ Sidebar.propTypes = {
 
 const useStyles = makeStyles(
     theme => ({
-        root: {},
+        root: {
+            height: 'calc(100vh - 3em)',
+        },
         docked: {},
         paper: {},
         paperAnchorLeft: {},
@@ -91,10 +96,19 @@ const useStyles = makeStyles(
         paperAnchorDockedRight: {},
         paperAnchorDockedBottom: {},
         modal: {},
+        fixed: {
+            position: 'fixed',
+            height: 'calc(100vh - 3em)',
+            overflowX: 'hidden',
+            // hide scrollbar
+            scrollbarWidth: 'none',
+            msOverflowStyle: 'none',
+            '&::-webkit-scrollbar': {
+                display: 'none',
+            },
+        },
         drawerPaper: {
             position: 'relative',
-            height: '100%',
-            overflowX: 'hidden',
             width: (props: { open?: boolean }) =>
                 props.open
                     ? lodashGet(theme, 'sidebar.width', DRAWER_WIDTH)


### PR DESCRIPTION
https://user-images.githubusercontent.com/99944/131044137-54867774-434d-4d34-b57c-05afdef3c499.mp4

I've decided not to shift the menu up when the appbar disappears, because in my tests this caused real UX problems (e.g. the menu just clicked moved down because the appbar reappeared and pushed the menu down). I'm not a big fan of the empty space on top of the menu, but we can live with it. 

- [x] Update layout and sidebar
- [x] Test on various form factors
- [x] Test on various browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Edge
  - [x] IE11
  - [x] Safari
- [x] Test on various apps

The behavior is weird on Safari (a scroll on the menu scrolls the entire page, but a scroll on the content doesn't scroll the menu) but acceptable.

Closes #4684
Supersedes #4753