### PR TITLE
fix: allow composition of child elements by using raName

### DIFF
--- a/packages/ra-core/src/core/CustomRoutes.tsx
+++ b/packages/ra-core/src/core/CustomRoutes.tsx
@@ -11,6 +11,8 @@ export const CustomRoutes = (props: CustomRoutesProps) => {
     return null;
 };
 
+CustomRoutes.raName = 'CustomRoutes';
+
 export type CustomRoutesProps = {
     children: ReactNode;
     noLayout?: boolean;

--- a/packages/ra-core/src/core/Resource.tsx
+++ b/packages/ra-core/src/core/Resource.tsx
@@ -39,3 +39,5 @@ export const Resource = (props: ResourceProps) => {
         </ResourceContextProvider>
     );
 };
+
+Resource.raName = 'Resource';

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -12,8 +12,7 @@ import {
     RenderResourcesFunction,
     ResourceProps,
 } from '../types';
-import { CustomRoutes, CustomRoutesProps } from './CustomRoutes';
-import { Resource } from './Resource';
+import { CustomRoutesProps } from './CustomRoutes';
 import { useRegisterResource } from './useRegisterResource';
 
 /**
@@ -226,7 +225,7 @@ const getRoutesAndResourceFromNodes = (children: ReactNode) => {
             resources.push(...customRoutesFromFragment.resources);
         }
 
-        if (element.type === CustomRoutes) {
+        if ((element.type as any).raName === 'CustomRoutes') {
             const customRoutesElement = element as ReactElement<
                 CustomRoutesProps
             >;
@@ -238,7 +237,7 @@ const getRoutesAndResourceFromNodes = (children: ReactNode) => {
             } else {
                 customRoutesWithLayout.push(customRoutesElement.props.children);
             }
-        } else if (element.type === Resource) {
+        } else if ((element.type as any).raName === 'Resource') {
             resources.push(element as ReactElement<ResourceProps>);
         }
     });


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/7284.

Like [mui does](https://mui.com/guides/composition/#wrapping-components), introduce a `raName` static on some child elements (`CustomRoutes` and `Resource`) in order to filter them in `useConfigureAdminRouterFromChildren`.

It will allow to compose components (for instance API Platform Admin [ResourceGuesser component](https://github.com/api-platform/admin/blob/main/src/ResourceGuesser.tsx)) by setting the same static property.