### PR TITLE
[RFR] Remove reliance on defaultProps for adding labels

### DIFF
--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -74,7 +74,8 @@ const SimpleShowLayout = ({
                         field.props.className
                     )}
                 >
-                    {field.props.addLabel ? (
+                    {field.props.addLabel ??
+                    (field.props.label || field.props.source) ? (
                         <Labeled
                             record={record}
                             resource={resource}

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -96,7 +96,8 @@ export const Tab = ({
                             field.props.className
                         )}
                     >
-                        {field.props.addLabel ? (
+                        {field.props.addLabel ??
+                        (field.props.label || field.props.source) ? (
                             <Labeled
                                 label={field.props.label}
                                 source={field.props.source}

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -42,7 +42,8 @@ export const TranslatableFieldsTabContent = (
             {Children.map(children, field =>
                 field && isValidElement<any>(field) ? (
                     <div key={field.props.source}>
-                        {field.props.addLabel ? (
+                        {field.props.addLabel ??
+                        (field.props.label || field.props.source) ? (
                             <Labeled
                                 record={record}
                                 resource={resource}

--- a/packages/ra-ui-materialui/src/form/FormInput.tsx
+++ b/packages/ra-ui-materialui/src/form/FormInput.tsx
@@ -40,7 +40,8 @@ const FormInput = <RecordType extends Record | Omit<Record, 'id'> = Record>(
                 input.props.formClassName
             )}
         >
-            {input.props.addLabel ? (
+            {input.props.addLabel ??
+            (input.props.label || input.props.source) ? (
                 <Labeled
                     id={id || input.props.source}
                     {...inputProps}


### PR DESCRIPTION
#6549 sees that adding a label to fields relies on the `addLabel` default prop being set. This reliance is compromised when wrapping the component with `useMemo`.

This code moves the reliance from `defaultProps` set on the field to the components displaying them all-the-while respecting the prop if it's being set by the user.