### PR TITLE
Refactor error boundaries

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -259,6 +259,36 @@ export const PostShow = () => (
 );
 ```
 
+## Error component signature has changed
+
+The `Error` component you can provide to the `<Layout>` used to receive two props: `error` and `errorInfo`. As we now use [react-error-boundary](https://github.com/bvaughn/react-error-boundary), this component now receive the two following props:
+
+- `error`: the error object.
+- `resetErrorBoundary`: a function you can call to reset the error boundary state.
+
+It is now the `Error` component responsability to call the `resetErrorBoundary` function whenever the browser location changes:
+
+```jsx
+import { useRef } from 'react';
+import { useLocation } from 'react-router';
+
+export const Error = (props: ErrorProps) => {
+    const { error, resetErrorBoundary, ...rest } = props;
+    const { pathname } = useLocation();
+    const originalPathname = useRef(pathname);
+
+    useEffect(() => {
+        if (pathname !== originalPathname.current) {
+            resetErrorBoundary();
+        }
+    }, [pathname, resetErrorBoundary]);
+
+    return (
+        ...
+    )
+}
+```
+
 # Upgrade to 3.0
 
 We took advantage of the major release to fix all the problems in react-admin that required a breaking change. As a consequence, you'll need to do many small changes in the code of existing react-admin v2 applications. Follow this step-by-step guide to upgrade to react-admin v3.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -272,7 +272,7 @@ It is now the `Error` component responsability to call the `resetErrorBoundary` 
 import { useRef } from 'react';
 import { useLocation } from 'react-router';
 
-export const Error = (props: ErrorProps) => {
+export const Error = (props) => {
     const { error, resetErrorBoundary, ...rest } = props;
     const { pathname } = useLocation();
     const originalPathname = useRef(pathname);

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -218,7 +218,6 @@ import { createElement } from 'react';
 import { useSelector } from 'react-redux';
 import { useMediaQuery } from '@material-ui/core';
 import { MenuItemLink, getResources } from 'react-admin';
-import { withRouter } from 'react-router-dom';
 import LabelIcon from '@material-ui/icons/Label';
 
 const Menu = ({ onMenuClick, logout }) => {
@@ -249,7 +248,7 @@ const Menu = ({ onMenuClick, logout }) => {
     );
 }
 
-export default withRouter(Menu);
+export default Menu;
 ```
 
 **Tip**: Note the `MenuItemLink` component. It must be used to avoid unwanted side effects in mobile views. It supports a custom text and icon (which must be a material-ui `<SvgIcon>`).

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1035,12 +1035,23 @@ import Button from '@material-ui/core/Button';
 import ErrorIcon from '@material-ui/icons/Report';
 import History from '@material-ui/icons/History';
 import { Title, useTranslate } from 'react-admin';
+import { useLocation } from 'react-router';
 
 const MyError = ({
     error,
-    errorInfo,
+    resetErrorBoundary,
     ...rest
 }) => {
+    const { pathname } = useLocation();
+    const originalPathname = useRef(pathname);
+
+    // Effect that resets the error state whenever the location changes
+    useEffect(() => {
+        if (pathname !== originalPathname.current) {
+            resetErrorBoundary();
+        }
+    }, [pathname, resetErrorBoundary]);
+
     const translate = useTranslate();
     return (
         <div>

--- a/examples/crm/src/Layout.tsx
+++ b/examples/crm/src/Layout.tsx
@@ -1,83 +1,33 @@
-import React, { Component, ErrorInfo, HtmlHTMLAttributes } from 'react';
-import PropTypes from 'prop-types';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import React, { HtmlHTMLAttributes } from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { CssBaseline, Container } from '@mui/material';
 import { CoreLayoutProps } from 'react-admin';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { Notification, Error } from 'react-admin';
 import Header from './Header';
 
-class Layout extends Component<LayoutProps, LayoutState> {
-    state: LayoutState = {
-        hasError: false,
-        errorMessage: undefined,
-        errorInfo: undefined,
-    };
-
-    constructor(props: any) {
-        super(props);
-        /**
-         * Reset the error state upon navigation
-         *
-         * @see https://stackoverflow.com/questions/48121750/browser-navigation-broken-by-use-of-react-error-boundaries
-         */
-        props.history.listen(() => {
-            if (this.state.hasError) {
-                this.setState({ hasError: false });
-            }
-        });
-    }
-
-    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-        this.setState({
-            hasError: true,
-            errorMessage: error,
-            errorInfo,
-        });
-    }
-
-    render() {
-        const { theme, title, children } = this.props;
-        const { hasError, errorMessage, errorInfo } = this.state;
-        return (
-            <ThemeProvider theme={createTheme(theme)}>
-                <CssBaseline />
-                <Header />
-                <Container>
-                    <main id="main-content">
-                        {hasError ? (
-                            <Error
-                                error={errorMessage as Error}
-                                errorInfo={errorInfo}
-                                title={title as string}
-                            />
-                        ) : (
-                            children
-                        )}
-                    </main>
-                </Container>
-                <Notification />
-            </ThemeProvider>
-        );
-    }
-
-    static propTypes = {
-        children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-        title: PropTypes.node.isRequired,
-    };
-}
+const Layout = (props: LayoutProps) => {
+    const { theme, children } = props;
+    return (
+        <ThemeProvider theme={createTheme(theme)}>
+            <CssBaseline />
+            <Header />
+            <Container>
+                <main id="main-content">
+                    {/* @ts-ignore */}
+                    <ErrorBoundary FallbackComponent={Error}>
+                        {children}
+                    </ErrorBoundary>
+                </main>
+            </Container>
+            <Notification />
+        </ThemeProvider>
+    );
+};
 
 export interface LayoutProps
     extends CoreLayoutProps,
-        Omit<HtmlHTMLAttributes<HTMLDivElement>, 'title'>,
-        RouteComponentProps {}
+        Omit<HtmlHTMLAttributes<HTMLDivElement>, 'title'> {}
 
-export interface LayoutState {
-    hasError: boolean;
-    errorMessage?: Error;
-    errorInfo?: ErrorInfo;
-}
-
-// @ts-ignore
-export default withRouter(Layout);
+export default Layout;

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -68,6 +68,7 @@
         "classnames": "~2.2.5",
         "css-mediaquery": "^0.1.2",
         "downshift": "3.2.7",
+        "react-error-boundary": "^3.1.4",
         "inflection": "~1.12.0",
         "jsonexport": "^2.4.1",
         "lodash": "~4.17.5",

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { Fragment, HtmlHTMLAttributes, useEffect, useRef } from 'react';
+import { FallbackProps } from 'react-error-boundary';
 import { styled } from '@mui/material/styles';
-import { Fragment, HtmlHTMLAttributes, ErrorInfo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
@@ -14,11 +15,20 @@ import ErrorIcon from '@mui/icons-material/Report';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import History from '@mui/icons-material/History';
 import { useTranslate } from 'ra-core';
+import { useLocation } from 'react-router';
 
 import { Title, TitlePropType } from './Title';
 
-export const Error = (props: ErrorProps): JSX.Element => {
-    const { error, errorInfo, className, title, ...rest } = props;
+export const Error = (props: ErrorProps) => {
+    const { error, resetErrorBoundary, className, title, ...rest } = props;
+    const { pathname } = useLocation();
+    const originalPathname = useRef(pathname);
+
+    useEffect(() => {
+        if (pathname !== originalPathname.current) {
+            resetErrorBoundary();
+        }
+    }, [pathname, resetErrorBoundary]);
 
     const translate = useTranslate();
 
@@ -38,17 +48,15 @@ export const Error = (props: ErrorProps): JSX.Element => {
                     <>
                         <Accordion className={ErrorClasses.panel}>
                             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                                {translate(error.toString(), {
-                                    _: error.toString(),
+                                {translate(error.message, {
+                                    _: error.message,
                                 })}
                             </AccordionSummary>
-                            {errorInfo && (
-                                <AccordionDetails
-                                    className={ErrorClasses.panelDetails}
-                                >
-                                    {errorInfo.componentStack}
-                                </AccordionDetails>
-                            )}
+                            <AccordionDetails
+                                className={ErrorClasses.panelDetails}
+                            >
+                                {error.stack}
+                            </AccordionDetails>
                         </Accordion>
 
                         <div className={ErrorClasses.advice}>
@@ -102,10 +110,10 @@ Error.propTypes = {
     title: TitlePropType,
 };
 
-export interface ErrorProps extends HtmlHTMLAttributes<HTMLDivElement> {
+export interface ErrorProps
+    extends HtmlHTMLAttributes<HTMLDivElement>,
+        FallbackProps {
     className?: string;
-    error: Error;
-    errorInfo?: ErrorInfo;
     title?: string;
 }
 

--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -1,22 +1,20 @@
 import React, {
-    Component,
     createElement,
     useEffect,
     useRef,
     useState,
     ErrorInfo,
-    ReactElement,
+    ReactNode,
     ComponentType,
     HtmlHTMLAttributes,
 } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { useSelector } from 'react-redux';
 import classnames from 'classnames';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { createTheme, styled, ThemeProvider } from '@mui/material/styles';
 import { DeprecatedThemeOptions } from '@mui/material';
-import { ComponentPropType, CoreLayoutProps } from 'ra-core';
-import compose from 'lodash/flowRight';
+import { CoreLayoutProps, ReduxState } from 'ra-core';
 
 import { AppBar as DefaultAppBar, AppBarProps } from './AppBar';
 import { Sidebar as DefaultSidebar } from './Sidebar';
@@ -26,96 +24,39 @@ import { Error as DefaultError } from './Error';
 import { defaultTheme } from '../defaultTheme';
 import { SkipNavigationButton } from '../button';
 
-class LayoutWithoutTheme extends Component<
-    LayoutWithoutThemeProps,
-    LayoutState
-> {
-    state: LayoutState = { hasError: false, error: null, errorInfo: null };
-
-    constructor(props) {
-        super(props);
-        /**
-         * Reset the error state upon navigation
-         *
-         * @see https://stackoverflow.com/questions/48121750/browser-navigation-broken-by-use-of-react-error-boundaries
-         */
-        props.history.listen(() => {
-            if (this.state.hasError) {
-                this.setState({ hasError: false });
-            }
-        });
-    }
-
-    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-        this.setState({ hasError: true, error, errorInfo });
-    }
-
-    render() {
-        return <LayoutContainer {...this.props} {...this.state} />;
-    }
-
-    static propTypes = {
-        appBar: ComponentPropType,
-        children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-        classes: PropTypes.object,
-        className: PropTypes.string,
-        dashboard: ComponentPropType,
-        error: ComponentPropType,
-        history: PropTypes.object.isRequired,
-        logout: PropTypes.element,
-        menu: ComponentPropType,
-        notification: ComponentPropType,
-        open: PropTypes.bool,
-        sidebar: ComponentPropType,
-        title: PropTypes.node.isRequired,
-    };
-
-    static defaultProps = {
-        appBar: DefaultAppBar,
-        error: DefaultError,
-        menu: DefaultMenu,
-        notification: DefaultNotification,
-        sidebar: DefaultSidebar,
-    };
-}
-
-const LayoutContainer = props => {
+const LayoutWithoutTheme = (props: LayoutWithoutThemeProps) => {
     const {
-        appBar,
+        appBar = DefaultAppBar,
         children,
         className,
-        error: ErrorComponent,
+        error: ErrorComponent = DefaultError,
         dashboard,
         error,
-        errorInfo,
-        hasError,
         logout,
-        menu,
-        notification,
-        open,
-        sidebar,
+        menu = DefaultMenu,
+        notification = DefaultNotification,
+        sidebar = DefaultSidebar,
         title,
-        // sanitize react-router props
-        match,
-        location,
-        history,
-        staticContext,
         ...rest
     } = props;
 
+    const open = useSelector<ReduxState, boolean>(
+        state => state.admin.ui.sidebarOpen
+    );
+
     return (
-        <>
+        // @ts-ignore
+        <ErrorBoundary FallbackComponent={ErrorComponent}>
             <StyledLayout
                 className={classnames('layout', LayoutClasses.root, className)}
                 {...rest}
             >
                 <SkipNavigationButton />
                 <div className={LayoutClasses.appFrame}>
-                    {createElement(appBar, { title, open, logout })}
+                    {createElement(appBar, { logout, open, title })}
                     <main className={LayoutClasses.contentWithSidebar}>
                         {createElement(sidebar, {
                             children: createElement(menu, {
-                                logout,
                                 hasDashboard: !!dashboard,
                             }),
                         })}
@@ -123,21 +64,13 @@ const LayoutContainer = props => {
                             id="main-content"
                             className={LayoutClasses.content}
                         >
-                            {hasError ? (
-                                <ErrorComponent
-                                    error={error}
-                                    errorInfo={errorInfo}
-                                    title={title}
-                                />
-                            ) : (
-                                children
-                            )}
+                            {children}
                         </div>
                     </main>
                 </div>
             </StyledLayout>
             {createElement(notification)}
-        </>
+        </ErrorBoundary>
     );
 };
 
@@ -147,14 +80,10 @@ export interface LayoutProps
     appBar?: ComponentType<AppBarProps>;
     classes?: any;
     className?: string;
-    error?: ComponentType<{
-        error?: Error;
-        errorInfo?: ErrorInfo;
-        title?: string | ReactElement<any>;
-    }>;
+    error?: ComponentType<FallbackProps>;
     menu?: ComponentType<MenuProps>;
     notification?: ComponentType;
-    sidebar?: ComponentType<{ children: JSX.Element }>;
+    sidebar?: ComponentType<{ children: ReactNode }>;
     theme?: DeprecatedThemeOptions;
 }
 
@@ -164,23 +93,9 @@ export interface LayoutState {
     errorInfo?: ErrorInfo;
 }
 
-interface LayoutWithoutThemeProps
-    extends RouteComponentProps,
-        Omit<LayoutProps, 'theme'> {
+interface LayoutWithoutThemeProps extends Omit<LayoutProps, 'theme'> {
     open?: boolean;
 }
-
-const mapStateToProps = state => ({
-    open: state.admin.ui.sidebarOpen,
-});
-
-const EnhancedLayout = compose(
-    connect(
-        mapStateToProps,
-        {} // Avoid connect passing dispatch in props
-    ),
-    withRouter
-)(LayoutWithoutTheme);
 
 export const Layout = ({
     theme: themeOverride,
@@ -198,7 +113,7 @@ export const Layout = ({
 
     return (
         <ThemeProvider theme={theme}>
-            <EnhancedLayout {...props} />
+            <LayoutWithoutTheme {...props} />
         </ThemeProvider>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -20492,6 +20492,13 @@ react-dropzone@^10.1.7:
     file-selector "^0.1.12"
     prop-types "^15.7.2"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.8:
   version "6.0.8"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.8.tgz#474ed11d04fc6bda3af643447d85e9127ed6b5de"


### PR DESCRIPTION
There's a downside. We used to display the error **inside** our layout. It's now **outside** it. I may revisit this later to make the integration nicer but this is on the critical path for react-router-v6 as there's no `withRouter` HOC anymore