### PR TITLE
fix(core): Dependency loop on ra-i18n-polyglot

### DIFF
--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -35,7 +35,6 @@
         "history": "^5.1.0",
         "ignore-styles": "~5.0.1",
         "npm-dts": "^1.3.10",
-        "ra-i18n-polyglot": "^4.0.0-beta.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.25.0",

--- a/packages/ra-core/src/form/ValidationError.spec.tsx
+++ b/packages/ra-core/src/form/ValidationError.spec.tsx
@@ -1,33 +1,31 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import ValidationError from './ValidationError';
-import { I18nContextProvider } from '../i18n';
+import { TestTranslationProvider } from '../i18n';
 
 const translate = jest.fn(key => key);
 
 const renderWithTranslations = content =>
     render(
-        <I18nContextProvider
-            value={polyglotI18nProvider(() => ({
+        <TestTranslationProvider
+            messages={{
                 ra: {
-                    // @ts-ignore
                     validation: {
                         required: 'Required',
-                        minValue: 'Min Value %{value}',
-                        oneOf: 'Must be one of %{list}',
+                        minValue: ({ value }) => `Min Value ${value}`,
+                        oneOf: ({ list }) => `Must be one of ${list}`,
                     },
                 },
                 myapp: {
                     validation: {
-                        match: 'Must match %{match}',
+                        match: ({ match }) => `Must match ${match}`,
                     },
                 },
-            }))}
+            }}
         >
             {content}
-        </I18nContextProvider>
+        </TestTranslationProvider>
     );
 
 describe('ValidationError', () => {

--- a/packages/ra-core/src/i18n/TestTranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TestTranslationProvider.tsx
@@ -11,10 +11,14 @@ export const TestTranslationProvider = ({
     <I18nContextProvider
         value={{
             translate: messages
-                ? (key: string, options?: any) =>
-                      lodashGet(messages, key)
-                          ? lodashGet(messages, key)
-                          : options._
+                ? (key: string, options?: any) => {
+                      const message = lodashGet(messages, key);
+                      return message
+                          ? typeof message === 'function'
+                              ? message(options)
+                              : message
+                          : options._;
+                  }
                 : translate,
             changeLocale: () => Promise.resolve(),
             getLocale: () => 'en',

--- a/yarn.lock
+++ b/yarn.lock
@@ -24952,7 +24952,6 @@ __metadata:
     npm-dts: ^1.3.10
     prop-types: ^15.6.1
     query-string: ^7.1.1
-    ra-i18n-polyglot: ^4.0.0-beta.2
     react: ^17.0.0
     react-dom: ^17.0.0
     react-hook-form: ^7.25.0


### PR DESCRIPTION
Core us used by most, so remove the ra-i18n-polyglot dev dependency.

This causes a dependency cycle while trying to build.

Implement a basic way of doing interpolation so we can test variables get passed correctly.

Closes: #7361 