### PR TITLE
Fix useGetOne query cache doesn't reflect the dataProvider call signature

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -575,7 +575,7 @@ import { useDataProvider, Loading, Error } from 'react-admin';
 const UserProfile = ({ userId }) => {
     const dataProvider = useDataProvider();
     const { data, isLoading, error } = useQuery(
-        ['user', 'getOne', userId], 
+        ['users', 'getOne', { id: userId }], 
         () => dataProvider.getOne('users', { id: userId })
     );
 

--- a/examples/simple/src/comments/PostPreview.tsx
+++ b/examples/simple/src/comments/PostPreview.tsx
@@ -19,7 +19,7 @@ const PostPreview = <RecordType extends Record = Record>({
     const record = queryClient.getQueryData<RecordType>([
         resource,
         'getOne',
-        String(id),
+        { id: String(id) },
     ]);
 
     return (

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -96,7 +96,7 @@ export const useCreate = <RecordType extends Record = Record>(
             ) => {
                 const { resource: callTimeResource = resource } = variables;
                 queryClient.setQueryData(
-                    [callTimeResource, 'getOne', String(data.id)],
+                    [callTimeResource, 'getOne', { id: String(data.id) }],
                     data
                 );
             },

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -301,7 +301,6 @@ export const useDelete = <RecordType extends Record = Record>(
          *
          * @example
          * [
-         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
          *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -309,7 +309,6 @@ export const useDeleteMany = <RecordType extends Record = Record>(
          *
          * @example
          * [
-         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
          *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -76,7 +76,7 @@ export const useGetList = <RecordType extends Record = Record>(
                 // optimistically populate the getOne cache
                 data.forEach(record => {
                     queryClient.setQueryData(
-                        [resource, 'getOne', String(record.id)],
+                        [resource, 'getOne', { id: String(record.id) }],
                         record
                     );
                 });

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -70,7 +70,7 @@ export const useGetMany = <RecordType extends Record = Record>(
                     const queryHash = hashQueryKey([
                         resource,
                         'getOne',
-                        String(id),
+                        { id: String(id) },
                     ]);
                     return queryCache.get<RecordType>(queryHash)?.state?.data;
                 });
@@ -84,7 +84,7 @@ export const useGetMany = <RecordType extends Record = Record>(
                 // optimistically populate the getOne cache
                 data.forEach(record => {
                     queryClient.setQueryData(
-                        [resource, 'getOne', String(record.id)],
+                        [resource, 'getOne', { id: String(record.id) }],
                         record
                     );
                 });

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -71,7 +71,11 @@ export const useGetManyAggregate = <RecordType extends Record = Record>(
     const { ids } = params;
     const placeholderData = useMemo(() => {
         const records = ids.map(id => {
-            const queryHash = hashQueryKey([resource, 'getOne', String(id)]);
+            const queryHash = hashQueryKey([
+                resource,
+                'getOne',
+                { id: String(id) },
+            ]);
             return queryCache.get<RecordType>(queryHash)?.state?.data;
         });
         if (records.some(record => record === undefined)) {
@@ -101,7 +105,7 @@ export const useGetManyAggregate = <RecordType extends Record = Record>(
                 // optimistically populate the getOne cache
                 data.forEach(record => {
                     queryClient.setQueryData(
-                        [resource, 'getOne', String(record.id)],
+                        [resource, 'getOne', { id: String(record.id) }],
                         record
                     );
                 });

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -92,7 +92,7 @@ export const useGetManyReference = <RecordType extends Record = Record>(
                 // optimistically populate the getOne cache
                 data.forEach(record => {
                     queryClient.setQueryData(
-                        [resource, 'getOne', String(record.id)],
+                        [resource, 'getOne', { id: String(record.id) }],
                         record
                     );
                 });

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -50,7 +50,7 @@ export const useGetOne = <RecordType extends Record = Record>(
         // Sometimes the id comes as a string (e.g. when read from the URL in a Show view).
         // Sometimes the id comes as a number (e.g. when read from a Record in useGetList response).
         // As the react-query cache is type-sensitive, we always stringify the identifier to get a match
-        [resource, 'getOne', String(id)],
+        [resource, 'getOne', { id: String(id) }],
         () =>
             dataProvider
                 .getOne<RecordType>(resource, { id })

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -109,7 +109,7 @@ export const useUpdate = <RecordType extends Record = Record>(
         type GetListResult = { data?: RecordType[]; total?: number };
 
         queryClient.setQueryData(
-            [resource, 'getOne', String(id)],
+            [resource, 'getOne', { id: String(id) }],
             (record: RecordType) => ({ ...record, ...data }),
             { updatedAt }
         );
@@ -292,11 +292,11 @@ export const useUpdate = <RecordType extends Record = Record>(
         const previousRecord = queryClient.getQueryData<RecordType>([
             callTimeResource,
             'getOne',
-            String(callTimeId),
+            { id: String(callTimeId) },
         ]);
 
         const queryKeys = [
-            [callTimeResource, 'getOne', String(callTimeId)],
+            [callTimeResource, 'getOne', { id: String(callTimeId) }],
             [callTimeResource, 'getList'],
             [callTimeResource, 'getMany'],
             [callTimeResource, 'getManyReference'],
@@ -309,7 +309,7 @@ export const useUpdate = <RecordType extends Record = Record>(
          *
          * @example
          * [
-         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
+         *   [['posts', 'getOne', { id: '1' }], { id: 1, title: 'Hello' }],
          *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -116,7 +116,7 @@ export const useUpdateMany = <RecordType extends Record = Record>(
 
         ids.forEach(id =>
             queryClient.setQueryData(
-                [resource, 'getOne', String(id)],
+                [resource, 'getOne', { id: String(id) }],
                 (record: RecordType) => ({ ...record, ...data }),
                 { updatedAt }
             )
@@ -309,7 +309,7 @@ export const useUpdateMany = <RecordType extends Record = Record>(
          *
          * @example
          * [
-         *   [['posts', 'getOne', '1'], { id: 1, title: 'Hello' }],
+         *   [['posts', 'getOne', { id: '1' }], { id: 1, title: 'Hello' }],
          *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]


### PR DESCRIPTION
## Problem

The react-query cache key used by `useGetOne` doesn't reflect the signature of the `dataProvider.getOne()` call: it's 

`[’resource, 'getOne', id]`

instead of

`[resource, 'getOne', { id }]`. 

It's the only dataProvider hook that has a different key than the dataProvider query. There is no reason for that, and it's disturbing when manipulating cache entries. We should either document it or fix it. 

## Solution

Use the same signature as `dataProvider.getOne`