### PR TITLE
Fix Throw an error if the `id` of a request doesn't match the response

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -55,7 +55,7 @@ describe('useEditController', () => {
         const getOne = jest
             .fn()
             .mockImplementationOnce(() =>
-                Promise.resolve({ data: { id: 12, title: 'hello' } })
+                Promise.resolve({ data: { id: 'test?', title: 'hello' } })
             );
         const dataProvider = ({ getOne } as unknown) as DataProvider;
         const { unmount } = renderWithRedux(

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -100,6 +100,13 @@ export const useEditController = <RecordType extends Record = Record>(
         ...queryOptions,
     });
 
+    // eslint-disable-next-line eqeqeq
+    if (record && record.id && record.id != id) {
+        throw new Error(
+            `useEditController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
+        );
+    }
+
     const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.edit', {
         name: getResourceLabel(resource, 1),

--- a/packages/ra-core/src/controller/show/useShowController.spec.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.spec.tsx
@@ -42,7 +42,7 @@ describe('useShowController', () => {
         const getOne = jest
             .fn()
             .mockImplementationOnce(() =>
-                Promise.resolve({ data: { id: 12, title: 'hello' } })
+                Promise.resolve({ data: { id: 'test?', title: 'hello' } })
             );
         const dataProvider = ({ getOne } as unknown) as DataProvider;
         renderWithRedux(

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -67,6 +67,13 @@ export const useShowController = <RecordType extends Record = Record>(
         ...queryOptions,
     });
 
+    // eslint-disable-next-line eqeqeq
+    if (record && record.id && record.id != id) {
+        throw new Error(
+            `useShowController: Fetched record's id attribute (${record.id}) must match the requested 'id' (${id})`
+        );
+    }
+
     const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.show', {
         name: getResourceLabel(resource, 1),


### PR DESCRIPTION
Fixes #5530