### PR TITLE
Make possible to use a SimpleList as a child of an ArrayField

### DIFF
--- a/packages/ra-ui-materialui/src/field/ArrayField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.spec.tsx
@@ -6,6 +6,7 @@ import ArrayField from './ArrayField';
 import NumberField from './NumberField';
 import TextField from './TextField';
 import Datagrid from '../list/datagrid/Datagrid';
+import SimpleList from '../list/SimpleList';
 
 describe('<ArrayField />', () => {
     const currentSort = { field: 'id', order: 'ASC' };
@@ -27,7 +28,27 @@ describe('<ArrayField />', () => {
         );
     });
 
-    it('should render the underlying iterator component', () => {
+    it('should render the alternative empty component', () => {
+        const { queryByText } = render(
+            <TestContext>
+                <ArrayField
+                    source="arr"
+                    resource="posts"
+                    record={{
+                        id: 123,
+                        arr: [],
+                    }}
+                >
+                    <Datagrid empty={<div>No posts</div>}>
+                        <NumberField source="id" />
+                    </Datagrid>
+                </ArrayField>
+            </TestContext>
+        );
+        expect(queryByText('No posts')).not.toBeNull();
+    });
+
+    it('should render the <Datagrid> iterator component', () => {
         const { queryByText } = render(
             <TestContext>
                 <ArrayField
@@ -58,7 +79,7 @@ describe('<ArrayField />', () => {
         expect(queryByText('456')).not.toBeNull();
     });
 
-    it('should render the alternative empty component', () => {
+    it('should render the <SimpleList> iterator component', () => {
         const { queryByText } = render(
             <TestContext>
                 <ArrayField
@@ -66,15 +87,25 @@ describe('<ArrayField />', () => {
                     resource="posts"
                     record={{
                         id: 123,
-                        arr: [],
+                        arr: [
+                            { id: 123, foo: 'bar' },
+                            { id: 456, foo: 'baz' },
+                        ],
                     }}
                 >
-                    <Datagrid empty={<div>No posts</div>}>
-                        <NumberField source="id" />
-                    </Datagrid>
+                    <SimpleList
+                        primaryText={record => record.foo}
+                        secondaryText={record => record.id}
+                    />
                 </ArrayField>
             </TestContext>
         );
-        expect(queryByText('No posts')).not.toBeNull();
+
+        // Test the fields values
+        expect(queryByText('bar')).not.toBeNull();
+        expect(queryByText('123')).not.toBeNull();
+
+        expect(queryByText('baz')).not.toBeNull();
+        expect(queryByText('456')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -165,7 +165,7 @@ export const ArrayField: FC<ArrayFieldProps> = memo(props => {
                 setPerPage: null,
                 setSort: null,
                 showFilter: null,
-                total: null,
+                total: ids.length,
             }}
         >
             {cloneElement(Children.only(children), {


### PR DESCRIPTION
## Description

The `<ArrayField>` builds a list context by passing null as total. The `SimpleList` expects a total > 0 to be rendered. Both are incompatible.

I studied two solutions:

1. Compute the total using ids (chosen)
2. Remove the total > 0 condition

To not introduce breaking changes, and because it's cleaner, I choose the first solution.

## Related Issue

Fixing https://github.com/marmelab/react-admin/issues/6974