### PR TITLE
Add previous data on transform

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -542,6 +542,22 @@ The `transform` function can also return a `Promise`, which allows you to do all
 
 **Tip**: The message will be translated.
 
+**Tip**: `<Edit>`'s transform prop function also get the `previousData` in its second argument:
+
+```jsx
+export const UserEdit = (props) => {
+    const transform = (data, { previousData }) => ({
+        ...data,
+        avoidChangeField: previousData.avoidChangeField
+    });
+    return (
+        <Edit {...props} transform={transform}>
+            ...
+        </Edit>
+    );
+}
+```
+
 ## Prefilling a `<Create>` Record
 
 Users may need to create a copy of an existing record. For that use case, use the `<CloneButton>` component. It reads the `record` from the current `RecordContext`.
@@ -2283,6 +2299,32 @@ const dataProvider = {
         }));
     },
 }
+```
+
+**Tip**: `<Edit>`'s transform prop function also get the `previousData` in its second argument:
+
+```jsx
+const PostEditToolbar = props => (
+    <Toolbar {...props}>
+        <SaveButton submitOnEnter={true} />
+        <SaveButton
+            label="post.action.save_and_notify"
+            transform={(data, { previousData }) => ({
+                ...data,
+                avoidChangeField: previousData.avoidChangeField
+            })}
+            submitOnEnter={false}
+        />
+    </Toolbar>
+);
+
+const PostEdit = () => (
+    <Edit>
+        <SimpleForm toolbar={<PostEditToolbar />}>
+            // ...
+        </SimpleForm>
+    </Edit>
+);
 ```
 
 ### Grouping Inputs

--- a/packages/ra-core/src/controller/edit/EditBase.spec.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.spec.tsx
@@ -299,7 +299,7 @@ describe('EditBase', () => {
                 Promise.resolve({ data: { id, ...previousData, ...data } })
             ),
         });
-        const transform = jest.fn(data => ({
+        const transform = jest.fn((data, _options) => ({
             ...data,
             test: 'test transformed',
         }));
@@ -337,7 +337,10 @@ describe('EditBase', () => {
         getByLabelText('save').click();
 
         await waitFor(() => {
-            expect(transform).toHaveBeenCalledWith({ test: 'test' });
+            expect(transform).toHaveBeenCalledWith(
+                { test: 'test' },
+                { previousData: undefined }
+            );
         });
         await waitFor(() => {
             expect(dataProvider.update).toHaveBeenCalledWith('posts', {
@@ -358,7 +361,7 @@ describe('EditBase', () => {
             ),
         });
         const transform = jest.fn();
-        const transformOverride = jest.fn(data => ({
+        const transformOverride = jest.fn((data, _options) => ({
             ...data,
             test: 'test transformed',
         }));
@@ -399,7 +402,10 @@ describe('EditBase', () => {
         getByLabelText('save').click();
 
         await waitFor(() => {
-            expect(transformOverride).toHaveBeenCalledWith({ test: 'test' });
+            expect(transformOverride).toHaveBeenCalledWith(
+                { test: 'test' },
+                { previousData: undefined }
+            );
         });
         await waitFor(() => {
             expect(dataProvider.update).toHaveBeenCalledWith('posts', {

--- a/packages/ra-core/src/controller/edit/EditBase.spec.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.spec.tsx
@@ -339,7 +339,7 @@ describe('EditBase', () => {
         await waitFor(() => {
             expect(transform).toHaveBeenCalledWith(
                 { test: 'test' },
-                { previousData: undefined }
+                { previousData: { id: 12, test: 'previous' } }
             );
         });
         await waitFor(() => {
@@ -404,7 +404,7 @@ describe('EditBase', () => {
         await waitFor(() => {
             expect(transformOverride).toHaveBeenCalledWith(
                 { test: 'test' },
-                { previousData: undefined }
+                { previousData: { id: 12, test: 'previous' } }
             );
         });
         await waitFor(() => {

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -661,9 +661,11 @@ describe('useEditController', () => {
             </CoreAdminContext>
         );
         await act(async () => saveCallback({ foo: 'bar' }));
-        expect(transform).toHaveBeenCalledWith({
-            foo: 'bar',
-        });
+        expect(transform).toHaveBeenCalledWith(
+            { foo: 'bar' },
+            { previousData: undefined }
+        );
+
         expect(update).toHaveBeenCalledWith('posts', {
             id: 12,
             data: { foo: 'bar', transformed: true },
@@ -712,9 +714,10 @@ describe('useEditController', () => {
             )
         );
         expect(transform).not.toHaveBeenCalled();
-        expect(transformSave).toHaveBeenCalledWith({
-            foo: 'bar',
-        });
+        expect(transformSave).toHaveBeenCalledWith(
+            { foo: 'bar' },
+            { previousData: undefined }
+        );
         expect(update).toHaveBeenCalledWith('posts', {
             id: 12,
             data: { foo: 'bar', transformed: true },

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -179,6 +179,7 @@ export const useEditController = <RecordType extends RaRecord = any>(
             resource,
             transform,
             update,
+            recordCached.previousData,
         ]
     );
 

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -99,7 +99,7 @@ export const useEditController = <RecordType extends RaRecord = any>(
         record,
     });
 
-    const [update, { isLoading: saving }] = useUpdate<RecordType>(
+    const [update, { isLoading: saving }, previousData] = useUpdate<RecordType>(
         resource,
         { id, previousData: record },
         { ...otherMutationOptions, mutationMode }
@@ -116,9 +116,9 @@ export const useEditController = <RecordType extends RaRecord = any>(
         ) =>
             Promise.resolve(
                 transformFromSave
-                    ? transformFromSave(data)
+                    ? transformFromSave(data, { previousData })
                     : transform
-                    ? transform(data)
+                    ? transform(data, { previousData })
                     : data
             ).then((data: Partial<RecordType>) =>
                 update(
@@ -173,6 +173,7 @@ export const useEditController = <RecordType extends RaRecord = any>(
             resource,
             transform,
             update,
+            previousData,
         ]
     );
 

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -99,9 +99,11 @@ export const useEditController = <RecordType extends RaRecord = any>(
         record,
     });
 
-    const [update, { isLoading: saving }, previousData] = useUpdate<RecordType>(
+    const recordCached = { id, previousData: record };
+
+    const [update, { isLoading: saving }] = useUpdate<RecordType>(
         resource,
-        { id, previousData: record },
+        recordCached,
         { ...otherMutationOptions, mutationMode }
     );
 
@@ -116,9 +118,13 @@ export const useEditController = <RecordType extends RaRecord = any>(
         ) =>
             Promise.resolve(
                 transformFromSave
-                    ? transformFromSave(data, { previousData })
+                    ? transformFromSave(data, {
+                          previousData: recordCached.previousData,
+                      })
                     : transform
-                    ? transform(data, { previousData })
+                    ? transform(data, {
+                          previousData: recordCached.previousData,
+                      })
                     : data
             ).then((data: Partial<RecordType>) =>
                 update(
@@ -173,7 +179,6 @@ export const useEditController = <RecordType extends RaRecord = any>(
             resource,
             transform,
             update,
-            previousData,
         ]
     );
 

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -390,7 +390,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
         }
     };
 
-    return [update, mutation, paramsRef.current.previousData];
+    return [update, mutation];
 };
 
 type Snapshot = [key: QueryKey, value: any][];
@@ -427,6 +427,5 @@ export type UseUpdateResult<RecordType extends RaRecord = any> = [
         unknown,
         Partial<UpdateParams<RecordType> & { resource?: string }>,
         unknown
-    >,
-    RecordType
+    >
 ];

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -390,7 +390,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
         }
     };
 
-    return [update, mutation];
+    return [update, mutation, paramsRef.current.previousData];
 };
 
 type Snapshot = [key: QueryKey, value: any][];
@@ -427,5 +427,6 @@ export type UseUpdateResult<RecordType extends RaRecord = any> = [
         unknown,
         Partial<UpdateParams<RecordType> & { resource?: string }>,
         unknown
-    >
+    >,
+    RecordType
 ];

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -230,7 +230,10 @@ export type OnSuccess = (
     context?: any
 ) => void;
 export type onError = (error?: any, variables?: any, context?: any) => void;
-export type TransformData = (data: any) => any | Promise<any>;
+export type TransformData = (
+    data: any,
+    options?: { previousData: any }
+) => any | Promise<any>;
 
 export interface UseDataProviderOptions {
     action?: string;

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -268,7 +268,7 @@ describe('<SaveButton />', () => {
         await waitFor(() => {
             expect(transform).toHaveBeenCalledWith(
                 { id: 123, title: 'ipsum' },
-                { previousData: undefined }
+                { previousData: { id: 123, title: 'lorem' } }
             );
             expect(update).toHaveBeenCalledWith('posts', {
                 id: '123',

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -266,7 +266,10 @@ describe('<SaveButton />', () => {
         );
         fireEvent.click(screen.getByText('ra.action.save'));
         await waitFor(() => {
-            expect(transform).toHaveBeenCalledWith({ id: 123, title: 'ipsum' });
+            expect(transform).toHaveBeenCalledWith(
+                { id: 123, title: 'ipsum' },
+                { previousData: undefined }
+            );
             expect(update).toHaveBeenCalledWith('posts', {
                 id: '123',
                 data: { id: 123, title: 'ipsum', transformed: true },

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -498,7 +498,7 @@ describe('<Edit />', () => {
                         id: 123,
                         title: 'ipsum',
                     },
-                    { previousData: undefined }
+                    { previousData: { id: 123, title: 'lorem' } }
                 );
 
                 expect(update).toHaveBeenCalledWith('foo', {
@@ -568,7 +568,133 @@ describe('<Edit />', () => {
                         id: 123,
                         title: 'ipsum',
                     },
-                    { previousData: undefined }
+                    { previousData: { id: 123, title: 'lorem' } }
+                );
+                expect(update).toHaveBeenCalledWith('foo', {
+                    id: '123',
+                    data: { id: 123, title: 'ipsum', transformed: true },
+                    previousData: { id: 123, title: 'lorem' },
+                });
+            });
+        });
+        it('should be passed previousData via argument on transform called', async () => {
+            const update = jest
+                .fn()
+                .mockImplementationOnce((_, { data }) =>
+                    Promise.resolve({ data })
+                );
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update,
+            } as any;
+            const transform = jest.fn().mockImplementationOnce(data => ({
+                ...data,
+                transformed: true,
+            }));
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button onClick={() => save({ ...record, title: 'ipsum' })}>
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <QueryClientProvider client={new QueryClient()}>
+                    <DataProviderContext.Provider value={dataProvider}>
+                        <Edit
+                            {...defaultEditProps}
+                            transform={transform}
+                            mutationMode="pessimistic"
+                        >
+                            <FakeForm />
+                        </Edit>
+                    </DataProviderContext.Provider>
+                </QueryClientProvider>
+            );
+            await waitFor(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await waitFor(() => {
+                expect(transform).toHaveBeenCalledWith(
+                    {
+                        id: 123,
+                        title: 'ipsum',
+                    },
+                    { previousData: { id: 123, title: 'lorem' } }
+                );
+
+                expect(update).toHaveBeenCalledWith('foo', {
+                    id: '123',
+                    data: { id: 123, title: 'ipsum', transformed: true },
+                    previousData: { id: 123, title: 'lorem' },
+                });
+            });
+        });
+        it('should be passed previousData via argument on transformSave called', async () => {
+            const update = jest
+                .fn()
+                .mockImplementationOnce((_, { data }) =>
+                    Promise.resolve({ data })
+                );
+            const dataProvider = {
+                getOne: () =>
+                    Promise.resolve({
+                        data: { id: 123, title: 'lorem' },
+                    }),
+                update,
+            } as any;
+            const transform = jest.fn();
+            const transformSave = jest.fn().mockImplementationOnce(data => ({
+                ...data,
+                transformed: true,
+            }));
+            const FakeForm = ({ record, save }) => (
+                <>
+                    <span>{record.title}</span>
+                    <button
+                        onClick={() =>
+                            save(
+                                { ...record, title: 'ipsum' },
+                                {
+                                    transform: transformSave,
+                                }
+                            )
+                        }
+                    >
+                        Update
+                    </button>
+                </>
+            );
+            const { queryAllByText, getByText } = renderWithRedux(
+                <QueryClientProvider client={new QueryClient()}>
+                    <DataProviderContext.Provider value={dataProvider}>
+                        <Edit
+                            {...defaultEditProps}
+                            transform={transform}
+                            mutationMode="pessimistic"
+                        >
+                            <FakeForm />
+                        </Edit>
+                    </DataProviderContext.Provider>
+                </QueryClientProvider>
+            );
+            await waitFor(() => {
+                expect(queryAllByText('lorem')).toHaveLength(1);
+            });
+            fireEvent.click(getByText('Update'));
+            await waitFor(() => {
+                expect(transform).not.toHaveBeenCalled();
+                expect(transformSave).toHaveBeenCalledWith(
+                    {
+                        id: 123,
+                        title: 'ipsum',
+                    },
+                    { previousData: { id: 123, title: 'lorem' } }
                 );
                 expect(update).toHaveBeenCalledWith('foo', {
                     id: '123',

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -493,10 +493,14 @@ describe('<Edit />', () => {
             });
             fireEvent.click(getByText('Update'));
             await waitFor(() => {
-                expect(transform).toHaveBeenCalledWith({
-                    id: 123,
-                    title: 'ipsum',
-                });
+                expect(transform).toHaveBeenCalledWith(
+                    {
+                        id: 123,
+                        title: 'ipsum',
+                    },
+                    { previousData: undefined }
+                );
+
                 expect(update).toHaveBeenCalledWith('foo', {
                     id: '123',
                     data: { id: 123, title: 'ipsum', transformed: true },
@@ -559,10 +563,13 @@ describe('<Edit />', () => {
             fireEvent.click(getByText('Update'));
             await waitFor(() => {
                 expect(transform).not.toHaveBeenCalled();
-                expect(transformSave).toHaveBeenCalledWith({
-                    id: 123,
-                    title: 'ipsum',
-                });
+                expect(transformSave).toHaveBeenCalledWith(
+                    {
+                        id: 123,
+                        title: 'ipsum',
+                    },
+                    { previousData: undefined }
+                );
                 expect(update).toHaveBeenCalledWith('foo', {
                     id: '123',
                     data: { id: 123, title: 'ipsum', transformed: true },


### PR DESCRIPTION
Closes #7054 

Add previous data argument transform method. My tests added is redundant because previousData always is passed and  asserted in every tests but, it's noting worth to keep description about expecting behavior, ready for this behavior is modified (however if you don't need it, I'll remove them).
