### PR TITLE
Add ApolloError in error body when handling errors

### DIFF
--- a/packages/ra-data-graphql/src/index.test.ts
+++ b/packages/ra-data-graphql/src/index.test.ts
@@ -39,7 +39,7 @@ describe('GraphQL data provider', () => {
                         data: {},
                     });
                 } catch (error) {
-                    expect(error.body).toBeDefined();
+                    expect(error.body).not.toBeNull();
                     expect(error.body.graphQLErrors).toBeDefined();
                     expect(error.body.graphQLErrors).toHaveLength(1);
                     return;

--- a/packages/ra-data-graphql/src/index.test.ts
+++ b/packages/ra-data-graphql/src/index.test.ts
@@ -1,0 +1,51 @@
+import { ApolloClient, ApolloError } from '@apollo/client';
+import { GraphQLError } from 'graphql';
+import gql from 'graphql-tag';
+
+import buildDataProvider, { BuildQueryFactory } from './index';
+
+describe('GraphQL data provider', () => {
+    describe('mutate', () => {
+        describe('with error', () => {
+            it('sets ApolloError in body', async () => {
+                const mockClient = {
+                    mutate: async () => {
+                        throw new ApolloError({
+                            graphQLErrors: [new GraphQLError('some error')],
+                        });
+                    },
+                };
+                const mockBuildQueryFactory = () => {
+                    return () => ({
+                        query: gql`
+                            mutation {
+                                updateMyResource {
+                                    result
+                                }
+                            }
+                        `,
+                        parseResponse: () => ({}),
+                    });
+                };
+                const dataProvider = await buildDataProvider({
+                    client: (mockClient as unknown) as ApolloClient<unknown>,
+                    introspection: false,
+                    buildQuery: (mockBuildQueryFactory as unknown) as BuildQueryFactory,
+                });
+                try {
+                    await dataProvider.update('myResource', {
+                        id: 1,
+                        previousData: { id: 1 },
+                        data: {},
+                    });
+                } catch (error) {
+                    expect(error.body).toBeDefined();
+                    expect(error.body.graphQLErrors).toBeDefined();
+                    expect(error.body.graphQLErrors).toHaveLength(1);
+                    return;
+                }
+                fail('expected data provider to throw an error');
+            });
+        });
+    });
+});

--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -221,7 +221,6 @@ export default async (options: Options): Promise<DataProvider> => {
 };
 
 const handleError = (error: ApolloError) => {
-    console.error({ error });
     if (error?.networkError as ServerError) {
         throw new HttpError(
             (error?.networkError as ServerError)?.message,
@@ -229,7 +228,7 @@ const handleError = (error: ApolloError) => {
         );
     }
 
-    throw new HttpError(error.message, 200);
+    throw new HttpError(error.message, 200, error);
 };
 
 const getQueryOperation = query => {


### PR DESCRIPTION
Fixes #6953

I added a test to check for correct error handling when executing a mutation.