### PR TITLE
Disable fileinput remove button

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -310,6 +310,8 @@ If the default Dropzone label doesn't fit with your need, you can pass a `placeh
 
 Note that the file upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data. Check [this example](./DataProviders.md#extending-a-data-provider-example-of-file-upload) for base64 encoding data by extending the REST Client.
 
+The `FileInput` component accepts the prop `disableRemove`, which can be a boolean or function that accepts an uploaded file as an argument and returns a boolean. This prop is passed directly to the `FileInputPreview` component. When it returns true, the `FileInputPreview` remove button will be disabled, allowing for conditionally allowing users to remove files from the form.
+
 #### CSS API
 
 | Rule name       | Description                                                                       |

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -25,6 +25,7 @@ export const FileInput = (
         accept,
         children,
         className,
+        disableRemove,
         format,
         helperText,
         label,
@@ -187,6 +188,7 @@ export const FileInput = (
                                 file={file}
                                 onRemove={onRemove(file)}
                                 className={FileInputClasses.removeButton}
+                                disableRemove={disableRemove}
                             >
                                 {cloneElement(childrenElement as ReactElement, {
                                     record: file,
@@ -208,6 +210,7 @@ FileInput.propTypes = {
     ]),
     children: PropTypes.element,
     className: PropTypes.string,
+    disableRemove: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     id: PropTypes.string,
     isRequired: PropTypes.bool,
     label: PropTypes.string,
@@ -254,6 +257,7 @@ export interface FileInputProps
     labelMultiple?: string;
     labelSingle?: string;
     placeholder?: ReactNode;
+    disableRemove?: Function | boolean;
 }
 
 export interface FileInputOptions extends DropzoneOptions {

--- a/packages/ra-ui-materialui/src/input/FileInputPreview.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInputPreview.spec.tsx
@@ -42,6 +42,28 @@ describe('<FileInputPreview />', () => {
         expect(onRemoveSpy).toHaveBeenCalled();
     });
 
+    it('should render a disabled delete button if passed prop `disabled`', () => {
+        const onRemoveSpy = jest.fn();
+
+        const { getByLabelText } = render(
+            <FileInputPreview
+                {...defaultProps}
+                disableRemove={true}
+                onRemove={onRemoveSpy}
+            >
+                <div>Child</div>
+            </FileInputPreview>
+        );
+
+        const deleteButton = getByLabelText('ra.action.delete');
+
+        expect(deleteButton['disabled']).toEqual(true);
+
+        fireEvent.click(deleteButton);
+
+        expect(onRemoveSpy).not.toHaveBeenCalled();
+    });
+
     it('should render passed children', () => {
         const { queryByText } = render(
             <FileInputPreview {...defaultProps}>

--- a/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
@@ -12,6 +12,7 @@ export const FileInputPreview = (props: FileInputPreviewProps) => {
         classes: classesOverride,
         className,
         onRemove,
+        disableRemove,
         file,
         ...rest
     } = props;
@@ -28,6 +29,15 @@ export const FileInputPreview = (props: FileInputPreviewProps) => {
         };
     }, [file]);
 
+    const isDisabled = file => {
+        if (typeof disableRemove === 'boolean') {
+            return disableRemove;
+        } else if (typeof disableRemove === 'function') {
+            return disableRemove(file);
+        }
+        return false;
+    };
+
     return (
         <Root className={className} {...rest}>
             <IconButton
@@ -35,9 +45,16 @@ export const FileInputPreview = (props: FileInputPreviewProps) => {
                 onClick={onRemove}
                 aria-label={translate('ra.action.delete')}
                 title={translate('ra.action.delete')}
+                disabled={isDisabled(file)}
                 size="large"
             >
-                <RemoveCircle className={FileInputPreviewClasses.removeIcon} />
+                <RemoveCircle
+                    className={
+                        isDisabled(file)
+                            ? FileInputPreviewClasses.disabledRemoveIcon
+                            : FileInputPreviewClasses.removeIcon
+                    }
+                />
             </IconButton>
             {children}
         </Root>
@@ -49,6 +66,7 @@ FileInputPreview.propTypes = {
     className: PropTypes.string,
     file: PropTypes.object,
     onRemove: PropTypes.func.isRequired,
+    disableRemove: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 };
 
 FileInputPreview.defaultProps = {
@@ -60,6 +78,7 @@ const PREFIX = 'RaFileInputPreview';
 const FileInputPreviewClasses = {
     removeButton: `${PREFIX}-removeButton`,
     removeIcon: `${PREFIX}-removeIcon`,
+    disabledRemoveIcon: `${PREFIX}-disabledRemoveIcon`,
 };
 
 const Root = styled('div', { name: PREFIX })(({ theme }) => ({
@@ -67,6 +86,9 @@ const Root = styled('div', { name: PREFIX })(({ theme }) => ({
 
     [`& .${FileInputPreviewClasses.removeIcon}`]: {
         color: theme.palette.error.main,
+    },
+    [`& .${FileInputPreviewClasses.disabledRemoveIcon}`]: {
+        color: theme.palette.text.disabled,
     },
 }));
 
@@ -76,4 +98,5 @@ export interface FileInputPreviewProps {
     classes?: object;
     onRemove: () => void;
     file: any;
+    disableRemove?: Function | boolean;
 }


### PR DESCRIPTION
This PR features the prop "disableRemove" being passed to `FileInput`, and subsequently to child component `FileInputPreview`, where it can be used to conditionally disable the delete/remove button on a file's preview.