### PR TITLE
Update filter syntax to support operators

### DIFF
--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -293,7 +293,7 @@ To create a custom filter UI, we'll have to override the default List Toolbar co
 The new element can use [the `useListContext` hook](./useListContext.md) to interact with the list filter more easily. The hook returns the following constants:
 
 - `filterValues`: Value of the filters based on the URI, e.g. `{ "commentable": true, "q": "lorem" }`
-- `setFilters()`: Callback to set the filter values, e.g. `setFilters({ "commentable":true })`
+- `setFilters()`: Callback to set the filter values, e.g. `setFilters([{ field: "commentable", value: true }])`
 - `displayedFilters`: Names of the filters displayed in the form, e.g. `['commentable', 'title']`
 - `showFilter()`: Callback to display an additional filter in the form, e.g. `showFilter('views')`
 - `hideFilter()`: Callback to hide a filter in the form, e.g. `hideFilter('title')`
@@ -361,7 +361,7 @@ const PostFilterForm = () => {
   };
 
   const resetFilter = () => {
-    setFilters({}, []);
+    setFilters([], []);
   };
 
   return (

--- a/docs/ListTutorial.md
+++ b/docs/ListTutorial.md
@@ -36,7 +36,7 @@ const BookList = () => {
     const [page, setPage] = useState(1);
     const perPage = 10;
     const { data, total, isLoading } = useGetList('books', {
-        filter: { q: filter },
+        filters: [{ field: 'q', value: filter }],
         pagination: { page, perPage },
         sort: { field: 'id', order: 'ASC' }
     });
@@ -113,7 +113,7 @@ const BookList = () => {
     const perPage = 10;
     const sort = { field: 'id', order: 'ASC' };
     const { data, total, isLoading } = useGetList('books', {
-        filter: { q: filter },
+        filters: [{ field: 'q', value: filter }],
         pagination: { page, perPage },
         sort,
     });
@@ -175,7 +175,7 @@ const BookList = () => {
     const perPage = 10;
     const sort = { field: 'id', order: 'ASC' };
     const { data, total, isLoading } = useGetList('books', {
-        filter: { q: filter },
+        filters: [{ field: 'q', value: filter }],
         pagination: { page, perPage },
         sort,
     });

--- a/docs/useChoicesContext.md
+++ b/docs/useChoicesContext.md
@@ -25,7 +25,7 @@ export const PostInput = (props) => {
     const { setFilters, displayedFilters } = useChoicesContext();
 
     const handleCheckboxChange = (event, checked) => {
-        setFilters({ published: checked }, displayedFilters);
+        setFilters([{ field: 'published', value: checked }], displayedFilters);
     };
 
     return (
@@ -81,7 +81,6 @@ const {
     sort, // a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
     setSort, // a callback to change the sort, e.g. setSort({ field: 'name', orfer: 'ASC' })
     // filtering
-    filter, // The permanent filter values, e.g. { title: 'lorem', nationality: 'fr' }
     filterValues, // a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
     displayedFilters, // a dictionary of the displayed filters, e.g. { title: true, nationality: true }
     setFilters, // a callback to update the filters, e.g. setFilters(filters, displayedFilters)

--- a/docs/useList.md
+++ b/docs/useList.md
@@ -48,7 +48,7 @@ import { useGetList, useList } from 'react-admin';
 const MyComponent = () => {
     const { data, isLoading } = useGetList(
         'posts',
-        { page: 1, perPage: 10 }
+        { pagination: { page: 1, perPage: 10 } }
     );
     const listContext = useList({ data, isLoading });
     return (
@@ -97,7 +97,7 @@ import { useGetList, useList } from 'react-admin';
 const MyComponent = () => {
     const { data, isFetching } = useGetList(
         'posts',
-        { page: 1, perPage: 10 }
+        { pagination: { page: 1, perPage: 10 } }
     );
     const listContext = useList({ data, isFetching });
     return (

--- a/examples/crm/src/deals/OnlyMineInput.tsx
+++ b/examples/crm/src/deals/OnlyMineInput.tsx
@@ -11,12 +11,22 @@ export const OnlyMineInput = ({ alwaysOn }: { alwaysOn: boolean }) => {
     const { identity } = useGetIdentity();
 
     const handleChange = () => {
-        const newFilterValues = { ...filterValues };
-        if (typeof filterValues.sales_id !== 'undefined') {
-            delete newFilterValues.sales_id;
-        } else {
-            newFilterValues.sales_id = identity && identity?.id;
-        }
+        const index = filterValues.findIndex(
+            filter => filter.field === 'sales_id'
+        );
+        const newFilterValues =
+            index !== -1
+                ? filterValues
+                      .slice(0, index)
+                      .concat(filterValues.slice(index + 1))
+                : [
+                      ...filterValues,
+                      {
+                          field: 'sales_id',
+                          value: identity && identity?.id,
+                      },
+                  ];
+
         setFilters(newFilterValues, displayedFilters);
     };
     return (

--- a/examples/demo/src/orders/OrderList.tsx
+++ b/examples/demo/src/orders/OrderList.tsx
@@ -124,11 +124,24 @@ const TabbedDatagrid = (props: TabbedDatagridProps) => {
 
     const handleChange = useCallback(
         (event: React.ChangeEvent<{}>, value: any) => {
-            setFilters &&
-                setFilters(
-                    { ...filterValues, status: value },
-                    displayedFilters
-                );
+            const index = filterValues.findIndex(
+                filter => filter.field === 'status'
+            );
+            const newFilterValues =
+                index !== -1
+                    ? filterValues.map(filter =>
+                          filter.field === 'status'
+                              ? { field: 'status', value }
+                              : filter
+                      )
+                    : [
+                          ...filterValues,
+                          {
+                              field: 'status',
+                              value,
+                          },
+                      ];
+            setFilters && setFilters(newFilterValues, displayedFilters);
         },
         [displayedFilters, filterValues, setFilters]
     );

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.spec.tsx
@@ -9,10 +9,7 @@ import { CoreAdminContext } from '../../core';
 const ReferenceArrayFieldController = props => {
     const { children, ...rest } = props;
     const controllerProps = useReferenceArrayFieldController({
-        sort: {
-            field: 'id',
-            order: 'ASC',
-        },
+        sort: { field: 'id', order: 'ASC' },
         ...rest,
     });
     return children(controllerProps);
@@ -60,7 +57,7 @@ describe('<useReferenceArrayFieldController />', () => {
         );
     });
 
-    it('should call dataProvider.getMAny on mount and return the result in the data prop', async () => {
+    it('should call dataProvider.getMany on mount and return the result in the data prop', async () => {
         const children = jest.fn().mockReturnValue('child');
         render(
             <CoreAdminContext dataProvider={dataProvider}>
@@ -99,25 +96,23 @@ describe('<useReferenceArrayFieldController />', () => {
                     resource="foo"
                     reference="bar"
                     record={{ id: 1, barIds: [1, 2] }}
-                    filter={{ title: 'bar1' }}
+                    filter={[{ field: 'title', value: 'bar1' }]}
                     source="barIds"
                 >
                     {children}
                 </ReferenceArrayFieldController>
             </CoreAdminContext>
         );
-        await waitFor(() =>
-            expect(dataProvider.getMany).toHaveBeenCalledTimes(1)
-        );
-        expect(children).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sort: { field: 'id', order: 'ASC' },
-                isFetching: false,
-                isLoading: false,
-                data: [{ id: 1, title: 'bar1' }],
-                error: null,
-            })
-        );
+        await waitFor(() => {
+            expect(children).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    isFetching: false,
+                    isLoading: false,
+                    data: [{ id: 1, title: 'bar1' }],
+                    error: null,
+                })
+            );
+        });
     });
 
     it('should filter array data based on the filter props', async () => {
@@ -138,7 +133,9 @@ describe('<useReferenceArrayFieldController />', () => {
                     resource="foo"
                     reference="bar"
                     record={{ id: 1, barIds: [1, 2, 3, 4] }}
-                    filter={{ items: ['two', 'four', 'five'] }}
+                    filter={[
+                        { field: 'items', value: ['two', 'four', 'five'] },
+                    ]}
                     source="barIds"
                 >
                     {children}

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -1,12 +1,15 @@
 import get from 'lodash/get';
 
-import { RaRecord, SortPayload } from '../../types';
+import { FilterItem, RaRecord, SortPayload } from '../../types';
 import { useGetManyAggregate } from '../../dataProvider';
 import { ListControllerResult, useList } from '../list';
 import { useNotify } from '../../notification';
+import { convertFiltersToFilterItems } from '../list/convertFiltersToFilterItems';
 
 export interface UseReferenceArrayFieldControllerParams {
-    filter?: any;
+    // permanent filter
+    filter?: FilterItem[];
+    filterDefaultValues?: FilterItem[];
     page?: number;
     perPage?: number;
     record?: RaRecord;
@@ -17,7 +20,7 @@ export interface UseReferenceArrayFieldControllerParams {
 }
 
 const emptyArray = [];
-const defaultFilter = {};
+const defaultFilter = [];
 const defaultSort = { field: null, order: null };
 
 /**
@@ -48,6 +51,7 @@ export const useReferenceArrayFieldController = (
 ): ListControllerResult => {
     const {
         filter = defaultFilter,
+        filterDefaultValues = defaultFilter,
         page = 1,
         perPage = 1000,
         record,
@@ -84,7 +88,8 @@ export const useReferenceArrayFieldController = (
     const listProps = useList({
         data,
         error,
-        filter,
+        filter: convertFiltersToFilterItems(filter),
+        filterDefaultValues,
         isFetching,
         isLoading,
         page,

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
@@ -107,7 +107,9 @@ describe('useReferenceManyFieldController', () => {
                     target: 'author_id',
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
+                    filters: [],
                     filter: {},
+                    meta: undefined,
                 }
             );
         });
@@ -227,7 +229,9 @@ describe('useReferenceManyFieldController', () => {
                     target: 'author_id',
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
+                    filters: [],
                     filter: {},
+                    meta: undefined,
                 }
             );
         });
@@ -266,7 +270,9 @@ describe('useReferenceManyFieldController', () => {
                     target: 'author_id',
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'ASC' },
+                    filters: [],
                     filter: {},
+                    meta: undefined,
                 }
             );
         });

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
@@ -103,6 +103,7 @@ describe('useReferenceOneFieldController', () => {
                 pagination: { page: 1, perPage: 1 },
                 sort: { field: 'id', order: 'ASC' },
                 filter: {},
+                filters: [],
             });
         });
     });
@@ -172,6 +173,7 @@ describe('useReferenceOneFieldController', () => {
                     target: 'author_id',
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
+                    filters: [],
                     filter: {},
                 }
             );
@@ -214,6 +216,7 @@ describe('useReferenceOneFieldController', () => {
                     target: 'author_id',
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
+                    filters: [],
                     filter: {},
                 }
             );

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
@@ -49,7 +49,7 @@ export const useReferenceOneFieldController = (
             id: get(record, source),
             pagination: { page: 1, perPage: 1 },
             sort: { field: 'id', order: 'ASC' },
-            filter: {},
+            filters: [],
         },
         {
             enabled: !!record,

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
@@ -203,6 +203,7 @@ describe('useReferenceArrayInputController', () => {
                 field: 'id',
                 order: 'DESC',
             },
+            filters: [],
             filter: {},
             meta: undefined,
         });
@@ -241,6 +242,7 @@ describe('useReferenceArrayInputController', () => {
                 field: 'foo',
                 order: 'ASC',
             },
+            filters: [{ field: 'permanentFilter', value: 'foo' }],
             filter: { permanentFilter: 'foo' },
             meta: undefined,
         });
@@ -250,7 +252,7 @@ describe('useReferenceArrayInputController', () => {
         const children = jest.fn(({ setFilters }) => (
             <button
                 aria-label="Filter"
-                onClick={() => setFilters({ q: 'bar' })}
+                onClick={() => setFilters([{ field: 'q', value: 'bar' }])}
             />
         ));
         const dataProvider = testDataProvider({
@@ -283,6 +285,8 @@ describe('useReferenceArrayInputController', () => {
                     order: 'DESC',
                 },
                 filter: { q: 'bar' },
+                filters: [{ field: 'q', value: 'bar' }],
+                meta: undefined,
             });
         });
     });
@@ -321,7 +325,7 @@ describe('useReferenceArrayInputController', () => {
         const children = jest.fn(({ setFilters }) => (
             <button
                 aria-label="Filter"
-                onClick={() => setFilters({ q: 'bar' })}
+                onClick={() => setFilters([{ field: 'q', value: 'bar' }])}
             />
         ));
         const dataProvider = testDataProvider({
@@ -571,6 +575,7 @@ describe('useReferenceArrayInputController', () => {
                     order: 'DESC',
                 },
                 filter: {},
+                filters: [],
                 meta: undefined,
             });
         });
@@ -587,6 +592,7 @@ describe('useReferenceArrayInputController', () => {
                     order: 'DESC',
                 },
                 filter: {},
+                filters: [],
                 meta: undefined,
             });
         });
@@ -603,6 +609,7 @@ describe('useReferenceArrayInputController', () => {
                     order: 'ASC',
                 },
                 filter: {},
+                filters: [],
                 meta: undefined,
             });
         });
@@ -633,9 +640,13 @@ describe('useReferenceArrayInputController', () => {
     describe('enableGetChoices', () => {
         it('should not fetch possible values using getList on load but only when enableGetChoices returns true', async () => {
             const children = jest.fn().mockReturnValue(<div />);
-            const enableGetChoices = jest.fn().mockImplementation(({ q }) => {
-                return q ? q.length > 2 : false;
-            });
+            const enableGetChoices = jest
+                .fn()
+                .mockImplementation(
+                    filters =>
+                        filters.find(filter => filter.field === 'q')?.value
+                            .length > 2
+                );
             const dataProvider = testDataProvider({
                 getList: jest
                     .fn()
@@ -661,10 +672,10 @@ describe('useReferenceArrayInputController', () => {
             await waitFor(() => {
                 expect(dataProvider.getList).not.toHaveBeenCalled();
             });
-            expect(enableGetChoices).toHaveBeenCalledWith({});
+            expect(enableGetChoices).toHaveBeenCalledWith([]);
 
             const { setFilters } = children.mock.calls[0][0];
-            setFilters({ q: 'hello world' });
+            setFilters([{ field: 'q', value: 'hello world' }]);
 
             await waitFor(() => {
                 expect(dataProvider.getList).toHaveBeenCalledTimes(1);
@@ -678,9 +689,13 @@ describe('useReferenceArrayInputController', () => {
                     field: 'id',
                     order: 'DESC',
                 },
+                filters: [{ field: 'q', value: 'hello world' }],
                 filter: { q: 'hello world' },
+                meta: undefined,
             });
-            expect(enableGetChoices).toHaveBeenCalledWith({ q: 'hello world' });
+            expect(enableGetChoices).toHaveBeenCalledWith([
+                { field: 'q', value: 'hello world' },
+            ]);
         });
 
         it('should fetch current value using getMany even if enableGetChoices is returning false', async () => {

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -18,7 +18,7 @@ import { ListControllerResult } from './useListController';
  * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
  * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
  * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
+ * @prop {Object}   filters an array of filter values, e.g. [{ field: 'title', value: 'lorem' }, { field: 'nationality', value: 'fr' }]
  * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
  * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
@@ -57,7 +57,7 @@ export const ListContext = createContext<ListControllerResult>({
     data: null,
     defaultTitle: null,
     displayedFilters: null,
-    filterValues: null,
+    filters: null,
     hasNextPage: null,
     hasPreviousPage: null,
     hideFilter: null,

--- a/packages/ra-core/src/controller/list/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/list/ListFilterContext.tsx
@@ -39,7 +39,7 @@ import { ListControllerResult } from './useListController';
  */
 export const ListFilterContext = createContext<ListFilterContextValue>({
     displayedFilters: null,
-    filterValues: null,
+    filters: null,
     hideFilter: null,
     setFilters: null,
     showFilter: null,
@@ -49,7 +49,7 @@ export const ListFilterContext = createContext<ListFilterContextValue>({
 export type ListFilterContextValue = Pick<
     ListControllerResult,
     | 'displayedFilters'
-    | 'filterValues'
+    | 'filters'
     | 'hideFilter'
     | 'setFilters'
     | 'showFilter'
@@ -63,7 +63,7 @@ export const usePickFilterContext = (
         () =>
             pick(context, [
                 'displayedFilters',
-                'filterValues',
+                'filters',
                 'hideFilter',
                 'setFilters',
                 'showFilter',
@@ -72,7 +72,7 @@ export const usePickFilterContext = (
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [
             context.displayedFilters,
-            context.filterValues,
+            context.filters,
             context.hideFilter,
             context.setFilters,
             context.showFilter,

--- a/packages/ra-core/src/controller/list/convertFiltersToFilterItems.ts
+++ b/packages/ra-core/src/controller/list/convertFiltersToFilterItems.ts
@@ -1,0 +1,16 @@
+import { FilterPayload, FilterItem } from '../../types';
+
+export const convertFiltersToFilterItems = (
+    filters: FilterItem[] | FilterPayload
+): FilterItem[] => {
+    if (filters == null) return emptyArray;
+    if (Array.isArray(filters)) {
+        return filters;
+    }
+    return Object.keys(filters).map(key => ({
+        field: key,
+        value: filters[key],
+    }));
+};
+
+const emptyArray = [];

--- a/packages/ra-core/src/controller/list/index.ts
+++ b/packages/ra-core/src/controller/list/index.ts
@@ -1,3 +1,4 @@
+export * from './convertFiltersToFilterItems';
 export * from './ListBase';
 export * from './ListContext';
 export * from './ListContextProvider';

--- a/packages/ra-core/src/controller/list/queryReducer.spec.ts
+++ b/packages/ra-core/src/controller/list/queryReducer.spec.ts
@@ -14,67 +14,69 @@ describe('Query Reducer', () => {
             expect(updatedState.page).toEqual(2);
         });
         it('should not update the filter', () => {
-            const initialFilter = {};
+            const initialFilter = [];
             const updatedState = queryReducer(
-                {
-                    filter: initialFilter,
-                    page: 1,
-                },
+                { filters: initialFilter, page: 1 },
                 {
                     type: 'SET_PAGE',
                     payload: 2,
                 }
             );
-            expect(updatedState.filter).toEqual(initialFilter);
+            expect(updatedState.filters).toEqual(initialFilter);
         });
     });
-    describe('SET_FILTER action', () => {
+    describe('SET_FILTERS action', () => {
         it('should add new filter with given value when set', () => {
             const updatedState = queryReducer(
                 {},
                 {
-                    type: 'SET_FILTER',
-                    payload: { filter: { title: 'foo' } },
+                    type: 'SET_FILTERS',
+                    payload: { filters: [{ field: 'title', value: 'foo' }] },
                 }
             );
-            expect(updatedState.filter).toEqual({ title: 'foo' });
+            expect(updatedState.filters).toEqual([
+                { field: 'title', value: 'foo' },
+            ]);
         });
 
         it('should replace existing filter with given value', () => {
             const updatedState = queryReducer(
+                { filters: [{ field: 'title', value: 'foo' }] },
                 {
-                    filter: {
-                        title: 'foo',
-                    },
-                },
-                {
-                    type: 'SET_FILTER',
-                    payload: { filter: { title: 'bar' } },
+                    type: 'SET_FILTERS',
+                    payload: { filters: [{ field: 'title', value: 'bar' }] },
                 }
             );
 
-            expect(updatedState.filter).toEqual({ title: 'bar' });
+            expect(updatedState.filters).toEqual([
+                { field: 'title', value: 'bar' },
+            ]);
         });
 
         it('should add new filter and displayedFilter with given value when set', () => {
             const updatedState = queryReducer(
                 {},
                 {
-                    type: 'SET_FILTER',
+                    type: 'SET_FILTERS',
                     payload: {
-                        filter: { title: 'foo' },
+                        filters: [{ field: 'title', value: 'foo' }],
                         displayedFilters: { title: true },
                     },
                 }
             );
-            expect(updatedState.filter).toEqual({ title: 'foo' });
+            expect(updatedState.filters).toEqual([
+                { field: 'title', value: 'foo' },
+            ]);
             expect(updatedState.displayedFilters).toEqual({ title: true });
         });
 
         it('should reset page to 1', () => {
             const updatedState = queryReducer(
                 { page: 3 },
-                { type: 'SET_FILTER', payload: {} }
+                {
+                    type: 'SET_FILTERS',
+                    payload: { filters: [], displayedFilters: {} },
+                }
             );
             expect(updatedState.page).toEqual(1);
         });
@@ -83,7 +85,7 @@ describe('Query Reducer', () => {
         it('should add the filter to the displayed filters and set the filter value', () => {
             const updatedState = queryReducer(
                 {
-                    filter: { bar: 1 },
+                    filters: [{ field: 'bar', value: 1 }],
                     displayedFilters: { bar: true },
                 },
                 {
@@ -91,7 +93,10 @@ describe('Query Reducer', () => {
                     payload: { filterName: 'foo', defaultValue: 'bar' },
                 }
             );
-            expect(updatedState.filter).toEqual({ bar: 1, foo: 'bar' });
+            expect(updatedState.filters).toEqual([
+                { field: 'bar', value: 1 },
+                { field: 'foo', value: 'bar' },
+            ]);
             expect(updatedState.displayedFilters).toEqual({
                 bar: true,
                 foo: true,
@@ -100,13 +105,15 @@ describe('Query Reducer', () => {
 
         it('should work with false default value', () => {
             const updatedState = queryReducer(
-                { filter: {}, displayedFilters: {} },
+                { filters: [], displayedFilters: {} },
                 {
                     type: 'SHOW_FILTER',
                     payload: { filterName: 'foo', defaultValue: false },
                 }
             );
-            expect(updatedState.filter).toEqual({ foo: false });
+            expect(updatedState.filters).toEqual([
+                { field: 'foo', value: false },
+            ]);
             expect(updatedState.displayedFilters).toEqual({
                 foo: true,
             });
@@ -115,7 +122,7 @@ describe('Query Reducer', () => {
         it('should work without default value', () => {
             const updatedState = queryReducer(
                 {
-                    filter: { bar: 1 },
+                    filters: [{ field: 'bar', value: 1 }],
                     displayedFilters: { bar: true },
                 },
                 {
@@ -123,7 +130,7 @@ describe('Query Reducer', () => {
                     payload: { filterName: 'foo' },
                 }
             );
-            expect(updatedState.filter).toEqual({ bar: 1 });
+            expect(updatedState.filters).toEqual([{ field: 'bar', value: 1 }]);
             expect(updatedState.displayedFilters).toEqual({
                 bar: true,
                 foo: true,
@@ -133,7 +140,7 @@ describe('Query Reducer', () => {
         it('should not change an already shown filter', () => {
             const updatedState = queryReducer(
                 {
-                    filter: { foo: 1 },
+                    filters: [{ field: 'bar', value: 1 }],
                     displayedFilters: { foo: true },
                 },
                 {
@@ -141,7 +148,7 @@ describe('Query Reducer', () => {
                     payload: { filterName: 'foo', defaultValue: 'bar' },
                 }
             );
-            expect(updatedState.filter).toEqual({ foo: 1 });
+            expect(updatedState.filters).toEqual([{ field: 'bar', value: 1 }]);
             expect(updatedState.displayedFilters).toEqual({ foo: true });
         });
     });
@@ -149,7 +156,10 @@ describe('Query Reducer', () => {
         it('should remove the filter from the displayed filters and reset the filter value', () => {
             const updatedState = queryReducer(
                 {
-                    filter: { foo: 2, bar: 1 },
+                    filters: [
+                        { field: 'foo', value: 2 },
+                        { field: 'bar', value: 1 },
+                    ],
                     displayedFilters: { foo: true, bar: true },
                 },
                 {
@@ -157,7 +167,7 @@ describe('Query Reducer', () => {
                     payload: 'bar',
                 }
             );
-            expect(updatedState.filter).toEqual({ foo: 2 });
+            expect(updatedState.filters).toEqual([{ field: 'foo', value: 2 }]);
             expect(updatedState.displayedFilters).toEqual({
                 foo: true,
             });
@@ -166,7 +176,7 @@ describe('Query Reducer', () => {
         it('should do nothing if the filter is already hidden', () => {
             const updatedState = queryReducer(
                 {
-                    filter: { foo: 2 },
+                    filters: [{ field: 'foo', value: 2 }],
                     displayedFilters: { foo: true },
                 },
                 {
@@ -174,7 +184,7 @@ describe('Query Reducer', () => {
                     payload: 'bar',
                 }
             );
-            expect(updatedState.filter).toEqual({ foo: 2 });
+            expect(updatedState.filters).toEqual([{ field: 'foo', value: 2 }]);
             expect(updatedState.displayedFilters).toEqual({
                 foo: true,
             });
@@ -211,11 +221,7 @@ describe('Query Reducer', () => {
         });
         it("should set order as the opposite of the one in previous state when sort hasn't change", () => {
             const updatedState = queryReducer(
-                {
-                    sort: 'foo',
-                    order: SORT_DESC,
-                    page: 1,
-                },
+                { sort: 'foo', order: SORT_DESC, page: 1 },
                 {
                     type: 'SET_SORT',
                     payload: { field: 'foo' },
@@ -229,11 +235,7 @@ describe('Query Reducer', () => {
         });
         it("should set order as the opposite of the one in previous state even if order is specified in the payload when sort hasn't change", () => {
             const updatedState = queryReducer(
-                {
-                    sort: 'foo',
-                    order: SORT_DESC,
-                    page: 1,
-                },
+                { sort: 'foo', order: SORT_DESC, page: 1 },
                 {
                     type: 'SET_SORT',
                     payload: { field: 'foo', order: SORT_DESC },
@@ -249,9 +251,7 @@ describe('Query Reducer', () => {
     describe('SET_PER_PAGE action', () => {
         it('should update per page count', () => {
             const updatedState = queryReducer(
-                {
-                    perPage: 10,
-                },
+                { perPage: 10 },
                 {
                     type: 'SET_PER_PAGE',
                     payload: 25,

--- a/packages/ra-core/src/controller/list/useList.spec.tsx
+++ b/packages/ra-core/src/controller/list/useList.spec.tsx
@@ -31,7 +31,7 @@ describe('<useList />', () => {
         render(
             <UseList
                 data={data}
-                filter={{ title: 'world' }}
+                filter={[{ field: 'title', value: 'world' }]}
                 sort={{ field: 'id', order: 'ASC' }}
                 callback={callback}
             />
@@ -61,7 +61,7 @@ describe('<useList />', () => {
         render(
             <UseList
                 data={data}
-                filter={{ items: ['two', 'four', 'five'] }}
+                filter={[{ field: 'items', value: ['two', 'four', 'five'] }]}
                 sort={{ field: 'id', order: 'ASC' }}
                 callback={callback}
             />
@@ -200,7 +200,7 @@ describe('<useList />', () => {
 
         const { rerender } = render(
             <UseList
-                filter={{ title: 'world' }}
+                filter={[{ field: 'title', value: 'world' }]}
                 sort={{ field: 'id', order: 'ASC' }}
                 callback={callback}
             />
@@ -211,7 +211,7 @@ describe('<useList />', () => {
                 data={data}
                 isFetching={true}
                 isLoading={false}
-                filter={{ title: 'world' }}
+                filter={[{ field: 'title', value: 'world' }]}
                 sort={{ field: 'id', order: 'ASC' }}
                 callback={callback}
             />

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -20,6 +20,7 @@ import {
     sanitizeListRestProps,
 } from './useListController';
 import { CoreAdminContext } from '../../core';
+import { FilterItem } from '../../types';
 
 describe('useListController', () => {
     const defaultProps = {
@@ -51,16 +52,22 @@ describe('useListController', () => {
 
     describe('setFilters', () => {
         let clock;
-        let childFunction = ({ setFilters, filterValues }) => (
+        let childFunction = ({
+            setFilters,
+            filters,
+        }: {
+            setFilters: any;
+            filters?: FilterItem[];
+        }) => (
             // TODO: we shouldn't import mui components in ra-core
             <TextField
                 inputProps={{
                     'aria-label': 'search',
                 }}
                 type="text"
-                value={filterValues.q || ''}
+                value={filters.find(f => f.field === 'q')?.value || ''}
                 onChange={event => {
-                    setFilters({ q: event.target.value });
+                    setFilters([{ field: 'q', value: event.target.value }]);
                 }}
             />
         );
@@ -94,7 +101,7 @@ describe('useListController', () => {
 
             expect(storeSpy).toHaveBeenCalledTimes(1);
             expect(storeSpy).toHaveBeenCalledWith('posts.listParams', {
-                filter: { q: 'hello' },
+                filters: [{ field: 'q', value: 'hello' }],
                 order: 'ASC',
                 page: 1,
                 perPage: 10,
@@ -137,7 +144,7 @@ describe('useListController', () => {
             expect(storeSpy).toHaveBeenCalledTimes(2);
 
             expect(storeSpy).toHaveBeenCalledWith('posts.listParams', {
-                filter: {},
+                filters: [],
                 displayedFilters: { q: true },
                 order: 'ASC',
                 page: 1,
@@ -173,7 +180,9 @@ describe('useListController', () => {
             expect(getList).toHaveBeenCalledTimes(1);
             expect(getList).toHaveBeenCalledWith(
                 'posts',
-                expect.objectContaining({ filter: { foo: 1 } })
+                expect.objectContaining({
+                    filters: [{ field: 'foo', value: 1 }],
+                })
             );
 
             // Check that the permanent filter is not included in the displayedFilters and filterValues (passed to Filter form and button)
@@ -181,7 +190,7 @@ describe('useListController', () => {
             expect(children).toHaveBeenCalledWith(
                 expect.objectContaining({
                     displayedFilters: {},
-                    filterValues: {},
+                    filters: [],
                 })
             );
 
@@ -195,7 +204,9 @@ describe('useListController', () => {
             expect(getList).toHaveBeenCalledTimes(2);
             expect(getList).toHaveBeenCalledWith(
                 'posts',
-                expect.objectContaining({ filter: { foo: 2 } })
+                expect.objectContaining({
+                    filters: [{ field: 'foo', value: 2 }],
+                })
             );
             expect(children).toHaveBeenCalledTimes(2);
         });

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -7,10 +7,17 @@ import { useNotify } from '../../notification';
 import { useGetList, UseGetListHookValue } from '../../dataProvider';
 import { SORT_ASC } from './queryReducer';
 import { defaultExporter } from '../../export';
-import { FilterPayload, SortPayload, RaRecord, Exporter } from '../../types';
+import {
+    FilterPayload,
+    SortPayload,
+    RaRecord,
+    Exporter,
+    FilterItem,
+} from '../../types';
 import { useResourceContext, useGetResourceLabel } from '../../core';
 import { useRecordSelection } from './useRecordSelection';
 import { useListParams } from './useListParams';
+import { convertFiltersToFilterItems } from './convertFiltersToFilterItems';
 
 /**
  * Prepare data for the List view
@@ -35,10 +42,10 @@ export const useListController = <RecordType extends RaRecord = any>(
     const {
         disableAuthentication,
         exporter = defaultExporter,
-        filterDefaultValues,
+        filterDefaultValues = defaultFilter,
         sort = defaultSort,
         perPage = 10,
-        filter,
+        filter = defaultFilter,
         debounce = 500,
         disableSyncWithLocation,
         queryOptions,
@@ -62,7 +69,7 @@ export const useListController = <RecordType extends RaRecord = any>(
 
     const [query, queryModifiers] = useListParams({
         resource,
-        filterDefaultValues,
+        filterDefaultValues: convertFiltersToFilterItems(filterDefaultValues),
         sort,
         perPage,
         debounce,
@@ -87,7 +94,7 @@ export const useListController = <RecordType extends RaRecord = any>(
                 perPage: query.perPage,
             },
             sort: { field: query.sort, order: query.order },
-            filter: { ...query.filter, ...filter },
+            filters: [...query.filters, ...convertFiltersToFilterItems(filter)],
         },
         {
             keepPreviousData: true,
@@ -144,8 +151,7 @@ export const useListController = <RecordType extends RaRecord = any>(
         displayedFilters: query.displayedFilters,
         error,
         exporter,
-        filter,
-        filterValues: query.filterValues,
+        filters: query.filters,
         hideFilter: queryModifiers.hideFilter,
         isFetching,
         isLoading,
@@ -180,8 +186,8 @@ export interface ListControllerProps<RecordType extends RaRecord = any> {
      */
     disableSyncWithLocation?: boolean;
     exporter?: Exporter | false;
-    filter?: FilterPayload;
-    filterDefaultValues?: object;
+    filter?: FilterItem[] | FilterPayload;
+    filterDefaultValues?: FilterItem[] | FilterPayload;
     perPage?: number;
     queryOptions?: UseQueryOptions<{
         data: RecordType[];
@@ -207,8 +213,7 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     displayedFilters: any;
     error?: any;
     exporter?: Exporter | false;
-    filter?: FilterPayload;
-    filterValues: any;
+    filters: FilterItem[];
     hideFilter: (filterName: string) => void;
     isFetching: boolean;
     isLoading: boolean;
@@ -221,7 +226,7 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     resource: string;
     selectedIds: RecordType['id'][];
     setFilters: (
-        filters: any,
+        filters: FilterItem[],
         displayedFilters: any,
         debounce?: boolean
     ) => void;
@@ -233,6 +238,8 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     hasNextPage: boolean;
     hasPreviousPage: boolean;
 }
+
+const defaultFilter = [];
 
 export const injectedProps = [
     'sort',

--- a/packages/ra-core/src/controller/list/useListParams.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListParams.spec.tsx
@@ -20,18 +20,16 @@ describe('useListParams', () => {
                     perPage: 15,
                     sort: 'name',
                     order: SORT_ASC,
-                    filter: { name: 'marmelab' },
+                    filters: [{ field: 'name', value: 'marmelab' }],
                 },
-                params: {
+                savedParams: {
                     page: 1,
                     perPage: 10,
                     sort: 'city',
                     order: SORT_DESC,
-                    filter: {
-                        city: 'Dijon',
-                    },
+                    filters: [{ field: 'city', value: 'Dijon' }],
                 },
-                filterDefaultValues: {},
+                filterDefaultValues: [],
                 perPage: 50,
                 sort: {
                     field: 'company',
@@ -44,26 +42,22 @@ describe('useListParams', () => {
                 perPage: 15,
                 sort: 'name',
                 order: SORT_ASC,
-                filter: {
-                    name: 'marmelab',
-                },
+                filters: [{ field: 'name', value: 'marmelab' }],
             });
         });
         it('Extends the values from the location with those from the props', () => {
             const query = getQuery({
                 queryFromLocation: {
-                    filter: { name: 'marmelab' },
+                    filters: [{ field: 'name', value: 'marmelab' }],
                 },
-                params: {
+                savedParams: {
                     page: 1,
                     perPage: 10,
                     sort: 'city',
                     order: SORT_DESC,
-                    filter: {
-                        city: 'Dijon',
-                    },
+                    filters: [{ field: 'city', value: 'Dijon' }],
                 },
-                filterDefaultValues: {},
+                filterDefaultValues: [],
                 perPage: 50,
                 sort: {
                     field: 'company',
@@ -76,24 +70,20 @@ describe('useListParams', () => {
                 perPage: 50,
                 sort: 'company',
                 order: SORT_DESC,
-                filter: {
-                    name: 'marmelab',
-                },
+                filters: [{ field: 'name', value: 'marmelab' }],
             });
         });
-        it('Sets the values from the store if location does not have them', () => {
+        it('Uses the values from the store if location does not have them', () => {
             const query = getQuery({
                 queryFromLocation: {},
-                params: {
+                savedParams: {
                     page: 2,
                     perPage: 10,
                     sort: 'city',
                     order: SORT_DESC,
-                    filter: {
-                        city: 'Dijon',
-                    },
+                    filters: [{ field: 'city', value: 'Dijon' }],
                 },
-                filterDefaultValues: {},
+                filterDefaultValues: [],
                 perPage: 50,
                 sort: {
                     field: 'company',
@@ -106,23 +96,19 @@ describe('useListParams', () => {
                 perPage: 10,
                 sort: 'city',
                 order: SORT_DESC,
-                filter: {
-                    city: 'Dijon',
-                },
+                filters: [{ field: 'city', value: 'Dijon' }],
             });
         });
         it('Extends the values from the store with those from the props', () => {
             const query = getQuery({
                 queryFromLocation: {},
-                params: {
+                savedParams: {
                     page: 2,
                     sort: 'city',
                     order: SORT_DESC,
-                    filter: {
-                        city: 'Dijon',
-                    },
+                    filters: [{ field: 'city', value: 'Dijon' }],
                 },
-                filterDefaultValues: {},
+                filterDefaultValues: [],
                 perPage: 50,
                 sort: {
                     field: 'company',
@@ -135,16 +121,14 @@ describe('useListParams', () => {
                 perPage: 50,
                 sort: 'city',
                 order: SORT_DESC,
-                filter: {
-                    city: 'Dijon',
-                },
+                filters: [{ field: 'city', value: 'Dijon' }],
             });
         });
         it('Uses the filterDefaultValues if neither the location or the store have them', () => {
             const query = getQuery({
                 queryFromLocation: {},
-                params: {},
-                filterDefaultValues: { city: 'Nancy' },
+                savedParams: {},
+                filterDefaultValues: [{ field: 'city', value: 'Nancy' }],
                 perPage: 50,
                 sort: {
                     field: 'company',
@@ -157,9 +141,7 @@ describe('useListParams', () => {
                 perPage: 50,
                 sort: 'company',
                 order: SORT_DESC,
-                filter: {
-                    city: 'Nancy',
-                },
+                filters: [{ field: 'city', value: 'Nancy' }],
             });
         });
     });
@@ -217,7 +199,9 @@ describe('useListParams', () => {
                             '?' +
                             stringify({
                                 displayedFilters: JSON.stringify({ foo: true }),
-                                filter: JSON.stringify({ foo: 'bar' }),
+                                filters: JSON.stringify([
+                                    { field: 'foo', value: 'bar' },
+                                ]),
                                 sort: 'id',
                                 order: 'ASC',
                                 page: 1,
@@ -256,7 +240,9 @@ describe('useListParams', () => {
                             '?' +
                             stringify({
                                 displayedFilters: JSON.stringify({ foo: true }),
-                                filter: JSON.stringify({ foo: 'bar' }),
+                                filters: JSON.stringify([
+                                    { field: 'foo', value: 'bar' },
+                                ]),
                                 sort: 'id',
                                 order: 'ASC',
                                 page: 1,
@@ -298,7 +284,9 @@ describe('useListParams', () => {
                                 displayedFilters: JSON.stringify({
                                     'foo.bar': true,
                                 }),
-                                filter: JSON.stringify({ foo: { bar: 'baz' } }),
+                                filters: JSON.stringify([
+                                    { field: 'foo.bar', value: 'baz' },
+                                ]),
                                 sort: 'id',
                                 order: 'ASC',
                                 page: 1,
@@ -340,7 +328,9 @@ describe('useListParams', () => {
                                 displayedFilters: JSON.stringify({
                                     'foo.bar': true,
                                 }),
-                                filter: JSON.stringify({ foo: { bar: 'baz' } }),
+                                filters: JSON.stringify([
+                                    { field: 'foo.bar', value: 'baz' },
+                                ]),
                                 sort: 'id',
                                 order: 'ASC',
                                 page: 1,
@@ -397,7 +387,7 @@ describe('useListParams', () => {
                 order: 'ASC',
                 page: 10,
                 perPage: 10,
-                filter: {},
+                filters: [],
             });
         });
 

--- a/packages/ra-core/src/dataProvider/useGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.spec.tsx
@@ -10,7 +10,7 @@ const UseGetList = ({
     resource = 'posts',
     pagination = { page: 1, perPage: 10 },
     sort = { field: 'id', order: 'DESC' },
-    filter = {},
+    filters = [],
     options = {},
     meta = undefined,
     callback = null,
@@ -18,7 +18,7 @@ const UseGetList = ({
 }) => {
     const hookValue = useGetList(
         resource,
-        { pagination, sort, filter, meta },
+        { pagination, sort, filters, meta },
         options
     );
     if (callback) callback(hookValue);
@@ -40,6 +40,7 @@ describe('useGetList', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
             expect(dataProvider.getList).toBeCalledWith('posts', {
+                filters: [],
                 filter: {},
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
@@ -111,6 +112,7 @@ describe('useGetList', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledWith('posts', {
+                filters: [],
                 filter: {},
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
@@ -129,7 +131,7 @@ describe('useGetList', () => {
                 {
                     pagination: { page: 1, perPage: 10 },
                     sort: { field: 'id', order: 'DESC' },
-                    filter: {},
+                    filters: [],
                 },
             ],
             {

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -35,7 +35,7 @@ import { useDataProvider } from './useDataProvider';
  * @prop params.id The identifier of the record to look for in target, e.g. '123'
  * @prop params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
  * @prop params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
- * @prop params.filter The request filters, e.g. { title: 'hello, world' }
+ * @prop params.filters The request filters, e.g. [{ field: 'title', value: 'hello, world' }]
  * @prop params.meta Optional meta parameters
  *
  *
@@ -68,11 +68,15 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
         id,
         pagination = { page: 1, perPage: 25 },
         sort = { field: 'id', order: 'DESC' },
-        filter = {},
+        filters = [],
         meta,
     } = params;
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
+    const filterObject = filters.reduce((acc, curr) => {
+        acc[curr.field] = curr.value;
+        return acc;
+    }, {});
     const result = useQuery<
         GetManyReferenceResult<RecordType>,
         Error,
@@ -81,7 +85,7 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
         [
             resource,
             'getManyReference',
-            { target, id, pagination, sort, filter, meta },
+            { target, id, pagination, sort, filters, meta },
         ],
         () =>
             dataProvider
@@ -90,7 +94,9 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
                     id,
                     pagination,
                     sort,
-                    filter,
+                    filters,
+                    // FIXME: remove in V5
+                    filter: filterObject,
                     meta,
                 })
                 .then(({ data, total, pageInfo }) => ({

--- a/packages/ra-core/src/form/choices/ChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/ChoicesContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { FilterPayload, RaRecord, SortPayload } from '../../types';
+import { FilterItem, RaRecord, SortPayload } from '../../types';
 
 /**
  * Context to store choices and functions to retrieve them.
@@ -11,10 +11,9 @@ export const ChoicesContext = createContext<ChoicesContextValue>(undefined);
 export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     allChoices: RecordType[];
     availableChoices: RecordType[];
-    displayedFilters: any;
+    displayedFilters: { [key: string]: boolean };
     error?: any;
-    filter?: FilterPayload;
-    filterValues: any;
+    filters: FilterItem[];
     hasNextPage: boolean;
     hasPreviousPage: boolean;
     hideFilter: (filterName: string) => void;
@@ -26,8 +25,8 @@ export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     resource: string;
     selectedChoices: RecordType[];
     setFilters: (
-        filters: any,
-        displayedFilters: any,
+        filters: FilterItem[],
+        displayedFilters: { [key: string]: boolean },
         debounce?: boolean
     ) => void;
     setPage: (page: number) => void;

--- a/packages/ra-core/src/form/choices/useChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/useChoicesContext.ts
@@ -22,11 +22,7 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
                 options.displayedFilters ??
                 list.displayedFilters,
             error: context?.error ?? options.error ?? list.error,
-            filter: context?.filter ?? options.filter ?? list.filter,
-            filterValues:
-                context?.filterValues ??
-                options.filterValues ??
-                list.filterValues,
+            filters: context?.filters ?? options.filters ?? list.filters,
             hasNextPage:
                 context?.hasNextPage ?? options.hasNextPage ?? list.hasNextPage,
             hasPreviousPage:

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -120,10 +120,20 @@ export type DataProvider = {
     [key: string]: any;
 };
 
+export interface FilterItem {
+    field: string;
+    value: any;
+    operator?: string; // default: '='
+}
+
 export interface GetListParams {
-    pagination: PaginationPayload;
-    sort: SortPayload;
-    filter: any;
+    pagination?: PaginationPayload;
+    sort?: SortPayload;
+    /**
+     * @deprecated use filters instead
+     */
+    filter?: { [key: string]: string };
+    filters?: FilterItem[];
     meta?: any;
 }
 export interface GetListResult<RecordType extends RaRecord = any> {
@@ -154,9 +164,13 @@ export interface GetManyResult<RecordType extends RaRecord = any> {
 export interface GetManyReferenceParams {
     target: string;
     id: Identifier;
-    pagination: PaginationPayload;
-    sort: SortPayload;
-    filter: any;
+    pagination?: PaginationPayload;
+    sort?: SortPayload;
+    /**
+     * @deprecated use filters instead
+     */
+    filter?: { [key: string]: string };
+    filters?: FilterItem[];
     meta?: any;
 }
 export interface GetManyReferenceResult<RecordType extends RaRecord = any> {

--- a/packages/ra-core/src/util/removeEmpty.spec.ts
+++ b/packages/ra-core/src/util/removeEmpty.spec.ts
@@ -3,28 +3,47 @@ import removeEmpty from './removeEmpty';
 
 describe('removeEmpty', () => {
     it('should not remove any properties with no empty values', () => {
-        const obj = { foo: 'fooval', bar: 'barval' };
-        expect(removeEmpty({ ...obj })).toEqual(obj);
+        const obj = [
+            { field: 'foo', value: 'fooval' },
+            { field: 'bar', value: 'barval' },
+        ];
+        expect(removeEmpty(obj)).toEqual(obj);
     });
 
-    it('should remove the empty values with empty values', () => {
-        const input = { foo: '', bar: null };
-        expect(removeEmpty(input)).toEqual({});
+    it('should remove the empty values', () => {
+        const input = [
+            { field: 'foo', value: '' },
+            { field: 'bar', value: null },
+        ];
+        expect(removeEmpty(input)).toEqual([]);
     });
 
-    it('should remove whole empty object with a nested empty value', () => {
-        const input = { foo: 'val', bar: { baz: '' } };
-        expect(removeEmpty(input)).toEqual({ foo: 'val' });
+    it('should remove compound keys with an empty value', () => {
+        const input = [
+            { field: 'foo', value: 'val' },
+            { field: 'bar.baz', value: '' },
+        ];
+        expect(removeEmpty(input)).toEqual([{ field: 'foo', value: 'val' }]);
     });
 
     it('should remove nested undefined values', () => {
-        const input = { foo: 'val', bar: { baz: undefined } };
-        expect(removeEmpty(input)).toEqual({ foo: 'val' });
+        const input = [
+            { field: 'foo', value: 'val' },
+            { field: 'bar.baz', value: undefined },
+        ];
+        expect(removeEmpty(input)).toEqual([{ field: 'foo', value: 'val' }]);
     });
 
     it('should preserve dates', () => {
         const date = new Date();
-        const input = { foo: 'val', bar: { baz: '' }, date };
-        expect(removeEmpty(input)).toEqual({ foo: 'val', date });
+        const input = [
+            { field: 'foo', value: 'val' },
+            { field: 'bar.baz', value: '' },
+            { field: 'date', value: date },
+        ];
+        expect(removeEmpty(input)).toEqual([
+            { field: 'foo', value: 'val' },
+            { field: 'date', value: date },
+        ]);
     });
 });

--- a/packages/ra-core/src/util/removeEmpty.ts
+++ b/packages/ra-core/src/util/removeEmpty.ts
@@ -1,7 +1,5 @@
 import { shallowEqual } from './shallowEqual';
-
-const isObject = obj =>
-    obj && Object.prototype.toString.call(obj) === '[object Object]';
+import { FilterItem } from '../types';
 
 const isEmpty = obj =>
     obj instanceof Date
@@ -11,15 +9,7 @@ const isEmpty = obj =>
           obj === undefined ||
           shallowEqual(obj, {});
 
-const removeEmpty = object =>
-    Object.keys(object).reduce((acc, key) => {
-        let child = object[key];
-
-        if (isObject(object[key])) {
-            child = removeEmpty(object[key]);
-        }
-
-        return isEmpty(child) ? acc : { ...acc, [key]: child };
-    }, {});
+const removeEmpty = (filters: FilterItem[]) =>
+    filters.filter(filterItem => !isEmpty(filterItem.value));
 
 export default removeEmpty;

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -48,7 +48,17 @@ export default (
         const query = {
             sort: JSON.stringify([field, order]),
             range: JSON.stringify([rangeStart, rangeEnd]),
-            filter: JSON.stringify(params.filter),
+            filter: JSON.stringify(
+                params.filters.reduce((acc, curr) => {
+                    acc[
+                        typeof curr.operator === 'undefined' ||
+                        curr.operator === '='
+                            ? curr.field
+                            : `${curr.field}_${curr.operator}`
+                    ] = curr.value;
+                    return acc;
+                }, {})
+            ),
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
         const options =
@@ -103,10 +113,19 @@ export default (
         const query = {
             sort: JSON.stringify([field, order]),
             range: JSON.stringify([(page - 1) * perPage, page * perPage - 1]),
-            filter: JSON.stringify({
-                ...params.filter,
-                [params.target]: params.id,
-            }),
+            filter: JSON.stringify(
+                params.filters
+                    .concat({ field: params.target, value: params.id })
+                    .reduce((acc, curr) => {
+                        acc[
+                            typeof curr.operator === 'undefined' ||
+                            curr.operator === '='
+                                ? curr.field
+                                : `${curr.field}_${curr.operator}`
+                        ] = curr.value;
+                        return acc;
+                    }, {})
+            ),
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
         const options =


### PR DESCRIPTION
## Problem

- There can be only one filter per field. This forces us to use "fake" fields to add 2 conditions on a field (e.g. "between")
- filters use only the equality operator. This forces us to use "fake" fields to support operators (e.g. "gte")

## Solution

Filter values are stored internally as arrays, and can contain an operator.

```js
[
    { field: 'title' , value: 'Lorem Ipsum', operator: 'like' },
    { field: 'author_id', value: 123 },
]
```

Make the change backward compatible for existing dataProviders by having `useGetList` and `useGetManyReference` pass *both* the old and the new filters.

```js
useGetList('posts', { filters: [{ field: 'title', value: 'lorem ipsum' }] });
// dataProvider.getList('posts', {
    filters: [{ field: 'title', value: 'lorem ipsum' }],
    filter: { title: 'lorem ipsum' }
});
```

Supersedes #7122

- [x] Make ra-core hooks accept an array value for `filter` and `filterDefaultValues`
- [x] Rename `filterValues` to `filters` in contexts
- [x] Fix ra-core tyoes and tests
- [ ] Update ra-ui-materialui commponents
- [ ] Fix ra-ui-material-ui tests
- [ ] Update existing dataProviders to support the new syntax
- [ ] Update demos
- [ ] Update doc
- [ ] Add changelog