### PR TITLE
fix import syntax used for React

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -64,7 +64,7 @@ Bootstrap the admin app by replacing the `src/App.js` by the following code:
 
 ```jsx
 // in src/App.js
-import * as React from "react";
+import React from "react";
 import { Admin } from 'react-admin';
 import jsonServerProvider from 'ra-data-json-server';
 
@@ -90,7 +90,7 @@ The `<Admin>` component expects one or more `<Resource>` child components. Each 
 
 ```diff
 // in src/App.js
-import * as React from "react";
+import React from "react";
 -import { Admin } from 'react-admin';
 +import { Admin, Resource, ListGuesser } from 'react-admin';
 import jsonServerProvider from 'ra-data-json-server';
@@ -128,7 +128,7 @@ Let's copy this code, and create a new `UserList` component, in a new file named
 
 ```jsx
 // in src/users.js
-import * as React from "react";
+import React from "react";
 import { List, Datagrid, TextField, EmailField } from 'react-admin';
 
 export const UserList = props => (
@@ -173,7 +173,7 @@ The `ListGuesser` created one column for every field in the response. That's a b
 
 ```diff
 // in src/users.js
-import * as React from "react";
+import React from "react";
 import { List, Datagrid, TextField, EmailField } from 'react-admin';
 
 export const UserList = props => (
@@ -204,7 +204,7 @@ For instance, the `website` field looks like a URL. Instead of displaying it as 
 
 ```diff
 // in src/users.js
-import * as React from "react";
+import React from "react";
 -import { List, Datagrid, TextField, EmailField } from 'react-admin';
 +import { List, Datagrid, TextField, EmailField, UrlField } from 'react-admin';
 
@@ -231,7 +231,7 @@ That means that writing a custom Field component is really straightforward. For 
 
 ```jsx
 // in src/MyUrlField.js
-import * as React from "react";
+import React from "react";
 import { useRecordContext } from 'react-admin';
 
 const MyUrlField = ({ source }) => {
@@ -250,7 +250,7 @@ You can use this component in `<UserList>`, instead of react-admin's `<UrlField>
 
 ```diff
 // in src/users.js
-import * as React from "react";
+import React from "react";
 -import { List, Datagrid, TextField, EmailField, UrlField } from 'react-admin';
 +import { List, Datagrid, TextField, EmailField } from 'react-admin';
 +import MyUrlField from './MyUrlField';
@@ -278,7 +278,7 @@ The `MyUrlField` component is a perfect opportunity to illustrate how to customi
 
 ```jsx
 // in src/MyUrlField.js
-import * as React from "react";
+import React from "react";
 import { useRecordContext } from 'react-admin';
 import { makeStyles } from '@material-ui/core/styles';
 import LaunchIcon from '@material-ui/icons/Launch';
@@ -333,7 +333,7 @@ React-admin knows how to take advantage of these foreign keys to fetch reference
 
 ```diff
 // in src/App.js
-import * as React from "react";
+import React from "react";
 -import { Admin, Resource } from 'react-admin';
 +import { Admin, Resource, ListGuesser } from 'react-admin';
 import jsonServerProvider from 'ra-data-json-server';
@@ -355,7 +355,7 @@ The `ListGuesser` suggests using a `<ReferenceField>` for the `userId` field. Le
 
 ```jsx
 // in src/posts.js
-import * as React from "react";
+import React from "react";
 import { List, Datagrid, TextField, ReferenceField } from 'react-admin';
 
 export const PostList = props => (
@@ -419,7 +419,7 @@ To finish the post list, place the post `id` field as first column, and remove t
 
 ```diff
 // in src/posts.js
-import * as React from "react";
+import React from "react";
 -import { List, Datagrid, TextField, ReferenceField } from 'react-admin';
 +import { List, Datagrid, TextField, ReferenceField, EditButton } from 'react-admin';
 
@@ -470,7 +470,7 @@ Copy the `PostEdit` code dumped by the guesser in the console to the `posts.js` 
 
 ```jsx
 // in src/posts.js
-import * as React from "react";
+import React from "react";
 import {
     List,
     Datagrid,
@@ -531,7 +531,7 @@ Before you can use that custom component in the `App.js`, copy the `PostEdit` co
 
 ```diff
 // in src/posts.js
-import * as React from "react";
+import React from "react";
 import {
     List,
     Datagrid,
@@ -685,7 +685,7 @@ By default, react-admin displays the list page of the first `Resource` element a
 
 ```jsx
 // in src/Dashboard.js
-import * as React from "react";
+import React from "react";
 import { Card, CardContent, CardHeader } from '@material-ui/core';
 
 export default () => (
@@ -782,7 +782,7 @@ First, you should know that you don't have to use the `<Datagrid>` component as 
 
 ```jsx
 // in src/posts.js
-import * as React from "react";
+import React from "react";
 import { List, SimpleList } from 'react-admin';
 
 export const PostList = (props) => (
@@ -806,7 +806,7 @@ That works fine on mobile, but now the desktop user experience is worse. The bes
 
 ```jsx
 // in src/posts.js
-import * as React from "react";
+import React from "react";
 import { useMediaQuery } from '@material-ui/core';
 import { List, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'react-admin';
 


### PR DESCRIPTION
`import * as React` is not a valid way to import React and results in an error as of React 17.0.2, so following the instructions as-is here currently wasn't working.