### PR TITLE
Fix examples of ra-test with fake dataProviders

### DIFF
--- a/packages/ra-test/README.md
+++ b/packages/ra-test/README.md
@@ -142,7 +142,7 @@ Here is an example with Jest and TestingLibrary, which is testing the [`UserShow
 // UserShow.spec.js
 import * as React from "react";
 import { render } from '@testing-library/react';
-import { Tab, TextField } from 'react-admin';
+import { Tab, TextField, DataProviderContext } from 'react-admin';
 
 import UserShow from './UserShow';
 
@@ -155,21 +155,23 @@ describe('UserShow', () => {
             expect(tabs.length).toEqual(1);
         });
 
-        it('should show the user identity in the first tab', () => {
+        it('should show the user identity in the first tab', async () => {
             const dataProvider = {
-                getOne: jest.fn().resolve({
+                getOne: () => Promise.resolve({
                     id: 1,
                     name: 'Leila'
                 })
             }
             const testUtils = render(
-                <TestContext>
-                    <UserShow permissions="user" id="1" />
-                </TestContext>
+                <DataProviderContext.Provider value={dataProvider}>
+                    <TestContext>
+                        <UserShow permissions="user" id="1" />
+                    </TestContext>
+                </DataProviderContext.Provider>
             );
 
-            expect(testUtils.queryByDisplayValue('1')).not.toBeNull();
-            expect(testUtils.queryByDisplayValue('Leila')).not.toBeNull();
+            expect(await testUtils.findByDisplayValue('1')).not.toBeNull();
+            expect(await testUtils.findByDisplayValue('Leila')).not.toBeNull();
         });
     });
 
@@ -181,39 +183,43 @@ describe('UserShow', () => {
             expect(tabs.length).toEqual(2);
         });
 
-        it('should show the user identity in the first tab', () => {
+        it('should show the user identity in the first tab', async () => {
             const dataProvider = {
-                getOne: jest.fn().resolve({
+                getOne: () => Promise.resolve({
                     id: 1,
                     name: 'Leila'
                 })
             }
             const testUtils = render(
-                <TestContext>
-                    <UserShow permissions="user" id="1" />
-                </TestContext>
+                <DataProviderContext.Provider value={dataProvider}>
+                    <TestContext>
+                        <UserShow permissions="user" id="1" />
+                    </TestContext>
+                </DataProviderContext.Provider>
             );
 
-            expect(testUtils.queryByDisplayValue('1')).not.toBeNull();
-            expect(testUtils.queryByDisplayValue('Leila')).not.toBeNull();
+            expect(await testUtils.findByDisplayValue('1')).not.toBeNull();
+            expect(await testUtils.findByDisplayValue('Leila')).not.toBeNull();
         });
 
-        it('should show the user role in the second tab', () => {
+        it('should show the user role in the second tab', async () => {
             const dataProvider = {
-                getOne: jest.fn().resolve({
+                getOne: () => Promise.resolve({
                     id: 1,
                     name: 'Leila',
                     role: 'admin'
                 })
             }
             const testUtils = render(
-                <TestContext>
-                    <UserShow permissions="user" id="1" />
-                </TestContext>
+                <DataProviderContext.Provider value={dataProvider}>
+                    <TestContext>
+                        <UserShow permissions="user" id="1" />
+                    </TestContext>
+                </DataProviderContext.Provider>
             );
 
             fireEvent.click(testUtils.getByText('Security'));
-            expect(testUtils.queryByDisplayValue('admin')).not.toBeNull();
+            expect(await testUtils.findByDisplayValue('admin')).not.toBeNull();
         });
     });
 });


### PR DESCRIPTION
You helped me in https://github.com/marmelab/react-admin/issues/6597, so I figured I could make the docs better for future me and everyone.

I haven't tested the code to see if it works. Also, a few notes:
- contrarily to some test I've seen in the react-admin code base, I didn't need the `await act(async () => await new Promise(r => setTimeout(r)));` dance. It seems that simply `await`ing was enough to follow properly the event loop.
- I've simplified the `jest.fn().resolve` since the examples weren't using the mocked function for some assertions
- I've replace `queryBy` with `findBy` which is the asynchronous equivalent. In my own code, it's required or the rendered content is the inital one before the dataProvider was called.

Feel free to adjust the code before merging, there's no guarantee it's correct in the context of the examples.