### PR TITLE
Configure jest to avoid rebuilding packages dependencies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,28 @@
+const path = require('path');
+
+module.exports = {
+    globalSetup: './test-global-setup.js',
+    setupFilesAfterEnv: ['./test-setup.js'],
+    preset: 'ts-jest/presets/js-with-ts',
+    testPathIgnorePatterns: [
+        '/node_modules/',
+        '/lib/',
+        '/esm/',
+        '/examples/simple/',
+    ],
+    transformIgnorePatterns: [
+        '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$',
+    ],
+    globals: {
+        'ts-jest': {
+            isolatedModules: true,
+        },
+    },
+    moduleNameMapper: {
+        '^ra-core(.*)$': path.join(__dirname, './packages/ra-core/src$1'),
+        '^ra-ui-materialui(.*)$': path.join(
+            __dirname,
+            './packages/ra-ui-materialui/src$1'
+        ),
+    },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     },
     moduleNameMapper: {
         '^ra-core(.*)$': path.join(__dirname, './packages/ra-core/src$1'),
+        '^ra-test(.*)$': path.join(__dirname, './packages/ra-test/src$1'),
         '^ra-ui-materialui(.*)$': path.join(
             __dirname,
             './packages/ra-ui-materialui/src$1'

--- a/package.json
+++ b/package.json
@@ -25,27 +25,6 @@
         "storybook": "start-storybook -p 9009",
         "build-storybook": "build-storybook --no-dll -c .storybook -o public --quiet"
     },
-    "jest": {
-        "globalSetup": "./test-global-setup.js",
-        "setupFilesAfterEnv": [
-            "./test-setup.js"
-        ],
-        "preset": "ts-jest/presets/js-with-ts",
-        "testPathIgnorePatterns": [
-            "/node_modules/",
-            "/lib/",
-            "/esm/",
-            "/examples/simple/"
-        ],
-        "transformIgnorePatterns": [
-            "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$"
-        ],
-        "globals": {
-            "ts-jest": {
-                "isolatedModules": true
-            }
-        }
-    },
     "devDependencies": {
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-controls": "^6.3.12",

--- a/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { Form } from 'react-final-form';
-import { required } from 'ra-core/lib';
+import { required } from 'ra-core';
 
 import { NumberInput } from './NumberInput';
 


### PR DESCRIPTION
Until now, when working for example on both `ra-core` and `ra-ui-materialui`, we had to stop the tests and rebuild `ra-core` for any changes to impact the `ra-ui-materialui` tests.

This is the jest equivalent of webpack aliases.

I configured it so that `ra-core` `ra-ui-materialui` and `ra-test` are aliased to their sources.