### PR TITLE
Don't optimistically overwrite getOne cache, only insert new entries

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -77,7 +77,7 @@ export const useGetList = <RecordType extends Record = Record>(
                 data.forEach(record => {
                     queryClient.setQueryData(
                         [resource, 'getOne', { id: String(record.id) }],
-                        record
+                        oldRecord => oldRecord ?? record
                     );
                 });
             },

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -85,7 +85,7 @@ export const useGetMany = <RecordType extends Record = Record>(
                 data.forEach(record => {
                     queryClient.setQueryData(
                         [resource, 'getOne', { id: String(record.id) }],
-                        record
+                        oldRecord => oldRecord ?? record
                     );
                 });
             },

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -106,7 +106,7 @@ export const useGetManyAggregate = <RecordType extends Record = Record>(
                 data.forEach(record => {
                     queryClient.setQueryData(
                         [resource, 'getOne', { id: String(record.id) }],
-                        record
+                        oldRecord => oldRecord ?? record
                     );
                 });
             },

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -93,7 +93,7 @@ export const useGetManyReference = <RecordType extends Record = Record>(
                 data.forEach(record => {
                     queryClient.setQueryData(
                         [resource, 'getOne', { id: String(record.id) }],
-                        record
+                        oldRecord => oldRecord ?? record
                     );
                 });
             },


### PR DESCRIPTION
## Problem

Running `getMany`/`getList` for a resource overwrites existing `getOne` caches for that resource. In a typical scenario `getOne` would be done after `getMany`/`getList` hiding this problem, but here is how I stumbled on it:

- Have a DataProvider where `getList` fetches only some of the fields, while `getOne` fetches all of them
- Have a resource with `Datagrid` whose `expand` is a `Show`.
- Open the `Datagrid`: calls `getList`
- Expand one row: calls `getOne`
- Go to another resource (expand state will be preserved)
- Go back: calls `getList` and `getOne` at the same time
- if `getList` response arrives first all is good
- if `getOne` response arrives first
  - `getList` response will overwrite `getOne` "rich" record with a more "poor" version
  - expanded `Show` ends up staying with only poor data

## Solution

Only insert into `getOne` cache if there isn't an entry at that key already. If there is an entry, let it be.