### PR TITLE
docs: remove deprecated props and unused imports

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -830,16 +830,12 @@ const App = () => (
 ```jsx
 // in src/Menu.js
 import * as React from 'react';
-import { createElement } from 'react';
 import { useSelector } from 'react-redux';
-import { useMediaQuery } from '@material-ui/core';
 import { DashboardMenuItem, Menu, MenuItemLink, getResources } from 'react-admin';
 import DefaultIcon from '@material-ui/icons/ViewList';
-import LabelIcon from '@material-ui/icons/Label';
 
 export const Menu = (props) => {
     const resources = useSelector(getResources);
-    const open = useSelector(state => state.admin.ui.sidebarOpen);
     return (
         <Menu {...props}>
             <DashboardMenuItem />
@@ -854,8 +850,6 @@ export const Menu = (props) => {
                     leftIcon={
                         resource.icon ? <resource.icon /> : <DefaultIcon />
                     }
-                    onClick={props.onMenuClick}
-                    sidebarIsOpen={open}
                 />
             ))}
             {/* add your custom menus here */}


### PR DESCRIPTION
`sidebarIsOpen` in _MenuItemLink_ component and `onMenuClick` in _Menu_ component has been deprecated in https://github.com/marmelab/react-admin/pull/6230 and they're no longer needed to create custom menu components.
Also there were some unused import statements, so I've clean them all.

Note that I've only updated the place where I referred, so there might be more deprecated / unused imports in the another lines of this file.