### PR TITLE
Fix resolveRedirectTo linkToRecord utilization

### DIFF
--- a/packages/ra-core/src/util/resolveRedirectTo.ts
+++ b/packages/ra-core/src/util/resolveRedirectTo.ts
@@ -12,7 +12,7 @@ export default (redirectTo, basePath: string, id?, data?) => {
         case 'edit':
             return linkToRecord(basePath, id);
         case 'show':
-            return `${linkToRecord(basePath, id)}/show`;
+            return linkToRecord(basePath, id, 'show');
         default:
             return redirectTo;
     }


### PR DESCRIPTION
As I was going through the redirect flow got wondering at one point why should we construct the same type of path at two places and as linkToRecord is already used and coupled - why not utilize to the fullest?