### PR TITLE
Add label field controller

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceFieldController.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldController.tsx
@@ -18,6 +18,7 @@ export interface ReferenceFieldControllerProps {
     resource: string;
     source: string;
     link?: string | boolean | LinkToFunctionType;
+    label?: string;
 }
 
 /**


### PR DESCRIPTION
It is necessary to have the label parameter to not throw an error on typescript as it is necessary in cases like this:
```
<ReferenceFieldController
        basePath="/"
        reference="friends"
        resource="/"
        source="friendsId"
        link={false}
        // @ts-ignore <-- needed as typescript throws an error
        label="Family member"
      >
        {({ referenceRecord, ...props }) => {
          return (
            <ReferenceField
              resource="/"
              reference="family"
              source="familyId"
              record={referenceRecord || undefined}
              link={false}
              addLabel={false}
            >
              <TextField source="name" />
            </ReferenceField>
          );
        }}
      </ReferenceFieldController>
```