### PR TITLE
Fix dateinput break simpleformiterator

### DIFF
--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -87,7 +87,6 @@ const DateInput = ({
     const { id, input, isRequired, meta } = useInput({
         defaultValue,
         format,
-        formatOnBlur: true,
         initialValue,
         name,
         onBlur,


### PR DESCRIPTION
Fixes #6584, #6459, #6573

We introduced the `formatOnBlur` on `DateInput` to fix issues with Safari but this was the cause of the SimpleFormIterator issue. I checked with BrowserStack that the DateInput was still working on the latest safari.