### PR TITLE
Fix `FilterButton` throws error if no filters are present 

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -90,7 +90,7 @@ The title can be either a string or an element of your own.
 
 ![Actions Toolbar](./img/actions-toolbar.png)
 
-You can replace the list of default actions by your own element using the `actions` prop:
+You can replace the list of default actions by your own elements using the `actions` prop:
 
 ```jsx
 import * as React from 'react';
@@ -119,17 +119,17 @@ export const PostList = (props) => (
         </List>
 );
 ```
+Note that in order to add the `<FilterButton>` component among your custom actions, either the parent `List` must have its `filters` prop set up or you must pass the filters to the button itself. 
 
 This allows you to further control how the default actions behave. For example, you could disable the `<ExportButton>` when the list is empty:
 
 {% raw %}
 ```jsx
 import * as React from 'react';
-import { cloneElement, useMemo, useContext } from 'react';
+import { cloneElement, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
     useListContext,
-    FilterContext,
     TopToolbar,
     CreateButton,
     ExportButton,
@@ -146,11 +146,10 @@ const ListActions = (props) => {
         ...rest
     } = props;
     const { total } = useListContext();
-    const filters = useContext(FilterContext);
 
     return (
         <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
-            { filters && <FilterButton /> }
+            <FilterButton />
             <CreateButton />
             <ExportButton disabled={total === 0} maxResults={maxResults} />
             {/* Add your custom actions */}

--- a/docs/List.md
+++ b/docs/List.md
@@ -125,16 +125,17 @@ This allows you to further control how the default actions behave. For example, 
 {% raw %}
 ```jsx
 import * as React from 'react';
-import { cloneElement, useMemo } from 'react';
+import { cloneElement, useMemo, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
     useListContext,
+    FilterContext,
     TopToolbar,
     CreateButton,
     ExportButton,
     FilterButton,
     Button,
-    sanitizeListRestProps    
+    sanitizeListRestProps
 } from 'react-admin';
 import IconEvent from '@material-ui/icons/Event';
 
@@ -144,12 +145,12 @@ const ListActions = (props) => {
         maxResults,
         ...rest
     } = props;
-    const {
-        total,
-    } = useListContext();
+    const { total } = useListContext();
+    const filters = useContext(FilterContext);
+
     return (
         <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
-            <FilterButton />
+            { filters && <FilterButton /> }
             <CreateButton />
             <ExportButton disabled={total === 0} maxResults={maxResults} />
             {/* Add your custom actions */}

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -43,7 +43,7 @@ const FilterButton = (props: FilterButtonProps): JSX.Element => {
     const anchorEl = useRef();
     const classes = useStyles(props);
 
-    const hiddenFilters = filters.filter(
+    const hiddenFilters = filters?.filter(
         (filterElement: JSX.Element) =>
             !filterElement.props.alwaysOn &&
             !displayedFilters[filterElement.props.source] &&
@@ -72,6 +72,10 @@ const FilterButton = (props: FilterButtonProps): JSX.Element => {
         },
         [showFilter, setOpen]
     );
+
+    if (!hiddenFilters) {
+        throw new Error('FilterButton requires filters prop to be set');
+    }
 
     if (hiddenFilters.length === 0) return null;
     return (

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -43,7 +43,11 @@ const FilterButton = (props: FilterButtonProps): JSX.Element => {
     const anchorEl = useRef();
     const classes = useStyles(props);
 
-    const hiddenFilters = filters?.filter(
+    if (filters === undefined) {
+        throw new Error('FilterButton requires filters prop to be set');
+    }
+
+    const hiddenFilters = filters.filter(
         (filterElement: JSX.Element) =>
             !filterElement.props.alwaysOn &&
             !displayedFilters[filterElement.props.source] &&
@@ -72,10 +76,6 @@ const FilterButton = (props: FilterButtonProps): JSX.Element => {
         },
         [showFilter, setOpen]
     );
-
-    if (!hiddenFilters) {
-        throw new Error('FilterButton requires filters prop to be set');
-    }
 
     if (hiddenFilters.length === 0) return null;
     return (


### PR DESCRIPTION
Fixes #7026