### PR TITLE
Fix propTypes.label for reference fields

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -106,7 +106,7 @@ ReferenceArrayField.propTypes = {
     addLabel: PropTypes.bool,
     className: PropTypes.string,
     children: PropTypes.element.isRequired,
-    label: PropTypes.string,
+    label: fieldPropTypes.label,
     record: PropTypes.any,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -86,7 +86,7 @@ ReferenceField.propTypes = {
     className: PropTypes.string,
     cellClassName: PropTypes.string,
     headerClassName: PropTypes.string,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    label: fieldPropTypes.label,
     record: PropTypes.any,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -118,7 +118,7 @@ ReferenceManyField.propTypes = {
     children: PropTypes.element.isRequired,
     className: PropTypes.string,
     filter: PropTypes.object,
-    label: PropTypes.string,
+    label: fieldPropTypes.label,
     perPage: PropTypes.number,
     record: PropTypes.any,
     reference: PropTypes.string.isRequired,

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -9,7 +9,7 @@ import {
     LinkToType,
 } from 'ra-core';
 
-import { PublicFieldProps, InjectedFieldProps } from './types';
+import { PublicFieldProps, fieldPropTypes, InjectedFieldProps } from './types';
 import { ReferenceFieldView } from './ReferenceField';
 
 /**
@@ -94,7 +94,7 @@ ReferenceOneField.propTypes = {
     addLabel: PropTypes.bool,
     children: PropTypes.element.isRequired,
     className: PropTypes.string,
-    label: PropTypes.string,
+    label: fieldPropTypes.label,
     record: PropTypes.any,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,


### PR DESCRIPTION
## Problem:

Prop types of reference fields specify `label: PropTypes.string`, even though `type PublicFieldProps` says `label?: string | ReactElement | boolean`. A big red error is printed to the console when using an element as label.

## Solution:

Use common `fieldPropTypes.label` definition in each propType definition.

---

I am being a bit sloppy here, as this just fixes the warnings that bug me. But it makes the codebase a bit better and should be easy to merge. A bigger refactoring of propTypes is needed. The same issue is with inputs.

I didn't investigate why `Reference*Field` propTypes don't extend the `fieldPropTypes` like other fields do, probably they have to override something.