### PR TITLE
Fix Tab component children missing fullWidth prop when addLabel was set

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -100,6 +100,7 @@ export const Tab = ({
                             <Labeled
                                 label={field.props.label}
                                 source={field.props.source}
+                                fullWidth={field.props.fullWidth}
                                 basePath={basePath}
                                 record={record}
                                 resource={resource}


### PR DESCRIPTION
Fixes #6674

Before:

![before](https://user-images.githubusercontent.com/8268610/143792141-4781ce7c-9fe0-4248-a1b1-1f876c4cb022.png)

After:

![after](https://user-images.githubusercontent.com/8268610/143792145-2cf6ea2c-2480-4e8b-94f5-d13fd135611f.png)

