### PR TITLE
[BC Break] Add ReferenceOneField

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -993,6 +993,29 @@ export const PostList = () => (
 );
 ```
 
+## No More Props Injection In `<ReferenceField>`
+
+`<ReferenceField>` creates a `RecordContext` for the reference record, and this allows using any of react-admin's Field components. It also used to pass many props to the underlying component (including the current `record`), but this is no longer the case. If you need to access the `record` in a child of `<ReferenceField>`, you need to use the `useRecordContext` hook instead.
+
+```diff
+const PostShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="title" />
+            <ReferenceField source="author_id" reference="users">
+                <NameField />
+            </ReferenceField>
+        </SimpleShowLayout>
+    </Show>
+);
+
+-const NameField = ({ record }) => {
++const NameField = () => {
++   const { record } = useRecordContext();
+    return <span>{record?.name}</span>;
+};
+```
+
 ## `useListContext` No Longer Returns An `ids` Prop
 
 The `ListContext` used to return two props for the list data: `data` and `ids`. To render the list data, you had to iterate over the `ids`. 

--- a/docs/FieldsForRelationships.md
+++ b/docs/FieldsForRelationships.md
@@ -24,11 +24,11 @@ To fetch the books of an author with react-admin, you can use:
 
 - [`<ReferenceManyField>`](#referencemanyfield) when the API uses a foreign key (e.g. each book has an `author_id` field)
 - [`<ReferenceArrayField>`](#referencearrayfield) when the API uses an array of foreign keys (e.g. each author has a `book_ids` field)
-- [`<ArrayField>`](#arrayfield) when the API embeds an array of records (e.g. each author has an `books` field)
+- [`<ArrayField>`](#arrayfield) when the API embeds an array of records (e.g. each author has a `books` field)
 
 ## Many-To-One
 
-On the other hand, **many-to-one relationships** are the opposite of one-to-many relationships (e.g. each book has one author). To fetch the the author of a book, you can use:
+On the other hand, **many-to-one relationships** are the opposite of one-to-many relationships (e.g. each book has one author). To fetch the author of a book, you can use:
 
 - [`<ReferenceField>`](#referencefield) when the API uses a foreign key (e.g. each book has an `author_id` field)
 - [Deep Field Source](#deep-field-source), when the API embeds the related record (e.g. each book has an `author` field containing an object)
@@ -37,7 +37,7 @@ Other kinds of relationships often reduce to one-to-many relationships.
 
 ## One-To-One
 
-For instance, **one-to-one relationships** (e.g. a book has one book_detail) are a special type of one-to-many relationship with a cardinality of 1. To fetch the details of a book, you can use:
+For instance, **one-to-one relationships** (e.g. a book has one `book_detail`) are a special type of one-to-many relationship with a cardinality of 1. To fetch the details of a book, you can use:
 
 - [`<ReferenceOneField>`](#referenceonefield) when the API uses a foreign key (e.g. each `book_detail` has a `book_id` field)
 - [`<ReferenceField>`](#referencefield) when the API uses a reverse foreign key (e.g. each `book` has a `book_detail_id` field)
@@ -167,7 +167,7 @@ const BookShow = () => (
 
 `<ReferenceField>` creates a `RecordContext` with the reference record, so you can use any component relying on this context (`<TextField>`, `<SimpleShowLayout>`, etc.).
 
-**Tip**: You don't need to worry about the fact that this components calls `<ReferenceField>` twice on the same table. React-admin will only make one call to the API.
+**Tip**: You don't need to worry about the fact that these components calls `<ReferenceField>` twice on the same table. React-admin will only make one call to the API.
 
 This is fine, but what if you need to display the author details for a list of books?
 
@@ -231,7 +231,7 @@ const AuthorShow = () => (
 
 `<ReferenceManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
 
-**Tip**: For many APIs, there is no difference between `dataProvider.getList()` and `dataProvider.getManyReference()`. The latter is a specialized version of the former, with a predefined `filter`. But some APIs expose related records as a subroute, and therefore need a special method to fetch them. For instance, the boks of an author can be exposed via the following endpoint: 
+**Tip**: For many APIs, there is no difference between `dataProvider.getList()` and `dataProvider.getManyReference()`. The latter is a specialized version of the former, with a predefined `filter`. But some APIs expose related records as a sub-route, and therefore need a special method to fetch them. For instance, the books of an author can be exposed via the following endpoint: 
 
 ```
 GET /authors/:id/books
@@ -405,7 +405,7 @@ const AuthorShow = () => (
 );
 ```
 
-`<ReferenceOneField>` behaves like `<ReferenceManyField>`: it uses the current `record` (a book in this example) to build a filter for the book details with the same the foreign key (`book_id`). Then, it uses `dataProvider.getManyReference('book_details', { target: 'book_id', id: book.id })` fetch the related details, and takes the first one.
+`<ReferenceOneField>` behaves like `<ReferenceManyField>`: it uses the current `record` (a book in this example) to build a filter for the book details with the foreign key (`book_id`). Then, it uses `dataProvider.getManyReference('book_details', { target: 'book_id', id: book.id })` to fetch the related details, and takes the first one.
 
 `<ReferenceOneField>` creates a `RecordContext` with the reference record, so you can use any component relying on this context (`<TextField>`, `<SimpleShowLayout>`, etc.).
 

--- a/docs/FieldsForRelationships.md
+++ b/docs/FieldsForRelationships.md
@@ -127,6 +127,8 @@ const AuthorShow = () => (
 );
 ```
 
+`<ArrayField>` creates a `ListContext` with the embedded records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+
 ## `<ReferenceField>`
 
 This field fetches a many-to-one relationship, e.g. the author of a book, when using a foreign key.
@@ -162,6 +164,8 @@ const BookShow = () => (
 ```
 
 `<ReferenceField>` uses the current `record` (a book in this example) to read the id of the reference using the foreign key (`author_id`). Then, it uses `dataProvider.getOne('authors', { id })` fetch the related author.
+
+`<ReferenceField>` creates a `RecordContext` with the reference record, so you can use any component relying on this context (`<TextField>`, `<SimpleShowLayout>`, etc.).
 
 **Tip**: You don't need to worry about the fact that this components calls `<ReferenceField>` twice on the same table. React-admin will only make one call to the API.
 
@@ -225,6 +229,8 @@ const AuthorShow = () => (
 
 `<ReferenceManyField>` uses the current `record` (an author in this example) to build a filter for the list of books on the foreign key field (`author_id`). Then, it uses `dataProvider.getManyReference('books', { target: 'author_id', id: book.id })` fetch the related books.
 
+`<ReferenceManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+
 **Tip**: For many APIs, there is no difference between `dataProvider.getList()` and `dataProvider.getManyReference()`. The latter is a specialized version of the former, with a predefined `filter`. But some APIs expose related records as a subroute, and therefore need a special method to fetch them. For instance, the boks of an author can be exposed via the following endpoint: 
 
 ```
@@ -270,6 +276,8 @@ const AuthorShow = () => (
 ```
 
 `<ReferenceArrayField>` reads the list of `book_ids` in the current `record` (an author in this example). Then, it uses `dataProvider.getMany('books', { ids })` fetch the related books.
+
+`<ReferenceArrayField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
 
 You can also use it in a List page:
 
@@ -359,6 +367,8 @@ const BookShow = props => (
 );
 ```
 
+`<ReferenceManyToManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+
 ## `<ReferenceOneField>`
 
 This field fetches a one-to-one relationship, e.g. the details of a book, when using a foreign key.
@@ -396,6 +406,8 @@ const AuthorShow = () => (
 ```
 
 `<ReferenceOneField>` behaves like `<ReferenceManyField>`: it uses the current `record` (a book in this example) to build a filter for the book details with the same the foreign key (`book_id`). Then, it uses `dataProvider.getManyReference('book_details', { target: 'book_id', id: book.id })` fetch the related details, and takes the first one.
+
+`<ReferenceOneField>` creates a `RecordContext` with the reference record, so you can use any component relying on this context (`<TextField>`, `<SimpleShowLayout>`, etc.).
 
 **Tip**: As with `<ReferenceField>`, you can call `<ReferenceOneField>` as many times as you need in the same component, react-admin will only make one call to `dataProvider.getManyReference()`.
 

--- a/docs/FieldsForRelationships.md
+++ b/docs/FieldsForRelationships.md
@@ -1,0 +1,402 @@
+---
+layout: default
+title: "Fields For Relationships"
+---
+
+# Fields For Relationships
+
+React-admin provides numerous components, called 'Reference' components, to deal with relationships between records. In fact, react-admin and the `dataProvider` interface are actually designed to facilitate the implementation of relational features such as:
+
+- showing the comments related to a post
+- showing the author of a post
+- choosing the author of a post
+- adding tags to a post
+
+React-admin handles relationships *regardless of the capacity of the API to manage relationships*. As long as you can provide a `dataProvider` for your API, all the relational features will work.
+
+React-admin provides helpers to fetch related records, depending on the type of relationship, and how the API implements it.
+
+## One-To-Many
+
+When one record has many related records, this is called a one-to-many relationship. For instance, if an author has written several books, `authors` has a one-to-many relationship with `books`. 
+
+To fetch the books of an author with react-admin, you can use:
+
+- [`<ReferenceManyField>`](#referencemanyfield) when the API uses a foreign key (e.g. each book has an `author_id` field)
+- [`<ReferenceArrayField>`](#referencearrayfield) when the API uses an array of foreign keys (e.g. each author has a `book_ids` field)
+- [`<ArrayField>`](#arrayfield) when the API embeds an array of records (e.g. each author has an `books` field)
+
+## Many-To-One
+
+On the other hand, **many-to-one relationships** are the opposite of one-to-many relationships (e.g. each book has one author). To fetch the the author of a book, you can use:
+
+- [`<ReferenceField>`](#referencefield) when the API uses a foreign key (e.g. each book has an `author_id` field)
+- [Deep Field Source](#deep-field-source), when the API embeds the related record (e.g. each book has an `author` field containing an object)
+
+Other kinds of relationships often reduce to one-to-many relationships. 
+
+## One-To-One
+
+For instance, **one-to-one relationships** (e.g. a book has one book_detail) are a special type of one-to-many relationship with a cardinality of 1. To fetch the details of a book, you can use:
+
+- [`<ReferenceOneField>`](#referenceonefield) when the API uses a foreign key (e.g. each `book_detail` has a `book_id` field)
+- [`<ReferenceField>`](#referencefield) when the API uses a reverse foreign key (e.g. each `book` has a `book_detail_id` field)
+- Deep Field Source, when the API embeds the related record (e.g. each book has a `book_detail` field containing an object)
+
+## Many-To-Many
+
+Also, **many-to-many relationships** are often modeled as two successive one-to-many relationships. For instance, if a book is co-authored by several people, we can model this as a one-to-many relationship between the book and the book_authors, and a one-to-many relationship between the book_authors and the authors. To fetch the books of an author, use:
+
+- [`<ReferenceManyToManyField>`](#referencemanytomanyfield) when the API uses a join table (e.g. a `book_authors` table with both `book_id` and `author_id` fields)
+- [`<ReferenceArrayField>`](#referencearrayfield) when the API uses an array of foreign keys (e.g. each author has a `book_ids` field, and each book has an `author_ids` field)
+- [`<ArrayField>`](#arrayfield), when the API embeds an array of records (e.g. each author has an `books` field, and each book has an `authors` field)
+
+## Deep Field Source
+
+When a many-to-one relationship (e.g. the author of a book) is materialized by an embedded object, then you don't need a Reference field - you can just use any regular field, and use a compound field name (e.g. "author.first_name").
+
+```
+┌──────────────────┐
+│ books            │
+│------------------│
+│ id               │
+│ author           │
+│  └ first_name    │
+│  └ last_name     │
+│  └ date_of_birth │
+│ title            │
+│ published_at     │
+└──────────────────┘
+```
+
+Here is an example usage:
+
+```jsx
+const BookShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="title" />
+            <DateField source="published_at" />
+            <FunctionField 
+                label="Author"
+                render={record => record && `${record.author.first_name} ${record.author.last_name}`}
+            />
+            <DateField label="Author DOB" source="author.date_of_birth" />
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+
+## `<ArrayField>`
+
+This field fetches a one-to-many relationship, e.g. the books of an author, when using an array embedded objects.
+
+```
+┌───────────────────────────┐
+│ author                    │
+│---------------------------│
+│ id                        │
+│ first_name                │
+│ last_name                 │
+│ date_of_birth             │
+│ books                     │
+│  └ { title, published_at} │
+│  └ { title, published_at} │
+│  └ { title, published_at} │
+└───────────────────────────┘
+```
+
+Here is an example usage:
+
+```jsx
+const AuthorShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <DateField source="date_of_birth" />
+            <ArrayField source="books">
+                <Datagrid>
+                    <TextField source="title" />
+                    <DateField source="published_at" />
+                </Datagrid>
+            </ArrayField>
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+## `<ReferenceField>`
+
+This field fetches a many-to-one relationship, e.g. the author of a book, when using a foreign key.
+
+```
+┌──────────────┐       ┌────────────────┐
+│ books        │       │ authors        │
+│--------------│       │----------------│
+│ id           │   ┌───│ id             │
+│ author_id    │╾──┘   │ first_name     │
+│ title        │       │ last_name      │
+│ published_at │       │ date_of_birth  │
+└──────────────┘       └────────────────┘
+```
+
+Here is an example usage:
+
+```jsx
+const BookShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="title" />
+            <DateField source="published_at" />
+            <ReferenceField label="Author" source="author_id" reference="authors">
+                <FunctionField render={record => record && `${record.first_name} ${record.last_name}`} />
+            </ReferenceField>
+            <ReferenceField label="Author DOB" source="author_id" reference="authors">
+                <DateField source="date_of_birth" />
+            </ReferenceField>
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+`<ReferenceField>` uses the current `record` (a book in this example) to read the id of the reference using the foreign key (`author_id`). Then, it uses `dataProvider.getOne('authors', { id })` fetch the related author.
+
+**Tip**: You don't need to worry about the fact that this components calls `<ReferenceField>` twice on the same table. React-admin will only make one call to the API.
+
+This is fine, but what if you need to display the author details for a list of books?
+
+```jsx
+const BookList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="title" />
+            <DateField source="published_at" />
+            <ReferenceField label="Author" source="author_id" reference="authors">
+                <FunctionField render={record => record && `${record.first_name} ${record.last_name}`} />
+            </ReferenceField>
+            <ReferenceField label="Author DOB" source="author_id" reference="authors">
+                <DateField source="date_of_birth" />
+            </ReferenceField>
+        </Datagrid>
+    </List>
+);
+```
+
+If each row of the book list triggers one call to `dataProvider.getOne('authors', { id })`, and if the list counts many rows (say, 25), the app will be very slow - and possibly blocked by the API for abusive usage. This is another version of the dreaded ["n+1 problem"](https://blog.appsignal.com/2020/06/09/n-plus-one-queries-explained.html).
+
+Fortunately, `<ReferenceField>` aggregates and deduplicates all the renders made in a page, and creates an optimised request. In the example above, instead of n calls to `dataProvider.getOne('authors', { id })`, the book list will make one call to `dataProvider.getMany('authors', { ids })`.
+
+## `<ReferenceManyField>`
+
+This field fetches a one-to-many relationship, e.g. the books of an author, when using a foreign key.
+
+```
+┌────────────────┐       ┌──────────────┐
+│ authors        │       │ books        │
+│----------------│       │--------------│
+│ id             │───┐   │ id           │
+│ first_name     │   └──╼│ author_id    │
+│ last_name      │       │ title        │
+│ date_of_birth  │       │ published_at │
+└────────────────┘       └──────────────┘
+```
+
+Here is an example usage:
+
+```jsx
+const AuthorShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <DateField source="date_of_birth" />
+            <ReferenceManyField reference="books" target="author_id">
+                <Datagrid>
+                    <TextField source="title" />
+                    <DateField source="published_at" />
+                </Datagrid>
+            </ReferenceManyField>
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+`<ReferenceManyField>` uses the current `record` (an author in this example) to build a filter for the list of books on the foreign key field (`author_id`). Then, it uses `dataProvider.getManyReference('books', { target: 'author_id', id: book.id })` fetch the related books.
+
+**Tip**: For many APIs, there is no difference between `dataProvider.getList()` and `dataProvider.getManyReference()`. The latter is a specialized version of the former, with a predefined `filter`. But some APIs expose related records as a subroute, and therefore need a special method to fetch them. For instance, the boks of an author can be exposed via the following endpoint: 
+
+```
+GET /authors/:id/books
+```
+
+That's why `<ReferenceManyField>` uses the `getManyReference()` method instead of `getList()`.
+
+## `<ReferenceArrayField>`
+
+This field fetches a one-to-many relationship, e.g. the books of an author, when using an array of foreign keys.
+
+```
+┌────────────────┐       ┌──────────────┐
+│ authors        │       │ books        │
+│----------------│       │--------------│
+│ id             │   ┌───│ id           │
+│ first_name     │   │   │ title        │
+│ last_name      │   │   │ published_at │
+│ date_of_birth  │   │   └──────────────┘
+│ book_ids       │╾──┘   
+└────────────────┘       
+```
+
+Here is an example usage:
+
+```jsx
+const AuthorShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <DateField source="date_of_birth" />
+            <ReferenceArrayField reference="books" source="book_ids">
+                <Datagrid>
+                    <TextField source="title" />
+                    <DateField source="published_at" />
+                </Datagrid>
+            </ReferenceArrayField>
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+`<ReferenceArrayField>` reads the list of `book_ids` in the current `record` (an author in this example). Then, it uses `dataProvider.getMany('books', { ids })` fetch the related books.
+
+You can also use it in a List page:
+
+```jsx
+const AuthorList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <DateField source="date_of_birth" />
+            <ReferenceArrayField reference="books" source="book_ids">
+                <SingleFieldList>
+                    <TextField source="title" />
+                </SingleFieldList>
+            </ReferenceArrayField>
+        </Datagrid>
+    </List>
+);
+```
+
+Just like for `<ReferenceField>`, `<ReferenceArrayField>` aggregates and deduplicates all the renders made in a page, and creates an optimised request. So for the entire list of authors, it will make only one call to `dataProvider.getMany('books', { ids })`.
+
+## `<ReferenceManyToManyField>`
+
+This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> field displays a many-to-many relationship implemented with two one-to-many relationships and a join table. 
+
+```
+┌──────────────────┐       ┌──────────────┐      ┌───────────────┐
+│ books            │       │ book_authors │      │ authors       │
+│------------------│       │--------------│      │---------------│
+│ id               │───┐   │ id           │      │ id            │
+│ title            │   └──╼│ book_id      │   ┌──│ first_name    │
+│ published_at     │       │ author_id    │╾──┘  │ last_name     │
+└──────────────────┘       │ is_public    │      │ date_of_birth │
+                           └──────────────┘      └───────────────┘
+```
+
+Here is how you would display the books of an author:
+
+```jsx
+const AuthorShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <DateField source="date_of_birth" />
+            <ReferenceManyToManyField 
+                reference="books"
+                through="book_authors"
+                using="author_id,book_id"
+            >
+                <Datagrid>
+                    <TextField source="title" />
+                    <DateField source="published_at" />
+                </Datagrid>
+            </ReferenceManyToManyField>
+            <EditButton />
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+And here is how you would display the authors of a book:
+
+```jsx
+const BookShow = props => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="title" />
+            <DateField source="published_at" />
+            <ReferenceManyToManyField 
+                reference="authors"
+                through="book_authors"
+                using="book_id,author_id"
+            >
+                <Datagrid>
+                    <FunctionField 
+                        label="Author"
+                        render={record => record && `${record.first_name} ${record.last_name}`}
+                    />
+                    <DateField source="date_of_birth" />
+                </Datagrid>
+            </ReferenceManyToManyField>
+            <EditButton />
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+## `<ReferenceOneField>`
+
+This field fetches a one-to-one relationship, e.g. the details of a book, when using a foreign key.
+
+```
+┌──────────────┐       ┌──────────────┐
+│ books        │       │ book_details │
+│--------------│       │--------------│
+│ id           │───┐   │ id           │
+│ title        │   └──╼│ book_id      │
+│ published_at │       │ genre        │
+└──────────────┘       │ ISBN         │
+                       └──────────────┘
+```
+
+Here is how to use it:
+
+```jsx
+const AuthorShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <DateField source="date_of_birth" />
+            <ReferenceOneField label="Genre" reference="book_details" target="book_id">
+                <TextField source="genre" />
+            </ReferenceManyToManyField>
+            <ReferenceOneField label="ISBN" reference="book_details" target="book_id">
+                <TextField source="ISBN" />
+            </ReferenceManyToManyField>
+            <EditButton />
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+`<ReferenceOneField>` behaves like `<ReferenceManyField>`: it uses the current `record` (a book in this example) to build a filter for the book details with the same the foreign key (`book_id`). Then, it uses `dataProvider.getManyReference('book_details', { target: 'book_id', id: book.id })` fetch the related details, and takes the first one.
+
+**Tip**: As with `<ReferenceField>`, you can call `<ReferenceOneField>` as many times as you need in the same component, react-admin will only make one call to `dataProvider.getManyReference()`.
+
+For the inverse relationships (the author linked to a biography), you can use a `<ReferenceField>`.

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -73,8 +73,12 @@
   <li {% if page.path contains 'CreateEdit.md' %} class="active" {% endif %}><a class="nav-link" href="./CreateEdit.html"><code>&lt;Create&gt;</code> and <code>&lt;Edit&gt;</code> Views</a></li>
 </ul>
 
-<ul><div>Fields and Inputs</div>
+<ul><div>Fields</div>
+  <li {% if page.path contains 'FieldsForRelationships.md' %} class="active" {% endif %}><a class="nav-link" href="./FieldsForRelationships.html">Fields for Relationships</a></li>
   <li {% if page.path contains 'Fields.md' %} class="active" {% endif %}><a class="nav-link" href="./Fields.html"><code>&lt;Field&gt;</code> Components</a></li>
+</ul>
+
+<ul><div>Inputs</div>
   <li {% if page.path contains 'Inputs.md' %} class="active" {% endif %}><a class="nav-link" href="./Inputs.html"><code>&lt;Input&gt;</code> Components</a></li>
 </ul>
 

--- a/examples/crm/src/companies/CompanyAvatar.tsx
+++ b/examples/crm/src/companies/CompanyAvatar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import { Avatar } from '@mui/material';
 import clsx from 'clsx';
+import { useRecordContext } from 'react-admin';
 
 import { Company } from '../types';
 
@@ -34,12 +35,11 @@ const StyledAvatar = styled(Avatar)({
 });
 
 export const CompanyAvatar = ({
-    record,
     size = 'large',
 }: {
-    record?: Company;
     size?: 'small' | 'large';
 }) => {
+    const record = useRecordContext<Company>();
     if (!record) return null;
     return (
         <StyledAvatar

--- a/examples/crm/src/companies/CompanyCard.tsx
+++ b/examples/crm/src/companies/CompanyCard.tsx
@@ -72,7 +72,7 @@ export const CompanyCard = ({ record }: { record: Company }) => {
         >
             <Paper className={classes.paper} elevation={elevation}>
                 <div className={classes.identity}>
-                    <CompanyAvatar record={record} />
+                    <CompanyAvatar />
                     <div className={classes.name}>
                         <Typography variant="subtitle2">
                             {record.name}

--- a/examples/crm/src/companies/CompanyEdit.tsx
+++ b/examples/crm/src/companies/CompanyEdit.tsx
@@ -84,19 +84,16 @@ export const CompanyEdit = () => {
     );
 };
 
-const CustomLayout = (props: any) => {
-    const record = useRecordContext(props);
-    return (
-        <CardContent>
-            <Box display="flex">
-                <LogoField record={record as any} />
-                <Box ml={2} flex="1" maxWidth={796}>
-                    {props.children}
-                </Box>
+const CustomLayout = (props: any) => (
+    <CardContent>
+        <Box display="flex">
+            <LogoField />
+            <Box ml={2} flex="1" maxWidth={796}>
+                {props.children}
             </Box>
-        </CardContent>
-    );
-};
+        </Box>
+    </CardContent>
+);
 
 const CustomDivider = () => (
     <Box mb={2}>

--- a/examples/crm/src/companies/CompanyEdit.tsx
+++ b/examples/crm/src/companies/CompanyEdit.tsx
@@ -6,7 +6,6 @@ import {
     SimpleForm,
     TextInput,
     SelectInput,
-    useRecordContext,
     required,
 } from 'react-admin';
 import { Box, CardContent, Divider } from '@mui/material';

--- a/examples/crm/src/companies/CompanyShow.tsx
+++ b/examples/crm/src/companies/CompanyShow.tsx
@@ -56,7 +56,7 @@ const CompanyShowContent = () => {
                 <Card>
                     <CardContent>
                         <Box display="flex" mb={1}>
-                            <LogoField record={record as any} />
+                            <LogoField />
                             <Box ml={2} flex="1">
                                 <Typography variant="h5">
                                     {record.name}

--- a/examples/crm/src/companies/LogoField.tsx
+++ b/examples/crm/src/companies/LogoField.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
+import { useRecordContext } from 'react-admin';
 
 const PREFIX = 'LogoField';
 
@@ -19,14 +20,13 @@ const sizeInPixel = {
 };
 
 export const LogoField = ({
-    record,
     source,
     size = 'medium',
 }: {
-    record?: { logo: string; name: string };
     source?: string;
     size?: 'small' | 'medium';
 }) => {
+    const record = useRecordContext<{ logo: string; name: string }>();
     if (!record) return null;
     return (
         <StyledImage

--- a/examples/crm/src/contacts/ContactAside.tsx
+++ b/examples/crm/src/contacts/ContactAside.tsx
@@ -103,7 +103,7 @@ export const ContactAside = ({ record, link = 'edit' }: any) => (
         <Box mb={3}>
             <Typography variant="subtitle2">Tags</Typography>
             <Divider />
-            <TagsListEdit record={record} />
+            <TagsListEdit />
         </Box>
 
         <ReferenceManyField

--- a/examples/crm/src/contacts/TagsList.tsx
+++ b/examples/crm/src/contacts/TagsList.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { ReferenceArrayField, SingleFieldList, ChipField } from 'react-admin';
+import {
+    ReferenceArrayField,
+    SingleFieldList,
+    ChipField,
+    useRecordContext,
+} from 'react-admin';
 
 import { Contact } from '../types';
 
@@ -16,15 +21,20 @@ const StyledReferenceArrayField = styled(ReferenceArrayField)({
     },
 });
 
-const ColoredChipField = ({ record, ...props }: any) =>
-    record ? (
+const ColoredChipField = (props: any) => {
+    const record = useRecordContext();
+    if (!record) {
+        return null;
+    }
+    return (
         <ChipField
             record={record}
             {...props}
             style={{ backgroundColor: record.color, border: 0 }}
             component="span"
         />
-    ) : null;
+    );
+};
 
 export const TagsList = ({ record }: { record: Contact }) => {
     if (!record) return null;

--- a/examples/crm/src/contacts/TagsListEdit.tsx
+++ b/examples/crm/src/contacts/TagsListEdit.tsx
@@ -7,6 +7,7 @@ import {
     useUpdate,
     useGetList,
     Identifier,
+    useRecordContext,
 } from 'react-admin';
 import {
     Chip,
@@ -26,7 +27,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import { colors } from '../tags/colors';
 import { Contact, Tag } from '../types';
 
-export const TagsListEdit = ({ record }: { record: Contact }) => {
+export const TagsListEdit = () => {
+    const record = useRecordContext<Contact>();
     const [open, setOpen] = useState(false);
     const [newTagName, setNewTagName] = useState('');
     const [newTagColor, setNewTagColor] = useState(colors[0]);
@@ -42,9 +44,7 @@ export const TagsListEdit = ({ record }: { record: Contact }) => {
     const { data: tags, isLoading: isLoadingRecordTags } = useGetMany<Tag>(
         'tags',
         { ids: record.tags },
-        {
-            enabled: record.tags && record.tags.length > 0,
-        }
+        { enabled: record && record.tags && record.tags.length > 0 }
     );
     const [update] = useUpdate<Contact>();
     const [create] = useCreate<Tag>();
@@ -123,7 +123,7 @@ export const TagsListEdit = ({ record }: { record: Contact }) => {
         );
     };
 
-    if (!isLoadingRecordTags || isLoadingAllTags) return null;
+    if (isLoadingRecordTags || isLoadingAllTags) return null;
     return (
         <>
             {tags?.map(tag => (

--- a/examples/demo/src/visitors/ColoredNumberField.tsx
+++ b/examples/demo/src/visitors/ColoredNumberField.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import { NumberField, NumberFieldProps } from 'react-admin';
+import { useRecordContext, NumberField, NumberFieldProps } from 'react-admin';
 
-const ColoredNumberField = (props: NumberFieldProps) =>
-    props.record && props.source ? (
-        props.record[props.source] > 500 ? (
-            <span style={{ color: 'red' }}>
-                <NumberField {...props} />
-            </span>
-        ) : (
-            <NumberField {...props} />
-        )
-    ) : null;
+const ColoredNumberField = (props: NumberFieldProps) => {
+    const record = useRecordContext(props);
+    if (!record || !props.source) {
+        return null;
+    }
+    return record[props.source] > 500 ? (
+        <NumberField {...props} sx={{ color: 'red' }} />
+    ) : (
+        <NumberField {...props} />
+    );
+};
 
 ColoredNumberField.defaultProps = NumberField.defaultProps;
 

--- a/examples/demo/src/visitors/CustomerLinkField.tsx
+++ b/examples/demo/src/visitors/CustomerLinkField.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
-import { Link, FieldProps } from 'react-admin';
+import { Link, FieldProps, useRecordContext } from 'react-admin';
 
 import FullNameField from './FullNameField';
 import { Customer } from '../types';
 
-const CustomerLinkField = (props: FieldProps<Customer>) =>
-    props.record ? (
-        <Link to={`/customers/${props.record.id}`}>
-            <FullNameField {...props} />
+const CustomerLinkField = (props: FieldProps<Customer>) => {
+    const record = useRecordContext();
+    if (!record) {
+        return null;
+    }
+    return (
+        <Link to={`/customers/${record.id}`}>
+            <FullNameField />
         </Link>
-    ) : null;
+    );
+};
 
 CustomerLinkField.defaultProps = {
     source: 'customer_id',

--- a/examples/demo/src/visitors/FullNameField.tsx
+++ b/examples/demo/src/visitors/FullNameField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import { memo } from 'react';
 
-import { FieldProps } from 'react-admin';
+import { FieldProps, useRecordContext } from 'react-admin';
 import AvatarField from './AvatarField';
 import { Customer } from '../types';
 
@@ -32,8 +32,8 @@ interface Props extends FieldProps<Customer> {
 }
 
 const FullNameField = (props: Props) => {
-    const { record, size } = props;
-
+    const { size } = props;
+    const record = useRecordContext<Customer>();
     return record ? (
         <Root className={classes.root}>
             <AvatarField

--- a/packages/ra-core/src/controller/field/index.ts
+++ b/packages/ra-core/src/controller/field/index.ts
@@ -1,3 +1,4 @@
 export * from './getResourceLinkPath';
 export * from './useReferenceArrayFieldController';
 export * from './useReferenceManyFieldController';
+export * from './useReferenceOneFieldController';

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import expect from 'expect';
+
+import { testDataProvider } from '../../dataProvider/testDataProvider';
+import { CoreAdminContext } from '../../core';
+import { useReferenceOneFieldController } from './useReferenceOneFieldController';
+
+const ReferenceOneFieldController = props => {
+    const { children, page = 1, perPage = 1, ...rest } = props;
+    const controllerProps = useReferenceOneFieldController({
+        page,
+        perPage,
+        ...rest,
+    });
+    return children(controllerProps);
+};
+
+describe('useReferenceOneFieldController', () => {
+    it('should set isLoading to true when the related record is not yet fetched', async () => {
+        const ComponentToTest = ({ isLoading }: { isLoading?: boolean }) => {
+            return <div>isLoading: {isLoading.toString()}</div>;
+        };
+        const dataProvider = testDataProvider({
+            getManyReference: () => Promise.resolve({ data: [], total: 0 }),
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceOneFieldController
+                    record={{ id: 123 }}
+                    source="id"
+                    reference="bios"
+                    target="author_id"
+                >
+                    {props => <ComponentToTest {...props} />}
+                </ReferenceOneFieldController>
+            </CoreAdminContext>
+        );
+
+        expect(screen.queryByText('isLoading: true')).not.toBeNull();
+        await waitFor(() => {
+            expect(screen.queryByText('isLoading: false')).not.toBeNull();
+        });
+    });
+
+    it('should set isLoading to false when related records have been fetched and there are results', async () => {
+        const ComponentToTest = ({ isLoading }: { isLoading?: boolean }) => {
+            return <div>isLoading: {isLoading.toString()}</div>;
+        };
+        const dataProvider = testDataProvider({
+            getManyReference: () =>
+                Promise.resolve({
+                    data: [{ id: 1, title: 'hello' }],
+                    total: 1,
+                }) as any,
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceOneFieldController
+                    record={{ id: 123 }}
+                    source="id"
+                    reference="bios"
+                    target="author_id"
+                >
+                    {props => <ComponentToTest {...props} />}
+                </ReferenceOneFieldController>
+            </CoreAdminContext>
+        );
+
+        expect(screen.queryByText('isLoading: true')).not.toBeNull();
+        await waitFor(() => {
+            expect(screen.queryByText('isLoading: false')).not.toBeNull();
+        });
+    });
+
+    it('should call dataProvider.getManyReferences on mount', async () => {
+        const dataProvider = testDataProvider({
+            getManyReference: jest
+                .fn()
+                .mockResolvedValue({ data: [], total: 0 }),
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceOneFieldController
+                    resource="authors"
+                    source="id"
+                    record={{ id: 123, name: 'James Joyce' }}
+                    reference="bios"
+                    target="author_id"
+                >
+                    {() => 'null'}
+                </ReferenceOneFieldController>
+            </CoreAdminContext>
+        );
+
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toHaveBeenCalledWith('bios', {
+                target: 'author_id',
+                id: 123,
+                pagination: { page: 1, perPage: 1 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: {},
+            });
+        });
+    });
+
+    it('should pass referenceRecord to children function', async () => {
+        const children = jest.fn().mockReturnValue('children');
+        const dataProvider = testDataProvider({
+            getManyReference: () =>
+                Promise.resolve({
+                    data: [{ id: 1, title: 'hello' }],
+                    total: 1,
+                }) as any,
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceOneFieldController
+                    resource="authors"
+                    source="id"
+                    record={{ id: 123, name: 'James Joyce' }}
+                    reference="books"
+                    target="author_id"
+                >
+                    {children}
+                </ReferenceOneFieldController>
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(children).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    referenceRecord: { id: 1, title: 'hello' },
+                })
+            );
+        });
+    });
+
+    it('should support custom source', async () => {
+        const dataProvider = testDataProvider({
+            getManyReference: jest
+                .fn()
+                .mockResolvedValue({ data: [], total: 0 }),
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceOneFieldController
+                    resource="authors"
+                    source="uniqueName"
+                    record={{
+                        id: 123,
+                        uniqueName: 'jamesjoyce256',
+                        name: 'James Joyce',
+                    }}
+                    reference="books"
+                    target="author_id"
+                >
+                    {() => 'null'}
+                </ReferenceOneFieldController>
+            </CoreAdminContext>
+        );
+
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toHaveBeenCalledWith(
+                'books',
+                {
+                    id: 'jamesjoyce256',
+                    target: 'author_id',
+                    pagination: { page: 1, perPage: 1 },
+                    sort: { field: 'id', order: 'ASC' },
+                    filter: {},
+                }
+            );
+        });
+    });
+
+    it('should call crudGetManyReference when its props changes', async () => {
+        const dataProvider = testDataProvider({
+            getManyReference: jest
+                .fn()
+                .mockResolvedValue({ data: [], total: 0 }),
+        });
+        const ControllerWrapper = ({ record }) => (
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceOneFieldController
+                    resource="authors"
+                    source="id"
+                    record={record}
+                    reference="books"
+                    target="author_id"
+                >
+                    {() => 'null'}
+                </ReferenceOneFieldController>
+            </CoreAdminContext>
+        );
+
+        const { rerender } = render(
+            <ControllerWrapper record={{ id: 123, name: 'James Joyce' }} />
+        );
+        expect(dataProvider.getManyReference).toBeCalledTimes(1);
+        rerender(
+            <ControllerWrapper record={{ id: 456, name: 'Marcel Proust' }} />
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledTimes(2);
+            expect(dataProvider.getManyReference).toHaveBeenCalledWith(
+                'books',
+                {
+                    id: 456,
+                    target: 'author_id',
+                    pagination: { page: 1, perPage: 1 },
+                    sort: { field: 'id', order: 'ASC' },
+                    filter: {},
+                }
+            );
+        });
+    });
+});

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
@@ -1,0 +1,83 @@
+import get from 'lodash/get';
+
+import { useGetManyReference } from '../../dataProvider';
+import { useNotify } from '../../sideEffect';
+import { Record } from '../../types';
+import { UseReferenceResult } from '../useReference';
+
+export interface UseReferenceOneFieldControllerParams {
+    record?: Record;
+    reference: string;
+    source?: string;
+    target: string;
+}
+
+/**
+ * Fetch a reference record in a one-to-one relationship, and return it when available
+ *
+ * The reference prop should be the name of one of the <Resource> components
+ * added as <Admin> child.
+ *
+ * @example
+ *
+ * const { data, isLoading, error } = useReferenceOneFieldController({
+ *     record: { id: 7, name: 'James Joyce'}
+ *     reference: 'bios',
+ *     target: 'author_id',
+ * });
+ *
+ * @typedef {Object} UseReferenceOneFieldControllerParams
+ * @prop {Object} props.record The current resource record
+ * @prop {string} props.reference The linked resource name
+ * @prop {string} props.target The target resource key
+ * @prop {string} props.source The key current record identifieer ('id' by default)
+ *
+ * @param {UseReferenceOneFieldControllerParams}
+ *
+ * @returns {UseReferenceResult} The request state. Destructure as { referenceRecord, isLoading, error }.
+ */
+export const useReferenceOneFieldController = (
+    props: UseReferenceOneFieldControllerParams
+): UseReferenceResult => {
+    const { reference, record, target, source = 'id' } = props;
+    const notify = useNotify();
+
+    const { data, error, isFetching, isLoading, refetch } = useGetManyReference(
+        reference,
+        {
+            target,
+            id: get(record, source),
+            pagination: { page: 1, perPage: 1 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: {},
+        },
+        {
+            enabled: !!record,
+            onError: error =>
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : error.message || 'ra.notification.http_error',
+                    {
+                        type: 'warning',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error && error.message
+                                    ? error.message
+                                    : undefined,
+                        },
+                    }
+                ),
+        }
+    );
+
+    return {
+        referenceRecord: data ? data[0] : undefined,
+        error,
+        isFetching,
+        isLoading,
+        refetch,
+    };
+};

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { Children, cloneElement, FC, memo, ReactElement } from 'react';
+import { FC, memo, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import get from 'lodash/get';
 import { Typography } from '@mui/material';
 import ErrorIcon from '@mui/icons-material/Error';
@@ -19,7 +18,6 @@ import {
 
 import { LinearProgress } from '../layout';
 import { Link } from '../Link';
-import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, fieldPropTypes, InjectedFieldProps } from './types';
 
 /**
@@ -169,21 +167,12 @@ const stopPropagation = e => e.stopPropagation();
 
 export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
     const {
-        basePath,
         children,
         className,
         error,
-        isFetching,
         isLoading,
-        record,
-        reference,
         referenceRecord,
-        refetch,
-        resource,
         resourceLinkPath,
-        source,
-        translateChoice = false,
-        ...rest
     } = props;
 
     if (error) {
@@ -211,21 +200,10 @@ export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
                 <RecordContextProvider value={referenceRecord}>
                     <Link
                         to={resourceLinkPath as string}
-                        className={className}
+                        className={`${ReferenceFieldClasses.link} ${className}`}
                         onClick={stopPropagation}
                     >
-                        {cloneElement(Children.only(children), {
-                            className: classnames(
-                                children.props.className,
-                                ReferenceFieldClasses.link // force color override for Typography components
-                            ),
-                            record: referenceRecord,
-                            refetch,
-                            resource: reference,
-                            basePath,
-                            translateChoice,
-                            ...sanitizeFieldRestProps(rest),
-                        })}
+                        {children}
                     </Link>
                 </RecordContextProvider>
             </Root>
@@ -234,13 +212,7 @@ export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
 
     return (
         <RecordContextProvider value={referenceRecord}>
-            {cloneElement(Children.only(children), {
-                record: referenceRecord,
-                resource: reference,
-                basePath,
-                translateChoice,
-                ...sanitizeFieldRestProps(rest),
-            })}
+            {children}
         </RecordContextProvider>
     );
 };
@@ -282,7 +254,5 @@ export const ReferenceFieldClasses = {
 };
 
 const Root = styled('span', { name: PREFIX })(({ theme }) => ({
-    [`& .${ReferenceFieldClasses.link}`]: {
-        color: theme.palette.primary.main,
-    },
+    [`& .${ReferenceFieldClasses.link}`]: {},
 }));

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import {
+    CoreAdminContext,
+    RecordContextProvider,
+    ResourceContextProvider,
+    ListContextProvider,
+} from 'ra-core';
+import { createMemoryHistory } from 'history';
+import { ThemeProvider } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
+
+import { TextField, DateField } from '../field';
+import { ReferenceOneField } from './ReferenceOneField';
+import { SimpleShowLayout } from '../detail/SimpleShowLayout';
+import { Datagrid } from '../list/datagrid/Datagrid';
+
+export default { title: 'ra-ui-materialui/fields/ReferenceOneField' };
+
+const dataProvider = {
+    getManyReference: (resource, params) => {
+        console.log('getManyReference', resource, params);
+        return Promise.resolve({
+            data: [
+                {
+                    id: 1,
+                    body:
+                        'James Joyce was an Irish novelist, poet and short story writer.',
+                    published_at: '2022-01-12T11:23:00',
+                },
+            ],
+            total: 1,
+        });
+    },
+} as any;
+
+const history = createMemoryHistory({ initialEntries: ['/books/1/show'] });
+
+const Wrapper = ({ children }) => (
+    <CoreAdminContext dataProvider={dataProvider} history={history}>
+        <ResourceContextProvider value="authors">
+            <RecordContextProvider
+                value={{ id: 1, first_name: 'James', last_name: 'Joyce' }}
+            >
+                {children}
+            </RecordContextProvider>
+        </ResourceContextProvider>
+    </CoreAdminContext>
+);
+
+export const Basic = () => (
+    <Wrapper>
+        <ReferenceOneField reference="bios" target="id">
+            <TextField source="body" />
+        </ReferenceOneField>
+    </Wrapper>
+);
+
+export const Multiple = () => (
+    <Wrapper>
+        <h3>Author</h3>
+        <TextField source="first_name" />
+        &nbsp;
+        <TextField source="last_name" />
+        <h3>Bio</h3>
+        <ReferenceOneField reference="bios" target="id">
+            <TextField source="body" />
+        </ReferenceOneField>
+        <h3>Bio published at</h3>
+        <ReferenceOneField reference="bios" target="id">
+            <DateField source="published_at" />
+        </ReferenceOneField>
+    </Wrapper>
+);
+
+export const InShowLayout = () => (
+    <Wrapper>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <ReferenceOneField label="Bio" reference="bios" target="id">
+                <TextField source="body" />
+            </ReferenceOneField>
+        </SimpleShowLayout>
+    </Wrapper>
+);
+
+const ListWrapper = ({ children }) => (
+    <ThemeProvider theme={createTheme()}>
+        <Wrapper>
+            <ListContextProvider
+                value={{
+                    total: 1,
+                    data: [{ id: 1, first_name: 'James', last_name: 'Joyce' }],
+                    currentSort: { field: 'first_name', order: 'ASC' },
+                }}
+            >
+                {children}
+            </ListContextProvider>
+        </Wrapper>
+    </ThemeProvider>
+);
+
+export const InDatagrid = () => (
+    <ListWrapper>
+        <Datagrid>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <ReferenceOneField label="Bio" reference="bios" target="id">
+                <TextField source="body" />
+            </ReferenceOneField>
+        </Datagrid>
+    </ListWrapper>
+);

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -1,0 +1,108 @@
+import React, { ReactElement } from 'react';
+import PropTypes from 'prop-types';
+import { Typography } from '@mui/material';
+import {
+    useReferenceOneFieldController,
+    useRecordContext,
+    ResourceContextProvider,
+    getResourceLinkPath,
+    LinkToType,
+} from 'ra-core';
+
+import { PublicFieldProps, InjectedFieldProps } from './types';
+import { ReferenceFieldView } from './ReferenceField';
+
+/**
+ * Render the related record in a one-to-one relationship
+ *
+ * Expects a single field as child
+ *
+ * @example // display the bio of the current author
+ * <ReferenceOneField reference="bios" target="author_id">
+ *     <TextField source="body" />
+ * </ReferenceOneField>
+ */
+export const ReferenceOneField = (props: ReferenceOneFieldProps) => {
+    const {
+        basePath,
+        resource,
+        children,
+        reference,
+        source,
+        target,
+        emptyText,
+        link = false,
+    } = props;
+    const record = useRecordContext(props);
+
+    const {
+        isLoading,
+        isFetching,
+        referenceRecord,
+        error,
+        refetch,
+    } = useReferenceOneFieldController({
+        record,
+        reference,
+        source,
+        target,
+    });
+
+    const resourceLinkPath = getResourceLinkPath({
+        basePath,
+        link,
+        record,
+        reference,
+        resource,
+        source,
+    });
+
+    return !record || (!isLoading && referenceRecord == null) ? (
+        emptyText ? (
+            <Typography component="span" variant="body2">
+                {emptyText}
+            </Typography>
+        ) : null
+    ) : (
+        <ResourceContextProvider value={reference}>
+            <ReferenceFieldView
+                isLoading={isLoading}
+                isFetching={isFetching}
+                referenceRecord={referenceRecord}
+                resourceLinkPath={resourceLinkPath}
+                basePath={basePath}
+                reference={reference}
+                refetch={refetch}
+                error={error}
+            >
+                {children}
+            </ReferenceFieldView>
+        </ResourceContextProvider>
+    );
+};
+
+export interface ReferenceOneFieldProps
+    extends PublicFieldProps,
+        InjectedFieldProps {
+    children: ReactElement;
+    reference: string;
+    target: string;
+    link?: LinkToType;
+}
+
+ReferenceOneField.propTypes = {
+    addLabel: PropTypes.bool,
+    children: PropTypes.element.isRequired,
+    className: PropTypes.string,
+    label: PropTypes.string,
+    record: PropTypes.any,
+    reference: PropTypes.string.isRequired,
+    resource: PropTypes.string,
+    source: PropTypes.string.isRequired,
+    target: PropTypes.string.isRequired,
+};
+
+ReferenceOneField.defaultProps = {
+    addLabel: true,
+    source: 'id',
+};

--- a/packages/ra-ui-materialui/src/field/index.ts
+++ b/packages/ra-ui-materialui/src/field/index.ts
@@ -12,6 +12,7 @@ export * from './NumberField';
 export * from './ReferenceArrayField';
 export * from './ReferenceField';
 export * from './ReferenceManyField';
+export * from './ReferenceOneField';
 export * from './RichTextField';
 export * from './sanitizeFieldRestProps';
 export * from './SelectField';


### PR DESCRIPTION
## Problem

I started documenting the react-admin ReferenceXXXfFields, and found ReferenceOne to be a missing spot in our strategy.

## Solution

- [x] Remove props injection in ReferenceField
- [x] Add ReferenceOneField (and the `useReferenceOneFieldController`), reusing the view from `<ReferenceField>`
- [x] Add documentation for relationship types and the react-admin solutions to handle them