### PR TITLE
[TypeScript] Add missing types for TranslationMessages

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -26,6 +26,8 @@ export interface TranslationMessages extends StringMap {
             remove: string;
             save: string;
             search: string;
+            select_all: string;
+            select_row: string;
             show: string;
             sort: string;
             undo: string;


### PR DESCRIPTION
https://github.com/marmelab/react-admin/commit/fd895a840aa681efe7e49251573e3762a6523b9b#diff-d55e636245f2994de4a9a74002cca1fec0a6a2e68d1805a5439a0c885f37263b