### PR TITLE
[RFR] fix(types): missing resource options label property

### DIFF
--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -464,6 +464,11 @@ export type ResourceMatch = Match<{
     id?: string;
 }>;
 
+export interface ResourceOptions {
+    label?: string;
+    [key: string]: any;
+}
+
 export interface ResourceProps {
     intent?: 'route' | 'registration';
     match?: ResourceMatch;
@@ -473,7 +478,7 @@ export interface ResourceProps {
     edit?: ComponentType<ResourceComponentPropsWithId>;
     show?: ComponentType<ResourceComponentPropsWithId>;
     icon?: ComponentType<any>;
-    options?: object;
+    options?: ResourceOptions;
 }
 
 export interface AdminProps {


### PR DESCRIPTION
This aim to solve two things:

1. Using object as type is not recommended as we can not access a
   property without having Typescript yelling this one can not exist on
   object (ts2339)
2. As specified on the documentation, the label options is available and
   use by the react-admin ecosystem. It should be explicitly defined.