### PR TITLE
Move ErrorBoundary Inside Layout

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -259,36 +259,6 @@ export const PostShow = () => (
 );
 ```
 
-## Error component signature has changed
-
-The `Error` component you can provide to the `<Layout>` used to receive two props: `error` and `errorInfo`. As we now use [react-error-boundary](https://github.com/bvaughn/react-error-boundary), this component now receive the two following props:
-
-- `error`: the error object.
-- `resetErrorBoundary`: a function you can call to reset the error boundary state.
-
-It is now the `Error` component responsability to call the `resetErrorBoundary` function whenever the browser location changes:
-
-```jsx
-import { useRef } from 'react';
-import { useLocation } from 'react-router';
-
-export const Error = (props) => {
-    const { error, resetErrorBoundary, ...rest } = props;
-    const { pathname } = useLocation();
-    const originalPathname = useRef(pathname);
-
-    useEffect(() => {
-        if (pathname !== originalPathname.current) {
-            resetErrorBoundary();
-        }
-    }, [pathname, resetErrorBoundary]);
-
-    return (
-        ...
-    )
-}
-```
-
 # Upgrade to 3.0
 
 We took advantage of the major release to fix all the problems in react-admin that required a breaking change. As a consequence, you'll need to do many small changes in the code of existing react-admin v2 applications. Follow this step-by-step guide to upgrade to react-admin v3.

--- a/packages/ra-ui-materialui/src/layout/index.ts
+++ b/packages/ra-ui-materialui/src/layout/index.ts
@@ -21,4 +21,5 @@ export * from './Title';
 export * from './TitleForRecord';
 export * from './TopToolbar';
 export * from './UserMenu';
+export * from './useResetErrorBoundaryOnLocationChange';
 export * from './useToggleSidebar';

--- a/packages/ra-ui-materialui/src/layout/useResetErrorBoundaryOnLocationChange.ts
+++ b/packages/ra-ui-materialui/src/layout/useResetErrorBoundaryOnLocationChange.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router';
+
+/**
+ * A hook to use inside the component passed to FallbackComponent
+ * of react-error-boundary. It resets the error boundary state whenever
+ * the location changes
+ * @param {Function} resetErrorBoundary
+ */
+export const useResetErrorBoundaryOnLocationChange = (
+    resetErrorBoundary: () => void
+) => {
+    const { pathname } = useLocation();
+    const originalPathname = useRef(pathname);
+
+    useEffect(() => {
+        if (pathname !== originalPathname.current) {
+            resetErrorBoundary();
+        }
+    }, [pathname, resetErrorBoundary]);
+};


### PR DESCRIPTION
- [x] Move ErrorBoundary inside Layout
- [x] Refactor so that we don't introduce breaking changes for this (error info)
- [x] Refactor to not make our users handle the reset on location change

![image](https://user-images.githubusercontent.com/1122076/141953701-aeb3f347-53eb-411b-8991-5728891f44d5.png)
