### PR TITLE
Fix inconsistencies in `ReferenceInput` and `ReferenceArrayInput`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3047,7 +3047,7 @@ const UserListFilter = [
 
 ### `<ReferenceInput>` and `<ReferenceArrayInput>` No Longer Accepts [Common Props](https://marmelab.com/react-admin/Inputs.html#common-input-props)
 
-Since they no longer inject props to their children. You have to pass this props to their child components.
+Since these components no longer inject props to their children, you have to pass these props to their children.
 
 ### `<ReferenceArrayInput>` No Longer Provides a `ListContext`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3047,7 +3047,32 @@ const UserListFilter = [
 
 ### `<ReferenceInput>` and `<ReferenceArrayInput>` No Longer Accepts [Common Props](https://marmelab.com/react-admin/Inputs.html#common-input-props)
 
-Since these components no longer inject props to their children, you have to pass these props to their children.
+Since these components no longer inject props to their children, you have to pass these props directly to them.
+
+```diff
+const UserInput = [
+    <ReferenceInput
+        source="email"
+        reference="users"
+-       label="User"
+-       validate={[required()]}
+-       fullWidth
+-       className="myCustomCLass"
+-       formClassName=="myCustomFormClass"
+-       helperText="Custom helper text"
+    >
+-        <AutocompleteInput />
++        <AutocompleteInput 
++            label="User" 
++            validate={[required()]}
++            fullWidth
++            className="myCustomClass"
++            formClassName=="myCustomFormClass"
++            helperText="Custom helper text"
++        />
+    </ReferenceInput>
+]
+```
 
 ### `<ReferenceArrayInput>` No Longer Provides a `ListContext`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3045,6 +3045,10 @@ const UserListFilter = [
 ]
 ```
 
+### `<ReferenceInput>` and `<ReferenceArrayInput>` No Longer Accepts [Common Props](https://marmelab.com/react-admin/Inputs.html#common-input-props)
+
+Since they no longer inject props to their children. You have to pass this props to their child components.
+
 ### `<ReferenceArrayInput>` No Longer Provides a `ListContext`
 
 As the `ChoicesContext` now provide an API very similar to the `ListContext`, it no longer sets up a `ListContext`. If you used this to display a `<Datagrid>`, we will soon provide the `<DatagridInput>` for this purpose.

--- a/docs/List.md
+++ b/docs/List.md
@@ -618,9 +618,9 @@ const PostList = () => {
     };
 
     return (
-        <Show queryOptions={{ onError }}>
+        <List queryOptions={{ onError }}>
             ...
-        </Show>
+        </List>
     );
 }
 ```

--- a/docs/ReferenceArrayInput.md
+++ b/docs/ReferenceArrayInput.md
@@ -41,7 +41,23 @@ import { ReferenceArrayInput, SelectArrayInput } from 'react-admin';
 
 ![SelectArrayInput](./img/select-array-input.gif)
 
-You can tweak how this component fetches the possible values using the `perPage`, `sort`, and `filter` props.
+## Properties
+
+| Prop               | Required | Type                                        | Default                            | Description                                                                                                         |
+|--------------------|----------|---------------------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `filter`           | Optional | `Object`                                    | `{}`                               | Permanent filters to use for getting the suggestion list                                                            |
+| `page`             | Optional | `number`                                    | 1                                  | The current page number                                                                                             |
+| `perPage`          | Optional | `number`                                    | 25                                 | Number of suggestions to show                                                                                       |
+| `reference`        | Required | `string`                                    | ''                                 | Name of the reference resource, e.g. 'posts'.                                                                       |
+| `sort`             | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }`   | How to order the list of suggestions                                                                                |
+| `enableGetChoices` | Optional | `({q: string}) => boolean`                  | `() => true`                       | Function taking the `filterValues` and returning a boolean to enable the `getList` call.                            |
+
+
+**Note**: `<ReferenceArrayInput>` doesn't accept the [common input props](./Inputs.md#common-input-props) is the responsability of children to apply them.
+
+## Usage
+
+You can tweak how this component fetches the possible values using the `page`, `perPage`, `sort`, and `filter` props.
 
 {% raw %}
 ```jsx
@@ -91,5 +107,3 @@ You can tweak how this component fetches the possible values using the `perPage`
     />
 </ReferenceArrayInput>
 ```
-
-`<ReferenceArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).

--- a/docs/ReferenceArrayInput.md
+++ b/docs/ReferenceArrayInput.md
@@ -53,7 +53,7 @@ import { ReferenceArrayInput, SelectArrayInput } from 'react-admin';
 | `enableGetChoices` | Optional | `({q: string}) => boolean`                  | `() => true`                       | Function taking the `filterValues` and returning a boolean to enable the `getList` call.                            |
 
 
-**Note**: `<ReferenceArrayInput>` doesn't accept the [common input props](./Inputs.md#common-input-props) is the responsability of children to apply them.
+**Note**: `<ReferenceArrayInput>` doesn't accept the [common input props](./Inputs.md#common-input-props) ; it is the responsability of children to apply them.
 
 ## Usage
 

--- a/docs/ReferenceInput.md
+++ b/docs/ReferenceInput.md
@@ -23,20 +23,21 @@ import { ReferenceInput, SelectInput } from 'react-admin';
 
 ## Properties
 
-| Prop               | Required | Type                                        | Default                               | Description                                                                                                           |
-|--------------------|----------|---------------------------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `filter`           | Optional | `Object`                                    | `{}`                                  | Permanent filters to use for getting the suggestion list                                                              |
-| `perPage`          | Optional | `number`                                    | 25                                    | Number of suggestions to show                                                                                         |
-| `reference`        | Required | `string`                                    | ''                                    | Name of the reference resource, e.g. 'posts'.                                                                         |
-| `sort`             | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }`      | How to order the list of suggestions                                                                                  |
-| `enableGetChoices` | Optional | `({q: string}) => boolean`                  | `() => true`                          | Function taking the `filterValues` and returning a boolean to enable the `getList` call.                              |
+| Prop               | Required | Type                                        | Default                          | Description                                                                                                       |
+|--------------------|----------|---------------------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `filter`           | Optional | `Object`                                    | `{}`                             | Permanent filters to use for getting the suggestion list                                                          |
+| `page`             | Optional | `number`                                    | 1                                | The current page number                                                                                           |
+| `perPage`          | Optional | `number`                                    | 25                               | Number of suggestions to show                                                                                     |
+| `reference`        | Required | `string`                                    | ''                               | Name of the reference resource, e.g. 'posts'.                                                                     |
+| `sort`             | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }` | How to order the list of suggestions                                                                              |
+| `enableGetChoices` | Optional | `({q: string}) => boolean`                  | `() => true`                     | Function taking the `filterValues` and returning a boolean to enable the `getList` call.                          |
 
 
-`<ReferenceInput>` also accepts the [common input props](./Inputs.md#common-input-props).
+**Note**: `<ReferenceInput>` doesn't accept the [common input props](./Inputs.md#common-input-props) is the responsability of children to apply them.
 
 ## Usage
 
-You can tweak how this component fetches the possible values using the `perPage`, `sort`, and `filter` props.
+You can tweak how this component fetches the possible values using the `page`, `perPage`, `sort`, and `filter` props.
 
 {% raw %}
 ```jsx

--- a/docs/ReferenceInput.md
+++ b/docs/ReferenceInput.md
@@ -33,7 +33,7 @@ import { ReferenceInput, SelectInput } from 'react-admin';
 | `enableGetChoices` | Optional | `({q: string}) => boolean`                  | `() => true`                     | Function taking the `filterValues` and returning a boolean to enable the `getList` call.                          |
 
 
-**Note**: `<ReferenceInput>` doesn't accept the [common input props](./Inputs.md#common-input-props) is the responsability of children to apply them.
+**Note**: `<ReferenceInput>` doesn't accept the [common input props](./Inputs.md#common-input-props) ; it is the responsability of children to apply them.
 
 ## Usage
 

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
@@ -223,6 +223,7 @@ describe('useReferenceArrayInputController', () => {
                         <ReferenceArrayInputController
                             {...defaultProps}
                             sort={{ field: 'foo', order: 'ASC' }}
+                            page={2}
                             perPage={5}
                             filter={{ permanentFilter: 'foo' }}
                         >
@@ -234,7 +235,7 @@ describe('useReferenceArrayInputController', () => {
         );
         expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
             pagination: {
-                page: 1,
+                page: 2,
                 perPage: 5,
             },
             sort: {

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
@@ -5,6 +5,7 @@ import { FilterPayload, RaRecord, SortPayload } from '../../types';
 import { useGetList, useGetManyAggregate } from '../../dataProvider';
 import { useReferenceParams } from './useReferenceParams';
 import { ChoicesContextValue } from '../../form';
+import { UseQueryOptions } from 'react-query';
 
 /**
  * Prepare data for the ReferenceArrayInput components
@@ -40,7 +41,7 @@ export const useReferenceArrayInputController = <
         page: initialPage = 1,
         perPage: initialPerPage = 25,
         sort: initialSort = { field: 'id', order: 'DESC' },
-        options = {},
+        queryOptions = {},
         reference,
         source,
     } = props;
@@ -101,7 +102,7 @@ export const useReferenceArrayInputController = <
             sort: { field: params.sort, order: params.order },
             filter: { ...params.filter, ...filter },
         },
-        { retry: false, enabled: isGetMatchingEnabled, ...options }
+        { retry: false, enabled: isGetMatchingEnabled, ...queryOptions }
     );
 
     // We merge the currently selected records with the matching ones, otherwise
@@ -180,7 +181,14 @@ export interface UseReferenceArrayInputParams<
 > {
     debounce?: number;
     filter?: FilterPayload;
-    options?: any;
+    queryOptions?: UseQueryOptions<{
+        data: RecordType[];
+        total?: number;
+        pageInfo?: {
+            hasNextPage?: boolean;
+            hasPreviousPage?: boolean;
+        };
+    }>;
     page?: number;
     perPage?: number;
     record?: RecordType;

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
@@ -37,6 +37,7 @@ export const useReferenceArrayInputController = <
         debounce,
         enableGetChoices,
         filter,
+        page: initialPage = 1,
         perPage: initialPerPage = 25,
         sort: initialSort = { field: 'id', order: 'DESC' },
         options = {},
@@ -66,6 +67,7 @@ export const useReferenceArrayInputController = <
 
     const [params, paramsModifiers] = useReferenceParams({
         resource: reference,
+        page: initialPage,
         perPage: initialPerPage,
         sort: initialSort,
         debounce,

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -5,6 +5,7 @@ import { FilterPayload, RaRecord, SortPayload } from '../../types';
 import { useReference } from '../useReference';
 import { ChoicesContextValue } from '../../form';
 import { useReferenceParams } from './useReferenceParams';
+import { UseQueryOptions } from 'react-query';
 
 const defaultReferenceSource = (resource: string, source: string) =>
     `${resource}@${source}`;
@@ -54,7 +55,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         page: initialPage = 1,
         perPage: initialPerPage = 25,
         sort: initialSort,
-        options = {},
+        queryOptions = {},
         reference,
         source,
     } = props;
@@ -96,7 +97,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         },
         {
             enabled: isGetMatchingEnabled,
-            ...options,
+            ...queryOptions,
         }
     );
 
@@ -168,10 +169,19 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
     };
 };
 
-export interface UseReferenceInputControllerParams {
+export interface UseReferenceInputControllerParams<
+    RecordType extends RaRecord = any
+> {
     debounce?: number;
     filter?: FilterPayload;
-    options?: any;
+    queryOptions?: UseQueryOptions<{
+        data: RecordType[];
+        total?: number;
+        pageInfo?: {
+            hasNextPage?: boolean;
+            hasPreviousPage?: boolean;
+        };
+    }>;
     page?: number;
     perPage?: number;
     record?: RaRecord;

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -53,8 +53,9 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         filter,
         page: initialPage = 1,
         perPage: initialPerPage = 25,
-        reference,
         sort: initialSort,
+        options = {},
+        reference,
         source,
     } = props;
 
@@ -64,6 +65,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         perPage: initialPerPage,
         sort: initialSort,
         debounce,
+        filter,
     });
 
     // selection logic
@@ -94,6 +96,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         },
         {
             enabled: isGetMatchingEnabled,
+            ...options,
         }
     );
 
@@ -168,6 +171,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
 export interface UseReferenceInputControllerParams {
     debounce?: number;
     filter?: FilterPayload;
+    options?: any;
     page?: number;
     perPage?: number;
     record?: RaRecord;

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
@@ -106,6 +106,7 @@ ReferenceArrayInput.propTypes = {
     className: PropTypes.string,
     filter: PropTypes.object,
     label: PropTypes.string,
+    page: PropTypes.number,
     perPage: PropTypes.number,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
@@ -118,6 +119,7 @@ ReferenceArrayInput.propTypes = {
 
 ReferenceArrayInput.defaultProps = {
     filter: {},
+    page: 1,
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
 };
@@ -126,6 +128,8 @@ export interface ReferenceArrayInputProps extends InputProps {
     children: ReactElement;
     className?: string;
     label?: string;
+    page?: number;
+    perPage?: number;
     reference: string;
     resource?: string;
     enableGetChoices?: (filters: any) => boolean;

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -109,6 +109,7 @@ ReferenceInput.propTypes = {
     filter: PropTypes.object,
     label: PropTypes.string,
     onChange: PropTypes.func,
+    page: PropTypes.number,
     perPage: PropTypes.number,
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
@@ -122,6 +123,7 @@ ReferenceInput.propTypes = {
 
 ReferenceInput.defaultProps = {
     filter: {},
+    page: 1,
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
 };
@@ -130,6 +132,7 @@ export interface ReferenceInputProps extends InputProps {
     children: ReactElement;
     className?: string;
     label?: string;
+    page?: number;
     perPage?: number;
     reference: string;
     // @deprecated


### PR DESCRIPTION
- [X] Improve documentation
- [X] Add common props upgrade reference to Upgrade Guide
- [X] `page` prop was not being used in `ReferenceArrayInput`
- [X] `options` prop was used in `useReferenceArrayInputController` but not in `useReferenceInputController` for the `getList` call
- [X] `filter` prop was not being used inside `useReferenceInputController`
- [X] Rename `options` prop to `queryOptions` and improve types in `useReferenceInputController` and `useReferenceArrayInputController`