### PR TITLE
Fix warn when unsaved changes

### DIFF
--- a/packages/ra-core/src/form/FormWithRedirect.spec.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.spec.tsx
@@ -14,7 +14,7 @@ describe('FormWithRedirect', () => {
 
     it('Does not make the form dirty when reinitialized from a record', () => {
         const renderProp = jest.fn(() => (
-            <Input source="name" defaultValue="Bar" />
+            <Input source="name" initialValue="Bar" />
         ));
         const { getByDisplayValue, rerender } = renderWithRedux(
             <FormWithRedirect
@@ -40,12 +40,8 @@ describe('FormWithRedirect', () => {
             />
         );
 
-        expect(renderProp.mock.calls[3][0].pristine).toEqual(true);
-        expect(getByDisplayValue('Foo')).not.toBeNull();
-        // 4 times because the first initialization with an empty value
-        // triggers a change on the input which has a defaultValue
-        // This is expected and identical to what FinalForm does (https://final-form.org/docs/final-form/types/FieldConfig#defaultvalue)
-        expect(renderProp).toHaveBeenCalledTimes(4);
+        expect(renderProp.mock.calls[1][0].pristine).toEqual(true);
+        expect(renderProp).toHaveBeenCalledTimes(2);
     });
 
     it('Does not make the form dirty when initialized from a record with a missing field and this field has an initialValue', () => {
@@ -65,9 +61,6 @@ describe('FormWithRedirect', () => {
 
         expect(renderProp.mock.calls[0][0].pristine).toEqual(true);
         expect(getByDisplayValue('Bar')).not.toBeNull();
-        // 4 times because the first initialization with an empty value
-        // triggers a change on the input which has a defaultValue
-        // This is expected and identical to what FinalForm does (https://final-form.org/docs/final-form/types/FieldConfig#defaultvalue)
         expect(renderProp).toHaveBeenCalledTimes(1);
     });
 
@@ -153,16 +146,17 @@ describe('FormWithRedirect', () => {
                 saving={false}
                 version={0}
                 record={{
-                    id: 1,
-                    anotherServerAddedProp: 'Bar',
+                    id: 2,
+                    name: undefined,
+                    anotherServerAddedProp: 'Bazinga',
                 }}
                 render={renderProp}
             />
         );
 
+        expect(renderProp).toHaveBeenCalledTimes(3);
         expect(renderProp.mock.calls[2][0].pristine).toEqual(false);
         expect(getByDisplayValue('Bar')).not.toBeNull();
-        expect(renderProp).toHaveBeenCalledTimes(3);
     });
 
     it('Does not make the form dirty when reinitialized from a different record with a missing field and this field has an initialValue', async () => {
@@ -190,9 +184,9 @@ describe('FormWithRedirect', () => {
                 saving={false}
                 version={0}
                 record={{
-                    id: 1,
+                    id: 2,
                     name: undefined,
-                    anotherServerAddedProp: 'Bar',
+                    anotherServerAddedProp: 'Bazinga',
                 }}
                 render={renderProp}
             />
@@ -200,10 +194,9 @@ describe('FormWithRedirect', () => {
 
         await waitFor(() => {
             expect(getByDisplayValue('Bar')).not.toBeNull();
-            expect(
-                renderProp.mock.calls[renderProp.mock.calls.length - 1][0]
-                    .pristine
-            ).toEqual(false);
         });
+        expect(
+            renderProp.mock.calls[renderProp.mock.calls.length - 1][0].pristine
+        ).toEqual(true);
     });
 });

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useRef, useCallback, useEffect, useMemo } from 'react';
 import { Form, FormProps, FormRenderProps } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
-import { useHistory } from 'react-router';
 import { useDispatch } from 'react-redux';
 
 import useResetSubmitErrors from './useResetSubmitErrors';
@@ -70,7 +69,6 @@ const FormWithRedirect = ({
 }: FormWithRedirectProps) => {
     const redirect = useRef(props.redirect);
     const onSave = useRef(save);
-    const history = useHistory();
     const formGroups = useRef<{ [key: string]: string[] }>({});
     const finalMutators = useMemo(
         () =>
@@ -187,9 +185,7 @@ const FormWithRedirect = ({
                         render={render}
                         save={save}
                         warnWhenUnsavedChanges={warnWhenUnsavedChanges}
-                        formRootPathname={
-                            formRootPathname ?? history.location.pathname
-                        }
+                        formRootPathname={formRootPathname}
                     />
                 )}
             />

--- a/packages/ra-core/src/form/FormWithRedirect.tsx
+++ b/packages/ra-core/src/form/FormWithRedirect.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useRef, useCallback, useEffect, useMemo } from 'react';
 import { Form, FormProps, FormRenderProps } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
+import { useHistory } from 'react-router';
+import { useDispatch } from 'react-redux';
 
 import useResetSubmitErrors from './useResetSubmitErrors';
 import sanitizeEmptyValues from './sanitizeEmptyValues';
@@ -13,7 +15,6 @@ import {
     OnFailure,
 } from '../types';
 import { RedirectionSideEffect } from '../sideEffect';
-import { useDispatch } from 'react-redux';
 import { setAutomaticRefresh } from '../actions/uiActions';
 import { FormContextProvider } from './FormContextProvider';
 import submitErrorsMutators from './submitErrorsMutators';
@@ -50,6 +51,7 @@ const FormWithRedirect = ({
     defaultValue,
     destroyOnUnregister,
     form,
+    formRootPathname,
     initialValues,
     initialValuesEqual,
     keepDirtyOnReinitialize = true,
@@ -68,6 +70,7 @@ const FormWithRedirect = ({
 }: FormWithRedirectProps) => {
     const redirect = useRef(props.redirect);
     const onSave = useRef(save);
+    const history = useHistory();
     const formGroups = useRef<{ [key: string]: string[] }>({});
     const finalMutators = useMemo(
         () =>
@@ -184,6 +187,9 @@ const FormWithRedirect = ({
                         render={render}
                         save={save}
                         warnWhenUnsavedChanges={warnWhenUnsavedChanges}
+                        formRootPathname={
+                            formRootPathname ?? history.location.pathname
+                        }
                     />
                 )}
             />
@@ -213,6 +219,7 @@ export type FormWithRedirectSave = (
 
 export interface FormWithRedirectOwnProps {
     defaultValue?: any;
+    formRootPathname?: string;
     record?: RaRecord;
     redirect?: RedirectionSideEffect;
     render: FormWithRedirectRender;
@@ -249,13 +256,14 @@ interface FormViewProps
 }
 
 const FormView = ({
+    formRootPathname,
     render,
     warnWhenUnsavedChanges,
     setRedirect,
     ...props
 }: FormViewProps) => {
     useResetSubmitErrors();
-    useWarnWhenUnsavedChanges(warnWhenUnsavedChanges);
+    useWarnWhenUnsavedChanges(warnWhenUnsavedChanges, formRootPathname);
     const dispatch = useDispatch();
     const { redirect, handleSubmit, pristine } = props;
 

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -4,13 +4,11 @@ import {
     FieldProps,
     FieldRenderProps,
     FieldInputProps,
-    useForm,
 } from 'react-final-form';
 import { Validator, composeValidators } from './validate';
 import isRequired from './isRequired';
 import { useFormGroupContext } from './useFormGroupContext';
 import { useFormContext } from './useFormContext';
-import { useRecordContext } from '../controller';
 
 export interface InputProps<T = any>
     extends Omit<
@@ -53,7 +51,6 @@ const useInput = ({
     const finalName = name || source;
     const formGroupName = useFormGroupContext();
     const formContext = useFormContext();
-    const record = useRecordContext();
 
     useEffect(() => {
         if (!formContext || !formGroupName) {
@@ -110,43 +107,6 @@ const useInput = ({
         },
         [onFocus, customOnFocus]
     );
-
-    const form = useForm();
-    const recordId = record?.id;
-    // Every time the record changes and doesn't include a value for this field,
-    // reset the field value to the initialValue (or defaultValue)
-    useEffect(() => {
-        if (
-            typeof input.checked !== 'undefined' || // checkbox that has a value from record
-            (input.value != null && input.value !== '') // any other input that has a value from record
-        ) {
-            // no need to apply a default value
-            return;
-        }
-
-        // Apply the default value if provided
-        // We use a change here which will make the form dirty but this is expected
-        // and identical to what FinalForm does (https://final-form.org/docs/final-form/types/FieldConfig#defaultvalue)
-        if (defaultValue != null) {
-            form.change(source, defaultValue);
-        }
-
-        // apply initial value if provided
-        if (initialValue != null) {
-            form.batch(() => {
-                form.change(source, initialValue);
-                form.resetFieldState(source);
-            });
-        }
-    }, [
-        recordId,
-        input.value,
-        input.checked,
-        defaultValue,
-        initialValue,
-        source,
-        form,
-    ]);
 
     // If there is an input prop, this input has already been enhanced by final-form
     // This is required in for inputs used inside other inputs (such as the SelectInput inside a ReferenceInput)

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.spec.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.spec.tsx
@@ -34,6 +34,15 @@ const FormBody = ({ handleSubmit, submitSucceeded }) => {
                 aria-labelledby="author-label"
                 component="input"
             />
+            <button type="button" onClick={() => history.push('/form')}>
+                Root form
+            </button>
+            <button type="button" onClick={() => history.push('/form/part1')}>
+                Form part 1
+            </button>
+            <button type="button" onClick={() => history.push('/form/part2')}>
+                Form part 2
+            </button>
             <button type="button" onClick={onLeave}>
                 Leave
             </button>
@@ -57,9 +66,9 @@ const FormUnderTest = ({ initialValues = {} }) => {
     );
 };
 
-const App = () => (
+const App = ({ initialEntries = ['/form'] }) => (
     <MemoryRouter
-        initialEntries={['/form']}
+        initialEntries={initialEntries}
         initialIndex={0}
         getUserConfirmation={(message, callback) => {
             const confirmed = window.confirm(message);
@@ -111,6 +120,69 @@ describe('useWarnWhenUnsavedChanges', () => {
             });
             expect(getByDisplayValue('John Doe')).not.toBeNull();
             fireEvent.click(getByText('Submit'));
+            // We don't check whether the redirection happened because final-form keeps the form
+            // dirty state even after the submit.
+            expect(window.confirm).not.toHaveBeenCalled();
+        }
+    );
+
+    test.each([
+        ['simple', 'First Name'],
+        ['nested', 'Author'],
+    ])(
+        'should not warn when navigating to a sub page of a form with submit button after updating %s field',
+        async (_, field) => {
+            window.confirm = jest.fn().mockReturnValue(true);
+            const { getByLabelText, getByDisplayValue, getByText } = render(
+                <App />
+            );
+            fireEvent.change(getByLabelText(field), {
+                target: { value: 'John Doe' },
+            });
+            expect(getByDisplayValue('John Doe')).not.toBeNull();
+            fireEvent.click(getByText('Form part 1'));
+            // We don't check whether the redirection happened because final-form keeps the form
+            // dirty state even after the submit.
+            expect(window.confirm).not.toHaveBeenCalled();
+        }
+    );
+
+    test.each([
+        ['simple', 'First Name'],
+        ['nested', 'Author'],
+    ])(
+        'should not warn when navigating from a sub page of a form to the another part with submit button after updating %s field',
+        async (_, field) => {
+            window.confirm = jest.fn().mockReturnValue(true);
+            const { getByLabelText, getByDisplayValue, getByText } = render(
+                <App initialEntries={['/form/part1']} />
+            );
+            fireEvent.change(getByLabelText(field), {
+                target: { value: 'John Doe' },
+            });
+            expect(getByDisplayValue('John Doe')).not.toBeNull();
+            fireEvent.click(getByText('Form part 2'));
+            // We don't check whether the redirection happened because final-form keeps the form
+            // dirty state even after the submit.
+            expect(window.confirm).not.toHaveBeenCalled();
+        }
+    );
+
+    test.each([
+        ['simple', 'First Name'],
+        ['nested', 'Author'],
+    ])(
+        'should not warn when navigating from a sub page of a form to the root part with submit button after updating %s field',
+        async (_, field) => {
+            window.confirm = jest.fn().mockReturnValue(true);
+            const { getByLabelText, getByDisplayValue, getByText } = render(
+                <App initialEntries={['/form/part1']} />
+            );
+            fireEvent.change(getByLabelText(field), {
+                target: { value: 'John Doe' },
+            });
+            expect(getByDisplayValue('John Doe')).not.toBeNull();
+            fireEvent.click(getByText('Root form'));
             // We don't check whether the redirection happened because final-form keeps the form
             // dirty state even after the submit.
             expect(window.confirm).not.toHaveBeenCalled();

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.spec.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.spec.tsx
@@ -1,17 +1,25 @@
 import * as React from 'react';
+import { useEffect } from 'react';
 import expect from 'expect';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Form, Field } from 'react-final-form';
 import { Route, MemoryRouter, useHistory } from 'react-router-dom';
 
 import useWarnWhenUnsavedChanges from './useWarnWhenUnsavedChanges';
 
-const FormBody = ({ handleSubmit }) => {
+const FormBody = ({ handleSubmit, submitSucceeded }) => {
     useWarnWhenUnsavedChanges(true);
     const history = useHistory();
     const onLeave = () => {
         history.push('/somewhere');
     };
+    useEffect(() => {
+        if (submitSucceeded) {
+            setTimeout(() => {
+                history.push('/submitted');
+            }, 100);
+        }
+    }, [submitSucceeded, history]);
     return (
         <form onSubmit={handleSubmit}>
             <label id="firstname-label">First Name</label>
@@ -35,9 +43,10 @@ const FormBody = ({ handleSubmit }) => {
 };
 
 const FormUnderTest = ({ initialValues = {} }) => {
-    const history = useHistory();
     const onSubmit = () => {
-        history.push('/submitted');
+        // The redirection can't happen on submit because final-form keep the form
+        // dirty state even after the submit.
+        return undefined;
     };
     return (
         <Form
@@ -49,7 +58,14 @@ const FormUnderTest = ({ initialValues = {} }) => {
 };
 
 const App = () => (
-    <MemoryRouter initialEntries={['/form']} initialIndex={0}>
+    <MemoryRouter
+        initialEntries={['/form']}
+        initialIndex={0}
+        getUserConfirmation={(message, callback) => {
+            const confirmed = window.confirm(message);
+            callback(confirmed);
+        }}
+    >
         <Route path="/form">
             <FormUnderTest />
         </Route>
@@ -59,24 +75,45 @@ const App = () => (
 );
 
 describe('useWarnWhenUnsavedChanges', () => {
-    it('should not warn when leaving form with no changes', () => {
-        const { getByText } = render(<App />);
-        fireEvent.click(getByText('Submit'));
-        getByText('Submitted');
+    let originalConsoleError;
+    beforeAll(() => {
+        originalConsoleError = console.error;
+        console.error = jest.fn(message => {
+            if (message.includes('Error: Not implemented: window.confirm')) {
+                return;
+            }
+            originalConsoleError(message);
+        });
     });
 
-    test.each([
+    afterAll(() => {
+        console.error = originalConsoleError;
+    });
+
+    it('should not warn when leaving form with no changes', async () => {
+        const { getByText } = render(<App />);
+        fireEvent.click(getByText('Submit'));
+        await waitFor(() => getByText('Submitted'));
+    });
+
+    test.only.each([
         ['simple', 'First Name'],
         ['nested', 'Author'],
     ])(
         'should not warn when leaving form with submit button after updating %s field',
-        (_, field) => {
-            const { getByLabelText, getByText } = render(<App />);
+        async (_, field) => {
+            window.confirm = jest.fn().mockReturnValue(true);
+            const { getByLabelText, getByDisplayValue, getByText } = render(
+                <App />
+            );
             fireEvent.change(getByLabelText(field), {
                 target: { value: 'John Doe' },
             });
+            expect(getByDisplayValue('John Doe')).not.toBeNull();
             fireEvent.click(getByText('Submit'));
-            getByText('Submitted');
+            // We don't check whether the redirection happened because final-form keeps the form
+            // dirty state even after the submit.
+            expect(window.confirm).not.toHaveBeenCalled();
         }
     );
 
@@ -88,17 +125,22 @@ describe('useWarnWhenUnsavedChanges', () => {
         (_, field) => {
             // mock click on "cancel" in the confirm dialog
             window.confirm = jest.fn().mockReturnValue(false);
-            const { getByLabelText, getByText, queryByText } = render(<App />);
+            const {
+                getByLabelText,
+                queryByDisplayValue,
+                getByText,
+                queryByText,
+            } = render(<App />);
             const input = getByLabelText(field) as HTMLInputElement;
             fireEvent.change(input, { target: { value: 'John Doe' } });
+            fireEvent.blur(input);
+            expect(queryByDisplayValue('John Doe')).not.toBeNull();
             fireEvent.click(getByText('Leave'));
             expect(window.confirm).toHaveBeenCalledWith(
                 'ra.message.unsaved_changes'
             );
             // check that we're still in the form and that the unsaved changes are here
-            expect(
-                (getByLabelText('First Name') as HTMLInputElement).value
-            ).toBe('John Doe');
+            expect(queryByDisplayValue('John Doe')).not.toBeNull();
             expect(queryByText('Somewhere')).toBeNull();
         }
     );
@@ -108,7 +150,7 @@ describe('useWarnWhenUnsavedChanges', () => {
         ['nested', 'Author'],
     ])(
         'should warn when leaving form with unsaved changes but accept override',
-        (_, field) => {
+        async (_, field) => {
             // mock click on "OK" in the confirm dialog
             window.confirm = jest.fn().mockReturnValue(true);
             const { getByLabelText, getByText, queryByText } = render(<App />);
@@ -119,7 +161,9 @@ describe('useWarnWhenUnsavedChanges', () => {
                 'ra.message.unsaved_changes'
             );
             // check that we're no longer in the form
-            expect(queryByText(field)).toBeNull();
+            await waitFor(() => {
+                expect(queryByText(field)).toBeNull();
+            });
             getByText('Somewhere');
         }
     );

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.spec.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.spec.tsx
@@ -8,7 +8,7 @@ import { Route, MemoryRouter, useHistory } from 'react-router-dom';
 import useWarnWhenUnsavedChanges from './useWarnWhenUnsavedChanges';
 
 const FormBody = ({ handleSubmit, submitSucceeded }) => {
-    useWarnWhenUnsavedChanges(true);
+    useWarnWhenUnsavedChanges(true, '/form');
     const history = useHistory();
     const onLeave = () => {
         history.push('/somewhere');
@@ -66,7 +66,7 @@ const App = () => (
             callback(confirmed);
         }}
     >
-        <Route path="/form">
+        <Route path="/form/:subpath?">
             <FormUnderTest />
         </Route>
         <Route path="/submitted" render={() => <span>Submitted</span>} />
@@ -96,7 +96,7 @@ describe('useWarnWhenUnsavedChanges', () => {
         await waitFor(() => getByText('Submitted'));
     });
 
-    test.only.each([
+    test.each([
         ['simple', 'First Name'],
         ['nested', 'Author'],
     ])(

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
@@ -25,7 +25,6 @@ const useWarnWhenUnsavedChanges = (enable: boolean) => {
                 initialLocation.current
             );
 
-            console.log({ pristine });
             if (!pristine && !isInsideForm) {
                 return translate('ra.message.unsaved_changes');
             }

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
@@ -9,11 +9,14 @@ import { useTranslate } from '../i18n';
  * - If the user confirms, the navigation continues and the changes are lost.
  * - If the user cancels, the navigation is cancelled and the changes are kept.
  */
-const useWarnWhenUnsavedChanges = (enable: boolean) => {
+const useWarnWhenUnsavedChanges = (
+    enable: boolean,
+    formRootPathname: string
+) => {
     const history = useHistory();
     const translate = useTranslate();
     const { pristine } = useFormState(UseFormStateSubscription);
-    const initialLocation = useRef(history.location.pathname);
+    const initialLocation = useRef(formRootPathname);
 
     useEffect(() => {
         if (!enable) {

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
@@ -1,84 +1,50 @@
 import { useEffect, useRef } from 'react';
-import { useForm } from 'react-final-form';
+import { useFormState, UseFormStateParams } from 'react-final-form';
 import { useHistory } from 'react-router-dom';
-import get from 'lodash/get';
 
 import { useTranslate } from '../i18n';
 
 /**
  * Display a confirmation dialog if the form has unsaved changes.
  * - If the user confirms, the navigation continues and the changes are lost.
- * - If the user cancels, the navigation is reverted and the changes are kept.
- *
- * We can't use history.block() here because forms have routes, too (for
- * instance TabbedForm), and the confirm dialog would show up when navigating
- * inside the form. So instead of relying on route change detection, we rely
- * on unmount detection. The resulting UI isn't perfect, because when they
- * click the cancel button, users briefly see the page they asked before
- * seeing the form page again. But that's the best we can do.
- *
- * @see history.block()
+ * - If the user cancels, the navigation is cancelled and the changes are kept.
  */
 const useWarnWhenUnsavedChanges = (enable: boolean) => {
-    const form = useForm();
     const history = useHistory();
     const translate = useTranslate();
-
-    // Keep track of the current location inside the form (e.g. active tab)
-    const formLocation = useRef(history.location);
-    useEffect(() => {
-        formLocation.current = history.location;
-    }, [history.location]);
+    const { pristine } = useFormState(UseFormStateSubscription);
+    const initialLocation = useRef(history.location.pathname);
 
     useEffect(() => {
         if (!enable) {
-            window.sessionStorage.removeItem('unsavedChanges');
             return;
         }
 
-        // on mount: apply unsaved changes
-        const unsavedChanges = JSON.parse(
-            window.sessionStorage.getItem('unsavedChanges')
-        );
-
-        if (unsavedChanges) {
-            Object.keys(unsavedChanges).forEach(key =>
-                form.change(key, unsavedChanges[key])
+        const release = history.block(location => {
+            const isInsideForm = location.pathname.startsWith(
+                initialLocation.current
             );
-            window.sessionStorage.removeItem('unsavedChanges');
-        }
 
-        // on unmount : check and save unsaved changes, then cancel navigation
+            console.log({ pristine });
+            if (!pristine && !isInsideForm) {
+                return translate('ra.message.unsaved_changes');
+            }
+
+            return undefined;
+        });
+
         return () => {
-            const formState = form.getState();
-            if (
-                formState.dirty &&
-                (!formState.submitSucceeded ||
-                    (formState.submitSucceeded &&
-                        formState.dirtySinceLastSubmit))
-            ) {
-                if (!window.confirm(translate('ra.message.unsaved_changes'))) {
-                    const dirtyFields = formState.submitSucceeded
-                        ? formState.dirtySinceLastSubmit
-                        : formState.dirtyFields;
-                    const dirtyFieldValues = Object.keys(dirtyFields).reduce(
-                        (acc, key) => {
-                            acc[key] = get(formState.values, key);
-                            return acc;
-                        },
-                        {}
-                    );
-                    window.sessionStorage.setItem(
-                        'unsavedChanges',
-                        JSON.stringify(dirtyFieldValues)
-                    );
-                    history.push(formLocation.current);
-                }
-            } else {
-                window.sessionStorage.removeItem('unsavedChanges');
+            if (release) {
+                release();
             }
         };
-    }, [translate]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [pristine, enable, history, translate]);
+};
+
+const UseFormStateSubscription: UseFormStateParams = {
+    // For some reason, subscribing only to pristine does not rerender when a field become dirty
+    // because it has a defaultValue (not initialValue as setting an initialValue does not make the field dirty)
+    subscription: { pristine: true, dirtyFields: true },
 };
 
 export default useWarnWhenUnsavedChanges;

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
@@ -11,12 +11,14 @@ import { useTranslate } from '../i18n';
  */
 const useWarnWhenUnsavedChanges = (
     enable: boolean,
-    formRootPathname: string
+    formRootPathname?: string
 ) => {
     const history = useHistory();
     const translate = useTranslate();
     const { pristine } = useFormState(UseFormStateSubscription);
-    const initialLocation = useRef(formRootPathname);
+    const initialLocation = useRef(
+        formRootPathname || history.location.pathname
+    );
 
     useEffect(() => {
         if (!enable) {

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -17,6 +17,7 @@ import {
     OnFailure,
 } from 'ra-core';
 import get from 'lodash/get';
+import { useRouteMatch, useLocation } from 'react-router';
 
 import { ClassesOverride } from '../types';
 import { TabbedFormView, useTabbedFormViewStyles } from './TabbedFormView';
@@ -88,12 +89,19 @@ import { TabbedFormView, useTabbedFormViewStyles } from './TabbedFormView';
  *
  * @param {Props} props
  */
-export const TabbedForm = (props: TabbedFormProps) => (
-    <FormWithRedirect
-        {...props}
-        render={formProps => <TabbedFormView {...formProps} />}
-    />
-);
+export const TabbedForm = (props: TabbedFormProps) => {
+    const match = useRouteMatch();
+    const location = useLocation();
+    const formRootPathname = match ? match.url : location.pathname;
+
+    return (
+        <FormWithRedirect
+            {...props}
+            formRootPathname={formRootPathname}
+            render={formProps => <TabbedFormView {...formProps} />}
+        />
+    );
+};
 
 TabbedForm.propTypes = {
     children: PropTypes.node,

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -29,6 +29,7 @@ export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
         children,
         className,
         classes: classesOverride,
+        formRootPathname,
         handleSubmit,
         handleSubmitWithRedirect,
         invalid,


### PR DESCRIPTION
Closes #6678.

## Tasks

- [x] Add unit tests for form subpaths

## Description

The linked issue above was introduced by #6272 that fixed the issue ##6198 introduced by #6005.

However, all those workarounds were in fact necessary because of our implementation for warning users about potential data loss  if they tried to leave a page with a form with modified fields. Indeed, the `useWarnWhenUnsavedChanges` was saving the form changes when the form was unmounted because a location change happened. If users cancelled the navigation, then the hook would renavigate to the previous location and reapplied the saved changes.

However, re-navigating to the previous location means we refetched the data, reapplied initial values for the loaded record (in case of edit) then reapplied the saved changes. All this lead to several workarounds to manage dirty states that introduced more problems.

This PR uses the history API to trigger the warning. This is better because it happens **before** the location change so we don't have to save changes and reapply them. This allows us to remove the workarounds.