### PR TITLE
Fix BC break v4: useCreate and useUpdate can return a promise

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -81,7 +81,7 @@ export const useCreateController = <
                     : transform
                     ? transform(data)
                     : data
-            ).then(data =>
+            ).then(data => {
                 create(
                     resource,
                     { data },
@@ -126,8 +126,8 @@ export const useCreateController = <
                                   );
                               },
                     }
-                )
-            );
+                );
+            });
         },
         [
             create,

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -109,17 +109,25 @@ export const useCreate = <RecordType extends RaRecord = any>(
     const create = (
         callTimeResource: string = resource,
         callTimeParams: Partial<CreateParams<RecordType>> = {},
-        createOptions?: MutateOptions<
+        createOptions: MutateOptions<
             RecordType,
             unknown,
             Partial<UseCreateMutateParams<RecordType>>,
             unknown
-        >
-    ) =>
+        > & { returnPromise?: boolean } = {}
+    ) => {
+        const { returnPromise, ...reactCreateOptions } = createOptions;
+        if (returnPromise) {
+            return mutation.mutateAsync(
+                { resource: callTimeResource, ...callTimeParams },
+                createOptions
+            );
+        }
         mutation.mutate(
             { resource: callTimeResource, ...callTimeParams },
-            createOptions
+            reactCreateOptions
         );
+    };
 
     return [create, mutation];
 };
@@ -138,7 +146,10 @@ export type UseCreateOptions<
     Partial<UseCreateMutateParams<RecordType>>
 >;
 
-export type UseCreateResult<RecordType extends RaRecord = any> = [
+export type UseCreateResult<
+    RecordType extends RaRecord = any,
+    TReturnPromise extends boolean = boolean
+> = [
     (
         resource?: string,
         params?: Partial<CreateParams<Partial<RecordType>>>,
@@ -147,8 +158,8 @@ export type UseCreateResult<RecordType extends RaRecord = any> = [
             unknown,
             Partial<UseCreateMutateParams<RecordType>>,
             unknown
-        >
-    ) => void,
+        > & { returnPromise?: TReturnPromise }
+    ) => TReturnPromise extends true ? Promise<RecordType> : void,
     UseMutationResult<
         RecordType,
         unknown,


### PR DESCRIPTION
Related PR: https://github.com/marmelab/react-admin/pull/5778.

To be able to handle correctly submission validation errors, the returned functions from `useCreate` and `useUpdate` need to be able to return a promise.
Only then doing like it is described in the documentation would be possible:
https://github.com/marmelab/react-admin/blob/efc89692fdf839d1267e030595a52a1127b23d71/docs/CreateEdit.md?plain=1#L1524-L1531