### PR TITLE
Fix `SimpleFormIterator` assigns items indexes incorrectly

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -133,7 +133,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
                     {fields.map((member, index) => (
                         <CSSTransition
                             nodeRef={nodeRef}
-                            key={ids.current[index]}
+                            key={index}
                             timeout={500}
                             classNames="fade"
                             {...TransitionProps}


### PR DESCRIPTION
Fixes #6722, #7118 and #7124