### PR TITLE
Bug in nested ArrayInput with initialValue(s)

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -16,7 +16,7 @@
         "ra-language-english": "^3.12.4",
         "ra-language-french": "^3.12.4",
         "react": "^17.0.0",
-        "react-admin": "^3.12.4",
+        "react-admin": "^3.19.0",
         "react-dom": "^17.0.0"
     },
     "devDependencies": {

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -17,7 +17,8 @@
         "ra-language-french": "^3.12.4",
         "react": "^17.0.0",
         "react-admin": "^3.19.0",
-        "react-dom": "^17.0.0"
+        "react-dom": "^17.0.0",
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
         "@babel/preset-react": "^7.12.10",

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -248,6 +248,7 @@ const PostEdit = ({ permissions, ...props }) => {
                                             <TextInput
                                                 source={getSource('url')}
                                                 initialValue=""
+                                                label="Url"
                                             />
                                             <ArrayInput
                                                 source={getSource(
@@ -258,6 +259,7 @@ const PostEdit = ({ permissions, ...props }) => {
                                                     <TextInput
                                                         source="name"
                                                         initialValue=""
+                                                        label="Author name"
                                                     />
                                                 </SimpleFormIterator>
                                             </ArrayInput>

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -231,12 +231,40 @@ const PostEdit = ({ permissions, ...props }) => {
                     <BooleanInput source="commentable" defaultValue />
                     <ArrayInput source="pictures">
                         <SimpleFormIterator>
-                            <TextInput source="url" initialValue="" />
-                            <ArrayInput source="metas.authors">
-                                <SimpleFormIterator>
-                                    <TextInput source="name" initialValue="" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
+                            <FormDataConsumer>
+                                {({ getSource, scopedFormData }) => {
+                                    if (
+                                        getSource &&
+                                        !scopedFormData?.metas?.authors
+                                    ) {
+                                        _.assign(scopedFormData, {
+                                            metas: {
+                                                authors: [],
+                                            },
+                                        });
+                                    }
+                                    return (
+                                        <>
+                                            <TextInput
+                                                source={getSource('url')}
+                                                initialValue=""
+                                            />
+                                            <ArrayInput
+                                                source={getSource(
+                                                    'metas.authors'
+                                                )}
+                                            >
+                                                <SimpleFormIterator>
+                                                    <TextInput
+                                                        source="name"
+                                                        initialValue=""
+                                                    />
+                                                </SimpleFormIterator>
+                                            </ArrayInput>
+                                        </>
+                                    );
+                                }}
+                            </FormDataConsumer>
                         </SimpleFormIterator>
                     </ArrayInput>
                     <TextInput disabled source="views" />

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -40,6 +40,7 @@ import {
     DialogContent,
     TextField as MuiTextField,
 } from '@material-ui/core';
+import _ from 'lodash';
 
 import PostTitle from './PostTitle';
 import TagReferenceInput from './TagReferenceInput';
@@ -105,7 +106,7 @@ const PostEdit = ({ permissions, ...props }) => {
     return (
         <Edit title={<PostTitle />} actions={<EditActions />} {...props}>
             <TabbedForm
-                initialValues={{ average_note: 0 }}
+                initialValues={_.merge({}, { average_note: 0, pictures: [] })}
                 warnWhenUnsavedChanges
             >
                 <FormTab label="post.form.summary">
@@ -228,6 +229,16 @@ const PostEdit = ({ permissions, ...props }) => {
                         validate={[required(), number(), minValue(0)]}
                     />
                     <BooleanInput source="commentable" defaultValue />
+                    <ArrayInput source="pictures">
+                        <SimpleFormIterator>
+                            <TextInput source="url" initialValue="" />
+                            <ArrayInput source="metas.authors">
+                                <SimpleFormIterator>
+                                    <TextInput source="name" initialValue="" />
+                                </SimpleFormIterator>
+                            </ArrayInput>
+                        </SimpleFormIterator>
+                    </ArrayInput>
                     <TextInput disabled source="views" />
                 </FormTab>
                 <FormTab label="post.form.comments">


### PR DESCRIPTION
**What you were expecting:**
When I open the Edit view of a resource that has nested ArrayInput and use some `initialValue(s)` both at the form level and the field, the inputs for this part of the data shows the value from the dataProvider.

**What happened instead:**
Instead, the inputs display the initialValue at the field level, making it easy for editor that modify another part of the record to override the existing data!

**Steps to reproduce:**
1. Open the code sandbox https://codesandbox.io/s/reproduce-nested-arrayinput-default-value-bfpnr
2. Open the Edit view of the post "Accusantium2 qui nihil voluptatum" (its url in the internal browser is https://bfpnr.sse.codesandbox.io/#/posts/1/2)
3. Look at the "Related Pictures" inputs : they're all empty because the inputs have `initialValue` set to `""` but `data.tsx` (should be `data.ts` BTW) has actual data.  

**Related code:**
The sandbox https://codesandbox.io/s/reproduce-nested-arrayinput-default-value-bfpnr has all the code, and I created this pull request to highlight the small set of changes I made to reproduce the bug.

**Other information:**
It may be related to a similar issue we created related to `<BooleanIinput />` in nested ArrayInput, not sure (https://github.com/marmelab/react-admin/issues/6511)

**Environment**

* React-admin version: 3.19.0, 3.19.2
* Last version that did not exhibit the issue (if applicable): N/A, we're not sure when the problem manifested itself.
* React version: 17
* Browser: Chrome, Brave, Firefox
* Stack trace (in case of a JS error):