### PR TITLE
fix: register resource inside the component

### DIFF
--- a/packages/ra-core/src/core/Resource.tsx
+++ b/packages/ra-core/src/core/Resource.tsx
@@ -1,34 +1,12 @@
 import * as React from 'react';
-import { isValidElement, useEffect } from 'react';
+import { isValidElement } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { ResourceProps } from '../types';
 import { ResourceContextProvider } from './ResourceContextProvider';
-import { useRegisterResource } from './useRegisterResource';
 
 export const Resource = (props: ResourceProps) => {
-    const registerResource = useRegisterResource();
-    const {
-        create: Create,
-        edit: Edit,
-        icon,
-        list: List,
-        name,
-        options,
-        show: Show,
-    } = props;
-
-    useEffect(() => {
-        registerResource({
-            name: name,
-            options: options,
-            hasList: !!List,
-            hasCreate: !!Create,
-            hasEdit: !!Edit,
-            hasShow: !!Show,
-            icon: icon,
-        });
-    }, [registerResource, name, options, List, Create, Edit, Show, icon]);
+    const { create: Create, edit: Edit, list: List, name, show: Show } = props;
 
     return (
         <ResourceContextProvider value={name}>
@@ -63,3 +41,21 @@ export const Resource = (props: ResourceProps) => {
 };
 
 Resource.raName = 'Resource';
+
+Resource.registerResource = ({
+    create,
+    edit,
+    icon,
+    list,
+    name,
+    options,
+    show,
+}: ResourceProps) => ({
+    name,
+    options,
+    hasList: !!list,
+    hasCreate: !!create,
+    hasEdit: !!edit,
+    hasShow: !!show,
+    icon: icon,
+});

--- a/packages/ra-core/src/core/Resource.tsx
+++ b/packages/ra-core/src/core/Resource.tsx
@@ -1,12 +1,34 @@
 import * as React from 'react';
-import { isValidElement } from 'react';
+import { isValidElement, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { ResourceProps } from '../types';
 import { ResourceContextProvider } from './ResourceContextProvider';
+import { useRegisterResource } from './useRegisterResource';
 
 export const Resource = (props: ResourceProps) => {
-    const { create: Create, edit: Edit, list: List, name, show: Show } = props;
+    const registerResource = useRegisterResource();
+    const {
+        create: Create,
+        edit: Edit,
+        icon,
+        list: List,
+        name,
+        options,
+        show: Show,
+    } = props;
+
+    useEffect(() => {
+        registerResource({
+            name: name,
+            options: options,
+            hasList: !!List,
+            hasCreate: !!Create,
+            hasEdit: !!Edit,
+            hasShow: !!Show,
+            icon: icon,
+        });
+    }, [registerResource, name, options, List, Create, Edit, Show, icon]);
 
     return (
         <ResourceContextProvider value={name}>

--- a/packages/ra-core/src/core/ResourceDefinitionContext.tsx
+++ b/packages/ra-core/src/core/ResourceDefinitionContext.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { createContext, useState } from 'react';
+import * as React from 'react';
+import { createContext, useCallback, useState } from 'react';
 import isEqual from 'lodash/isEqual';
 
 import { ResourceDefinition } from '../types';
@@ -45,7 +45,7 @@ export const ResourceDefinitionContextProvider = ({
         defaultDefinitions
     );
 
-    const setDefinition = (config: ResourceDefinition) => {
+    const setDefinition = useCallback((config: ResourceDefinition) => {
         setState(prev =>
             isEqual(prev[config.name], config)
                 ? prev
@@ -54,7 +54,7 @@ export const ResourceDefinitionContextProvider = ({
                       [config.name]: config,
                   }
         );
-    };
+    }, []);
 
     return (
         <ResourceDefinitionContext.Provider

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -13,7 +13,6 @@ import {
     ResourceProps,
 } from '../types';
 import { CustomRoutesProps } from './CustomRoutes';
-import { useRegisterResource } from './useRegisterResource';
 
 /**
  * This hook inspects the CoreAdminRouter children and returns them separated in three groups:
@@ -40,7 +39,6 @@ export const useConfigureAdminRouterFromChildren = (
     const getPermissions = useGetPermissions();
     const doLogout = useLogout();
     const { authenticated } = useAuthState();
-    const registerResource = useRegisterResource();
     // Gather custom routes and resources that were declared as direct children of CoreAdminRouter
     // e.g. Not returned from the child function (if any)
     // We need to know right away wether some resources were declared to correctly
@@ -143,21 +141,6 @@ export const useConfigureAdminRouterFromChildren = (
         setResources,
         setStatus,
     ]);
-
-    // Whenever the resources change, we must ensure they're all registered
-    useEffect(() => {
-        resources.forEach(resource => {
-            registerResource({
-                name: resource.props.name,
-                options: resource.props.options,
-                hasList: !!resource.props.list,
-                hasCreate: !!resource.props.create,
-                hasEdit: !!resource.props.edit,
-                hasShow: !!resource.props.show,
-                icon: resource.props.icon,
-            });
-        });
-    }, [registerResource, resources]);
 
     return {
         customRoutesWithLayout,

--- a/packages/ra-core/src/core/useRegisterResource.ts
+++ b/packages/ra-core/src/core/useRegisterResource.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 
 import { ResourceDefinitionContext } from './ResourceDefinitionContext';
 import { ResourceDefinition } from '../types';
@@ -6,9 +6,14 @@ import { ResourceDefinition } from '../types';
 export const useRegisterResource = () => {
     const [, setResourceConfiguration] = useContext(ResourceDefinitionContext);
 
-    return (...resources: ResourceDefinition[]) => {
-        resources.forEach(resource => {
-            setResourceConfiguration(resource);
-        });
-    };
+    const registerResource = useCallback(
+        (...resources: ResourceDefinition[]) => {
+            resources.forEach(resource => {
+                setResourceConfiguration(resource);
+            });
+        },
+        [setResourceConfiguration]
+    );
+
+    return registerResource;
 };


### PR DESCRIPTION
This is a proposal to register the resource inside the component itself rather than in `useConfigureAdminRouterFromChildren`.

The main issue I was solving was to make the [ResourceGuesser component from API Platform Admin](https://github.com/api-platform/admin/blob/main/src/ResourceGuesser.tsx) works with react-admin 4: since the list/create/edit/show props are not explicitly given to the component, it is not correctly registered (and for instance the menu is not correctly filled since `hasList` is always false).

I don't have a workaround to make it work in the current implementation of react-admin 4.

However I think my proposal is interesting for you too: I don't think it is the `useConfigureAdminRouterFromChildren` responsibility to watch the resources and register them, having it in the Resource component itself seems a better idea.

I hope my proposal will satisfy you, if not, if you have any idea to make it work differently please tell me.