### PR TITLE
Remove no longer necessary HACK around a @mui/material problem

### DIFF
--- a/packages/ra-ui-materialui/src/auth/Logout.tsx
+++ b/packages/ra-ui-materialui/src/auth/Logout.tsx
@@ -15,7 +15,7 @@ import { useTranslate, useLogout } from 'ra-core';
  * Used for the Logout Menu item in the sidebar
  */
 export const Logout: FunctionComponent<
-    LogoutProps & MenuItemProps<'li', { button: true }> // HACK: https://github.com/mui-org/material-ui/issues/16245
+    LogoutProps & MenuItemProps<'li'>
 > = React.forwardRef(function Logout(props, ref) {
     const {
         className,

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -143,9 +143,7 @@ interface Props {
     tooltipProps?: TooltipProps;
 }
 
-export type MenuItemLinkProps = Props &
-    LinkProps &
-    MenuItemProps<'li', { button?: true }>; // HACK: https://github.com/mui-org/material-ui/issues/16245
+export type MenuItemLinkProps = Props & LinkProps & MenuItemProps<'li'>;
 
 MenuItemLink.propTypes = {
     className: PropTypes.string,


### PR DESCRIPTION
## Problem

A strange typing of `MenuItemProps` has been employed to work around mui-org/material-ui#16245

This was causing the following code to fail with a strange type error:

```typescript
createElement(AdminUI, {
  layout: Layout,
  dashboard: Dashboard,
  catchAll: NotFound,
  loginPage: Login as LoginComponent,
  logout: Logout,
})
```

## Solution

The issue has been resolved. The hack can be removed. Type error in my code was resolved, by removing it from `Logout`. I also found the same hack in `MenuItemLinkProps` and did the same change there, but haven't tested its effect. 