### PR TITLE
Improve DatagridHeaderCell sort icon manipulation

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -106,14 +106,15 @@ export const DatagridHeaderCellClasses = {
     icon: `${PREFIX}-icon`,
 };
 
+// Remove the sort icons when not active
 const StyledTableCell = styled(TableCell, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-    [`& .MuiSvgIcon-root`]: {
+    [`& .MuiTableSortLabel-icon`]: {
         display: 'none',
     },
-    [`& .Mui-active .MuiSvgIcon-root`]: {
+    [`& .Mui-active .MuiTableSortLabel-icon`]: {
         display: 'inline',
     },
 }));


### PR DESCRIPTION
If you try to render an icon different from the sort icon in a Datagrid's header cell, it will be hidden from view