### PR TITLE
Fix CreateButton Fab _scrollToTop state prop

### DIFF
--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -50,7 +50,8 @@ const CreateButton = (props: CreateButtonProps) => {
             component={Link}
             color="primary"
             className={classnames(CreateButtonClasses.floating, className)}
-            to={location}
+            to={location.pathname}
+            state={location.state}
             aria-label={label && translate(label)}
             {...sanitizeButtonRestProps(rest)}
         >


### PR DESCRIPTION
#### Problem

`_scrollToTop` not happening when clicking the mobile (FAB) version of `CreateButton`.

https://user-images.githubusercontent.com/79251424/149657631-f035901c-4e55-4736-8ce2-9c8f17b36290.mp4



#### Reason

[`Link`](https://reactrouter.com/docs/en/v6/api#link) expects `state` to be passed as a prop, not as a field of `to`. `Button` handles that through [`Button.getLinkParams`](https://github.com/marmelab/react-admin/blob/a57ff9f0374bf1b68920f2518a311c3af75e495a/packages/ra-ui-materialui/src/button/Button.tsx#L206).

#### Quick (*bugfix*) solution

Pass `location.state` as `state` and `location.pathname` as `to`.

---

#### feature request

Move the Fab-code into `Button`, handle its props with `getLinkParams`, allow making other buttons `Fab`-able (e.g. sensible for `EditButton` in the `Show` view, `SaveButton` in the `Edit` view, etc)