### PR TITLE
【Bugfix】accept prop of FileInput and ImageInput can't receive string array type 

### DIFF
--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -242,14 +242,14 @@ const StyledLabeled = styled(Labeled, { name: PREFIX })(({ theme }) => ({
     [`&.${FileInputClasses.root}`]: { width: '100%' },
 }));
 
-export interface FileInputProps {
-    accept?: string;
+export interface FileInputProps
+    extends Pick<
+        DropzoneOptions,
+        'accept' | 'multiple' | 'maxSize' | 'minSize'
+    > {
     children?: ReactNode;
     labelMultiple?: string;
     labelSingle?: string;
-    maxSize?: number;
-    minSize?: number;
-    multiple?: boolean;
     placeholder?: ReactNode;
 }
 

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -202,7 +202,10 @@ export const FileInput = (
 };
 
 FileInput.propTypes = {
-    accept: PropTypes.string,
+    accept: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+    ]),
     children: PropTypes.element,
     className: PropTypes.string,
     id: PropTypes.string,


### PR DESCRIPTION
DropzoneOptions props's accept can receive string[] type but, FileInputProps is can't because the redefined type is wrong.
I replace that as it uses inherited DropzoneOptions' props types if these are redefined of them.