### PR TITLE
[BC Break] Migrate useDelete and useDeleteMany to react query

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -215,7 +215,7 @@ For mutations:
 -   [123, 456],
 -   { likes: 12 },
 -);
--updateMany(resource, id, data, previousData, options);
+-updateMany(resource, ids, data, options);
 +const [updateMany, { isLoading }] = useUpdateMany(
 +   'posts',
 +   {
@@ -224,6 +224,37 @@ For mutations:
 +   }
 +);
 +updateMany(resource, { ids, data }, options);
+
+// useDelete
+-const [deleteOne, { loading }] = useDelete(
+-   'posts',
+-   123,
+-   { id: 123, title: "hello, world", likes: 122 }
+-);
+-deleteOne(resource, id, previousData, options);
++const [deleteOne, { isLoading }] = useDelete(
++   'posts',
++   {
++       id: 123,
++       previousData: { id: 123, title: "hello, world", likes: 122 }
++   }
++);
++deleteOne(resource, { id, previousData }, options);
+
+// useDeleteMany
+-const [deleteMany, { loading }] = useDeleteMany(
+-   'posts',
+-   [123, 456],
+-);
+-deleteMany(resource, ids, options);
++const [deleteMany, { isLoading }] = useDeleteMany(
++   'posts',
++   {
++       ids: [123, 456],
++   }
++);
++deleteMany(resource, { ids }, options);
+
 ```
 
 This new signature should be easier to learn and use.
@@ -237,6 +268,8 @@ To upgrade, check every instance of your code of the following hooks:
 - `useCreate`
 - `useUpdate`
 - `useUpdateMany`
+- `useDelete`
+- `useDeleteMany`
 
 And update the calls. If you're using TypeScript, your code won't compile until you properly upgrade the calls. 
 
@@ -257,6 +290,14 @@ const IncreaseLikeButton = ({ record }) => {
 ```
 
 TypeScript will complain if you don't.
+
+To upgrade, check every instance of your code of the following hooks:
+
+- `useCreate`
+- `useUpdate`
+- `useUpdateMany`
+- `useDelete`
+- `useDeleteMany`
 
 Note that your code will be more readable if you pass the mutation parameters to the mutation callback instead of the mutation hook, e.g.
 
@@ -375,6 +416,10 @@ The change concerns the following components:
 - `useShowController`
 - `<Show>`
 - `<ShowBase>`
+- `useDeleteWithUndoController`
+- `useDeleteWithConfirmController`
+- `<DeleteButton>`
+- `<BulkDeleteButton>`
 
 ## `onSuccess` Callback On DataProvider Hooks And Components Has A New Signature
 
@@ -411,6 +456,12 @@ The change concerns the following components:
 - `useShowController`
 - `<Show>`
 - `<ShowBase>`
+- `useDelete`
+- `useDeleteWithUndoController`
+- `useDeleteWithConfirmController`
+- `<DeleteButton>`
+- `useDeleteMany`
+- `<BulkDeleteButton>`
 
 ## `<Edit successMessage>` Prop Was Removed
 

--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -187,9 +187,7 @@ describe('List Page', () => {
             cy.contains('1-10 of 13'); // wait for data
             ListPagePosts.toggleSelectSomeItems(3);
             ListPagePosts.applyDeleteBulkAction();
-            // FIXME once dataProvider hookls are migrated to react-query
-            // cy.contains('1-10 of 10');
-            cy.contains('1-7 of 7');
+            cy.contains('1-10 of 10');
         });
 
         it('should allow to select items with the shift key on different pages', () => {

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -431,8 +431,11 @@ import { useCreate } from 'react-admin';
 const LikeButton = ({ record }) => {
     const like = { postId: record.id };
     const [create, { isLoading, error }] = useCreate('likes', { data: like });
+    const handleClick = () => {
+        create()
+    }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={isLoading} onClick={() => create()}>Like</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Like</button>;
 };
 ```
 
@@ -471,8 +474,11 @@ import { useUpdate } from 'react-admin';
 const IncreaseLikeButton = ({ record }) => {
     const diff = { likes: record.likes + 1 };
     const [update, { isLoading, error }] = useUpdate('likes', { id: record.id, data: diff, previousData: record });
+    const handleClick = () => {
+        update()
+    }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={isLoading} onClick={() => update()}>Like</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Like</button>;
 };
 ```
 
@@ -507,8 +513,11 @@ import { useUpdateMany } from 'react-admin';
 
 const BulkResetViewsButton = ({ selectedIds }) => {
     const [updateMany, { isLoading, error }] = useUpdateMany('posts', { ids: selectedIds, data: { views: 0 } });
+    const handleClick = () => {
+        updateMany();
+    }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={isLoading} onClick={() => updateMany()}>Reset views</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Reset views</button>;
 };
 ```
 
@@ -516,13 +525,13 @@ const BulkResetViewsButton = ({ selectedIds }) => {
 
 ```jsx
 // syntax
-const [deleteOne, { data, loading, loaded, error }] = useDelete(resource, { id, previousData }, options);
+const [deleteOne, { data, isFetching, isLoading, error }] = useDelete(resource, { id, previousData }, options);
 ```
 
 The `deleteOne()` method can be called with the same parameters as the hook:
 
 ```jsx
-deleteOne(resource, { ids, previousData }, options);
+deleteOne(resource, { id, previousData }, options);
 ```
 
 ```jsx
@@ -532,7 +541,7 @@ import { useDelete } from 'react-admin';
 const DeleteButton = ({ record }) => {
     const [deleteOne, { isLoading, error }] = useDelete();
     const handleClick = () => {
-        deleteOne('likes', { id: record.id }, record)
+        deleteOne('likes', { id: record.id , previousData: record })
     }
     if (error) { return <p>ERROR</p>; }
     return <button disabled={isLoading} onClick={handleClick}>Delete</div>;
@@ -542,9 +551,12 @@ const DeleteButton = ({ record }) => {
 import { useDelete } from 'react-admin';
 
 const DeleteButton = ({ record }) => {
-    const [deleteOne, { isLoading, error }] = useDelete('likes', { id: record.id }, record);
+    const [deleteOne, { isLoading, error }] = useDelete('likes', { id: record.id, previousData: record });
+    const handleClick = () => {
+        deleteOne()
+    }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={isLoading} onClick={() => deleteOne()}>Delete</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Delete</button>;
 };
 ```
 
@@ -552,34 +564,38 @@ const DeleteButton = ({ record }) => {
 
 ```jsx
 // syntax
-const [deleteMany, { data, loading, loaded, error }] = useDeleteMany(resource, ids, options);
+const [deleteMany, { data, isFetching, isLoading, error }] = useDeleteMany(resource, { ids }, options);
 ```
 
-The `deleteMany()` function can be called in 3 different ways:
- - with the same parameters as the `useDeleteMany()` hook: `deleteMany(resource, ids, options)`
- - with the same syntax as `useMutation`: `deleteMany({ resource, payload: { ids } }, options)`
- - with no parameter (if they were already passed to `useDeleteMany()`): `deleteMany()`
+The `deleteMany()` method can be called with the same parameters as the hook:
+
+```jsx
+deleteMany(resource, { ids }, options);
+```
 
 ```jsx
 // set params when calling the dleteMany callback
 import { useDeleteMany } from 'react-admin';
 
 const BulkDeletePostsButton = ({ selectedIds }) => {
-    const [deleteMany, { loading, error }] = useDeleteMany();
+    const [deleteMany, { isLoading, error }] = useDeleteMany();
     const handleClick = () => {
-        deleteMany('posts', selectedIds)
+        deleteMany('posts', { ids: selectedIds })
     }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={deleteMany}>Delete selected posts</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Delete selected posts</button>;
 };
 
 // set params when calling the hook
 import { useDeleteMany } from 'react-admin';
 
 const BulkDeletePostsButton = ({ selectedIds }) => {
-    const [deleteMany, { loading, error }] = useDeleteMany('posts', selectedIds);
+    const [deleteMany, { isLoading, error }] = useDeleteMany('posts', { ids: selectedIds });
+    const handleClick = () => {
+        deleteMany()
+    }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={deleteMany}>Delete selected posts</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Delete selected posts</button>;
 };
 ```
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -516,34 +516,35 @@ const BulkResetViewsButton = ({ selectedIds }) => {
 
 ```jsx
 // syntax
-const [deleteOne, { data, loading, loaded, error }] = useDelete(resource, id, previousData, options);
+const [deleteOne, { data, loading, loaded, error }] = useDelete(resource, { id, previousData }, options);
 ```
 
-The `deleteOne()` function can be called in 3 different ways:
- - with the same parameters as the `useDelete()` hook: `deleteOne(resource, id, previousData, options)`
- - with the same syntax as `useMutation`: `deleteOne({ resource, payload: { id, previousData } }, options)`
- - with no parameter (if they were already passed to `useDelete()`): `deleteOne()`
+The `deleteOne()` method can be called with the same parameters as the hook:
+
+```jsx
+deleteOne(resource, { ids, previousData }, options);
+```
 
 ```jsx
 // set params when calling the deleteOne callback
 import { useDelete } from 'react-admin';
 
 const DeleteButton = ({ record }) => {
-    const [deleteOne, { loading, error }] = useDelete();
+    const [deleteOne, { isLoading, error }] = useDelete();
     const handleClick = () => {
-        deleteOne('likes', record.id, record)
+        deleteOne('likes', { id: record.id }, record)
     }
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={handleClick}>Delete</button>;
+    return <button disabled={isLoading} onClick={handleClick}>Delete</div>;
 };
 
 // set params when calling the hook
 import { useDelete } from 'react-admin';
 
 const DeleteButton = ({ record }) => {
-    const [deleteOne, { loading, error }] = useDelete('likes', record.id, record);
+    const [deleteOne, { isLoading, error }] = useDelete('likes', { id: record.id }, record);
     if (error) { return <p>ERROR</p>; }
-    return <button disabled={loading} onClick={deleteOne}>Delete</button>;
+    return <button disabled={isLoading} onClick={() => deleteOne()}>Delete</button>;
 };
 ```
 

--- a/examples/crm/src/notes/Note.tsx
+++ b/examples/crm/src/notes/Note.tsx
@@ -114,17 +114,25 @@ export const Note = ({
 
     const [update, { isLoading }] = useUpdate();
 
-    const [handleDelete] = useDelete(resource, { id: note.id }, note, {
-        mutationMode: 'undoable',
-        onSuccess: () => {
-            notify('Note deleted', { type: 'info', undoable: true });
-            update(reference, {
-                id: record.id,
-                data: { nb_notes: record.nb_notes - 1 },
-                previousData: record,
-            });
-        },
-    });
+    const [deleteNote] = useDelete(
+        resource,
+        { id: note.id, previousData: note },
+        {
+            mutationMode: 'undoable',
+            onSuccess: () => {
+                notify('Note deleted', { type: 'info', undoable: true });
+                update(reference, {
+                    id: record.id,
+                    data: { nb_notes: record.nb_notes - 1 },
+                    previousData: record,
+                });
+            },
+        }
+    );
+
+    const handleDelete = () => {
+        deleteNote();
+    };
 
     const handleEnterEditMode = () => {
         setEditing(true);

--- a/examples/crm/src/notes/Note.tsx
+++ b/examples/crm/src/notes/Note.tsx
@@ -114,7 +114,7 @@ export const Note = ({
 
     const [update, { isLoading }] = useUpdate();
 
-    const [handleDelete] = useDelete(resource, note.id, note, {
+    const [handleDelete] = useDelete(resource, { id: note.id }, note, {
         mutationMode: 'undoable',
         onSuccess: () => {
             notify('Note deleted', { type: 'info', undoable: true });

--- a/packages/ra-core/src/actions/listActions.ts
+++ b/packages/ra-core/src/actions/listActions.ts
@@ -59,6 +59,23 @@ export const toggleListItem = (
     meta: { resource },
 });
 
+export const UNSELECT_LIST_ITEMS = 'RA/UNSELECT_LIST_ITEMS';
+
+export interface UnselectListItemsAction {
+    readonly type: typeof UNSELECT_LIST_ITEMS;
+    readonly payload: any;
+    readonly meta: { resource: string };
+}
+
+export const unselectListItems = (
+    resource: string,
+    ids: Identifier[]
+): UnselectListItemsAction => ({
+    type: UNSELECT_LIST_ITEMS,
+    payload: ids,
+    meta: { resource },
+});
+
 export const TOGGLE_LIST_ITEM_EXPAND = 'RA/TOGGLE_LIST_ITEM_EXPAND';
 
 export interface ToggleListItemExpandAction {

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -84,42 +84,46 @@ const useDeleteWithConfirmController = <RecordType extends Record = Record>(
     const notify = useNotify();
     const redirect = useRedirect();
     const refresh = useRefresh();
-    const [deleteOne, { isLoading }] = useDelete<RecordType>(resource, null, {
-        onSuccess: deletedRecord => {
-            setOpen(false);
+    const [deleteOne, { isLoading }] = useDelete<RecordType>(
+        resource,
+        undefined,
+        {
+            onSuccess: deletedRecord => {
+                setOpen(false);
 
-            notify('ra.notification.deleted', {
-                type: 'info',
-                messageArgs: { smart_count: 1 },
-                undoable: mutationMode === 'undoable',
-            });
-            redirect(redirectTo, basePath || `/${resource}`);
-            refresh();
-        },
-        onError: (error: Error) => {
-            setOpen(false);
+                notify('ra.notification.deleted', {
+                    type: 'info',
+                    messageArgs: { smart_count: 1 },
+                    undoable: mutationMode === 'undoable',
+                });
+                redirect(redirectTo, basePath || `/${resource}`);
+                refresh();
+            },
+            onError: (error: Error) => {
+                setOpen(false);
 
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                {
-                    type: 'warning',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                ? error.message
-                                : undefined,
-                    },
-                }
-            );
-            refresh();
-        },
-        mutationMode,
-        ...mutationOptions,
-    });
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : error.message || 'ra.notification.http_error',
+                    {
+                        type: 'warning',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error && error.message
+                                    ? error.message
+                                    : undefined,
+                        },
+                    }
+                );
+                refresh();
+            },
+            mutationMode,
+            ...mutationOptions,
+        }
+    );
 
     const handleDialogOpen = e => {
         setOpen(true);

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -11,6 +11,7 @@ import {
     useRefresh,
     useNotify,
     useRedirect,
+    useUnselect,
     RedirectionSideEffect,
 } from '../../sideEffect';
 import { Record, MutationMode, DeleteParams } from '../../types';
@@ -82,6 +83,7 @@ const useDeleteWithConfirmController = <RecordType extends Record = Record>(
     const resource = useResourceContext(props);
     const [open, setOpen] = useState(false);
     const notify = useNotify();
+    const unselect = useUnselect();
     const redirect = useRedirect();
     const refresh = useRefresh();
     const [deleteOne, { isLoading }] = useDelete<RecordType>(
@@ -90,12 +92,12 @@ const useDeleteWithConfirmController = <RecordType extends Record = Record>(
         {
             onSuccess: deletedRecord => {
                 setOpen(false);
-
                 notify('ra.notification.deleted', {
                     type: 'info',
                     messageArgs: { smart_count: 1 },
                     undoable: mutationMode === 'undoable',
                 });
+                unselect(resource, [record.id]);
                 redirect(redirectTo, basePath || `/${resource}`);
                 refresh();
             },

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -4,15 +4,16 @@ import {
     ReactEventHandler,
     SyntheticEvent,
 } from 'react';
+import { UseMutationOptions } from 'react-query';
+
 import { useDelete } from '../../dataProvider';
-import { CRUD_DELETE } from '../../actions';
 import {
     useRefresh,
     useNotify,
     useRedirect,
     RedirectionSideEffect,
 } from '../../sideEffect';
-import { Record, MutationMode, OnFailure, OnSuccess } from '../../types';
+import { Record, MutationMode, DeleteParams } from '../../types';
 import { useResourceContext } from '../../core';
 
 /**
@@ -30,7 +31,7 @@ import { useResourceContext } from '../../core';
  * }) => {
  *     const {
  *         open,
- *         loading,
+ *         isLoading,
  *         handleDialogOpen,
  *         handleDialogClose,
  *         handleDelete,
@@ -53,7 +54,7 @@ import { useResourceContext } from '../../core';
  *             </Button>
  *             <Confirm
  *                 isOpen={open}
- *                 loading={loading}
+ *                 loading={isLoading}
  *                 title="ra.message.delete_title"
  *                 content="ra.message.delete_content"
  *                 translateOptions={{
@@ -67,8 +68,8 @@ import { useResourceContext } from '../../core';
  *     );
  * };
  */
-const useDeleteWithConfirmController = (
-    props: UseDeleteWithConfirmControllerParams
+const useDeleteWithConfirmController = <RecordType extends Record = Record>(
+    props: UseDeleteWithConfirmControllerParams<RecordType>
 ): UseDeleteWithConfirmControllerReturn => {
     const {
         record,
@@ -76,55 +77,48 @@ const useDeleteWithConfirmController = (
         basePath,
         mutationMode,
         onClick,
-        onSuccess,
-        onFailure,
+        mutationOptions,
     } = props;
     const resource = useResourceContext(props);
     const [open, setOpen] = useState(false);
     const notify = useNotify();
     const redirect = useRedirect();
     const refresh = useRefresh();
-    const [deleteOne, { loading }] = useDelete(resource, null, null, {
-        action: CRUD_DELETE,
-        onSuccess: response => {
+    const [deleteOne, { isLoading }] = useDelete<RecordType>(resource, null, {
+        onSuccess: deletedRecord => {
             setOpen(false);
-            if (onSuccess === undefined) {
-                notify('ra.notification.deleted', {
-                    type: 'info',
-                    messageArgs: { smart_count: 1 },
-                    undoable: mutationMode === 'undoable',
-                });
-                redirect(redirectTo, basePath || `/${resource}`);
-                refresh();
-            } else {
-                onSuccess(response);
-            }
+
+            notify('ra.notification.deleted', {
+                type: 'info',
+                messageArgs: { smart_count: 1 },
+                undoable: mutationMode === 'undoable',
+            });
+            redirect(redirectTo, basePath || `/${resource}`);
+            refresh();
         },
-        onFailure: error => {
+        onError: (error: Error) => {
             setOpen(false);
-            if (onFailure === undefined) {
-                notify(
-                    typeof error === 'string'
-                        ? error
-                        : error.message || 'ra.notification.http_error',
-                    {
-                        type: 'warning',
-                        messageArgs: {
-                            _:
-                                typeof error === 'string'
-                                    ? error
-                                    : error && error.message
-                                    ? error.message
-                                    : undefined,
-                        },
-                    }
-                );
-                refresh();
-            } else {
-                onFailure(error);
-            }
+
+            notify(
+                typeof error === 'string'
+                    ? error
+                    : error.message || 'ra.notification.http_error',
+                {
+                    type: 'warning',
+                    messageArgs: {
+                        _:
+                            typeof error === 'string'
+                                ? error
+                                : error && error.message
+                                ? error.message
+                                : undefined,
+                    },
+                }
+            );
+            refresh();
         },
         mutationMode,
+        ...mutationOptions,
     });
 
     const handleDialogOpen = e => {
@@ -140,34 +134,43 @@ const useDeleteWithConfirmController = (
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();
-            deleteOne({
-                payload: { id: record.id, previousData: record },
-            });
+            deleteOne(resource, { id: record.id, previousData: record });
             if (typeof onClick === 'function') {
                 onClick(event);
             }
         },
-        [deleteOne, onClick, record]
+        [deleteOne, onClick, record, resource]
     );
 
-    return { open, loading, handleDialogOpen, handleDialogClose, handleDelete };
+    return {
+        open,
+        isLoading,
+        handleDialogOpen,
+        handleDialogClose,
+        handleDelete,
+    };
 };
 
-export interface UseDeleteWithConfirmControllerParams {
+export interface UseDeleteWithConfirmControllerParams<
+    RecordType extends Record = Record
+> {
     basePath?: string;
     mutationMode?: MutationMode;
-    record?: Record;
+    record?: RecordType;
     redirect?: RedirectionSideEffect;
     // @deprecated. This hook get the resource from the context
     resource?: string;
     onClick?: ReactEventHandler<any>;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        DeleteParams<RecordType>
+    >;
 }
 
 export interface UseDeleteWithConfirmControllerReturn {
     open: boolean;
-    loading: boolean;
+    isLoading: boolean;
     handleDialogOpen: (e: SyntheticEvent) => void;
     handleDialogClose: (e: SyntheticEvent) => void;
     handleDelete: ReactEventHandler<any>;

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -86,46 +86,7 @@ const useDeleteWithConfirmController = <RecordType extends Record = Record>(
     const unselect = useUnselect();
     const redirect = useRedirect();
     const refresh = useRefresh();
-    const [deleteOne, { isLoading }] = useDelete<RecordType>(
-        resource,
-        undefined,
-        {
-            onSuccess: deletedRecord => {
-                setOpen(false);
-                notify('ra.notification.deleted', {
-                    type: 'info',
-                    messageArgs: { smart_count: 1 },
-                    undoable: mutationMode === 'undoable',
-                });
-                unselect(resource, [record.id]);
-                redirect(redirectTo, basePath || `/${resource}`);
-                refresh();
-            },
-            onError: (error: Error) => {
-                setOpen(false);
-
-                notify(
-                    typeof error === 'string'
-                        ? error
-                        : error.message || 'ra.notification.http_error',
-                    {
-                        type: 'warning',
-                        messageArgs: {
-                            _:
-                                typeof error === 'string'
-                                    ? error
-                                    : error && error.message
-                                    ? error.message
-                                    : undefined,
-                        },
-                    }
-                );
-                refresh();
-            },
-            mutationMode,
-            ...mutationOptions,
-        }
-    );
+    const [deleteOne, { isLoading }] = useDelete<RecordType>();
 
     const handleDialogOpen = e => {
         setOpen(true);
@@ -140,12 +101,64 @@ const useDeleteWithConfirmController = <RecordType extends Record = Record>(
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();
-            deleteOne(resource, { id: record.id, previousData: record });
+            deleteOne(
+                resource,
+                { id: record.id, previousData: record },
+                {
+                    onSuccess: () => {
+                        setOpen(false);
+                        notify('ra.notification.deleted', {
+                            type: 'info',
+                            messageArgs: { smart_count: 1 },
+                            undoable: mutationMode === 'undoable',
+                        });
+                        unselect(resource, [record.id]);
+                        redirect(redirectTo, basePath || `/${resource}`);
+                        refresh();
+                    },
+                    onError: (error: Error) => {
+                        setOpen(false);
+
+                        notify(
+                            typeof error === 'string'
+                                ? error
+                                : error.message || 'ra.notification.http_error',
+                            {
+                                type: 'warning',
+                                messageArgs: {
+                                    _:
+                                        typeof error === 'string'
+                                            ? error
+                                            : error && error.message
+                                            ? error.message
+                                            : undefined,
+                                },
+                            }
+                        );
+                        refresh();
+                    },
+                    mutationMode,
+                    ...mutationOptions,
+                }
+            );
             if (typeof onClick === 'function') {
                 onClick(event);
             }
         },
-        [deleteOne, onClick, record, resource]
+        [
+            basePath,
+            deleteOne,
+            mutationMode,
+            mutationOptions,
+            notify,
+            onClick,
+            record,
+            redirect,
+            redirectTo,
+            refresh,
+            resource,
+            unselect,
+        ]
     );
 
     return {

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -1,13 +1,14 @@
 import { useCallback, ReactEventHandler } from 'react';
+import { UseMutationOptions } from 'react-query';
+
 import { useDelete } from '../../dataProvider';
-import { CRUD_DELETE } from '../../actions';
 import {
     useRefresh,
     useNotify,
     useRedirect,
     RedirectionSideEffect,
 } from '../../sideEffect';
-import { Record, OnFailure, OnSuccess } from '../../types';
+import { Record, DeleteParams } from '../../types';
 import { useResourceContext } from '../../core';
 
 /**
@@ -27,7 +28,7 @@ import { useResourceContext } from '../../core';
  *     onClick,
  *     ...rest
  * }) => {
- *     const { loading, handleDelete } = useDeleteWithUndoController({
+ *     const { isLoading, handleDelete } = useDeleteWithUndoController({
  *         resource,
  *         record,
  *         basePath,
@@ -38,7 +39,7 @@ import { useResourceContext } from '../../core';
  *     return (
  *         <Button
  *             onClick={handleDelete}
- *             disabled={loading}
+ *             disabled={isLoading}
  *             label="ra.action.delete"
  *             {...rest}
  *         >
@@ -47,89 +48,85 @@ import { useResourceContext } from '../../core';
  *     );
  * };
  */
-const useDeleteWithUndoController = (
-    props: UseDeleteWithUndoControllerParams
+const useDeleteWithUndoController = <RecordType extends Record = Record>(
+    props: UseDeleteWithUndoControllerParams<RecordType>
 ): UseDeleteWithUndoControllerReturn => {
     const {
         record,
         basePath,
         redirect: redirectTo = 'list',
         onClick,
-        onSuccess,
-        onFailure,
+        mutationOptions,
     } = props;
     const resource = useResourceContext(props);
     const notify = useNotify();
     const redirect = useRedirect();
     const refresh = useRefresh();
 
-    const [deleteOne, { loading }] = useDelete(resource, null, null, {
-        action: CRUD_DELETE,
-        onSuccess:
-            onSuccess !== undefined
-                ? onSuccess
-                : () => {
-                      notify('ra.notification.deleted', {
-                          type: 'info',
-                          messageArgs: { smart_count: 1 },
-                          undoable: true,
-                      });
-                      redirect(redirectTo, basePath || `/${resource}`);
-                      refresh();
-                  },
-        onFailure:
-            onFailure !== undefined
-                ? onFailure
-                : error => {
-                      notify(
-                          typeof error === 'string'
-                              ? error
-                              : error.message || 'ra.notification.http_error',
-                          {
-                              type: 'warning',
-                              messageArgs: {
-                                  _:
-                                      typeof error === 'string'
-                                          ? error
-                                          : error && error.message
-                                          ? error.message
-                                          : undefined,
-                              },
-                          }
-                      );
-                      refresh();
-                  },
+    const [deleteOne, { isLoading }] = useDelete<RecordType>(resource, null, {
+        onSuccess: () => {
+            notify('ra.notification.deleted', {
+                type: 'info',
+                messageArgs: { smart_count: 1 },
+                undoable: true,
+            });
+            redirect(redirectTo, basePath || `/${resource}`);
+            refresh();
+        },
+        onError: (error: Error) => {
+            notify(
+                typeof error === 'string'
+                    ? error
+                    : error.message || 'ra.notification.http_error',
+                {
+                    type: 'warning',
+                    messageArgs: {
+                        _:
+                            typeof error === 'string'
+                                ? error
+                                : error && error.message
+                                ? error.message
+                                : undefined,
+                    },
+                }
+            );
+            refresh();
+        },
         mutationMode: 'undoable',
+        ...mutationOptions,
     });
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();
-            deleteOne({
-                payload: { id: record.id, previousData: record },
-            });
+            deleteOne(resource, { id: record.id, previousData: record });
             if (typeof onClick === 'function') {
                 onClick(event);
             }
         },
-        [deleteOne, onClick, record]
+        [deleteOne, onClick, record, resource]
     );
 
-    return { loading, handleDelete };
+    return { isLoading, handleDelete };
 };
 
-export interface UseDeleteWithUndoControllerParams {
+export interface UseDeleteWithUndoControllerParams<
+    RecordType extends Record = Record
+> {
     basePath?: string;
-    record?: Record;
+    record?: RecordType;
     redirect?: RedirectionSideEffect;
     // @deprecated. This hook get the resource from the context
     resource?: string;
     onClick?: ReactEventHandler<any>;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        DeleteParams<RecordType>
+    >;
 }
 
 export interface UseDeleteWithUndoControllerReturn {
-    loading: boolean;
+    isLoading: boolean;
     handleDelete: ReactEventHandler<any>;
 }
 

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -63,38 +63,42 @@ const useDeleteWithUndoController = <RecordType extends Record = Record>(
     const redirect = useRedirect();
     const refresh = useRefresh();
 
-    const [deleteOne, { isLoading }] = useDelete<RecordType>(resource, null, {
-        onSuccess: () => {
-            notify('ra.notification.deleted', {
-                type: 'info',
-                messageArgs: { smart_count: 1 },
-                undoable: true,
-            });
-            redirect(redirectTo, basePath || `/${resource}`);
-            refresh();
-        },
-        onError: (error: Error) => {
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                {
-                    type: 'warning',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                ? error.message
-                                : undefined,
-                    },
-                }
-            );
-            refresh();
-        },
-        mutationMode: 'undoable',
-        ...mutationOptions,
-    });
+    const [deleteOne, { isLoading }] = useDelete<RecordType>(
+        resource,
+        undefined,
+        {
+            onSuccess: () => {
+                notify('ra.notification.deleted', {
+                    type: 'info',
+                    messageArgs: { smart_count: 1 },
+                    undoable: true,
+                });
+                redirect(redirectTo, basePath || `/${resource}`);
+                refresh();
+            },
+            onError: (error: Error) => {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : error.message || 'ra.notification.http_error',
+                    {
+                        type: 'warning',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error && error.message
+                                    ? error.message
+                                    : undefined,
+                        },
+                    }
+                );
+                refresh();
+            },
+            mutationMode: 'undoable',
+            ...mutationOptions,
+        }
+    );
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -64,53 +64,65 @@ const useDeleteWithUndoController = <RecordType extends Record = Record>(
     const unselect = useUnselect();
     const redirect = useRedirect();
     const refresh = useRefresh();
+    const [deleteOne, { isLoading }] = useDelete<RecordType>();
 
-    const [deleteOne, { isLoading }] = useDelete<RecordType>(
-        resource,
-        undefined,
-        {
-            onSuccess: () => {
-                notify('ra.notification.deleted', {
-                    type: 'info',
-                    messageArgs: { smart_count: 1 },
-                    undoable: true,
-                });
-                unselect(resource, [record.id]);
-                redirect(redirectTo, basePath || `/${resource}`);
-                refresh();
-            },
-            onError: (error: Error) => {
-                notify(
-                    typeof error === 'string'
-                        ? error
-                        : error.message || 'ra.notification.http_error',
-                    {
-                        type: 'warning',
-                        messageArgs: {
-                            _:
-                                typeof error === 'string'
-                                    ? error
-                                    : error && error.message
-                                    ? error.message
-                                    : undefined,
-                        },
-                    }
-                );
-                refresh();
-            },
-            mutationMode: 'undoable',
-            ...mutationOptions,
-        }
-    );
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();
-            deleteOne(resource, { id: record.id, previousData: record });
+            deleteOne(
+                resource,
+                { id: record.id, previousData: record },
+                {
+                    onSuccess: () => {
+                        notify('ra.notification.deleted', {
+                            type: 'info',
+                            messageArgs: { smart_count: 1 },
+                            undoable: true,
+                        });
+                        unselect(resource, [record.id]);
+                        redirect(redirectTo, basePath || `/${resource}`);
+                        refresh();
+                    },
+                    onError: (error: Error) => {
+                        notify(
+                            typeof error === 'string'
+                                ? error
+                                : error.message || 'ra.notification.http_error',
+                            {
+                                type: 'warning',
+                                messageArgs: {
+                                    _:
+                                        typeof error === 'string'
+                                            ? error
+                                            : error && error.message
+                                            ? error.message
+                                            : undefined,
+                                },
+                            }
+                        );
+                        refresh();
+                    },
+                    mutationMode: 'undoable',
+                    ...mutationOptions,
+                }
+            );
             if (typeof onClick === 'function') {
                 onClick(event);
             }
         },
-        [deleteOne, onClick, record, resource]
+        [
+            basePath,
+            deleteOne,
+            mutationOptions,
+            notify,
+            onClick,
+            record,
+            redirect,
+            redirectTo,
+            refresh,
+            resource,
+            unselect,
+        ]
     );
 
     return { isLoading, handleDelete };

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -6,6 +6,7 @@ import {
     useRefresh,
     useNotify,
     useRedirect,
+    useUnselect,
     RedirectionSideEffect,
 } from '../../sideEffect';
 import { Record, DeleteParams } from '../../types';
@@ -60,6 +61,7 @@ const useDeleteWithUndoController = <RecordType extends Record = Record>(
     } = props;
     const resource = useResourceContext(props);
     const notify = useNotify();
+    const unselect = useUnselect();
     const redirect = useRedirect();
     const refresh = useRefresh();
 
@@ -73,6 +75,7 @@ const useDeleteWithUndoController = <RecordType extends Record = Record>(
                     messageArgs: { smart_count: 1 },
                     undoable: true,
                 });
+                unselect(resource, [record.id]);
                 redirect(redirectTo, basePath || `/${resource}`);
                 refresh();
             },

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -9,7 +9,6 @@ import undoableEventEmitter from './undoableEventEmitter';
 import useDataProvider from './useDataProvider';
 import useMutation, { UseMutationValue } from './useMutation';
 import withDataProvider from './withDataProvider';
-import useDelete from './useDelete';
 import useDeleteMany from './useDeleteMany';
 import useRefreshWhenVisible from './useRefreshWhenVisible';
 import useIsAutomaticRefreshEnabled from './useIsAutomaticRefreshEnabled';
@@ -25,6 +24,7 @@ export * from './useQuery';
 export * from './useCreate';
 export * from './useUpdate';
 export * from './useUpdateMany';
+export * from './useDelete';
 
 export type { Options } from './fetch';
 export type { QueryProps, UseMutationValue, MutationProps };
@@ -40,7 +40,6 @@ export {
     undoableEventEmitter,
     useDataProvider,
     useMutation,
-    useDelete,
     useDeleteMany,
     useRefreshWhenVisible,
     withDataProvider,

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -9,7 +9,6 @@ import undoableEventEmitter from './undoableEventEmitter';
 import useDataProvider from './useDataProvider';
 import useMutation, { UseMutationValue } from './useMutation';
 import withDataProvider from './withDataProvider';
-import useDeleteMany from './useDeleteMany';
 import useRefreshWhenVisible from './useRefreshWhenVisible';
 import useIsAutomaticRefreshEnabled from './useIsAutomaticRefreshEnabled';
 
@@ -25,6 +24,7 @@ export * from './useCreate';
 export * from './useUpdate';
 export * from './useUpdateMany';
 export * from './useDelete';
+export * from './useDeleteMany';
 
 export type { Options } from './fetch';
 export type { QueryProps, UseMutationValue, MutationProps };
@@ -40,7 +40,6 @@ export {
     undoableEventEmitter,
     useDataProvider,
     useMutation,
-    useDeleteMany,
     useRefreshWhenVisible,
     withDataProvider,
     useIsAutomaticRefreshEnabled,

--- a/packages/ra-core/src/dataProvider/useDelete.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.optimistic.stories.tsx
@@ -129,7 +129,10 @@ const ErrorCore = () => {
             {
                 mutationMode: 'optimistic',
                 onSuccess: () => setSuccess('success'),
-                onError: e => setError(e),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
             }
         );
     };

--- a/packages/ra-core/src/dataProvider/useDelete.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.optimistic.stories.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from 'react-query';
+
+import { CoreAdminContext } from '../core';
+import { useDelete } from './useDelete';
+import { useGetList } from './useGetList';
+
+export default { title: 'ra-core/dataProvider/useDelete/optimistic' };
+
+export const SuccessCase = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const index = posts.findIndex(p => p.id === params.id);
+                    posts.splice(index, 1);
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [deleteOne, { isLoading }] = useDelete();
+    const handleClick = () => {
+        deleteOne(
+            'posts',
+            {
+                id: 1,
+                previousData: { id: 1, title: 'Hello' },
+            },
+            {
+                mutationMode: 'optimistic',
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+    };
+    return (
+        <>
+            <ul>
+                {data?.map(post => (
+                    <li key={post.id}>{post.title}</li>
+                ))}
+            </ul>
+            <div>
+                <button onClick={handleClick} disabled={isLoading}>
+                    Delete first post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const ErrorCase = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <ErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const ErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, refetch } = useGetList('posts');
+    const [deleteOne, { isLoading }] = useDelete();
+    const handleClick = () => {
+        setError(undefined);
+        deleteOne(
+            'posts',
+            {
+                id: 1,
+                previousData: { id: 1, title: 'Hello World' },
+            },
+            {
+                mutationMode: 'optimistic',
+                onSuccess: () => setSuccess('success'),
+                onError: e => setError(e),
+            }
+        );
+    };
+    return (
+        <>
+            <ul>
+                {data?.map(post => (
+                    <li key={post.id}>{post.title}</li>
+                ))}
+            </ul>
+            <div>
+                <button onClick={handleClick} disabled={isLoading}>
+                    Delete first post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {error && <div>{error.message}</div>}
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDelete.pessimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.pessimistic.stories.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from 'react-query';
+
+import { CoreAdminContext } from '../core';
+import { useDelete } from './useDelete';
+import { useGetList } from './useGetList';
+
+export default { title: 'ra-core/dataProvider/useDelete/pessimistic' };
+
+export const SuccessCase = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const index = posts.findIndex(p => p.id === params.id);
+                    posts.splice(index, 1);
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [deleteOne, { isLoading }] = useDelete();
+    const handleClick = () => {
+        deleteOne(
+            'posts',
+            {
+                id: 1,
+                previousData: { id: 1, title: 'Hello' },
+            },
+            {
+                mutationMode: 'pessimistic',
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+    };
+    return (
+        <>
+            <ul>
+                {data?.map(post => (
+                    <li key={post.id}>{post.title}</li>
+                ))}
+            </ul>
+            <div>
+                <button onClick={handleClick} disabled={isLoading}>
+                    Delete first post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const ErrorCase = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <ErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const ErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, refetch } = useGetList('posts');
+    const [deleteOne, { isLoading }] = useDelete();
+    const handleClick = () => {
+        setError(undefined);
+        deleteOne(
+            'posts',
+            {
+                id: 1,
+                previousData: { id: 1, title: 'Hello World' },
+            },
+            {
+                mutationMode: 'pessimistic',
+                onSuccess: () => setSuccess('success'),
+                onError: e => setError(e),
+            }
+        );
+    };
+    return (
+        <>
+            <ul>
+                {data?.map(post => (
+                    <li key={post.id}>{post.title}</li>
+                ))}
+            </ul>
+            <div>
+                <button onClick={handleClick} disabled={isLoading}>
+                    Delete first post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {error && <div>{error.message}</div>}
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -5,7 +5,7 @@ import expect from 'expect';
 
 import { DataProvider, Record } from '../types';
 import DataProviderContext from './DataProviderContext';
-import useDelete from './useDelete';
+import { useDelete } from './useDelete';
 
 describe('useDelete', () => {
     it('returns a callback that can be used with deleteOne arguments', () => {

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -92,7 +92,7 @@ describe('useDelete', () => {
         });
     });
 
-    it('returns a state typed based on the parametric type', async () => {
+    it('returns data typed based on the parametric type', async () => {
         interface Product extends Record {
             sku: string;
         }

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -1,41 +1,57 @@
-import { useCallback } from 'react';
-import { Record } from '../types';
-import useMutation, { MutationOptions, Mutation } from './useMutation';
+import { useRef } from 'react';
+import {
+    useMutation,
+    useQueryClient,
+    UseMutationOptions,
+    UseMutationResult,
+    MutateOptions,
+    QueryKey,
+} from 'react-query';
+
+import useDataProvider from './useDataProvider';
+import undoableEventEmitter from './undoableEventEmitter';
+import { Record, DeleteParams, MutationMode } from '../types';
 
 /**
- * Get a callback to call the dataProvider.delete() method, the result
- * of the call (the deleted record), and the loading state.
+ * Get a callback to call the dataProvider.delete() method, the result and the loading state.
+ *
+ * @param {string} resource
+ * @param {Params} params The delete parameters { id, previousData }
+ * @param {Object} options Options object to pass to the queryClient.
+ * May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
+ *
+ * @typedef Params
+ * @prop params.id The resource identifier, e.g. 123
+ * @prop params.previousData The record before the update is applied
+ *
+ * @returns The current mutation state. Destructure as [deleteOne, { data, error, isLoading }].
  *
  * The return value updates according to the request state:
  *
- * - initial: [deleteOne, { loading: false, loaded: false }]
- * - start:   [deleteOne, { loading: true, loaded: false }]
- * - success: [deleteOne, { data: [data from response], loading: false, loaded: true }]
- * - error:   [deleteOne, { error: [error from response], loading: false, loaded: false }]
+ * - initial: [deleteOne, { isLoading: false, isIdle: true }]
+ * - start:   [deleteOne, { isLoading: true }]
+ * - success: [deleteOne, { data: [data from response], isLoading: false, isSuccess: true }]
+ * - error:   [deleteOne, { error: [error from response], isLoading: false, isError: true }]
  *
- * @param resource The resource name, e.g. 'posts'
- * @param id The resource identifier, e.g. 123
- * @param previousData The record before the delete is applied
- * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * The deleteOne() function must be called with a resource and a parameter object: deleteOne(resource, { id, data, previousData }, options)
  *
- * @returns The current request state. Destructure as [deleteOne, { data, error, loading, loaded }].
+ * This hook uses react-query useMutation under the hood.
+ * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * The deleteOne() function can be called in 3 different ways:
- *  - with the same parameters as the useDelete() hook: deleteOne(resource, id, previousData, options)
- *  - with the same syntax as useMutation: deleteOne({ resource, payload: { id, previousData } }, options)
- *  - with no parameter (if they were already passed to useDelete()): deleteOne()
+ * @see https://react-query.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the deleteOne callback
  *
  * import { useDelete } from 'react-admin';
  *
  * const DeleteButton = ({ record }) => {
- *     const [deleteOne, { loading, error }] = useDelete();
+ *     const [deleteOne, { isLoading, error }] = useDelete();
  *     const handleClick = () => {
- *         deleteOne('likes', record.id, record)
+ *         deleteOne('likes', { id: record.id }, record)
  *     }
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={handleClick}>Delete</div>;
+ *     return <button disabled={isLoading} onClick={handleClick}>Delete</div>;
  * };
  *
  * @example // set params when calling the hook
@@ -43,66 +59,355 @@ import useMutation, { MutationOptions, Mutation } from './useMutation';
  * import { useDelete } from 'react-admin';
  *
  * const DeleteButton = ({ record }) => {
- *     const [deleteOne, { loading, error }] = useDelete('likes', record.id, record);
+ *     const [deleteOne, { isLoading, error }] = useDelete('likes', { id: record.id }, record);
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={deleteOne}>Delete</button>;
+ *     return <button disabled={isLoading} onClick={() => deleteOne()}>Delete</button>;
  * };
+ *
+ * @example // TypeScript
+ * const [delete, { data }] = useDelete<Product>('products', { id, previousData: product });
+ *                    \-- data is Product
  */
-const useDelete = <RecordType extends Record = Record>(
+export const useDelete = <RecordType extends Record = Record>(
     resource?: string,
-    id?: RecordType['id'],
-    previousData: any = {},
-    options?: MutationOptions
-): UseDeleteHookValue<RecordType> => {
-    const [mutate, state] = useMutation(
-        { type: 'delete', resource, payload: { id, previousData } },
-        options
-    );
+    params: Partial<DeleteParams<RecordType>> = {},
+    options: UseDeleteOptions<RecordType> = {}
+): UseDeleteResult<RecordType> => {
+    const dataProvider = useDataProvider();
+    const queryClient = useQueryClient();
+    const { id, previousData } = params;
+    const { mutationMode = 'pessimistic', ...reactMutationOptions } = options;
+    const mode = useRef<MutationMode>(mutationMode);
+    const paramsRef = useRef<Partial<DeleteParams<RecordType>>>({});
+    const snapshot = useRef<Snapshot>([]);
 
-    const deleteOne = useCallback(
-        (
-            resource?: string | Partial<Mutation> | Event,
-            id?: RecordType['id'] | Partial<MutationOptions>,
-            previousData?: any,
-            options?: MutationOptions
-        ) => {
-            if (typeof resource === 'string') {
-                const query = {
-                    type: 'delete',
-                    resource,
-                    payload: {
-                        id: id as RecordType['id'],
-                        previousData,
-                    },
-                };
-                return mutate(query, options);
-            } else {
-                return mutate(
-                    resource as Mutation | Event,
-                    id as MutationOptions
-                );
+    const updateCache = ({ resource, id }) => {
+        // hack: only way to tell react-query not to fetch this query for the next 5 seconds
+        // because setQueryData doesn't accept a stale time option
+        const now = Date.now();
+        const updatedAt = mode.current === 'undoable' ? now + 5 * 1000 : now;
+
+        const updateColl = (old: RecordType[]) => {
+            if (!old) return;
+            const index = old.findIndex(
+                // eslint-disable-next-line eqeqeq
+                record => record.id == id
+            );
+            if (index === -1) {
+                return old;
             }
-        },
-        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+            return [...old.slice(0, index), ...old.slice(index + 1)];
+        };
+
+        type GetListResult = { data?: RecordType[]; total?: number };
+
+        queryClient.setQueriesData(
+            [resource, 'getList'],
+            (res: GetListResult) => {
+                if (!res || !res.data) return res;
+                const newCollection = updateColl(res.data);
+                const recordWasFound = newCollection.length < res.data.length;
+                return recordWasFound
+                    ? {
+                          data: newCollection,
+                          total: res.total - 1,
+                      }
+                    : res;
+            },
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            [resource, 'getMany'],
+            (coll: RecordType[]) =>
+                coll && coll.length > 0 ? updateColl(coll) : coll,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            [resource, 'getManyReference'],
+            (res: GetListResult) => {
+                if (!res || !res.data) return res;
+                const newCollection = updateColl(res.data);
+                const recordWasFound = newCollection.length < res.data.length;
+                return recordWasFound
+                    ? {
+                          data: newCollection,
+                          total: res.total - 1,
+                      }
+                    : res;
+            },
+            { updatedAt }
+        );
+    };
+
+    const mutation = useMutation<
+        RecordType,
+        unknown,
+        Partial<UseDeleteMutateParams<RecordType>>
+    >(
+        ({
+            resource: callTimeResource = resource,
+            id: callTimeId = paramsRef.current.id,
+            previousData: callTimePreviousData = paramsRef.current.previousData,
+        } = {}) =>
+            dataProvider
+                .delete<RecordType>(callTimeResource, {
+                    id: callTimeId,
+                    previousData: callTimePreviousData,
+                })
+                .then(({ data }) => data),
+        {
+            ...reactMutationOptions,
+            onMutate: async (
+                variables: Partial<UseDeleteMutateParams<RecordType>>
+            ) => {
+                if (reactMutationOptions.onMutate) {
+                    const userContext =
+                        (await reactMutationOptions.onMutate(variables)) || {};
+                    return {
+                        snapshot: snapshot.current,
+                        // @ts-ignore
+                        ...userContext,
+                    };
+                } else {
+                    // Return a context object with the snapshot value
+                    return { snapshot: snapshot.current };
+                }
+            },
+            onError: (
+                error: unknown,
+                variables: Partial<UseDeleteMutateParams<RecordType>> = {},
+                context: { snapshot: Snapshot }
+            ) => {
+                if (
+                    mode.current === 'optimistic' ||
+                    mode.current === 'undoable'
+                ) {
+                    // If the mutation fails, use the context returned from onMutate to rollback
+                    context.snapshot.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                }
+
+                if (reactMutationOptions.onError) {
+                    return reactMutationOptions.onError(
+                        error,
+                        variables,
+                        context
+                    );
+                }
+                // call-time error callback is executed by react-query
+            },
+            onSuccess: (
+                data: RecordType,
+                variables: Partial<UseDeleteMutateParams<RecordType>> = {},
+                context: unknown
+            ) => {
+                if (mode.current === 'pessimistic') {
+                    // update the getOne and getList query cache with the new result
+                    const {
+                        resource: callTimeResource = resource,
+                        id: callTimeId = id,
+                    } = variables;
+                    updateCache({
+                        resource: callTimeResource,
+                        id: callTimeId,
+                    });
+
+                    if (reactMutationOptions.onSuccess) {
+                        reactMutationOptions.onSuccess(
+                            data,
+                            variables,
+                            context
+                        );
+                    }
+                    // call-time success callback is executed by react-query
+                }
+            },
+            onSettled: (
+                data: RecordType,
+                error: unknown,
+                variables: Partial<UseDeleteMutateParams<RecordType>> = {},
+                context: { snapshot: Snapshot }
+            ) => {
+                if (
+                    mode.current === 'optimistic' ||
+                    mode.current === 'undoable'
+                ) {
+                    // Always refetch after error or success:
+                    context.snapshot.forEach(([key]) => {
+                        queryClient.invalidateQueries(key);
+                    });
+                }
+
+                if (reactMutationOptions.onSettled) {
+                    return reactMutationOptions.onSettled(
+                        data,
+                        error,
+                        variables,
+                        context
+                    );
+                }
+            },
+        }
     );
 
-    return [deleteOne, state];
+    const mutate = async (
+        callTimeResource: string = resource,
+        callTimeParams: Partial<DeleteParams<RecordType>> = {},
+        updateOptions: MutateOptions<
+            RecordType,
+            unknown,
+            Partial<UseDeleteMutateParams<RecordType>>,
+            unknown
+        > & { mutationMode?: MutationMode } = {}
+    ) => {
+        const { mutationMode, onSuccess, onSettled, onError } = updateOptions;
+
+        // store the hook time params *at the moment of the call*
+        // because they may change afterwards, which would break the undoable mode
+        // as the previousData would be overwritten by the optimistic update
+        paramsRef.current = params;
+
+        if (mutationMode) {
+            mode.current = mutationMode;
+        }
+
+        if (mode.current === 'pessimistic') {
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                { onSuccess, onSettled, onError }
+            );
+        }
+
+        const {
+            id: callTimeId = id,
+            previousData: callTimePreviousData = previousData,
+        } = callTimeParams;
+
+        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // except we do it in a mutate wrapper instead of the onMutate callback
+        // to have access to success side effects
+
+        const queryKeys = [
+            [callTimeResource, 'getList'],
+            [callTimeResource, 'getMany'],
+            [callTimeResource, 'getManyReference'],
+        ];
+
+        /**
+         * Snapshot the previous values via queryClient.getQueriesData()
+         *
+         * The snapshotData ref will contain an array of tuples [query key, associated data]
+         *
+         * @example
+         * [
+         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
+         *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+         *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+         * ]
+         *
+         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         */
+        snapshot.current = queryKeys.reduce(
+            (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),
+            [] as Snapshot
+        );
+
+        // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
+        await Promise.all(
+            snapshot.current.map(([key]) => queryClient.cancelQueries(key))
+        );
+
+        // Optimistically update to the new value
+        updateCache({
+            resource: callTimeResource,
+            id: callTimeId,
+        });
+
+        // run the success callbacks during the next tick
+        if (onSuccess) {
+            setTimeout(
+                () =>
+                    onSuccess(
+                        callTimePreviousData,
+                        { resource: callTimeResource, ...callTimeParams },
+                        { snapshot: snapshot.current }
+                    ),
+                0
+            );
+        }
+        if (reactMutationOptions.onSuccess) {
+            setTimeout(
+                () =>
+                    reactMutationOptions.onSuccess(
+                        callTimePreviousData,
+                        { resource: callTimeResource, ...callTimeParams },
+                        { snapshot: snapshot.current }
+                    ),
+                0
+            );
+        }
+
+        if (mode.current === 'optimistic') {
+            // call the mutate method without success side effects
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                { onSettled, onError }
+            );
+        } else {
+            // undoable mutation: register the mutation for later
+            undoableEventEmitter.once('end', ({ isUndo }) => {
+                if (isUndo) {
+                    // rollback
+                    snapshot.current.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                } else {
+                    // call the mutate method without success side effects
+                    mutation.mutate(
+                        { resource: callTimeResource, ...callTimeParams },
+                        { onSettled, onError }
+                    );
+                }
+            });
+        }
+    };
+
+    return [mutate, mutation];
 };
 
-type UseDeleteHookValue<RecordType extends Record = Record> = [
-    (
-        resource?: string | Partial<Mutation> | Event,
-        id?: RecordType['id'] | Partial<MutationOptions>,
-        previousData?: RecordType,
-        options?: MutationOptions
-    ) => void | Promise<any>,
-    {
-        data?: RecordType;
-        total?: number;
-        error?: any;
-        loading: boolean;
-        loaded: boolean;
-    }
-];
+type Snapshot = [key: QueryKey, value: any][];
 
-export default useDelete;
+export interface UseDeleteMutateParams<RecordType extends Record = Record> {
+    resource?: string;
+    id?: RecordType['id'];
+    data?: Partial<RecordType>;
+    previousData?: any;
+}
+
+export type UseDeleteOptions<
+    RecordType extends Record = Record
+> = UseMutationOptions<
+    RecordType,
+    unknown,
+    Partial<UseDeleteMutateParams<RecordType>>
+> & { mutationMode?: MutationMode };
+
+export type UseDeleteResult<RecordType extends Record = Record> = [
+    (
+        resource?: string,
+        params?: Partial<DeleteParams<RecordType>>,
+        options?: MutateOptions<
+            RecordType,
+            unknown,
+            Partial<UseDeleteMutateParams<RecordType>>,
+            unknown
+        > & { mutationMode?: MutationMode }
+    ) => Promise<void>,
+    UseMutationResult<
+        RecordType,
+        unknown,
+        Partial<DeleteParams<RecordType> & { resource?: string }>,
+        unknown
+    >
+];

--- a/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
@@ -159,7 +159,10 @@ const ErrorCore = () => {
             {
                 mutationMode: 'undoable',
                 onSuccess: () => setSuccess('success'),
-                onError: e => setError(e),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
             }
         );
         setNotification(true);

--- a/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from 'react-query';
+
+import { CoreAdminContext } from '../core';
+import undoableEventEmitter from './undoableEventEmitter';
+import { useDelete } from './useDelete';
+import { useGetList } from './useGetList';
+
+export default { title: 'ra-core/dataProvider/useDelete/undoable' };
+
+export const SuccessCase = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const index = posts.findIndex(p => p.id === params.id);
+                    posts.splice(index, 1);
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [deleteOne, { isLoading }] = useDelete();
+    const handleClick = () => {
+        deleteOne(
+            'posts',
+            {
+                id: 1,
+                previousData: { id: 1, title: 'Hello' },
+            },
+            {
+                mutationMode: 'undoable',
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+        setNotification(true);
+    };
+    return (
+        <>
+            <ul>
+                {data?.map(post => (
+                    <li key={post.id}>{post.title}</li>
+                ))}
+            </ul>
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                undoableEventEmitter.emit('end', {
+                                    isUndo: false,
+                                });
+                                setNotification(false);
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                undoableEventEmitter.emit('end', {
+                                    isUndo: true,
+                                });
+                                setNotification(false);
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isLoading}>
+                        Delete first post
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const ErrorCase = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <ErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const ErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, refetch } = useGetList('posts');
+    const [deleteOne, { isLoading }] = useDelete();
+    const handleClick = () => {
+        setError(undefined);
+        deleteOne(
+            'posts',
+            {
+                id: 1,
+                previousData: { id: 1, title: 'Hello World' },
+            },
+            {
+                mutationMode: 'undoable',
+                onSuccess: () => setSuccess('success'),
+                onError: e => setError(e),
+            }
+        );
+        setNotification(true);
+    };
+    return (
+        <>
+            <ul>
+                {data?.map(post => (
+                    <li key={post.id}>{post.title}</li>
+                ))}
+            </ul>
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                undoableEventEmitter.emit('end', {
+                                    isUndo: false,
+                                });
+                                setNotification(false);
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                undoableEventEmitter.emit('end', {
+                                    isUndo: true,
+                                });
+                                setNotification(false);
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isLoading}>
+                        Delete first post
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {error && <div>{error.message}</div>}
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -1,39 +1,16 @@
 import * as React from 'react';
-import { renderWithRedux } from 'ra-test';
+import { waitFor, render } from '@testing-library/react';
 import expect from 'expect';
 
-import { DataProvider } from '../types';
-import DataProviderContext from './DataProviderContext';
-import useDeleteMany from './useDeleteMany';
+import { CoreAdminContext } from '../core';
+import { testDataProvider } from './testDataProvider';
+import { useDeleteMany } from './useDeleteMany';
 
 describe('useDeleteMany', () => {
-    it('returns a callback that can be used with update arguments', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('returns a callback that can be used with update arguments', async () => {
+        const dataProvider = testDataProvider({
             deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
-        let localDeleteMany;
-        const Dummy = () => {
-            const [deleteMany] = useDeleteMany();
-            localDeleteMany = deleteMany;
-            return <span />;
-        };
-
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
-                <Dummy />
-            </DataProviderContext.Provider>
-        );
-        localDeleteMany('foo', [1, 2]);
-        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
         });
-    });
-
-    it('returns a callback that can be used with mutation payload', () => {
-        const dataProvider: Partial<DataProvider> = {
-            deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
         let localDeleteMany;
         const Dummy = () => {
             const [deleteMany] = useDeleteMany();
@@ -41,67 +18,64 @@ describe('useDeleteMany', () => {
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        localDeleteMany({
-            type: 'deleteMany',
-            resource: 'foo',
-            payload: {
+        localDeleteMany('foo', { ids: [1, 2] });
+        await waitFor(() => {
+            expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
                 ids: [1, 2],
-            },
-        });
-        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
+            });
         });
     });
 
-    it('returns a callback that can be used with no arguments', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('returns a callback that can be used with no arguments', async () => {
+        const dataProvider = testDataProvider({
             deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
+        });
         let localDeleteMany;
         const Dummy = () => {
-            const [deleteMany] = useDeleteMany('foo', [1, 2]);
+            const [deleteMany] = useDeleteMany('foo', { ids: [1, 2] });
             localDeleteMany = deleteMany;
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
         localDeleteMany();
-        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
-            ids: [1, 2],
+        await waitFor(() => {
+            expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
+                ids: [1, 2],
+            });
         });
     });
 
-    it('merges hook call time and callback call time queries', () => {
-        const dataProvider: Partial<DataProvider> = {
+    it('uses call time params over hook time params', async () => {
+        const dataProvider = testDataProvider({
             deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] } as any)),
-        };
+        });
         let localDeleteMany;
         const Dummy = () => {
-            const [deleteMany] = useDeleteMany('foo', [1, 2]);
+            const [deleteMany] = useDeleteMany('foo', { ids: [1, 2] });
             localDeleteMany = deleteMany;
             return <span />;
         };
 
-        renderWithRedux(
-            // @ts-expect-error
-            <DataProviderContext.Provider value={dataProvider}>
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
                 <Dummy />
-            </DataProviderContext.Provider>
+            </CoreAdminContext>
         );
-        localDeleteMany({ payload: { ids: [3, 4] } });
-        expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
-            ids: [3, 4],
+        localDeleteMany('foo', { ids: [3, 4] });
+        await waitFor(() => {
+            expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
+                ids: [3, 4],
+            });
         });
     });
 });

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -50,7 +50,7 @@ import { Record, DeleteManyParams, MutationMode } from '../types';
  *         deleteMany('posts', { ids: selectedIds })
  *     }
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={isLoading} onClick={deleteMany}>Delete selected posts</button>;
+ *     return <button disabled={isLoading} onClick={handleClick}>Delete selected posts</button>;
  * };
  *
  * @example // set params when calling the hook
@@ -59,8 +59,11 @@ import { Record, DeleteManyParams, MutationMode } from '../types';
  *
  * const BulkDeletePostsButton = ({ selectedIds }) => {
  *     const [deleteMany, { isLoading, error }] = useDeleteMany('posts', { ids: selectedIds });
+ *     const handleClick = () => {
+ *         deleteMany()
+ *     }
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={isLoading} onClick={() => deleteMany()}>Delete selected posts</button>;
+ *     return <button disabled={isLoading} onClick={handleClick}>Delete selected posts</button>;
  * };
  *
  * @example // TypeScript

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -119,7 +119,9 @@ export const useDeleteMany = <RecordType extends Record = Record>(
                 return recordWasFound
                     ? {
                           data: newCollection,
-                          total: res.total - 1,
+                          total:
+                              res.total -
+                              (res.data.length - newCollection.length),
                       }
                     : res;
             },
@@ -140,7 +142,9 @@ export const useDeleteMany = <RecordType extends Record = Record>(
                 return recordWasFound
                     ? {
                           data: newCollection,
-                          total: res.total - 1,
+                          total:
+                              res.total -
+                              (res.data.length - newCollection.length),
                       }
                     : res;
             },

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -1,40 +1,56 @@
-import { useCallback } from 'react';
-import { Identifier } from '../types';
-import useMutation, { MutationOptions, Mutation } from './useMutation';
+import { useRef } from 'react';
+import {
+    useMutation,
+    useQueryClient,
+    UseMutationOptions,
+    UseMutationResult,
+    MutateOptions,
+    QueryKey,
+} from 'react-query';
+
+import useDataProvider from './useDataProvider';
+import undoableEventEmitter from './undoableEventEmitter';
+import { Record, DeleteManyParams, MutationMode } from '../types';
 
 /**
- * Get a callback to call the dataProvider.deleteMany() method, the result
- * of the call (the list of deleted record ids), and the loading state.
+ * Get a callback to call the dataProvider.delete() method, the result and the loading state.
+ *
+ * @param {string} resource
+ * @param {Params} params The delete parameters { ids }
+ * @param {Object} options Options object to pass to the queryClient.
+ * May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
+ *
+ * @typedef Params
+ * @prop params.ids The resource identifiers, e.g. [123, 456]
+ *
+ * @returns The current mutation state. Destructure as [deleteMany, { data, error, isLoading }].
  *
  * The return value updates according to the request state:
  *
- * - initial: [deleteMany, { loading: false, loaded: false }]
- * - start:   [deleteMany, { loading: true, loaded: false }]
- * - success: [deleteMany, { data: [data from response], loading: false, loaded: true }]
- * - error:   [deleteMany, { error: [error from response], loading: false, loaded: false }]
+ * - initial: [deleteMany, { isLoading: false, isIdle: true }]
+ * - start:   [deleteMany, { isLoading: true }]
+ * - success: [deleteMany, { data: [data from response], isLoading: false, isSuccess: true }]
+ * - error:   [deleteMany, { error: [error from response], isLoading: false, isError: true }]
  *
- * @param resource The resource name, e.g. 'posts'
- * @param ids The resource identifiers, e.g. [123, 456]
- * @param options Options object to pass to the dataProvider. May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
+ * The deleteMany() function must be called with a resource and a parameter object: deleteMany(resource, { id, data, previousData }, options)
  *
- * @returns The current request state. Destructure as [deleteMany, { data, error, loading, loaded }].
+ * This hook uses react-query useMutation under the hood.
+ * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * The deleteMany() function can be called in 3 different ways:
- *  - with the same parameters as the useDeleteMany() hook: deleteMany(resource, ids, options)
- *  - with the same syntax as useMutation: deleteMany({ resource, payload: { ids } }, options)
- *  - with no parameter (if they were already passed to useDeleteMany()): deleteMany()
+ * @see https://react-query.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the deleteMany callback
  *
  * import { useDeleteMany } from 'react-admin';
  *
  * const BulkDeletePostsButton = ({ selectedIds }) => {
- *     const [deleteMany, { loading, error }] = useDeleteMany();
+ *     const [deleteMany, { isLoading, error }] = useDeleteMany();
  *     const handleClick = () => {
- *         deleteMany('posts', selectedIds)
+ *         deleteMany('posts', { ids: selectedIds })
  *     }
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={deleteMany}>Delete selected posts</button>;
+ *     return <button disabled={isLoading} onClick={deleteMany}>Delete selected posts</button>;
  * };
  *
  * @example // set params when calling the hook
@@ -42,61 +58,355 @@ import useMutation, { MutationOptions, Mutation } from './useMutation';
  * import { useDeleteMany } from 'react-admin';
  *
  * const BulkDeletePostsButton = ({ selectedIds }) => {
- *     const [deleteMany, { loading, error }] = useDeleteMany('posts', selectedIds);
+ *     const [deleteMany, { isLoading, error }] = useDeleteMany('posts', { ids: selectedIds });
  *     if (error) { return <p>ERROR</p>; }
- *     return <button disabled={loading} onClick={deleteMany}>Delete selected posts</button>;
+ *     return <button disabled={isLoading} onClick={() => deleteMany()}>Delete selected posts</button>;
  * };
+ *
+ * @example // TypeScript
+ * const [deleteMany, { data }] = useDeleteMany<Product>('products', { ids });
+ *                        \-- data is Product
  */
-const useDeleteMany = (
+export const useDeleteMany = <RecordType extends Record = Record>(
     resource?: string,
-    ids?: Identifier[],
-    options?: MutationOptions
-): UseDeleteManyHookValue => {
-    const [mutate, state] = useMutation(
-        { type: 'deleteMany', resource, payload: { ids } },
-        options
-    );
+    params: Partial<DeleteManyParams<RecordType>> = {},
+    options: UseDeleteManyOptions<RecordType> = {}
+): UseDeleteManyResult<RecordType> => {
+    const dataProvider = useDataProvider();
+    const queryClient = useQueryClient();
+    const { ids } = params;
+    const { mutationMode = 'pessimistic', ...reactMutationOptions } = options;
+    const mode = useRef<MutationMode>(mutationMode);
+    const paramsRef = useRef<Partial<DeleteManyParams<RecordType>>>({});
+    const snapshot = useRef<Snapshot>([]);
 
-    const deleteMany = useCallback(
-        (
-            resource?: string | Partial<Mutation> | Event,
-            ids?: Identifier[] | Partial<MutationOptions>,
-            options?: MutationOptions
-        ) => {
-            if (typeof resource === 'string') {
-                const query = {
-                    type: 'deleteMany',
-                    resource,
-                    payload: {
-                        ids: ids as Identifier[],
-                    },
-                };
-                return mutate(query, options);
-            } else {
-                return mutate(
-                    resource as Mutation | Event,
-                    ids as MutationOptions
+    const updateCache = ({ resource, ids }) => {
+        // hack: only way to tell react-query not to fetch this query for the next 5 seconds
+        // because setQueryData doesn't accept a stale time option
+        const now = Date.now();
+        const updatedAt = mode.current === 'undoable' ? now + 5 * 1000 : now;
+
+        const updateColl = (old: RecordType[]) => {
+            if (!old) return;
+            let newCollection = [...old];
+            ids.forEach(id => {
+                const index = newCollection.findIndex(
+                    // eslint-disable-next-line eqeqeq
+                    record => record.id == id
                 );
-            }
-        },
-        [mutate] // eslint-disable-line react-hooks/exhaustive-deps
+                if (index === -1) {
+                    return;
+                }
+                newCollection = [
+                    ...newCollection.slice(0, index),
+                    ...newCollection.slice(index + 1),
+                ];
+            });
+            return newCollection;
+        };
+
+        type GetListResult = { data?: RecordType[]; total?: number };
+
+        queryClient.setQueriesData(
+            [resource, 'getList'],
+            (res: GetListResult) => {
+                if (!res || !res.data) return res;
+                const newCollection = updateColl(res.data);
+                const recordWasFound = newCollection.length < res.data.length;
+                return recordWasFound
+                    ? {
+                          data: newCollection,
+                          total: res.total - 1,
+                      }
+                    : res;
+            },
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            [resource, 'getMany'],
+            (coll: RecordType[]) =>
+                coll && coll.length > 0 ? updateColl(coll) : coll,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            [resource, 'getManyReference'],
+            (res: GetListResult) => {
+                if (!res || !res.data) return res;
+                const newCollection = updateColl(res.data);
+                const recordWasFound = newCollection.length < res.data.length;
+                return recordWasFound
+                    ? {
+                          data: newCollection,
+                          total: res.total - 1,
+                      }
+                    : res;
+            },
+            { updatedAt }
+        );
+    };
+
+    const mutation = useMutation<
+        RecordType['id'][],
+        unknown,
+        Partial<UseDeleteManyMutateParams<RecordType>>
+    >(
+        ({
+            resource: callTimeResource = resource,
+            ids: callTimeIds = paramsRef.current.ids,
+        } = {}) =>
+            dataProvider
+                .deleteMany<RecordType>(callTimeResource, {
+                    ids: callTimeIds,
+                })
+                .then(({ data }) => data),
+        {
+            ...reactMutationOptions,
+            onMutate: async (
+                variables: Partial<UseDeleteManyMutateParams<RecordType>>
+            ) => {
+                if (reactMutationOptions.onMutate) {
+                    const userContext =
+                        (await reactMutationOptions.onMutate(variables)) || {};
+                    return {
+                        snapshot: snapshot.current,
+                        // @ts-ignore
+                        ...userContext,
+                    };
+                } else {
+                    // Return a context object with the snapshot value
+                    return { snapshot: snapshot.current };
+                }
+            },
+            onError: (
+                error: unknown,
+                variables: Partial<UseDeleteManyMutateParams<RecordType>> = {},
+                context: { snapshot: Snapshot }
+            ) => {
+                if (
+                    mode.current === 'optimistic' ||
+                    mode.current === 'undoable'
+                ) {
+                    // If the mutation fails, use the context returned from onMutate to rollback
+                    context.snapshot.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                }
+
+                if (reactMutationOptions.onError) {
+                    return reactMutationOptions.onError(
+                        error,
+                        variables,
+                        context
+                    );
+                }
+                // call-time error callback is executed by react-query
+            },
+            onSuccess: (
+                data: RecordType['id'][],
+                variables: Partial<UseDeleteManyMutateParams<RecordType>> = {},
+                context: unknown
+            ) => {
+                if (mode.current === 'pessimistic') {
+                    // update the getOne and getList query cache with the new result
+                    const {
+                        resource: callTimeResource = resource,
+                        ids: callTimeIds = ids,
+                    } = variables;
+                    updateCache({
+                        resource: callTimeResource,
+                        ids: callTimeIds,
+                    });
+
+                    if (reactMutationOptions.onSuccess) {
+                        reactMutationOptions.onSuccess(
+                            data,
+                            variables,
+                            context
+                        );
+                    }
+                    // call-time success callback is executed by react-query
+                }
+            },
+            onSettled: (
+                data: RecordType['id'][],
+                error: unknown,
+                variables: Partial<UseDeleteManyMutateParams<RecordType>> = {},
+                context: { snapshot: Snapshot }
+            ) => {
+                if (
+                    mode.current === 'optimistic' ||
+                    mode.current === 'undoable'
+                ) {
+                    // Always refetch after error or success:
+                    context.snapshot.forEach(([key]) => {
+                        queryClient.invalidateQueries(key);
+                    });
+                }
+
+                if (reactMutationOptions.onSettled) {
+                    return reactMutationOptions.onSettled(
+                        data,
+                        error,
+                        variables,
+                        context
+                    );
+                }
+            },
+        }
     );
 
-    return [deleteMany, state];
+    const mutate = async (
+        callTimeResource: string = resource,
+        callTimeParams: Partial<DeleteManyParams<RecordType>> = {},
+        updateOptions: MutateOptions<
+            RecordType['id'][],
+            unknown,
+            Partial<UseDeleteManyMutateParams<RecordType>>,
+            unknown
+        > & { mutationMode?: MutationMode } = {}
+    ) => {
+        const { mutationMode, onSuccess, onSettled, onError } = updateOptions;
+
+        // store the hook time params *at the moment of the call*
+        // because they may change afterwards, which would break the undoable mode
+        // as the previousData would be overwritten by the optimistic update
+        paramsRef.current = params;
+
+        if (mutationMode) {
+            mode.current = mutationMode;
+        }
+
+        if (mode.current === 'pessimistic') {
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                { onSuccess, onSettled, onError }
+            );
+        }
+
+        const { ids: callTimeIds = ids } = callTimeParams;
+
+        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // except we do it in a mutate wrapper instead of the onMutate callback
+        // to have access to success side effects
+
+        const queryKeys = [
+            [callTimeResource, 'getList'],
+            [callTimeResource, 'getMany'],
+            [callTimeResource, 'getManyReference'],
+        ];
+
+        /**
+         * Snapshot the previous values via queryClient.getQueriesData()
+         *
+         * The snapshotData ref will contain an array of tuples [query key, associated data]
+         *
+         * @example
+         * [
+         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
+         *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+         *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+         * ]
+         *
+         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         */
+        snapshot.current = queryKeys.reduce(
+            (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),
+            [] as Snapshot
+        );
+
+        // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
+        await Promise.all(
+            snapshot.current.map(([key]) => queryClient.cancelQueries(key))
+        );
+
+        // Optimistically update to the new value
+        updateCache({
+            resource: callTimeResource,
+            ids: callTimeIds,
+        });
+
+        // run the success callbacks during the next tick
+        if (onSuccess) {
+            setTimeout(
+                () =>
+                    onSuccess(
+                        callTimeIds,
+                        { resource: callTimeResource, ...callTimeParams },
+                        { snapshot: snapshot.current }
+                    ),
+                0
+            );
+        }
+        if (reactMutationOptions.onSuccess) {
+            setTimeout(
+                () =>
+                    reactMutationOptions.onSuccess(
+                        callTimeIds,
+                        { resource: callTimeResource, ...callTimeParams },
+                        { snapshot: snapshot.current }
+                    ),
+                0
+            );
+        }
+
+        if (mode.current === 'optimistic') {
+            // call the mutate method without success side effects
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                { onSettled, onError }
+            );
+        } else {
+            // undoable mutation: register the mutation for later
+            undoableEventEmitter.once('end', ({ isUndo }) => {
+                if (isUndo) {
+                    // rollback
+                    snapshot.current.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                } else {
+                    // call the mutate method without success side effects
+                    mutation.mutate(
+                        { resource: callTimeResource, ...callTimeParams },
+                        { onSettled, onError }
+                    );
+                }
+            });
+        }
+    };
+
+    return [mutate, mutation];
 };
 
-type UseDeleteManyHookValue = [
+type Snapshot = [key: QueryKey, value: any][];
+
+export interface UseDeleteManyMutateParams<RecordType extends Record = Record> {
+    resource?: string;
+    ids?: RecordType['id'][];
+}
+
+export type UseDeleteManyOptions<
+    RecordType extends Record = Record
+> = UseMutationOptions<
+    RecordType['id'][],
+    unknown,
+    Partial<UseDeleteManyMutateParams<RecordType>>
+> & { mutationMode?: MutationMode };
+
+export type UseDeleteManyResult<RecordType extends Record = Record> = [
     (
-        resource?: string | Partial<Mutation> | Event,
-        ids?: Identifier[] | Partial<MutationOptions>,
-        options?: MutationOptions
-    ) => void | Promise<any>,
-    {
-        data?: Identifier[];
-        total?: number;
-        error?: any;
-        loading: boolean;
-        loaded: boolean;
-    }
+        resource?: string,
+        params?: Partial<DeleteManyParams<RecordType>>,
+        options?: MutateOptions<
+            RecordType['id'][],
+            unknown,
+            Partial<UseDeleteManyMutateParams<RecordType>>,
+            unknown
+        > & { mutationMode?: MutationMode }
+    ) => Promise<void>,
+    UseMutationResult<
+        RecordType['id'][],
+        unknown,
+        Partial<DeleteManyParams<RecordType> & { resource?: string }>,
+        unknown
+    >
 ];
-export default useDeleteMany;

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -17,7 +17,7 @@ import { Identifier } from '..';
  * Get a callback to call the dataProvider.updateMany() method, the result and the loading state.
  *
  * @param {string} resource
- * @param {Params} params The updateMany parameters { ids, data, previousData }
+ * @param {Params} params The updateMany parameters { ids, data }
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: { refresh: true } }
  * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
@@ -25,7 +25,6 @@ import { Identifier } from '..';
  * @typedef Params
  * @prop params.ids The resource identifiers, e.g. [123, 456]
  * @prop params.data The updates to merge into the record, e.g. { views: 10 }
- * @prop params.previousData The record before the update is applied
  *
  * @returns The current mutation state. Destructure as [updateMany, { data, error, isLoading }].
  *

--- a/packages/ra-core/src/reducer/admin/resource/list/selectedIds.ts
+++ b/packages/ra-core/src/reducer/admin/resource/list/selectedIds.ts
@@ -4,10 +4,9 @@ import {
     SetListSelectedIdsAction,
     TOGGLE_LIST_ITEM,
     ToggleListItemAction,
-    CRUD_DELETE_SUCCESS,
-    CrudDeleteSuccessAction,
+    UNSELECT_LIST_ITEMS,
+    UnselectListItemsAction,
 } from '../../../../actions';
-import { DELETE, DELETE_MANY } from '../../../../core';
 import { Identifier } from '../../../../types';
 
 const initialState = [];
@@ -17,12 +16,7 @@ type State = Identifier[];
 type ActionTypes =
     | SetListSelectedIdsAction
     | ToggleListItemAction
-    | CrudDeleteSuccessAction
-    | {
-          type: 'DELETE_ACTION';
-          meta: { optimistic: true; fetch: string };
-          payload: any;
-      }
+    | UnselectListItemsAction
     | {
           type: 'OTHER_ACTION';
           meta: any;
@@ -47,30 +41,20 @@ const selectedIdsReducer: Reducer<State> = (
             return [...previousState, action.payload];
         }
     }
-    if (action.type === CRUD_DELETE_SUCCESS) {
-        const index = previousState.indexOf(action.payload.data.id);
-        if (index > -1) {
-            return [
-                ...previousState.slice(0, index),
-                ...previousState.slice(index + 1),
-            ];
-        }
-    }
-
-    if (action.meta && action.meta.optimistic) {
-        if (action.meta.fetch === DELETE) {
-            const index = previousState.indexOf(action.payload.id);
-            if (index === -1) {
-                return previousState;
+    if (action.type === UNSELECT_LIST_ITEMS) {
+        const ids = action.payload;
+        if (!ids || ids.length === 0) return previousState;
+        let newState = [...previousState];
+        ids.forEach(id => {
+            const index = newState.indexOf(id);
+            if (index > -1) {
+                newState = [
+                    ...previousState.slice(0, index),
+                    ...previousState.slice(index + 1),
+                ];
             }
-            return [
-                ...previousState.slice(0, index),
-                ...previousState.slice(index + 1),
-            ];
-        }
-        if (action.meta.fetch === DELETE_MANY) {
-            return previousState.filter(id => !action.payload.ids.includes(id));
-        }
+        });
+        return newState;
     }
 
     return action.meta && action.meta.unselectAll

--- a/packages/ra-core/src/sideEffect/index.ts
+++ b/packages/ra-core/src/sideEffect/index.ts
@@ -2,7 +2,8 @@ import useRedirect, { RedirectionSideEffect } from './useRedirect';
 import useNotify from './useNotify';
 import useRefresh from './useRefresh';
 import useUnselectAll from './useUnselectAll';
+import useUnselect from './useUnselect';
 
 export type { RedirectionSideEffect };
 
-export { useRedirect, useNotify, useRefresh, useUnselectAll };
+export { useRedirect, useNotify, useRefresh, useUnselectAll, useUnselect };

--- a/packages/ra-core/src/sideEffect/useUnselect.ts
+++ b/packages/ra-core/src/sideEffect/useUnselect.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { unselectListItems } from '../actions';
+import { Identifier } from '../types';
+
+/**
+ * Hook to Unselect the rows of a datagrid
+ *
+ * @example
+ *
+ * const unselect = useUnselect();
+ * unselect('posts', [123, 456]);
+ */
+const useUnselectAll = () => {
+    const dispatch = useDispatch();
+    return useCallback(
+        (resource: string, ids: Identifier[]) => {
+            dispatch(unselectListItems(resource, ids));
+        },
+        [dispatch]
+    );
+};
+
+export default useUnselectAll;

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -111,10 +111,10 @@ export type DataProvider = {
         params: UpdateParams
     ) => Promise<UpdateResult<RecordType>>;
 
-    updateMany: (
+    updateMany: <RecordType extends Record = Record>(
         resource: string,
         params: UpdateManyParams
-    ) => Promise<UpdateManyResult>;
+    ) => Promise<UpdateManyResult<RecordType>>;
 
     create: <RecordType extends Record = Record>(
         resource: string,
@@ -123,13 +123,13 @@ export type DataProvider = {
 
     delete: <RecordType extends Record = Record>(
         resource: string,
-        params: DeleteParams
+        params: DeleteParams<RecordType>
     ) => Promise<DeleteResult<RecordType>>;
 
-    deleteMany: (
+    deleteMany: <RecordType extends Record = Record>(
         resource: string,
-        params: DeleteManyParams
-    ) => Promise<DeleteManyResult>;
+        params: DeleteManyParams<RecordType>
+    ) => Promise<DeleteManyResult<RecordType>>;
 
     [key: string]: any;
 };
@@ -188,8 +188,8 @@ export interface UpdateManyParams<T = any> {
     ids: Identifier[];
     data: T;
 }
-export interface UpdateManyResult {
-    data?: Identifier[];
+export interface UpdateManyResult<RecordType extends Record = Record> {
+    data?: RecordType['id'][];
     validUntil?: ValidUntil;
 }
 
@@ -209,11 +209,11 @@ export interface DeleteResult<RecordType extends Record = Record> {
     data: RecordType;
 }
 
-export interface DeleteManyParams {
-    ids: Identifier[];
+export interface DeleteManyParams<RecordType extends Record = Record> {
+    ids: RecordType['id'][];
 }
-export interface DeleteManyResult {
-    data?: Identifier[];
+export interface DeleteManyResult<RecordType extends Record = Record> {
+    data?: RecordType['id'][];
 }
 
 export type DataProviderResult<RecordType extends Record = Record> =
@@ -281,6 +281,12 @@ export type DataProviderProxy<
         options?: UseDataProviderOptions
     ) => Promise<UpdateResult<RecordType>>;
 
+    updateMany: <RecordType extends Record = Record>(
+        resource: string,
+        params: UpdateManyParams,
+        options?: UseDataProviderOptions
+    ) => Promise<UpdateManyResult<RecordType>>;
+
     create: <RecordType extends Record = Record>(
         resource: string,
         params: CreateParams
@@ -290,6 +296,11 @@ export type DataProviderProxy<
         resource: string,
         params: DeleteParams
     ) => Promise<DeleteResult<RecordType>>;
+
+    deleteMany: <RecordType extends Record = Record>(
+        resource: string,
+        params: DeleteManyParams<RecordType>
+    ) => Promise<DeleteManyResult<RecordType>>;
 };
 
 export type MutationMode = 'pessimistic' | 'optimistic' | 'undoable';

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -201,9 +201,9 @@ export interface CreateResult<RecordType extends Record = Record> {
     validUntil?: ValidUntil;
 }
 
-export interface DeleteParams {
+export interface DeleteParams<RecordType extends Record = Record> {
     id: Identifier;
-    previousData?: Record;
+    previousData?: RecordType;
 }
 export interface DeleteResult<RecordType extends Record = Record> {
     data: RecordType;

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -5,7 +5,6 @@ import ActionDelete from '@mui/icons-material/Delete';
 import inflection from 'inflection';
 import { alpha, styled } from '@mui/material/styles';
 import {
-    CRUD_DELETE_MANY,
     MutationMode,
     useDeleteMany,
     useListContext,
@@ -40,37 +39,40 @@ export const BulkDeleteWithConfirmButton = (
     const refresh = useRefresh();
     const translate = useTranslate();
     const resource = useResourceContext(props);
-    const [deleteMany, { loading }] = useDeleteMany(resource, selectedIds, {
-        action: CRUD_DELETE_MANY,
-        onSuccess: () => {
-            refresh();
-            notify('ra.notification.deleted', {
-                type: 'info',
-                messageArgs: { smart_count: selectedIds.length },
-            });
-            unselectAll(resource);
-        },
-        onFailure: error => {
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                {
-                    type: 'warning',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                ? error.message
-                                : undefined,
-                    },
-                }
-            );
-            setOpen(false);
-        },
-        mutationMode,
-    });
+    const [deleteMany, { isLoading }] = useDeleteMany(
+        resource,
+        { ids: selectedIds },
+        {
+            onSuccess: () => {
+                refresh();
+                notify('ra.notification.deleted', {
+                    type: 'info',
+                    messageArgs: { smart_count: selectedIds.length },
+                });
+                unselectAll(resource);
+            },
+            onError: (error: Error) => {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : error.message || 'ra.notification.http_error',
+                    {
+                        type: 'warning',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error && error.message
+                                    ? error.message
+                                    : undefined,
+                        },
+                    }
+                );
+                setOpen(false);
+            },
+            mutationMode,
+        }
+    );
 
     const handleClick = e => {
         setOpen(true);
@@ -101,7 +103,7 @@ export const BulkDeleteWithConfirmButton = (
             </StyledButton>
             <Confirm
                 isOpen={isOpen}
-                loading={loading}
+                loading={isLoading}
                 title={confirmTitle}
                 content={confirmContent}
                 translateOptions={{

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { ReactElement, SyntheticEvent } from 'react';
 import PropTypes from 'prop-types';
+import { UseMutationOptions } from 'react-query';
 import {
     Record,
     RedirectionSideEffect,
     MutationMode,
-    OnSuccess,
-    OnFailure,
+    DeleteParams,
 } from 'ra-core';
 
 import { ButtonProps } from './Button';
@@ -50,16 +50,20 @@ import { DeleteWithConfirmButton } from './DeleteWithConfirmButton';
  *     return <Edit actions={<EditActions />} {...props} />;
  * };
  */
-export const DeleteButton = (props: DeleteButtonProps) => {
+export const DeleteButton = <RecordType extends Record = Record>(
+    props: DeleteButtonProps<RecordType>
+) => {
     const { mutationMode = 'undoable', record, ...rest } = props;
     if (!record || record.id == null) {
         return null;
     }
 
     return mutationMode === 'undoable' ? (
-        <DeleteWithUndoButton record={record} {...rest} />
+        // @ts-ignore I looked for the error for one hour without finding it
+        <DeleteWithUndoButton<RecordType> record={record} {...rest} />
     ) : (
-        <DeleteWithConfirmButton
+        <DeleteWithConfirmButton<RecordType>
+            // @ts-ignore I looked for the error for one hour without finding it
             mutationMode={mutationMode}
             record={record}
             {...rest}
@@ -67,7 +71,8 @@ export const DeleteButton = (props: DeleteButtonProps) => {
     );
 };
 
-interface Props {
+export interface DeleteButtonProps<RecordType extends Record = Record>
+    extends Omit<ButtonProps, 'record'> {
     basePath?: string;
     classes?: object;
     className?: string;
@@ -76,8 +81,7 @@ interface Props {
     icon?: ReactElement;
     label?: string;
     mutationMode?: MutationMode;
-    onClick?: (e: MouseEvent) => void;
-    record?: Record;
+    record?: RecordType;
     redirect?: RedirectionSideEffect;
     resource?: string;
     // May be injected by Toolbar
@@ -87,11 +91,12 @@ interface Props {
     pristine?: boolean;
     saving?: boolean;
     submitOnEnter?: boolean;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        DeleteParams<RecordType>
+    >;
 }
-
-export type DeleteButtonProps = Props & ButtonProps;
 
 DeleteButton.propTypes = {
     basePath: PropTypes.string,

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 import expect from 'expect';
-import { DataProvider, DataProviderContext, MutationMode } from 'ra-core';
-import { QueryClientProvider, QueryClient } from 'react-query';
-import { renderWithRedux, TestContext } from 'ra-test';
+import { CoreAdminContext, testDataProvider } from 'ra-core';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { DeleteWithConfirmButton } from './DeleteWithConfirmButton';
@@ -26,46 +24,30 @@ const invalidButtonDomProps = {
     resource: 'posts',
     saving: false,
     submitOnEnter: true,
-    mutationMode: 'pessimistic' as MutationMode,
+    mutationMode: 'pessimistic',
 };
 
 describe('<DeleteWithConfirmButton />', () => {
     it('should render a button with no DOM errors', () => {
         const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        const { getByLabelText } = render(
-            <TestContext
-                initialState={{
-                    admin: {
-                        resources: {
-                            posts: {
-                                data: {
-                                    1: {
-                                        id: 1,
-                                        foo: 'bar',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                }}
-            >
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
                 <ThemeProvider theme={theme}>
                     <DeleteWithConfirmButton {...invalidButtonDomProps} />
                 </ThemeProvider>
-            </TestContext>
+            </CoreAdminContext>
         );
 
         expect(spy).not.toHaveBeenCalled();
-        expect(getByLabelText('ra.action.delete').getAttribute('type')).toEqual(
-            'button'
-        );
+        expect(
+            screen.getByLabelText('ra.action.delete').getAttribute('type')
+        ).toEqual('button');
 
         spy.mockRestore();
     });
 
     const defaultEditProps = {
-        basePath: '',
         id: '123',
         resource: 'posts',
         location: {},
@@ -74,41 +56,36 @@ describe('<DeleteWithConfirmButton />', () => {
     };
 
     it('should allow to override the resource', async () => {
-        const dataProvider = ({
+        const dataProvider = testDataProvider({
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
             delete: jest.fn().mockResolvedValueOnce({ data: { id: 123 } }),
-        } as unknown) as DataProvider;
+        });
         const EditToolbar = props => (
             <Toolbar {...props}>
                 <DeleteWithConfirmButton resource="comments" />
             </Toolbar>
         );
-        const {
-            queryByDisplayValue,
-            getByLabelText,
-            getByText,
-        } = renderWithRedux(
+        render(
             <ThemeProvider theme={theme}>
-                <QueryClientProvider client={new QueryClient()}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <Edit {...defaultEditProps}>
-                            <SimpleForm toolbar={<EditToolbar />}>
-                                <TextInput source="title" />
-                            </SimpleForm>
-                        </Edit>
-                    </DataProviderContext.Provider>
-                </QueryClientProvider>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Edit {...defaultEditProps}>
+                        <SimpleForm toolbar={<EditToolbar />}>
+                            <TextInput source="title" />
+                        </SimpleForm>
+                    </Edit>
+                </CoreAdminContext>
             </ThemeProvider>
         );
         // waitFor for the dataProvider.getOne() return
         await waitFor(() => {
-            expect(queryByDisplayValue('lorem')).not.toBeNull();
+            expect(screen.queryByDisplayValue('lorem')).not.toBeNull();
         });
-        fireEvent.click(getByLabelText('ra.action.delete'));
-        fireEvent.click(getByText('ra.action.confirm'));
+        fireEvent.click(screen.getByLabelText('ra.action.delete'));
+        fireEvent.click(screen.getByText('ra.action.confirm'));
         await waitFor(() => {
             expect(dataProvider.delete).toHaveBeenCalledWith('comments', {
                 id: 123,
@@ -118,140 +95,138 @@ describe('<DeleteWithConfirmButton />', () => {
     });
 
     it('should allows to undo the deletion after confirmation if mutationMode is undoable', async () => {
-        const dataProvider = ({
+        const dataProvider = testDataProvider({
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
             delete: jest.fn().mockResolvedValueOnce({ data: { id: 123 } }),
-        } as unknown) as DataProvider;
+        });
         const EditToolbar = props => (
             <Toolbar {...props}>
                 <DeleteWithConfirmButton mutationMode="undoable" />
             </Toolbar>
         );
-        const {
-            queryByDisplayValue,
-            queryByText,
-            getByLabelText,
-            getByText,
-        } = renderWithRedux(
+        render(
             <ThemeProvider theme={theme}>
-                <QueryClientProvider client={new QueryClient()}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <>
-                            <Edit {...defaultEditProps}>
-                                <SimpleForm toolbar={<EditToolbar />}>
-                                    <TextInput source="title" />
-                                </SimpleForm>
-                            </Edit>
-                            <Notification />
-                        </>
-                    </DataProviderContext.Provider>
-                </QueryClientProvider>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <>
+                        <Edit {...defaultEditProps}>
+                            <SimpleForm toolbar={<EditToolbar />}>
+                                <TextInput source="title" />
+                            </SimpleForm>
+                        </Edit>
+                        <Notification />
+                    </>
+                </CoreAdminContext>
             </ThemeProvider>
         );
         // waitFor for the dataProvider.getOne() return
         await waitFor(() => {
-            expect(queryByDisplayValue('lorem')).not.toBeNull();
+            expect(screen.queryByDisplayValue('lorem')).not.toBeNull();
         });
-        fireEvent.click(getByLabelText('ra.action.delete'));
-        fireEvent.click(getByText('ra.action.confirm'));
+        fireEvent.click(screen.getByLabelText('ra.action.delete'));
+        fireEvent.click(screen.getByText('ra.action.confirm'));
 
         await waitFor(() => {
-            expect(queryByText('ra.notification.deleted')).not.toBeNull();
+            expect(
+                screen.queryByText('ra.notification.deleted')
+            ).not.toBeNull();
         });
-        expect(queryByText('ra.action.undo')).not.toBeNull();
+        expect(screen.queryByText('ra.action.undo')).not.toBeNull();
     });
 
-    it('should allow to override the onSuccess side effects', async () => {
-        const dataProvider = ({
+    it('should allow to override the success side effects', async () => {
+        const dataProvider = testDataProvider({
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
             delete: jest.fn().mockResolvedValueOnce({ data: { id: 123 } }),
-        } as unknown) as DataProvider;
+        });
         const onSuccess = jest.fn();
         const EditToolbar = props => (
             <Toolbar {...props}>
-                <DeleteWithConfirmButton onSuccess={onSuccess} />
+                <DeleteWithConfirmButton mutationOptions={{ onSuccess }} />
             </Toolbar>
         );
-        const {
-            queryByDisplayValue,
-            getByLabelText,
-            getByText,
-        } = renderWithRedux(
+        render(
             <ThemeProvider theme={theme}>
-                <QueryClientProvider client={new QueryClient()}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <Edit {...defaultEditProps}>
-                            <SimpleForm toolbar={<EditToolbar />}>
-                                <TextInput source="title" />
-                            </SimpleForm>
-                        </Edit>
-                    </DataProviderContext.Provider>
-                </QueryClientProvider>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Edit {...defaultEditProps}>
+                        <SimpleForm toolbar={<EditToolbar />}>
+                            <TextInput source="title" />
+                        </SimpleForm>
+                    </Edit>
+                </CoreAdminContext>
             </ThemeProvider>
         );
         // waitFor for the dataProvider.getOne() return
         await waitFor(() => {
-            expect(queryByDisplayValue('lorem')).not.toBeNull();
+            expect(screen.queryByDisplayValue('lorem')).not.toBeNull();
         });
-        fireEvent.click(getByLabelText('ra.action.delete'));
-        fireEvent.click(getByText('ra.action.confirm'));
+        fireEvent.click(screen.getByLabelText('ra.action.delete'));
+        fireEvent.click(screen.getByText('ra.action.confirm'));
         await waitFor(() => {
             expect(dataProvider.delete).toHaveBeenCalled();
-            expect(onSuccess).toHaveBeenCalledWith({
-                data: { id: 123 },
-            });
+            expect(onSuccess).toHaveBeenCalledWith(
+                { id: 123 },
+                {
+                    id: 123,
+                    previousData: { id: 123, title: 'lorem' },
+                    resource: 'posts',
+                },
+                { snapshot: [] }
+            );
         });
     });
 
-    it('should allow to override the onFailure side effects', async () => {
-        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
-        const dataProvider = ({
+    it('should allow to override the error side effects', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const dataProvider = testDataProvider({
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
-            delete: jest.fn().mockRejectedValueOnce({ message: 'not good' }),
-        } as unknown) as DataProvider;
-        const onFailure = jest.fn();
+            delete: jest.fn().mockRejectedValueOnce(new Error('not good')),
+        });
+        const onError = jest.fn();
         const EditToolbar = props => (
             <Toolbar {...props}>
-                <DeleteWithConfirmButton onFailure={onFailure} />
+                <DeleteWithConfirmButton mutationOptions={{ onError }} />
             </Toolbar>
         );
-        const {
-            queryByDisplayValue,
-            getByLabelText,
-            getByText,
-        } = renderWithRedux(
-            <QueryClientProvider client={new QueryClient()}>
-                <ThemeProvider theme={theme}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <Edit {...defaultEditProps}>
-                            <SimpleForm toolbar={<EditToolbar />}>
-                                <TextInput source="title" />
-                            </SimpleForm>
-                        </Edit>
-                    </DataProviderContext.Provider>
-                </ThemeProvider>
-            </QueryClientProvider>
+        render(
+            <ThemeProvider theme={theme}>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Edit {...defaultEditProps}>
+                        <SimpleForm toolbar={<EditToolbar />}>
+                            <TextInput source="title" />
+                        </SimpleForm>
+                    </Edit>
+                </CoreAdminContext>
+            </ThemeProvider>
         );
         // waitFor for the dataProvider.getOne() return
         await waitFor(() => {
-            expect(queryByDisplayValue('lorem')).toBeDefined();
+            expect(screen.queryByDisplayValue('lorem')).toBeDefined();
         });
-        fireEvent.click(getByLabelText('ra.action.delete'));
-        fireEvent.click(getByText('ra.action.confirm'));
+        fireEvent.click(screen.getByLabelText('ra.action.delete'));
+        fireEvent.click(screen.getByText('ra.action.confirm'));
         await waitFor(() => {
             expect(dataProvider.delete).toHaveBeenCalled();
-            expect(onFailure).toHaveBeenCalledWith({
-                message: 'not good',
-            });
+            expect(onError).toHaveBeenCalledWith(
+                new Error('not good'),
+                {
+                    id: 123,
+                    previousData: { id: 123, title: 'lorem' },
+                    resource: 'posts',
+                },
+                { snapshot: [] }
+            );
         });
     });
 });

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -10,11 +10,11 @@ import { alpha } from '@mui/material/styles';
 import ActionDelete from '@mui/icons-material/Delete';
 import classnames from 'classnames';
 import inflection from 'inflection';
+import { UseMutationOptions } from 'react-query';
 import {
     MutationMode,
-    OnSuccess,
-    OnFailure,
     Record,
+    DeleteParams,
     RedirectionSideEffect,
     useDeleteWithConfirmController,
     useResourceContext,
@@ -24,8 +24,8 @@ import {
 import { Confirm } from '../layout';
 import { Button, ButtonProps } from './Button';
 
-export const DeleteWithConfirmButton = (
-    props: DeleteWithConfirmButtonProps
+export const DeleteWithConfirmButton = <RecordType extends Record = Record>(
+    props: DeleteWithConfirmButtonProps<RecordType>
 ) => {
     const {
         basePath,
@@ -38,8 +38,7 @@ export const DeleteWithConfirmButton = (
         onClick,
         record,
         redirect = 'list',
-        onSuccess,
-        onFailure,
+        mutationOptions,
         ...rest
     } = props;
     const translate = useTranslate();
@@ -48,7 +47,7 @@ export const DeleteWithConfirmButton = (
 
     const {
         open,
-        loading,
+        isLoading,
         handleDialogOpen,
         handleDialogClose,
         handleDelete,
@@ -58,8 +57,7 @@ export const DeleteWithConfirmButton = (
         basePath,
         mutationMode,
         onClick,
-        onSuccess,
-        onFailure,
+        mutationOptions,
         resource,
     });
 
@@ -80,7 +78,7 @@ export const DeleteWithConfirmButton = (
             </StyledButton>
             <Confirm
                 isOpen={open}
-                loading={loading}
+                loading={isLoading}
                 title={confirmTitle}
                 content={confirmContent}
                 translateOptions={{
@@ -105,7 +103,9 @@ export const DeleteWithConfirmButton = (
 
 const defaultIcon = <ActionDelete />;
 
-interface Props {
+export interface DeleteWithConfirmButtonProps<
+    RecordType extends Record = Record
+> extends Omit<ButtonProps, 'record'> {
     basePath?: string;
     className?: string;
     confirmTitle?: string;
@@ -114,7 +114,7 @@ interface Props {
     label?: string;
     mutationMode?: MutationMode;
     onClick?: ReactEventHandler<any>;
-    record?: Record;
+    record?: RecordType;
     redirect?: RedirectionSideEffect;
     resource?: string;
     // May be injected by Toolbar - sanitized in Button
@@ -124,11 +124,12 @@ interface Props {
     pristine?: boolean;
     saving?: boolean;
     submitOnEnter?: boolean;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        DeleteParams<RecordType>
+    >;
 }
-
-export type DeleteWithConfirmButtonProps = Props & ButtonProps;
 
 DeleteWithConfirmButton.propTypes = {
     basePath: PropTypes.string,

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.spec.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 import expect from 'expect';
-import { DataProvider, DataProviderContext, MutationMode } from 'ra-core';
-import { QueryClientProvider, QueryClient } from 'react-query';
-import { renderWithRedux, TestContext } from 'ra-test';
+import { MutationMode, CoreAdminContext, testDataProvider } from 'ra-core';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { Toolbar, SimpleForm } from '../form';
@@ -32,33 +30,18 @@ describe('<DeleteWithUndoButton />', () => {
     it('should render a button with no DOM errors', () => {
         const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        const { getByLabelText } = render(
-            <TestContext
-                initialState={{
-                    admin: {
-                        resources: {
-                            posts: {
-                                data: {
-                                    1: {
-                                        id: 1,
-                                        foo: 'bar',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                }}
-            >
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
                 <ThemeProvider theme={theme}>
                     <DeleteWithUndoButton {...invalidButtonDomProps} />
                 </ThemeProvider>
-            </TestContext>
+            </CoreAdminContext>
         );
 
         expect(spy).not.toHaveBeenCalled();
-        expect(getByLabelText('ra.action.delete').getAttribute('type')).toEqual(
-            'button'
-        );
+        expect(
+            screen.getByLabelText('ra.action.delete').getAttribute('type')
+        ).toEqual('button');
 
         spy.mockRestore();
     });
@@ -78,39 +61,47 @@ describe('<DeleteWithUndoButton />', () => {
     };
 
     it('should allow to override the onSuccess side effects', async () => {
-        const dataProvider = ({
+        const dataProvider = testDataProvider({
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
+            // @ts-ignore
             delete: () => Promise.resolve({ data: { id: 123 } }),
-        } as unknown) as DataProvider;
+        });
         const onSuccess = jest.fn();
         const EditToolbar = props => (
             <Toolbar {...props}>
-                <DeleteWithUndoButton onSuccess={onSuccess} />
+                <DeleteWithUndoButton mutationOptions={{ onSuccess }} />
             </Toolbar>
         );
-        const { queryByDisplayValue, getByLabelText } = renderWithRedux(
+        render(
             <ThemeProvider theme={theme}>
-                <QueryClientProvider client={new QueryClient()}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <Edit {...defaultEditProps}>
-                            <SimpleForm toolbar={<EditToolbar />}>
-                                <TextInput source="title" />
-                            </SimpleForm>
-                        </Edit>
-                    </DataProviderContext.Provider>
-                </QueryClientProvider>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Edit {...defaultEditProps}>
+                        <SimpleForm toolbar={<EditToolbar />}>
+                            <TextInput source="title" />
+                        </SimpleForm>
+                    </Edit>
+                </CoreAdminContext>
             </ThemeProvider>
         );
         // waitFor for the dataProvider.getOne() return
         await waitFor(() => {
-            expect(queryByDisplayValue('lorem')).not.toBeNull();
+            expect(screen.queryByDisplayValue('lorem')).not.toBeNull();
         });
-        fireEvent.click(getByLabelText('ra.action.delete'));
+        fireEvent.click(screen.getByLabelText('ra.action.delete'));
         await waitFor(() => {
-            expect(onSuccess).toHaveBeenCalledWith({});
+            expect(onSuccess).toHaveBeenCalledWith(
+                { id: 123, title: 'lorem' },
+                {
+                    id: 123,
+                    previousData: { id: 123, title: 'lorem' },
+                    resource: 'posts',
+                },
+                { snapshot: [] }
+            );
         });
     });
 });

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
@@ -5,18 +5,20 @@ import PropTypes from 'prop-types';
 import { alpha } from '@mui/material/styles';
 import ActionDelete from '@mui/icons-material/Delete';
 import classnames from 'classnames';
+import { UseMutationOptions } from 'react-query';
 import {
     Record,
     RedirectionSideEffect,
     useDeleteWithUndoController,
-    OnSuccess,
-    OnFailure,
+    DeleteParams,
     useResourceContext,
 } from 'ra-core';
 
 import { Button, ButtonProps } from './Button';
 
-export const DeleteWithUndoButton = (props: DeleteWithUndoButtonProps) => {
+export const DeleteWithUndoButton = <RecordType extends Record = Record>(
+    props: DeleteWithUndoButtonProps<RecordType>
+) => {
     const {
         label = 'ra.action.delete',
         className,
@@ -25,26 +27,24 @@ export const DeleteWithUndoButton = (props: DeleteWithUndoButtonProps) => {
         record,
         basePath,
         redirect = 'list',
-        onSuccess,
-        onFailure,
+        mutationOptions,
         ...rest
     } = props;
 
     const resource = useResourceContext(props);
-    const { loading, handleDelete } = useDeleteWithUndoController({
+    const { isLoading, handleDelete } = useDeleteWithUndoController({
         record,
         resource,
         basePath,
         redirect,
         onClick,
-        onSuccess,
-        onFailure,
+        mutationOptions,
     });
 
     return (
         <StyledButton
             onClick={handleDelete}
-            disabled={loading}
+            disabled={isLoading}
             label={label}
             className={classnames(
                 'ra-delete-button',
@@ -59,13 +59,16 @@ export const DeleteWithUndoButton = (props: DeleteWithUndoButtonProps) => {
     );
 };
 
-interface Props {
+const defaultIcon = <ActionDelete />;
+
+export interface DeleteWithUndoButtonProps<RecordType extends Record = Record>
+    extends Omit<ButtonProps, 'record'> {
     basePath?: string;
     className?: string;
     icon?: ReactElement;
     label?: string;
     onClick?: ReactEventHandler<any>;
-    record?: Record;
+    record?: RecordType;
     redirect?: RedirectionSideEffect;
     resource?: string;
     // May be injected by Toolbar - sanitized in Button
@@ -75,13 +78,12 @@ interface Props {
     pristine?: boolean;
     saving?: boolean;
     submitOnEnter?: boolean;
-    onSuccess?: OnSuccess;
-    onFailure?: OnFailure;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        unknown,
+        DeleteParams<RecordType>
+    >;
 }
-
-const defaultIcon = <ActionDelete />;
-
-export type DeleteWithUndoButtonProps = Props & ButtonProps;
 
 DeleteWithUndoButton.propTypes = {
     basePath: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
@@ -1,8 +1,18 @@
 import * as React from 'react';
-import { fireEvent, getByText, waitFor } from '@testing-library/react';
+import {
+    screen,
+    render,
+    fireEvent,
+    getByText,
+    waitFor,
+} from '@testing-library/react';
 import expect from 'expect';
-import { SaveContextProvider, SideEffectContextProvider } from 'ra-core';
-import { renderWithRedux } from 'ra-test';
+import {
+    CoreAdminContext,
+    SaveContextProvider,
+    SideEffectContextProvider,
+    testDataProvider,
+} from 'ra-core';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { SimpleForm } from '../../form';
@@ -28,28 +38,36 @@ describe('<SimpleFormIterator />', () => {
     };
     const sideEffectValue = {};
 
-    it('should display one input group per row', () => {
-        const { queryAllByLabelText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
+    const Wrapper = ({ children }) => (
+        <ThemeProvider theme={theme}>
+            <CoreAdminContext dataProvider={testDataProvider()}>
                 <SaveContextProvider value={saveContextValue}>
                     <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: 'foo' }, { email: 'bar' }],
-                            }}
-                        >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
+                        {children}
                     </SideEffectContextProvider>
                 </SaveContextProvider>
-            </ThemeProvider>
+            </CoreAdminContext>
+        </ThemeProvider>
+    );
+
+    it('should display one input group per row', () => {
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: 'foo' }, { email: 'bar' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'resources.undefined.fields.email'
         );
         expect(inputElements).toHaveLength(2);
@@ -60,27 +78,23 @@ describe('<SimpleFormIterator />', () => {
     });
 
     it('should render disabled inputs when disabled is true', () => {
-        const { queryAllByLabelText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: 'foo' }, { email: 'bar' }],
-                            }}
-                        >
-                            <ArrayInput source="emails" disabled>
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: 'foo' }, { email: 'bar' }],
+                    }}
+                >
+                    <ArrayInput source="emails" disabled>
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'resources.undefined.fields.email'
         );
         expect(inputElements).toHaveLength(2);
@@ -91,27 +105,23 @@ describe('<SimpleFormIterator />', () => {
     });
 
     it('should allow to override the disabled prop of each inputs', () => {
-        const { queryAllByLabelText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: 'foo' }, { email: 'bar' }],
-                            }}
-                        >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput source="email" disabled />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: 'foo' }, { email: 'bar' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" disabled />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'resources.undefined.fields.email'
         );
         expect(inputElements).toHaveLength(2);
@@ -122,141 +132,115 @@ describe('<SimpleFormIterator />', () => {
     });
 
     it('should display an add item button at least', () => {
-        const { getByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(getByText('ra.action.add')).not.toBeNull();
+        expect(screen.getByText('ra.action.add')).not.toBeNull();
     });
 
     it('should not display add button if disableAdd is truthy', () => {
-        const { queryAllByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator disableAdd>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator disableAdd>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByText('ra.action.add').length).toBe(0);
+        expect(screen.queryAllByText('ra.action.add').length).toBe(0);
     });
 
     it('should not display add button if disabled is truthy', () => {
-        const { queryAllByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails" disabled>
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails" disabled>
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByText('ra.action.add').length).toBe(0);
+        expect(screen.queryAllByText('ra.action.add').length).toBe(0);
     });
 
     it('should not display remove button if disableRemove is truthy', () => {
-        const { queryAllByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: '' }, { email: '' }],
-                            }}
-                        >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator disableRemove>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: '' }, { email: '' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator disableRemove>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByText('ra.action.remove').length).toBe(0);
+        expect(screen.queryAllByText('ra.action.remove').length).toBe(0);
     });
 
     it('should not display remove button if disabled is truthy', () => {
-        const { queryAllByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: '' }, { email: '' }],
-                            }}
-                        >
-                            <ArrayInput source="emails" disabled>
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: '' }, { email: '' }],
+                    }}
+                >
+                    <ArrayInput source="emails" disabled>
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByText('ra.action.remove').length).toBe(0);
+        expect(screen.queryAllByText('ra.action.remove').length).toBe(0);
     });
 
     it('should add children row on add button click', async () => {
-        const {
-            getByText,
-            queryAllByLabelText,
-            queryAllByText,
-        } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        const addItemElement = getByText('ra.action.add').closest('button');
+        const addItemElement = screen
+            .getByText('ra.action.add')
+            .closest('button');
 
         fireEvent.click(addItemElement);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText(
+            const inputElements = screen.queryAllByLabelText(
                 'resources.undefined.fields.email'
             );
 
@@ -265,14 +249,14 @@ describe('<SimpleFormIterator />', () => {
 
         fireEvent.click(addItemElement);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText(
+            const inputElements = screen.queryAllByLabelText(
                 'resources.undefined.fields.email'
             );
 
             expect(inputElements.length).toBe(2);
         });
 
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'resources.undefined.fields.email'
         ) as HTMLInputElement[];
 
@@ -282,43 +266,34 @@ describe('<SimpleFormIterator />', () => {
             }))
         ).toEqual([{ email: '' }, { email: '' }]);
 
-        expect(queryAllByText('ra.action.remove').length).toBe(2);
+        expect(screen.queryAllByText('ra.action.remove').length).toBe(2);
     });
 
     it('should add correct children on add button click without source', async () => {
-        const {
-            getByText,
-            queryAllByLabelText,
-            queryAllByText,
-        } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput
-                                        source="email"
-                                        label="CustomLabel"
-                                    />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" label="CustomLabel" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        const addItemElement = getByText('ra.action.add').closest('button');
+        const addItemElement = screen
+            .getByText('ra.action.add')
+            .closest('button');
 
         fireEvent.click(addItemElement);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText('CustomLabel');
+            const inputElements = screen.queryAllByLabelText('CustomLabel');
 
             expect(inputElements.length).toBe(1);
         });
 
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'CustomLabel'
         ) as HTMLInputElement[];
 
@@ -326,44 +301,38 @@ describe('<SimpleFormIterator />', () => {
             '',
         ]);
 
-        expect(queryAllByText('ra.action.remove').length).toBe(1);
+        expect(screen.queryAllByText('ra.action.remove').length).toBe(1);
     });
 
     it('should add correct children with default value on add button click without source', async () => {
-        const {
-            getByText,
-            queryAllByLabelText,
-            queryAllByText,
-        } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput
-                                        source="email"
-                                        label="CustomLabel"
-                                        defaultValue={5}
-                                    />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput
+                                source="email"
+                                label="CustomLabel"
+                                defaultValue={5}
+                            />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        const addItemElement = getByText('ra.action.add').closest('button');
+        const addItemElement = screen
+            .getByText('ra.action.add')
+            .closest('button');
 
         fireEvent.click(addItemElement);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText('CustomLabel');
+            const inputElements = screen.queryAllByLabelText('CustomLabel');
 
             expect(inputElements.length).toBe(1);
         });
 
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'CustomLabel'
         ) as HTMLInputElement[];
 
@@ -371,29 +340,25 @@ describe('<SimpleFormIterator />', () => {
             '5',
         ]);
 
-        expect(queryAllByText('ra.action.remove').length).toBe(1);
+        expect(screen.queryAllByText('ra.action.remove').length).toBe(1);
     });
 
     it('should remove children row on remove button click', async () => {
         const emails = [{ email: 'foo@bar.com' }, { email: 'bar@foo.com' }];
 
-        const { queryAllByLabelText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm record={{ id: 'whatever', emails }}>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm record={{ id: 'whatever', emails }}>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'resources.undefined.fields.email'
         ) as HTMLInputElement[];
 
@@ -410,7 +375,7 @@ describe('<SimpleFormIterator />', () => {
 
         fireEvent.click(removeFirstButton);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText(
+            const inputElements = screen.queryAllByLabelText(
                 'resources.undefined.fields.email'
             ) as HTMLInputElement[];
 
@@ -425,23 +390,19 @@ describe('<SimpleFormIterator />', () => {
     it('should reorder children on reorder buttons click', async () => {
         const emails = [{ email: 'foo@bar.com' }, { email: 'bar@foo.com' }];
 
-        const { queryAllByLabelText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm record={{ id: 'whatever', emails }}>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator>
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm record={{ id: 'whatever', emails }}>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        const inputElements = queryAllByLabelText(
+        const inputElements = screen.queryAllByLabelText(
             'resources.undefined.fields.email'
         ) as HTMLInputElement[];
 
@@ -451,11 +412,13 @@ describe('<SimpleFormIterator />', () => {
             }))
         ).toEqual(emails);
 
-        const moveDownFirstButton = queryAllByLabelText('ra.action.move_down');
+        const moveDownFirstButton = screen.queryAllByLabelText(
+            'ra.action.move_down'
+        );
 
         fireEvent.click(moveDownFirstButton[0]);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText(
+            const inputElements = screen.queryAllByLabelText(
                 'resources.undefined.fields.email'
             ) as HTMLInputElement[];
 
@@ -466,11 +429,11 @@ describe('<SimpleFormIterator />', () => {
             ).toEqual([{ email: 'bar@foo.com' }, { email: 'foo@bar.com' }]);
         });
 
-        const moveUpButton = queryAllByLabelText('ra.action.move_up');
+        const moveUpButton = screen.queryAllByLabelText('ra.action.move_up');
 
         fireEvent.click(moveUpButton[1]);
         await waitFor(() => {
-            const inputElements = queryAllByLabelText(
+            const inputElements = screen.queryAllByLabelText(
                 'resources.undefined.fields.email'
             ) as HTMLInputElement[];
 
@@ -483,58 +446,46 @@ describe('<SimpleFormIterator />', () => {
     });
 
     it('should not display the default add button if a custom add button is passed', () => {
-        const { getByText, queryAllByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    addButton={
-                                        <button>Custom Add Button</button>
-                                    }
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            addButton={<button>Custom Add Button</button>}
+                        >
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByText('ra.action.add').length).toBe(0);
-        expect(getByText('Custom Add Button')).not.toBeNull();
+        expect(screen.queryAllByText('ra.action.add').length).toBe(0);
+        expect(screen.getByText('Custom Add Button')).not.toBeNull();
     });
 
     it('should not display the default remove button if a custom remove button is passed', () => {
-        const { getByText, queryAllByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: '' }],
-                            }}
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: '' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            removeButton={<button>Custom Remove Button</button>}
                         >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    removeButton={
-                                        <button>Custom Remove Button</button>
-                                    }
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByText('ra.action.remove').length).toBe(0);
-        expect(getByText('Custom Remove Button')).not.toBeNull();
+        expect(screen.queryAllByText('ra.action.remove').length).toBe(0);
+        expect(screen.getByText('Custom Remove Button')).not.toBeNull();
     });
 
     it('should not display the default reorder element if a custom reorder element is passed', () => {
@@ -542,171 +493,145 @@ describe('<SimpleFormIterator />', () => {
             <button>Custom reorder Button</button>
         );
 
-        const { getByText, queryAllByLabelText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: '' }],
-                            }}
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: '' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            reOrderButtons={<CustomReOrderButtons />}
                         >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    reOrderButtons={<CustomReOrderButtons />}
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(queryAllByLabelText('ra.action.move_up').length).toBe(0);
-        expect(queryAllByLabelText('ra.action.move_down').length).toBe(0);
-        expect(getByText('Custom reorder Button')).not.toBeNull();
+        expect(screen.queryAllByLabelText('ra.action.move_up').length).toBe(0);
+        expect(screen.queryAllByLabelText('ra.action.move_down').length).toBe(
+            0
+        );
+        expect(screen.getByText('Custom reorder Button')).not.toBeNull();
     });
 
     it('should display custom row label', () => {
-        const { getByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: 'foo' }, { email: 'bar' }],
-                            }}
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: 'foo' }, { email: 'bar' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            getItemLabel={index => `3.${index}`}
                         >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    getItemLabel={index => `3.${index}`}
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(getByText('3.0')).toBeDefined();
-        expect(getByText('3.1')).toBeDefined();
+        expect(screen.getByText('3.0')).toBeDefined();
+        expect(screen.getByText('3.1')).toBeDefined();
     });
 
     it('should call the onClick method when the custom add button is clicked', async () => {
         const onClick = jest.fn().mockImplementation(e => e.preventDefault());
-        const { getByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    addButton={
-                                        <button onClick={onClick}>
-                                            Custom Add Button
-                                        </button>
-                                    }
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            addButton={
+                                <button onClick={onClick}>
+                                    Custom Add Button
+                                </button>
+                            }
+                        >
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
-        fireEvent.click(getByText('Custom Add Button'));
+        fireEvent.click(screen.getByText('Custom Add Button'));
         expect(onClick).toHaveBeenCalled();
     });
 
     it('should call the onClick method when the custom remove button is clicked', async () => {
         const onClick = jest.fn().mockImplementation(e => e.preventDefault());
-        const { getByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: '' }],
-                            }}
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: '' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            removeButton={
+                                <button onClick={onClick}>
+                                    Custom Remove Button
+                                </button>
+                            }
                         >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    removeButton={
-                                        <button onClick={onClick}>
-                                            Custom Remove Button
-                                        </button>
-                                    }
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
-        fireEvent.click(getByText('Custom Remove Button'));
+        fireEvent.click(screen.getByText('Custom Remove Button'));
         expect(onClick).toHaveBeenCalled();
     });
 
     it('should display the custom add button', () => {
-        const { getByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm>
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    addButton={
-                                        <button>Custom Add Button</button>
-                                    }
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+        render(
+            <Wrapper>
+                <SimpleForm>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            addButton={<button>Custom Add Button</button>}
+                        >
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(getByText('Custom Add Button')).not.toBeNull();
+        expect(screen.getByText('Custom Add Button')).not.toBeNull();
     });
 
     it('should display the custom remove button', () => {
-        const { getByText } = renderWithRedux(
-            <ThemeProvider theme={theme}>
-                <SaveContextProvider value={saveContextValue}>
-                    <SideEffectContextProvider value={sideEffectValue}>
-                        <SimpleForm
-                            record={{
-                                id: 'whatever',
-                                emails: [{ email: '' }],
-                            }}
+        render(
+            <Wrapper>
+                <SimpleForm
+                    record={{
+                        id: 'whatever',
+                        emails: [{ email: '' }],
+                    }}
+                >
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator
+                            removeButton={<button>Custom Remove Button</button>}
                         >
-                            <ArrayInput source="emails">
-                                <SimpleFormIterator
-                                    removeButton={
-                                        <button>Custom Remove Button</button>
-                                    }
-                                >
-                                    <TextInput source="email" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
-                        </SimpleForm>
-                    </SideEffectContextProvider>
-                </SaveContextProvider>
-            </ThemeProvider>
+                            <TextInput source="email" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </Wrapper>
         );
 
-        expect(getByText('Custom Remove Button')).not.toBeNull();
+        expect(screen.getByText('Custom Remove Button')).not.toBeNull();
     });
 });


### PR DESCRIPTION
- [x] Update `useDelete` and `useDeleteMany` to use react-query
- [x] Replace onSuccess and onFailure `<DeleteButton>` props with mutationOptions
- [x] Fix tests, docs and examples
- [x] Add upgrade instructions

```diff
// useDelete
-const [deleteOne, { loading }] = useDelete(
-   'posts',
-   123,
-   { id: 123, title: "hello, world", likes: 122 }
-);
-deleteOne(resource, id, previousData, options);
+const [deleteOne, { isLoading }] = useDelete(
+   'posts',
+   {
+       id: 123,
+       previousData: { id: 123, title: "hello, world", likes: 122 }
+   }
+);
+deleteOne(resource, { id, previousData }, options);

// useDeleteMany
-const [deleteMany, { loading }] = useDeleteMany(
-   'posts',
-   [123, 456],
-);
-deleteMany(resource, ids, options);
+const [deleteMany, { isLoading }] = useDeleteMany(
+   'posts',
+   {
+       ids: [123, 456],
+   }
+);
+deleteMany(resource, { ids }, options);
```