### PR TITLE
fix: use right index for the transition in SimpleFormIterator

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -99,7 +99,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
                     {fields.map((member, index) => (
                         <CSSTransition
                             nodeRef={nodeRef}
-                            key={member.id}
+                            key={index}
                             timeout={500}
                             classNames="fade"
                             {...TransitionProps}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10920253/159059001-a3dfed97-25aa-4266-b774-e6c6aa88685d.png)
After:
![image](https://user-images.githubusercontent.com/10920253/159058868-b1f26cc0-2c93-4049-9244-6d8d5946934d.png)

It's probably because the `id` of the fields is changing (`id` is generated from [useFieldArray](https://react-hook-form.com/api/usefieldarray/)), and the `ref` needs to be changed as well (see http://reactcommunity.org/react-transition-group/transition/#Transition-prop-nodeRef).

Using the previous code from master is needed to solve this issue.
I needed to revert https://github.com/marmelab/react-admin/pull/7123 as well, I don't understand how the change in this PR can work.