### PR TITLE
Add record context in SimpleList

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -2499,7 +2499,7 @@ export const PostList = (props) => (
 
 For each record, `<SimpleList>` executes the `primaryText`, `secondaryText`, `linkType`, `rowStyle`, `leftAvatar`, `leftIcon`, `rightAvatar`, and `rightIcon` props functions, and creates a `<ListItem>` with the result.
 
-The `primaryText`, `secondaryText` and `tertiaryText` functions can return a React element. This means you can use any react-admin fields, including reference fields:
+The `primaryText`, `secondaryText` and `tertiaryText` functions can return a React element. This means you can use any react-admin field, including reference fields:
 
 ```jsx
 // in src/posts.js

--- a/docs/List.md
+++ b/docs/List.md
@@ -2499,6 +2499,34 @@ export const PostList = (props) => (
 
 For each record, `<SimpleList>` executes the `primaryText`, `secondaryText`, `linkType`, `rowStyle`, `leftAvatar`, `leftIcon`, `rightAvatar`, and `rightIcon` props functions, and creates a `<ListItem>` with the result.
 
+The `primaryText`, `secondaryText` and `tertiaryText` functions can return a React element. This means you can use any react-admin fields, including reference fields:
+
+```jsx
+// in src/posts.js
+import * as React from "react";
+import { List, SimpleList } from 'react-admin';
+
+const postRowStyle = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+
+export const PostList = (props) => (
+    <List {...props}>
+        <SimpleList
+            primaryText={<TextField source="title" />}
+            secondaryText={record => `${record.views} views`}
+            tertiaryText={
+                <ReferenceField reference="categories" source="category_id">
+                    <TextField source="name" />
+                </ReferenceField>
+            }
+            linkType={record => record.canEdit ? "edit" : "show"}
+            rowStyle={postRowStyle}
+        />
+    </List>
+);
+```
+
 **Tip**: To use a `<SimpleList>` on small screens and a `<Datagrid>` on larger screens, use material-ui's `useMediaQuery` hook:
 
 ```jsx

--- a/packages/ra-ui-materialui/src/list/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { render, waitFor, within } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { ListContext } from 'ra-core';
+
+import SimpleList from './SimpleList';
+import TextField from '../field/TextField';
+
+const renderWithRouter = children => {
+    const history = createMemoryHistory();
+
+    return {
+        history,
+        ...render(<Router history={history}>{children}</Router>),
+    };
+};
+
+describe('<SimpleList />', () => {
+    it('should render a list of items which provide a record context', async () => {
+        const { getByText } = renderWithRouter(
+            <ListContext.Provider
+                value={{
+                    loaded: true,
+                    loading: false,
+                    ids: [1, 2],
+                    data: {
+                        1: { id: 1, title: 'foo' },
+                        2: { id: 2, title: 'bar' },
+                    },
+                    total: 2,
+                    resource: 'posts',
+                    basePath: '/posts',
+                }}
+            >
+                <SimpleList
+                    primaryText={record => record.id.toString()}
+                    secondaryText={<TextField source="title" />}
+                />
+            </ListContext.Provider>
+        );
+
+        await waitFor(() => {
+            expect(
+                within(getByText('1').closest('li')).queryByText('foo')
+            ).not.toBeNull();
+            expect(
+                within(getByText('2').closest('li')).queryByText('bar')
+            ).not.toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
SimpleList now wrap each item inside a record context and support React elements directly for the `primaryText`, `secondaryText` and `tertiaryText` props.

This allows to use any of the react-admin fields and make it way easier to display referenced records data:

```jsx
// in src/posts.js
import * as React from "react";
import { List, SimpleList } from 'react-admin';

const postRowStyle = (record, index) => ({
    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
});

export const PostList = (props) => (
    <List {...props}>
        <SimpleList
            primaryText={<TextField source="title" />}
            secondaryText={record => `${record.views} views`}
            tertiaryText={
                <ReferenceField reference="categories" source="category_id">
                    <TextField source="name" />
                </ReferenceField>
            }
            linkType={record => record.canEdit ? "edit" : "show"}
            rowStyle={postRowStyle}
        />
    </List>
);
```

It also fixes a semantic issue as the SimpleList display an `ul` but the children were anchors instead of `li`