### PR TITLE
[RFR] Allow "false" prop for SimpleList toolbar, removing element

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -60,7 +60,10 @@ SimpleForm.propTypes = {
     save: PropTypes.func,
     saving: PropTypes.bool,
     submitOnEnter: PropTypes.bool,
-    toolbar: PropTypes.element,
+    toolbar: PropTypes.oneOfType([
+        PropTypes.element,
+        false,
+    ]),
     undoable: PropTypes.bool,
     validate: PropTypes.func,
     version: PropTypes.number,
@@ -82,7 +85,7 @@ export interface SimpleFormProps
     mutationMode?: MutationMode;
     resource?: string;
     submitOnEnter?: boolean;
-    toolbar?: ReactElement;
+    toolbar?: ReactElement | false;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';

--- a/packages/ra-ui-materialui/src/form/SimpleFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormView.tsx
@@ -87,7 +87,10 @@ SimpleFormView.propTypes = {
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     saving: PropTypes.bool,
     submitOnEnter: PropTypes.bool,
-    toolbar: PropTypes.element,
+    toolbar: PropTypes.oneOfType([
+        PropTypes.element,
+        false,
+    ]),
     undoable: PropTypes.bool,
     validate: PropTypes.func,
 };
@@ -107,7 +110,7 @@ export interface SimpleFormViewProps extends FormWithRedirectRenderProps {
     mutationMode?: MutationMode;
     record?: Partial<Record>;
     resource?: string;
-    toolbar?: ReactElement;
+    toolbar?: ReactElement | false;
     /** @deprecated use mutationMode: undoable instead */
     undoable?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';


### PR DESCRIPTION
Because the toolbar in the SimpleFormView renders based on a logical AND operator, it is possible to remove that element by passing "false" to the toolbar prop on a SimpleForm component, for the purpose of using RA Input components wrapped in a custom form that doesn't require the traditional toolbar. 

However, passing false will throw a type error:

Type 'false' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'.ts(2322)
SimpleForm.d.ts(68, 5): The expected type comes from property 'toolbar' which is declared here on type 'IntrinsicAttributes & SimpleFormProps'

This PR alters the PropTypes and interface defined Types to allow for false as a value for "toolbar."

Thank you!