### PR TITLE
[BC Break] Migrate useCreate to react-query

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -179,6 +179,18 @@ For queries:
 For mutations:
 
 ```diff
+// useCreate
+-const [create, { loading }] = useCreate(
+-   'posts',
+-   { title: 'hello, world!' },
+-);
+-create(resource, data, options);
++const [create, { isLoading }] = useCreate(
++   'posts',
++   { data: { title: 'hello, world!' } }
++);
++create(resource, { data }, options);
+
 // useUpdate
 -const [update, { loading }] = useUpdate(
 -   'posts',
@@ -222,6 +234,7 @@ To upgrade, check every instance of your code of the following hooks:
 - `useGetList`
 - `useGetMany`
 - `useGetManyReference`
+- `useCreate`
 - `useUpdate`
 - `useUpdateMany`
 
@@ -319,12 +332,42 @@ const PostEdit = () => {
 };
 ```
 
+Here is how to customize side effects on the `create` mutation in `<Create>`:
+
+```diff
+const PostCreate = () => {
+    const onSuccess = () => {
+        // do something
+    };
+    const onFailure = () => {
+        // do something
+    };
+    return (
+        <Create 
+-           onSuccess={onSuccess}
+-           onFailure={onFailure}
++           mutationOptions={{
++               onSuccess: onSuccess,
++               onError: onFailure
++           }}
+        >
+            <SimpleForm>
+                <TextInput source="title" />
+            </SimpleForm>
+        </Create>
+    );
+};
+```
+
 Note that the `onFailure` prop was renamed to `onError` in the options, to match the react-query convention.
 
 **Tip**: `<Edit>` also has a `queryOption` prop allowing you to specify custom success and error side effects for the `getOne` query.
 
 The change concerns the following components:
 
+- `useCreateController`
+- `<Create>`
+- `<CreateBase>`
 - `useEditController`
 - `<Edit>`
 - `<EditBase>`
@@ -355,6 +398,10 @@ const handleClick = () => {
 
 The change concerns the following components:
 
+- `useCreate`
+- `useCreateController`
+- `<Create>`
+- `<CreateBase>`
 - `useUpdate`
 - `useEditController`
 - `<Edit>`

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -401,13 +401,15 @@ const PostComments = ({ record }) => {
 
 ```jsx
 // syntax
-const [create, { data, loading, loaded, error }] = useCreate(resource, data, options);
+const [create, { data, isFetching, isLoading, error }] = useCreate(resource, { data }, options);
 ```
 
-The `create()` function can be called in 3 different ways:
- - with the same parameters as the `useCreate()` hook: `create(resource, data, options)`
- - with the same syntax as `useMutation`: `create({ resource, payload: { data } }, options)`
- - with no parameter (if they were already passed to `useCreate()`): `create()`
+The `create()` method can be called with the same parameters as the hook:
+
+```jsx
+create(resource, { data }, options);
+```
+
 
 ```jsx
 // set params when calling the update callback
@@ -415,12 +417,12 @@ import { useCreate } from 'react-admin';
 
 const LikeButton = ({ record }) => {
     const like = { postId: record.id };
-    const [create, { loading, error }] = useCreate();
+    const [create, { isLoading, error }] = useCreate();
     const handleClick = () => {
-        create('likes', like)
+        create('likes', { data: like })
     }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={handleClick}>Like</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Like</button>;
 };
 
 // set params when calling the hook
@@ -428,9 +430,9 @@ import { useCreate } from 'react-admin';
 
 const LikeButton = ({ record }) => {
     const like = { postId: record.id };
-    const [create, { loading, error }] = useCreate('likes', like);
+    const [create, { isLoading, error }] = useCreate('likes', { data: like });
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={() => create()}>Like</button>;
+    return <button disabled={isLoading} onClick={() => create()}>Like</button>;
 };
 ```
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -100,8 +100,7 @@ You can customize the `<Create>` and `<Edit>` components using the following pro
 * [`component`](#component)
 * [`undoable`](#undoable) (`<Edit>` only) (deprecated)
 * [`mutationMode`](#mutationmode) (`<Edit>` only) 
-* [`onSuccess`](#onsuccess)
-* [`onFailure`](#onfailure)
+* [`mutationOptions](#mutationoptions)
 * [`transform`](#transform)
 * [`successMessage`](#success-message) (deprecated - use `onSuccess` instead)
 
@@ -387,9 +386,11 @@ const PostEdit = () => (
 );
 ```
 
-### `onSuccess`
+### `mutationOptions`
 
-By default, when the save action succeeds, react-admin shows a notification, and redirects to another page. You can override this behavior and pass custom side effects by providing a function as `onSuccess` prop:
+You can customize the options you pass to react-query's `useMutation` hook, e.g. to override succes or error side effects, by setting the `mutationOptions` prop.
+
+Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to another page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
 
 ```jsx
 import * as React from 'react';
@@ -407,7 +408,7 @@ const PostEdit = () => {
     };
 
     return (
-        <Edit onSuccess={onSuccess}>
+        <Edit mutationProps={{ onSuccess }}>
             <SimpleForm>
                 ...
             </SimpleForm>
@@ -457,7 +458,7 @@ const PostEdit = () => {
     };
 
     return (
-        <Edit onSuccess={onSuccess} mutationMode="pessimistic">
+        <Edit mutationProps={{ onSuccess }} mutationMode="pessimistic">
             <SimpleForm>
                 ...
             </SimpleForm>
@@ -470,11 +471,7 @@ const PostEdit = () => {
 
 **Tip**: If you want to have different success side effects based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save and redirect to the list", and another to "save and display an empty form"), you can set the `onSuccess` prop on the `<SaveButton>` component, too.
 
-### `onFailure`
-
-By default, when the save action fails at the dataProvider level, react-admin shows an error notification. On an Edit page with `mutationMode` set to `undoable` or `optimistic`, it refreshes the page, too.
-
-You can override this behavior and pass custom side effects by providing a function as `onFailure` prop:
+Similarly, you can override the failure side effects with an `onError` otion. By default, when the save action fails at the dataProvider level, react-admin shows an error notification. On an Edit page with `mutationMode` set to `undoable` or `optimistic`, it refreshes the page, too.
 
 ```jsx
 import * as React from 'react';
@@ -485,14 +482,14 @@ const PostEdit = () => {
     const refresh = useRefresh();
     const redirect = useRedirect();
 
-    const onFailure = (error) => {
+    const onError = (error) => {
         notify(`Could not edit post: ${error.message}`);
         redirect('/posts');
         refresh();
     };
 
     return (
-        <Edit onFailure={onFailure}>
+        <Edit mutationProps={{ onError }}>
             <SimpleForm>
                 ...
             </SimpleForm>
@@ -501,9 +498,9 @@ const PostEdit = () => {
 }
 ```
 
-The `onFailure` function receives the error from the dataProvider call (`dataProvider.create()` or `dataProvider.update()`), which is a JavaScript Error object (see [the dataProvider documentation for details](./DataProviders.md#error-format)).
+The `onError` function receives the error from the dataProvider call (`dataProvider.create()` or `dataProvider.update()`), which is a JavaScript Error object (see [the dataProvider documentation for details](./DataProviders.md#error-format)).
 
-The default `onFailure` function is:
+The default `onError` function is:
 
 ```jsx
 // for the <Create> component:

--- a/examples/crm/src/contacts/TagsListEdit.tsx
+++ b/examples/crm/src/contacts/TagsListEdit.tsx
@@ -24,7 +24,7 @@ import ControlPointIcon from '@mui/icons-material/ControlPoint';
 import EditIcon from '@mui/icons-material/Edit';
 
 import { colors } from '../tags/colors';
-import { Contact } from '../types';
+import { Contact, Tag } from '../types';
 
 export const TagsListEdit = ({ record }: { record: Contact }) => {
     const [open, setOpen] = useState(false);
@@ -33,22 +33,21 @@ export const TagsListEdit = ({ record }: { record: Contact }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [disabled, setDisabled] = useState(false);
 
-    const { data: allTags, refetch, isLoading: isLoadingAllTags } = useGetList(
-        'tags',
-        {
-            pagination: { page: 1, perPage: 10 },
-            sort: { field: 'name', order: 'ASC' },
-        }
-    );
-    const { data: tags, isLoading: isLoadingRecordTags } = useGetMany(
+    const { data: allTags, refetch, isLoading: isLoadingAllTags } = useGetList<
+        Tag
+    >('tags', {
+        pagination: { page: 1, perPage: 10 },
+        sort: { field: 'name', order: 'ASC' },
+    });
+    const { data: tags, isLoading: isLoadingRecordTags } = useGetMany<Tag>(
         'tags',
         { ids: record.tags },
         {
             enabled: record.tags && record.tags.length > 0,
         }
     );
-    const [update] = useUpdate();
-    const [create] = useCreate();
+    const [update] = useUpdate<Contact>();
+    const [create] = useCreate<Tag>();
 
     const unselectedTags =
         allTags && allTags.filter(tag => !record.tags.includes(tag.id));
@@ -99,14 +98,14 @@ export const TagsListEdit = ({ record }: { record: Contact }) => {
         setDisabled(true);
         create(
             'tags',
-            { name: newTagName, color: newTagColor },
+            { data: { name: newTagName, color: newTagColor } },
             {
-                onSuccess: ({ data }) => {
+                onSuccess: tag => {
                     update(
                         'contacts',
                         {
                             id: record.id,
-                            data: { tags: [...record.tags, data.id] },
+                            data: { tags: [...record.tags, tag.id] },
                             previousData: record,
                         },
                         {

--- a/examples/crm/src/dataGenerator/types.ts
+++ b/examples/crm/src/dataGenerator/types.ts
@@ -1,5 +1,5 @@
 import { Record } from 'react-admin';
-import { Company, Contact, ContactNote, Deal } from '../types';
+import { Company, Contact, ContactNote, Deal, Tag } from '../types';
 
 export interface Db {
     companies: Company[];
@@ -8,6 +8,6 @@ export interface Db {
     deals: Deal[];
     dealNotes: Record[];
     sales: Record[];
-    tags: Record[];
+    tags: Tag[];
     tasks: Record[];
 }

--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -38,7 +38,7 @@ export const DealCreate = ({ open }: { open: boolean }) => {
         redirect('/deals');
     };
 
-    const onSuccess = ({ data: deal }: { data: Deal }) => {
+    const onSuccess = (deal: Deal) => {
         redirect('/deals');
         // increase the index of all deals in the same stage as the new deal
         dataProvider
@@ -64,10 +64,10 @@ export const DealCreate = ({ open }: { open: boolean }) => {
 
     return (
         <StyledDialog open={open} onClose={handleClose}>
-            <Create
+            <Create<Deal>
                 resource="deals"
                 className={classes.root}
-                onSuccess={onSuccess}
+                mutationOptions={{ onSuccess }}
             >
                 <SimpleForm initialValues={{ index: 0 }}>
                     <TextInput

--- a/examples/crm/src/notes/NewNote.tsx
+++ b/examples/crm/src/notes/NewNote.tsx
@@ -55,7 +55,7 @@ export const NewNote = ({
     const [text, setText] = useState('');
     const [status, setStatus] = useState(record && record.status);
     const [date, setDate] = useState(getCurrentDate());
-    const [create, { loading }] = useCreate();
+    const [create, { isLoading }] = useCreate();
     const [update] = useUpdate();
     // FIXME: use refetch instead when ReferenceManyField exposes it in the ListContext
     const refresh = useRefresh();
@@ -83,13 +83,17 @@ export const NewNote = ({
             },
             previousData: record,
         });
-        create(resource, data, {
-            onSuccess: () => {
-                setText('');
-                notify('Note added successfully');
-                refresh();
-            },
-        });
+        create(
+            resource,
+            { data },
+            {
+                onSuccess: () => {
+                    setText('');
+                    notify('Note added successfully');
+                    refresh();
+                },
+            }
+        );
         return false;
     };
     return (
@@ -139,7 +143,7 @@ export const NewNote = ({
                         type="submit"
                         variant="contained"
                         color="primary"
-                        disabled={!text || loading}
+                        disabled={!text || isLoading}
                     >
                         Add this note
                     </Button>

--- a/examples/crm/src/types.ts
+++ b/examples/crm/src/types.ts
@@ -63,3 +63,8 @@ export interface Deal extends Record {
     index: number;
     nb_notes: number;
 }
+
+export interface Tag extends Record {
+    name: string;
+    color: string;
+}

--- a/examples/simple/src/comments/CommentEdit.tsx
+++ b/examples/simple/src/comments/CommentEdit.tsx
@@ -71,19 +71,18 @@ const inputText = record =>
 const CreatePost = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
     const [value, setValue] = React.useState(filter || '');
-    const [create] = useCreate('posts');
+    const [create] = useCreate();
     const handleSubmit = (event: React.FormEvent) => {
         event.preventDefault();
         create(
+            'posts',
             {
-                payload: {
-                    data: {
-                        title: value,
-                    },
+                data: {
+                    title: value,
                 },
             },
             {
-                onSuccess: ({ data }) => {
+                onSuccess: data => {
                     setValue('');
                     const choice = data;
                     onCreate(choice);

--- a/examples/simple/src/comments/PostQuickCreate.tsx
+++ b/examples/simple/src/comments/PostQuickCreate.tsx
@@ -49,14 +49,18 @@ const PostQuickCreate = ({ onCancel, onSave, ...props }) => {
 
     const handleSave = useCallback(
         values => {
-            create('posts', values, {
-                onSuccess: ({ data }) => {
-                    onSave(data);
-                },
-                onFailure: error => {
-                    notify(error.message, 'error');
-                },
-            });
+            create(
+                'posts',
+                { data: values },
+                {
+                    onSuccess: data => {
+                        onSave(data);
+                    },
+                    onError: (error: Error) => {
+                        notify(error.message, 'error');
+                    },
+                }
+            );
         },
         [create, notify, onSave]
     );

--- a/examples/simple/src/posts/TagReferenceInput.tsx
+++ b/examples/simple/src/posts/TagReferenceInput.tsx
@@ -73,21 +73,15 @@ const TagReferenceInput = ({
 const CreateTag = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
     const [value, setValue] = React.useState(filter || '');
-    const [create] = useCreate('tags');
+    const [create] = useCreate();
     const handleSubmit = (event: React.FormEvent) => {
         event.preventDefault();
         create(
+            'tags',
+            { data: { name: { en: value } } },
+
             {
-                payload: {
-                    data: {
-                        name: {
-                            en: value,
-                        },
-                    },
-                },
-            },
-            {
-                onSuccess: ({ data }) => {
+                onSuccess: data => {
                     setValue('');
                     const choice = data;
                     onCreate(choice);

--- a/packages/ra-core/src/controller/create/CreateContext.tsx
+++ b/packages/ra-core/src/controller/create/CreateContext.tsx
@@ -35,6 +35,7 @@ export const CreateContext = createContext<CreateControllerResult>({
     save: null,
     saving: null,
     successMessage: null,
+    version: null,
 });
 
 CreateContext.displayName = 'CreateContext';

--- a/packages/ra-core/src/controller/create/CreateContext.tsx
+++ b/packages/ra-core/src/controller/create/CreateContext.tsx
@@ -25,8 +25,8 @@ export const CreateContext = createContext<CreateControllerResult>({
     onFailureRef: null,
     onSuccessRef: null,
     transformRef: null,
-    loaded: null,
-    loading: null,
+    isFetching: null,
+    isLoading: null,
     redirect: null,
     setOnFailure: null,
     setOnSuccess: null,
@@ -35,7 +35,6 @@ export const CreateContext = createContext<CreateControllerResult>({
     save: null,
     saving: null,
     successMessage: null,
-    version: null,
 });
 
 CreateContext.displayName = 'CreateContext';

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -85,7 +85,7 @@ export const useCreateController = <
         setTransform,
     } = useSaveModifiers({ onSuccess, onFailure, transform });
 
-    const [create, { loading: saving }] = useCreate(resource);
+    const [create, { isLoading: saving }] = useCreate();
 
     const save = useCallback(
         (
@@ -105,14 +105,14 @@ export const useCreateController = <
                     : data
             ).then(data =>
                 create(
-                    { payload: { data } },
+                    resource,
+                    { data },
                     {
-                        action: CRUD_CREATE,
                         onSuccess: onSuccessFromSave
                             ? onSuccessFromSave
                             : onSuccessRef.current
                             ? onSuccessRef.current
-                            : ({ data: newRecord }) => {
+                            : newRecord => {
                                   notify(
                                       successMessage ||
                                           'ra.notification.created',
@@ -128,11 +128,11 @@ export const useCreateController = <
                                       newRecord
                                   );
                               },
-                        onFailure: onFailureFromSave
+                        onError: onFailureFromSave
                             ? onFailureFromSave
                             : onFailureRef.current
                             ? onFailureRef.current
-                            : error => {
+                            : (error: Error) => {
                                   notify(
                                       typeof error === 'string'
                                           ? error

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -20,6 +20,7 @@ import {
     useSaveModifiers,
 } from '../saveModifiers';
 import { useTranslate } from '../../i18n';
+import useVersion from '../useVersion';
 import { Record, OnSuccess, OnFailure, CreateParams } from '../../types';
 import {
     useResourceContext,
@@ -66,6 +67,7 @@ export const useCreateController = <
     const redirect = useRedirect();
     const recordToUse =
         record ?? getRecordFromLocation(location) ?? emptyRecord;
+    const version = useVersion();
     const { onSuccess, onError, ...otherMutationOptions } = mutationOptions;
 
     if (process.env.NODE_ENV !== 'production' && successMessage) {
@@ -188,6 +190,7 @@ export const useCreateController = <
         resource,
         record: recordToUse,
         redirect: getDefaultRedirectRoute(hasShow, hasEdit),
+        version,
     };
 };
 
@@ -235,6 +238,7 @@ export interface CreateControllerResult<
     record?: Partial<RecordType>;
     redirect: RedirectionSideEffect;
     resource: string;
+    version: number;
 }
 
 const emptyRecord = {};

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -3,6 +3,7 @@ import { useCallback, MutableRefObject } from 'react';
 import { parse } from 'query-string';
 import { useLocation } from 'react-router-dom';
 import { Location } from 'history';
+import { UseMutationOptions } from 'react-query';
 
 import { useAuthenticated } from '../../auth';
 import { useCreate } from '../../dataProvider';
@@ -19,9 +20,7 @@ import {
     useSaveModifiers,
 } from '../saveModifiers';
 import { useTranslate } from '../../i18n';
-import useVersion from '../useVersion';
-import { CRUD_CREATE } from '../../actions';
-import { Record, OnSuccess, OnFailure } from '../../types';
+import { Record, OnSuccess, OnFailure, CreateParams } from '../../types';
 import {
     useResourceContext,
     useResourceDefinition,
@@ -52,11 +51,10 @@ export const useCreateController = <
 ): CreateControllerResult<RecordType> => {
     const {
         disableAuthentication,
-        onSuccess,
-        onFailure,
         record,
         successMessage,
         transform,
+        mutationOptions = {},
     } = props;
 
     useAuthenticated({ enabled: !disableAuthentication });
@@ -68,7 +66,7 @@ export const useCreateController = <
     const redirect = useRedirect();
     const recordToUse =
         record ?? getRecordFromLocation(location) ?? emptyRecord;
-    const version = useVersion();
+    const { onSuccess, onError, ...otherMutationOptions } = mutationOptions;
 
     if (process.env.NODE_ENV !== 'production' && successMessage) {
         console.log(
@@ -83,9 +81,13 @@ export const useCreateController = <
         setOnFailure,
         transformRef,
         setTransform,
-    } = useSaveModifiers({ onSuccess, onFailure, transform });
+    } = useSaveModifiers({ onSuccess, onFailure: onError, transform });
 
-    const [create, { isLoading: saving }] = useCreate();
+    const [create, { isLoading: saving }] = useCreate(
+        resource,
+        undefined,
+        otherMutationOptions
+    );
 
     const save = useCallback(
         (
@@ -172,8 +174,8 @@ export const useCreateController = <
     });
 
     return {
-        loading: false,
-        loaded: true,
+        isFetching: false,
+        isLoading: false,
         saving,
         defaultTitle,
         onFailureRef,
@@ -186,7 +188,6 @@ export const useCreateController = <
         resource,
         record: recordToUse,
         redirect: getDefaultRedirectRoute(hasShow, hasEdit),
-        version,
     };
 };
 
@@ -196,8 +197,11 @@ export interface CreateControllerProps<
     disableAuthentication?: boolean;
     record?: Partial<RecordType>;
     resource?: string;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        CreateParams<RecordType>
+    >;
     successMessage?: string;
     transform?: TransformData;
 }
@@ -209,8 +213,8 @@ export interface CreateControllerResult<
     // @deprecated - to be removed in 4.0d
     data?: RecordType;
     defaultTitle: string;
-    loading: boolean;
-    loaded: boolean;
+    isFetching: boolean;
+    isLoading: boolean;
     onSuccessRef: MutableRefObject<OnSuccess>;
     onFailureRef: MutableRefObject<OnFailure>;
     transformRef: MutableRefObject<TransformData>;
@@ -231,7 +235,6 @@ export interface CreateControllerResult<
     record?: Partial<RecordType>;
     redirect: RedirectionSideEffect;
     resource: string;
-    version: number;
 }
 
 const emptyRecord = {};

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -9,7 +9,6 @@ import undoableEventEmitter from './undoableEventEmitter';
 import useDataProvider from './useDataProvider';
 import useMutation, { UseMutationValue } from './useMutation';
 import withDataProvider from './withDataProvider';
-import useCreate from './useCreate';
 import useDelete from './useDelete';
 import useDeleteMany from './useDeleteMany';
 import useRefreshWhenVisible from './useRefreshWhenVisible';
@@ -23,6 +22,7 @@ export * from './useGetManyAggregate';
 export * from './useGetManyReference';
 export * from './useQueryWithStore';
 export * from './useQuery';
+export * from './useCreate';
 export * from './useUpdate';
 export * from './useUpdateMany';
 
@@ -40,7 +40,6 @@ export {
     undoableEventEmitter,
     useDataProvider,
     useMutation,
-    useCreate,
     useDelete,
     useDeleteMany,
     useRefreshWhenVisible,

--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -1,41 +1,17 @@
 import * as React from 'react';
-import { renderWithRedux } from 'ra-test';
-import { waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import expect from 'expect';
 
-import { DataProvider, Record } from '../types';
-import DataProviderContext from './DataProviderContext';
-import useCreate from './useCreate';
+import { Record } from '../types';
+import { testDataProvider } from './testDataProvider';
+import { useCreate } from './useCreate';
+import { CoreAdminContext } from '../core';
 
 describe('useCreate', () => {
-    it('returns a callback that can be used with create arguments', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('returns a callback that can be used with create arguments', async () => {
+        const dataProvider = testDataProvider({
             create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
-        };
-        let localCreate;
-        const Dummy = () => {
-            const [create] = useCreate();
-            localCreate = create;
-            return <span />;
-        };
-
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
-                <Dummy />
-            </DataProviderContext.Provider>
-        );
-        localCreate('foo', { bar: 'baz' });
-        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
-            data: { bar: 'baz' },
         });
-    });
-
-    it('returns a callback that can be used with mutation payload', () => {
-        const dataProvider: Partial<DataProvider> = {
-            create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
-            update: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
-        };
         let localCreate;
         const Dummy = () => {
             const [create] = useCreate();
@@ -43,68 +19,64 @@ describe('useCreate', () => {
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        localCreate({
-            type: 'update',
-            resource: 'foo',
-            payload: {
+        localCreate('foo', { data: { bar: 'baz' } });
+        await waitFor(() => {
+            expect(dataProvider.create).toHaveBeenCalledWith('foo', {
                 data: { bar: 'baz' },
-            },
-        });
-        expect(dataProvider.create).not.toHaveBeenCalled();
-        expect(dataProvider.update).toHaveBeenCalledWith('foo', {
-            data: { bar: 'baz' },
+            });
         });
     });
 
-    it('returns a callback that can be used with no arguments', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('returns a callback that can be used with no arguments', async () => {
+        const dataProvider = testDataProvider({
             create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
-        };
+        });
         let localCreate;
         const Dummy = () => {
-            const [create] = useCreate('foo', { bar: 'baz' });
+            const [create] = useCreate('foo', { data: { bar: 'baz' } });
             localCreate = create;
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
         localCreate();
-        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
-            data: { bar: 'baz' },
+        await waitFor(() => {
+            expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+                data: { bar: 'baz' },
+            });
         });
     });
 
-    it('merges hook call time and callback call time queries', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('uses call time params over hook time params', async () => {
+        const dataProvider = testDataProvider({
             create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
-        };
+        });
         let localCreate;
         const Dummy = () => {
-            const [create] = useCreate('foo', { bar: 'baz' });
+            const [create] = useCreate('foo', { data: { bar: 'baz' } });
             localCreate = create;
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        localCreate({ payload: { data: { foo: 456 } } });
-        expect(dataProvider.create).toHaveBeenCalledWith('foo', {
-            data: { bar: 'baz', foo: 456 },
+        localCreate('foo', { data: { foo: 456 } });
+        await waitFor(() => {
+            expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+                data: { foo: 456 },
+            });
         });
     });
 
@@ -112,11 +84,11 @@ describe('useCreate', () => {
         interface Product extends Record {
             sku: string;
         }
-        const dataProvider: Partial<DataProvider> = {
+        const dataProvider = testDataProvider({
             create: jest.fn(() =>
                 Promise.resolve({ data: { id: 1, sku: 'abc' } } as any)
             ),
-        };
+        });
         let localCreate;
         let sku;
         const Dummy = () => {
@@ -125,14 +97,13 @@ describe('useCreate', () => {
             sku = data && data.sku;
             return <span />;
         };
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        expect(sku).toBeNull();
-        localCreate('products', { sku: 'abc' });
+        expect(sku).toBeUndefined();
+        localCreate('products', { data: { sku: 'abc' } });
         await waitFor(() => {
             expect(sku).toEqual('abc');
         });

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -105,15 +105,19 @@ export const useCreate = <RecordType extends Record = Record>(
     );
 
     const create = (
-        resource?: string,
-        params?: Partial<CreateParams<Partial<RecordType>>>,
-        options?: MutateOptions<
+        callTimeResource: string = resource,
+        callTimeParams: Partial<CreateParams<RecordType>> = {},
+        createOptions?: MutateOptions<
             RecordType,
             unknown,
             Partial<UseCreateMutateParams<RecordType>>,
             unknown
         >
-    ) => mutation.mutate({ resource, data: params.data }, options);
+    ) =>
+        mutation.mutate(
+            { resource: callTimeResource, ...callTimeParams },
+            createOptions
+        );
 
     return [create, mutation];
 };

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -1,40 +1,54 @@
-import { useCallback } from 'react';
-import { Record } from '../types';
-import useMutation, { MutationOptions, Mutation } from './useMutation';
+import { useRef } from 'react';
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+    useQueryClient,
+    MutateOptions,
+} from 'react-query';
+
+import useDataProvider from './useDataProvider';
+import { Record, CreateParams } from '../types';
 
 /**
  * Get a callback to call the dataProvider.create() method, the result and the loading state.
  *
+ * @param {string} resource
+ * @param {Params} params The create parameters { data }
+ * @param {Object} options Options object to pass to the queryClient.
+ * May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ *
+ * @typedef Params
+ * @prop params.data The record to create, e.g. { title: 'hello, world' }
+ *
+ * @returns The current mutation state. Destructure as [create, { data, error, isLoading }].
+ *
  * The return value updates according to the request state:
  *
- * - initial: [create, { loading: false, loaded: false }]
- * - start:   [create, { loading: true, loaded: false }]
- * - success: [create, { data: [data from response], loading: false, loaded: true }]
- * - error:   [create, { error: [error from response], loading: false, loaded: false }]
+ * - initial: [create, { isLoading: false, isIdle: true }]
+ * - start:   [create, { isLoading: true }]
+ * - success: [create, { data: [data from response], isLoading: false, isSuccess: true }]
+ * - error:   [create, { error: [error from response], isLoading: false, isError: true }]
  *
- * @param resource The resource name, e.g. 'posts'
- * @param data The data to initialize the new record with, e.g. { title: 'hello, world' }
- * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * The create() function must be called with a resource and a parameter object: create(resource, { data }, options)
  *
- * @returns The current request state. Destructure as [create, { data, error, loading, loaded }].
+ * This hook uses react-query useMutation under the hood.
+ * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * The create() function can be called in 3 different ways:
- *  - with the same parameters as the useCreate() hook: create(resource, data, options)
- *  - with the same syntax as useMutation: create({ resource, payload: { data } }, options)
- *  - with no parameter (if they were already passed to useCreate()): create()
+ * @see https://react-query.tanstack.com/reference/useMutation
  *
- * @example // set params when calling the update callback
+ * @example // set params when calling the create callback
  *
  * import { useCreate } from 'react-admin';
  *
  * const LikeButton = ({ record }) => {
  *     const like = { postId: record.id };
- *     const [create, { loading, error }] = useCreate();
+ *     const [create, { isLoading, error }] = useCreate();
  *     const handleClick = () => {
- *         create('likes', like)
+ *         create('likes', { data: like })
  *     }
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={handleClick}>Like</button>;
+ *     return <button disabled={isLoading} onClick={handleClick}>Like</button>;
  * };
  *
  * @example // set params when calling the hook
@@ -43,62 +57,95 @@ import useMutation, { MutationOptions, Mutation } from './useMutation';
  *
  * const LikeButton = ({ record }) => {
  *     const like = { postId: record.id };
- *     const [create, { loading, error }] = useCreate('likes', like);
+ *     const [create, { isLoading, error }] = useCreate('likes', { data: like });
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={create}>Like</button>;
+ *     return <button disabled={isLoading} onClick={() => create()}>Like</button>;
  * };
+ *
+ * @example // TypeScript
+ * const [create, { data }] = useCreate<Product>('products', { data: product });
+ *                    \-- data is Product
  */
-const useCreate = <RecordType extends Record = Record>(
+export const useCreate = <RecordType extends Record = Record>(
     resource?: string,
-    data?: Partial<RecordType>,
-    options?: MutationOptions
-): UseCreateHookValue<RecordType> => {
-    const [mutate, state] = useMutation(
-        { type: 'create', resource, payload: { data } },
-        options
-    );
+    params: Partial<CreateParams> = {},
+    options: UseCreateOptions<RecordType> = {}
+): UseCreateResult<RecordType> => {
+    const dataProvider = useDataProvider();
+    const queryClient = useQueryClient();
+    const paramsRef = useRef<Partial<CreateParams<RecordType>>>(params);
 
-    const create = useCallback(
-        (
-            resource?: string | Partial<Mutation> | Event,
-            data?: Partial<RecordType>,
-            options?: MutationOptions
-        ) => {
-            if (typeof resource === 'string') {
-                const query = {
-                    type: 'create',
-                    resource,
-                    payload: {
-                        data,
-                    },
-                };
-                return mutate(query, options);
-            } else {
-                return mutate(
-                    resource as Mutation | Event,
-                    data as MutationOptions
+    const mutation = useMutation<
+        RecordType,
+        unknown,
+        Partial<UseCreateMutateParams<RecordType>>
+    >(
+        ({
+            resource: callTimeResource = resource,
+            data: callTimeData = paramsRef.current.data,
+        } = {}) =>
+            dataProvider
+                .create<RecordType>(callTimeResource, {
+                    data: callTimeData,
+                })
+                .then(({ data }) => data),
+        {
+            onSuccess: (
+                data: RecordType,
+                variables: Partial<UseCreateMutateParams<RecordType>> = {}
+            ) => {
+                const { resource: callTimeResource = resource } = variables;
+                queryClient.setQueryData(
+                    [callTimeResource, 'getOne', String(data.id)],
+                    data
                 );
-            }
-        },
-        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+            },
+            ...options,
+        }
     );
 
-    return [create, state];
+    const create = (
+        resource?: string,
+        params?: Partial<CreateParams<Partial<RecordType>>>,
+        options?: MutateOptions<
+            RecordType,
+            unknown,
+            Partial<UseCreateMutateParams<RecordType>>,
+            unknown
+        >
+    ) => mutation.mutate({ resource, data: params.data }, options);
+
+    return [create, mutation];
 };
 
-type UseCreateHookValue<RecordType extends Record = Record> = [
-    (
-        resource?: string | Partial<Mutation> | Event,
-        data?: Partial<RecordType>,
-        options?: MutationOptions
-    ) => void | Promise<any>,
-    {
-        data?: RecordType;
-        total?: number;
-        error?: any;
-        loading: boolean;
-        loaded: boolean;
-    }
-];
+export interface UseCreateMutateParams<RecordType extends Record = Record> {
+    resource?: string;
+    data?: Partial<RecordType>;
+}
 
-export default useCreate;
+export type UseCreateOptions<
+    RecordType extends Record = Record
+> = UseMutationOptions<
+    RecordType,
+    unknown,
+    Partial<UseCreateMutateParams<RecordType>>
+>;
+
+export type UseCreateResult<RecordType extends Record = Record> = [
+    (
+        resource?: string,
+        params?: Partial<CreateParams<Partial<RecordType>>>,
+        options?: MutateOptions<
+            RecordType,
+            unknown,
+            Partial<UseCreateMutateParams<RecordType>>,
+            unknown
+        >
+    ) => void,
+    UseMutationResult<
+        RecordType,
+        unknown,
+        Partial<UseCreateMutateParams<RecordType>>,
+        unknown
+    >
+];

--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -53,10 +53,7 @@ const useRedirect = () => {
             state: object = {}
         ) => {
             if (!redirectTo) {
-                if (
-                    Object.keys(locationRef.current.state).length !== 0 ||
-                    locationRef.current.search
-                ) {
+                if (locationRef.current.state || locationRef.current.search) {
                     navigate(
                         {
                             ...locationRef.current,

--- a/packages/ra-core/src/sideEffect/useRedirect.ts
+++ b/packages/ra-core/src/sideEffect/useRedirect.ts
@@ -53,7 +53,10 @@ const useRedirect = () => {
             state: object = {}
         ) => {
             if (!redirectTo) {
-                if (locationRef.current.state || locationRef.current.search) {
+                if (
+                    Object.keys(locationRef.current.state).length !== 0 ||
+                    locationRef.current.search
+                ) {
                     navigate(
                         {
                             ...locationRef.current,

--- a/packages/ra-ui-materialui/src/detail/Create.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import expect from 'expect';
-import { renderWithRedux } from 'ra-test';
+import { CoreAdminContext, testDataProvider } from 'ra-core';
+import { screen, render } from '@testing-library/react';
 
 import { Create } from './Create';
 
@@ -16,11 +17,13 @@ describe('<Create />', () => {
     it('should display aside component', () => {
         const Dummy = () => <div />;
         const Aside = () => <div id="aside">Hello</div>;
-        const { queryAllByText } = renderWithRedux(
-            <Create {...defaultCreateProps} aside={<Aside />}>
-                <Dummy />
-            </Create>
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
+                <Create {...defaultCreateProps} aside={<Aside />}>
+                    <Dummy />
+                </Create>
+            </CoreAdminContext>
         );
-        expect(queryAllByText('Hello')).toHaveLength(1);
+        expect(screen.queryAllByText('Hello')).toHaveLength(1);
     });
 });

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -89,7 +89,6 @@ Create.propTypes = {
     record: PropTypes.object,
     hasList: PropTypes.bool,
     successMessage: PropTypes.string,
-    onSuccess: PropTypes.func,
-    onFailure: PropTypes.func,
+    mutationOptions: PropTypes.object,
     transform: PropTypes.func,
 };

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -26,6 +26,7 @@ export const CreateView = (props: CreateViewProps) => {
         resource,
         save,
         saving,
+        version,
     } = useCreateContext(props);
 
     return (
@@ -62,6 +63,7 @@ export const CreateView = (props: CreateViewProps) => {
                                 ? save
                                 : children.props.save,
                         saving,
+                        version,
                     })}
                 </Content>
                 {aside &&
@@ -73,6 +75,7 @@ export const CreateView = (props: CreateViewProps) => {
                                 ? save
                                 : children.props.save,
                         saving,
+                        version,
                     })}
             </div>
         </Root>
@@ -118,8 +121,8 @@ const sanitizeRestProps = ({
     hasList = null,
     hasShow = null,
     history = null,
-    loaded = null,
-    loading = null,
+    isFetching = null,
+    isLoading = null,
     location = null,
     match = null,
     onFailure = null,

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -26,7 +26,6 @@ export const CreateView = (props: CreateViewProps) => {
         resource,
         save,
         saving,
-        version,
     } = useCreateContext(props);
 
     return (
@@ -63,7 +62,6 @@ export const CreateView = (props: CreateViewProps) => {
                                 ? save
                                 : children.props.save,
                         saving,
-                        version,
                     })}
                 </Content>
                 {aside &&
@@ -75,7 +73,6 @@ export const CreateView = (props: CreateViewProps) => {
                                 ? save
                                 : children.props.save,
                         saving,
-                        version,
                     })}
             </div>
         </Root>

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -4,10 +4,9 @@ import {
     Identifier,
     Record as RaRecord,
     MutationMode,
-    OnSuccess,
-    OnFailure,
     TransformData,
     UpdateParams,
+    CreateParams,
 } from 'ra-core';
 import { UseQueryOptions, UseMutationOptions } from 'react-query';
 
@@ -38,8 +37,11 @@ export interface CreateProps<RecordType extends RaRecord = RaRecord> {
     component?: ElementType;
     record?: Partial<RecordType>;
     resource?: string;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        CreateParams<RecordType>
+    >;
     transform?: TransformData;
     title?: string | ReactElement;
 }


### PR DESCRIPTION
- [x] Update `useCreate` to use react-query
- [x] Replace `onSuccess` and `onFailure` `<Create>` props with `mutationOptions`
- [x] Fix tests, docs and examples
- [x] Add upgrade instructions

```diff
// useCreate
-const [create, { loading }] = useCreate(
-   'posts',
-   { title: 'hello, world!' },
-);
-create(resource, data, options);
+const [create, { isLoading }] = useCreate(
+   'posts',
+   { data: { title: 'hello, world!' } }
+);
+create(resource, { data }, options);
```