### PR TITLE
[BC Break] Update useGetOne signature to reflect the getOne signature

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -694,7 +694,7 @@ The dataProvider hooks (`useGetOne`, etc) return the request state. The `loading
 ```diff
 const BookDetail = ({ id }) => {
 -   const { data, error, loaded } = useGetOne('books', id);
-+   const { data, error, isLoading } = useGetOne('books', id);
++   const { data, error, isLoading } = useGetOne('books', { id });
 -   if (!loaded) {
 +   if (isLoading) {
         return <Loading />;
@@ -727,7 +727,7 @@ If you were using components dependent on the dataProvider hooks in isolation (e
 
 // this component relies on dataProvider hooks
 const BookDetail = ({ id }) => {
-    const { data, error, isLoading } = useGetOne('books', id);
+    const { data, error, isLoading } = useGetOne('books', { id });
     if (isLoading) {
         return <Loading />;
     }

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -291,7 +291,7 @@ The specialized hooks based on `useQuery` (`useGetList`, `useGetOne`, `useGetMan
 **Tip**: If you use TypeScript, you can specify the record type for more type safety:
 
 ```jsx
-const { data, isLoading } = useGetOne<Product>('products', 123);
+const { data, isLoading } = useGetOne<Product>('products', { id: 123 });
 //        \- type of data is Product
 ```
 
@@ -329,13 +329,13 @@ This hook calls `dataProvider.getOne()` when the component mounts.
 
 ```jsx
 // syntax
-const { data, isFetching, isLoading, error, refetch } = useGetOne(resource, id, options);
+const { data, isFetching, isLoading, error, refetch } = useGetOne(resource, { id }, options);
 
 // example
 import { useGetOne } from 'react-admin';
 
 const UserProfile = ({ record }) => {
-    const { data, isLoading, error } = useGetOne('users', record.id);
+    const { data, isLoading, error } = useGetOne('users', { id: record.id });
     if (isLoading) { return <Loading />; }
     if (error) { return <p>ERROR</p>; }
     return <div>User {data.username}</div>;

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -370,7 +370,7 @@ React-admin uses the `fullName` and the `avatar` (an image source, or a data-uri
 import { useGetIdentity, useGetOne } from 'react-admin';
 
 const PostDetail = ({ id }) => {
-    const { data: post, isLoading: postLoading } = useGetOne('posts', id);
+    const { data: post, isLoading: postLoading } = useGetOne('posts', { id });
     const { identity, loading: identityLoading } = useGetIdentity();
     if (postLoading || identityLoading) return <>Loading...</>;
     if (!post.lockedBy || post.lockedBy === identity.id) {
@@ -799,7 +799,7 @@ Here is an example Edit component, which falls back to a Show component is the r
 import { useGetIdentity, useGetOne } from 'react-admin';
 
 const PostDetail = ({ id }) => {
-    const { data: post, isLoading: postLoading } = useGetOne('posts', id);
+    const { data: post, isLoading: postLoading } = useGetOne('posts', { id });
     const { identity, loading: identityLoading } = useGetIdentity();
     if (postLoading || identityLoading) return <>Loading...</>;
     if (!post.lockedBy || post.lockedBy === identity.id) {

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -767,7 +767,7 @@ Here is a glimpse of the `useGetOne` hook usage:
 import { useGetOne } from 'react-admin';
 
 const UserProfile = ({ record }) => {
-    const { data, isLoading, error } = useGetOne('users', record.id);
+    const { data, isLoading, error } = useGetOne('users', { id: record.id });
     if (isLoading) { return <Loading />; }
     if (error) { return <p>ERROR</p>; }
     return <div>User {data.username}</div>;

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -45,7 +45,7 @@ React-admin Field components also accept a `record` prop. This allows you to use
 // { id: 123, title: "Hello, world", author: "John Doe", body: "..." }
 
 const PostShow = ({ id }) => {
-    const { data, isLoading } = useGetOne('books', id);
+    const { data, isLoading } = useGetOne('books', { id });
     if (isLoading) return <span>Loading</span>; 
     return (
         <dl>
@@ -1621,7 +1621,7 @@ import { Link } from 'react-router-dom';
 
 const AuthorField = () => {
     const post = useRecordContext(props);
-    const { data, isLoading } = useGetOne('users', post.user_id);
+    const { data, isLoading } = useGetOne('users', { id: post.user_id });
     const userShowPage = linkToRecord('/users', post.user_id, 'show');
 
     return isLoading ? null : <Link to={userShowPage}>{data.username}</Link>;

--- a/docs/ShowTutorial.md
+++ b/docs/ShowTutorial.md
@@ -24,9 +24,12 @@ import { Card, Stack, Typography } from '@mui/material';
 const BookShow = () => {
     const { id } = useParams(); // this component is rendered in the /books/:id path
     const redirect = useRedirect();
-    const { data, isLoading } = useGetOne('books', id, {
-        onError: () => redirect('/books') // redirect to the list if the book is not found
-    });
+    const { data, isLoading } = useGetOne(
+        'books',
+        { id },
+        // redirect to the list if the book is not found
+        { onError: () => redirect('/books') }
+    );
     if (isLoading) { return <Loading />; }
     return (
         <div>
@@ -64,9 +67,11 @@ import { Card, Stack } from '@mui/material';
 const BookShow = () => {
     const { id } = useParams();
     const redirect = useRedirect();
-    const { data, isLoading } = useGetOne('books', id, {
-        onError: () => redirect('/books')
-    });
+    const { data, isLoading } = useGetOne(
+        'books',
+        { id },
+        { onError: () => redirect('/books') }
+    );
     if (isLoading) { return <Loading />; }
     return (
         <div>
@@ -98,9 +103,11 @@ import { Card, Stack } from '@mui/material';
 const BookShow = () => {
     const { id } = useParams();
     const redirect = useRedirect();
-    const { data, isLoading } = useGetOne('books', id, {
-        onError: () => redirect('/books')
-    });
+    const { data, isLoading } = useGetOne(
+        'books',
+        { id },
+        { onError: () => redirect('/books') }
+    );
     if (isLoading) { return <Loading />; }
     return (
         <RecordContextProvider value={data}>
@@ -133,9 +140,11 @@ import { useGetOne, useRedirect, RecordContextProvider, SimpleShowLayout, Title,
 const BookShow = () => {
     const { id } = useParams();
     const redirect = useRedirect();
-    const { data } = useGetOne('books', id, {
-        onError: () => redirect('/books')
-    });
+    const { data, isLoading } = useGetOne(
+        'books',
+        { id },
+        { onError: () => redirect('/books') }
+    );
     return (
         <RecordContextProvider value={data}>
             <div>

--- a/docs/useRecordContext.md
+++ b/docs/useRecordContext.md
@@ -68,7 +68,7 @@ If you have fetched a `record` and you want to make it available to descendants,
 import { useGetOne, RecordContextProvider } from 'react-admin';
 
 const RecordFetcher = ({ id, resource, children }) => {
-    const { data, isLoading, error } = useGetOne(resource, id);
+    const { data, isLoading, error } = useGetOne(resource, { id });
     if (isLoading) return <p>Loading...</p>;
     if (error) return <p>Error :(</p>;
     return (

--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -26,7 +26,7 @@ const defaultIdentity = {
  * import { useGetIdentity, useGetOne } from 'react-admin';
  *
  * const PostDetail = ({ id }) => {
- *     const { data: post, isLoading: postLoading } = useGetOne('posts', id);
+ *     const { data: post, isLoading: postLoading } = useGetOne('posts', { id });
  *     const { identity, loading: identityLoading } = useGetIdentity();
  *     if (postLoading || identityLoading) return <>Loading...</>;
  *     if (!post.lockedBy || post.lockedBy === identity.id) {

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -84,18 +84,22 @@ export const useEditController = <RecordType extends Record = Record>(
 
     const { data: record, error, isLoading, isFetching, refetch } = useGetOne<
         RecordType
-    >(resource, id, {
-        onError: () => {
-            notify('ra.notification.item_doesnt_exist', {
-                type: 'warning',
-            });
-            redirect('list', `/${resource}`);
-            refresh();
-        },
+    >(
+        resource,
+        { id },
+        {
+            onError: () => {
+                notify('ra.notification.item_doesnt_exist', {
+                    type: 'warning',
+                });
+                redirect('list', `/${resource}`);
+                refresh();
+            },
 
-        retry: false,
-        ...queryOptions,
-    });
+            retry: false,
+            ...queryOptions,
+        }
+    );
 
     // eslint-disable-next-line eqeqeq
     if (record && record.id && record.id != id) {

--- a/packages/ra-core/src/controller/record/RecordContext.tsx
+++ b/packages/ra-core/src/controller/record/RecordContext.tsx
@@ -28,7 +28,7 @@ RecordContext.displayName = 'RecordContext';
  * import { useGetOne, RecordContextProvider } from 'ra-core';
  *
  * const Show = ({ resource, id }) => {
- *     const { data } = useGetOne(resource, id);
+ *     const { data } = useGetOne(resource, { id });
  *     return (
  *         <RecordContextProvider value={data}>
  *             ...

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -59,17 +59,21 @@ export const useShowController = <RecordType extends Record = Record>(
 
     const { data: record, error, isLoading, isFetching, refetch } = useGetOne<
         RecordType
-    >(resource, id, {
-        onError: () => {
-            notify('ra.notification.item_doesnt_exist', {
-                type: 'warning',
-            });
-            redirect('list', `/${resource}`);
-            refresh();
-        },
-        retry: false,
-        ...queryOptions,
-    });
+    >(
+        resource,
+        { id },
+        {
+            onError: () => {
+                notify('ra.notification.item_doesnt_exist', {
+                    type: 'warning',
+                });
+                redirect('list', `/${resource}`);
+                refresh();
+            },
+            retry: false,
+            ...queryOptions,
+        }
+    );
 
     // eslint-disable-next-line eqeqeq
     if (record && record.id && record.id != id) {

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -24,7 +24,7 @@ import useDataProvider from './useDataProvider';
  * @param {string} resource The resource name, e.g. 'posts'
  * @param {Params} params The getList parameters { pagination, sort, filter }
  * @param {Object} options Options object to pass to the queryClient.
- * May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh() } }
  *
  * @typedef Params
  * @props params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -20,12 +20,12 @@ import useDataProvider from './useDataProvider';
  * @param {Options} options Options object to pass to the react-query queryClient.
  *
  * @typedef Params
- * @property id a resource identifier, e.g. 123
+ * @prop id a resource identifier, e.g. 123
  *
  * @typedef Options
- * @property enabled Flag to conditionally run the query. If it's false, the query will not run
- * @property onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
- * @property onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
+ * @prop enabled Flag to conditionally run the query. If it's false, the query will not run
+ * @prop onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
+ * @prop onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
  *
  * @returns The current request state. Destructure as { data, error, isLoading, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -1,4 +1,4 @@
-import { Identifier, Record, GetOneParams } from '../types';
+import { Record, GetOneParams } from '../types';
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import useDataProvider from './useDataProvider';
 

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -20,11 +20,12 @@ import useDataProvider from './useDataProvider';
  * @param {Options} options Options object to pass to the react-query queryClient.
  *
  * @typedef Params
- * @props params.id a resource identifier, e.g. 123
+ * @property id a resource identifier, e.g. 123
+ *
  * @typedef Options
- * @pprops options.enabled Flag to conditionally run the query. If it's false, the query will not run
- * @pprops options.onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
- * @pprops options.onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
+ * @property enabled Flag to conditionally run the query. If it's false, the query will not run
+ * @property onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
+ * @property onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
  *
  * @returns The current request state. Destructure as { data, error, isLoading, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -1,4 +1,4 @@
-import { Identifier, Record } from '../types';
+import { Identifier, Record, GetOneParams } from '../types';
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import useDataProvider from './useDataProvider';
 
@@ -16,11 +16,15 @@ import useDataProvider from './useDataProvider';
  * with the same parameters, until the response arrives.
  *
  * @param resource The resource name, e.g. 'posts'
- * @param id The resource identifier, e.g. 123
- * @param {Object} options Options object to pass to the react-query queryClient.
- * @param {boolean} options.enabled Flag to conditionally run the query. If it's false, the query will not run
- * @param {Function} options.onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
- * @param {Function} options.onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
+ * @param {Params} params The getOne parameters { id }, e.g. { id: 123 }
+ * @param {Options} options Options object to pass to the react-query queryClient.
+ *
+ * @typedef Params
+ * @props params.id a resource identifier, e.g. 123
+ * @typedef Options
+ * @pprops options.enabled Flag to conditionally run the query. If it's false, the query will not run
+ * @pprops options.onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
+ * @pprops options.onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
  *
  * @returns The current request state. Destructure as { data, error, isLoading, refetch }.
  *
@@ -29,7 +33,7 @@ import useDataProvider from './useDataProvider';
  * import { useGetOne } from 'react-admin';
  *
  * const UserProfile = ({ record }) => {
- *     const { data, isLoading, error } = useGetOne('users', record.id);
+ *     const { data, isLoading, error } = useGetOne('users', { id: record.id });
  *     if (isLoading) { return <Loading />; }
  *     if (error) { return <p>ERROR</p>; }
  *     return <div>User {data.username}</div>;
@@ -37,7 +41,7 @@ import useDataProvider from './useDataProvider';
  */
 export const useGetOne = <RecordType extends Record = Record>(
     resource: string,
-    id: Identifier,
+    { id }: GetOneParams,
     options?: UseQueryOptions<RecordType>
 ): UseGetOneHookValue<RecordType> => {
     const dataProvider = useDataProvider();

--- a/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
@@ -41,7 +41,7 @@ export const SuccessCase = () => {
 const SuccessCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
-    const { data, refetch } = useGetOne('posts', 1);
+    const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isLoading }] = useUpdate();
     const handleClick = () => {
         update(
@@ -109,7 +109,7 @@ const ErrorCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
-    const { data, refetch } = useGetOne('posts', 1);
+    const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isLoading }] = useUpdate();
     const handleClick = () => {
         update(

--- a/packages/ra-core/src/dataProvider/useUpdate.pessimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.pessimistic.stories.tsx
@@ -41,7 +41,7 @@ export const SuccessCase = () => {
 const SuccessCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
-    const { data, refetch } = useGetOne('posts', 1);
+    const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isLoading }] = useUpdate();
     const handleClick = () => {
         update(
@@ -109,7 +109,7 @@ const ErrorCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
-    const { data, refetch } = useGetOne('posts', 1);
+    const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isLoading }] = useUpdate();
     const handleClick = () => {
         setError(undefined);

--- a/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
@@ -43,7 +43,7 @@ const SuccessCore = () => {
     const isMutating = useIsMutating();
     const [notification, setNotification] = useState<boolean>(false);
     const [success, setSuccess] = useState<string>();
-    const { data, refetch } = useGetOne('posts', 1);
+    const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isLoading }] = useUpdate();
     const handleClick = () => {
         update(
@@ -139,7 +139,7 @@ const ErrorCore = () => {
     const [notification, setNotification] = useState<boolean>(false);
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
-    const { data, refetch } = useGetOne('posts', 1);
+    const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isLoading }] = useUpdate();
     const handleClick = () => {
         update(

--- a/packages/ra-test/README.md
+++ b/packages/ra-test/README.md
@@ -80,7 +80,7 @@ test('should render a book', async () => {
     };
 
     const Book = ({ id }) => {
-        const { data, isLoading } = useGetOne('books', id);
+        const { data, isLoading } = useGetOne('books', { id });
         return isLoading ? <span>loading</span> : <span>{data.title}</span>;
     };
 

--- a/packages/ra-test/src/TestContext.stories.tsx
+++ b/packages/ra-test/src/TestContext.stories.tsx
@@ -17,7 +17,7 @@ const dataProvider = {
 } as any;
 
 const Book = ({ id }) => {
-    const { data, isLoading } = useGetOne('books', id);
+    const { data, isLoading } = useGetOne('books', { id });
     return isLoading ? <span>loading</span> : <span>{data.title}</span>;
 };
 


### PR DESCRIPTION
To make it consistent with `useGetList`, `useUpdate`, and other dataProvider hooks to come. 

```diff
-const { data, isLoading } = useGetOne('posts', 123);
+const { data, isLoading } = useGetOne('posts', { id: 123 });
```