### PR TITLE
[RFR] Make previousData of DeleteParams optional

### DIFF
--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -202,7 +202,7 @@ export interface CreateResult<RecordType = Record> {
 
 export interface DeleteParams {
     id: Identifier;
-    previousData: Record;
+    previousData?: Record;
 }
 export interface DeleteResult<RecordType = Record> {
     data?: RecordType;


### PR DESCRIPTION
The _previousData_ property of _DeleteParams_ added in #4851 should be optional. That way the _delete_ function can be called in a loop if _deleteMany_ is not supported by the API. It also seems inconsistent to require _previousData_ for deleting one entity but not for deleting multiple.