### PR TITLE
Avoid cloning elements in AppBar

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1462,9 +1462,10 @@ When a React element was provided as the `userMenu` prop, the `<AppBar>` used to
 -import { UserMenu } from 'react-admin';
 +import { Logout, UserMenu } from 'react-admin';
 
-export const MyUserMenu = (props) => (
+-export const MyUserMenu = (props) => (
++export const MyUserMenu = () => (
 -    <UserMenu {...props}>
-+    <UserMenu {...props} logout={<Logout />}>
++    <UserMenu logout={<Logout />}>
         <MenuItemLink
             to="/configuration"
             primaryText="pos.configuration"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1460,7 +1460,7 @@ As we already provide a way to override the user menu displayed in the `<AppBar>
 
 If you passed your own logout component through this prop, you must now provide a custom user menu:
 
-```
+```diff
 -import { Admin, Logout } from 'react-admin';
 +import { Admin, AppBar, Layout, Logout, UserMenu } from 'react-admin';
 
@@ -1492,7 +1492,7 @@ Finally, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should
 
 ```diff
 -import { MenuItemLink, UserMenu } from 'react-admin';
-+import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
++import { Logout, UserMenu, useUserMenu } from 'react-admin';
 import { Link } from 'react-router-dom';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1454,29 +1454,41 @@ export const PostEdit = () => (
 
 Use the `<Title>` component instead.
 
-## No More Props Injection In `<AppBar>`
+## `<AppBar>` and `<UserMenu>` No Longer Inject Props
 
 When a React element was provided as the `userMenu` prop, the `<AppBar>` used to clone it and inject the `logout` prop (a React element). This is no longer the case and if you provided a custom user menu, you now have to include the logout yourself.
 
-Besides, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should pass the `<Logout>` component as one of the `<UserMenu>` children.
+Besides, the `<UserMenu>` used to clone its children to inject the `onClick` prop, allowing them to close the menu. It now provides a `onClose` function through a new `UserContext` accessible by calling the `useUserMenu` hook.
+
+Finally, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should pass the `<Logout>` component as one of the `<UserMenu>` children.
 
 ```diff
--import { UserMenu } from 'react-admin';
-+import { Logout, UserMenu } from 'react-admin';
+-import { MenuItemLink, UserMenu } from 'react-admin';
++import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
 
--export const MyUserMenu = (props) => (
-+export const MyUserMenu = () => (
--    <UserMenu {...props}>
-+    <UserMenu>
+-const ConfigurationMenu = (props) => {
++const ConfigurationMenu = () => {
++    const { onClose } = useUserMenu();
+    return (
         <MenuItemLink
             to="/configuration"
             primaryText="pos.configuration"
             leftIcon={<SettingsIcon />}
             sidebarIsOpen
+-            onClick={props.onClick}
++            onClick={onClose}
         />
+    );
+};
+
+-const CustomUserMenu = (props) => (
++const CustomUserMenu = () => (
+-    <UserMenu {...props}>
++    <UserMenu>
+        <ConfigurationMenu />
 +        <Logout />
     </UserMenu>
-)
+);
 ```
 
 ## `<MenuItemLink>` Automatically Translates `primaryText`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1454,9 +1454,9 @@ export const PostEdit = () => (
 
 Use the `<Title>` component instead.
 
-## `<Admin>`, `<Layout>`, `<AppBar>` And `<UserMenu>` No Longer Accept A `logout` Prop
+## `<Admin>`, `<Layout>`, `<AppBar>` And `<UserMenu>` No Longer Accept A `logout` Or `logoutButton` Prop
 
-As we already provide a way to override the user menu displayed in the `<AppBar>`, we removed the `logout` prop from the `<Admin>`, `<Layout>`, `<AppBar>` and `<UserMenu>` components.
+As we already provide a way to override the user menu displayed in the `<AppBar>`, we removed the `logoutButton` prop from the `<Admin>` component and the `logout` prop from the `<Layout>`, `<AppBar>` and `<UserMenu>` components.
 
 If you passed your own logout component through this prop, you must now provide a custom user menu:
 
@@ -1474,7 +1474,7 @@ const MyCustomLogout = () => <Logout className="my-class-name" />;
 
 const MyAdmin = () => (
     <Admin
--        logout={<MyCustomLogout />}
+-        logoutButton={<MyCustomLogout />}
 +        layout={<MyLayout />}
     >
         // ....

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1488,7 +1488,7 @@ When a React element was provided as the `userMenu` prop, the `<AppBar>` used to
 
 Besides, the `<UserMenu>` used to clone its children to inject the `onClick` prop, allowing them to close the menu. It now provides a `onClose` function through a new `UserContext` accessible by calling the `useUserMenu` hook.
 
-Finally, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should pass the `<Logout>` component as one of the `<UserMenu>` children.
+Finally, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should pass the `<Logout>` component as one of the `<UserMenu>` children. Besides, you should not use an `<MenuItemLink>` in `<UserMenu>` as they also close the `<SideBar>` on mobile:
 
 ```diff
 -import { MenuItemLink, UserMenu } from 'react-admin';
@@ -1504,6 +1504,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 +const ConfigurationMenu = forwardRef((props, ref) => {
 +    const { onClose } = useUserMenu();
     return (
+-        <MenuItemLink
         <MenuItem
             // It's important to pass the props to allow MaterialUI to manage the keyboard navigation
             {...props}
@@ -1518,6 +1519,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
             <ListItemText>
                 Configuration
             </ListItemText>
+-        </MenuItemLink>
         </MenuItem>
     );
 });

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1454,6 +1454,34 @@ export const PostEdit = () => (
 
 Use the `<Title>` component instead.
 
+## `<Admin>`, `<Layout>`, `<AppBar>` And `<UserMenu>` No Longer Accept A `logout` Prop
+
+As we already provide a way to override the user menu displayed in the `<AppBar>`, we removed the `logout` prop from the `<Admin>`, `<Layout>`, `<AppBar>` and `<UserMenu>` components.
+
+If you passed your own logout component through this prop, you must now provide a custom user menu:
+
+```
+-import { Admin, Logout } from 'react-admin';
++import { Admin, AppBar, Layout, Logout, UserMenu } from 'react-admin';
+
+const MyCustomLogout = () => <Logout className="my-class-name" />;
+
++ const MyUserMenu = () => <UserMenu><MyCustomLogout /></UserMenu>;
+
++ const MyAppBar = () => <AppBar userMenu={<MyUserMenu />} />;
+
++ const MyLayout = () => <Layout appBar={MyAppBar} />;
+
+const MyAdmin = () => (
+    <Admin
+-        logout={<MyCustomLogout />}
++        layout={<MyLayout />}
+    >
+        // ....
+    </Admin>
+)
+```
+
 ## `<AppBar>` and `<UserMenu>` No Longer Inject Props
 
 When a React element was provided as the `userMenu` prop, the `<AppBar>` used to clone it and inject the `logout` prop (a React element). This is no longer the case and if you provided a custom user menu, you now have to include the logout yourself.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1454,6 +1454,49 @@ export const PostEdit = () => (
 
 Use the `<Title>` component instead.
 
+## No More Props Injection In `<AppBar>`
+
+When a React element was provided as the `userMenu` prop, the `<AppBar>` used to clone it and inject the `logout` prop (a React element). This is no longer the case and if you provided a custom user menu, you now have to include the logout yourself.
+
+```diff
+-import { UserMenu } from 'react-admin';
++import { Logout, UserMenu } from 'react-admin';
+
+-export const MyUserMenu = (props) => (
++export const MyUserMenu = () => (
+-    <UserMenu {...props}>
++    <UserMenu {...props} logout={<Logout />}>
+        <MenuItemLink
+            to="/configuration"
+            primaryText="pos.configuration"
+            leftIcon={<SettingsIcon />}
+            sidebarIsOpen
+        />
+    </UserMenu>
+)
+```
+
+## `<MenuItemLink>` Automatically Translate `primaryText`
+
+You can pass a translation key directly as the `primaryText` prop for `<MenuItemLink>`.
+
+```diff
+const CustomUserMenu = (props: any) => {
+-    const translate = useTranslate();
+    return (
+        <UserMenu {...props}>
+            <MenuItemLink
+                to="/configuration"
+-                primaryText={translate('pos.configuration')}
++                primaryText="pos.configuration"
+                leftIcon={<SettingsIcon />}
+                sidebarIsOpen
+            />
+        </UserMenu>
+    )
+);
+```
+
 ## `useListContext` No Longer Returns An `ids` Prop
 
 The `ListContext` used to return two props for the list data: `data` and `ids`. To render the list data, you had to iterate over the `ids`. 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1465,21 +1465,34 @@ Finally, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should
 ```diff
 -import { MenuItemLink, UserMenu } from 'react-admin';
 +import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
+import { Link } from 'react-router-dom';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import SettingsIcon from '@mui/icons-material/Settings';
 
 -const ConfigurationMenu = (props) => {
-+const ConfigurationMenu = () => {
+// It's important to pass the ref to allow MaterialUI to manage the keyboard navigation
++const ConfigurationMenu = forwardRef((props, ref) => {
 +    const { onClose } = useUserMenu();
     return (
-        <MenuItemLink
+        <MenuItem
+            // It's important to pass the props to allow MaterialUI to manage the keyboard navigation
+            {...props}
+            component={Link}
             to="/configuration"
-            primaryText="pos.configuration"
-            leftIcon={<SettingsIcon />}
-            sidebarIsOpen
 -            onClick={props.onClick}
 +            onClick={onClose}
-        />
+        >
+            <ListItemIcon>
+                <SettingsIcon />
+            </ListItemIcon>
+            <ListItemText>
+                Configuration
+            </ListItemText>
+        </MenuItem>
     );
-};
+});
 
 -const CustomUserMenu = (props) => (
 +const CustomUserMenu = () => (
@@ -1496,20 +1509,19 @@ Finally, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should
 You can pass a translation key directly as the `primaryText` prop for `<MenuItemLink>`.
 
 ```diff
-const CustomUserMenu = (props: any) => {
+const MyMenuItem = forwardRef((props, ref) => {
 -    const translate = useTranslate();
     return (
-        <UserMenu {...props}>
-            <MenuItemLink
-                to="/configuration"
--                primaryText={translate('pos.configuration')}
-+                primaryText="pos.configuration"
-                leftIcon={<SettingsIcon />}
-                sidebarIsOpen
-            />
-        </UserMenu>
+        <MenuItemLink
+            ref={ref}
+            {...props}
+            to="/configuration"
+-            primaryText={translate('pos.configuration')}
++            primaryText="pos.configuration"
+            leftIcon={<SettingsIcon />}
+        />
     )
-);
+});
 ```
 
 ## `useListContext` No Longer Returns An `ids` Prop

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1458,6 +1458,8 @@ Use the `<Title>` component instead.
 
 When a React element was provided as the `userMenu` prop, the `<AppBar>` used to clone it and inject the `logout` prop (a React element). This is no longer the case and if you provided a custom user menu, you now have to include the logout yourself.
 
+Besides, the `<UserMenu>` no longer accepts a `logout` prop. Instead, you should pass the `<Logout>` component as one of the `<UserMenu>` children.
+
 ```diff
 -import { UserMenu } from 'react-admin';
 +import { Logout, UserMenu } from 'react-admin';
@@ -1465,13 +1467,14 @@ When a React element was provided as the `userMenu` prop, the `<AppBar>` used to
 -export const MyUserMenu = (props) => (
 +export const MyUserMenu = () => (
 -    <UserMenu {...props}>
-+    <UserMenu logout={<Logout />}>
++    <UserMenu>
         <MenuItemLink
             to="/configuration"
             primaryText="pos.configuration"
             leftIcon={<SettingsIcon />}
             sidebarIsOpen
         />
++        <Logout />
     </UserMenu>
 )
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1462,8 +1462,7 @@ When a React element was provided as the `userMenu` prop, the `<AppBar>` used to
 -import { UserMenu } from 'react-admin';
 +import { Logout, UserMenu } from 'react-admin';
 
--export const MyUserMenu = (props) => (
-+export const MyUserMenu = () => (
+export const MyUserMenu = (props) => (
 -    <UserMenu {...props}>
 +    <UserMenu {...props} logout={<Logout />}>
         <MenuItemLink
@@ -1476,7 +1475,7 @@ When a React element was provided as the `userMenu` prop, the `<AppBar>` used to
 )
 ```
 
-## `<MenuItemLink>` Automatically Translate `primaryText`
+## `<MenuItemLink>` Automatically Translates `primaryText`
 
 You can pass a translation key directly as the `primaryText` prop for `<MenuItemLink>`.
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -220,7 +220,7 @@ import { useMediaQuery } from '@material-ui/core';
 import { MenuItemLink, useResourceDefinitions, useSidebarState } from 'react-admin';
 import LabelIcon from '@mui/icons-material/Label';
 
-const Menu = ({ onMenuClick, logout }) => {
+const Menu = ({ onMenuClick }) => {
     const isXSmall = useMediaQuery(theme => theme.breakpoints.down('xs'));
     const [open] = useSidebarState();
     const resources = useResourceDefinitions();
@@ -244,7 +244,6 @@ const Menu = ({ onMenuClick, logout }) => {
                 onClick={onMenuClick}
                 sidebarIsOpen={open}
             />
-            {isXSmall && logout}
         </div>
     );
 }
@@ -253,8 +252,6 @@ export default Menu;
 ```
 
 **Tip**: Note the `MenuItemLink` component. It must be used to avoid unwanted side effects in mobile views. It supports a custom text and icon (which must be a material-ui `<SvgIcon>`).
-
-**Tip**: Note that we include the `logout` item only on small devices. Indeed, the `logout` button is already displayed in the AppBar on larger devices.
 
 Then, pass it to the `<Admin>` component as the `menu` prop:
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -38,7 +38,6 @@ Here are all the props accepted by the component:
 - [`theme`](#theme)
 - [`layout`](#layout)
 - [`loginPage`](#loginpage)
-- [`logoutButton`](#logoutbutton)
 - [`history`](#history)
 - [`basename`](#basename)
 - [`ready`](#ready)
@@ -346,24 +345,9 @@ const App = () => (
 
 You can also disable it completely along with the `/login` route by passing `false` to this prop.
 
-See The [Authentication documentation](./Authentication.md#customizing-the-login-and-logout-components) for more details.
+See The [Authentication documentation](./Authentication.md#customizing-the-login-component) for more details.
 
-**Tip**: Before considering writing your own login page component, please take a look at how to change the default [background image](./Theming.md#using-a-custom-login-page) or the [Material UI theme](#theme). See the [Authentication documentation](./Authentication.md#customizing-the-login-and-logout-components) for more details.
-
-## `logoutButton`
-
-If you customize the `loginPage`, you probably need to override the `logoutButton`, too - because they share the authentication strategy.
-
-```jsx
-import MyLoginPage from './MyLoginPage';
-import MyLogoutButton from './MyLogoutButton';
-
-const App = () => (
-    <Admin loginPage={MyLoginPage} logoutButton={MyLogoutButton}>
-        ...
-    </Admin>
-);
-```
+**Tip**: Before considering writing your own login page component, please take a look at how to change the default [background image](./Theming.md#using-a-custom-login-page) or the [Material UI theme](#theme). See the [Authentication documentation](./Authentication.md#customizing-the-login-component) for more details.
 
 ## `history`
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -754,13 +754,13 @@ const MyPage = () => {
 
 ### `useLogout()` Hook
 
-Just like `useLogin()`, `useLogout()` returns a callback that you can use to call `authProvider.logout()`. Use it to build a custom Logout button, like the following: 
+Just like `useLogin()`, `useLogout()` returns a callback that you can use to call `authProvider.logout()`. Use it to build a custom Logout button and use it in a custom UserMenu, like the following: 
 
 ```jsx
-// in src/MyLogoutButton.js
+// in src/MyLayout.js
 import * as React from 'react';
 import { forwardRef } from 'react';
-import { useLogout } from 'react-admin';
+import { AppBar, Layout, UserMenu, useLogout } from 'react-admin';
 import { MenuItem } from '@mui/material';
 import ExitIcon from '@mui/icons-material/PowerSettingsNew';
 
@@ -777,20 +777,34 @@ const MyLogoutButton = forwardRef((props, ref) => {
     );
 });
 
-export default MyLogoutButton;
+const MyUserMenu = () => (
+    <UserMenu>
+        <MyLogoutButton />
+    </UserMenu>
+);
+
+const MyAppBar = () => (
+    <AppBar userMenu={<UserMenu />} />
+);
+
+const MyLayout = () => (
+    <Layout appBar={MyAppBar} />
+);
+
+export default MyLayout;
 ```
 
-Then pass the Logout button to the `<Admin>` component, as follows:
+Then pass the layout to you admin:
 
 ```jsx
 // in src/App.js
 import * as React from "react";
 import { Admin } from 'react-admin';
 
-import MyLogoutButton from './MyLogoutButton';
+import MyLayout from './MyLayout';
 
 const App = () => (
-    <Admin logoutButton={MyLogoutButton} authProvider={authProvider}>
+    <Admin layout={MyLayout} authProvider={authProvider}>
     ...
     </Admin>
 );
@@ -936,10 +950,9 @@ import * as React from "react";
 import { Admin } from 'react-admin';
 
 import MyLoginPage from './MyLoginPage';
-import MyLogoutButton from './MyLogoutButton';
 
 const App = () => (
-    <Admin loginPage={MyLoginPage} logoutButton={MyLogoutButton} authProvider={authProvider}>
+    <Admin loginPage={MyLoginPage} authProvider={authProvider}>
     ...
     </Admin>
 );
@@ -1162,7 +1175,7 @@ What if you want to check the permissions inside a [custom menu](./Admin.md#menu
 import * as React from "react";
 import { MenuItemLink, usePermissions } from 'react-admin';
 
-const Menu = ({ onMenuClick, logout }) => {
+const Menu = ({ onMenuClick }) => {
     const { permissions } = usePermissions();
     return (
         <div>
@@ -1171,7 +1184,6 @@ const Menu = ({ onMenuClick, logout }) => {
             {permissions === 'admin' &&
                 <MenuItemLink to="/custom-route" primaryText="Miscellaneous" onClick={onMenuClick} />
             }
-            {logout}
         </div>
     );
 }

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -1002,9 +1002,11 @@ const MyLoginPage = ({ theme }) => {
 };
 
 export default MyLoginPage;
+```
 
 ### Customizing The Logout Component
 
+```jsx
 // in src/MyLogoutButton.js
 import * as React from 'react';
 import { forwardRef } from 'react';

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -936,13 +936,13 @@ const App = () => (
 
 ## Recipes
 
-### Customizing The Login and Logout Components
+### Customizing The Login Component
 
 Using `authProvider` is enough to implement a full-featured authorization system if the authentication relies on a username and password.
 
 But what if you want to use an email instead of a username? What if you want to use a Single-Sign-On (SSO) with a third-party authentication service? What if you want to use two-factor authentication?
 
-For all these cases, it's up to you to implement your own `LoginPage` component, which will be displayed under the `/login` route instead of the default username/password form, and your own `LogoutButton` component, which will be displayed in the sidebar. Pass both these components to the `<Admin>` component:
+For all these cases, it's up to you to implement your own `LoginPage` component, which will be displayed under the `/login` route instead of the default username/password form. Pass this component to the `<Admin>` component:
 
 ```jsx
 // in src/App.js
@@ -958,7 +958,7 @@ const App = () => (
 );
 ```
 
-Use the `useLogin` and `useLogout` hooks in your custom `LoginPage` and `LogoutButton` components.
+Use the `useLogin` hook in your custom `LoginPage` component.
 
 ```jsx
 // in src/MyLoginPage.js
@@ -1003,6 +1003,8 @@ const MyLoginPage = ({ theme }) => {
 
 export default MyLoginPage;
 
+### Customizing The Logout Component
+
 // in src/MyLogoutButton.js
 import * as React from 'react';
 import { forwardRef } from 'react';
@@ -1033,6 +1035,24 @@ export default MyLogoutButton;
 // ...
 -   const handleClick = () => logout();
 +   const handleClick = () => logout('/custom-login');
+```
+
+To use it, you must provide a custom `UserMenu`:
+
+```jsx
+import MyLogoutButton from './MyLogoutButton';
+
+const MyUserMenu = () => <UserMenu><MyLogoutButton /></UserMenu>;
+
+const MyAppBar = () => <AppBar userMenu={<MyUserMenu />} />;
+
+const MyLayout = () => <Layout appBar={MyAppBar} />;
+
+const App = () => (
+    <Admin layout={MyLayout}>
+        // ...
+    </Admin>
+);
 ```
 
 ### Restricting Access to Resources or Views

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -422,7 +422,6 @@ To override the style of all instances of `<MenuItemLink>` using the [material-u
 | ------------ | -------- | --------------- | ------------------- | ----------------------------------- |
 | `children`   | Optional | `ReactElement`  | -                   | elements to use as menu items       |
 | `label`      | Required | `string`        | 'ra.auth.user_menu' | label or translation message to use |
-| `logout`     | Optional | `ReactElement`  | -                   | logout component                    |
 | `icon`       | Optional | `ReactElement`  | `<AccountCircle>`   | iconElement, e.g. `<CommentIcon />` |
 
 #### `sx`: CSS API

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -160,7 +160,7 @@ But with the default menu, resources without `list` prop aren't shown.
 In order to have a specific resource without `list` prop listed on the menu, you have to [write your own custom menu](./Theming.md#using-a-custom-menu).
 
 ```jsx
- const MyMenu = ({ resources, onMenuClick, logout }) => (
+ const MyMenu = ({ resources, onMenuClick }) => (
     <div>
         {resources.map(resource => (
             <MenuItemLink to={`/${resource.name}`} primaryText={resource.name} onClick={onMenuClick} />

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1000,8 +1000,6 @@ Just use an empty `filter` query parameter to force empty filters:
 
 ## Using a Custom Login Page
 
-### Changing the Background Image
-
 By default, the login page displays a gradient background. If you want to change the background, you can use the default Login page component and pass an image URL as the `backgroundImage` prop.
 
 ```jsx
@@ -1022,8 +1020,6 @@ const App = () => (
 ```
 
 ## Using a Custom Logout Button
-
-### Changing the Icon
 
 It is possible to use a completely [custom logout button](./Authentication.md#customizing-the-logout-component) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -395,26 +395,56 @@ export default MyLayout;
 
 ### UserMenu Customization
 
-You can replace the default user menu by your own by setting the `userMenu` prop of the `<AppBar>` component. For instance, to add custom menu items, just decorate the default [`<UserMenu>`](./Buttons.md#usermenu) by adding children to it:
+You can replace the default user menu by your own by setting the `userMenu` prop of the `<AppBar>` component. For instance, to add custom menu items, you can render the default [`<UserMenu>`](./Buttons.md#usermenu) and add children to it. Don't forget to include the `<Logout>` component if you want to keep the logout menu item. Besides, in order to properly close the menu once an item is added, call the `onClose` method retrieved from the UserContext through the `useUserMenu` hook. This is handled for you if you use `<MenuItemLink>`:
 
 ```jsx
 import * as React from 'react';
-import { AppBar, UserMenu, MenuItemLink } from 'react-admin';
+import { AppBar, Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
 import SettingsIcon from '@mui/icons-material/Settings';
 
-const ConfigurationMenu = forwardRef(({ onClick }, ref) => (
-    <MenuItemLink
-        ref={ref}
-        to="/configuration"
-        primaryText="Configuration"
-        leftIcon={<SettingsIcon />}
-        onClick={onClick} // close the menu on click
-    />
-));
+// It's important to pass the ref to allow MaterialUI to manage the keyboard navigation
+const ConfigurationMenu = React.forwardRef((props, ref) => {
+    return (
+        <MenuItemLink
+            ref={ref}
+            // It's important to pass the props to allow MaterialUI to manage the keyboard navigation
+            {...props}
+            to="/configuration"
+            primaryText="Configuration"
+            leftIcon={<SettingsIcon />}
+        />
+    );
+});
+
+// It's important to pass the ref to allow MaterialUI to manage the keyboard navigation
+const SwitchLanguage = forwardRef((props, ref) => {
+    const [locale, setLocale] = useLocaleState();
+    // We are not using MenuItemLink so we retrieve the onClose function from the UserContext
+    const { onClose } = useUserMenu();
+
+    return (
+        <MenuItem
+            ref={ref}
+            // It's important to pass the props to allow MaterialUI to manage the keyboard navigation
+            {...props}
+            sx={{ color: 'text.secondary' }}
+            onClick={event => {
+                setLocale(locale === 'en' ? 'fr' : 'en');
+                onClose(); // Close the menu
+            }}
+        >
+            <ListItemIcon sx={{ minWidth: 5 }}>
+                <Language />
+            </ListItemIcon>
+            Switch Language
+        </MenuItem>
+    );
+});
 
 const MyUserMenu = props => (
     <UserMenu {...props}>
         <ConfigurationMenu />
+        <SwitchLanguage />
     </UserMenu>
 );
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -399,7 +399,9 @@ You can replace the default user menu by your own by setting the `userMenu` prop
 
 ```jsx
 import * as React from 'react';
-import { AppBar, Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
+import { AppBar, Logout, UserMenu, useUserMenu } from 'react-admin';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 // It's important to pass the ref to allow MaterialUI to manage the keyboard navigation
@@ -410,9 +412,14 @@ const ConfigurationMenu = React.forwardRef((props, ref) => {
             // It's important to pass the props to allow MaterialUI to manage the keyboard navigation
             {...props}
             to="/configuration"
-            primaryText="Configuration"
-            leftIcon={<SettingsIcon />}
-        />
+        >
+            <ListItemIcon>
+                <SettingsIcon />
+            </ListItemIcon>
+            <ListItemText>
+               Configuration
+            </ListItemText>
+        </MenuItemLink>
     );
 });
 
@@ -436,7 +443,9 @@ const SwitchLanguage = forwardRef((props, ref) => {
             <ListItemIcon sx={{ minWidth: 5 }}>
                 <Language />
             </ListItemIcon>
-            Switch Language
+            <ListItemText>
+                Switch Language
+            </ListItemText>
         </MenuItem>
     );
 });
@@ -445,6 +454,7 @@ const MyUserMenu = props => (
     <UserMenu {...props}>
         <ConfigurationMenu />
         <SwitchLanguage />
+        <Logout />
     </UserMenu>
 );
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -600,7 +600,6 @@ const useStyles = makeStyles(theme => ({
 const MyLayout = ({
     children,
     dashboard,
-    logout,
     title,
 }) => {
     const classes = useStyles();
@@ -609,10 +608,10 @@ const MyLayout = ({
     return (
         <div className={classes.root}>
             <div className={classes.appFrame}>
-                <AppBar title={title} open={open} logout={logout} />
+                <AppBar title={title} open={open} />
                 <main className={classes.contentWithSidebar}>
                     <Sidebar>
-                        <Menu logout={logout} hasDashboard={!!dashboard} />
+                        <Menu hasDashboard={!!dashboard} />
                     </Sidebar>
                     <div className={classes.content}>
                         {children}
@@ -629,7 +628,6 @@ MyLayout.propTypes = {
         PropTypes.func,
         PropTypes.string,
     ]),
-    logout: ComponentPropType,
     title: PropTypes.string.isRequired,
 };
 
@@ -1027,13 +1025,19 @@ const App = () => (
 It is possible to use a completely [custom logout button](./Admin.md#logoutbutton) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
 
 ```jsx
-import { Admin, Logout } from 'react-admin';
+import { Admin, AppBar, Layout, Logout, UserMenu } from 'react-admin';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 
 const MyLogoutButton = props => <Logout {...props} icon={<ExitToAppIcon/>} />;
 
+const MyUserMenu = () => <UserMenu><MyLogoutButton /></UserMenu>;
+
+const MyAppBar = () => <AppBar userMenu={<MyUserMenu />} />;
+
+const MyLayout = () => <Layout appBar={MyAppBar} />;
+
 const App = () => (
-    <Admin logoutButton={MyLogoutButton}>
+    <Admin layout={MyLayout}>
         // ...
     </Admin>
 );

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1022,7 +1022,7 @@ const App = () => (
 
 ### Changing the Icon
 
-It is possible to use a completely [custom logout button](./Theming.md#customizing-the-logout-component) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
+It is possible to use a completely [custom logout button](./Authentication.md#customizing-the-logout-component) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
 
 ```jsx
 import { Admin, AppBar, Layout, Logout, UserMenu } from 'react-admin';

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -400,6 +400,8 @@ You can replace the default user menu by your own by setting the `userMenu` prop
 ```jsx
 import * as React from 'react';
 import { AppBar, Logout, UserMenu, useUserMenu } from 'react-admin';
+import { Link } from 'react-router-dom';
+import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -407,8 +409,9 @@ import SettingsIcon from '@mui/icons-material/Settings';
 // It's important to pass the ref to allow MaterialUI to manage the keyboard navigation
 const ConfigurationMenu = React.forwardRef((props, ref) => {
     return (
-        <MenuItemLink
+        <MenuItem
             ref={ref}
+            component={Link}
             // It's important to pass the props to allow MaterialUI to manage the keyboard navigation
             {...props}
             to="/configuration"
@@ -419,7 +422,7 @@ const ConfigurationMenu = React.forwardRef((props, ref) => {
             <ListItemText>
                Configuration
             </ListItemText>
-        </MenuItemLink>
+        </MenuItem>
     );
 });
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1022,7 +1022,7 @@ const App = () => (
 
 ### Changing the Icon
 
-It is possible to use a completely [custom logout button](./Admin.md#logoutbutton) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
+It is possible to use a completely [custom logout button](./Theming.md#customizing-the-logout-component) or you can simply override some properties of the default button. If you want to change the icon, you can use the default `<Logout>` component and pass a different icon as the `icon` prop.
 
 ```jsx
 import { Admin, AppBar, Layout, Logout, UserMenu } from 'react-admin';

--- a/examples/crm/src/Header.tsx
+++ b/examples/crm/src/Header.tsx
@@ -68,7 +68,9 @@ const Header = () => {
                         </Box>
                         <Box display="flex">
                             <LoadingIndicator />
-                            <UserMenu logout={<Logout />} />
+                            <UserMenu>
+                                <Logout />
+                            </UserMenu>
                         </Box>
                     </Box>
                 </Toolbar>

--- a/examples/demo/src/layout/AppBar.tsx
+++ b/examples/demo/src/layout/AppBar.tsx
@@ -1,29 +1,21 @@
 import * as React from 'react';
-import {
-    AppBar,
-    Logout,
-    MenuItemLink,
-    UserMenu,
-    useUserMenu,
-} from 'react-admin';
+import { AppBar, Logout, MenuItemLink, UserMenu } from 'react-admin';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 import Logo from './Logo';
 
-const ConfigurationMenu = () => {
-    const { onClose } = useUserMenu();
-    return (
-        <MenuItemLink
-            to="/configuration"
-            primaryText="pos.configuration"
-            leftIcon={<SettingsIcon />}
-            sidebarIsOpen
-            onClick={onClose}
-        />
-    );
-};
+const ConfigurationMenu = React.forwardRef((props, ref) => (
+    <MenuItemLink
+        ref={ref}
+        {...props}
+        to="/configuration"
+        primaryText="pos.configuration"
+        leftIcon={<SettingsIcon />}
+        sidebarIsOpen
+    />
+));
 
 const CustomUserMenu = () => (
     <UserMenu>

--- a/examples/demo/src/layout/AppBar.tsx
+++ b/examples/demo/src/layout/AppBar.tsx
@@ -1,29 +1,20 @@
 import * as React from 'react';
-import { forwardRef } from 'react';
-import { AppBar, UserMenu, MenuItemLink, useTranslate } from 'react-admin';
+import { AppBar, UserMenu, MenuItemLink, Logout } from 'react-admin';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 import Logo from './Logo';
 
-const ConfigurationMenu = forwardRef<any, any>((props, ref) => {
-    const translate = useTranslate();
-    return (
+const CustomUserMenu = (props: any) => (
+    <UserMenu {...props} logout={<Logout />}>
         <MenuItemLink
-            ref={ref}
             to="/configuration"
-            primaryText={translate('pos.configuration')}
+            primaryText="pos.configuration"
             leftIcon={<SettingsIcon />}
             onClick={props.onClick}
             sidebarIsOpen
         />
-    );
-});
-
-const CustomUserMenu = (props: any) => (
-    <UserMenu {...props}>
-        <ConfigurationMenu />
     </UserMenu>
 );
 

--- a/examples/demo/src/layout/AppBar.tsx
+++ b/examples/demo/src/layout/AppBar.tsx
@@ -1,19 +1,34 @@
 import * as React from 'react';
-import { AppBar, UserMenu, MenuItemLink, Logout } from 'react-admin';
+import {
+    AppBar,
+    Logout,
+    MenuItemLink,
+    UserMenu,
+    useUserMenu,
+} from 'react-admin';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 import Logo from './Logo';
 
-const CustomUserMenu = () => (
-    <UserMenu logout={<Logout />}>
+const ConfigurationMenu = () => {
+    const { onClose } = useUserMenu();
+    return (
         <MenuItemLink
             to="/configuration"
             primaryText="pos.configuration"
             leftIcon={<SettingsIcon />}
             sidebarIsOpen
+            onClick={onClose}
         />
+    );
+};
+
+const CustomUserMenu = () => (
+    <UserMenu>
+        <ConfigurationMenu />
+        <Logout />
     </UserMenu>
 );
 

--- a/examples/demo/src/layout/AppBar.tsx
+++ b/examples/demo/src/layout/AppBar.tsx
@@ -6,13 +6,12 @@ import SettingsIcon from '@mui/icons-material/Settings';
 
 import Logo from './Logo';
 
-const CustomUserMenu = (props: any) => (
-    <UserMenu {...props} logout={<Logout />}>
+const CustomUserMenu = () => (
+    <UserMenu logout={<Logout />}>
         <MenuItemLink
             to="/configuration"
             primaryText="pos.configuration"
             leftIcon={<SettingsIcon />}
-            onClick={props.onClick}
             sidebarIsOpen
         />
     </UserMenu>

--- a/examples/demo/src/layout/AppBar.tsx
+++ b/examples/demo/src/layout/AppBar.tsx
@@ -1,22 +1,32 @@
 import * as React from 'react';
-import { AppBar, Logout, MenuItemLink, UserMenu } from 'react-admin';
+import { AppBar, Logout, UserMenu, useTranslate } from 'react-admin';
+import { Link } from 'react-router-dom';
 import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 import Logo from './Logo';
 
-const ConfigurationMenu = React.forwardRef((props, ref) => (
-    <MenuItemLink
-        ref={ref}
-        {...props}
-        to="/configuration"
-        primaryText="pos.configuration"
-        leftIcon={<SettingsIcon />}
-        sidebarIsOpen
-    />
-));
-
+const ConfigurationMenu = React.forwardRef((props, ref) => {
+    const translate = useTranslate();
+    return (
+        <MenuItem
+            component={Link}
+            // @ts-ignore
+            ref={ref}
+            {...props}
+            to="/configuration"
+        >
+            <ListItemIcon>
+                <SettingsIcon />
+            </ListItemIcon>
+            <ListItemText>{translate('pos.configuration')}</ListItemText>
+        </MenuItem>
+    );
+});
 const CustomUserMenu = () => (
     <UserMenu>
         <ConfigurationMenu />

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -27,8 +27,8 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
     }
 );
 
-const MyUserMenu = props => (
-    <UserMenu {...props} logout={<Logout />}>
+const MyUserMenu = () => (
+    <UserMenu logout={<Logout />}>
         <SwitchLanguage />
     </UserMenu>
 );

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -9,12 +9,7 @@ import {
     useLocaleState,
     useUserMenu,
 } from 'react-admin';
-import {
-    MenuItem,
-    MenuItemProps,
-    ListItemIcon,
-    ListItemText,
-} from '@mui/material';
+import { MenuItem, MenuItemProps, ListItemIcon } from '@mui/material';
 import Language from '@mui/icons-material/Language';
 
 const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
@@ -35,7 +30,7 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
                 <ListItemIcon sx={{ minWidth: 5 }}>
                     <Language />
                 </ListItemIcon>
-                <ListItemText>Switch Language</ListItemText>
+                Switch Language
             </MenuItem>
         );
     }

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
 import { forwardRef, memo } from 'react';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import { AppBar, Layout, Logout, UserMenu, useLocaleState } from 'react-admin';
+import {
+    AppBar,
+    Layout,
+    Logout,
+    UserMenu,
+    useLocaleState,
+    useUserMenu,
+} from 'react-admin';
 import { MenuItem, MenuItemProps, ListItemIcon } from '@mui/material';
 import Language from '@mui/icons-material/Language';
 
 const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
     (props, ref) => {
         const [locale, setLocale] = useLocaleState();
+        const { onClose } = useUserMenu();
 
         return (
             <MenuItem
@@ -15,7 +23,7 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
                 sx={{ color: 'text.secondary' }}
                 onClick={event => {
                     setLocale(locale === 'en' ? 'fr' : 'en');
-                    props.onClick(event);
+                    onClose();
                 }}
             >
                 <ListItemIcon sx={{ minWidth: 5 }}>
@@ -28,8 +36,9 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
 );
 
 const MyUserMenu = () => (
-    <UserMenu logout={<Logout />}>
+    <UserMenu>
         <SwitchLanguage />
+        <Logout />
     </UserMenu>
 );
 

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { forwardRef, memo } from 'react';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import { Layout, AppBar, UserMenu, useLocaleState } from 'react-admin';
+import { AppBar, Layout, Logout, UserMenu, useLocaleState } from 'react-admin';
 import { MenuItem, MenuItemProps, ListItemIcon } from '@mui/material';
 import Language from '@mui/icons-material/Language';
 
@@ -28,7 +28,7 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
 );
 
 const MyUserMenu = props => (
-    <UserMenu {...props}>
+    <UserMenu {...props} logout={<Logout />}>
         <SwitchLanguage />
     </UserMenu>
 );

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -20,6 +20,7 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
         return (
             <MenuItem
                 ref={ref}
+                {...props}
                 sx={{ color: 'text.secondary' }}
                 onClick={event => {
                     setLocale(locale === 'en' ? 'fr' : 'en');

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -9,7 +9,12 @@ import {
     useLocaleState,
     useUserMenu,
 } from 'react-admin';
-import { MenuItem, MenuItemProps, ListItemIcon } from '@mui/material';
+import {
+    MenuItem,
+    MenuItemProps,
+    ListItemIcon,
+    ListItemText,
+} from '@mui/material';
 import Language from '@mui/icons-material/Language';
 
 const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
@@ -30,7 +35,7 @@ const SwitchLanguage = forwardRef<HTMLLIElement, MenuItemProps>(
                 <ListItemIcon sx={{ minWidth: 5 }}>
                     <Language />
                 </ListItemIcon>
-                Switch Language
+                <ListItemText>Switch Language</ListItemText>
             </MenuItem>
         );
     }

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -97,7 +97,6 @@ export const CoreAdmin = (props: CoreAdminProps) => {
         layout,
         loading,
         loginPage,
-        logoutButton,
         menu, // deprecated, use a custom layout instead
         title = 'React Admin',
     } = props;
@@ -119,7 +118,6 @@ export const CoreAdmin = (props: CoreAdminProps) => {
                 title={title}
                 loading={loading}
                 loginPage={loginPage}
-                logoutButton={authProvider ? logoutButton : undefined}
             >
                 {children}
             </CoreAdminUI>

--- a/packages/ra-core/src/core/CoreAdminRoutes.tsx
+++ b/packages/ra-core/src/core/CoreAdminRoutes.tsx
@@ -30,7 +30,6 @@ export const CoreAdminRoutes = (props: CoreAdminRoutesProps) => {
         catchAll: CatchAll,
         dashboard,
         loading: LoadingPage,
-        logout,
         menu,
         ready: Ready,
         title,
@@ -63,12 +62,7 @@ export const CoreAdminRoutes = (props: CoreAdminRoutesProps) => {
                 path="/*"
                 element={
                     <div>
-                        <Layout
-                            dashboard={dashboard}
-                            logout={logout}
-                            menu={menu}
-                            title={title}
-                        >
+                        <Layout dashboard={dashboard} menu={menu} title={title}>
                             <Routes>
                                 {customRoutesWithLayout}
                                 {Children.map(resources, resource => (

--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createElement, ComponentType, useMemo, useEffect } from 'react';
+import { ComponentType, useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 
 import { CoreAdminRoutes } from './CoreAdminRoutes';
@@ -27,7 +27,6 @@ export interface CoreAdminUIProps {
     layout?: LayoutComponent;
     loading?: LoadingComponent;
     loginPage?: LoginComponent | boolean;
-    logoutButton?: ComponentType;
     menu?: ComponentType;
     ready?: ComponentType;
     title?: TitleComponent;
@@ -42,16 +41,10 @@ export const CoreAdminUI = (props: CoreAdminUIProps) => {
         layout = DefaultLayout,
         loading = Noop,
         loginPage: LoginPage = false,
-        logoutButton,
         menu, // deprecated, use a custom layout instead
         ready = Ready,
         title = 'React Admin',
     } = props;
-
-    const logoutElement = useMemo(
-        () => logoutButton && createElement(logoutButton),
-        [logoutButton]
-    );
 
     useEffect(() => {
         if (
@@ -80,7 +73,6 @@ export const CoreAdminUI = (props: CoreAdminUIProps) => {
                         dashboard={dashboard}
                         layout={layout}
                         loading={loading}
-                        logout={logoutElement}
                         menu={menu}
                         ready={ready}
                         title={title}

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -287,9 +287,7 @@ export type DashboardComponent = ComponentType<WithPermissionsChildrenParams>;
 export interface CoreLayoutProps {
     children?: ReactNode;
     dashboard?: DashboardComponent;
-    logout?: ReactNode;
     menu?: ComponentType<{
-        logout?: ReactNode;
         hasDashboard?: boolean;
     }>;
     title?: TitleComponent;

--- a/packages/ra-no-code/src/ui/Menu.tsx
+++ b/packages/ra-no-code/src/ui/Menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { ReactNode, FC } from 'react';
+import { FC } from 'react';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import clsx from 'clsx';
@@ -83,12 +83,10 @@ export interface MenuProps {
     className?: string;
     dense?: boolean;
     hasDashboard?: boolean;
-    logout?: ReactNode;
 }
 
 Menu.propTypes = {
     className: PropTypes.string,
     dense: PropTypes.bool,
     hasDashboard: PropTypes.bool,
-    logout: PropTypes.element,
 };

--- a/packages/ra-ui-materialui/src/auth/Logout.tsx
+++ b/packages/ra-ui-materialui/src/auth/Logout.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { styled, Theme } from '@mui/material/styles';
 import { useCallback, FunctionComponent, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { ListItemIcon, MenuItem, useMediaQuery } from '@mui/material';
+import {
+    ListItemIcon,
+    ListItemText,
+    MenuItem,
+    useMediaQuery,
+} from '@mui/material';
 import { MenuItemProps } from '@mui/material/MenuItem';
 
 import ExitIcon from '@mui/icons-material/PowerSettingsNew';
@@ -41,7 +46,7 @@ export const Logout: FunctionComponent<
             <ListItemIcon className={LogoutClasses.icon}>
                 {icon ? icon : <ExitIcon />}
             </ListItemIcon>
-            {translate('ra.auth.logout')}
+            <ListItemText>{translate('ra.auth.logout')}</ListItemText>
         </StyledMenuItem>
     );
 });

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FC } from 'react';
 import { styled } from '@mui/material/styles';
-import { Children, cloneElement, memo } from 'react';
+import { Children, memo } from 'react';
 import PropTypes from 'prop-types';
 import {
     AppBar as MuiAppBar,
@@ -101,7 +101,7 @@ export const AppBar: FC<AppBarProps> = memo(props => {
                             <UserMenu logout={logout} />
                         ) : null
                     ) : (
-                        cloneElement(userMenu, { logout })
+                        userMenu
                     )}
                 </Toolbar>
             </StyledAppBar>

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -25,7 +25,6 @@ import { HideOnScroll } from './HideOnScroll';
  * @param {ReactNode} props.children React node/s to be rendered as children of the AppBar
  * @param {string} props.className CSS class applied to the MuiAppBar component
  * @param {string} props.color The color of the AppBar
- * @param {Component} props.logout The logout button component that will be pass to the UserMenu component
  * @param {boolean} props.open State of the <Admin/> Sidebar
  * @param {Element | boolean} props.userMenu A custom user menu component for the AppBar. <UserMenu/> component by default. Pass false to disable.
  *
@@ -59,7 +58,6 @@ export const AppBar: FC<AppBarProps> = memo(props => {
         children,
         className,
         color = 'secondary',
-        logout,
         open,
         title,
         userMenu = DefaultUserMenu,
@@ -97,7 +95,7 @@ export const AppBar: FC<AppBarProps> = memo(props => {
                     <LoadingIndicator />
                     {typeof userMenu === 'boolean' ? (
                         userMenu === true ? (
-                            <UserMenu>{logout}</UserMenu>
+                            <UserMenu />
                         ) : null
                     ) : (
                         userMenu
@@ -119,7 +117,6 @@ AppBar.propTypes = {
         'transparent',
     ]),
     container: ComponentPropType,
-    logout: PropTypes.element,
     // @deprecated
     open: PropTypes.bool,
     userMenu: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
@@ -129,7 +126,6 @@ const DefaultUserMenu = <UserMenu />;
 
 export interface AppBarProps extends Omit<MuiAppBarProps, 'title'> {
     container?: React.ElementType<any>;
-    logout?: React.ReactNode;
     // @deprecated
     open?: boolean;
     title?: string | JSX.Element;

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -23,7 +23,6 @@ import { HideOnScroll } from './HideOnScroll';
  *
  * @param {Object} props
  * @param {ReactNode} props.children React node/s to be rendered as children of the AppBar
- * @param {Object} props.classes CSS class names
  * @param {string} props.className CSS class applied to the MuiAppBar component
  * @param {string} props.color The color of the AppBar
  * @param {Component} props.logout The logout button component that will be pass to the UserMenu component
@@ -98,7 +97,7 @@ export const AppBar: FC<AppBarProps> = memo(props => {
                     <LoadingIndicator />
                     {typeof userMenu === 'boolean' ? (
                         userMenu === true ? (
-                            <UserMenu logout={logout} />
+                            <UserMenu>{logout}</UserMenu>
                         ) : null
                     ) : (
                         userMenu

--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -24,7 +24,6 @@ export const Layout = (props: LayoutProps) => {
         className,
         dashboard,
         error: errorComponent,
-        logout,
         menu: Menu = DefaultMenu,
         sidebar: Sidebar = DefaultSidebar,
         title,
@@ -42,7 +41,7 @@ export const Layout = (props: LayoutProps) => {
         <StyledLayout className={clsx('layout', className)} {...rest}>
             <SkipNavigationButton />
             <div className={LayoutClasses.appFrame}>
-                <AppBar logout={logout} open={open} title={title} />
+                <AppBar open={open} title={title} />
                 <main className={LayoutClasses.contentWithSidebar}>
                     <Sidebar>
                         <Menu hasDashboard={!!dashboard} />

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material';
 
 import { useSidebarState } from './useSidebarState';
-import { useUserMenu } from './useUserMenu';
 import { useTranslate } from 'ra-core';
 
 /**
@@ -79,7 +78,6 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
 
     const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('md'));
     const translate = useTranslate();
-    const userMenuContext = useUserMenu();
 
     const [open, setOpen] = useSidebarState();
     const handleMenuTap = useCallback(
@@ -87,10 +85,9 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
             if (isSmall) {
                 setOpen(false);
             }
-            userMenuContext && userMenuContext.onClose();
             onClick && onClick(e);
         },
-        [setOpen, isSmall, onClick, userMenuContext]
+        [setOpen, isSmall, onClick]
     );
 
     const match = useMatch(
@@ -100,7 +97,6 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
     const renderMenuItem = () => {
         return (
             <StyledMenuItem
-                // @ts-ignore
                 className={clsx(className, {
                     [MenuItemLinkClasses.active]: !!match,
                 })}

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 
 import { useSidebarState } from './useSidebarState';
+import { useUserMenu } from './useUserMenu';
 import { useTranslate } from 'ra-core';
 
 /**
@@ -78,6 +79,7 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
 
     const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('md'));
     const translate = useTranslate();
+    const userMenuContext = useUserMenu();
 
     const [open, setOpen] = useSidebarState();
     const handleMenuTap = useCallback(
@@ -85,9 +87,10 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
             if (isSmall) {
                 setOpen(false);
             }
+            userMenuContext && userMenuContext.onClose();
             onClick && onClick(e);
         },
-        [setOpen, isSmall, onClick]
+        [setOpen, isSmall, onClick, userMenuContext]
     );
 
     const match = useMatch(

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -1,10 +1,4 @@
-import React, {
-    forwardRef,
-    cloneElement,
-    useCallback,
-    ReactElement,
-    ReactNode,
-} from 'react';
+import React, { forwardRef, useCallback, ReactElement, ReactNode } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
@@ -20,6 +14,7 @@ import {
 } from '@mui/material';
 
 import { useSidebarState } from './useSidebarState';
+import { useTranslate } from 'ra-core';
 
 /**
  * Displays a menu item with a label and an icon - or only the icon with a tooltip when the sidebar is minimized.
@@ -82,6 +77,8 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
     } = props;
 
     const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('md'));
+    const translate = useTranslate();
+
     const [open, setOpen] = useSidebarState();
     const handleMenuTap = useCallback(
         e => {
@@ -113,12 +110,12 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
             >
                 {leftIcon && (
                     <ListItemIcon className={MenuItemLinkClasses.icon}>
-                        {cloneElement(leftIcon, {
-                            titleAccess: primaryText,
-                        })}
+                        {leftIcon}
                     </ListItemIcon>
                 )}
-                {primaryText}
+                {typeof primaryText === 'string'
+                    ? translate(primaryText, { _: primaryText })
+                    : primaryText}
             </StyledMenuItem>
         );
     };
@@ -126,7 +123,15 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
     return open ? (
         renderMenuItem()
     ) : (
-        <Tooltip title={primaryText} placement="right" {...tooltipProps}>
+        <Tooltip
+            title={
+                typeof primaryText === 'string'
+                    ? translate(primaryText, { _: primaryText })
+                    : primaryText
+            }
+            placement="right"
+            {...tooltipProps}
+        >
             {renderMenuItem()}
         </Tooltip>
     );

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
-import { useTranslate, useGetIdentity } from 'ra-core';
+import { useAuthProvider, useGetIdentity, useTranslate } from 'ra-core';
 import {
     Tooltip,
     IconButton,
@@ -13,26 +13,35 @@ import {
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import { UserMenuContextProvider } from './UserMenuContextProvider';
+import { Logout } from '../auth';
 
 /**
- * The UserMenu component renders a Mui Button that shows a Menu with at least the logout action.
+ * The UserMenu component renders a Mui Button that shows a Menu.
  * It accepts children that must be Mui MenuItem components.
  *
  * @example
- * import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
- *
- * const ConfigurationMenu = () => {
+ * import { Logout, UserMenu, useUserMenu } from 'react-admin';
+ * import MenuItem from '@mui/material/MenuItem';
+ * import ListItemIcon from '@mui/material/ListItemIcon';
+ * import ListItemText from '@mui/material/ListItemText';
+ * import SettingsIcon from '@mui/icons-material/Settings';
+
+ * const ConfigurationMenu = React.forwardRef((props, ref) => {
  *     const { onClose } = useUserMenu();
  *     return (
- *         <MenuItemLink
+ *         <MenuItem
+ *             ref={ref}
+ *             {...props}
  *             to="/configuration"
- *             primaryText="pos.configuration"
- *             leftIcon={<SettingsIcon />}
- *             sidebarIsOpen
  *             onClick={onClose}
- *         />
+ *         >
+ *             <ListItemIcon>
+ *                 <SettingsIcon />
+ *             </ListItemIcon>
+ *             <ListItemText>Configuration</ListItemText>
+ *         </MenuItem>
  *     );
- * };
+ * });
  *
  * export const MyUserMenu = () => (
  *     <UserMenu>
@@ -51,9 +60,10 @@ export const UserMenu = (props: UserMenuProps) => {
     const [anchorEl, setAnchorEl] = useState(null);
     const translate = useTranslate();
     const { loaded, identity } = useGetIdentity();
+    const authProvider = useAuthProvider();
 
     const {
-        children,
+        children = !!authProvider ? <Logout /> : null,
         className,
         label = 'ra.auth.user_menu',
         icon = defaultIcon,

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import { useTranslate, useGetIdentity } from 'ra-core';
@@ -12,25 +12,34 @@ import {
     PopoverOrigin,
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
+import { UserMenuContextProvider } from './UserMenuContextProvider';
 
 /**
  * The UserMenu component renders a Mui Button that shows a Menu with at least the logout action.
  * It accepts children that must be Mui MenuItem components.
  *
  * @example
- * import { Logout, MenuItemLink, UserMenu } from 'react-admin';
+ * import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
  *
- * export const MyUserMenu = () => (
- *     <UserMenu>
+ * const ConfigurationMenu = () => {
+ *     const { onClose } = useUserMenu();
+ *     return (
  *         <MenuItemLink
  *             to="/configuration"
  *             primaryText="pos.configuration"
  *             leftIcon={<SettingsIcon />}
  *             sidebarIsOpen
+ *             onClick={onClose}
  *         />
+ *     );
+ * };
+ *
+ * export const MyUserMenu = () => (
+ *     <UserMenu>
+ *         <ConfigurationMenu />
  *         <Logout />
  *     </UserMenu>
- * )
+ * );
  * @param props
  * @param {ReactNode} props.children React node/s to be rendered as children of the UserMenu. Must be Mui MenuItem components
  * @param {string} props.className CSS class applied to the MuiAppBar component
@@ -50,11 +59,11 @@ export const UserMenu = (props: UserMenuProps) => {
         icon = defaultIcon,
     } = props;
 
+    const handleMenu = event => setAnchorEl(event.currentTarget);
+    const handleClose = useCallback(() => setAnchorEl(null), []);
+    const context = useMemo(() => ({ onClose: handleClose }), [handleClose]);
     if (!children) return null;
     const open = Boolean(anchorEl);
-
-    const handleMenu = event => setAnchorEl(event.currentTarget);
-    const handleClose = () => setAnchorEl(null);
 
     return (
         <Root className={className}>
@@ -92,17 +101,19 @@ export const UserMenu = (props: UserMenuProps) => {
                     </IconButton>
                 </Tooltip>
             )}
-            <Menu
-                id="menu-appbar"
-                disableScrollLock
-                anchorEl={anchorEl}
-                anchorOrigin={AnchorOrigin}
-                transformOrigin={TransformOrigin}
-                open={open}
-                onClose={handleClose}
-            >
-                {children}
-            </Menu>
+            <UserMenuContextProvider value={context}>
+                <Menu
+                    id="menu-appbar"
+                    disableScrollLock
+                    anchorEl={anchorEl}
+                    anchorOrigin={AnchorOrigin}
+                    transformOrigin={TransformOrigin}
+                    open={open}
+                    onClose={handleClose}
+                >
+                    {children}
+                </Menu>
+            </UserMenuContextProvider>
         </Root>
     );
 };

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import { UserMenuContextProvider } from './UserMenuContextProvider';
-import { Logout } from '../auth';
+import { Logout } from '../auth/Logout';
 
 /**
  * The UserMenu component renders a Mui Button that shows a Menu.

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { ReactNode, useState } from 'react';
 import { styled } from '@mui/material/styles';
-import { Children, cloneElement, isValidElement, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslate, useGetIdentity } from 'ra-core';
 import {
@@ -13,6 +13,31 @@ import {
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 
+/**
+ * The UserMenu component renders a Mui Button that shows a Menu with at least the logout action.
+ * It accepts children that must be Mui MenuItem components.
+ *
+ * @example
+ * import { Logout, MenuItemLink, UserMenu } from 'react-admin';
+ *
+ * export const MyUserMenu = () => (
+ *     <UserMenu>
+ *         <MenuItemLink
+ *             to="/configuration"
+ *             primaryText="pos.configuration"
+ *             leftIcon={<SettingsIcon />}
+ *             sidebarIsOpen
+ *         />
+ *         <Logout />
+ *     </UserMenu>
+ * )
+ * @param props
+ * @param {ReactNode} props.children React node/s to be rendered as children of the UserMenu. Must be Mui MenuItem components
+ * @param {string} props.className CSS class applied to the MuiAppBar component
+ * @param {string} props.label The label of the UserMenu button. Accepts translation keys
+ * @param {Element} props.icon The icon of the UserMenu button.
+ *
+ */
 export const UserMenu = (props: UserMenuProps) => {
     const [anchorEl, setAnchorEl] = useState(null);
     const translate = useTranslate();
@@ -23,10 +48,9 @@ export const UserMenu = (props: UserMenuProps) => {
         className,
         label = 'ra.auth.user_menu',
         icon = defaultIcon,
-        logout,
     } = props;
 
-    if (!logout && !children) return null;
+    if (!children) return null;
     const open = Boolean(anchorEl);
 
     const handleMenu = event => setAnchorEl(event.currentTarget);
@@ -77,14 +101,7 @@ export const UserMenu = (props: UserMenuProps) => {
                 open={open}
                 onClose={handleClose}
             >
-                {Children.map(children, menuItem =>
-                    isValidElement(menuItem)
-                        ? cloneElement<any>(menuItem, {
-                              onClick: handleClose,
-                          })
-                        : null
-                )}
-                {logout}
+                {children}
             </Menu>
         </Root>
     );
@@ -94,16 +111,14 @@ UserMenu.propTypes = {
     children: PropTypes.node,
     classes: PropTypes.object,
     label: PropTypes.string,
-    logout: PropTypes.element,
     icon: PropTypes.node,
 };
 
 export interface UserMenuProps {
-    children?: React.ReactNode;
+    children?: ReactNode;
     className?: string;
     label?: string;
-    logout?: React.ReactNode;
-    icon?: React.ReactNode;
+    icon?: ReactNode;
 }
 
 const PREFIX = 'RaUserMenu';

--- a/packages/ra-ui-materialui/src/layout/UserMenuContext.ts
+++ b/packages/ra-ui-materialui/src/layout/UserMenuContext.ts
@@ -1,0 +1,37 @@
+import { createContext } from 'react';
+
+/**
+ * This context provides access to a function for closing the user menu.
+ *
+ * @example
+ * import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
+ *
+ * const ConfigurationMenu = () => {
+ *     const { onClose } = useUserMenu();
+ *     return (
+ *         <MenuItemLink
+ *             to="/configuration"
+ *             primaryText="pos.configuration"
+ *             leftIcon={<SettingsIcon />}
+ *             sidebarIsOpen
+ *             onClick={onClose}
+ *         />
+ *     );
+ * };
+ *
+ * export const MyUserMenu = () => (
+ *     <UserMenu>
+ *         <ConfigurationMenu />
+ *         <Logout />
+ *     </UserMenu>
+ * );
+ */
+export const UserMenuContext = createContext<UserMenuContextValue>(undefined);
+
+export type UserMenuContextValue = {
+    /**
+     * Closes the user menu
+     * @see UserMenu
+     */
+    onClose: () => void;
+};

--- a/packages/ra-ui-materialui/src/layout/UserMenuContextProvider.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenuContextProvider.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { ReactNode } from 'react';
+import { UserMenuContext, UserMenuContextValue } from './UserMenuContext';
+
+/**
+ * A React context provider that provides access to the user menu context.
+ * @param props
+ * @param {ReactNode} props.children
+ * @param {UserMenuContextValue} props.value The user menu context
+ */
+export const UserMenuContextProvider = ({ children, value }) => (
+    <UserMenuContext.Provider value={value}>
+        {children}
+    </UserMenuContext.Provider>
+);
+
+export type UserMenuContextProviderProps = {
+    children: ReactNode;
+    value: UserMenuContextValue;
+};

--- a/packages/ra-ui-materialui/src/layout/index.ts
+++ b/packages/ra-ui-materialui/src/layout/index.ts
@@ -20,5 +20,7 @@ export * from './Theme';
 export * from './Title';
 export * from './TopToolbar';
 export * from './UserMenu';
+export * from './UserMenuContext';
 export * from './useResetErrorBoundaryOnLocationChange';
 export * from './useSidebarState';
+export * from './useUserMenu';

--- a/packages/ra-ui-materialui/src/layout/useUserMenu.ts
+++ b/packages/ra-ui-materialui/src/layout/useUserMenu.ts
@@ -1,0 +1,31 @@
+import { useContext } from 'react';
+import { UserMenuContext } from './UserMenuContext';
+
+/**
+ * A hook to retrieve the user menu context, which provides access to a function for closing the user menu.
+ * @returns {UserMenuContextValue}
+ *
+ * @example
+ * import { Logout, MenuItemLink, UserMenu, useUserMenu } from 'react-admin';
+ *
+ * const ConfigurationMenu = () => {
+ *     const { onClose } = useUserMenu();
+ *     return (
+ *         <MenuItemLink
+ *             to="/configuration"
+ *             primaryText="pos.configuration"
+ *             leftIcon={<SettingsIcon />}
+ *             sidebarIsOpen
+ *             onClick={onClose}
+ *         />
+ *     );
+ * };
+ *
+ * export const MyUserMenu = () => (
+ *     <UserMenu>
+ *         <ConfigurationMenu />
+ *         <Logout />
+ *     </UserMenu>
+ * );
+ */
+export const useUserMenu = () => useContext(UserMenuContext);

--- a/packages/react-admin/src/Admin.tsx
+++ b/packages/react-admin/src/Admin.tsx
@@ -99,7 +99,6 @@ export const Admin = (props: AdminProps) => {
         layout,
         loading,
         loginPage,
-        logoutButton,
         menu, // deprecated, use a custom layout instead
         notification,
         store,
@@ -133,7 +132,6 @@ export const Admin = (props: AdminProps) => {
                 title={title}
                 loading={loading}
                 loginPage={loginPage}
-                logoutButton={authProvider ? logoutButton : undefined}
                 notification={notification}
                 ready={ready}
             >


### PR DESCRIPTION
- [x] Avoid cloning elements in AppBar
- [x] Automatically translate MenuItemLink primaryText
- [x] Documentation
- [x] Remove the `logout` prop