### PR TITLE
Fix missing type for TranslationMessages

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -39,6 +39,7 @@ export interface TranslationMessages extends StringMap {
             update: string;
             move_up: string;
             move_down: string;
+            open: string;
         };
         boolean: {
             [key: string]: StringMap | string;


### PR DESCRIPTION
Fix missing type for TranslationMessages.

(`ra.action.open`)

https://github.com/marmelab/react-admin/commit/f94b669d9db3a0f13cb092666f3b11bd7ca424f5#diff-d55e636245f2994de4a9a74002cca1fec0a6a2e68d1805a5439a0c885f37263b

