### PR TITLE
Fix lerna config to build simple project

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,7 @@
   "lerna": "2.5.1",
   "packages": [
     "examples/data-generator",
+    "examples/simple",
     "packages/*"
   ],
   "version": "3.19.2"


### PR DESCRIPTION
On a clean install and build of the project, you don't get the `examples/simple/dist` folder needed by cypress to run the tests