### PR TITLE
SimpleList: add a divider prop

### DIFF
--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -44,6 +44,7 @@ It accepts the following props:
 * [`rightAvatar`](#rightavatar)
 * [`rightIcon`](#righticon)
 * [`rowStyle`](#rowstyle)
+* [`divider`](#divider)
 
 ## `leftAvatar`
 
@@ -128,6 +129,10 @@ export const PostList = (props) => (
     </List>
 );
 ```
+
+## `divider`
+
+This optional prop should be a boolean. When setting it to `true` a 1px light border is added to the bottom of the `ListItem`.
 
 ## `secondaryText`
 

--- a/packages/ra-ui-materialui/src/list/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList.tsx
@@ -43,6 +43,7 @@ import { SimpleListLoading } from './SimpleListLoading';
  * - rightIcon: same
  * - linkType: 'edit' or 'show', or a function returning 'edit' or 'show' based on the record
  * - rowStyle: function returning a style object based on (record, index)
+ * - divider: add a light border to the bottom of each list item
  *
  * @example // Display all posts as a List
  * const postRowStyle = (record, index) => ({
@@ -76,6 +77,7 @@ export const SimpleList = <RecordType extends Record = Record>(
         secondaryText,
         tertiaryText,
         rowStyle,
+        divider = false,
         ...rest
     } = props;
     const { data, isLoading, total } = useListContext<RecordType>(props);
@@ -112,7 +114,7 @@ export const SimpleList = <RecordType extends Record = Record>(
         <Root className={className} {...sanitizeListRestProps(rest)}>
             {data.map((record, rowIndex) => (
                 <RecordContextProvider key={record.id} value={record}>
-                    <ListItem disablePadding>
+                    <ListItem disablePadding divider>
                         <LinkOrNot
                             linkType={linkType}
                             resource={resource}
@@ -202,6 +204,7 @@ SimpleList.propTypes = {
     secondaryText: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
     tertiaryText: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
     rowStyle: PropTypes.func,
+    divider: PropTypes.bool,
 };
 
 export type FunctionToElement<RecordType extends Record = Record> = (
@@ -222,6 +225,7 @@ export interface SimpleListProps<RecordType extends Record = Record>
     secondaryText?: FunctionToElement<RecordType> | ReactElement;
     tertiaryText?: FunctionToElement<RecordType> | ReactElement;
     rowStyle?: (record: Record, index: number) => any;
+    divider?: boolean;
     // can be injected when using the component without context
     resource?: string;
     data?: RecordType[];


### PR DESCRIPTION
Adds a `divider` prop that goes straight onto mui's `ListItem`.

MUI documentation:
- https://mui.com/components/dividers/#list-dividers
- https://mui.com/api/list-item/#props