### PR TITLE
[DOC] Add GeoServer data provider

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -78,6 +78,7 @@ Developers from the react-admin community have open-sourced Data Providers for m
 * **[Feathersjs](https://www.feathersjs.com/)**: [josx/ra-data-feathers](https://github.com/josx/ra-data-feathers)
 * **[Firebase Firestore](https://firebase.google.com/docs/firestore)**: [benwinding/react-admin-firebase](https://github.com/benwinding/react-admin-firebase).
 * **[Firebase Realtime Database](https://firebase.google.com/docs/database)**: [aymendhaya/ra-data-firebase-client](https://github.com/aymendhaya/ra-data-firebase-client).
+* **[GeoServer](http://geoserver.org/)**: [sergioedo/ra-data-geoserver](https://github.com/sergioedo/ra-data-geoserver)
 * **[Google Sheets](https://www.google.com/sheets/about/)**: [marmelab/ra-data-google-sheets](https://github.com/marmelab/ra-data-google-sheets)
 * **[GraphQL](https://graphql.org/)**: [marmelab/ra-data-graphql](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql) (uses [Apollo](https://www.apollodata.com/))
 * **[HAL](http://stateless.co/hal_specification.html)**: [b-social/ra-data-hal](https://github.com/b-social/ra-data-hal)


### PR DESCRIPTION
I would like to share with the react-admin community a data provider for [GeoServer](http://geoserver.org/). This allows you to manage spatial data (geometry features) through the standard WFS API offered by GeoServer. I think it can be useful in managing entities with location data (points, lines, polygons...).