### PR TITLE
Use {...rest} in <FormDataConsumer> children

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -874,6 +874,7 @@ describe('<AutocompleteInput />', () => {
                                         },
                                     ]}
                                     source="id"
+                                    {...rest}
                                 />
                             );
                         }}


### PR DESCRIPTION
Shouldn't all children pass the {...rest} props? Or not? Not sure what is correct, not clear in the docs. Can you please explain? Thanks.