### PR TITLE
Sanitize emptyText, enableGetChoices @ SAI

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -332,6 +332,7 @@ const sanitizeRestProps = ({
     filterToQuery,
     formClassName,
     initializeForm,
+    initialValue,
     input,
     isRequired,
     label,

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -326,6 +326,8 @@ const sanitizeRestProps = ({
     crudGetOInputWithOptionsPropsne,
     defaultValue,
     disableValue,
+    emptyText,
+    enableGetChoices,
     filter,
     filterToQuery,
     formClassName,


### PR DESCRIPTION
When using a SelectArrayInput as a child of a ReferenceArrayInput, DOM errors will be thrown for the props "emptyText" and "enableGetChoices". This commit sanitizes those props before they are passed to the FormControl component, which triggers the DOM error.