### PR TITLE
Update datagrid style overrides [RFR]

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -679,6 +679,7 @@ The `<Datagrid>` component accepts the usual `className` prop. You can also over
 | Rule name                      | Description                                      |
 | ------------------------------ | ------------------------------------------------ |
 | `& .RaDatagrid-table`          | Applied to the table element                     |
+| `& .RaDatagrid-tableWrapper`   | Applied to the div that wraps table element      |
 | `& .RaDatagrid-thead`          | Applied to the table header                      |
 | `& .RaDatagrid-tbody`          | Applied to the table body                        |
 | `& .RaDatagrid-headerCell`     | Applied to each header cell                      |

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -678,8 +678,8 @@ The `<Datagrid>` component accepts the usual `className` prop. You can also over
 
 | Rule name                      | Description                                      |
 | ------------------------------ | ------------------------------------------------ |
-| `& .RaDatagrid-table`          | Applied to the table element                     |
 | `& .RaDatagrid-tableWrapper`   | Applied to the div that wraps table element      |
+| `& .RaDatagrid-table`          | Applied to the table element                     |
 | `& .RaDatagrid-thead`          | Applied to the table header                      |
 | `& .RaDatagrid-tbody`          | Applied to the table body                        |
 | `& .RaDatagrid-headerCell`     | Applied to each header cell                      |

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -232,45 +232,47 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                             : defaultBulkActionButtons}
                     </BulkActionsToolbar>
                 ) : null}
-                <Table
-                    ref={ref}
-                    className={clsx(DatagridClasses.table, className)}
-                    size={size}
-                    {...sanitizeRestProps(rest)}
-                >
-                    {createOrCloneElement(
-                        header,
-                        {
-                            children,
-                            sort,
-                            data,
-                            hasExpand: !!expand,
-                            hasBulkActions,
-                            isRowSelectable,
-                            onSelect,
-                            resource,
-                            selectedIds,
-                            setSort,
-                        },
-                        children
-                    )}
-                    {createOrCloneElement(
-                        body,
-                        {
-                            expand,
-                            rowClick,
-                            data,
-                            hasBulkActions,
-                            hover,
-                            onToggleItem: handleToggleItem,
-                            resource,
-                            rowStyle,
-                            selectedIds,
-                            isRowSelectable,
-                        },
-                        children
-                    )}
-                </Table>
+                <div className={DatagridClasses.tableWrapper}>
+                    <Table
+                        ref={ref}
+                        className={clsx(DatagridClasses.table, className)}
+                        size={size}
+                        {...sanitizeRestProps(rest)}
+                    >
+                        {createOrCloneElement(
+                            header,
+                            {
+                                children,
+                                sort,
+                                data,
+                                hasExpand: !!expand,
+                                hasBulkActions,
+                                isRowSelectable,
+                                onSelect,
+                                resource,
+                                selectedIds,
+                                setSort,
+                            },
+                            children
+                        )}
+                        {createOrCloneElement(
+                            body,
+                            {
+                                expand,
+                                rowClick,
+                                data,
+                                hasBulkActions,
+                                hover,
+                                onToggleItem: handleToggleItem,
+                                resource,
+                                rowStyle,
+                                selectedIds,
+                                isRowSelectable,
+                            },
+                            children
+                        )}
+                    </Table>
+                </div>
             </DatagridRoot>
         </DatagridContextProvider>
     );

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
@@ -4,6 +4,7 @@ const PREFIX = 'RaDatagrid';
 
 export const DatagridClasses = {
     table: `${PREFIX}-table`,
+    tableWrapper: `${PREFIX}-tableWrapper`,
     thead: `${PREFIX}-thead`,
     tbody: `${PREFIX}-tbody`,
     headerRow: `${PREFIX}-headerRow`,
@@ -21,10 +22,11 @@ export const DatagridClasses = {
     expandedPanel: `${PREFIX}-expandedPanel`,
 };
 
-export const DatagridRoot = styled('div', { name: PREFIX })(({ theme }) => ({
+export const DatagridRoot = styled('div', { name: PREFIX, overridesResolver: (props, styles) => styles.root, })(({ theme }) => ({
     [`& .${DatagridClasses.table}`]: {
         tableLayout: 'auto',
     },
+    [`& .${DatagridClasses.tableWrapper}`]: {},
     [`& .${DatagridClasses.thead}`]: {},
     [`& .${DatagridClasses.tbody}`]: {},
     [`& .${DatagridClasses.headerRow}`]: {},

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
@@ -22,7 +22,10 @@ export const DatagridClasses = {
     expandedPanel: `${PREFIX}-expandedPanel`,
 };
 
-export const DatagridRoot = styled('div', { name: PREFIX, overridesResolver: (props, styles) => styles.root, })(({ theme }) => ({
+export const DatagridRoot = styled('div', {
+    name: PREFIX,
+    overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
     [`& .${DatagridClasses.table}`]: {
         tableLayout: 'auto',
     },


### PR DESCRIPTION
The datagrid override seems is forgotten in the first beta version.

This pull request also adds a table wrapper, so we can set a width for table and make a scroll bar appear right below the table.

(Previously in examples, the scrollbar always appears on the bottom of the page, when scrolling horizontally datagrid may cover the menu)