### PR TITLE
[RFR] Fix redirection after login behaviour when using fetch actions

### DIFF
--- a/packages/ra-core/src/actions/fetchActions.ts
+++ b/packages/ra-core/src/actions/fetchActions.ts
@@ -18,9 +18,13 @@ export const FETCH_ERROR = 'RA/FETCH_ERROR';
 
 export interface FetchErrorAction {
     readonly type: typeof FETCH_ERROR;
+    readonly error: any;
 }
 
-export const fetchError = (): FetchErrorAction => ({ type: FETCH_ERROR });
+export const fetchError = (error: any): FetchErrorAction => ({
+    type: FETCH_ERROR,
+    error,
+});
 
 export const FETCH_CANCEL = 'RA/FETCH_CANCEL';
 

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -34,8 +34,15 @@ const useLogin = (): Login => {
     const locationState = location.state as any;
     const history = useHistory();
     const dispatch = useDispatch();
-    const nextPathName = locationState && locationState.nextPathname;
-    const nextSearch = locationState && locationState.nextSearch;
+    const nextPathname =
+        locationState && typeof locationState.nextPathname === 'string'
+            ? locationState.nextPathname
+            : '';
+    const nextSearch =
+        locationState && typeof locationState.nextSearch === 'string'
+            ? locationState.nextSearch
+            : '';
+    const nextUrl = `${nextPathname}${nextSearch}`;
 
     const login = useCallback(
         (params: any = {}, pathName) =>
@@ -43,12 +50,11 @@ const useLogin = (): Login => {
                 dispatch(resetNotification());
                 const redirectUrl = pathName
                     ? pathName
-                    : nextPathName + nextSearch ||
-                      defaultAuthParams.afterLoginUrl;
+                    : nextUrl || defaultAuthParams.afterLoginUrl;
                 history.push(redirectUrl);
                 return ret;
             }),
-        [authProvider, history, nextPathName, nextSearch, dispatch]
+        [authProvider, history, nextUrl, dispatch]
     );
 
     const loginWithoutProvider = useCallback(

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -87,6 +87,7 @@ const useLogout = (): Logout => {
                 pathname: defaultAuthParams.loginUrl,
                 state: {
                     nextPathname: history.location && history.location.pathname,
+                    nextSearch: history.location && history.location.search,
                 },
             });
             dispatch(clearState());

--- a/packages/ra-core/src/sideEffect/auth.spec.ts
+++ b/packages/ra-core/src/sideEffect/auth.spec.ts
@@ -238,7 +238,14 @@ describe('Auth saga', () => {
             await runSaga(
                 {
                     dispatch,
-                    getState: () => ({ router: { location: '/posts' } }),
+                    getState: () => ({
+                        router: {
+                            location: {
+                                pathname: '/posts',
+                                search: '?_sort=date',
+                            },
+                        },
+                    }),
                 },
                 handleFetchError(authProvider),
                 action
@@ -249,7 +256,10 @@ describe('Auth saga', () => {
                 expect(dispatch).toHaveBeenCalledWith(
                     push({
                         pathname: '/custom',
-                        state: { nextPathname: '/posts' },
+                        state: {
+                            nextPathname: '/posts',
+                            nextSearch: '?_sort=date',
+                        },
                     })
                 );
                 expect(dispatch).toHaveBeenCalledWith(hideNotification());

--- a/packages/ra-core/src/sideEffect/auth.ts
+++ b/packages/ra-core/src/sideEffect/auth.ts
@@ -43,7 +43,8 @@ const nextPathnameSelector = state => {
     return locationState && locationState.nextPathname;
 };
 
-const currentPathnameSelector = state => state.router.location;
+const currentPathnameSelector = state => state.router.location.pathname;
+const currentSearchSelector = state => state.router.location.search;
 
 const getErrorMessage = (error, defaultMessage) =>
     typeof error === 'string'
@@ -118,11 +119,12 @@ export const handleFetchError = (authProvider: AuthProvider) =>
             yield call([authProvider, 'checkError'], error);
         } catch (e) {
             const nextPathname = yield select(currentPathnameSelector);
+            const nextSearch = yield select(currentSearchSelector);
             const redirectTo = yield call([authProvider, 'logout'], undefined);
             yield put(
                 push({
                     pathname: redirectTo || '/login',
-                    state: { nextPathname },
+                    state: { nextPathname, nextSearch },
                 })
             );
             // Clear the state before showing a notification as it would be dismissed immediately otherwise


### PR DESCRIPTION
This pull requests aims at fixing the redirect after login behaviour when using a fetch action such as `fetchError`.

At the moment `fetchError` always logs the user out independently of the `authProvider.checkError` result. And the redirection after that logout is broken since the `nextPathname` is incorrectly fetched from the redux store.

I have tested the changes with different scenarios on the simple example and could not see any problem.