### PR TITLE
[Doc] Explain how to use dataProvider hooks in TestContext

### DIFF
--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -82,11 +82,8 @@ React-admin requires a valid dataProvider function to work.`);
     const [store] = useState(() =>
         !reduxIsAlreadyInitialized
             ? createAdminStore({
-                  authProvider: finalAuthProvider,
                   customReducers,
-                  dataProvider: finalDataProvider,
                   initialState,
-                  history: finalHistory,
               })
             : undefined
     );

--- a/packages/ra-core/src/core/createAdminStore.ts
+++ b/packages/ra-core/src/core/createAdminStore.ts
@@ -1,12 +1,6 @@
 import { createStore, StoreEnhancer } from 'redux';
-import { History } from 'history';
 
-import {
-    AuthProvider,
-    DataProvider,
-    I18nProvider,
-    InitialState,
-} from '../types';
+import { InitialState } from '../types';
 import createAppReducer from '../reducer';
 import { CLEAR_STATE } from '../actions/clearActions';
 
@@ -15,23 +9,12 @@ interface Window {
 }
 
 interface Params {
-    dataProvider: DataProvider;
-    history: History;
-    authProvider?: AuthProvider;
     customReducers?: any;
-    i18nProvider?: I18nProvider;
     initialState?: InitialState;
-    locale?: string;
 }
 
-export default ({
-    dataProvider,
-    history,
-    customReducers = {},
-    authProvider = null,
-    initialState,
-}: Params) => {
-    const appReducer = createAppReducer(customReducers, history);
+export default ({ customReducers = {}, initialState }: Params) => {
+    const appReducer = createAppReducer(customReducers);
 
     const resettableAppReducer = (state, action) =>
         appReducer(

--- a/packages/ra-core/src/reducer/index.ts
+++ b/packages/ra-core/src/reducer/index.ts
@@ -10,7 +10,7 @@ interface CustomReducers {
     [key: string]: Reducer;
 }
 
-export default (customReducers: CustomReducers, history) =>
+export default (customReducers: CustomReducers) =>
     combineReducers({
         admin,
         ...customReducers,

--- a/packages/ra-test/src/TestContext.spec.tsx
+++ b/packages/ra-test/src/TestContext.spec.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import expect from 'expect';
-import { render } from '@testing-library/react';
-import { refreshView } from 'ra-core';
+import { render, screen } from '@testing-library/react';
+import { refreshView, useGetOne, DataProviderContext } from 'ra-core';
 
 import TestContext, { defaultStore } from './TestContext';
+
+import { WithDataProvider } from './TestContext.stories';
 
 const primedStore = {
     admin: {
@@ -159,6 +161,12 @@ describe('TestContext.js', () => {
                     foo: testValue,
                 },
             });
+        });
+
+        it('should work with useDataProvider actions', async () => {
+            render(<WithDataProvider />);
+            expect(screen.getByText('loading')).toBeDefined();
+            await screen.findByText('foo');
         });
     });
 });

--- a/packages/ra-test/src/TestContext.stories.tsx
+++ b/packages/ra-test/src/TestContext.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { useGetOne, DataProviderContext } from 'ra-core';
+
+import TestContext from './TestContext';
+
+export default { title: 'ra-test/TestContext' };
+
+const dataProvider = {
+    getOne: () =>
+        Promise.resolve({
+            data: {
+                id: 1,
+                title: 'foo',
+            },
+        }),
+} as any;
+
+const Book = ({ id }) => {
+    const { data, loaded } = useGetOne('books', id);
+    return loaded ? <span>{data.title}</span> : <span>loading</span>;
+};
+
+export const WithDataProvider = () => (
+    <TestContext
+        enableReducers={true}
+        // FIXME: Resources must be initialized to allow dataProvider hooks to work
+        initialState={{ admin: { resources: { books: { data: {} } } } }}
+    >
+        <DataProviderContext.Provider value={dataProvider}>
+            <Book id={1} />
+        </DataProviderContext.Provider>
+    </TestContext>
+);


### PR DESCRIPTION
It's very hard to test a component that uses the dataProvider hooks with TestContext, because of a Gotcha about Resource registration that no one knows about.

The first step is to document it. The second step is to move away from Redux for the dataProvider optimistic strategy (to be done in the future).