### PR TITLE
fix: initialValue prop not used when input value is null

### DIFF
--- a/packages/ra-core/src/form/useInput.spec.tsx
+++ b/packages/ra-core/src/form/useInput.spec.tsx
@@ -206,6 +206,38 @@ describe('useInput', () => {
         expect(queryByDisplayValue('foo')).not.toBeNull();
     });
 
+    it('applies the initialValue when input has null value', () => {
+        const { queryByDisplayValue } = renderWithRedux(
+            <FormWithRedirect
+                record={{
+                    title: null,
+                }}
+                onSubmit={jest.fn()}
+                render={() => {
+                    return (
+                        <Input
+                            source="title"
+                            resource="posts"
+                            initialValue="foo"
+                        >
+                            {({ id, input }) => {
+                                return (
+                                    <input
+                                        type="text"
+                                        id={id}
+                                        aria-label="Title"
+                                        {...input}
+                                    />
+                                );
+                            }}
+                        </Input>
+                    );
+                }}
+            />
+        );
+        expect(queryByDisplayValue('foo')).not.toBeNull();
+    });
+
     it('does not apply the initialValue when input has a value of 0', () => {
         const { queryByDisplayValue } = renderWithRedux(
             <FormWithRedirect

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -5,6 +5,7 @@ import {
     FieldRenderProps,
     FieldInputProps,
 } from 'react-final-form';
+import get from 'lodash/get';
 import { Validator, composeValidators } from './validate';
 import isRequired from './isRequired';
 import { useFormGroupContext } from './useFormGroupContext';
@@ -73,7 +74,7 @@ const useInput = ({
     // This ensure dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level initialValues so that it works as it should in final-form
     // (ie. field level initialValue override form level initialValues for this field).
-    let inputInitialValue = record ? record[source] : undefined;
+    let inputInitialValue = get(record, source);
     if (inputInitialValue === null || inputInitialValue === undefined) {
         inputInitialValue = initialValue;
     }

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -74,12 +74,9 @@ const useInput = ({
     // This ensure dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level initialValues so that it works as it should in final-form
     // (ie. field level initialValue override form level initialValues for this field).
-    let inputInitialValue = get(record, source);
-    if (inputInitialValue === null || inputInitialValue === undefined) {
-        inputInitialValue = initialValue;
-    }
+    const inputInitialValue = get(record, source, initialValue);
     const { input, meta } = useFinalFormField(finalName, {
-        initialValue: inputInitialValue,
+        initialValue: inputInitialValue ?? initialValue,
         defaultValue,
         validate: sanitizedValidate,
         ...options,

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -5,7 +5,6 @@ import {
     FieldRenderProps,
     FieldInputProps,
 } from 'react-final-form';
-import get from 'lodash/get';
 import { Validator, composeValidators } from './validate';
 import isRequired from './isRequired';
 import { useFormGroupContext } from './useFormGroupContext';
@@ -74,8 +73,12 @@ const useInput = ({
     // This ensure dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level initialValues so that it works as it should in final-form
     // (ie. field level initialValue override form level initialValues for this field).
+    let inputInitialValue = record ? record[source] : undefined;
+    if (inputInitialValue === null || inputInitialValue === undefined) {
+        inputInitialValue = initialValue;
+    }
     const { input, meta } = useFinalFormField(finalName, {
-        initialValue: get(record, source, initialValue),
+        initialValue: inputInitialValue,
         defaultValue,
         validate: sanitizedValidate,
         ...options,


### PR DESCRIPTION
fixes #7132

I have replaced the lodash get method so that it is easier for maintainers / contributors to see what happens.
Lodash `get` will not use the default value when the result is `null`. While we need the initialValue to be returned for both null and undefined values as written in react admin docs. See docs for, the DateInput component.
