### PR TITLE
Revert main views don't render a Card

### DIFF
--- a/docs/Show.md
+++ b/docs/Show.md
@@ -11,7 +11,7 @@ The `<Show>` component handles the logic of the Show page:
 - it computes the default page title
 - it creates a `ShowContext` and a `RecordContext`,
 - it renders the page layout with the correct title and actions
-- it renders its child component (a show layout component like `<SimpleShowLayout>`)
+- it renders its child component (a show layout component like `<SimpleShowLayout>`) in a Material-ui `<Card>`
 
 ## Usage
 
@@ -56,6 +56,7 @@ That's enough to display the post show view:
 ## Props
 
 * [`actions`](#actions): override the actions toolbar with a custom component
+* [`aside`](#aside): A component to render as a sidebar of the show view
 * `className`: passed to the root component
 * [`children`](#layout): the components that render the record fields
 * [`component`](#root-component): overrides the root component
@@ -92,7 +93,7 @@ export const PostShow = () => (
 );
 ```
 
-You can also pass React elements as children, so as to build a custom layout. Check [Building a custom Show Layout](./ShowTutorial.md#building-a-custom-layout) for more details.
+You can also pass a React element as child, so as to build a custom layout. Check [Building a custom Show Layout](./ShowTutorial.md#building-a-custom-layout) for more details.
 
 ## Page Title
 
@@ -249,29 +250,38 @@ const PostShow = () => (
 
 ## Root Component
 
-By default, the Show view renders the main content area inside a `<div>`. The actual layout of the record fields depends on the Show Layout component you're using (`<SimpleShowLayout>`, `<TabbedShowLayout>`, or a custom layout component).
+By default, the Show view renders the main content area inside a material-ui `<Card>`. The actual layout of the record fields depends on the Show Layout component you're using (`<SimpleShowLayout>`, `<TabbedShowLayout>`, or a custom layout component).
 
 You can override the main area container by passing a `component` prop:
 
+{% raw %}
 ```jsx
-import { Card } from '@mui/material';
+import { Box } from '@mui/material';
 
-// use a Card as root component
+const ShowWrapper = ({ children }) => (
+    <Box sx={{ margin: 2, border: 'solid 1px grey' }}>
+        {children}
+    </Box>
+);
+
+// use a ShowWrapper as root component
 const PostShow = props => (
-    <Show component={Card} {...props}>
+    <Show component={ShowWrapper} {...props}>
         ...
     </Show>
 );
 ```
+{% endraw %}
 
 ## CSS API
 
 The `<Show>` component accepts the usual `className` prop but you can override many class names injected to the inner components by React-admin thanks to the `sx` property (as most Material UI components, see their [documentation about it](https://mui.com/customization/how-to-customize/#overriding-nested-component-styles)). This property accepts the following subclasses:
 
-| Rule name   | Description                                                                                |
-| ----------- | ------------------------------------------------------------------------------------------ |
-| `root`      | Alternative to using `className`. Applied to the root element                              |
-| `main`      | Applied to the main container                                                              |
+| Rule name   | Description                                                   |
+| ----------- | ------------------------------------------------------------- |
+| `root`      | Alternative to using `className`. Applied to the root element |
+| `main`      | Applied to the main container                                 |
+| `card`      | Applied to the `<Card>` element                               |
 
 To override the style of all instances of `<Show>` using the [material-ui style overrides](https://mui.com/customization/theme-components/), use the `RaShow` key.
 

--- a/docs/ShowBase.md
+++ b/docs/ShowBase.md
@@ -12,7 +12,7 @@ The `<ShowBase>` component handles the headless logic of the Show page:
 - it creates a `ShowContext` and a `RecordContext`,
 - it renders its child component
 
-Contrary to `<Show>`, it does not render the page layout, so no title and actions.
+Contrary to `<Show>`, it does not render the page layout, so no title, no actions, and no `<Card>`.
 
 ## Usage
 

--- a/docs/ShowTutorial.md
+++ b/docs/ShowTutorial.md
@@ -124,11 +124,12 @@ const BookShow = () => {
 
 ## `<SimpleShowLayout>` Displays Fields In A Stack
 
-Displaying a stack of fields with a label in a Card is such a common task that react-admin provides a helper component for that. It's called [`<SimpleShowLayout>`](./SimpleShowLayout.md):
+Displaying a stack of fields with a label is such a common task that react-admin provides a helper component for that. It's called [`<SimpleShowLayout>`](./SimpleShowLayout.md):
 
 ```jsx
 import { useParams } from 'react-router-dom';
 import { useGetOne, useRedirect, RecordContextProvider, SimpleShowLayout, Title, TextField, DateField } from 'react-admin';
+import { Card } from '@mui/material';
 
 const BookShow = () => {
     const { id } = useParams();
@@ -140,10 +141,12 @@ const BookShow = () => {
         <RecordContextProvider value={data}>
             <div>
                 <Title title="Book Show" />
-                <SimpleShowLayout>
-                    <TextField label="Title" source="title" />
-                    <DateField label="Publication Date" source="published_at" />
-                </SimpleShowLayout>
+                <Card>
+                    <SimpleShowLayout>
+                        <TextField label="Title" source="title" />
+                        <DateField label="Publication Date" source="published_at" />
+                    </SimpleShowLayout>
+                </Card>
             </div>
         </RecordContextProvider>
     );
@@ -158,6 +161,7 @@ The initial logic that grabs the id from the location and fetches the record fro
 
 ```jsx
 import { useShowController, SimpleShowLayout, Title, TextField, DateField } from 'react-admin';
+import { Card } from '@mui/material';
 
 const BookShow = () => {
     const { data } = useShowController();
@@ -165,10 +169,12 @@ const BookShow = () => {
         <RecordContextProvider value={data}>
             <div>
                 <Title title="Book Show" />
-                <SimpleShowLayout>
-                    <TextField label="Title" source="title" />
-                    <DateField label="Publication Date" source="published_at" />
-                </SimpleShowLayout>
+                <Card>
+                    <SimpleShowLayout>
+                        <TextField label="Title" source="title" />
+                        <DateField label="Publication Date" source="published_at" />
+                    </SimpleShowLayout>
+                </Card>
             </div>
         </RecordContextProvider>
     );
@@ -183,15 +189,18 @@ As calling the Show controller and putting its result into a context is also com
 
 ```jsx
 import { ShowBase, SimpleShowLayout, Title, TextField, DateField } from 'react-admin';
+import { Card } from '@mui/material';
 
 const BookShow = () => (
     <ShowBase>
         <div>
             <Title title="Book Show" />
-            <SimpleShowLayout>
-                <TextField label="Title" source="title" />
-                <DateField label="Publication Date" source="published_at" />
-            </SimpleShowLayout>
+            <Card>
+                <SimpleShowLayout>
+                    <TextField label="Title" source="title" />
+                    <DateField label="Publication Date" source="published_at" />
+                </SimpleShowLayout>
+            </Card>
         </div>
     </ShowBase>
 );
@@ -199,7 +208,7 @@ const BookShow = () => (
 
 ## `<Show>` Renders Title, Fields, And Actions
 
-`<ShowBase>` is a headless component: it renders only its children. But almost every show view needs a wrapping `<div>` and a title. That's why react-admin provides [the `<Show>` component](./Show.md), which includes the `<ShowBase>` component, a title build from the resource name, and even an "Edit" button if the resource has an edit component:
+`<ShowBase>` is a headless component: it renders only its children. But almost every show view needs a wrapping `<div>`, a title, and a `<Card>`. That's why react-admin provides [the `<Show>` component](./Show.md), which includes the `<ShowBase>` component, a title built from the resource name, and even an "Edit" button if the resource has an edit component:
 
 ```jsx
 import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
@@ -304,38 +313,36 @@ In many cases, neither the `<SimpleShowLayout>` nor the `<TabbedShowLayout>` com
 
 For instance, to display several fields in a single line, you can use material-ui's `<Grid>` component:
 
+{% raw %}
 ```jsx
 import { Show, SimpleShowLayout, TextField, DateField, ReferenceField } from 'react-admin';
-import { Card, CardContent, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 
 const BookShow = () => (
     <Show emptyWhileLoading>
-        <Card>
-            <CardContent>
-                <Grid container spacing={2}>
-                    <Grid item xs={12} sm={6}>
-                        <TextField label="Title" source="title" />
-                    </Grid>
-                    <Grid item xs={12} sm={6}>
-                        <ReferenceField label="Author" source="author_id" reference="authors">
-                            <TextField source="name" />
-                        </ReferenceField>
-                    </Grid>
-                    <Grid item xs={12} sm={6}>
-                        <DateField label="Publication Date" source="published_at" />
-                    </Grid>
-                    <Grid item xs={12} sm={6}>
-                        <WithRecord label="Rating" render={record => <>
-                            {[...Array(record.rating)].map((_, index) => <StarIcon key={index} />)}
-                        </>} />
-                    </Grid>
-                </Grid>
-            </CardContent>
-        </Card>
+        <Grid container spacing={2} sx={{ margin: 2 }}>
+            <Grid item xs={12} sm={6}>
+                <TextField label="Title" source="title" />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+                <ReferenceField label="Author" source="author_id" reference="authors">
+                    <TextField source="name" />
+                </ReferenceField>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+                <DateField label="Publication Date" source="published_at" />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+                <WithRecord label="Rating" render={record => <>
+                    {[...Array(record.rating)].map((_, index) => <StarIcon key={index} />)}
+                </>} />
+            </Grid>
+        </Grid>
     </Show>
 );
 ```
+{% endraw %}
 
 **Tip**: With `emptyWhileLoading` turned on, the `<Show>` component doesn't render its child component until the record is available. Without this flag, the Field components would render even during the loading phase, and may break if they aren't planned to work with an empty record context. You could grab the `isLoading` state from the `ShowContext` instead, but that would force you to split the `<BookShow>` component into two.  
 
@@ -347,7 +354,7 @@ import StarIcon from '@mui/icons-material/Star';
 
 const BookShow = () => (
     <Show emptyWhileLoading>
-        <Grid container spacing={2}>
+        <Grid container spacing={2} sx={{ margin: 2 }}>
             <Grid item xs={12} sm={8}>
                 <SimpleShowLayout>
                     <TextField label="Title" source="title" />

--- a/docs/SimpleShowLayout.md
+++ b/docs/SimpleShowLayout.md
@@ -27,7 +27,6 @@ const PostShow = () => (
 
 * [`children`](#fields): components rendering a record field
 * `className`: passed to the root component
-* [`component`](#root-component): overrides the root component
 * [`divider`](#divider): optional element to render between each field
 * [`record`](#controlled-mode): can be injected when outside a RecordContext 
 * [`spacing`](#spacing): optional integer to set the spacing between the fields
@@ -146,21 +145,6 @@ const PostShow = () => (
     <Show>
         <SimpleShowLayout divider={<Divider flexItem />}>
             <PostTitle label="title" />
-        </SimpleShowLayout>
-    </Show>
-);
-```
-
-## Root Component
-
-By default, the `<SimpleShowLayout>` view renders the main content area inside a `<div>`. You can override the main area container by passing a `component` prop:
-
-```jsx
-// use a span as root component
-const PostShow = () => (
-    <Show>
-        <SimpleShowLayout component="span">
-            <TextField source="title" />
         </SimpleShowLayout>
     </Show>
 );

--- a/docs/SimpleShowLayout.md
+++ b/docs/SimpleShowLayout.md
@@ -5,7 +5,7 @@ title: "SimpleShowLayout"
 
 # `<SimpleShowLayout>`
 
-The `<SimpleShowLayout>` pulls the `record` from the `RecordContext`. It renders a material-ui `<Card>` containing the record fields in a single-column layout (via material-ui's `<Stack>` component). `<SimpleShowLayout>` delegates the actual rendering of fields to its children. It wraps each field inside [a `<FieldWithLabel>` component](./FieldWithLabel.md) to add a label.
+The `<SimpleShowLayout>` pulls the `record` from the `RecordContext`. It renders the record fields in a single-column layout (via material-ui's `<Stack>` component). `<SimpleShowLayout>` delegates the actual rendering of fields to its children. It wraps each field inside [a `<FieldWithLabel>` component](./FieldWithLabel.md) to add a label.
 
 ## Usage
 
@@ -33,7 +33,7 @@ const PostShow = () => (
 * [`spacing`](#spacing): optional integer to set the spacing between the fields
 * [`sx`](#css-api): Override the styles
 
-Additional props are passed to the root component (`<Card>`).
+Additional props are passed to the root component (`<div>`).
 
 ## Fields
 
@@ -42,19 +42,17 @@ Additional props are passed to the root component (`<Card>`).
 ```jsx
 const PostShow = () => (
     <Show>
-        <Card>
-            <Stack>
-                <FieldWithLabel label="Title">
-                    <TextField source="title" />
-                </FieldWithLabel>
-                <FieldWithLabel label="Body">
-                    <RichTextField source="body" />
-                </FieldWithLabel>
-                <FieldWithLabel label="Nb Views">
-                    <NumberField source="nb_views" />
-                </FieldWithLabel>
-            </Stack>
-        </Card>
+        <Stack>
+            <FieldWithLabel label="Title">
+                <TextField source="title" />
+            </FieldWithLabel>
+            <FieldWithLabel label="Body">
+                <RichTextField source="body" />
+            </FieldWithLabel>
+            <FieldWithLabel label="Nb Views">
+                <NumberField source="nb_views" />
+            </FieldWithLabel>
+        </Stack>
     </Show>
 );
 ```
@@ -74,13 +72,11 @@ const PostShow = () => (
 // translates to
 const PostShow = () => (
     <Show>
-        <Card>
-            <Stack>
-                <FieldWithLabel label="My Custom Title">
-                    <TextField source="title" />
-                </FieldWithLabel>
-            </Stack>
-        </Card>
+        <Stack>
+            <FieldWithLabel label="My Custom Title">
+                <TextField source="title" />
+            </FieldWithLabel>
+        </Stack>
     </Show>
 );
 ```
@@ -99,11 +95,9 @@ const PostShow = () => (
 // translates to
 const PostShow = () => (
     <Show>
-        <Card>
-            <Stack>
-                <TextField source="title" />
-            </Stack>
-        </Card>
+        <Stack>
+            <TextField source="title" />
+        </Stack>
     </Show>
 );
 ```
@@ -159,13 +153,13 @@ const PostShow = () => (
 
 ## Root Component
 
-By default, the `<SimpleShowLayout>` view renders the main content area inside a material-ui `<Card>`. You can override the main area container by passing a `component` prop:
+By default, the `<SimpleShowLayout>` view renders the main content area inside a `<div>`. You can override the main area container by passing a `component` prop:
 
 ```jsx
-// use a div as root component
+// use a span as root component
 const PostShow = () => (
     <Show>
-        <SimpleShowLayout component="div">
+        <SimpleShowLayout component="span">
             <TextField source="title" />
         </SimpleShowLayout>
     </Show>
@@ -179,28 +173,24 @@ const PostShow = () => (
 ```jsx
 const BookShow = () => (
     <Show>
-        <Card>
-            <Grid container spacing={2}>
-                <Grid item xs={6}>
-                    <SimpleShowLayout component="div">
-                        <TextField source="id" />
-                        <TextField source="title" />
-                    </SimpleShowLayout>
-                </Grid>
-                <Grid item xs={6}>
-                    <SimpleShowLayout component="div">
-                        <TextField source="author" />
-                        <TextField source="summary" />
-                        <NumberField source="year" />
-                    </SimpleShowLayout>
-                </Grid>
+        <Grid container spacing={2}>
+            <Grid item xs={6}>
+                <SimpleShowLayout>
+                    <TextField source="id" />
+                    <TextField source="title" />
+                </SimpleShowLayout>
             </Grid>
-        </Card>
+            <Grid item xs={6}>
+                <SimpleShowLayout>
+                    <TextField source="author" />
+                    <TextField source="summary" />
+                    <NumberField source="year" />
+                </SimpleShowLayout>
+            </Grid>
+        </Grid>
     </Show>
 );
 ```
-
-Just make sure that you set `component="div"` to avoid rendering a card inside another card.
 
 ## Controlled Mode
 

--- a/docs/TabbedShowLayout.md
+++ b/docs/TabbedShowLayout.md
@@ -5,7 +5,7 @@ title: "TabbedShowLayout"
 
 # `<TabbedShowLayout>`
 
-The `<TabbedShowLayout>` pulls the `record` from the `RecordContext`. It renders a material-ui `<Card>` containing a set of `<Tabs>`, each of which contains a list of record fields in a single-column layout (via material-ui's `<Stack>` component). `<TabbedShowLayout>` delegates the actual rendering of fields to its children, which should be `<Tab>` components. `<Tab>`  wraps each field inside a `<FieldWithLabel>` component to add a label.
+The `<TabbedShowLayout>` pulls the `record` from the `RecordContext`. It renders a set of `<Tabs>`, each of which contains a list of record fields in a single-column layout (via material-ui's `<Stack>` component). `<TabbedShowLayout>` delegates the actual rendering of fields to its children, which should be `<Tab>` components. `<Tab>`  wraps each field inside a `<FieldWithLabel>` component to add a label.
 
 Switching tabs will update the current url. By default, it uses the tabs indexes and the first tab will be displayed at the root url. You can customize the path by providing a `path` prop to each `Tab` component. If you'd like the first one to act as an index page, just omit the `path` prop.
 
@@ -64,7 +64,7 @@ export const PostShow = () => (
 * [`syncWithLocation`](#sync-tabs-with-location): optional boolean to disable storing the active tab in the url
 * [`tabs`](#custom-tab-component): custom Tabs component
 
-Additional props are passed to the root component (`<Card>`).
+Additional props are passed to the root component (`<div>`).
 
 ## Tabs
 
@@ -230,13 +230,13 @@ const PostShow = () => (
 
 ## Root Component
 
-By default, `<TabbedShowLayout>` view renders the main content area inside a material-ui `<Card>`. You can override the main area container by passing a `component` prop:
+By default, `<TabbedShowLayout>` view renders the main content area inside a `<div>`. You can override the main area container by passing a `component` prop:
 
 ```jsx
-// use a div as root component
+// use a span as root component
 const PostShow = () => (
     <Show>
-        <TabbedShowLayout component="div">
+        <TabbedShowLayout component="span">
             <Tab label="main">
                 <TextField source="title" />
             </Tab>

--- a/docs/TabbedShowLayout.md
+++ b/docs/TabbedShowLayout.md
@@ -56,7 +56,6 @@ export const PostShow = () => (
 
 * [`children`](#tabs): components rendering a tab
 * `className`: passed to the root component
-* [`component`](#root-component): overrides the root component
 * [`divider`](#divider): optional element to render between each field
 * [`record`](#controlled-mode): can be injected when outside a RecordContext 
 * [`spacing`](#spacing): optional integer to set the spacing between the fields
@@ -222,23 +221,6 @@ const PostShow = () => (
         <TabbedShowLayout divider={<Divider flexItem />}>
             <Tab label="main">
                 <PostTitle label="title" />
-            </Tab>
-        </TabbedShowLayout>
-    </Show>
-);
-```
-
-## Root Component
-
-By default, `<TabbedShowLayout>` view renders the main content area inside a `<div>`. You can override the main area container by passing a `component` prop:
-
-```jsx
-// use a span as root component
-const PostShow = () => (
-    <Show>
-        <TabbedShowLayout component="span">
-            <Tab label="main">
-                <TextField source="title" />
             </Tab>
         </TabbedShowLayout>
     </Show>

--- a/packages/ra-ui-materialui/src/detail/Show.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.tsx
@@ -113,7 +113,7 @@ describe('<Show />', () => {
 
     it('should allow to display custom actions with the actions prop', () => {
         render(<Actions />);
-        expect(screen.getByText('Actions')).toBeDefined();
+        expect(screen.getByText('Edit')).toBeDefined();
     });
 
     it('should display a default title based on resource and id', async () => {

--- a/packages/ra-ui-materialui/src/detail/Show.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.stories.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { Admin } from 'react-admin';
 import { Resource, useRecordContext } from 'ra-core';
 import { createMemoryHistory } from 'history';
-import { Stack, Card } from '@mui/material';
+import { Box, Card, Stack } from '@mui/material';
 import { TextField } from '../field';
 import { Labeled } from '../input';
 import { SimpleShowLayout } from './SimpleShowLayout';
+import { EditButton } from '../button';
+import TopToolbar from '../layout/TopToolbar';
 import { Show } from './Show';
 
 export default { title: 'ra-ui-materialui/detail/Show' };
@@ -45,23 +47,20 @@ export const Basic = () => (
 
 const PostShowWithFields = () => (
     <Show>
-        <Card sx={{ padding: 2, flex: 1 }}>
-            <Stack spacing={2}>
-                <Labeled label="Title">
-                    <TextField source="title" />
-                </Labeled>
-                <Labeled label="Author">
-                    <TextField source="author" />
-                </Labeled>
-                <Labeled label="Summary">
-                    <TextField source="summary" />
-                </Labeled>
-                <Labeled label="Year">
-                    <TextField source="year" />
-                </Labeled>
-            </Stack>
-        </Card>
-        <Card sx={{ width: 100, marginLeft: '1em' }}>Sidebar</Card>
+        <Stack spacing={2} sx={{ padding: 2 }}>
+            <Labeled label="Title">
+                <TextField source="title" />
+            </Labeled>
+            <Labeled label="Author">
+                <TextField source="author" />
+            </Labeled>
+            <Labeled label="Summary">
+                <TextField source="summary" />
+            </Labeled>
+            <Labeled label="Year">
+                <TextField source="year" />
+            </Labeled>
+        </Stack>
     </Show>
 );
 
@@ -72,7 +71,13 @@ export const WithFields = () => (
 );
 
 const PostShowWithCustomActions = () => (
-    <Show actions={<Card>Actions</Card>}>
+    <Show
+        actions={
+            <TopToolbar>
+                <EditButton />
+            </TopToolbar>
+        }
+    >
         <BookTitle />
     </Show>
 );
@@ -95,10 +100,27 @@ export const Title = () => (
     </Admin>
 );
 
+const AsideComponent = () => <Card sx={{ padding: 2 }}>Aside</Card>;
+
+const PostShowWithAside = () => (
+    <Show aside={<AsideComponent />}>
+        <BookTitle />
+    </Show>
+);
+
+export const Aside = () => (
+    <Admin dataProvider={dataProvider} history={history}>
+        <Resource name="books" show={PostShowWithAside} />
+    </Admin>
+);
+
 const CustomWrapper = ({ children }) => (
-    <Card sx={{ padding: 2, width: 200 }} data-testid="custom-component">
+    <Box
+        sx={{ padding: 2, width: 200, border: 'solid 1px black' }}
+        data-testid="custom-component"
+    >
         {children}
-    </Card>
+    </Box>
 );
 
 const PostShowWithComponent = () => (

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { Card } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import classnames from 'classnames';
 import { useShowContext } from 'ra-core';
@@ -13,9 +14,10 @@ const defaultActions = <ShowActions />;
 export const ShowView = (props: ShowViewProps) => {
     const {
         actions = defaultActions,
+        aside,
         children,
         className,
-        component: Content = 'div',
+        component: Content = Card,
         emptyWhileLoading = false,
         title,
         ...rest
@@ -38,7 +40,10 @@ export const ShowView = (props: ShowViewProps) => {
                 defaultTitle={defaultTitle}
             />
             {actions !== false && actions}
-            <Content className={ShowClasses.main}>{children}</Content>
+            <div className={ShowClasses.main}>
+                <Content className={ShowClasses.card}>{children}</Content>
+                {aside}
+            </div>
         </Root>
     );
 };
@@ -77,6 +82,7 @@ const PREFIX = 'RaShow';
 export const ShowClasses = {
     root: `${PREFIX}-root`,
     main: `${PREFIX}-main`,
+    card: `${PREFIX}-card`,
 };
 
 const Root = styled('div', { name: PREFIX })(({ theme }) => ({
@@ -85,5 +91,8 @@ const Root = styled('div', { name: PREFIX })(({ theme }) => ({
     },
     [`& .${ShowClasses.main}`]: {
         display: 'flex',
+    },
+    [`& .${ShowClasses.card}`]: {
+        flex: '1 1 auto',
     },
 }));

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Card } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import classnames from 'classnames';
-import { useShowContext } from 'ra-core';
+import { useShowContext, useResourceDefinition } from 'ra-core';
 
 import { ShowProps } from '../types';
 import { ShowActions } from './ShowActions';
@@ -13,7 +13,7 @@ const defaultActions = <ShowActions />;
 
 export const ShowView = (props: ShowViewProps) => {
     const {
-        actions = defaultActions,
+        actions,
         aside,
         children,
         className,
@@ -24,6 +24,10 @@ export const ShowView = (props: ShowViewProps) => {
     } = props;
 
     const { defaultTitle, record, version } = useShowContext(props);
+    const { hasEdit } = useResourceDefinition(props);
+
+    const finalActions =
+        typeof actions === 'undefined' && hasEdit ? defaultActions : actions;
 
     if (!children || (!record && emptyWhileLoading)) {
         return null;
@@ -39,8 +43,12 @@ export const ShowView = (props: ShowViewProps) => {
                 record={record}
                 defaultTitle={defaultTitle}
             />
-            {actions !== false && actions}
-            <div className={ShowClasses.main}>
+            {finalActions !== false && finalActions}
+            <div
+                className={classnames(ShowClasses.main, {
+                    [ShowClasses.noActions]: !finalActions,
+                })}
+            >
                 <Content className={ShowClasses.card}>{children}</Content>
                 {aside}
             </div>
@@ -82,15 +90,19 @@ const PREFIX = 'RaShow';
 export const ShowClasses = {
     root: `${PREFIX}-root`,
     main: `${PREFIX}-main`,
+    noActions: `${PREFIX}-noActions`,
     card: `${PREFIX}-card`,
 };
 
 const Root = styled('div', { name: PREFIX })(({ theme }) => ({
     [`&.${ShowClasses.root}`]: {
-        paddingTop: theme.spacing(2),
+        paddingTop: theme.spacing(1),
     },
     [`& .${ShowClasses.main}`]: {
         display: 'flex',
+    },
+    [`& .${ShowClasses.noActions}`]: {
+        marginTop: '1em',
     },
     [`& .${ShowClasses.card}`]: {
         flex: '1 1 auto',

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.stories.tsx
@@ -120,13 +120,13 @@ export const SeveralColumns = () => (
         <RecordContextProvider value={record}>
             <Grid container spacing={2}>
                 <Grid item xs={6}>
-                    <SimpleShowLayout component="div">
+                    <SimpleShowLayout>
                         <TextField source="id" />
                         <TextField source="title" />
                     </SimpleShowLayout>
                 </Grid>
                 <Grid item xs={6}>
-                    <SimpleShowLayout component="div">
+                    <SimpleShowLayout>
                         <TextField source="author" />
                         <TextField source="summary" />
                         <NumberField source="year" />

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Children, isValidElement, ReactNode, ElementType } from 'react';
 import { styled } from '@mui/material/styles';
-import { Card, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 import { ResponsiveStyleValue, SxProps } from '@mui/system';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -15,9 +15,8 @@ import { FieldWithLabel } from './FieldWithLabel';
 /**
  * Layout for a Show view showing fields in one column.
  *
- * It pulls the record from the RecordContext. It renders a material-ui `<Card>`
- * containing the record fields in a single-column layout (via material-ui's
- * `<Stack>` component).
+ * It pulls the record from the RecordContext. It renders the record fields in
+ * a single-column layout (via material-ui's `<Stack>` component).
  * `<SimpleShowLayout>` delegates the actual rendering of fields to its children.
  * It wraps each field inside a `<Labeled>` component to add a label.
  *
@@ -122,7 +121,7 @@ export const SimpleShowLayoutClasses = {
     row: `${PREFIX}-row`,
 };
 
-const Root = styled(Card, { name: PREFIX })(({ theme }) => ({
+const Root = styled('div', { name: PREFIX })(({ theme }) => ({
     flex: 1,
     padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
     [`& .${SimpleShowLayoutClasses.stack}`]: {},

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Children, isValidElement, ReactNode, ElementType } from 'react';
+import { Children, isValidElement, ReactNode } from 'react';
 import { styled } from '@mui/material/styles';
 import { Stack } from '@mui/material';
 import { ResponsiveStyleValue, SxProps } from '@mui/system';

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -53,21 +53,14 @@ import { FieldWithLabel } from './FieldWithLabel';
  * @param {Object} props.sx Custom style object.
  */
 export const SimpleShowLayout = (props: SimpleShowLayoutProps) => {
-    const {
-        className,
-        children,
-        component: Component = Root,
-        divider,
-        spacing = 1,
-        ...rest
-    } = props;
+    const { className, children, divider, spacing = 1, ...rest } = props;
     const record = useRecordContext(props);
     if (!record) {
         return null;
     }
     return (
         <OptionalRecordContextProvider value={props.record}>
-            <Component className={className} {...sanitizeRestProps(rest)}>
+            <Root className={className} {...sanitizeRestProps(rest)}>
                 <Stack
                     spacing={spacing}
                     divider={divider}
@@ -90,7 +83,7 @@ export const SimpleShowLayout = (props: SimpleShowLayoutProps) => {
                         ) : null
                     )}
                 </Stack>
-            </Component>
+            </Root>
         </OptionalRecordContextProvider>
     );
 };
@@ -98,7 +91,6 @@ export const SimpleShowLayout = (props: SimpleShowLayoutProps) => {
 export interface SimpleShowLayoutProps {
     children: ReactNode;
     className?: string;
-    component?: ElementType;
     divider?: ReactNode;
     record?: Record;
     spacing?: ResponsiveStyleValue<number | string>;
@@ -108,7 +100,6 @@ export interface SimpleShowLayoutProps {
 SimpleShowLayout.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    component: PropTypes.elementType,
     record: PropTypes.object,
     spacing: PropTypes.any,
     sx: PropTypes.any,
@@ -131,8 +122,6 @@ const Root = styled('div', { name: PREFIX })(({ theme }) => ({
 }));
 
 const sanitizeRestProps = ({
-    children,
-    className,
     record,
     resource,
     basePath,

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
@@ -79,7 +79,6 @@ export const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
     const {
         children,
         className,
-        component: Component = Root,
         spacing,
         divider,
         syncWithLocation = true,
@@ -116,7 +115,7 @@ export const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
 
     return (
         <OptionalRecordContextProvider value={props.record}>
-            <Component className={className} {...sanitizeRestProps(rest)}>
+            <Root className={className} {...sanitizeRestProps(rest)}>
                 {syncWithLocation ? (
                     <Routes>
                         <Route
@@ -173,7 +172,7 @@ export const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
                         </div>
                     </>
                 )}
-            </Component>
+            </Root>
         </OptionalRecordContextProvider>
     );
 };
@@ -181,7 +180,6 @@ export const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
 export interface TabbedShowLayoutProps {
     children: ReactNode;
     className?: string;
-    component?: ElementType;
     divider?: ReactNode;
     record?: Record;
     rootPath?: string;
@@ -195,7 +193,6 @@ export interface TabbedShowLayoutProps {
 TabbedShowLayout.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    component: PropTypes.elementType,
     record: PropTypes.object,
     spacing: PropTypes.any,
     sx: PropTypes.any,
@@ -220,8 +217,6 @@ const Root = styled('div', { name: PREFIX })(({ theme }) => ({
 }));
 
 const sanitizeRestProps = ({
-    children,
-    className,
     record,
     resource,
     basePath,

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
@@ -12,7 +12,7 @@ import {
 import PropTypes from 'prop-types';
 import { ResponsiveStyleValue, SxProps } from '@mui/system';
 import { styled } from '@mui/material/styles';
-import { Card, Divider } from '@mui/material';
+import { Divider } from '@mui/material';
 import { Outlet, Routes, Route } from 'react-router-dom';
 import {
     Record,
@@ -28,9 +28,9 @@ import {
 /**
  * Layout for a Show view showing fields grouped in tabs and laid out in a single column.
  *
- * It pulls the record from the RecordContext. It renders a material-ui `<Card>`
- * containing a set of `<Tabs>`, each of which contains a list of record fields
- * in a single-column layout (via material-ui's `<Stack>` component).
+ * It pulls the record from the RecordContext. It renders a set of `<Tabs>`,
+ * each of which contains a list of record fields in a single-column layout
+ * (via material-ui's `<Stack>` component).
  * `<TabbedShowLayout>` delegates the actual rendering of fields to its children,
  * which should be `<Tab>` components.
  * `<Tab>` wraps each field inside a <Labeled> component to add a label.
@@ -212,7 +212,7 @@ export const TabbedShowLayoutClasses = {
     content: `${PREFIX}-content`,
 };
 
-const Root = styled(Card, { name: PREFIX })(({ theme }) => ({
+const Root = styled('div', { name: PREFIX })(({ theme }) => ({
     flex: 1,
     [`& .${TabbedShowLayoutClasses.content}`]: {
         padding: `${theme.spacing(1)} ${theme.spacing(2)}`,

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -69,6 +69,7 @@ export interface CreateProps<RecordType extends RaRecord = RaRecord> {
 
 export interface ShowProps<RecordType extends RaRecord = RaRecord> {
     actions?: ReactElement | false;
+    aside?: ReactElement;
     children: ReactNode;
     className?: string;
     component?: ElementType;


### PR DESCRIPTION
I think we should revert the changes we made to detail views (Edit, Create and Show) in v4 to move the Card decoration to the content element (SimpleForm) instead of the container, and to remove the aside prop.

The reasoning behind the original change was to allow developers to put whatever they want as children of Show or List, letting them have 2-columns layouts without an extra prop. But in practice, it doesn't work, because the result of a view with several children looks bad because the actions (and pagination in the List view) still take the full width. 

![image](https://user-images.githubusercontent.com/99944/145213335-6ad4269e-a1b9-48fd-8bb6-c17614c6ccee.png)

partially reverts #6746
