### PR TITLE
New Feature: Creating a cloning button to allow an individual item in an `ArrayInput` to be cloned

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -1241,13 +1241,13 @@ import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admi
 </ArrayInput>
 ```
 
-You can also use `addButton` and `removeButton` props to pass your custom add and remove buttons to `SimpleFormIterator`.
+You can also use `addButton`, `removeButton` and `cloneButton` props to pass your custom add, remove and clone buttons to `SimpleFormIterator`.
 
 ```jsx
 import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admin';
 
 <ArrayInput source="backlinks">
-    <SimpleFormIterator addButton={<CustomAddButton />} removeButton={<CustomRemoveButton />}>
+    <SimpleFormIterator addButton={<CustomAddButton />} removeButton={<CustomRemoveButton />} cloneButton={<CustomCloneButton />}>
         <DateInput source="date" />
         <TextInput source="url" />
     </SimpleFormIterator>
@@ -1273,7 +1273,7 @@ import { ArrayInput, SimpleFormIterator, DateInput, TextInput } from 'react-admi
 import { ArrayInput, SimpleFormIterator, DateInput, TextInput, FormDataConsumer } from 'react-admin';
 
 <ArrayInput source="backlinks">
-    <SimpleFormIterator disableRemove >
+    <SimpleFormIterator disableRemove disableClone>
         <DateInput source="date" />
         <FormDataConsumer>
             {({ getSource, scopedFormData }) => {
@@ -2073,6 +2073,21 @@ You can tweak how this component fetches the possible values using the `perPage`
 ```
 {% endraw %}
 
+**Tip**: `<ReferenceArrayInput>` can also used with an `<AutocompleteArrayInput>` to allow filtering the choices. By default, it will fetch the choices on mount, but you can prevent this by using the `enableGetChoices`. This prop should be a function that receives the `filterValues` as parameter and return a boolean. In order to also hide the choices when `enableGetChoices` returns `false`, you should use `shouldRenderSuggestions` on the `<AutocompleteArrayInput>`:
+
+```jsx
+<ReferenceArrayInput
+  label="Tags"
+  reference="tags"
+  source="tags"
+  enableGetChoices={({ q }) => (q ? q.length >= 2 : false)}
+>
+  <AutocompleteArrayInput
+    shouldRenderSuggestions={(value: string) => value.length >= 2}
+  />
+</ReferenceArrayInput>
+```
+
 In addition to the `ReferenceArrayInputContext`, `<ReferenceArrayInput>` also sets up a `ListContext` providing access to the records from the reference resource in a similar fashion to that of the `<List>` component. This `ListContext` value is accessible with the [`useListContext`](./List.md#uselistcontext) hook.
 
 `<ReferenceArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
@@ -2134,6 +2149,8 @@ import { ReferenceInput, SelectInput } from 'react-admin';
 | `perPage`       | Optional | `number`                                    | 25                                    | Number of suggestions to show                                                                                         |
 | `reference`     | Required | `string`                                    | ''                                    | Name of the reference resource, e.g. 'posts'.                                                                         |
 | `sort`          | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }`      | How to order the list of suggestions                                                                                  |
+| `enableGetChoices`     | Optional | `({q: string}) => boolean`                  | `() => true`                          | Function taking the `filterValues` and returning a boolean to enable the `getList` call.                              |
+
 
 `<ReferenceInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
@@ -2221,6 +2238,16 @@ The child component receives the following props from `<ReferenceInput>`:
 - `setFilter`: function to call to update the filter of the request for possible values
 - `setPagination`: : function to call to update the pagination of the request for possible values
 - `setSort`: function to call to update the sorting of the request for possible values
+
+**Tip** You can make the `getList()` call lazy by using the `enableGetChoices` prop. This prop should be a function that receives the `filterValues` as parameter and return a boolean. This can be useful when using an `AutocompleteInput` on a resource with a lot of data. The following example only starts fetching the options when the query has at least 2 characters:
+```jsx
+<ReferenceInput
+     source="post_id"
+     reference="posts"
+     enableGetChoices={({ q }) => q.length >= 2}>
+    <AutocompleteInput optionText="title" />
+</ReferenceInput>
+```
 
 **Tip**: Why does `<ReferenceInput>` use the `dataProvider.getMany()` method with a single value `[id]` instead of `dataProvider.getOne()` to fetch the record for the current value? Because when there are many `<ReferenceInput>` for the same resource in a form (for instance when inside an `<ArrayInput>`), react-admin *aggregates* the calls to `dataProvider.getMany()` into a single one with `[id1, id2, ...]`. This speeds up the UI and avoids hitting the API too much.
 

--- a/packages/ra-ui-materialui/src/input/ArrayInput/CloneItemButton.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/CloneItemButton.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import QueueIcon from '@material-ui/icons/Queue';
+import { Button, ButtonProps } from '../../button';
+import { useSimpleFormIteratorItem } from './useSimpleFormIteratorItem';
+
+export const CloneItemButton = (props: Omit<ButtonProps, 'onClick'>) => {
+    const { clone } = useSimpleFormIteratorItem();
+
+    return (
+        <Button label="ra.action.clone" onClick={() => clone()} {...props}>
+            <QueueIcon />
+        </Button>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -27,12 +27,14 @@ import {
     SimpleFormIteratorItem,
 } from './SimpleFormIteratorItem';
 import { AddItemButton as DefaultAddItemButton } from './AddItemButton';
+import { CloneItemButton as DefaultCloneItemButton } from './CloneItemButton';
 import { RemoveItemButton as DefaultRemoveItemButton } from './RemoveItemButton';
 import { ReOrderButtons as DefaultReOrderButtons } from './ReOrderButtons';
 
 export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
     const {
         addButton = <DefaultAddItemButton />,
+        cloneButton = <DefaultCloneItemButton />,
         removeButton = <DefaultRemoveItemButton />,
         reOrderButtons = <DefaultReOrderButtons />,
         basePath,
@@ -43,6 +45,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
         source,
         disabled,
         disableAdd,
+        disableClone,
         disableRemove,
         disableReordering,
         variant,
@@ -90,6 +93,14 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
         [fields]
     );
 
+    const cloneField = useCallback(
+        (index: number) => {
+            ids.current.push(nextId.current++);
+            fields.push(fields.value[index]);
+        },
+        [fields]
+    );
+
     // add field and call the onClick event of the button passed as addButton prop
     const handleAddButtonClick = (
         originalOnClickHandler: MouseEventHandler
@@ -116,10 +127,11 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
         () => ({
             total: fields.length,
             add: addField,
+            clone: cloneField,
             remove: removeField,
             reOrder: handleReorder,
         }),
-        [fields.length, addField, removeField, handleReorder]
+        [fields.length, addField, removeField, cloneField, handleReorder]
     );
     return fields ? (
         <SimpleFormIteratorContext.Provider value={context}>
@@ -141,7 +153,9 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
                             <SimpleFormIteratorItem
                                 basePath={basePath}
                                 classes={classes}
+                                cloneButton={cloneButton}
                                 disabled={disabled}
+                                disableClone={disableClone}
                                 disableRemove={disableRemove}
                                 disableReordering={disableReordering}
                                 fields={fields}
@@ -150,6 +164,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
                                 margin={margin}
                                 member={member}
                                 meta={meta}
+                                onCloneField={cloneField}
                                 onRemoveField={removeField}
                                 onReorder={handleReorder}
                                 record={(records && records[index]) || {}}
@@ -186,12 +201,14 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
 
 SimpleFormIterator.defaultProps = {
     disableAdd: false,
+    disableClone: false,
     disableRemove: false,
 };
 
 SimpleFormIterator.propTypes = {
     defaultValue: PropTypes.any,
     addButton: PropTypes.element,
+    cloneButton: PropTypes.element,
     removeButton: PropTypes.element,
     basePath: PropTypes.string,
     children: PropTypes.node,
@@ -206,6 +223,7 @@ SimpleFormIterator.propTypes = {
     resource: PropTypes.string,
     translate: PropTypes.func,
     disableAdd: PropTypes.bool,
+    disableClone: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     disableRemove: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     TransitionProps: PropTypes.shape({}),
 };
@@ -217,9 +235,11 @@ export interface SimpleFormIteratorProps
     children?: ReactNode;
     classes?: ClassesOverride<typeof useSimpleFormIteratorStyles>;
     className?: string;
+    cloneButton?: ReactElement;
     defaultValue?: any;
     disabled?: boolean;
     disableAdd?: boolean;
+    disableClone?: boolean | DisableRemoveFunction;
     disableRemove?: boolean | DisableRemoveFunction;
     disableReordering?: boolean;
     getItemLabel?: (index: number) => string;

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorContext.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorContext.ts
@@ -13,6 +13,7 @@ export const SimpleFormIteratorContext = createContext<
 export type SimpleFormIteratorContextValue = {
     total: number;
     add: () => void;
+    clone: (index: number) => void;
     remove: (index: number) => void;
     reOrder: (index: number, newIndex: number) => void;
 };

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItemContext.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItemContext.ts
@@ -13,6 +13,7 @@ export const SimpleFormIteratorItemContext = createContext<
 export type SimpleFormIteratorItemContextValue = {
     index: number;
     total: number;
+    clone: () => void;
     remove: () => void;
     reOrder: (newIndex: number) => void;
 };


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I am trying to duplicate items on the ArrayInput withought having to click add, and then manually fill in the information. Particularly annoying if you only need to change one field!

**Describe the solution you'd like**
New Feature allowing a simpleFormIterator item to be cloned. A button placed next to the existing remove an item button.

**Describe alternatives you've considered**
No alternatives.

**Additional context**
For my case it's needed as large array sections and changing minor values is very annoying. SimpleFormIterator handles most things really well, but this would be a bonus.