### PR TITLE
Fix useList ids and data state

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -2019,15 +2019,9 @@ const data = [
     { id: 2, name: 'Sylvester' },
     { id: 3, name: 'Jean-Claude' },
 ]
-const ids = [1, 2, 3];
 
 const MyComponent = () => {
-    const listContext = useList({
-        data,
-        ids,
-        basePath: '/resource',
-        resource: 'resource',
-    });
+    const listContext = useList({ data });
     return (
         <ListContextProvider value={listContext}>
             <Datagrid>

--- a/packages/ra-core/src/controller/useList.spec.tsx
+++ b/packages/ra-core/src/controller/useList.spec.tsx
@@ -27,12 +27,10 @@ describe('<useList />', () => {
             { id: 1, title: 'hello' },
             { id: 2, title: 'world' },
         ];
-        const ids = [1, 2];
 
         render(
             <UseList
                 data={data}
-                ids={ids}
                 loaded
                 loading
                 filter={{ title: 'world' }}
@@ -70,8 +68,6 @@ describe('<useList />', () => {
             <UseList
                 data={data}
                 ids={ids}
-                loaded
-                loading
                 filter={{ items: ['two', 'four', 'five'] }}
                 sort={{ field: 'id', order: 'ASC' }}
                 callback={callback}
@@ -83,7 +79,7 @@ describe('<useList />', () => {
                 expect.objectContaining({
                     currentSort: { field: 'id', order: 'ASC' },
                     loaded: true,
-                    loading: true,
+                    loading: false,
                     data: {
                         1: { id: 1, items: ['one', 'two'] },
                         3: { id: 3, items: 'four' },

--- a/packages/ra-core/src/controller/useList.ts
+++ b/packages/ra-core/src/controller/useList.ts
@@ -25,15 +25,9 @@ import { ListControllerProps } from '.';
  *     { id: 2, name: 'Sylvester' },
  *     { id: 3, name: 'Jean-Claude' },
  * ]
- * const ids = [1, 2, 3];
  *
  * const MyComponent = () => {
- *     const listContext = useList({
- *         data,
- *         ids,
- *         basePath: '/resource';
- *         resource: 'resource';
- *     });
+ *     const listContext = useList({ data });
  *     return (
  *         <ListContextProvider value={listContext}>
  *             <Datagrid>
@@ -46,9 +40,9 @@ import { ListControllerProps } from '.';
  *
  * @param {UseListOptions} props
  * @param {Record[]} props.data An array of records
- * @param {Identifier[]} props.ids An array of the record identifiers
- * @param {Boolean} props.loaded: A boolean indicating whether the data has been loaded at least once
- * @param {Boolean} props.loading: A boolean indicating whether the data is being loaded
+ * @param {Identifier[]} props.ids Optional. An array of the record identifiers
+ * @param {Boolean} props.loaded: Optional. A boolean indicating whether the data has been loaded at least once
+ * @param {Boolean} props.loading: Optional. A boolean indicating whether the data is being loaded
  * @param {Error | String} props.error: Optional. The error if any occurred while loading the data
  * @param {Object} props.filter: Optional. An object containing the filters applied on the data
  * @param {Number} props.page: Optional. The initial page index
@@ -60,9 +54,9 @@ export const useList = (props: UseListOptions): UseListValue => {
         data,
         error,
         filter = defaultFilter,
-        ids,
-        loaded,
-        loading,
+        ids = Array.isArray(data) ? data.map(record => record.id) : [],
+        loaded = true,
+        loading = false,
         page: initialPage = 1,
         perPage: initialPerPage = 1000,
         sort: initialSort = defaultSort,
@@ -74,8 +68,8 @@ export const useList = (props: UseListOptions): UseListValue => {
         total: number;
     }>(() => ({
         data: Array.isArray(data) ? indexById(data) : {},
-        ids: Array.isArray(ids) ? ids : [],
-        total: Array.isArray(ids) ? ids.length : 0,
+        ids,
+        total: ids.length,
     }));
 
     // pagination logic
@@ -241,8 +235,8 @@ export interface UseListOptions<RecordType extends Record = Record> {
     ids?: Identifier[];
     error?: any;
     filter?: FilterPayload;
-    loading: boolean;
-    loaded: boolean;
+    loading?: boolean;
+    loaded?: boolean;
     page?: number;
     perPage?: number;
     sort?: SortPayload;


### PR DESCRIPTION
- [x] if `data` is passed to `useList` and `ids` are not, `ids` should be taken from `data`
- [x] `loading` and `loaded` props made optional and defaulted to `loaded`=`true` and `loading`=`false` (like in next branch)
       I know is a BC, but it shouldn't be of any consequence
- [x] Updated tests
- [x] Update documentation