### PR TITLE
Fix Throw an error if the id of a request doesn't match the response

### DIFF
--- a/packages/ra-core/src/controller/details/useEditController.ts
+++ b/packages/ra-core/src/controller/details/useEditController.ts
@@ -151,10 +151,12 @@ export const useEditController = <RecordType extends Record = Record>(
         },
     });
 
-    warning(
-        record && record.id && record.id !== id,
-        `useEditController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
-    );
+    if (record && record.id && record.id !== id) {
+        warning(
+            true,
+            `useEditController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
+        );
+    }
 
     const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.edit', {

--- a/packages/ra-core/src/controller/details/useEditController.ts
+++ b/packages/ra-core/src/controller/details/useEditController.ts
@@ -26,6 +26,7 @@ import {
     useSaveModifiers,
 } from '../saveModifiers';
 import { useResourceContext, useGetResourceLabel } from '../../core';
+import { warning } from '../../util';
 
 export interface EditProps {
     basePath?: string;
@@ -149,6 +150,11 @@ export const useEditController = <RecordType extends Record = Record>(
             refresh();
         },
     });
+
+    warning(
+        record && record.id && record.id !== id,
+        `useEditController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
+    );
 
     const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.edit', {

--- a/packages/ra-core/src/controller/details/useEditController.ts
+++ b/packages/ra-core/src/controller/details/useEditController.ts
@@ -150,7 +150,8 @@ export const useEditController = <RecordType extends Record = Record>(
         },
     });
 
-    if (record && record.id && record.id !== id) {
+    // eslint-disable-next-line eqeqeq
+    if (record && record.id && record.id != id) {
         throw new Error(
             `useEditController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
         );

--- a/packages/ra-core/src/controller/details/useEditController.ts
+++ b/packages/ra-core/src/controller/details/useEditController.ts
@@ -26,7 +26,6 @@ import {
     useSaveModifiers,
 } from '../saveModifiers';
 import { useResourceContext, useGetResourceLabel } from '../../core';
-import { warning } from '../../util';
 
 export interface EditProps {
     basePath?: string;
@@ -152,8 +151,7 @@ export const useEditController = <RecordType extends Record = Record>(
     });
 
     if (record && record.id && record.id !== id) {
-        warning(
-            true,
+        throw new Error(
             `useEditController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
         );
     }

--- a/packages/ra-core/src/controller/details/useShowController.ts
+++ b/packages/ra-core/src/controller/details/useShowController.ts
@@ -6,7 +6,6 @@ import { useTranslate } from '../../i18n';
 import { useNotify, useRedirect, useRefresh } from '../../sideEffect';
 import { CRUD_GET_ONE } from '../../actions';
 import { useResourceContext, useGetResourceLabel } from '../../core';
-import { warning } from '../../util';
 
 export interface ShowProps {
     basePath?: string;
@@ -89,8 +88,7 @@ export const useShowController = <RecordType extends Record = Record>(
     });
 
     if (record && record.id && record.id !== id) {
-        warning(
-            true,
+        throw new Error(
             `useShowController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
         );
     }

--- a/packages/ra-core/src/controller/details/useShowController.ts
+++ b/packages/ra-core/src/controller/details/useShowController.ts
@@ -6,6 +6,7 @@ import { useTranslate } from '../../i18n';
 import { useNotify, useRedirect, useRefresh } from '../../sideEffect';
 import { CRUD_GET_ONE } from '../../actions';
 import { useResourceContext, useGetResourceLabel } from '../../core';
+import { warning } from '../../util';
 
 export interface ShowProps {
     basePath?: string;
@@ -86,6 +87,11 @@ export const useShowController = <RecordType extends Record = Record>(
                 refresh();
             }),
     });
+
+    warning(
+        record && record.id && record.id !== id,
+        `useShowController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
+    );
 
     const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.show', {

--- a/packages/ra-core/src/controller/details/useShowController.ts
+++ b/packages/ra-core/src/controller/details/useShowController.ts
@@ -88,10 +88,12 @@ export const useShowController = <RecordType extends Record = Record>(
             }),
     });
 
-    warning(
-        record && record.id && record.id !== id,
-        `useShowController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
-    );
+    if (record && record.id && record.id !== id) {
+        warning(
+            true,
+            `useShowController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
+        );
+    }
 
     const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.show', {

--- a/packages/ra-core/src/controller/details/useShowController.ts
+++ b/packages/ra-core/src/controller/details/useShowController.ts
@@ -87,7 +87,8 @@ export const useShowController = <RecordType extends Record = Record>(
             }),
     });
 
-    if (record && record.id && record.id !== id) {
+    // eslint-disable-next-line eqeqeq
+    if (record && record.id && record.id != id) {
         throw new Error(
             `useShowController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
         );


### PR DESCRIPTION
Fixes #5530

Throw an error if the `id` for an edit or a show requested doesn't match the `id` in the response