### PR TITLE
Fix AutocompleteInput erases input while typing

### DIFF
--- a/packages/ra-core/src/form/useChoices.ts
+++ b/packages/ra-core/src/form/useChoices.ts
@@ -67,7 +67,7 @@ const useChoices = ({
 
             return translateChoice
                 ? translate(choiceName, { _: choiceName })
-                : choiceName;
+                : String(choiceName);
         },
         [optionText, translate, translateChoice]
     );

--- a/packages/ra-core/src/form/useSuggestions.ts
+++ b/packages/ra-core/src/form/useSuggestions.ts
@@ -1,4 +1,4 @@
-import { useCallback, isValidElement } from 'react';
+import { useCallback, isValidElement, ReactElement } from 'react';
 import set from 'lodash/set';
 import useChoices, { OptionText, UseChoicesOptions } from './useChoices';
 import { useTranslate } from '../i18n';
@@ -138,7 +138,7 @@ const defaultMatchSuggestion = getChoiceText => (
         : suggestionText &&
               suggestionText.match(
                   // We must escape any RegExp reserved characters to avoid errors
-                  // For example, the filter might contains * which must be escaped as \*
+                  // For example, the filter might contain * which must be escaped as \*
                   new RegExp(exact ? `^${regex}$` : regex, 'i')
               );
 };
@@ -183,7 +183,7 @@ export const getSuggestionsFactory = ({
     selectedItem,
     suggestionLimit = 0,
 }: UseSuggestionsOptions & {
-    getChoiceText: (choice: any) => string;
+    getChoiceText: (choice: any) => string | ReactElement;
     getChoiceValue: (choice: any) => string;
 }) => filter => {
     let suggestions = [];

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -185,8 +185,8 @@ export const AutocompleteInput = (props: AutocompleteInputProps) => {
     );
 
     const classes = useStyles(props);
-    let inputEl = useRef<HTMLInputElement>();
-    let anchorEl = useRef<any>();
+    const inputEl = useRef<HTMLInputElement>();
+    const anchorEl = useRef<any>();
     const translate = useTranslate();
 
     const {
@@ -320,7 +320,9 @@ export const AutocompleteInput = (props: AutocompleteInputProps) => {
                 selectedItem === null
                 ? ''
                 : inputText
-                ? inputText(getChoiceText(selectedItem).props.record)
+                ? /* @ts-ignore */ inputText(
+                      getChoiceText(selectedItem).props.record
+                  )
                 : getChoiceText(selectedItem)
         );
     }, [
@@ -377,7 +379,9 @@ export const AutocompleteInput = (props: AutocompleteInputProps) => {
             setFilterValue(
                 input.value
                     ? inputText
-                        ? inputText(getChoiceText(selectedItem).props.record)
+                        ? /* @ts-ignore */ inputText(
+                              getChoiceText(selectedItem).props.record
+                          )
                         : getChoiceText(selectedItem)
                     : ''
             );


### PR DESCRIPTION
Having a `AutocompleteInput` with an `optionText` being set to a field that is not of type `string` throws an internal error

```jsx
<ReferenceInput
    label={'Product'}
    source={'category_id'}
    reference={'products'}
>

{ /* record:
{ 
    id: 7, // =>  type is number
    name: 'Washed jacket', 
    category_id: 5
}
 */ }
    <AutocompleteInput optionText="id" /> /* While typeing, the input gets cleared */
</ReferenceInput>
```

This attempts to fix `optionText` of type `string` when the data type is not a `string` but it doesn't when `optionText` is of type `Function`.

May be related to #6214