### PR TITLE
[RFC] Can define `variant` and `margin` for Inputs globaly with Material UI theming

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -1771,6 +1771,36 @@ export const PostEdit = () => (
 );
 ```
 
+**Tip**: If, for some reason, you need to define the `variant` globaly for all your app, you can creat your own theme, following [Material UI themes documentation](https://material-ui.com/customization/themes/).
+
+
+```jsx
+import { defaultTheme } from 'react-admin';
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+    ...defaultTheme,
+    components: {
+        MuiTextField: { // define the props of all instances of this component
+            defaultProps: {
+                variant: 'standard', // can be : 'standard' | 'filled' | 'outlined' -  react-admin default : 'filled'
+            }
+        },
+        MuiFormControl: {
+            defaultProps: {
+                variant: 'standard',
+            }
+        }
+    },
+});
+
+const App = () => (
+    <Admin theme={theme} dataProvider={simpleRestProvider('http://path.to.my.api')}>
+        // ...
+    </Admin>
+);
+```
+
 ### Margin
 
 By default, react-admin input components use the Material Design "dense" margin. If you want to use the "normal" or "none" margins, you can either set the `margin` prop on each Input component individually, or set the `margin` prop directly on the Form component. In that case, the Form component will transmit the `margin` to each Input.
@@ -1782,6 +1812,36 @@ export const PostEdit = () => (
             ...
         </SimpleForm>
     </Edit>
+);
+```
+
+**Tip**: As the `variant`, you can define `margin` globaly for all your app.
+
+
+```jsx
+import { defaultTheme } from 'react-admin';
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+    ...defaultTheme,
+    components: {
+        MuiTextField: { // define the props of all instances of this component
+            defaultProps: {
+                margin: 'normal', // can be : 'none' | 'dense' | 'normal'  -  react-admin default : 'dense' on desktop, 'normal' on mobile
+            }
+        },
+        MuiFormControl: {
+            defaultProps: {
+                margin: 'normal',
+            }
+        }
+    },
+});
+
+const App = () => (
+    <Admin theme={theme} dataProvider={simpleRestProvider('http://path.to.my.api')}>
+        // ...
+    </Admin>
 );
 ```
 

--- a/docs/ReferenceManyField.md
+++ b/docs/ReferenceManyField.md
@@ -57,7 +57,7 @@ You can use a `<Datagrid>` instead of a `<SingleFieldList>` - but not inside ano
 
 ```jsx
 import * as React from 'react';
-import { ReferenceManyField, Datagrid, DateField, EditButton, Show, SimpleShowLayout, TextField } from "react-admin";
+import { ReferenceManyField, Datagrid, DateField, EditButton, Show, SimpleShowLayout, TextField } from 'react-admin';
 
 const PostShow = props => (
   <Show {...props}>

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -296,6 +296,15 @@ const myTheme = merge({}, defaultTheme, {
         // Use the system font instead of the default Roboto font.
         fontFamily: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Arial', 'sans-serif'].join(','),
     },
+    components: {
+        MuiTextField: { // define the props of all instances of this component
+            defaultProps: {
+                variant: 'standard',
+                margin: 'normal',
+            }
+        },
+        MuiFormControl: {}
+    },
     overrides: {
         MuiButton: { // override the styles of all instances of this component
             root: { // Name of the rule
@@ -471,7 +480,7 @@ const MyAppBar = props => <AppBar {...props} userMenu={<MyUserMenu />} />;
 You can specify the `Sidebar` width by setting the `width` and `closedWidth` property on your custom material-ui theme:
 
 ```jsx
-import { defaultTheme } from "react-admin";
+import { defaultTheme } from 'react-admin';
 import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -9,6 +9,7 @@ import {
     InputLabel,
     styled,
     GlobalStyles,
+    useTheme,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 
@@ -16,6 +17,8 @@ import { RaRichTextClasses, RaRichTextStyles } from './styles';
 import QuillSnowStylesheet from './QuillSnowStylesheet';
 
 export const RichTextInput = (props: RichTextInputProps) => {
+    const theme = useTheme();
+
     const {
         options = {}, // Quill editor options
         toolbar = true,
@@ -26,7 +29,8 @@ export const RichTextInput = (props: RichTextInputProps) => {
         source,
         resource,
         variant,
-        margin = 'dense',
+        margin = theme.components?.MuiFormControl?.defaultProps?.margin ||
+            'dense',
         ...rest
     } = props;
     const quillInstance = useRef<Quill>();

--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -34,7 +34,7 @@ import { SimpleFormView } from './SimpleFormView';
  * @prop {string} redirect
  * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  * @prop {string} variant Apply variant to all inputs. Possible values are 'standard', 'outlined', and 'filled' (default)
- * @prop {string} margin Apply variant to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
+ * @prop {string} margin Apply margin to all inputs. Possible values are 'none', 'normal', and 'dense' (default)
  * @prop {boolean} sanitizeEmptyValues Whether or not deleted record attributes should be recreated with a `null` value (default: true)
  *
  * @param {Props} props

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -8,7 +8,12 @@ import {
     InputProps,
 } from 'ra-core';
 import { useFieldArray } from 'react-final-form-arrays';
-import { InputLabel, FormControl, FormHelperText } from '@mui/material';
+import {
+    InputLabel,
+    FormControl,
+    FormHelperText,
+    useTheme,
+} from '@mui/material';
 
 import { LinearProgress } from '../../layout';
 import { InputHelperText } from '../InputHelperText';
@@ -58,6 +63,8 @@ import { ArrayInputContext } from './ArrayInputContext';
  * @see https://github.com/final-form/react-final-form-arrays
  */
 export const ArrayInput = (props: ArrayInputProps) => {
+    const theme = useTheme();
+
     const {
         className,
         defaultValue,
@@ -72,7 +79,8 @@ export const ArrayInput = (props: ArrayInputProps) => {
         validate,
         variant,
         disabled,
-        margin = 'dense',
+        margin = theme.components?.MuiTextField?.defaultProps?.margin ||
+            'dense',
         ...rest
     } = props;
     const sanitizedValidate = Array.isArray(validate)

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -18,6 +18,7 @@ import {
     Chip,
     TextField,
     TextFieldProps,
+    useTheme,
 } from '@mui/material';
 import {
     ChoicesInputProps,
@@ -101,6 +102,8 @@ import { InputHelperText } from './InputHelperText';
  * <AutocompleteInput source="author_id" options={{ color: 'secondary', InputLabelProps: { shrink: true } }} />
  */
 export const AutocompleteInput = (props: AutocompleteInputProps) => {
+    const theme = useTheme();
+
     const {
         allowEmpty,
         choices,
@@ -126,7 +129,6 @@ export const AutocompleteInput = (props: AutocompleteInputProps) => {
         loading,
         limitChoicesToValue,
         matchSuggestion,
-        margin = 'dense',
         meta: metaOverride,
         multiple = false,
         noOptionsText,
@@ -149,7 +151,10 @@ export const AutocompleteInput = (props: AutocompleteInputProps) => {
         TextFieldProps,
         translateChoice,
         validate,
-        variant = 'filled',
+        variant = theme.components?.MuiTextField?.defaultProps?.variant ||
+            'filled',
+        margin = theme.components?.MuiTextField?.defaultProps?.margin ||
+            'dense',
         ...rest
     } = props;
 

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -3,6 +3,7 @@ import { styled } from '@mui/material/styles';
 import { useCallback, FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
+import { useTheme } from '@mui/material';
 import FormLabel from '@mui/material/FormLabel';
 import FormControl, { FormControlProps } from '@mui/material/FormControl';
 import FormGroup from '@mui/material/FormGroup';
@@ -80,6 +81,8 @@ import { LinearProgress } from '../layout';
  * The object passed as `options` props is passed to the material-ui <Checkbox> components
  */
 export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = props => {
+    const theme = useTheme();
+
     const {
         choices = [],
         className,
@@ -89,7 +92,8 @@ export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = pr
         label,
         loaded,
         loading,
-        margin = 'dense',
+        margin = theme.components?.MuiFormControl?.defaultProps?.margin ||
+            'dense',
         onBlur,
         onChange,
         onFocus,

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from '@mui/material';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
 
@@ -47,6 +48,8 @@ export const DateInput = ({
     variant = 'filled',
     ...rest
 }: DateInputProps) => {
+    const theme = useTheme();
+
     const { id, input, isRequired, meta } = useInput({
         defaultValue,
         format,
@@ -71,8 +74,12 @@ export const DateInput = ({
             // Workaround https://github.com/final-form/react-final-form/issues/529
             // & https://github.com/final-form/react-final-form/issues/431
             value={format(input.value) || ''}
-            variant={variant}
-            margin={margin}
+            variant={
+                theme.components?.MuiTextField?.defaultProps?.variant || variant
+            }
+            margin={
+                theme.components?.MuiTextField?.defaultProps?.margin || margin
+            }
             type="date"
             error={!!(touched && (error || submitError))}
             helperText={

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from '@mui/material';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
 
@@ -36,6 +37,8 @@ export const DateTimeInput = ({
     variant = 'filled',
     ...rest
 }: DateTimeInputProps) => {
+    const theme = useTheme();
+
     const { id, input, isRequired, meta } = useInput({
         defaultValue,
         format,
@@ -60,8 +63,12 @@ export const DateTimeInput = ({
             // Workaround https://github.com/final-form/react-final-form/issues/529
             // and https://github.com/final-form/react-final-form/issues/431
             value={format(input.value) || ''}
-            variant={variant}
-            margin={margin}
+            variant={
+                theme.components?.MuiTextField?.defaultProps?.variant || variant
+            }
+            margin={
+                theme.components?.MuiTextField?.defaultProps?.margin || margin
+            }
             error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText

--- a/packages/ra-ui-materialui/src/input/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/input/Labeled.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from '@mui/material';
 import InputLabel from '@mui/material/InputLabel';
 import FormControl from '@mui/material/FormControl';
 import { FieldTitle, useResourceContext } from 'ra-core';
@@ -22,6 +23,8 @@ import { FieldTitle, useResourceContext } from 'ra-core';
  * </Labeled>
  */
 export const Labeled = (props: LabeledProps) => {
+    const theme = useTheme();
+
     const {
         children,
         className,
@@ -30,7 +33,8 @@ export const Labeled = (props: LabeledProps) => {
         input,
         isRequired,
         label,
-        margin = 'dense',
+        margin = theme.components?.MuiFormControl?.defaultProps?.margin ||
+            'dense',
         meta,
         source,
         ...rest

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTheme } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
@@ -10,12 +11,13 @@ import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
 
 export const NullableBooleanInput = (props: NullableBooleanInputProps) => {
+    const theme = useTheme();
+
     const {
         className,
         format = getStringFromBoolean,
         helperText,
         label,
-        margin = 'dense',
         onBlur,
         onChange,
         onFocus,
@@ -24,7 +26,10 @@ export const NullableBooleanInput = (props: NullableBooleanInputProps) => {
         resource,
         source,
         validate,
-        variant = 'filled',
+        variant = theme.components?.MuiTextField?.defaultProps?.variant ||
+            'filled',
+        margin = theme.components?.MuiTextField?.defaultProps?.margin ||
+            'dense',
         nullLabel = 'ra.boolean.null',
         falseLabel = 'ra.boolean.false',
         trueLabel = 'ra.boolean.true',

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from '@mui/material';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { useInput, FieldTitle, InputProps } from 'ra-core';
 
@@ -38,6 +39,8 @@ export const NumberInput = ({
     inputProps: overrideInputProps,
     ...rest
 }: NumberInputProps) => {
+    const theme = useTheme();
+
     const {
         id,
         input,
@@ -62,7 +65,12 @@ export const NumberInput = ({
         <TextField
             id={id}
             {...input}
-            variant={variant}
+            variant={
+                theme.components?.MuiTextField?.defaultProps?.variant || variant
+            }
+            margin={
+                theme.components?.MuiTextField?.defaultProps?.margin || margin
+            }
             error={!!(touched && (error || submitError))}
             helperText={
                 <InputHelperText
@@ -79,7 +87,6 @@ export const NumberInput = ({
                     isRequired={isRequired}
                 />
             }
-            margin={margin}
             inputProps={inputProps}
             {...options}
             {...sanitizeInputRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -6,6 +6,7 @@ import {
     FormHelperText,
     FormLabel,
     RadioGroup,
+    useTheme,
 } from '@mui/material';
 import { RadioGroupProps } from '@mui/material/RadioGroup';
 import { FormControlProps } from '@mui/material/FormControl';
@@ -76,6 +77,8 @@ import { LinearProgress } from '../layout';
  * The object passed as `options` props is passed to the material-ui <RadioButtonGroup> component
  */
 export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
+    const theme = useTheme();
+
     const {
         choices = [],
         format,
@@ -85,7 +88,8 @@ export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
         label,
         loaded,
         loading,
-        margin = 'dense',
+        margin = theme.components?.MuiFormControl?.defaultProps?.margin ||
+            'dense',
         onBlur,
         onChange,
         onFocus,

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -8,6 +8,7 @@ import {
     IconButton,
     TextField as MuiTextField,
     TextFieldProps,
+    useTheme,
 } from '@mui/material';
 import ClearIcon from '@mui/icons-material/Clear';
 import { InputProps, useTranslate } from 'ra-core';
@@ -16,14 +17,18 @@ import { InputProps, useTranslate } from 'ra-core';
  * An override of the default Material-UI TextField which is resettable
  */
 export const ResettableTextField = (props: ResettableTextFieldProps) => {
+    const theme = useTheme();
+
     const {
         clearAlwaysVisible,
         InputProps,
         value,
         resettable,
         disabled,
-        variant = 'filled',
-        margin = 'dense',
+        variant = theme.components?.MuiTextField?.defaultProps?.variant ||
+            'filled',
+        margin = theme.components?.MuiTextField?.defaultProps?.margin ||
+            'dense',
         ...rest
     } = props;
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -9,6 +9,7 @@ import {
     FormHelperText,
     FormControl,
     Chip,
+    useTheme,
 } from '@mui/material';
 import classnames from 'classnames';
 import {
@@ -81,6 +82,8 @@ import {
  * ];
  */
 export const SelectArrayInput = (props: SelectArrayInputProps) => {
+    const theme = useTheme();
+
     const {
         choices = [],
         className,
@@ -93,7 +96,6 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         label,
         loaded,
         loading,
-        margin = 'dense',
         onBlur,
         onChange,
         onCreate,
@@ -106,7 +108,10 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         source,
         translateChoice,
         validate,
-        variant = 'filled',
+        variant = theme.components?.MuiFormControl?.defaultProps?.variant ||
+            'filled',
+        margin = theme.components?.MuiFormControl?.defaultProps?.margin ||
+            'dense',
         ...rest
     } = props;
 

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
 import { TextFieldProps } from '@mui/material/TextField';
 import { styled } from '@mui/material/styles';
@@ -101,6 +102,8 @@ import {
  *
  */
 export const SelectInput = (props: SelectInputProps) => {
+    const theme = useTheme();
+
     const {
         allowEmpty,
         choices = [],
@@ -119,7 +122,8 @@ export const SelectInput = (props: SelectInputProps) => {
         label,
         loaded,
         loading,
-        margin = 'dense',
+        margin = theme.components?.MuiTextField?.defaultProps?.margin ||
+            'dense',
         onBlur,
         onChange,
         onCreate,


### PR DESCRIPTION
## Description

For some reason, in enterprise project we need to keep ReactAdmin v2 `variant: 'standard'` for all inputs. 

Our forms are very complex, with Material Ui `<SteppedForm>`, and with a lot (some much) inputs. We can't change `variant` and `margin` in `<SimpleForm>` because we don't use it and define it in each `<Input>` add so much lines of duplication code.

To resolve it, I suggest the possibility to can define `variant` and `margin` globaly with theming system.

## Usage

```jsx
import { createTheme } from '@material-ui/core/styles';

const theme = createTheme({
    components: {
        MuiTextField: { // define the props of all instances of this component
            defaultProps: {
                variant: 'standard',
                margin: 'normal',
            }
        },
        MuiFormControl: {} // Same properties
    },
});

const App = () => (
    <Admin theme={theme}>
        // ...
    </Admin>
);

```
