### PR TITLE
Fix Don't show a warning if only one argument is passed to `useNotify`

### DIFF
--- a/packages/ra-core/src/sideEffect/useNotify.ts
+++ b/packages/ra-core/src/sideEffect/useNotify.ts
@@ -52,9 +52,11 @@ const useNotify = () => {
                         }
                     )
                 );
-            } else {
+            } else if (type) {
                 const { type: messageType, ...options } = type;
                 dispatch(showNotification(message, messageType, options));
+            } else {
+                dispatch(showNotification(message));
             }
         },
         [dispatch]

--- a/packages/ra-core/src/sideEffect/useNotify.ts
+++ b/packages/ra-core/src/sideEffect/useNotify.ts
@@ -37,7 +37,7 @@ const useNotify = () => {
         ) => {
             if (typeof type === 'string' || !type) {
                 warning(
-                    true,
+                    typeof type === 'string',
                     'This way of calling useNotify callback is deprecated. Please use the new syntax passing notify("[Your message]", { ...restOfArguments })'
                 );
                 dispatch(

--- a/packages/ra-core/src/sideEffect/useNotify.ts
+++ b/packages/ra-core/src/sideEffect/useNotify.ts
@@ -35,7 +35,7 @@ const useNotify = () => {
             autoHideDuration?: number,
             multiLine?: boolean
         ) => {
-            if (typeof type === 'string' || !type) {
+            if (typeof type === 'string') {
                 warning(
                     typeof type === 'string',
                     'This way of calling useNotify callback is deprecated. Please use the new syntax passing notify("[Your message]", { ...restOfArguments })'

--- a/packages/ra-core/src/sideEffect/useNotify.ts
+++ b/packages/ra-core/src/sideEffect/useNotify.ts
@@ -52,11 +52,9 @@ const useNotify = () => {
                         }
                     )
                 );
-            } else if (type) {
+            } else {
                 const { type: messageType, ...options } = type;
                 dispatch(showNotification(message, messageType, options));
-            } else {
-                dispatch(showNotification(message));
             }
         },
         [dispatch]

--- a/packages/ra-core/src/sideEffect/useNotify.ts
+++ b/packages/ra-core/src/sideEffect/useNotify.ts
@@ -37,7 +37,7 @@ const useNotify = () => {
         ) => {
             if (typeof type === 'string') {
                 warning(
-                    typeof type === 'string',
+                    true,
                     'This way of calling useNotify callback is deprecated. Please use the new syntax passing notify("[Your message]", { ...restOfArguments })'
                 );
                 dispatch(


### PR DESCRIPTION
This PR avoids throwing a warning if only a message is used in `useNotify` callback call, since everything else is optional.

```js
const  notify = useNotify();

// Warning: This way of calling useNotify callback is deprecated. Please use the new syntax passing notify("[Your message]", { ...restOfArguments })
notify('Showing a simple message'); 