### PR TITLE
Fix SelectInput and AutocompleteInput default width

### DIFF
--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
 import PersonIcon from '@mui/icons-material/Person';
 import {
     Avatar,
@@ -32,40 +31,6 @@ import {
     useListContext,
     useTranslate,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
-
-const PREFIX = 'CommentList';
-
-const classes = {
-    card: `${PREFIX}-card`,
-    cardContent: `${PREFIX}-cardContent`,
-    cardLink: `${PREFIX}-cardLink`,
-    cardLinkLink: `${PREFIX}-cardLinkLink`,
-    cardActions: `${PREFIX}-cardActions`,
-};
-
-// TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
-const Root = styled(Grid)(({ theme }) => ({
-    [`& .${classes.card}`]: {
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-    },
-
-    [`& .${classes.cardContent}`]: theme.typography.body1,
-
-    [`& .${classes.cardLink}`]: {
-        ...theme.typography.body1,
-        flexGrow: 1,
-    },
-
-    [`& .${classes.cardLinkLink}`]: {
-        display: 'inline',
-    },
-
-    [`& .${classes.cardActions}`]: {
-        justifyContent: 'flex-end',
-    },
-}));
 
 const commentFilters = [
     <SearchInput source="q" alwaysOn />,
@@ -105,10 +70,16 @@ const CommentGrid = () => {
 
     if (!data) return null;
     return (
-        <Root spacing={2} container>
+        <Grid spacing={2} container>
             {data.map(record => (
                 <Grid item key={record.id} sm={12} md={6} lg={4}>
-                    <Card className={classes.card}>
+                    <Card
+                        sx={{
+                            height: '100%',
+                            display: 'flex',
+                            flexDirection: 'column',
+                        }}
+                    >
                         <CardHeader
                             className="comment"
                             title={
@@ -129,7 +100,7 @@ const CommentGrid = () => {
                                 </Avatar>
                             }
                         />
-                        <CardContent className={classes.cardContent}>
+                        <CardContent>
                             <TextField
                                 record={record}
                                 source="body"
@@ -142,7 +113,7 @@ const CommentGrid = () => {
                                 }}
                             />
                         </CardContent>
-                        <CardContent className={classes.cardLink}>
+                        <CardContent sx={{ flexGrow: 1 }}>
                             <Typography component="span" variant="body2">
                                 {translate('comment.list.about')}&nbsp;
                             </Typography>
@@ -151,20 +122,17 @@ const CommentGrid = () => {
                                 source="post_id"
                                 reference="posts"
                             >
-                                <TextField
-                                    source="title"
-                                    className={classes.cardLinkLink}
-                                />
+                                <TextField source="title" />
                             </ReferenceField>
                         </CardContent>
-                        <CardActions className={classes.cardActions}>
+                        <CardActions sx={{ justifyContent: 'flex-end' }}>
                             <EditButton record={record} />
                             <ShowButton record={record} />
                         </CardActions>
                     </Card>
                 </Grid>
             ))}
-        </Root>
+        </Grid>
     );
 };
 
@@ -194,12 +162,12 @@ const ListView = () => {
     const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('md'));
     const { defaultTitle } = useListContext();
     return (
-        <Root>
+        <>
             <Title defaultTitle={defaultTitle} />
             <ListToolbar filters={commentFilters} actions={<ListActions />} />
             {isSmall ? <CommentMobileList /> : <CommentGrid />}
             <Pagination rowsPerPageOptions={[6, 9, 12]} />
-        </Root>
+        </>
     );
 };
 

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -581,18 +581,16 @@ describe('<Edit />', () => {
                     </button>
                 </>
             );
-            const { queryAllByText, getByText } = renderWithRedux(
-                <QueryClientProvider client={new QueryClient()}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <Edit
-                            {...defaultEditProps}
-                            transform={transform}
-                            mutationMode="pessimistic"
-                        >
-                            <FakeForm />
-                        </Edit>
-                    </DataProviderContext.Provider>
-                </QueryClientProvider>
+            const { queryAllByText, getByText } = render(
+                <AdminContext dataProvider={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        transform={transform}
+                        mutationMode="pessimistic"
+                    >
+                        <FakeForm />
+                    </Edit>
+                </AdminContext>
             );
             await waitFor(() => {
                 expect(queryAllByText('lorem')).toHaveLength(1);
@@ -649,18 +647,16 @@ describe('<Edit />', () => {
                     </button>
                 </>
             );
-            const { queryAllByText, getByText } = renderWithRedux(
-                <QueryClientProvider client={new QueryClient()}>
-                    <DataProviderContext.Provider value={dataProvider}>
-                        <Edit
-                            {...defaultEditProps}
-                            transform={transform}
-                            mutationMode="pessimistic"
-                        >
-                            <FakeForm />
-                        </Edit>
-                    </DataProviderContext.Provider>
-                </QueryClientProvider>
+            const { queryAllByText, getByText } = render(
+                <AdminContext dataProvider={dataProvider}>
+                    <Edit
+                        {...defaultEditProps}
+                        transform={transform}
+                        mutationMode="pessimistic"
+                    >
+                        <FakeForm />
+                    </Edit>
+                </AdminContext>
             );
             await waitFor(() => {
                 expect(queryAllByText('lorem')).toHaveLength(1);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -11,7 +11,7 @@ import {
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
-
+import { styled } from '@mui/material/styles';
 import {
     Autocomplete,
     AutocompleteProps,
@@ -375,7 +375,7 @@ If you provided a React element for the optionText prop, you must also provide t
     };
 
     return (
-        <>
+        <Root>
             <Autocomplete
                 blurOnSelect
                 clearText={translate(clearText, { _: clearText })}
@@ -410,6 +410,7 @@ If you provided a React element for the optionText prop, you must also provide t
                         }
                         margin={margin}
                         variant={variant}
+                        className={AutocompleteClasses.input}
                         {...TextFieldProps}
                         {...params}
                     />
@@ -472,7 +473,7 @@ If you provided a React element for the optionText prop, you must also provide t
                 }}
             />
             {createElement}
-        </>
+        </Root>
     );
 };
 
@@ -503,6 +504,18 @@ export interface AutocompleteInputProps<
     source?: string;
     TextFieldProps?: TextFieldProps;
 }
+
+const PREFIX = 'RaAutocompleteInput';
+
+export const AutocompleteClasses = {
+    input: `${PREFIX}-input`,
+};
+
+const Root = styled('span', { name: PREFIX })(({ theme }) => ({
+    [`& .${AutocompleteClasses.input}`]: {
+        minWidth: theme.spacing(20),
+    },
+}));
 
 const DefaultSetFilter = () => {};
 

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -29,7 +29,6 @@ export const SearchInput = (props: SearchInputProps) => {
                     </InputAdornment>
                 ),
             }}
-            className={SearchInputClasses.input}
             size="small"
             {...props}
         />
@@ -40,12 +39,6 @@ export type SearchInputProps = CommonInputProps & TextInputProps;
 
 const PREFIX = 'RaSearchInput';
 
-export const SearchInputClasses = {
-    input: `${PREFIX}-input`,
-};
-
 const StyledTextInput = styled(TextInput, { name: PREFIX })({
-    [`&.${SearchInputClasses.input}`]: {
-        marginTop: 0,
-    },
+    marginTop: 0,
 });

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -366,16 +366,12 @@ const sanitizeRestProps = ({
 
 const PREFIX = 'RaSelectInput';
 
-const classes = {
-    input: `${PREFIX}-input`,
-};
-
-const StyledResettableTextField = styled(ResettableTextField)(({ theme }) => ({
-    ...ResettableTextFieldStyles,
-    [classes.input]: {
+const StyledResettableTextField = styled(ResettableTextField, { name: PREFIX })(
+    ({ theme }) => ({
+        ...ResettableTextFieldStyles,
         minWidth: theme.spacing(20),
-    },
-}));
+    })
+);
 
 export type SelectInputProps = Omit<CommonInputProps, 'source'> &
     ChoicesProps &

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -19,7 +19,6 @@ import {
     useForm,
     useFormContext,
 } from 'react-hook-form';
-import classnames from 'classnames';
 import lodashSet from 'lodash/set';
 import lodashGet from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -111,7 +111,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
 
     return (
         <StyledForm
-            className={classnames(className, FilterFormClasses.form)}
+            className={className}
             {...sanitizeRestProps(rest)}
             onSubmit={handleSubmit}
         >
@@ -192,19 +192,16 @@ const handleFormSubmit = () => {};
 const PREFIX = 'RaFilterForm';
 
 export const FilterFormClasses = {
-    form: `${PREFIX}-form`,
     clearFix: `${PREFIX}-clearFix`,
 };
 
 const StyledForm = styled('form', { name: PREFIX })(({ theme }) => ({
-    [`&.${FilterFormClasses.form}`]: {
-        marginTop: theme.spacing(-1),
-        minHeight: theme.spacing(8),
-        display: 'flex',
-        alignItems: 'flex-end',
-        flexWrap: 'wrap',
-        pointerEvents: 'none',
-    },
+    marginTop: theme.spacing(-1),
+    minHeight: theme.spacing(8),
+    display: 'flex',
+    alignItems: 'flex-end',
+    flexWrap: 'wrap',
+    pointerEvents: 'none',
 
     [`& .${FilterFormClasses.clearFix}`]: { clear: 'right' },
 }));


### PR DESCRIPTION
Closes #6700

Setting a default width for selects is necessary in mui 5 as it was in mui 4, see https://github.com/mui-org/material-ui/issues/8778

Before:

![image](https://user-images.githubusercontent.com/99944/151425303-7e1ab76c-a8de-4893-87fa-2249cea465d1.png)


After:

![image](https://user-images.githubusercontent.com/99944/151425167-2f41314c-0b42-4e9e-9dd6-ed69271b4b94.png)
