### PR TITLE
Keep sidebar state persistent during navigation 

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,53 +45,6 @@
 
     <body>
         <header>
-            <div
-                id="banner"
-                style="
-                    background-color: rgb(243, 168, 71);
-                    padding: 3px;
-                    text-align: center;
-                    color: #1f2937;
-                    display: none;
-                "
-            >
-                React-admin Enterprise is 1 year old! To celebrate, new
-                customers get a 20% discount on yearly
-                <a
-                    style="color: #1e3a8a"
-                    href="https://app.gumroad.com/reactadmin#LFaKw"
-                    >Team</a
-                >
-                &amp;
-                <a
-                    style="color: #1e3a8a"
-                    href="https://reactadmin.gumroad.com/#DvTQvi"
-                    >Business</a
-                >
-                plans.
-                <span aria-label="Close" style="position: absolute; right: 10px"
-                    ><a href="javascript:hideBanner()" style="color: #1f2937"
-                        ><span aria-hidden="true">X</span></a
-                    ></span
-                >
-            </div>
-            <script>
-                function hideBanner() {
-                    document.getElementById('banner').style.display = 'none';
-                    window.localStorage.setItem('hideBannerDate', Date.now());
-                }
-                const hideBannerDate = parseInt(
-                    window.localStorage.getItem('hideBannerDate'),
-                    10
-                );
-                if (
-                    !hideBannerDate ||
-                    Date.now() - hideBannerDate > 14 * 24 * 60 * 60 * 1000
-                ) {
-                    // two weeks
-                    document.getElementById('banner').style.display = 'block';
-                }
-            </script>
             <nav>
                 <a href="#" data-target="slide-out" class="sidenav-trigger"
                     ><i class="material-icons">menu</i></a
@@ -195,7 +148,7 @@
                     .replace(/^-+/, '') // Trim - from start of text
                     .replace(/-+$/, ''); // Trim - from end of text
             }
-            document.addEventListener('DOMContentLoaded', function () {
+            function buildPageToC() {
                 M.Sidenav.init(document.querySelectorAll('.sidenav'));
                 // Initialize version selector
                 M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'));
@@ -212,7 +165,73 @@
                     collapseDepth: 2,
                     hasInnerContainers: true,
                 });
+            }
+            // build ToC on page load
+            document.addEventListener('DOMContentLoaded', function () {
+                buildPageToC();
             });
+
+            var allMenus = Array.from(document.querySelectorAll(`.sidenav a.nav-link`));
+            var navLinks = allMenus.map(link => link.href);
+            
+            function replaceContent(text) {
+                var tmpElement = document.createElement('div');
+                tmpElement.innerHTML = text;
+                var content = document.querySelector('.DocSearch-content');
+                content.innerHTML = tmpElement.querySelector('.DocSearch-content').innerHTML;
+                window.scrollTo(0, 0);
+                buildPageToC();
+            }
+            
+            function changeSelectedMenu() {
+                var activeMenu = document.querySelector(`.sidenav li.active`);
+                activeMenu && activeMenu.classList.remove('active');
+                allMenus.find(menuEl => menuEl.href === location.href)
+                    .parentNode.classList.add('active');
+            }
+            
+            // Replace full page reloads by a fill of the content area
+            // so that the side navigation keeps its state
+            function catchNavigation() {
+                // use a global event listener to also catch links inside the content area 
+                document.addEventListener('click', (event) => {
+                    var link = event.target.closest('a');
+                    if (!link) {
+                        return; // click not on a link
+                    }
+                    var location = document.location.href.split('#')[0];
+                    var href = link.href;
+                    if (href.indexOf(`${location}#`) === 0) {
+                        return; // click on an anchor in the current page
+                    }
+                    if (!navLinks.includes(href)) {
+                        return; // not a navigation link
+                    }
+                    // now we're sure it's an internal navigation link
+                    // transform it to an AJAX call
+                    event.preventDefault();
+                    // fetch the new content
+                    fetch(href)
+                        .then(res => res.text())
+                        .then(replaceContent);
+                    // change the URL
+                    history.pushState(null, null, href);
+                    changeSelectedMenu();
+                })
+                // make back button work again
+                window.addEventListener('popstate', (event) => {
+                    if (document.location.href.indexOf('#') !== -1) {
+                        // popstate triggered by a click on an anchor, not back button
+                        return;
+                    }
+                    // fetch the new content
+                    fetch(location.pathname)
+                        .then(res => res.text())
+                        .then(replaceContent);
+                    changeSelectedMenu();
+                })
+            }
+            catchNavigation();
         </script>
         <script
             type="text/javascript"

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -1,40 +1,40 @@
-<li {% if page.path contains 'Readme.md' %} class="active" {% endif %}><a href="./Readme.html">Read Me</a></li>
-<li {% if page.path contains 'Tutorial.md' %} class="active" {% endif %}><a href="./Tutorial.html">Tutorial</a></li>
+<li {% if page.path contains 'Readme.md' %} class="active" {% endif %}><a class="nav-link" href="./Readme.html">Read Me</a></li>
+<li {% if page.path contains 'Tutorial.md' %} class="active" {% endif %}><a class="nav-link" href="./Tutorial.html">Tutorial</a></li>
 
 <ul><div>App Configuration</div>
-  <li {% if page.path contains 'Admin.md' %} class="active" {% endif %}><a href="./Admin.html"><code>&lt;Admin&gt;</code></a></li>
-  <li {% if page.path contains 'DataProviders.md' %} class="active" {% endif %}><a href="./DataProviders.html">Data Providers</a></li>
-  <li {% if page.path contains 'Authentication.md' %} class="active" {% endif %}><a href="./Authentication.html">Auth Providers</a></li>
-  <li {% if page.path contains 'Translation.md' %} class="active" {% endif %}><a href="./Translation.html">Translation & i18n</a></li>
-  <li {% if page.path contains 'Resource.md' %} class="active" {% endif %}><a href="./Resource.html"><code>&lt;Resource&gt;</code></a></li>
+  <li {% if page.path contains 'Admin.md' %} class="active" {% endif %}><a class="nav-link" href="./Admin.html"><code>&lt;Admin&gt;</code></a></li>
+  <li {% if page.path contains 'DataProviders.md' %} class="active" {% endif %}><a class="nav-link" href="./DataProviders.html">Data Providers</a></li>
+  <li {% if page.path contains 'Authentication.md' %} class="active" {% endif %}><a class="nav-link" href="./Authentication.html">Auth Providers</a></li>
+  <li {% if page.path contains 'Translation.md' %} class="active" {% endif %}><a class="nav-link" href="./Translation.html">Translation & i18n</a></li>
+  <li {% if page.path contains 'Resource.md' %} class="active" {% endif %}><a class="nav-link" href="./Resource.html"><code>&lt;Resource&gt;</code></a></li>
 </ul>
 
 <ul><div>View Configuration</div>
-  <li {% if page.path contains 'List.md' %} class="active" {% endif %}><a href="./List.html"><code>&lt;List&gt;</code> View</a></li>
-  <li {% if page.path contains 'CreateEdit.md' %} class="active" {% endif %}><a href="./CreateEdit.html"><code>&lt;Create&gt;</code> and <code>&lt;Edit&gt;</code> Views</a></li>
-  <li {% if page.path contains 'Show.md' %} class="active" {% endif %}><a href="./Show.html"><code>&lt;Show&gt;</code> View</a></li>
+  <li {% if page.path contains 'List.md' %} class="active" {% endif %}><a class="nav-link" href="./List.html"><code>&lt;List&gt;</code> View</a></li>
+  <li {% if page.path contains 'CreateEdit.md' %} class="active" {% endif %}><a class="nav-link" href="./CreateEdit.html"><code>&lt;Create&gt;</code> and <code>&lt;Edit&gt;</code> Views</a></li>
+  <li {% if page.path contains 'Show.md' %} class="active" {% endif %}><a class="nav-link" href="./Show.html"><code>&lt;Show&gt;</code> View</a></li>
 </ul>
 
 <ul><div>Fields and Inputs</div>
-  <li {% if page.path contains 'Fields.md' %} class="active" {% endif %}><a href="./Fields.html"><code>&lt;Field&gt;</code> Components</a></li>
-  <li {% if page.path contains 'Inputs.md' %} class="active" {% endif %}><a href="./Inputs.html"><code>&lt;Input&gt;</code> Components</a></li>
+  <li {% if page.path contains 'Fields.md' %} class="active" {% endif %}><a class="nav-link" href="./Fields.html"><code>&lt;Field&gt;</code> Components</a></li>
+  <li {% if page.path contains 'Inputs.md' %} class="active" {% endif %}><a class="nav-link" href="./Inputs.html"><code>&lt;Input&gt;</code> Components</a></li>
 </ul>
 
 <ul><div>Other UI components</div>
-  <li {% if page.path contains 'Buttons.md' %} class="active" {% endif %}><a href="./Buttons.html">Buttons</a></li>
+  <li {% if page.path contains 'Buttons.md' %} class="active" {% endif %}><a class="nav-link" href="./Buttons.html">Buttons</a></li>
 </ul>
 
 <ul><div>Recipes</div>
-  <li {% if page.path contains 'Actions.md' %} class="active" {% endif %}><a href="./Actions.html">Querying the API</a></li>
-  <li {% if page.path contains 'Theming.md' %} class="active" {% endif %}><a href="./Theming.html">Theming</a></li>
-  <li {% if page.path contains 'Caching.md' %} class="active" {% endif %}><a href="./Caching.html">Caching</a></li>
-  <li {% if page.path contains 'CustomApp.md' %} class="active" {% endif %}><a href="./CustomApp.html">Including in Another App</a></li>
-  <li {% if page.path contains 'UnitTesting.md' %} class="active" {% endif %}><a href="./UnitTesting.html">Unit Testing</a></li>
-  <li {% if page.path contains 'AdvancedTutorials.md' %} class="active" {% endif %}><a href="./AdvancedTutorials.html">Advanced tutorials</a></li>
+  <li {% if page.path contains 'Actions.md' %} class="active" {% endif %}><a class="nav-link" href="./Actions.html">Querying the API</a></li>
+  <li {% if page.path contains 'Theming.md' %} class="active" {% endif %}><a class="nav-link" href="./Theming.html">Theming</a></li>
+  <li {% if page.path contains 'Caching.md' %} class="active" {% endif %}><a class="nav-link" href="./Caching.html">Caching</a></li>
+  <li {% if page.path contains 'CustomApp.md' %} class="active" {% endif %}><a class="nav-link" href="./CustomApp.html">Including in Another App</a></li>
+  <li {% if page.path contains 'UnitTesting.md' %} class="active" {% endif %}><a class="nav-link" href="./UnitTesting.html">Unit Testing</a></li>
+  <li {% if page.path contains 'AdvancedTutorials.md' %} class="active" {% endif %}><a class="nav-link" href="./AdvancedTutorials.html">Advanced tutorials</a></li>
 </ul>
 
-<li {% if page.path contains 'Ecosystem.md' %} class="active" {% endif %}><a href="./Ecosystem.html">Ecosystem</a></li>
-<li {% if page.path contains 'Architecture.md' %} class="active" {% endif %}><a href="./Architecture.html">Architecture</a></li>
-<li {% if page.path contains 'FAQ.md' %} class="active" {% endif %}><a href="./FAQ.html">FAQ</a></li>
-<li {% if page.path contains 'Reference.md' %} class="active" {% endif %}><a href="./Reference.html">Reference</a></li>
-<li><a href="https://github.com/marmelab/react-admin/releases" target="_blank">Changelog</a></li>
+<li {% if page.path contains 'Ecosystem.md' %} class="active" {% endif %}><a class="nav-link" href="./Ecosystem.html">Ecosystem</a></li>
+<li {% if page.path contains 'Architecture.md' %} class="active" {% endif %}><a class="nav-link" href="./Architecture.html">Architecture</a></li>
+<li {% if page.path contains 'FAQ.md' %} class="active" {% endif %}><a class="nav-link" href="./FAQ.html">FAQ</a></li>
+<li {% if page.path contains 'Reference.md' %} class="active" {% endif %}><a class="nav-link" href="./Reference.html">Reference</a></li>
+<li><a class="nav-link" href="https://github.com/marmelab/react-admin/releases" target="_blank">Changelog</a></li>


### PR DESCRIPTION
## Problem

We can't use multi-level menus on the doc navigation, because the doc uses static pages (jekyll), so every click on a menu link reloads the entire page and resets the menu state. If the menu sidebar was scrolled, or submenus open, they will reset to default state as soon as the user changes page. 

We need multi-level menus to split the documentation into more pages, and add more chapters.

## Solution 

- [ ] ~~Replace Jekyll by Next, and the static page by SRR, and add a ton of complexity on the doc build process~~
- [x] Use good old JavaScript to transform clinks on the menu links into AJAX calls that only refresh the page content

https://user-images.githubusercontent.com/99944/139468190-4069ce59-54f6-48a8-900d-42ed42f19911.mp4



