### PR TITLE
Add onSuccess and onFailure handlers to bulk delete buttons

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.tsx
@@ -51,6 +51,8 @@ BulkDeleteButton.propTypes = {
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     undoable: PropTypes.bool,
     icon: PropTypes.element,
+    onSuccess: PropTypes.func,
+    onFailure: PropTypes.func,
 };
 
 BulkDeleteButton.defaultProps = {

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -49,6 +49,8 @@ const BulkDeleteWithConfirmButton = (
         label,
         onClick,
         selectedIds,
+        onSuccess,
+        onFailure,
         ...rest
     } = props;
     const [isOpen, setOpen] = useState(false);
@@ -61,31 +63,40 @@ const BulkDeleteWithConfirmButton = (
     const [deleteMany, { loading }] = useDeleteMany(resource, selectedIds, {
         action: CRUD_DELETE_MANY,
         onSuccess: () => {
-            refresh();
-            notify('ra.notification.deleted', {
-                type: 'info',
-                messageArgs: { smart_count: selectedIds.length },
-            });
+            setOpen(false);
             unselectAll(resource);
+            if (onSuccess) {
+                onSuccess();
+            } else {
+                refresh();
+                notify('ra.notification.deleted', {
+                    type: 'info',
+                    messageArgs: { smart_count: selectedIds.length },
+                });
+            }
         },
         onFailure: error => {
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                {
-                    type: 'warning',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                ? error.message
-                                : undefined,
-                    },
-                }
-            );
             setOpen(false);
+            if (onFailure) {
+                onFailure(error);
+            } else {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : error.message || 'ra.notification.http_error',
+                    {
+                        type: 'warning',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error && error.message
+                                    ? error.message
+                                    : undefined,
+                        },
+                    }
+                );
+            }
         },
     });
 
@@ -172,6 +183,8 @@ BulkDeleteWithConfirmButton.propTypes = {
     resource: PropTypes.string,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     icon: PropTypes.element,
+    onSuccess: PropTypes.func,
+    onFailure: PropTypes.func,
 };
 
 BulkDeleteWithConfirmButton.defaultProps = {

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -40,6 +40,8 @@ const BulkDeleteWithUndoButton = (props: BulkDeleteWithUndoButtonProps) => {
         icon,
         label,
         onClick,
+        onSuccess,
+        onFailure,
         ...rest
     } = props;
     const { selectedIds } = useListContext(props);
@@ -51,32 +53,41 @@ const BulkDeleteWithUndoButton = (props: BulkDeleteWithUndoButtonProps) => {
     const [deleteMany, { loading }] = useDeleteMany(resource, selectedIds, {
         action: CRUD_DELETE_MANY,
         onSuccess: () => {
-            notify('ra.notification.deleted', {
-                type: 'info',
-                messageArgs: { smart_count: selectedIds.length },
-                undoable: true,
-            });
             unselectAll(resource);
-            refresh();
+            if (onSuccess) {
+                onSuccess();
+            } else {
+                notify('ra.notification.deleted', {
+                    type: 'info',
+                    messageArgs: { smart_count: selectedIds.length },
+                    undoable: true,
+                });
+                unselectAll(resource);
+                refresh();
+            }
         },
         onFailure: error => {
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                {
-                    type: 'warning',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                ? error.message
-                                : undefined,
-                    },
-                }
-            );
-            refresh();
+            if (onFailure) {
+                onFailure(error);
+            } else {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : error.message || 'ra.notification.http_error',
+                    {
+                        type: 'warning',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error && error.message
+                                    ? error.message
+                                    : undefined,
+                        },
+                    }
+                );
+                refresh();
+            }
         },
         undoable: true,
     });
@@ -123,6 +134,8 @@ BulkDeleteWithUndoButton.propTypes = {
     resource: PropTypes.string,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     icon: PropTypes.element,
+    onSuccess: PropTypes.func,
+    onFailure: PropTypes.func,
 };
 
 BulkDeleteWithUndoButton.defaultProps = {


### PR DESCRIPTION
In this PR I add the `onSuccess` and `onFailure` handlers to the bulk delete buttons. This is the same behavior in the `DeleteButton` component.

Thanks!