### PR TITLE
Sanitize enableGetChoices from ReferenceInput child component

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -168,6 +168,7 @@ export interface ReferenceInputProps extends InputProps {
 
 const sanitizeRestProps = ({
     dataStatus = null,
+    enableGetChoices = null,
     filter = null,
     filterToQuery = null,
     onChange = null,


### PR DESCRIPTION
When using a SelectInput as a child of a ReferenceInput, and using the prop "enableGetChoices" to prevent an initial call for options, a type error will be thrown:

```jsx
Warning: React does not recognize the `enableGetChoices` prop on a DOM element.
```

This PR sanitizes enableGetChoices on ReferenceInput's extant rest props sanitize function.
