### PR TITLE
Replace Labeled with FieldWithLabel in show views

### DIFF
--- a/cypress/support/ShowPage.js
+++ b/cypress/support/ShowPage.js
@@ -1,7 +1,7 @@
 export default (url, initialField = 'title') => ({
     elements: {
         body: 'body',
-        field: name => `.ra-field-${name} > div > span`,
+        field: name => `.ra-field-${name} > p > span`,
         fields: `.ra-field`,
         snackbar: 'div[role="alertdialog"]',
         tabs: `.show-tab`,

--- a/cypress/support/ShowPage.js
+++ b/cypress/support/ShowPage.js
@@ -1,7 +1,7 @@
 export default (url, initialField = 'title') => ({
     elements: {
         body: 'body',
-        field: name => `.ra-field-${name} > div > div > span`,
+        field: name => `.ra-field-${name} > div > span`,
         fields: `.ra-field`,
         snackbar: 'div[role="alertdialog"]',
         tabs: `.show-tab`,

--- a/docs/FieldWithLabel.md
+++ b/docs/FieldWithLabel.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: "FieldWithLabel"
+---
+
+# `<FieldWithLabel>`
+
+`<FieldWithLabel>` adds a label on top of its child if the child exposes a `label` prop, or if it's a field with a `source` prop. It's used in Show layouts, to display both a field and its label. 
+
+## Usage
+
+`<FieldWithLabel>` is mostly an internal component - you don't need it if you're using `<SimpleShowLayout>` or `<TabbedshowLayout>`. But, in a custom layout, if you want to display a label on top of a field value, just wrap the Field component with `<FieldWithLabel>`. 
+
+```jsx
+import { Show, FieldWithLabel, TextField } from 'react-admin';
+import { Card, Stack } from '@mui/material';
+
+const BookShow = () => (
+   <Show>
+      <Card>
+         <Stack>
+            <FieldWithLabel>
+               <TextField source="title" />
+            </FieldWithLabel>
+         </Stack>
+     </Car>
+  </Show>
+);
+```
+
+## Label
+
+`<FieldWithLabel>` uses the humanized `source`, and renders it above the field value. So for the previous example, the label would be `"Title"`.
+
+`<FieldWithLabel>` can also use an explicit `label` prop: 
+
+```jsx
+import { Show, FieldWithLabel, TextField } from 'react-admin';
+import { Card, Stack } from '@mui/material';
+
+const BookShow = () => (
+   <Show>
+      <Card>
+         <Stack>
+            <FieldWithLabel label="My custom label">
+               <TextField source="title" />
+            </FieldWithLabel>
+         </Stack>
+     </Car>
+  </Show>
+);
+```
+
+A component inside `<FieldWithLabel>` can opt out of label decoration by using the `label={false}` prop.
+
+```jsx
+import { Show, FieldWithLabel, TextField } from 'react-admin';
+import { Card, Stack } from '@mui/material';
+
+const BookShow = () => (
+   <Show>
+      <Card>
+         <Stack>
+            <FieldWithLabel>
+               <TextField source="title" label={false} />
+            </FieldWithLabel>
+         </Stack>
+     </Car>
+  </Show>
+);
+```
+
+## API
+
+* [`FieldWithLabel`]
+
+[`FieldWithLabel`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/FieldWithLabel.tsx

--- a/docs/FieldWithLabel.md
+++ b/docs/FieldWithLabel.md
@@ -30,7 +30,9 @@ const BookShow = () => (
 
 ## Label
 
-`<FieldWithLabel>` uses the humanized `source`, and renders it above the field value. So for the previous example, the label would be `"Title"`.
+`<FieldWithLabel>` uses the humanized `source`, and renders it above the field value. So for the previous example, the label would be `"Title"`. 
+
+`<FieldWithLabel>` uses the i18n layer, so you can translate the label. The message key for a label is `resources.{resource}.fields.{source}` (e.g. `resources.books.fields.title` for the element above). Check [the Translation chapter](./Translation.md) for more information.
 
 `<FieldWithLabel>` can also use an explicit `label` prop: 
 

--- a/docs/ShowGuesser.md
+++ b/docs/ShowGuesser.md
@@ -30,7 +30,7 @@ It also dumps the components it has guessed in the console, where you can copy i
 
 `<ShowGuesser>` doesn't expose any prop, as it's not designed to be customized. You should replace it with a custom `<Show>` component as soon as you need to customize it.
 
-React-admin provides guessers for the `List` view (`ListGuesser`), the `Edit` view (`EditGuesser`), and the `Show` view (`ShowGuesser`).
+React-admin provides guessers for the `List` view ([`<ListGuesser>`](./List.md#the-listguesser-component)), the `Edit` view ([`<EditGuesser>`](./CreateEdit.md#the-editguesser-component)), and the `Show` view (`ShowGuesser`).
 
 **Tip**: Do not use the guessers in production. They are slower than manually-defined components, because they have to infer types based on the content. Besides, the guesses are not always perfect.
 

--- a/docs/ShowTutorial.md
+++ b/docs/ShowTutorial.md
@@ -52,13 +52,13 @@ You can pass this `BookShow` component as the `show` prop of the `<Resource name
 
 This example uses the `useGetOne` hook instead of `fetch` because `useGetOne` already contains the authentication and request state logic. But you could totally write a Show view with `fetch`.
 
-## `<Labeled>` Displays Fields With Labels
+## `<FieldWithLabel>` Displays Labels Over Fields
 
-When you build Show views like the one above, you have to repeat quite a lot of code for each field. React-admin Field components can help avoid that repetition. The following example leverages the `<Labeled>`, `<TextField>`, and `<DateField>` components for that purpose:
+When you build Show views like the one above, you have to repeat quite a lot of code for each field. React-admin Field components can help avoid that repetition. The following example leverages the `<FieldWithLabel>`, `<TextField>`, and `<DateField>` components for that purpose:
 
 ```jsx
 import { useParams } from 'react-router-dom';
-import { useGetOne, useRedirect, Title, Labeled, TextField, DateField } from 'react-admin';
+import { useGetOne, useRedirect, Title, FieldWithLabel, TextField, DateField } from 'react-admin';
 import { Card, Stack } from '@mui/material';
 
 const BookShow = () => {
@@ -73,12 +73,12 @@ const BookShow = () => {
             <Title title="Book Show"/>
             <Card>
                 <Stack spacing={1}>
-                    <Labeled label="Title">
+                    <FieldWithLabel label="Title">
                         <TextField source="title" record={data} />
-                    </Labeled>
-                    <Labeled label="Publication Date">
+                    </FieldWithLabel>
+                    <FieldWithLabel label="Publication Date">
                         <DateField source="published_at" record={data} />
-                    </Labeled>
+                    </FieldWithLabel>
                 </Stack>
             </Card>
         </div>
@@ -92,7 +92,7 @@ Field components require a `record` to render, but they can grab it from a `Reco
 
 ```jsx
 import { useParams } from 'react-router-dom';
-import { useGetOne, useRedirect, RecordContextProvider, Title, Labeled, TextField, DateField } from 'react-admin';
+import { useGetOne, useRedirect, RecordContextProvider, Title, FieldWithLabel, TextField, DateField } from 'react-admin';
 import { Card, Stack } from '@mui/material';
 
 const BookShow = () => {
@@ -108,12 +108,12 @@ const BookShow = () => {
                 <Title title="Book Show"/>
                 <Card>
                     <Stack spacing={1}>
-                        <Labeled label="Title">
+                        <FieldWithLabel label="Title">
                             <TextField source="title" />
-                        </Labeled>
-                        <Labeled label="Publication Date">
+                        </FieldWithLabel>
+                        <FieldWithLabel label="Publication Date">
                             <DateField source="published_at" />
-                        </Labeled>
+                        </FieldWithLabel>
                     </Stack>
                 </Card>
             </div>
@@ -360,8 +360,8 @@ const BookShow = () => (
             <Grid item xs={12} sm={4}>
                 <Typography>Details</Typography>
                 <Stack spacing={1}>
-                    <Labeled label="ISBN"><TextField source="isbn" /></Labeled>
-                    <Labeled label="Last rating"><DateField source="last_rated_at" /></Labeled>
+                    <FieldWithLabel label="ISBN"><TextField source="isbn" /></FieldWithLabel>
+                    <FieldWithLabel label="Last rating"><DateField source="last_rated_at" /></FieldWithLabel>
                 </Stack>
             </Grid>
         </Grid>

--- a/docs/SimpleShowLayout.md
+++ b/docs/SimpleShowLayout.md
@@ -5,7 +5,7 @@ title: "SimpleShowLayout"
 
 # `<SimpleShowLayout>`
 
-The `<SimpleShowLayout>` pulls the `record` from the `RecordContext`. It renders a material-ui `<Card>` containing the record fields in a single-column layout (via material-ui's `<Stack>` component). `<SimpleShowLayout>` delegates the actual rendering of fields to its children. It wraps each field inside a `<Labeled>` component to add a label.
+The `<SimpleShowLayout>` pulls the `record` from the `RecordContext`. It renders a material-ui `<Card>` containing the record fields in a single-column layout (via material-ui's `<Stack>` component). `<SimpleShowLayout>` delegates the actual rendering of fields to its children. It wraps each field inside [a `<FieldWithLabel>` component](./FieldWithLabel.md) to add a label.
 
 ## Usage
 
@@ -37,29 +37,29 @@ Additional props are passed to the root component (`<Card>`).
 
 ## Fields
 
-`<SimpleShowLayout>` renders each child inside a `<Labeled>` component. The above snippet roughly translates to:
+`<SimpleShowLayout>` renders each child inside a `<FieldWithLabel>` component. The above snippet roughly translates to:
 
 ```jsx
 const PostShow = () => (
     <Show>
         <Card>
             <Stack>
-                <Labeled label="Title">
+                <FieldWithLabel label="Title">
                     <TextField source="title" />
-                </Labeled>
-                <Labeled label="Body">
+                </FieldWithLabel>
+                <FieldWithLabel label="Body">
                     <RichTextField source="body" />
-                </Labeled>
-                <Labeled label="Nb Views">
+                </FieldWithLabel>
+                <FieldWithLabel label="Nb Views">
                     <NumberField source="nb_views" />
-                </Labeled>
+                </FieldWithLabel>
             </Stack>
         </Card>
     </Show>
 );
 ```
 
-The `<Labeled label>` uses the humanized source by default. You can customize it by passing a `label` prop to the fields:
+The `<FieldWithLabel label>` uses the humanized source by default. You can customize it by passing a `label` prop to the fields:
 
 ```jsx
 const PostShow = () => (
@@ -76,16 +76,16 @@ const PostShow = () => (
     <Show>
         <Card>
             <Stack>
-                <Labeled label="My Custom Title">
+                <FieldWithLabel label="My Custom Title">
                     <TextField source="title" />
-                </Labeled>
+                </FieldWithLabel>
             </Stack>
         </Card>
     </Show>
 );
 ```
 
-You can disable the `<Labeled>` decoration by passing setting `label={false}` on a field:
+You can disable the `<FieldWithLabel>` decoration by passing setting `label={false}` on a field:
 
 ```jsx
 const PostShow = () => (
@@ -172,6 +172,36 @@ const PostShow = () => (
 );
 ```
 
+## More Than One Column
+
+`<SimpleShowLayout>` arranges fields with labels in a single column. If you need more than one column, nothing prevents you from using this layout several times:
+
+```jsx
+const BookShow = () => (
+    <Show>
+        <Card>
+            <Grid container spacing={2}>
+                <Grid item xs={6}>
+                    <SimpleShowLayout component="div">
+                        <TextField source="id" />
+                        <TextField source="title" />
+                    </SimpleShowLayout>
+                </Grid>
+                <Grid item xs={6}>
+                    <SimpleShowLayout component="div">
+                        <TextField source="author" />
+                        <TextField source="summary" />
+                        <NumberField source="year" />
+                    </SimpleShowLayout>
+                </Grid>
+            </Grid>
+        </Card>
+    </Show>
+);
+```
+
+Just make sure that you set `component="div"` to avoid rendering a card inside another card.
+
 ## Controlled Mode
 
 By default, `<SimpleShowLayout>` reads the record from the `ResourceContext`. But by passing a `record` prop, you can render the component outside of a `ResourceContext`.
@@ -208,9 +238,9 @@ To override the style of all instances of `<SimpleShowLayout>` using the [materi
 ## API
 
 * [`<SimpleShowLayout>`]
-* [`<Labeled>`]
+* [`<FieldWithLabel>`]
 * [`useRecordContext`]
 
 [`<SimpleShowLayout>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
-[`<Labeled>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/input/Labeled.tsx
+[`<FieldWithLabel>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/FieldWithLabel.tsx
 [`useRecordContext`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/controller/useRecordContext.ts

--- a/docs/TabbedShowLayout.md
+++ b/docs/TabbedShowLayout.md
@@ -5,7 +5,7 @@ title: "TabbedShowLayout"
 
 # `<TabbedShowLayout>`
 
-The `<TabbedShowLayout>` pulls the `record` from the `RecordContext`. It renders a material-ui `<Card>` containing a set of `<Tabs>`, each of which contains a list of record fields in a single-column layout (via material-ui's `<Stack>` component). `<TabbedShowLayout>` delegates the actual rendering of fields to its children, which should be `<Tab>` components. `<Tab>`  wraps each field inside a `<Labeled>` component to add a label.
+The `<TabbedShowLayout>` pulls the `record` from the `RecordContext`. It renders a material-ui `<Card>` containing a set of `<Tabs>`, each of which contains a list of record fields in a single-column layout (via material-ui's `<Stack>` component). `<TabbedShowLayout>` delegates the actual rendering of fields to its children, which should be `<Tab>` components. `<Tab>`  wraps each field inside a `<FieldWithLabel>` component to add a label.
 
 Switching tabs will update the current url. By default, it uses the tabs indexes and the first tab will be displayed at the root url. You can customize the path by providing a `path` prop to each `Tab` component. If you'd like the first one to act as an index page, just omit the `path` prop.
 
@@ -102,7 +102,7 @@ export const PostShow = () => (
 
 ## Tab Fields
 
-`<Tab>` renders each child inside a `<Labeled>` component. This component uses the humanized source as label by default. You can customize it by passing a `label` prop to the fields:
+`<Tab>` renders each child inside a `<FieldWithLabel>` component. This component uses the humanized source as label by default. You can customize it by passing a `label` prop to the fields:
 
 ```jsx
 const PostShow = () => (
@@ -116,7 +116,7 @@ const PostShow = () => (
 );
 ```
 
-You can disable the `<Labeled>` decoration by passing setting `label={false}` on a field:
+You can disable the `<FieldWithLabel>` decoration by passing setting `label={false}` on a field:
 
 ```jsx
 const PostShow = () => (
@@ -312,10 +312,10 @@ To style the tabs, the `<Tab>` component accepts two props:
 
 * [`<TabbedShowLayout>`]
 * [`<Tab>`]
-* [`<Labeled>`]
+* [`<FieldWithLabel>`]
 * [`useRecordContext`]
 
-[`<Labeled>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/input/Labeled.tsx
+[`<FieldWithLabel>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/FieldWithLabel.tsx
 [`<TabbedShowLayout>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
 [`<Tab>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/Tab.tsx
 [`useRecordContext`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/controller/useRecordContext.ts

--- a/docs/WithRecord.md
+++ b/docs/WithRecord.md
@@ -17,7 +17,7 @@ import { Show, SimpleShowLayout, WithRecord } from 'react-admin';
 const BookShow = () => (
    <Show>
       <SimpleShowLayout>
-         <WithRecord render={record => <span>{record.author}</span>} />
+         <WithRecord label="author" render={record => <span>{record.author}</span>} />
      </SimpleShowLayout>
   </Show>
 );

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -16,6 +16,7 @@
   <li {% if page.path contains 'TabbedShowLayout.md' %} class="active" {% endif %}><a class="nav-link" href="./TabbedShowLayout.html"><code>&lt;TabbedShowLayout&gt;</code></a></li>
   <li {% if page.path contains 'ShowGuesser.md' %} class="active" {% endif %}><a class="nav-link" href="./ShowGuesser.html"><code>&lt;ShowGuesser&gt;</code></a></li>
   <li {% if page.path contains 'ShowBase.md' %} class="active" {% endif %}><a class="nav-link" href="./ShowBase.html"><code>&lt;ShowBase&gt;</code></a></li>
+  <li {% if page.path contains 'FieldWithLabel.md' %} class="active" {% endif %}><a class="nav-link" href="./FieldWithLabel.html"><code>&lt;FieldWithLabel&gt;</code></a></li>
   <li {% if page.path contains 'useShowController.md' %} class="active" {% endif %}><a class="nav-link" href="./useShowController.html"><code>useShowController</code></a></li>
   <li {% if page.path contains 'useShowContext.md' %} class="active" {% endif %}><a class="nav-link" href="./useShowContext.html"><code>useShowContext</code></a></li>
 </ul>

--- a/packages/ra-core/src/util/FieldTitle.tsx
+++ b/packages/ra-core/src/util/FieldTitle.tsx
@@ -3,6 +3,7 @@ import { ReactElement, memo } from 'react';
 
 import useTranslate from '../i18n/useTranslate';
 import getFieldLabelTranslationArgs from './getFieldLabelTranslationArgs';
+import { useResourceContext } from '../core/useResourceContext';
 
 export interface FieldTitleProps {
     isRequired?: boolean;
@@ -12,7 +13,8 @@ export interface FieldTitleProps {
 }
 
 export const FieldTitle = (props: FieldTitleProps) => {
-    const { resource, source, label, isRequired } = props;
+    const { source, label, isRequired } = props;
+    const resource = useResourceContext(props);
     const translate = useTranslate();
 
     if (label === false || label === '') {

--- a/packages/ra-ui-materialui/src/detail/FieldWithLabel.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/FieldWithLabel.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen } from '@testing-library/react';
+
+import {
+    Basic,
+    CustomLabel,
+    ExplicitLabel,
+    NoLabel,
+    NonField,
+    NoDoubleLabel,
+} from './FieldWithLabel.stories';
+
+describe('<FieldWithLabel />', () => {
+    it('should render the child', () => {
+        render(<Basic />);
+        screen.getByText('War and Peace');
+    });
+
+    it('should render a title based on the resource and source', () => {
+        render(<Basic />);
+        screen.getByText('resources.books.fields.title');
+    });
+
+    it('should use custom label in child', () => {
+        render(<CustomLabel />);
+        screen.getByText('My custom Title');
+    });
+
+    it('should use explicit label prop', () => {
+        render(<ExplicitLabel />);
+        screen.getByText('My custom Title');
+    });
+
+    it('should allow to disable label', () => {
+        render(<NoLabel />);
+        expect(screen.queryByText('resources.books.fields.title')).toBeNull();
+    });
+
+    it('should render the child even for non-fields', () => {
+        render(<NonField />);
+        screen.getByText('War and Peace');
+    });
+
+    it('should not add label to a FieldWithLabel child', () => {
+        render(<NoDoubleLabel />);
+        expect(screen.queryAllByText('My custom Title')).toHaveLength(1);
+    });
+});

--- a/packages/ra-ui-materialui/src/detail/FieldWithLabel.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/FieldWithLabel.stories.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import {
+    RecordContextProvider,
+    ResourceContext,
+    useRecordContext,
+    WithRecord,
+} from 'ra-core';
+import { TextField } from '../field/TextField';
+import { FieldWithLabel } from './FieldWithLabel';
+
+export default { title: 'ra-ui-materialui/detail/FieldWithLabel' };
+
+const record = {
+    id: 1,
+    title: 'War and Peace',
+    author: 'Leo Tolstoy',
+    summary:
+        "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+    year: 1869,
+};
+
+export const Basic = () => (
+    <ResourceContext.Provider value="books">
+        <RecordContextProvider value={record}>
+            <FieldWithLabel>
+                <TextField source="title" />
+            </FieldWithLabel>
+        </RecordContextProvider>
+    </ResourceContext.Provider>
+);
+
+export const CustomLabel = () => (
+    <ResourceContext.Provider value="books">
+        <RecordContextProvider value={record}>
+            <FieldWithLabel>
+                <TextField label="My custom Title" source="title" />
+            </FieldWithLabel>
+        </RecordContextProvider>
+    </ResourceContext.Provider>
+);
+
+export const ExplicitLabel = () => (
+    <ResourceContext.Provider value="books">
+        <RecordContextProvider value={record}>
+            <FieldWithLabel label="My custom Title">
+                <TextField source="title" />
+            </FieldWithLabel>
+        </RecordContextProvider>
+    </ResourceContext.Provider>
+);
+
+export const NoLabel = () => (
+    <ResourceContext.Provider value="books">
+        <RecordContextProvider value={record}>
+            <FieldWithLabel>
+                <TextField label={false} source="title" />
+            </FieldWithLabel>
+        </RecordContextProvider>
+    </ResourceContext.Provider>
+);
+
+export const NonField = () => (
+    <FieldWithLabel>
+        <span>War and Peace</span>
+    </FieldWithLabel>
+);
+
+export const NoDoubleLabel = () => (
+    <ResourceContext.Provider value="books">
+        <RecordContextProvider value={record}>
+            <FieldWithLabel>
+                <FieldWithLabel label="My custom Title">
+                    <TextField source="title" />
+                </FieldWithLabel>
+            </FieldWithLabel>
+        </RecordContextProvider>
+    </ResourceContext.Provider>
+);

--- a/packages/ra-ui-materialui/src/detail/FieldWithLabel.tsx
+++ b/packages/ra-ui-materialui/src/detail/FieldWithLabel.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { ReactElement } from 'react';
+import { Typography, Stack } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+import { FieldTitle } from 'ra-core';
+
+/**
+ * Wrap a field with a label if necessary.
+ *
+ * The label is displayed if:
+ * - the field has a label prop that is not false, or
+ * - the field has a source prop
+ *
+ * @example
+ * <FieldWithLabel>
+ *     <FooComponent source="title" />
+ * </FieldWithLabel>
+ */
+export const FieldWithLabel = ({
+    label,
+    children,
+    className = '',
+}: FieldWithLabelProps) =>
+    children.props.label !== false &&
+    typeof children.type !== 'string' &&
+    // @ts-ignore
+    children.type?.displayName !== 'Labeled' &&
+    // @ts-ignore
+    children.type?.displayName !== 'FieldWithLabel' ? (
+        <Root className={`${className} ${FieldWithLabelClasses.root}`}>
+            <Typography
+                color="textSecondary"
+                className={FieldWithLabelClasses.label}
+            >
+                <FieldTitle
+                    label={label || children.props.label}
+                    source={children.props.source}
+                />
+            </Typography>
+            {children}
+        </Root>
+    ) : (
+        <div className={`${className} ${FieldWithLabelClasses.root}`}>
+            {children}
+        </div>
+    );
+
+FieldWithLabel.displayName = 'FieldWithLabel';
+
+export interface FieldWithLabelProps {
+    children: ReactElement;
+    className?: string;
+    label?: string | ReactElement;
+}
+
+const PREFIX = 'RaFieldWithLabel';
+
+export const FieldWithLabelClasses = {
+    root: `${PREFIX}-root`,
+    label: `${PREFIX}-label`,
+};
+
+const Root = styled(Stack, { name: PREFIX })(({ theme }) => ({
+    [`&.${FieldWithLabelClasses.root}`]: {
+        marginBottom: '0.2em',
+    },
+    [`& .${FieldWithLabelClasses.label}`]: {
+        fontSize: '0.75em',
+        marginBottom: '0.2em',
+    },
+}));

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Divider as MuiDivider } from '@mui/material';
+import { Grid, Divider as MuiDivider } from '@mui/material';
 import {
     RecordContextProvider,
     ResourceContext,
     useRecordContext,
     WithRecord,
 } from 'ra-core';
-import { Labeled } from '../input/Labeled';
+import { FieldWithLabel } from './FieldWithLabel';
 import { TextField, NumberField } from '../field';
 import { SimpleShowLayout } from './SimpleShowLayout';
 
@@ -57,9 +57,9 @@ export const CustomLabel = () => (
             <SimpleShowLayout>
                 <TextField label="Identifier" source="id" />
                 <TextField source="title" />
-                <Labeled label="Author name">
+                <FieldWithLabel label="Author name">
                     <TextField source="author" />
-                </Labeled>
+                </FieldWithLabel>
                 <TextField label={false} source="summary" />
                 <NumberField source="year" />
             </SimpleShowLayout>
@@ -111,6 +111,28 @@ export const SX = () => (
                 <TextField source="summary" />
                 <NumberField source="year" />
             </SimpleShowLayout>
+        </RecordContextProvider>
+    </ResourceContext.Provider>
+);
+
+export const SeveralColumns = () => (
+    <ResourceContext.Provider value="books">
+        <RecordContextProvider value={record}>
+            <Grid container spacing={2}>
+                <Grid item xs={6}>
+                    <SimpleShowLayout component="div">
+                        <TextField source="id" />
+                        <TextField source="title" />
+                    </SimpleShowLayout>
+                </Grid>
+                <Grid item xs={6}>
+                    <SimpleShowLayout component="div">
+                        <TextField source="author" />
+                        <TextField source="summary" />
+                        <NumberField source="year" />
+                    </SimpleShowLayout>
+                </Grid>
+            </Grid>
         </RecordContextProvider>
     </ResourceContext.Provider>
 );

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -10,8 +10,7 @@ import {
     useRecordContext,
     OptionalRecordContextProvider,
 } from 'ra-core';
-
-import { Labeled } from '../input';
+import { FieldWithLabel } from './FieldWithLabel';
 
 /**
  * Layout for a Show view showing fields in one column.
@@ -77,29 +76,18 @@ export const SimpleShowLayout = (props: SimpleShowLayoutProps) => {
                 >
                     {Children.map(children, field =>
                         field && isValidElement<any>(field) ? (
-                            <div
+                            <FieldWithLabel
                                 key={field.props.source}
                                 className={classnames(
-                                    `ra-field ra-field-${field.props.source}`,
+                                    'ra-field',
+                                    field.props.source &&
+                                        `ra-field-${field.props.source}`,
                                     SimpleShowLayoutClasses.row,
                                     field.props.className
                                 )}
                             >
-                                {field.props.label !== false &&
-                                typeof field.type !== 'string' &&
-                                // @ts-ignore
-                                field.type?.displayName !== 'Labeled' &&
-                                (field.props.source || field.props.label) ? (
-                                    <Labeled
-                                        label={field.props.label}
-                                        source={field.props.source}
-                                    >
-                                        {field}
-                                    </Labeled>
-                                ) : (
-                                    field
-                                )}
-                            </div>
+                                {field}
+                            </FieldWithLabel>
                         ) : null
                     )}
                 </Stack>

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -7,7 +7,7 @@ import { ResponsiveStyleValue } from '@mui/system';
 import { useTranslate, Record } from 'ra-core';
 import classnames from 'classnames';
 
-import { Labeled } from '../input/Labeled';
+import { FieldWithLabel } from './FieldWithLabel';
 
 /**
  * Tab element for the SimpleShowLayout.
@@ -90,29 +90,17 @@ export const Tab = ({
         <Stack className={contentClassName} spacing={spacing} divider={divider}>
             {React.Children.map(children, field =>
                 field && isValidElement<any>(field) ? (
-                    <div
+                    <FieldWithLabel
                         key={field.props.source}
                         className={classnames(
                             'ra-field',
-                            `ra-field-${field.props.source}`,
+                            field.props.source &&
+                                `ra-field-${field.props.source}`,
                             field.props.className
                         )}
                     >
-                        {field.props.label !== false &&
-                        typeof field.type !== 'string' &&
-                        // @ts-ignore
-                        field.type?.displayName !== 'Labeled' &&
-                        (field.props.source || field.props.label) ? (
-                            <Labeled
-                                label={field.props.label}
-                                source={field.props.source}
-                            >
-                                {field}
-                            </Labeled>
-                        ) : (
-                            field
-                        )}
-                    </div>
+                        {field}
+                    </FieldWithLabel>
                 ) : null
             )}
         </Stack>

--- a/packages/ra-ui-materialui/src/detail/index.ts
+++ b/packages/ra-ui-materialui/src/detail/index.ts
@@ -5,6 +5,7 @@ export * from './Edit';
 export * from './EditActions';
 export * from './EditGuesser';
 export * from './EditView';
+export * from './FieldWithLabel';
 export * from './Show';
 export * from './ShowActions';
 export * from './ShowGuesser';


### PR DESCRIPTION
`<FieldWithLabel>` adds a label on top of its child if the child exposes a `label` prop, or if it's a field with a `source` prop. It's used in Show layouts, to display both a field and its label. 

## Usage

`<FieldWithLabel>` is mostly an internal component - you don't need it if you're using `<SimpleShowLayout>` or `<TabbedshowLayout>`. But, in a custom layout, if you want to display a label on top of a field value, just wrap the Field component with `<FieldWithLabel>`. 

```jsx
import { Show, FieldWithLabel, TextField } from 'react-admin';
import { Card, Stack } from '@mui/material';

const BookShow = () => (
   <Show>
      <Card>
         <Stack>
            <FieldWithLabel>
               <TextField source="title" />
            </FieldWithLabel>
         </Stack>
     </Car>
  </Show>
);
```