### PR TITLE
Fix export TranslationMessages `StringMap` type

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -1,4 +1,4 @@
-interface StringMap {
+export interface StringMap {
     [key: string]: StringMap | string | undefined;
 }
 


### PR DESCRIPTION
Because of the missing `StringMap` type you get a type error trying to use `TranslationMessages`.
You can see this in the `simple` project