### PR TITLE
Added expandedPanel to Datagrid styles

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -2394,6 +2394,7 @@ The `Datagrid` component accepts the usual `className` prop but you can override
 | `expandIconCell` | Applied to each expandable cell                               |
 | `expandIcon`     | Applied to each expand icon                                   |
 | `expanded`       | Applied to each expanded icon                                 |
+| `expandedPanel`  | Applied to each expandable panel                              |
 | `checkbox`       | Applied to each checkbox cell                                 |
 
 You can customize the `<Datagrid>` styles by passing a `classes` object as prop, through `useStyles()`. Here is an example:

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -40,7 +40,12 @@ const computeNbColumns = (expand, children, hasBulkActions) =>
           React.Children.toArray(children).filter(child => !!child).length // non-null children
         : 0; // we don't need to compute columns if there is no expand panel;
 
-const defaultClasses = { expandIconCell: '', checkbox: '', rowCell: '' };
+const defaultClasses = {
+    expandIconCell: '',
+    checkbox: '',
+    rowCell: '',
+    expandedPanel: '',
+};
 
 const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
     const {
@@ -199,7 +204,11 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
                 )}
             </TableRow>
             {expandable && expanded && (
-                <TableRow key={`${id}-expand`} id={`${id}-expand`}>
+                <TableRow
+                    key={`${id}-expand`}
+                    id={`${id}-expand`}
+                    className={classes.expandedPanel}
+                >
                     <TableCell colSpan={nbColumns}>
                         {isValidElement(expand)
                             ? cloneElement(expand, {

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
@@ -45,6 +45,7 @@ const useDatagridStyles = makeStyles(
         expanded: {
             transform: 'rotate(0deg)',
         },
+        expandedPanel: {},
     }),
     { name: 'RaDatagrid' }
 );


### PR DESCRIPTION
I have a project where I needed to use expandable Datagrid rows and have a different background color on the expanded panel row that appears.

For this purpose, it would be very useful to be able to override the CSS class of these rows, which this PR enables.

Not quite sure about the name `expandedPanel`. I also thought about `expandedRow`, but that seemed ambiguous as it could also mean the original always-visible row the user clicked on in order to make the second row appear.

Also, while styling the row element was necessary in my case, other people may need to style the cell instead. Maybe we should make both overridable, but I didn't do that yet.