### PR TITLE
feat: Improve type hints around DataProvider

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -841,27 +841,6 @@ const App = () => {
 }
 ```
 
-### Changed Signature of DataProvider
-
-`DataProvider` is now implemented as a `type alias` wrapping an interface.
-
-To provide more functionality and better inference, the Generic signature of the methods have changed.
-
-#### Methods
-
-The previous signature of `.getList<Model>(...)` is no longer supported.
-
-The recommended upgrade path is to move defining your Models at the DataProvider level:
-
-```diff
--const dataProvider: DataProvider = {...};
--const results = dataProvider.getList<Model>('someResource');
-+const dataProvider: DataProvider<{someResource: Model}> = {...};
-+const results = dataProvider.getList('someResource');
-```
-
-For more complete examples, see `ra-data-fakerest` and `ra-data-localstorage`
-
 ## Auth Provider
 
 Some of the hooks allowing to call the `authProvider` methods are asynchronous: they return their result only when the `authProvider` promise resolves, and set the `loading` property to `true` until then.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -841,6 +841,27 @@ const App = () => {
 }
 ```
 
+### Changed Signature of DataProvider
+
+`DataProvider` is now implemented as a `type alias` wrapping an interface.
+
+To provide more functionality and better inference, the Generic signature of the methods have changed.
+
+#### Methods
+
+The previous signature of `.getList<Model>(...)` is no longer supported.
+
+The recommended upgrade path is to move defining your Models at the DataProvider level:
+
+```diff
+-const dataProvider: DataProvider = {...};
+-const results = dataProvider.getList<Model>('someResource');
++const dataProvider: DataProvider<{someResource: Model}> = {...};
++const results = dataProvider.getList('someResource');
+```
+
+For more complete examples, see `ra-data-fakerest` and `ra-data-localstorage`
+
 ## Auth Provider
 
 Some of the hooks allowing to call the `authProvider` methods are asynchronous: they return their result only when the `authProvider` promise resolves, and set the `loading` property to `true` until then.

--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -388,14 +388,14 @@ Content-Type: application/json
 
 Here is an example implementation, that you can use as a base for your own Data Providers:
 
-```js
-import { fetchUtils } from 'react-admin';
+```ts
+import { fetchUtils, DataProvider } from 'react-admin';
 import { stringify } from 'query-string';
 
 const apiUrl = 'https://my.api.com/';
 const httpClient = fetchUtils.fetchJson;
 
-export default {
+const MyDataProvider: DataProvider = {
     getList: (resource, params) => {
         const { page, perPage } = params.pagination;
         const { field, order } = params.sort;
@@ -452,7 +452,7 @@ export default {
 
     updateMany: (resource, params) => {
         const query = {
-            filter: JSON.stringify({ id: params.ids}),
+            filter: JSON.stringify({ id: params.ids }),
         };
         return httpClient(`${apiUrl}/${resource}?${stringify(query)}`, {
             method: 'PUT',
@@ -465,7 +465,7 @@ export default {
             method: 'POST',
             body: JSON.stringify(params.data),
         }).then(({ json }) => ({
-            data: { ...params.data, id: json.id },
+            data: { ...params.data, id: json.id as number },
         })),
 
     delete: (resource, params) =>
@@ -475,13 +475,14 @@ export default {
 
     deleteMany: (resource, params) => {
         const query = {
-            filter: JSON.stringify({ id: params.ids}),
+            filter: JSON.stringify({ id: params.ids }),
         };
         return httpClient(`${apiUrl}/${resource}?${stringify(query)}`, {
             method: 'DELETE',
-            body: JSON.stringify(params.data),
+            body: JSON.stringify(params.ids),
         }).then(({ json }) => ({ data: json }));
     },
 };
+export default MyDataProvider;
 ```
 

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -86,7 +86,7 @@ export const useCreate = <RecordType extends RaRecord = any>(
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .create<RecordType>(callTimeResource, {
+                .create<string, RecordType>(callTimeResource, {
                     data: callTimeData,
                     meta: callTimeMeta,
                 })

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -86,7 +86,7 @@ export const useCreate = <RecordType extends RaRecord = any>(
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .create<string, RecordType>(callTimeResource, {
+                .create<RecordType>(callTimeResource, {
                     data: callTimeData,
                     meta: callTimeMeta,
                 })
@@ -144,13 +144,12 @@ export interface UseCreateMutateParams<RecordType extends RaRecord = any> {
     meta?: any;
 }
 
-export type UseCreateOptions<
-    RecordType extends RaRecord = any
-> = UseMutationOptions<
-    RecordType,
-    unknown,
-    Partial<UseCreateMutateParams<RecordType>>
->;
+export type UseCreateOptions<RecordType extends RaRecord = any> =
+    UseMutationOptions<
+        RecordType,
+        unknown,
+        Partial<UseCreateMutateParams<RecordType>>
+    >;
 
 export type UseCreateResult<
     RecordType extends RaRecord = any,

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -151,7 +151,7 @@ export const useDelete = <RecordType extends RaRecord = any>(
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .delete<RecordType>(callTimeResource, {
+                .delete<string, RecordType>(callTimeResource, {
                     id: callTimeId,
                     previousData: callTimePreviousData,
                     meta: callTimeMeta,

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -151,7 +151,7 @@ export const useDelete = <RecordType extends RaRecord = any>(
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .delete<string, RecordType>(callTimeResource, {
+                .delete<RecordType>(callTimeResource, {
                     id: callTimeId,
                     previousData: callTimePreviousData,
                     meta: callTimeMeta,
@@ -387,13 +387,12 @@ export interface UseDeleteMutateParams<RecordType extends RaRecord = any> {
     meta?: any;
 }
 
-export type UseDeleteOptions<
-    RecordType extends RaRecord = any
-> = UseMutationOptions<
-    RecordType,
-    unknown,
-    Partial<UseDeleteMutateParams<RecordType>>
-> & { mutationMode?: MutationMode };
+export type UseDeleteOptions<RecordType extends RaRecord = any> =
+    UseMutationOptions<
+        RecordType,
+        unknown,
+        Partial<UseDeleteMutateParams<RecordType>>
+    > & { mutationMode?: MutationMode };
 
 export type UseDeleteResult<RecordType extends RaRecord = any> = [
     (

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -163,7 +163,7 @@ export const useDeleteMany = <RecordType extends RaRecord = any>(
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .deleteMany<RecordType>(callTimeResource, {
+                .deleteMany(callTimeResource, {
                     ids: callTimeIds,
                     meta: callTimeMeta,
                 })

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -163,7 +163,7 @@ export const useDeleteMany = <RecordType extends RaRecord = any>(
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .deleteMany(callTimeResource, {
+                .deleteMany<RecordType>(callTimeResource, {
                     ids: callTimeIds,
                     meta: callTimeMeta,
                 })
@@ -393,13 +393,12 @@ export interface UseDeleteManyMutateParams<RecordType extends RaRecord = any> {
     meta?: any;
 }
 
-export type UseDeleteManyOptions<
-    RecordType extends RaRecord = any
-> = UseMutationOptions<
-    RecordType['id'][],
-    unknown,
-    Partial<UseDeleteManyMutateParams<RecordType>>
-> & { mutationMode?: MutationMode };
+export type UseDeleteManyOptions<RecordType extends RaRecord = any> =
+    UseMutationOptions<
+        RecordType['id'][],
+        unknown,
+        Partial<UseDeleteManyMutateParams<RecordType>>
+    > & { mutationMode?: MutationMode };
 
 export type UseDeleteManyResult<RecordType extends RaRecord = any> = [
     (

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -71,7 +71,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
         [resource, 'getList', { pagination, sort, filter, meta }],
         () =>
             dataProvider
-                .getList<RecordType>(resource, {
+                .getList<string, RecordType>(resource, {
                     pagination,
                     sort,
                     filter,

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -71,7 +71,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
         [resource, 'getList', { pagination, sort, filter, meta }],
         () =>
             dataProvider
-                .getList<string, RecordType>(resource, {
+                .getList<RecordType>(resource, {
                     pagination,
                     sort,
                     filter,
@@ -96,14 +96,16 @@ export const useGetList = <RecordType extends RaRecord = any>(
         }
     );
 
-    return (result.data
-        ? {
-              ...result,
-              data: result.data?.data,
-              total: result.data?.total,
-              pageInfo: result.data?.pageInfo,
-          }
-        : result) as UseQueryResult<RecordType[], Error> & {
+    return (
+        result.data
+            ? {
+                  ...result,
+                  data: result.data?.data,
+                  total: result.data?.total,
+                  pageInfo: result.data?.pageInfo,
+              }
+            : result
+    ) as UseQueryResult<RecordType[], Error> & {
         total?: number;
         pageInfo?: {
             hasNextPage?: boolean;
@@ -112,12 +114,11 @@ export const useGetList = <RecordType extends RaRecord = any>(
     };
 };
 
-export type UseGetListHookValue<
-    RecordType extends RaRecord = any
-> = UseQueryResult<RecordType[], Error> & {
-    total?: number;
-    pageInfo?: {
-        hasNextPage?: boolean;
-        hasPreviousPage?: boolean;
+export type UseGetListHookValue<RecordType extends RaRecord = any> =
+    UseQueryResult<RecordType[], Error> & {
+        total?: number;
+        pageInfo?: {
+            hasNextPage?: boolean;
+            hasPreviousPage?: boolean;
+        };
     };
-};

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -63,7 +63,7 @@ export const useGetMany = <RecordType extends RaRecord = any>(
         [resource, 'getMany', { ids: ids.map(id => String(id)), meta }],
         () =>
             dataProvider
-                .getMany<RecordType>(resource, { ids, meta })
+                .getMany<string, RecordType>(resource, { ids, meta })
                 .then(({ data }) => data),
         {
             placeholderData: () => {

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -63,7 +63,7 @@ export const useGetMany = <RecordType extends RaRecord = any>(
         [resource, 'getMany', { ids: ids.map(id => String(id)), meta }],
         () =>
             dataProvider
-                .getMany<string, RecordType>(resource, { ids, meta })
+                .getMany<RecordType>(resource, { ids, meta })
                 .then(({ data }) => data),
         {
             placeholderData: () => {
@@ -96,6 +96,5 @@ export const useGetMany = <RecordType extends RaRecord = any>(
     );
 };
 
-export type UseGetManyHookValue<
-    RecordType extends RaRecord = any
-> = UseQueryResult<RecordType[], Error>;
+export type UseGetManyHookValue<RecordType extends RaRecord = any> =
+    UseQueryResult<RecordType[], Error>;

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -85,7 +85,7 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
         ],
         () =>
             dataProvider
-                .getManyReference<string, RecordType>(resource, {
+                .getManyReference<RecordType>(resource, {
                     target,
                     id,
                     pagination,
@@ -112,14 +112,16 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
         }
     );
 
-    return (result.data
-        ? {
-              ...result,
-              data: result.data?.data,
-              total: result.data?.total,
-              pageInfo: result.data?.pageInfo,
-          }
-        : result) as UseQueryResult<RecordType[], Error> & {
+    return (
+        result.data
+            ? {
+                  ...result,
+                  data: result.data?.data,
+                  total: result.data?.total,
+                  pageInfo: result.data?.pageInfo,
+              }
+            : result
+    ) as UseQueryResult<RecordType[], Error> & {
         total?: number;
         pageInfo?: {
             hasNextPage?: boolean;
@@ -128,12 +130,11 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
     };
 };
 
-export type UseGetManyReferenceHookValue<
-    RecordType extends RaRecord = any
-> = UseQueryResult<RecordType[], Error> & {
-    total?: number;
-    pageInfo?: {
-        hasNextPage?: boolean;
-        hasPreviousPage?: boolean;
+export type UseGetManyReferenceHookValue<RecordType extends RaRecord = any> =
+    UseQueryResult<RecordType[], Error> & {
+        total?: number;
+        pageInfo?: {
+            hasNextPage?: boolean;
+            hasPreviousPage?: boolean;
+        };
     };
-};

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -85,7 +85,7 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
         ],
         () =>
             dataProvider
-                .getManyReference<RecordType>(resource, {
+                .getManyReference<string, RecordType>(resource, {
                     target,
                     id,
                     pagination,

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -53,12 +53,11 @@ export const useGetOne = <RecordType extends RaRecord = any>(
         [resource, 'getOne', { id: String(id), meta }],
         () =>
             dataProvider
-                .getOne<string, RecordType>(resource, { id, meta })
+                .getOne<RecordType>(resource, { id, meta })
                 .then(({ data }) => data),
         options
     );
 };
 
-export type UseGetOneHookValue<
-    RecordType extends RaRecord = any
-> = UseQueryResult<RecordType>;
+export type UseGetOneHookValue<RecordType extends RaRecord = any> =
+    UseQueryResult<RecordType>;

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -53,7 +53,7 @@ export const useGetOne = <RecordType extends RaRecord = any>(
         [resource, 'getOne', { id: String(id), meta }],
         () =>
             dataProvider
-                .getOne<RecordType>(resource, { id, meta })
+                .getOne<string, RecordType>(resource, { id, meta })
                 .then(({ data }) => data),
         options
     );

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -151,7 +151,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
             previousData: callTimePreviousData = paramsRef.current.previousData,
         } = {}) =>
             dataProvider
-                .update<RecordType>(callTimeResource, {
+                .update<string, RecordType>(callTimeResource, {
                     id: callTimeId,
                     data: callTimeData,
                     previousData: callTimePreviousData,

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -151,7 +151,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
             previousData: callTimePreviousData = paramsRef.current.previousData,
         } = {}) =>
             dataProvider
-                .update<string, RecordType>(callTimeResource, {
+                .update<RecordType>(callTimeResource, {
                     id: callTimeId,
                     data: callTimeData,
                     previousData: callTimePreviousData,
@@ -265,13 +265,8 @@ export const useUpdate = <RecordType extends RaRecord = any>(
             unknown
         > & { mutationMode?: MutationMode; returnPromise?: boolean } = {}
     ) => {
-        const {
-            mutationMode,
-            returnPromise,
-            onSuccess,
-            onSettled,
-            onError,
-        } = updateOptions;
+        const { mutationMode, returnPromise, onSuccess, onSettled, onError } =
+            updateOptions;
 
         // store the hook time params *at the moment of the call*
         // because they may change afterwards, which would break the undoable mode
@@ -421,13 +416,12 @@ export interface UseUpdateMutateParams<RecordType extends RaRecord = any> {
     meta?: any;
 }
 
-export type UseUpdateOptions<
-    RecordType extends RaRecord = any
-> = UseMutationOptions<
-    RecordType,
-    unknown,
-    Partial<UseUpdateMutateParams<RecordType>>
-> & { mutationMode?: MutationMode };
+export type UseUpdateOptions<RecordType extends RaRecord = any> =
+    UseMutationOptions<
+        RecordType,
+        unknown,
+        Partial<UseUpdateMutateParams<RecordType>>
+    > & { mutationMode?: MutationMode };
 
 export type UseUpdateResult<
     RecordType extends RaRecord = any,

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -9,10 +9,10 @@ import { AuthActionType } from './auth/types';
 
 export type Identifier = string | number;
 
-export interface RaRecord {
+export type RaRecord = {
     id: Identifier;
     [key: string]: any;
-}
+};
 
 export interface SortPayload {
     field: string;
@@ -42,12 +42,12 @@ export type I18nProvider = {
     [key: string]: any;
 };
 
-export interface UserIdentity {
+export type UserIdentity = {
     id: Identifier;
     fullName?: string;
     avatar?: string;
     [key: string]: any;
-}
+};
 
 /**
  * authProvider types
@@ -72,54 +72,105 @@ export type LegacyAuthProvider = (
  * dataProvider types
  */
 
-export type DataProvider<ResourceType extends string = string> = {
-    getList: <RecordType extends RaRecord = any>(
+// Hack: persists literal keys, while allowing normal strings.
+type LooseStringKeyOf<T> = (keyof T & string) | (string & {});
+export interface RegisterDataProvider {
+    [K: string]: RaRecord;
+}
+export type DataProviderDefinition =
+    | Partial<RegisterDataProvider>
+    | {
+          [K: string]: RaRecord;
+      };
+
+export interface BaseDataProvider<
+    ResourceDefinition extends DataProviderDefinition
+> {
+    getList: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: GetListParams
     ) => Promise<GetListResult<RecordType>>;
 
-    getOne: <RecordType extends RaRecord = any>(
+    getOne: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: GetOneParams
     ) => Promise<GetOneResult<RecordType>>;
 
-    getMany: <RecordType extends RaRecord = any>(
+    getMany: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: GetManyParams
     ) => Promise<GetManyResult<RecordType>>;
 
-    getManyReference: <RecordType extends RaRecord = any>(
+    getManyReference: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: GetManyReferenceParams
     ) => Promise<GetManyReferenceResult<RecordType>>;
 
-    update: <RecordType extends RaRecord = any>(
+    update: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: UpdateParams
     ) => Promise<UpdateResult<RecordType>>;
 
-    updateMany: <RecordType extends RaRecord = any>(
+    updateMany: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: UpdateManyParams
     ) => Promise<UpdateManyResult<RecordType>>;
 
-    create: <RecordType extends RaRecord = any>(
+    create: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: CreateParams
     ) => Promise<CreateResult<RecordType>>;
 
-    delete: <RecordType extends RaRecord = any>(
+    delete: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: DeleteParams<RecordType>
     ) => Promise<DeleteResult<RecordType>>;
 
-    deleteMany: <RecordType extends RaRecord = any>(
+    deleteMany: <
+        ResourceType extends LooseStringKeyOf<ResourceDefinition>,
+        RecordType extends RaRecord = ResourceDefinition[ResourceType]
+    >(
         resource: ResourceType,
         params: DeleteManyParams<RecordType>
     ) => Promise<DeleteManyResult<RecordType>>;
 
     [key: string]: any;
-};
+}
+
+// Backwards compatibility, acts a translation layer, so `DataProvider<string>` is still valid.
+export type DataProvider<
+    MaybeResourceDefinition extends
+        | string
+        | DataProviderDefinition = DataProviderDefinition
+> = BaseDataProvider<
+    MaybeResourceDefinition extends string
+        ? DataProviderDefinition[MaybeResourceDefinition]
+        : MaybeResourceDefinition
+>;
 
 export interface GetListParams {
     pagination: PaginationPayload;

--- a/packages/ra-data-fakerest/src/index.ts
+++ b/packages/ra-data-fakerest/src/index.ts
@@ -33,7 +33,18 @@ function log(type, resource, params, response) {
  *   ],
  * })
  */
-export default (data, loggingEnabled = false): DataProvider => {
+export default <
+    T extends {
+        // Don't use Record, it pushes the Literals to the end
+        [P in keyof T & string];
+    },
+    // Workaround, to keep Literals in the hint
+    // See: https://github.com/microsoft/TypeScript/issues/29729
+    ResourceName extends string = (keyof T & string) | (string & {})
+>(
+    data: T,
+    loggingEnabled = false
+): DataProvider<ResourceName> => {
     const restServer = new FakeRest.Server();
     restServer.init(data);
     if (typeof window !== 'undefined') {
@@ -116,7 +127,7 @@ export default (data, loggingEnabled = false): DataProvider => {
      * @param {Object} params The data request params, depending on the type
      * @returns {Promise} The response
      */
-    const handle = (type, resource, params): Promise<any> => {
+    const handle = (type, resource: ResourceName, params): Promise<any> => {
         const collection = restServer.getCollection(resource);
         if (!collection && type !== 'create') {
             const error = new UndefinedResourceError(

--- a/packages/ra-data-fakerest/src/index.ts
+++ b/packages/ra-data-fakerest/src/index.ts
@@ -18,12 +18,9 @@ type ExtractArray<T> = T extends Array<infer U> ? U : never;
 type FakeData<T = { [k: string]: RaRecord[] }> = {
     [P in keyof T & string]: RaRecord[];
 };
-type ExtractDataProviderDefinition<
-    T extends {
-        // Don't use Record, it pushes the Literals to the end
-        [P in keyof T & string]: RaRecord[];
-    }
-> = {};
+type ExtractDataProviderDefinition<T extends FakeData<T>> = {
+    [P in keyof T]: ExtractArray<T[P]>;
+};
 
 /**
  * Respond to react-admin data queries using a local JavaScript object
@@ -46,9 +43,7 @@ type ExtractDataProviderDefinition<
  */
 export default <
     T extends FakeData<T>,
-    ResourceDefintion extends DataProviderDefinition = {
-        [P in keyof T]: ExtractArray<T[P]>;
-    }
+    ResourceDefintion extends DataProviderDefinition = ExtractDataProviderDefinition<T>
 >(
     data: T,
     loggingEnabled = false


### PR DESCRIPTION
This moves `DataProvider` to be an interface, which allows for end-users to have better inference.

Some immediate wins included:
- FakeServer has been updated to infer types for end-users, speeding up prototyping
- LocalStorage can now discard its type definitions, cleaning the implementation (example of how this change improves life for end-users)
- Ability to inject known records (docs todo)

Example from the CRM project:
![image](https://user-images.githubusercontent.com/2099618/157041359-12b9b56f-9030-4237-9e3b-72a25d0018fc.png)

Future PR:
- wire up hooks to fetch their types from the `DataProvider` definition
  _This might cause problems if you have parallel Admin panels running, as types are global, whereas DP is scoped to a component's context provider. If wanted, we can setup a registry-registry to represent distinct entrypoints of the DP. Sounds messy, but let me know if this is a known usecase._

closes: #7326