### PR TITLE
Speed up development on demos by using esbuild and aliases

### DIFF
--- a/examples/crm/craco.config.js
+++ b/examples/crm/craco.config.js
@@ -1,0 +1,85 @@
+const CracoEsbuildPlugin = require('craco-esbuild');
+const CracoAlias = require('craco-alias');
+const fs = require('fs');
+const path = require('path');
+
+const packages = fs.readdirSync(path.resolve(__dirname, '../../packages'));
+const aliases = packages.reduce((acc, dirName) => {
+    const packageJson = require(path.resolve(
+        __dirname,
+        '../../packages',
+        dirName,
+        'package.json'
+    ));
+    acc[packageJson.name] = path.resolve(
+        __dirname,
+        `../../packages/${packageJson.name}/src`
+    );
+    return acc;
+}, {});
+
+const findWebpackPlugin = (webpackConfig, pluginName) =>
+    webpackConfig.resolve.plugins.find(
+        ({ constructor }) => constructor && constructor.name === pluginName
+    );
+
+const enableTypescriptImportsFromExternalPaths = (
+    webpackConfig,
+    newIncludePaths
+) => {
+    const oneOfRule = webpackConfig.module.rules.find(rule => rule.oneOf);
+    if (oneOfRule) {
+        const tsxRule = oneOfRule.oneOf.find(
+            rule => rule.test && rule.test.toString().includes('ts')
+        );
+
+        if (tsxRule) {
+            tsxRule.include = Array.isArray(tsxRule.include)
+                ? [...tsxRule.include, ...newIncludePaths]
+                : [tsxRule.include, ...newIncludePaths];
+        }
+    }
+};
+
+const addPathsToModuleScopePlugin = (webpackConfig, paths) => {
+    const moduleScopePlugin = findWebpackPlugin(
+        webpackConfig,
+        'ModuleScopePlugin'
+    );
+    if (!moduleScopePlugin) {
+        throw new Error(
+            `Expected to find plugin "ModuleScopePlugin", but didn't.`
+        );
+    }
+    moduleScopePlugin.appSrcs = [...moduleScopePlugin.appSrcs, ...paths];
+};
+
+const enableImportsFromExternalPaths = (webpackConfig, paths) => {
+    enableTypescriptImportsFromExternalPaths(webpackConfig, paths);
+    addPathsToModuleScopePlugin(webpackConfig, paths);
+};
+
+module.exports = {
+    plugins: [
+        { plugin: CracoEsbuildPlugin },
+        {
+            plugin: {
+                overrideWebpackConfig: ({ webpackConfig }) => {
+                    enableImportsFromExternalPaths(
+                        webpackConfig,
+                        Object.values(aliases)
+                    );
+                    return webpackConfig;
+                },
+            },
+        },
+        {
+            plugin: CracoAlias,
+            options: {
+                source: 'options',
+                baseUrl: './',
+                aliases,
+            },
+        },
+    ],
+};

--- a/examples/crm/package.json
+++ b/examples/crm/package.json
@@ -23,6 +23,7 @@
         "react-scripts": "^5.0.0"
     },
     "devDependencies": {
+        "@craco/craco": "^6.4.3",
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
@@ -33,15 +34,17 @@
         "@types/react": "^17.0.20",
         "@types/react-beautiful-dnd": "^13.0.0",
         "@types/react-dom": "^17.0.9",
+        "craco-alias": "^3.0.1",
+        "craco-esbuild": "^0.5.0",
         "rewire": "^5.0.0",
         "source-map-explorer": "^2.0.0",
         "typescript": "^4.4.0",
         "web-vitals": "^1.0.1"
     },
     "scripts": {
-        "start": "react-scripts start",
+        "start": "craco start",
         "build": "yarn node ./build.js",
-        "test": "react-scripts test",
+        "test": "craco test",
         "eject": "react-scripts eject"
     },
     "homepage": ".",

--- a/examples/demo/craco.config.js
+++ b/examples/demo/craco.config.js
@@ -1,0 +1,85 @@
+const CracoEsbuildPlugin = require('craco-esbuild');
+const CracoAlias = require('craco-alias');
+const fs = require('fs');
+const path = require('path');
+
+const packages = fs.readdirSync(path.resolve(__dirname, '../../packages'));
+const aliases = packages.reduce((acc, dirName) => {
+    const packageJson = require(path.resolve(
+        __dirname,
+        '../../packages',
+        dirName,
+        'package.json'
+    ));
+    acc[packageJson.name] = path.resolve(
+        __dirname,
+        `../../packages/${packageJson.name}/src`
+    );
+    return acc;
+}, {});
+
+const findWebpackPlugin = (webpackConfig, pluginName) =>
+    webpackConfig.resolve.plugins.find(
+        ({ constructor }) => constructor && constructor.name === pluginName
+    );
+
+const enableTypescriptImportsFromExternalPaths = (
+    webpackConfig,
+    newIncludePaths
+) => {
+    const oneOfRule = webpackConfig.module.rules.find(rule => rule.oneOf);
+    if (oneOfRule) {
+        const tsxRule = oneOfRule.oneOf.find(
+            rule => rule.test && rule.test.toString().includes('ts')
+        );
+
+        if (tsxRule) {
+            tsxRule.include = Array.isArray(tsxRule.include)
+                ? [...tsxRule.include, ...newIncludePaths]
+                : [tsxRule.include, ...newIncludePaths];
+        }
+    }
+};
+
+const addPathsToModuleScopePlugin = (webpackConfig, paths) => {
+    const moduleScopePlugin = findWebpackPlugin(
+        webpackConfig,
+        'ModuleScopePlugin'
+    );
+    if (!moduleScopePlugin) {
+        throw new Error(
+            `Expected to find plugin "ModuleScopePlugin", but didn't.`
+        );
+    }
+    moduleScopePlugin.appSrcs = [...moduleScopePlugin.appSrcs, ...paths];
+};
+
+const enableImportsFromExternalPaths = (webpackConfig, paths) => {
+    enableTypescriptImportsFromExternalPaths(webpackConfig, paths);
+    addPathsToModuleScopePlugin(webpackConfig, paths);
+};
+
+module.exports = {
+    plugins: [
+        { plugin: CracoEsbuildPlugin },
+        {
+            plugin: {
+                overrideWebpackConfig: ({ webpackConfig }) => {
+                    enableImportsFromExternalPaths(
+                        webpackConfig,
+                        Object.values(aliases)
+                    );
+                    return webpackConfig;
+                },
+            },
+        },
+        {
+            plugin: CracoAlias,
+            options: {
+                source: 'options',
+                baseUrl: './',
+                aliases,
+            },
+        },
+    ],
+};

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -40,9 +40,9 @@
     },
     "scripts": {
         "analyze": "source-map-explorer 'build/static/js/*.js'",
-        "start": "react-scripts start",
+        "start": "craco start",
         "build": "yarn node ./build.js",
-        "eject": "react-scripts test"
+        "eject": "craco test"
     },
     "homepage": ".",
     "browserslist": [
@@ -52,6 +52,7 @@
         "not op_mini all"
     ],
     "devDependencies": {
+        "@craco/craco": "^6.4.3",
         "@types/classnames": "^2.2.9",
         "@types/fetch-mock": "^7.3.2",
         "@types/jest": "^26.0.19",
@@ -61,6 +62,8 @@
         "@types/react": "^17.0.20",
         "@types/react-dom": "^17.0.9",
         "@types/react-redux": "^7.1.1",
+        "craco-alias": "^3.0.1",
+        "craco-esbuild": "^0.5.0",
         "rewire": "^5.0.0",
         "source-map-explorer": "^2.0.0",
         "typescript": "^4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.12.17":
+  version: 7.16.12
+  resolution: "@babel/core@npm:7.16.12"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.16.8
+    "@babel/helper-compilation-targets": ^7.16.7
+    "@babel/helper-module-transforms": ^7.16.7
+    "@babel/helpers": ^7.16.7
+    "@babel/parser": ^7.16.12
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.16.10
+    "@babel/types": ^7.16.8
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 3e62056eb6e9e20dc785001d720f7958d4e407e5d3ad6203471f85482381c59b5fd9237601be10941aa47394a3bbba2679e7c5850c31225bbae3aa0db45009bf
+  languageName: node
+  linkType: hard
+
 "@babel/eslint-parser@npm:^7.16.3":
   version: 7.16.5
   resolution: "@babel/eslint-parser@npm:7.16.5"
@@ -449,6 +472,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 6b67c437ce785e8a1509eb8d2da0fa2c97cfd3755e308c1ada50f5e01ff506ab4801dfa16cc3e5facee40b61b99295c66e71c4e28514a3547d65b2eec5d4d306
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.16.10, @babel/parser@npm:^7.16.12":
+  version: 7.16.12
+  resolution: "@babel/parser@npm:7.16.12"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: e706d04885c7e816930e7ecbbcd899aac818ffe822541a165bbf6dee22bbe9f0be68ca090f2406aa3d9a6b25222a17e01ea12c30fb3f7c71920296d90a54d90c
   languageName: node
   linkType: hard
 
@@ -1136,7 +1168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.16.8":
+"@babel/plugin-transform-modules-commonjs@npm:^7.12.13, @babel/plugin-transform-modules-commonjs@npm:^7.16.8":
   version: 7.16.8
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.16.8"
   dependencies:
@@ -1649,6 +1681,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.16.10":
+  version: 7.16.10
+  resolution: "@babel/traverse@npm:7.16.10"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.16.8
+    "@babel/helper-environment-visitor": ^7.16.7
+    "@babel/helper-function-name": ^7.16.7
+    "@babel/helper-hoist-variables": ^7.16.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/parser": ^7.16.10
+    "@babel/types": ^7.16.8
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: f0c1bac0f037f72a64628f768d1343326bc27facec2fa22b2c855400481faac3e6f4bbefc878c995e60885f6ca4580af56ab15ef147a3ba9d17c871e9804b019
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.6, @babel/types@npm:^7.12.7, @babel/types@npm:^7.16.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.16.8
   resolution: "@babel/types@npm:7.16.8"
@@ -1675,6 +1725,40 @@ __metadata:
   bin:
     watch: cli.js
   checksum: 8678b6f582bdc5ffe59c0d45c2ad21f4ea1d162ec7ddb32e85078fca481c26958f27bcdef6007b8e9a066da090ccf9d31e1753f8de1e5f32466a04227d70dc31
+  languageName: node
+  linkType: hard
+
+"@craco/craco@npm:^6.4.3":
+  version: 6.4.3
+  resolution: "@craco/craco@npm:6.4.3"
+  dependencies:
+    cosmiconfig: ^7.0.1
+    cosmiconfig-typescript-loader: ^1.0.0
+    cross-spawn: ^7.0.0
+    lodash: ^4.17.15
+    semver: ^7.3.2
+    webpack-merge: ^4.2.2
+  peerDependencies:
+    react-scripts: ^4.0.0
+  bin:
+    craco: bin/craco.js
+  checksum: 599731c54edb82dbc758aee1f63d2050fa6f3a9aaac5e5cc21d78e207cc6225e428183152d162f6b71a23d775f57f2c532850bfe3d88a0dae37ad0286474f2b8
+  languageName: node
+  linkType: hard
+
+"@cspotcode/source-map-consumer@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@cspotcode/source-map-consumer@npm:0.8.0"
+  checksum: 44428e50f896df065c3a22d6bddeac344f3e31af57cbc2ddf753a95addcabbe685d92e534f4dcde0cabbbcfbc122d1cb957785b36344d54c422b781a8d1a2a01
+  languageName: node
+  linkType: hard
+
+"@cspotcode/source-map-support@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@cspotcode/source-map-support@npm:0.7.0"
+  dependencies:
+    "@cspotcode/source-map-consumer": 0.8.0
+  checksum: be290e5b9f49c1fa83997f80e02c29d5bece279fad08d8b7ee862c68aaf74be613cfcf396d19701273a5d47436f08905b36fdd286bef704767b493394a8ade39
   languageName: node
   linkType: hard
 
@@ -5683,6 +5767,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.8
+  resolution: "@tsconfig/node10@npm:1.0.8"
+  checksum: d400f7b5c02acd74620f892c0f41cea39e7c1b5f7f272ad6f127f4b1fba23346b2d8e30d272731a733675494145f6aa74f9faf050390c034c7c553123ab979b3
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node12@npm:1.0.9"
+  checksum: fc1fb68a89d8a641953036d23d95fe68f69f74d37a499db20791b09543ad23afe7ae9ee0840eea92dd470bdcba69eef6f1ed3fe90ba64d763bcd3f738e364597
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@tsconfig/node14@npm:1.0.1"
+  checksum: abd4e27d9ad712e1e229716a3dbf35d5cbb580d624a82d67414e7606cefd85d502e58800a2ab930d46a428fcfcb199436283b1a88e47d738ca1a5f7fd022ee74
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@tsconfig/node16@npm:1.0.2"
+  checksum: d402706562444a173d48810d13fdf866c78f1b876ed8962eeac6c7cddf4e29e8aaa06dc28093219e3e9eb6316799cf4d9a7acba62c6a4e215ee0c94d83f9081f
+  languageName: node
+  linkType: hard
+
 "@types/aria-query@npm:^4.2.0":
   version: 4.2.2
   resolution: "@types/aria-query@npm:4.2.2"
@@ -7211,6 +7323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: dbe92f5b2452c93e960c5594e666dd1fae141b965ff2cb4a1e1d0381e3e4db4274c5ce4ffa3d681a86ca2a8d4e29d5efc0670a08e23fd2800051ea387df56ca2
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^5.0.0":
   version: 5.7.4
   resolution: "acorn@npm:5.7.4"
@@ -7645,6 +7764,13 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^2.0.6
   checksum: 03cb45f2892767773c86a616205fc67feb8dfdd56685d1b34999cfa6c0d2aebe73ec0e6ba88a406422b998dea24138337fdb9a3f9b172d7c2a7f75d02f3df088
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
   languageName: node
   linkType: hard
 
@@ -11281,6 +11407,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig-typescript-loader@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "cosmiconfig-typescript-loader@npm:1.0.4"
+  dependencies:
+    cosmiconfig: ^7
+    ts-node: ^10.4.0
+  peerDependencies:
+    "@types/node": "*"
+    cosmiconfig: ">=7"
+    typescript: ">=3"
+  checksum: 7cf673ddcebdb5a54ea70a69550209993849c2b043c0dce65b56c6a95c7d234866b132577cde2237cbe9180034916c41be0e635410527c085c10f02297d4d864
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:^5.2.0":
   version: 5.2.1
   resolution: "cosmiconfig@npm:5.2.1"
@@ -11306,7 +11446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.0.1":
+"cosmiconfig@npm:^7, cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.0.1":
   version: 7.0.1
   resolution: "cosmiconfig@npm:7.0.1"
   dependencies:
@@ -11345,6 +11485,26 @@ __metadata:
     p-filter: ^2.1.0
     p-map: ^3.0.0
   checksum: 84611fdd526a0582ae501a0fa1e1d55e16348c69110eb17be5fc0c087b7b2aa6caec014286b669e4f123750d01e0c4db77d32fdcdb9840c3df4d161a137a345a
+  languageName: node
+  linkType: hard
+
+"craco-alias@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "craco-alias@npm:3.0.1"
+  checksum: 238aa77d41d43b44d6ffe4bc0bcd4b5731add47753698a59f7d8572056d07d648a4fc40890333ddaad6d551a62b768494280db07510743bdd7c80e087fea3e8b
+  languageName: node
+  linkType: hard
+
+"craco-esbuild@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "craco-esbuild@npm:0.5.0"
+  dependencies:
+    esbuild-jest: 0.5.0
+    esbuild-loader: ^2.18.0
+  peerDependencies:
+    "@craco/craco": ^6.0.0
+    react-scripts: ^5.0.0
+  checksum: 41c41ba6916e10b46ca7ceca0db6f41cd78ab86037330bd11bc54ecc8571d12f5fb245a192764e28fe9573e5458271f6023f3799973d1b4d7ee45d6fdd732c9e
   languageName: node
   linkType: hard
 
@@ -11391,6 +11551,13 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: 24332bab51011652a9a0a6d160eed1e8caa091b802335324ae056b0dcb5acbc9fcf173cf10d128eba8548c3ce98dfa4eadaa01bd02f44a34414baee26b651835
+  languageName: node
+  linkType: hard
+
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: 157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
   languageName: node
   linkType: hard
 
@@ -12391,6 +12558,7 @@ __metadata:
   resolution: "demo@workspace:examples/demo"
   dependencies:
     "@apollo/client": ^3.3.19
+    "@craco/craco": ^6.4.3
     "@mui/icons-material": ^5.0.1
     "@mui/material": ^5.0.2
     "@types/classnames": ^2.2.9
@@ -12405,6 +12573,8 @@ __metadata:
     "@types/react-redux": ^7.1.1
     "@types/recharts": ^1.8.10
     classnames: ~2.2.5
+    craco-alias: ^3.0.1
+    craco-esbuild: ^0.5.0
     data-generator-retail: ^4.0.0-alpha.2
     date-fns: ^1.29.0
     fakerest: ^3.0.0
@@ -13362,6 +13532,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-android-arm64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-android-arm64@npm:0.14.14"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "esbuild-darwin-64@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-darwin-64@npm:0.13.15"
@@ -13372,6 +13549,13 @@ __metadata:
 "esbuild-darwin-64@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-darwin-64@npm:0.14.11"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-darwin-64@npm:0.14.14"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -13390,6 +13574,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-darwin-arm64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-darwin-arm64@npm:0.14.14"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "esbuild-freebsd-64@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-freebsd-64@npm:0.13.15"
@@ -13400,6 +13591,13 @@ __metadata:
 "esbuild-freebsd-64@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-freebsd-64@npm:0.14.11"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-freebsd-64@npm:0.14.14"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -13418,6 +13616,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-freebsd-arm64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-freebsd-arm64@npm:0.14.14"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-jest@npm:0.5.0":
+  version: 0.5.0
+  resolution: "esbuild-jest@npm:0.5.0"
+  dependencies:
+    "@babel/core": ^7.12.17
+    "@babel/plugin-transform-modules-commonjs": ^7.12.13
+    babel-jest: ^26.6.3
+  peerDependencies:
+    esbuild: ">=0.8.50"
+  checksum: 32921608498bf23928c4ca4db3b41775cf6d2ef9c1a5a1fa166bacfb3c3c83792e1192d50d8022cbef744241b6fa2fc2d9c34d36eaed988e8d52bde46761c37e
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-32@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-linux-32@npm:0.13.15"
@@ -13428,6 +13646,13 @@ __metadata:
 "esbuild-linux-32@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-linux-32@npm:0.14.11"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-32@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-32@npm:0.14.14"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -13446,6 +13671,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-64@npm:0.14.14"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-arm64@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-linux-arm64@npm:0.13.15"
@@ -13456,6 +13688,13 @@ __metadata:
 "esbuild-linux-arm64@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-linux-arm64@npm:0.14.11"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-arm64@npm:0.14.14"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -13474,6 +13713,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-arm@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-arm@npm:0.14.14"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-mips64le@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-linux-mips64le@npm:0.13.15"
@@ -13484,6 +13730,13 @@ __metadata:
 "esbuild-linux-mips64le@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-linux-mips64le@npm:0.14.11"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-mips64le@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-mips64le@npm:0.14.14"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -13502,10 +13755,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-ppc64le@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-ppc64le@npm:0.14.14"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-s390x@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-linux-s390x@npm:0.14.11"
   conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-s390x@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-linux-s390x@npm:0.14.14"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"esbuild-loader@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "esbuild-loader@npm:2.18.0"
+  dependencies:
+    esbuild: ^0.14.6
+    joycon: ^3.0.1
+    json5: ^2.2.0
+    loader-utils: ^2.0.0
+    tapable: ^2.2.0
+    webpack-sources: ^2.2.0
+  peerDependencies:
+    webpack: ^4.40.0 || ^5.0.0
+  checksum: 885eb4e692da66e4d7a6814abace0d10eee4d62b7c7cacfedd1c995f43b0ec7f2bef9eb80ca624f720aca20e80b1540f3994efc319a1b59fb7acf7c6d801d63f
   languageName: node
   linkType: hard
 
@@ -13519,6 +13802,13 @@ __metadata:
 "esbuild-netbsd-64@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-netbsd-64@npm:0.14.11"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-netbsd-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-netbsd-64@npm:0.14.14"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -13537,6 +13827,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-openbsd-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-openbsd-64@npm:0.14.14"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-sunos-64@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-sunos-64@npm:0.13.15"
@@ -13547,6 +13844,13 @@ __metadata:
 "esbuild-sunos-64@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-sunos-64@npm:0.14.11"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-sunos-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-sunos-64@npm:0.14.14"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -13565,6 +13869,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-windows-32@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-windows-32@npm:0.14.14"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "esbuild-windows-64@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-windows-64@npm:0.13.15"
@@ -13579,6 +13890,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-windows-64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-windows-64@npm:0.14.14"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-windows-arm64@npm:0.13.15":
   version: 0.13.15
   resolution: "esbuild-windows-arm64@npm:0.13.15"
@@ -13589,6 +13907,13 @@ __metadata:
 "esbuild-windows-arm64@npm:0.14.11":
   version: 0.14.11
   resolution: "esbuild-windows-arm64@npm:0.14.11"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-arm64@npm:0.14.14":
+  version: 0.14.14
+  resolution: "esbuild-windows-arm64@npm:0.14.14"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -13717,6 +14042,71 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 3cb7bd8a65bb6d78f46fd93204318fe667d9f1f8fd6e44dfb61da7f385c8906bf70a085d66a49b8ce5498ef564a8fb109efd6ca09b00dca1f90ab119b145dfcf
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.14.6":
+  version: 0.14.14
+  resolution: "esbuild@npm:0.14.14"
+  dependencies:
+    esbuild-android-arm64: 0.14.14
+    esbuild-darwin-64: 0.14.14
+    esbuild-darwin-arm64: 0.14.14
+    esbuild-freebsd-64: 0.14.14
+    esbuild-freebsd-arm64: 0.14.14
+    esbuild-linux-32: 0.14.14
+    esbuild-linux-64: 0.14.14
+    esbuild-linux-arm: 0.14.14
+    esbuild-linux-arm64: 0.14.14
+    esbuild-linux-mips64le: 0.14.14
+    esbuild-linux-ppc64le: 0.14.14
+    esbuild-linux-s390x: 0.14.14
+    esbuild-netbsd-64: 0.14.14
+    esbuild-openbsd-64: 0.14.14
+    esbuild-sunos-64: 0.14.14
+    esbuild-windows-32: 0.14.14
+    esbuild-windows-64: 0.14.14
+    esbuild-windows-arm64: 0.14.14
+  dependenciesMeta:
+    esbuild-android-arm64:
+      optional: true
+    esbuild-darwin-64:
+      optional: true
+    esbuild-darwin-arm64:
+      optional: true
+    esbuild-freebsd-64:
+      optional: true
+    esbuild-freebsd-arm64:
+      optional: true
+    esbuild-linux-32:
+      optional: true
+    esbuild-linux-64:
+      optional: true
+    esbuild-linux-arm:
+      optional: true
+    esbuild-linux-arm64:
+      optional: true
+    esbuild-linux-mips64le:
+      optional: true
+    esbuild-linux-ppc64le:
+      optional: true
+    esbuild-linux-s390x:
+      optional: true
+    esbuild-netbsd-64:
+      optional: true
+    esbuild-openbsd-64:
+      optional: true
+    esbuild-sunos-64:
+      optional: true
+    esbuild-windows-32:
+      optional: true
+    esbuild-windows-64:
+      optional: true
+    esbuild-windows-arm64:
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 379dda9c29559b1542da9bc98cacf331cff9a8cbcf1a7e9c322715ede618837d390931040650b5feeab6fa129701eec9702bb5b803de88c1827c4811c6c061ce
   languageName: node
   linkType: hard
 
@@ -20702,7 +21092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:1.x":
+"make-error@npm:1.x, make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: 171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
@@ -25371,6 +25761,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-admin-crm@workspace:examples/crm"
   dependencies:
+    "@craco/craco": ^6.4.3
     "@mui/icons-material": ^5.0.1
     "@mui/material": ^5.0.2
     "@nivo/bar": ^0.67.0
@@ -25386,6 +25777,8 @@ __metadata:
     "@types/react-beautiful-dnd": ^13.0.0
     "@types/react-dom": ^17.0.9
     clsx: ^1.1.1
+    craco-alias: ^3.0.1
+    craco-esbuild: ^0.5.0
     date-fns: ^2.19.0
     faker: ~5.4.0
     lodash: ~4.17.5
@@ -29772,6 +30165,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.4.0":
+  version: 10.4.0
+  resolution: "ts-node@npm:10.4.0"
+  dependencies:
+    "@cspotcode/source-map-support": 0.7.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 380f84e561f379545a6648c7da0c8510a53e78a554b437e40bd180d5d1f305f32d8b9b327e9eb1177f60d61893940430bb3fa74d62e0a6f6e1a839366e2cda5c
+  languageName: node
+  linkType: hard
+
 "ts-pnp@npm:^1.1.6":
   version: 1.2.0
   resolution: "ts-pnp@npm:1.2.0"
@@ -31122,6 +31551,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-merge@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "webpack-merge@npm:4.2.2"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: 283cb4ffe4d4ae6de23d595154868780126835ded241748da0b070c6cca6974c229493ac0b6b7160c2c92950c950c8e5edf036a192da78e32e22a9c81593ad16
+  languageName: node
+  linkType: hard
+
 "webpack-sources@npm:^1.0.1, webpack-sources@npm:^1.1.0, webpack-sources@npm:^1.4.0, webpack-sources@npm:^1.4.1, webpack-sources@npm:^1.4.3":
   version: 1.4.3
   resolution: "webpack-sources@npm:1.4.3"
@@ -32194,6 +32632,13 @@ __metadata:
     yeoman-environment:
       optional: true
   checksum: b4292ffc0e520e6a1f8c999605a679144d69d857de1bf2a0e4e54bcb1fa79edef8ebd6451bb6c944d9caef898aa81798e9ad555022408bf4750e6e4e82424006
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Working on the e-commerce and crm demos is a pain because of the default CRA config:
- You have to build the ra packages at least once before running the demos
- You have to rebuild the ra packages whenever they change
- You have to restart the demo to actually see the changes
- The e-commerce demo takes forever to start and load

## Solution

For development **only**, leverage esbuild and aliases using craco

## Benchmarks on Dell XPS 13

### Webpack:
- need to build ra packages at least once and rebuild them each time they change: 1m21
- first run of the demo: 1m until usable
- subsequent runs of the demo: 15s

### Craco with Esbuild and aliases (dev only):
- no need to build/rebuild the packages ever
- first run of the demo: 30s until usable
- subsequent runs of the demo: 10s

## Limitations

While we don't have to build ra packages anymore while working on the demos, I haven't been able to make fast refresh handle the ra packages changes so you still have to refresh the page manually. We didn't have this feature with the default CRA either though so we still get some great benefits.