### PR TITLE
Fix resolveBrowserLocale tests

### DIFF
--- a/packages/ra-core/src/i18n/TranslationUtils.spec.ts
+++ b/packages/ra-core/src/i18n/TranslationUtils.spec.ts
@@ -7,20 +7,22 @@ import {
 
 describe('TranslationUtils', () => {
     describe('resolveBrowserLocale', () => {
+        let languageGetter;
         beforeEach(() => {
+            //https://stackoverflow.com/questions/52868727/how-to-mock-window-navigator-language-using-jest
             // @ts-ignore
-            global.window = {};
+            languageGetter = jest.spyOn(window.navigator, 'language', 'get');
+            languageGetter.mockReturnValue('en-US');
         });
 
         it("should return default locale if there's no available locale in browser", () => {
             // @ts-ignore
-            window.navigator = {};
+            languageGetter.mockReturnValue(undefined);
             expect(resolveBrowserLocale()).toEqual(DEFAULT_LOCALE);
         });
 
         it('should splice browser language to take first two locale letters', () => {
             // @ts-ignore
-            window.navigator = { language: 'en-US' };
             expect(resolveBrowserLocale()).toEqual('en');
         });
     });


### PR DESCRIPTION
Noticed a bug at `resolveBrowserLocale` tests during #7170 investigation to implement a new feature (#7193).

**Problem**:
As `navigator.language` is a **read-only property** (see [MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) about it), it wasn't being affected by the `window.navigator = {}`. You can see that at `should return default locale if there's no available locale in browser` test, it is an invalid test.

![Captura de tela em 2022-02-05 18-09-45](https://user-images.githubusercontent.com/29988718/152659145-c9f5e1f2-8acc-468c-ba3c-025120345d1e.png)

**Solution**:
Implement correctly using `jest.spyOn` function, see this answer: https://stackoverflow.com/a/52870312
![Captura de tela em 2022-02-05 17-35-07](https://user-images.githubusercontent.com/29988718/152659149-6e52cd27-6f89-46e6-a6aa-2576030a8072.png)

Should this fix enter before #7193 @WiXSL ?
