### PR TITLE
Fix runtime error when type is not supplied to useNotify

### DIFF
--- a/packages/ra-core/src/sideEffect/useNotify.ts
+++ b/packages/ra-core/src/sideEffect/useNotify.ts
@@ -41,12 +41,16 @@ const useNotify = () => {
                     'This way of calling useNotify callback is deprecated. Please use the new syntax passing notify("[Your message]", { ...restOfArguments })'
                 );
                 dispatch(
-                    showNotification(message, (type || 'info') as NotificationType, {
-                        messageArgs,
-                        undoable,
-                        autoHideDuration,
-                        multiLine,
-                    })
+                    showNotification(
+                        message,
+                        (type || 'info') as NotificationType,
+                        {
+                            messageArgs,
+                            undoable,
+                            autoHideDuration,
+                            multiLine,
+                        }
+                    )
                 );
             } else {
                 const { type: messageType, ...options } = type;


### PR DESCRIPTION
When you dont supply `type` to the `useNotify` it will throw runtime error, even though `type` is marked as optional in the type.

This is a breaking change.