### PR TITLE
Fix error messages can't be copied

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -45,6 +45,7 @@ const useStyles = makeStyles(
             maxWidth: '60em',
         },
         panelDetails: {
+            flexDirection: 'column',
             whiteSpace: 'pre-wrap',
         },
         toolbar: {
@@ -84,22 +85,18 @@ const Error = (props: ErrorProps): JSX.Element => {
                 <div>{translate('ra.message.error')}</div>
                 {process.env.NODE_ENV !== 'production' && (
                     <>
-                        <Typography className={classes.panel}>
-                            {translate(error.toString(), {
-                                _: error.toString(),
-                            })}
-                        </Typography>
                         <Accordion className={classes.panel}>
                             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                                 Error stack
                             </AccordionSummary>
-                            {errorInfo && (
-                                <AccordionDetails
-                                    className={classes.panelDetails}
-                                >
-                                    {errorInfo.componentStack}
-                                </AccordionDetails>
-                            )}
+                            <AccordionDetails className={classes.panelDetails}>
+                                <b>
+                                    {translate(error.toString(), {
+                                        _: error.toString(),
+                                    })}
+                                </b>
+                                {errorInfo && errorInfo.componentStack}
+                            </AccordionDetails>
                         </Accordion>
 
                         <div className={classes.advice}>

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -44,8 +44,10 @@ const useStyles = makeStyles(
             marginTop: '1em',
             maxWidth: '60em',
         },
+        panelSumary: {
+            userSelect: 'all',
+        },
         panelDetails: {
-            flexDirection: 'column',
             whiteSpace: 'pre-wrap',
         },
         toolbar: {
@@ -86,17 +88,21 @@ const Error = (props: ErrorProps): JSX.Element => {
                 {process.env.NODE_ENV !== 'production' && (
                     <>
                         <Accordion className={classes.panel}>
-                            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                                Error stack
+                            <AccordionSummary
+                                className={classes.panelSumary}
+                                expandIcon={<ExpandMoreIcon />}
+                            >
+                                {translate(error.toString(), {
+                                    _: error.toString(),
+                                })}
                             </AccordionSummary>
-                            <AccordionDetails className={classes.panelDetails}>
-                                <b>
-                                    {translate(error.toString(), {
-                                        _: error.toString(),
-                                    })}
-                                </b>
-                                {errorInfo && errorInfo.componentStack}
-                            </AccordionDetails>
+                            {errorInfo && (
+                                <AccordionDetails
+                                    className={classes.panelDetails}
+                                >
+                                    {errorInfo.componentStack}
+                                </AccordionDetails>
+                            )}
                         </Accordion>
 
                         <div className={classes.advice}>

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -84,11 +84,14 @@ const Error = (props: ErrorProps): JSX.Element => {
                 <div>{translate('ra.message.error')}</div>
                 {process.env.NODE_ENV !== 'production' && (
                     <>
+                        <Typography className={classes.panel}>
+                            {translate(error.toString(), {
+                                _: error.toString(),
+                            })}
+                        </Typography>
                         <Accordion className={classes.panel}>
                             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                                {translate(error.toString(), {
-                                    _: error.toString(),
-                                })}
+                                Error stack
                             </AccordionSummary>
                             {errorInfo && (
                                 <AccordionDetails


### PR DESCRIPTION
Fixes #6749

Before;
![140480134-5697c857-b012-4517-b943-4d19c76b5da9](https://user-images.githubusercontent.com/8268610/150347680-30f8e390-7cb8-45b6-a308-c5e0f864fa9f.png)

After:
![error](https://user-images.githubusercontent.com/8268610/150347536-fdc580a1-5e93-4410-85f6-13b9d8297fbf.png)
