### PR TITLE
[BC Break] Update useUpdateMany to use react-query

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -179,6 +179,7 @@ For queries:
 For mutations:
 
 ```diff
+// useUpdate
 -const [update, { loading }] = useUpdate(
 -   'posts',
 -   123,
@@ -195,6 +196,22 @@ For mutations:
 +   }
 +);
 +update(resource, { id, data, previousData }, options);
+
+// useUpdateMany
+-const [updateMany, { loading }] = useUpdateMany(
+-   'posts',
+-   [123, 456],
+-   { likes: 12 },
+-);
+-updateMany(resource, id, data, previousData, options);
++const [updateMany, { isLoading }] = useUpdateMany(
++   'posts',
++   {
++       ids: [123, 456],
++       data: { likes: 12 },
++   }
++);
++updateMany(resource, { ids, data }, options);
 ```
 
 This new signature should be easier to learn and use.
@@ -206,6 +223,7 @@ To upgrade, check every instance of your code of the following hooks:
 - `useGetMany`
 - `useGetManyReference`
 - `useUpdate`
+- `useUpdateMany`
 
 And update the calls. If you're using TypeScript, your code won't compile until you properly upgrade the calls. 
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -481,7 +481,7 @@ const IncreaseLikeButton = ({ record }) => {
 const [updateMany, { data, isFetching, isLoading, error }] = useUpdateMany(resource, { ids, data }, options);
 ```
 
-The `update()` method can be called with the same parameters as the hook:
+The `updateMany()` method can be called with the same parameters as the hook:
 
 ```jsx
 updateMany(resource, { ids, data }, options);

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -470,7 +470,7 @@ const IncreaseLikeButton = ({ record }) => {
     const diff = { likes: record.likes + 1 };
     const [update, { isLoading, error }] = useUpdate('likes', { id: record.id, data: diff, previousData: record });
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={isLoading} onClick={update}>Like</button>;
+    return <button disabled={isLoading} onClick={() => update()}>Like</button>;
 };
 ```
 
@@ -478,34 +478,35 @@ const IncreaseLikeButton = ({ record }) => {
 
 ```jsx
 // syntax
-const [updateMany, { data, loading, loaded, error }] = useUpdateMany(resource, ids, data, options);
+const [updateMany, { data, isFetching, isLoading, error }] = useUpdateMany(resource, { ids, data }, options);
 ```
 
-The `updateMany()` function can be called in 3 different ways:
- - with the same parameters as the `useUpdateMany()` hook: `update(resource, ids, data, options)`
- - with the same syntax as `useMutation`: `update({ resource, payload: { ids, data } }, options)`
- - with no parameter (if they were already passed to `useUpdateMany()`): `updateMany()`
+The `update()` method can be called with the same parameters as the hook:
+
+```jsx
+updateMany(resource, { ids, data }, options);
+```
 
 ```jsx
 // set params when calling the updateMany callback
 import { useUpdateMany } from 'react-admin';
 
 const BulkResetViewsButton = ({ selectedIds }) => {
-    const [updateMany, { loading, error }] = useUpdateMany();
+    const [updateMany, { isLoading, error }] = useUpdateMany();
     const handleClick = () => {
-        updateMany('posts', selectedIds, { views: 0 });
+        updateMany('posts', { ids: selectedIds, data: { views: 0 } });
     }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={handleClick}>Reset views</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Reset views</button>;
 };
 
 // set params when calling the hook
 import { useUpdateMany } from 'react-admin';
 
 const BulkResetViewsButton = ({ selectedIds }) => {
-    const [updateMany, { loading, error }] = useUpdateMany('posts', selectedIds, { views: 0 });
+    const [updateMany, { isLoading, error }] = useUpdateMany('posts', { ids: selectedIds, data: { views: 0 } });
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={updateMany}>Reset views</button>;
+    return <button disabled={isLoading} onClick={() => updateMany()}>Reset views</button>;
 };
 ```
 

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -224,25 +224,24 @@ const CustomResetViewsButton = () => {
     const refresh = useRefresh();
     const notify = useNotify();
     const unselectAll = useUnselectAll();
-    const [updateMany, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         'posts',
-        selectedIds,
-        { views: 0 },
+        { ids: selectedIds, data: { views: 0 } },
         {
             onSuccess: () => {
                 refresh();
                 notify('Posts updated');
                 unselectAll('posts');
             },
-            onFailure: error => notify('Error: posts not updated', { type: 'warning' }),
+            onError: error => notify('Error: posts not updated', { type: 'warning' }),
         }
     );
 
     return (
         <Button
             label="simple.action.resetViews"
-            disabled={loading}
-            onClick={updateMany}
+            disabled={isLoading}
+            onClick={() => updateMany}
         >
             <VisibilityOff />
         </Button>
@@ -262,8 +261,8 @@ import {
     Confirm,
     useListContext,
     useUpdateMany,
-    useRefresh,
     useNotify,
+    useRefresh,
     useUnselectAll,
 } from 'react-admin';
 
@@ -273,17 +272,16 @@ const CustomResetViewsButton = () => {
     const refresh = useRefresh();
     const notify = useNotify();
     const unselectAll = useUnselectAll();
-    const [updateMany, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         'posts',
-        selectedIds,
-        { views: 0 },
+        { ids: selectedIds, data: { views: 0 } },
         {
             onSuccess: () => {
                 refresh();
                 notify('Posts updated');
                 unselectAll('posts');
             },
-            onFailure: error => notify('Error: posts not updated', { type: 'warning' }),
+            onError: error => notify('Error: posts not updated', { type: 'warning' }),
         }
     );
     const handleClick = () => setOpen(true);
@@ -299,7 +297,7 @@ const CustomResetViewsButton = () => {
             <Button label="Reset Views" onClick={handleClick} />
             <Confirm
                 isOpen={open}
-                loading={loading}
+                loading={isLoading}
                 title="Update View Count"
                 content="Are you sure you want to reset the views for these items?"
                 onConfirm={handleConfirm}
@@ -325,10 +323,10 @@ export default CustomResetViewsButton;
 import * as React from "react";
 import {
     Button,
--    Confirm,
+-   Confirm,
     useListContext,
     useUpdateMany,
-    useRefresh,
+-   useRefresh,
     useNotify,
     useUnselectAll,
 } from 'react-admin';
@@ -336,21 +334,20 @@ import { VisibilityOff } from '@mui/icons-material';
 
 const CustomResetViewsButton = () => {
     const { selectedIds } = useListContext();
-    const refresh = useRefresh();
+-   const refresh = useRefresh();
     const notify = useNotify();
     const unselectAll = useUnselectAll();
-    const [updateMany, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         'posts',
-        selectedIds,
-        { views: 0 },
+        { ids: selectedIds, data: { views: 0 } },
         {
             onSuccess: () => {
-                refresh();
+-               refresh();
 -               notify('Posts updated');
 +               notify('Posts updated', { undoable: true }); // the last argument forces the display of 'undo' in the notification
                 unselectAll('posts');
             },
-            onFailure: error => notify('Error: posts not updated', { type: 'warning' }),
+            onError: error => notify('Error: posts not updated', { type: 'warning' }),
 +           mutationMode: 'undoable'
         }
     );
@@ -358,7 +355,7 @@ const CustomResetViewsButton = () => {
     return (
         <Button
             label="simple.action.resetViews"
-            disabled={loading}
+            disabled={isLoading}
             onClick={updateMany}
         >
             <VisibilityOff />

--- a/examples/demo/src/reviews/BulkAcceptButton.tsx
+++ b/examples/demo/src/reviews/BulkAcceptButton.tsx
@@ -8,7 +8,6 @@ import {
     useNotify,
     useRefresh,
     useUnselectAll,
-    CRUD_UPDATE_MANY,
     BulkActionProps,
     Identifier,
 } from 'react-admin';
@@ -21,12 +20,10 @@ const BulkAcceptButton = (props: BulkActionProps) => {
     const refresh = useRefresh();
     const unselectAll = useUnselectAll('reviews');
 
-    const [approve, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         'reviews',
-        selectedIds,
-        { status: 'accepted' },
+        { ids: selectedIds, data: { status: 'accepted' } },
         {
-            action: CRUD_UPDATE_MANY,
             mutationMode: 'undoable',
             onSuccess: () => {
                 notify('resources.reviews.notification.approved_success', {
@@ -36,7 +33,7 @@ const BulkAcceptButton = (props: BulkActionProps) => {
                 refresh();
                 unselectAll();
             },
-            onFailure: () => {
+            onError: () => {
                 notify('resources.reviews.notification.approved_error', {
                     type: 'warning',
                 });
@@ -47,8 +44,8 @@ const BulkAcceptButton = (props: BulkActionProps) => {
     return (
         <Button
             label="resources.reviews.action.accept"
-            onClick={approve}
-            disabled={loading}
+            onClick={() => updateMany()}
+            disabled={isLoading}
         >
             <ThumbUp />
         </Button>

--- a/examples/demo/src/reviews/BulkAcceptButton.tsx
+++ b/examples/demo/src/reviews/BulkAcceptButton.tsx
@@ -6,7 +6,6 @@ import {
     Button,
     useUpdateMany,
     useNotify,
-    useRefresh,
     useUnselectAll,
     BulkActionProps,
     Identifier,
@@ -17,7 +16,6 @@ const noSelection: Identifier[] = [];
 const BulkAcceptButton = (props: BulkActionProps) => {
     const { selectedIds = noSelection } = props;
     const notify = useNotify();
-    const refresh = useRefresh();
     const unselectAll = useUnselectAll('reviews');
 
     const [updateMany, { isLoading }] = useUpdateMany(
@@ -30,7 +28,6 @@ const BulkAcceptButton = (props: BulkActionProps) => {
                     type: 'info',
                     undoable: true,
                 });
-                refresh();
                 unselectAll();
             },
             onError: () => {

--- a/examples/demo/src/reviews/BulkRejectButton.tsx
+++ b/examples/demo/src/reviews/BulkRejectButton.tsx
@@ -6,7 +6,6 @@ import {
     Button,
     useUpdateMany,
     useNotify,
-    useRefresh,
     useUnselectAll,
     BulkActionProps,
     Identifier,
@@ -17,7 +16,6 @@ const noSelection: Identifier[] = [];
 const BulkRejectButton = (props: BulkActionProps) => {
     const { selectedIds = noSelection } = props;
     const notify = useNotify();
-    const refresh = useRefresh();
     const unselectAll = useUnselectAll('reviews');
 
     const [updateMany, { isLoading }] = useUpdateMany(
@@ -30,7 +28,6 @@ const BulkRejectButton = (props: BulkActionProps) => {
                     type: 'info',
                     undoable: true,
                 });
-                refresh();
                 unselectAll();
             },
             onError: () => {

--- a/examples/demo/src/reviews/BulkRejectButton.tsx
+++ b/examples/demo/src/reviews/BulkRejectButton.tsx
@@ -8,7 +8,6 @@ import {
     useNotify,
     useRefresh,
     useUnselectAll,
-    CRUD_UPDATE_MANY,
     BulkActionProps,
     Identifier,
 } from 'react-admin';
@@ -21,12 +20,10 @@ const BulkRejectButton = (props: BulkActionProps) => {
     const refresh = useRefresh();
     const unselectAll = useUnselectAll('reviews');
 
-    const [reject, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         'reviews',
-        selectedIds,
-        { status: 'rejected' },
+        { ids: selectedIds, data: { status: 'rejected' } },
         {
-            action: CRUD_UPDATE_MANY,
             mutationMode: 'undoable',
             onSuccess: () => {
                 notify('resources.reviews.notification.approved_success', {
@@ -36,7 +33,7 @@ const BulkRejectButton = (props: BulkActionProps) => {
                 refresh();
                 unselectAll();
             },
-            onFailure: () => {
+            onError: () => {
                 notify('resources.reviews.notification.approved_error', {
                     type: 'warning',
                 });
@@ -47,8 +44,8 @@ const BulkRejectButton = (props: BulkActionProps) => {
     return (
         <Button
             label="resources.reviews.action.reject"
-            onClick={reject}
-            disabled={loading}
+            onClick={() => updateMany()}
+            disabled={isLoading}
         >
             <ThumbDown />
         </Button>

--- a/examples/simple/src/posts/ResetViewsButton.tsx
+++ b/examples/simple/src/posts/ResetViewsButton.tsx
@@ -1,50 +1,39 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import {
-    useUpdateMany,
-    useNotify,
-    useUnselectAll,
-    Button,
-    CRUD_UPDATE_MANY,
-} from 'react-admin';
-import { useQueryClient } from 'react-query';
+import { useUpdateMany, useNotify, useUnselectAll, Button } from 'react-admin';
 
 const ResetViewsButton = ({ resource, selectedIds }) => {
     const notify = useNotify();
-    const queryClient = useQueryClient();
     const unselectAll = useUnselectAll();
-    const [updateMany, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         resource,
-        selectedIds,
-        { views: 0 },
+        { ids: selectedIds, data: { views: 0 } },
         {
-            action: CRUD_UPDATE_MANY,
             onSuccess: () => {
                 notify('ra.notification.updated', {
                     type: 'info',
                     messageArgs: { smart_count: selectedIds.length },
+                    undoable: true,
                 });
                 unselectAll(resource);
-                // FIXME: Remove when useUpdateMany is migrated to react-query
-                setTimeout(() => queryClient.refetchQueries(['posts']), 500);
             },
-            onFailure: error =>
+            onError: (error: Error | string) =>
                 notify(
                     typeof error === 'string'
                         ? error
                         : error.message || 'ra.notification.http_error',
                     { type: 'warning' }
                 ),
-            mutationMode: 'optimistic',
+            mutationMode: 'undoable',
         }
     );
 
     return (
         <Button
             label="simple.action.resetViews"
-            disabled={loading}
-            onClick={updateMany}
+            disabled={isLoading}
+            onClick={() => updateMany()}
         >
             <VisibilityOff />
         </Button>

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -9,7 +9,6 @@ import undoableEventEmitter from './undoableEventEmitter';
 import useDataProvider from './useDataProvider';
 import useMutation, { UseMutationValue } from './useMutation';
 import withDataProvider from './withDataProvider';
-import useUpdateMany from './useUpdateMany';
 import useCreate from './useCreate';
 import useDelete from './useDelete';
 import useDeleteMany from './useDeleteMany';
@@ -25,6 +24,7 @@ export * from './useGetManyReference';
 export * from './useQueryWithStore';
 export * from './useQuery';
 export * from './useUpdate';
+export * from './useUpdateMany';
 
 export type { Options } from './fetch';
 export type { QueryProps, UseMutationValue, MutationProps };
@@ -40,7 +40,6 @@ export {
     undoableEventEmitter,
     useDataProvider,
     useMutation,
-    useUpdateMany,
     useCreate,
     useDelete,
     useDeleteMany,

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -322,7 +322,9 @@ export const useUpdate = <RecordType extends Record = Record>(
         );
 
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
-        await snapshot.current.map(([key]) => queryClient.cancelQueries(key));
+        await Promise.all(
+            snapshot.current.map(([key]) => queryClient.cancelQueries(key))
+        );
 
         // Optimistically update to the new value
         updateCache({

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -83,7 +83,7 @@ export const useUpdate = <RecordType extends Record = Record>(
     const paramsRef = useRef<Partial<UpdateParams<RecordType>>>({});
     const rollbackData = useRef<RollbackData>([]);
 
-    const updateCache = async ({ resource, id, data }) => {
+    const updateCache = ({ resource, id, data }) => {
         // hack: only way to tell react-query not to fetch this query for the next 5 seconds
         // because setQueryData doesn't accept a stale time option
         const now = Date.now();
@@ -303,12 +303,12 @@ export const useUpdate = <RecordType extends Record = Record>(
         ].map(key => ({ key, value: queryClient.getQueryData(key) }));
 
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
-        await rollbackData.current.forEach(({ key }) =>
+        await rollbackData.current.map(({ key }) =>
             queryClient.cancelQueries(key)
         );
 
         // Optimistically update to the new value in getOne
-        await updateCache({
+        updateCache({
             resource: callTimeResource,
             id: callTimeId,
             data: callTimeData,

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -324,7 +324,7 @@ export const useUpdate = <RecordType extends Record = Record>(
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
         await snapshot.current.map(([key]) => queryClient.cancelQueries(key));
 
-        // Optimistically update to the new value in getOne
+        // Optimistically update to the new value
         updateCache({
             resource: callTimeResource,
             id: callTimeId,

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -183,7 +183,9 @@ export const useUpdate = <RecordType extends Record = Record>(
                 ) {
                     // If the mutation fails, use the context returned from onMutate to roll back
                     context.rollbackData.forEach(({ key, value }) => {
-                        queryClient.setQueryData(key, value);
+                        value.forEach(([queryKey, queryValue]) =>
+                            queryClient.setQueryData(queryKey, queryValue)
+                        );
                     });
                 }
 
@@ -300,7 +302,7 @@ export const useUpdate = <RecordType extends Record = Record>(
             [callTimeResource, 'getList'],
             [callTimeResource, 'getMany'],
             [callTimeResource, 'getManyReference'],
-        ].map(key => ({ key, value: queryClient.getQueryData(key) }));
+        ].map(key => ({ key, value: queryClient.getQueriesData(key) }));
 
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
         await rollbackData.current.map(({ key }) =>
@@ -350,7 +352,9 @@ export const useUpdate = <RecordType extends Record = Record>(
                 if (isUndo) {
                     // rollback
                     rollbackData.current.forEach(({ key, value }) => {
-                        queryClient.setQueryData(key, value);
+                        value.forEach(([queryKey, queryValue]) =>
+                            queryClient.setQueryData(queryKey, queryValue)
+                        );
                     });
                 } else {
                     // call the mutate without success side effects

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -356,7 +356,7 @@ export const useUpdate = <RecordType extends Record = Record>(
         }
 
         if (mode.current === 'optimistic') {
-            // call the mutate without success side effects
+            // call the mutate method without success side effects
             return mutation.mutate(
                 { resource: callTimeResource, ...callTimeParams },
                 { onSettled, onError }
@@ -370,7 +370,7 @@ export const useUpdate = <RecordType extends Record = Record>(
                         queryClient.setQueryData(key, value);
                     });
                 } else {
-                    // call the mutate without success side effects
+                    // call the mutate method without success side effects
                     mutation.mutate(
                         { resource: callTimeResource, ...callTimeParams },
                         { onSettled, onError }

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -167,9 +167,10 @@ export const useUpdate = <RecordType extends Record = Record>(
                         // @ts-ignore
                         ...userContext,
                     };
+                } else {
+                    // Return a context object with the snapshot value
+                    return { rollbackData: rollbackData.current };
                 }
-                // Return a context object with the snapshot value
-                return rollbackData.current;
             },
             onError: (
                 error: unknown,
@@ -295,32 +296,11 @@ export const useUpdate = <RecordType extends Record = Record>(
 
         // Snapshot the previous values
         rollbackData.current = [
-            {
-                key: [callTimeResource, 'getOne', String(callTimeId)],
-                value: previousRecord,
-            },
-            {
-                key: [callTimeResource, 'getList'],
-                value: queryClient.getQueriesData([
-                    callTimeResource,
-                    'getList',
-                ]),
-            },
-            {
-                key: [callTimeResource, 'getMany'],
-                value: queryClient.getQueriesData([
-                    callTimeResource,
-                    'getMany',
-                ]),
-            },
-            {
-                key: [callTimeResource, 'getManyReference'],
-                value: queryClient.getQueriesData([
-                    callTimeResource,
-                    'getManyReference',
-                ]),
-            },
-        ];
+            [callTimeResource, 'getOne', String(callTimeId)],
+            [callTimeResource, 'getList'],
+            [callTimeResource, 'getMany'],
+            [callTimeResource, 'getManyReference'],
+        ].map(key => ({ key, value: queryClient.getQueryData(key) }));
 
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
         await rollbackData.current.forEach(({ key }) =>
@@ -341,7 +321,7 @@ export const useUpdate = <RecordType extends Record = Record>(
                     onSuccess(
                         previousRecord,
                         { resource: callTimeResource, ...callTimeParams },
-                        rollbackData.current
+                        { rollbackData: rollbackData.current }
                     ),
                 0
             );
@@ -352,7 +332,7 @@ export const useUpdate = <RecordType extends Record = Record>(
                     reactMutationOptions.onSuccess(
                         previousRecord,
                         { resource: callTimeResource, ...callTimeParams },
-                        rollbackData.current
+                        { rollbackData: rollbackData.current }
                     ),
                 0
             );

--- a/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
@@ -1,112 +1,88 @@
 import * as React from 'react';
-import { renderWithRedux } from 'ra-test';
+import { render, waitFor } from '@testing-library/react';
 import expect from 'expect';
 
-import { DataProvider } from '../types';
-import DataProviderContext from './DataProviderContext';
-import useUpdateMany from './useUpdateMany';
+import { testDataProvider } from './testDataProvider';
+import { CoreAdminContext } from '../core';
+import { useUpdateMany } from './useUpdateMany';
 
 describe('useUpdateMany', () => {
-    it('returns a callback that can be used with update arguments', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('returns a callback that can be used with update arguments', async () => {
+        const dataProvider = testDataProvider({
             updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
-        let localUpdateMany;
-        const Dummy = () => {
-            const [updateMany] = useUpdateMany();
-            localUpdateMany = updateMany;
-            return <span />;
-        };
-
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
-                <Dummy />
-            </DataProviderContext.Provider>
-        );
-        localUpdateMany('foo', [1, 2], { bar: 'baz' });
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
-            data: { bar: 'baz' },
         });
-    });
-
-    it('returns a callback that can be used with mutation payload', () => {
-        const dataProvider: Partial<DataProvider> = {
-            updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
         let localUpdateMany;
         const Dummy = () => {
             const [updateMany] = useUpdateMany();
             localUpdateMany = updateMany;
             return <span />;
         };
-
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        localUpdateMany({
-            type: 'updateMany',
-            resource: 'foo',
-            payload: {
+        localUpdateMany('foo', { ids: [1, 2], data: { bar: 'baz' } });
+        await waitFor(() => {
+            expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
                 ids: [1, 2],
                 data: { bar: 'baz' },
-            },
-        });
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
-            data: { bar: 'baz' },
+            });
         });
     });
 
-    it('returns a callback that can be used with no arguments', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('returns a callback that can be used with no arguments', async () => {
+        const dataProvider = testDataProvider({
             updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
+        });
         let localUpdateMany;
         const Dummy = () => {
-            const [updateMany] = useUpdateMany('foo', [1, 2], { bar: 'baz' });
+            const [updateMany] = useUpdateMany('foo', {
+                ids: [1, 2],
+                data: { bar: 'baz' },
+            });
             localUpdateMany = updateMany;
             return <span />;
         };
-
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
         localUpdateMany();
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
-            data: { bar: 'baz' },
+        await waitFor(() => {
+            expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+                ids: [1, 2],
+                data: { bar: 'baz' },
+            });
         });
     });
 
-    it('merges hook call time and callback call time queries', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('uses callback call time params rather than hook call time params', async () => {
+        const dataProvider = testDataProvider({
             updateMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
+        });
         let localUpdateMany;
         const Dummy = () => {
-            const [updateMany] = useUpdateMany('foo', [1, 2], { bar: 'baz' });
+            const [updateMany] = useUpdateMany('foo', {
+                ids: [1, 2],
+                data: { bar: 'baz' },
+            });
             localUpdateMany = updateMany;
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        localUpdateMany({ payload: { data: { foo: 456 } } });
-        expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
-            data: { bar: 'baz', foo: 456 },
+        localUpdateMany('foo', { data: { foo: 456 } });
+        await waitFor(() => {
+            expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+                ids: [1, 2],
+                data: { foo: 456 },
+            });
         });
     });
 });

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -323,7 +323,9 @@ export const useUpdateMany = <RecordType extends Record = Record>(
         );
 
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
-        await snapshot.current.map(([key]) => queryClient.cancelQueries(key));
+        await Promise.all(
+            snapshot.current.map(([key]) => queryClient.cancelQueries(key))
+        );
 
         // Optimistically update to the new data
         await updateCache({

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -357,7 +357,7 @@ export const useUpdateMany = <RecordType extends Record = Record>(
         }
 
         if (mode.current === 'optimistic') {
-            // call the mutate without success side effects
+            // call the mutate method without success side effects
             return mutation.mutate(
                 { resource: callTimeResource, ...callTimeParams },
                 { onSettled, onError }
@@ -371,7 +371,7 @@ export const useUpdateMany = <RecordType extends Record = Record>(
                         queryClient.setQueryData(key, value);
                     });
                 } else {
-                    // call the mutate without success side effects
+                    // call the mutate method without success side effects
                     mutation.mutate(
                         { resource: callTimeResource, ...callTimeParams },
                         { onSettled, onError }

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -360,10 +360,7 @@ export const useUpdateMany = <RecordType extends Record = Record>(
             // call the mutate without success side effects
             return mutation.mutate(
                 { resource: callTimeResource, ...callTimeParams },
-                {
-                    onSettled,
-                    onError,
-                }
+                { onSettled, onError }
             );
         } else {
             // undoable mutation: register the mutation for later
@@ -377,10 +374,7 @@ export const useUpdateMany = <RecordType extends Record = Record>(
                     // call the mutate without success side effects
                     mutation.mutate(
                         { resource: callTimeResource, ...callTimeParams },
-                        {
-                            onSettled,
-                            onError,
-                        }
+                        { onSettled, onError }
                     );
                 }
             });

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -1,41 +1,59 @@
-import { useCallback } from 'react';
-import { Record } from '../types';
-import useMutation, { MutationOptions, Mutation } from './useMutation';
+import { useRef } from 'react';
+import {
+    useMutation,
+    useQueryClient,
+    UseMutationOptions,
+    UseMutationResult,
+    MutateOptions,
+    QueryKey,
+} from 'react-query';
+
+import useDataProvider from './useDataProvider';
+import undoableEventEmitter from './undoableEventEmitter';
+import { Record, UpdateManyParams, MutationMode } from '../types';
+import { Identifier } from '..';
 
 /**
- * Get a callback to call the dataProvider.updateMany() method, the result
- * of the call (the list of updated record ids), and the loading state.
+ * Get a callback to call the dataProvider.updateMany() method, the result and the loading state.
+ *
+ * @param {string} resource
+ * @param {Params} params The updateMany parameters { ids, data, previousData }
+ * @param {Object} options Options object to pass to the queryClient.
+ * May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
+ *
+ * @typedef Params
+ * @prop params.ids The resource identifiers, e.g. [123, 456]
+ * @prop params.data The updates to merge into the record, e.g. { views: 10 }
+ * @prop params.previousData The record before the update is applied
+ *
+ * @returns The current mutation state. Destructure as [updateMany, { data, error, isLoading }].
  *
  * The return value updates according to the request state:
  *
- * - initial: [updateMany, { loading: false, loaded: false }]
- * - start:   [updateMany, { loading: true, loaded: false }]
- * - success: [updateMany, { data: [data from response], loading: false, loaded: true }]
- * - error:   [updateMany, { error: [error from response], loading: false, loaded: false }]
+ * - initial: [updateMany, { isLoading: false, isIdle: true }]
+ * - start:   [updateMany, { isLoading: true }]
+ * - success: [updateMany, { data: [data from response], isLoading: false, isSuccess: true }]
+ * - error:   [updateMany, { error: [error from response], isLoading: false, isError: true }]
  *
- * @param resource The resource name, e.g. 'posts'
- * @param ids The resource identifiers, e.g. [123, 456]
- * @param data The updates to merge into all records, e.g. { views: 10 }
- * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * The updateMany() function must be called with a resource and a parameter object: updateMany(resource, { ids, data, previousData }, options)
  *
- * @returns The current request state. Destructure as [updateMany, { data, error, loading, loaded }].
+ * This hook uses react-query useMutation under the hood.
+ * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * The updateMany() function can be called in 3 different ways:
- *  - with the same parameters as the useUpdateMany() hook: update(resource, ids, data, options)
- *  - with the same syntax as useMutation: update({ resource, payload: { ids, data } }, options)
- *  - with no parameter (if they were already passed to useUpdateMany()): updateMany()
+ * @see https://react-query.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the updateMany callback
  *
  * import { useUpdateMany } from 'react-admin';
  *
  * const BulkResetViewsButton = ({ selectedIds }) => {
- *     const [updateMany, { loading, error }] = useUpdateMany();
+ *     const [updateMany, { isLoading, error }] = useUpdateMany();
  *     const handleClick = () => {
- *         updateMany('posts', selectedIds, { views: 0 });
+ *         updateMany('posts', { ids: selectedIds, data: { views: 0 } });
  *     }
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={handleClick}>Reset views</button>;
+ *     return <button disabled={isLoading} onClick={handleClick}>Reset views</button>;
  * };
  *
  * @example // set params when calling the hook
@@ -43,66 +61,367 @@ import useMutation, { MutationOptions, Mutation } from './useMutation';
  * import { useUpdateMany } from 'react-admin';
  *
  * const BulkResetViewsButton = ({ selectedIds }) => {
- *     const [updateMany, { loading, error }] = useUpdateMany('posts', selectedIds, { views: 0 });
+ *     const [updateMany, { isLoading, error }] = useUpdateMany('posts', { ids: selectedIds, data: { views: 0 } });
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={updateMany}>Reset views</button>;
+ *     return <button disabled={isLoading} onClick={updateMany}>Reset views</button>;
  * };
  */
-const useUpdateMany = <RecordType extends Record = Record>(
+export const useUpdateMany = <RecordType extends Record = Record>(
     resource?: string,
-    ids?: RecordType['id'][],
-    data?: Partial<RecordType>,
-    options?: MutationOptions
-): UseUpdateManyHookValue<RecordType> => {
-    const [mutate, state] = useMutation(
-        { type: 'updateMany', resource, payload: { ids, data } },
-        options
+    params: Partial<UpdateManyParams<Partial<RecordType>>> = {},
+    options: UseUpdateManyOptions<RecordType> = {}
+): UseUpdateManyResult<RecordType> => {
+    const dataProvider = useDataProvider();
+    const queryClient = useQueryClient();
+    const { ids, data } = params;
+    const { mutationMode = 'pessimistic', ...reactMutationOptions } = options;
+    const mode = useRef<MutationMode>(mutationMode);
+    const paramsRef = useRef<Partial<UpdateManyParams<Partial<RecordType>>>>(
+        {}
     );
+    const snapshot = useRef<Snapshot>([]);
 
-    const updateMany = useCallback(
-        (
-            resource?: string | Partial<Mutation> | Event,
-            ids?: RecordType['id'][] | Partial<MutationOptions>,
-            data?: Partial<RecordType>,
-            options?: MutationOptions
-        ) => {
-            if (typeof resource === 'string') {
-                const query = {
-                    type: 'updateMany',
-                    resource,
-                    payload: {
-                        ids: ids as RecordType['id'][],
+    const updateCache = async ({
+        resource,
+        ids,
+        data,
+    }: {
+        resource: string;
+        ids: Identifier[];
+        data: any;
+    }) => {
+        // hack: only way to tell react-query not to fetch this query for the next 5 seconds
+        // because setQueryData doesn't accept a stale time option
+        const updatedAt =
+            mode.current === 'undoable' ? Date.now() + 1000 * 5 : Date.now();
+
+        const updateColl = (old: RecordType[]) => {
+            if (!old) return;
+            let newCollection = [...old];
+            ids.forEach(id => {
+                // eslint-disable-next-line eqeqeq
+                const index = old.findIndex(record => record.id == id);
+                if (index === -1) {
+                    return;
+                }
+                newCollection = [
+                    ...newCollection.slice(0, index),
+                    { ...newCollection[index], ...data },
+                    ...newCollection.slice(index + 1),
+                ];
+            });
+            return newCollection;
+        };
+
+        type GetListResult = { data?: RecordType[]; total?: number };
+
+        ids.forEach(id =>
+            queryClient.setQueryData(
+                [resource, 'getOne', String(id)],
+                (record: RecordType) => ({ ...record, ...data }),
+                { updatedAt }
+            )
+        );
+        queryClient.setQueriesData(
+            [resource, 'getList'],
+            (res: GetListResult) =>
+                res && res.data
+                    ? { data: updateColl(res.data), total: res.total }
+                    : res,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            [resource, 'getMany'],
+            (coll: RecordType[]) =>
+                coll && coll.length > 0 ? updateColl(coll) : coll,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            [resource, 'getManyReference'],
+            (res: GetListResult) =>
+                res && res.data
+                    ? { data: updateColl(res.data), total: res.total }
+                    : res,
+            { updatedAt }
+        );
+    };
+
+    const mutation = useMutation<
+        Array<RecordType['id']>,
+        unknown,
+        Partial<UseUpdateManyMutateParams<RecordType>>
+    >(
+        ({
+            resource: callTimeResource = resource,
+            ids: callTimeIds = paramsRef.current.ids,
+            data: callTimeData = paramsRef.current.data,
+        } = {}) =>
+            dataProvider
+                .updateMany(callTimeResource, {
+                    ids: callTimeIds,
+                    data: callTimeData,
+                })
+                .then(({ data }) => data),
+        {
+            ...reactMutationOptions,
+            onMutate: async (
+                variables: Partial<UseUpdateManyMutateParams<RecordType>>
+            ) => {
+                if (reactMutationOptions.onMutate) {
+                    const userContext =
+                        (await reactMutationOptions.onMutate(variables)) || {};
+                    return {
+                        snapshot: snapshot.current,
+                        // @ts-ignore
+                        ...userContext,
+                    };
+                } else {
+                    // Return a context object with the snapshot value
+                    return { snapshot: snapshot.current };
+                }
+            },
+            onError: (
+                error: unknown,
+                variables: Partial<UseUpdateManyMutateParams<RecordType>> = {},
+                context: { snapshot: Snapshot }
+            ) => {
+                if (
+                    mode.current === 'optimistic' ||
+                    mode.current === 'undoable'
+                ) {
+                    // If the mutation fails, use the context returned from onMutate to rollback
+                    context.snapshot.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                }
+
+                if (reactMutationOptions.onError) {
+                    return reactMutationOptions.onError(
+                        error,
+                        variables,
+                        context
+                    );
+                }
+                // call-time error callback is executed by react-query
+            },
+            onSuccess: (
+                data: Array<RecordType['id']>,
+                variables: Partial<UseUpdateManyMutateParams<RecordType>> = {},
+                context: unknown
+            ) => {
+                if (mode.current === 'pessimistic') {
+                    // update the getOne and getList query cache with the new result
+                    const {
+                        resource: callTimeResource = resource,
+                        ids: callTimeIds = ids,
+                    } = variables;
+                    updateCache({
+                        resource: callTimeResource,
+                        ids: callTimeIds,
                         data,
-                    },
-                };
-                return mutate(query, options);
-            } else {
-                return mutate(
-                    resource as Mutation | Event,
-                    ids as MutationOptions
-                );
-            }
-        },
-        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+                    });
+
+                    if (reactMutationOptions.onSuccess) {
+                        reactMutationOptions.onSuccess(
+                            data,
+                            variables,
+                            context
+                        );
+                    }
+                    // call-time success callback is executed by react-query
+                }
+            },
+            onSettled: (
+                data: Array<RecordType['id']>,
+                error: unknown,
+                variables: Partial<UseUpdateManyMutateParams<RecordType>> = {},
+                context: { snapshot: Snapshot }
+            ) => {
+                if (
+                    mode.current === 'optimistic' ||
+                    mode.current === 'undoable'
+                ) {
+                    // Always refetch after error or success:
+                    context.snapshot.forEach(([key]) => {
+                        queryClient.invalidateQueries(key);
+                    });
+                }
+
+                if (reactMutationOptions.onSettled) {
+                    return reactMutationOptions.onSettled(
+                        data,
+                        error,
+                        variables,
+                        context
+                    );
+                }
+            },
+        }
     );
 
-    return [updateMany, state];
+    const updateMany = async (
+        callTimeResource: string = resource,
+        callTimeParams: Partial<UpdateManyParams<RecordType>> = {},
+        updateOptions: MutateOptions<
+            Array<RecordType['id']>,
+            unknown,
+            Partial<UseUpdateManyMutateParams<RecordType>>,
+            unknown
+        > & { mutationMode?: MutationMode } = {}
+    ) => {
+        const { mutationMode, onSuccess, onSettled, onError } = updateOptions;
+
+        // store the hook time params *at the moment of the call*
+        // because they may change afterwards, which would break the undoable mode
+        // as the previousData would be overwritten by the optimistic update
+        paramsRef.current = params;
+
+        if (mutationMode) {
+            mode.current = mutationMode;
+        }
+
+        if (mode.current === 'pessimistic') {
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                { onSuccess, onSettled, onError }
+            );
+        }
+
+        const {
+            ids: callTimeIds = ids,
+            data: callTimeData = data,
+        } = callTimeParams;
+
+        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // except we do it in a mutate wrapper instead of the onMutate callback
+        // to have access to success side effects
+
+        const queryKeys = [
+            [callTimeResource, 'getOne'],
+            [callTimeResource, 'getList'],
+            [callTimeResource, 'getMany'],
+            [callTimeResource, 'getManyReference'],
+        ];
+
+        /**
+         * Snapshot the previous values via queryClient.getQueriesData()
+         *
+         * The snapshotData ref will contain an array of tuples [query key, associated data]
+         *
+         * @example
+         * [
+         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
+         *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+         *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+         * ]
+         *
+         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         */
+        snapshot.current = queryKeys.reduce(
+            (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),
+            [] as Snapshot
+        );
+
+        // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
+        await snapshot.current.map(([key]) => queryClient.cancelQueries(key));
+
+        // Optimistically update to the new data
+        await updateCache({
+            resource: callTimeResource,
+            ids: callTimeIds,
+            data: callTimeData,
+        });
+
+        // run the success callbacks during the next tick
+        if (onSuccess) {
+            setTimeout(
+                () =>
+                    onSuccess(
+                        callTimeIds,
+                        { resource: callTimeResource, ...callTimeParams },
+                        { snapshot: snapshot.current }
+                    ),
+                0
+            );
+        }
+        if (reactMutationOptions.onSuccess) {
+            setTimeout(
+                () =>
+                    reactMutationOptions.onSuccess(
+                        callTimeIds,
+                        { resource: callTimeResource, ...callTimeParams },
+                        { snapshot: snapshot.current }
+                    ),
+                0
+            );
+        }
+
+        if (mode.current === 'optimistic') {
+            // call the mutate without success side effects
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                {
+                    onSettled,
+                    onError,
+                }
+            );
+        } else {
+            // undoable mutation: register the mutation for later
+            undoableEventEmitter.once('end', ({ isUndo }) => {
+                if (isUndo) {
+                    // rollback
+                    snapshot.current.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                } else {
+                    // call the mutate without success side effects
+                    mutation.mutate(
+                        { resource: callTimeResource, ...callTimeParams },
+                        {
+                            onSettled,
+                            onError,
+                        }
+                    );
+                }
+            });
+        }
+    };
+
+    return [updateMany, mutation];
 };
 
-type UseUpdateManyHookValue<RecordType extends Record = Record> = [
-    (
-        resource?: string | Partial<Mutation> | Event,
-        ids?: RecordType['id'][] | Partial<MutationOptions>,
-        data?: Partial<RecordType>,
-        options?: MutationOptions
-    ) => void | Promise<any>,
-    {
-        data?: RecordType['id'][];
-        total?: number;
-        error?: any;
-        loading: boolean;
-        loaded: boolean;
-    }
-];
+type Snapshot = [key: QueryKey, value: any][];
 
-export default useUpdateMany;
+export interface UseUpdateManyMutateParams<RecordType extends Record = Record> {
+    resource?: string;
+    ids?: Array<RecordType['id']>;
+    data?: Partial<RecordType>;
+    previousData?: any;
+}
+
+export type UseUpdateManyOptions<
+    RecordType extends Record = Record
+> = UseMutationOptions<
+    Array<RecordType['id']>,
+    unknown,
+    Partial<UseUpdateManyMutateParams<RecordType>>
+> & { mutationMode?: MutationMode };
+
+export type UseUpdateManyResult<RecordType extends Record = Record> = [
+    (
+        resource?: string,
+        params?: Partial<UpdateManyParams<RecordType>>,
+        options?: MutateOptions<
+            Array<RecordType['id']>,
+            unknown,
+            Partial<UseUpdateManyMutateParams<RecordType>>,
+            unknown
+        > & { mutationMode?: MutationMode }
+    ) => Promise<void>,
+    UseMutationResult<
+        Array<RecordType['id']>,
+        unknown,
+        Partial<UpdateManyParams<Partial<RecordType>> & { resource?: string }>,
+        unknown
+    >
+];

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -11,7 +11,6 @@ import {
     useRefresh,
     useNotify,
     useUnselectAll,
-    CRUD_UPDATE_MANY,
     useResourceContext,
     MutationMode,
 } from 'ra-core';
@@ -48,7 +47,7 @@ export const BulkUpdateWithConfirmButton = (
             });
             unselectAll(resource);
         },
-        onFailure = error => {
+        onError = (error: Error | string) => {
             notify(
                 typeof error === 'string'
                     ? error
@@ -70,14 +69,12 @@ export const BulkUpdateWithConfirmButton = (
         ...rest
     } = props;
 
-    const [updateMany, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         resource,
-        selectedIds,
-        data,
+        { ids: selectedIds, data },
         {
-            action: CRUD_UPDATE_MANY,
             onSuccess,
-            onFailure,
+            onError,
             mutationMode,
         }
     );
@@ -111,7 +108,7 @@ export const BulkUpdateWithConfirmButton = (
             </StyledButton>
             <Confirm
                 isOpen={isOpen}
-                loading={loading}
+                loading={isLoading}
                 title={confirmTitle}
                 content={confirmContent}
                 translateOptions={{

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -9,7 +9,6 @@ import {
     useRefresh,
     useNotify,
     useUnselectAll,
-    CRUD_UPDATE_MANY,
     useResourceContext,
     useListContext,
 } from 'ra-core';
@@ -43,7 +42,7 @@ export const BulkUpdateWithUndoButton = (
             unselectAll(resource);
             refresh();
         },
-        onFailure = error => {
+        onError = (error: Error | string) => {
             notify(
                 typeof error === 'string'
                     ? error
@@ -65,14 +64,12 @@ export const BulkUpdateWithUndoButton = (
         ...rest
     } = props;
 
-    const [updateMany, { loading }] = useUpdateMany(
+    const [updateMany, { isLoading }] = useUpdateMany(
         resource,
-        selectedIds,
-        data,
+        { ids: selectedIds, data },
         {
-            action: CRUD_UPDATE_MANY,
             onSuccess,
-            onFailure,
+            onError,
             mutationMode: 'undoable',
         }
     );
@@ -89,7 +86,7 @@ export const BulkUpdateWithUndoButton = (
             onClick={handleClick}
             label={label}
             className={BulkUpdateWithUndoButtonClasses.updateButton}
-            disabled={loading}
+            disabled={isLoading}
             {...sanitizeRestProps(rest)}
         >
             {icon}

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -285,7 +285,7 @@ describe('<Edit />', () => {
                         title: 'ipsum',
                     },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    { rollbackData: [] }
+                    { snapshot: [] }
                 );
             });
         });
@@ -338,7 +338,7 @@ describe('<Edit />', () => {
                         title: 'ipsum',
                     },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    { rollbackData: [] }
+                    { snapshot: [] }
                 );
                 expect(onSuccess).not.toHaveBeenCalled();
             });
@@ -385,7 +385,7 @@ describe('<Edit />', () => {
                 expect(onError).toHaveBeenCalledWith(
                     { message: 'not good' },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    { rollbackData: [] }
+                    { snapshot: [] }
                 );
             });
         });
@@ -438,7 +438,7 @@ describe('<Edit />', () => {
                         message: 'not good',
                     },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    { rollbackData: [] }
+                    { snapshot: [] }
                 );
                 expect(onError).not.toHaveBeenCalled();
             });

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -285,7 +285,7 @@ describe('<Edit />', () => {
                         title: 'ipsum',
                     },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    {}
+                    { rollbackData: [] }
                 );
             });
         });
@@ -338,14 +338,14 @@ describe('<Edit />', () => {
                         title: 'ipsum',
                     },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    {}
+                    { rollbackData: [] }
                 );
                 expect(onSuccess).not.toHaveBeenCalled();
             });
         });
     });
 
-    describe('onFailure prop', () => {
+    describe('onError prop', () => {
         it('should allow to override the default error side effects', async () => {
             jest.spyOn(console, 'error').mockImplementationOnce(() => {});
             const dataProvider = {
@@ -385,7 +385,7 @@ describe('<Edit />', () => {
                 expect(onError).toHaveBeenCalledWith(
                     { message: 'not good' },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    {}
+                    { rollbackData: [] }
                 );
             });
         });
@@ -438,7 +438,7 @@ describe('<Edit />', () => {
                         message: 'not good',
                     },
                     { data: { id: 123, title: 'ipsum' }, resource: 'foo' },
-                    {}
+                    { rollbackData: [] }
                 );
                 expect(onError).not.toHaveBeenCalled();
             });


### PR DESCRIPTION
- [x] Refactor `useUpdate` for better readability and portability
- [x] Update `useUpdateMany` to use react-query
- [x] Fix tests, docs and examples
- [x] Add upgrade instructions

```diff
-const [updateMany, { loading }] = useUpdateMany(
-   'posts',
-   [123, 456],
-   { likes: 12 },
-);
-updateMany(resource, id, data, previousData, options);
+const [updateMany, { isLoading }] = useUpdateMany(
+   'posts',
+   {
+       ids: [123, 456],
+       data: { likes: 12 },
+   }
+);
+updateMany(resource, { ids, data }, options);
```