### PR TITLE
Fix ReferenceInput: use id to add current value to possible sources

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -134,10 +134,12 @@ export const useReferenceInputController = (
         id: input.value,
         reference,
     });
-
     // add current value to possible sources
     let finalData: Record[], finalTotal: number;
-    if (!referenceRecord || possibleValuesData.includes(input.value)) {
+    if (
+        !referenceRecord ||
+        possibleValuesData.find(record => record.id === input.value)
+    ) {
         finalData = possibleValuesData;
         finalTotal = possibleValuesTotal;
     } else {


### PR DESCRIPTION
`input.value` should be compared with `record.id` instead of `record`.

Bug introduced in #6918.