### PR TITLE
Add `expandSingle` prop to Datagrid

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -46,6 +46,7 @@ Here are all the props accepted by the component:
 * [`children`](#children)
 * [`empty`](#empty)
 * [`expand`](#expand)
+* [`expandSingle`](#expandsingle) 
 * [`header`](#header)
 * [`hover`](#hover)
 * [`isRowExpandable`](#isrowexpandable)
@@ -471,6 +472,21 @@ const PostList = () => (
     </List>
 )
 ```
+
+## `expandSingle`
+
+The `expandSingle` allows a single row to be expanded at a time.
+
+```jsx
+export const PostList = () => (
+    <List>
+        <Datagrid expandSingle>
+            ...
+        </Datagrid>
+    </List>
+);
+```
+
 
 ## `header`
 

--- a/packages/ra-core/src/controller/list/useExpanded.tsx
+++ b/packages/ra-core/src/controller/list/useExpanded.tsx
@@ -45,7 +45,7 @@ export const useExpanded = (
                 ? [id]
                 : [...ids, id];
         });
-    }, [setExpandedIds, id]);
+    }, [setExpandedIds, id, single]);
 
     return [expanded, toggleExpanded];
 };

--- a/packages/ra-core/src/controller/list/useExpanded.tsx
+++ b/packages/ra-core/src/controller/list/useExpanded.tsx
@@ -8,7 +8,7 @@ import { Identifier } from '../../types';
  *
  * @param {string} resource The resource name, e.g. 'posts'
  * @param {string|integer} id The record identifier, e.g. 123
- *
+ * @param {boolean} single Forces only one id to be expanded at a time
  * @returns {Object} Destructure as [expanded, toggleExpanded].
  *
  * @example
@@ -19,7 +19,8 @@ import { Identifier } from '../../types';
  */
 export const useExpanded = (
     resource: string,
-    id: Identifier
+    id: Identifier,
+    single: boolean = false
 ): [boolean, () => void] => {
     const [expandedIds, setExpandedIds] = useStore<Identifier[]>(
         `${resource}.datagrid.expanded`,
@@ -37,7 +38,11 @@ export const useExpanded = (
             }
             const index = ids.findIndex(el => el == id); // eslint-disable-line eqeqeq
             return index > -1
-                ? [...ids.slice(0, index), ...ids.slice(index + 1)]
+                ? single
+                    ? []
+                    : [...ids.slice(0, index), ...ids.slice(index + 1)]
+                : single
+                ? [id]
                 : [...ids, id];
         });
     }, [setExpandedIds, id]);

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -131,6 +131,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
         rowStyle,
         size = 'small',
         sx,
+        expandSingle = false,
         ...rest
     } = props;
 
@@ -147,8 +148,9 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
 
     const hasBulkActions = !!bulkActionButtons !== false;
 
-    const contextValue = useMemo(() => ({ isRowExpandable }), [
+    const contextValue = useMemo(() => ({ isRowExpandable, expandSingle }), [
         isRowExpandable,
+        expandSingle,
     ]);
 
     const lastSelected = useRef(null);
@@ -313,6 +315,7 @@ Datagrid.propTypes = {
     total: PropTypes.number,
     isRowSelectable: PropTypes.func,
     isRowExpandable: PropTypes.func,
+    expandSingle: PropTypes.bool,
 };
 
 export interface DatagridProps<RecordType extends RaRecord = any>
@@ -344,6 +347,7 @@ export interface DatagridProps<RecordType extends RaRecord = any>
     onToggleItem?: (id: Identifier) => void;
     setSort?: (sort: SortPayload) => void;
     selectedIds?: Identifier[];
+    expandSingle?: boolean;
     total?: number;
 }
 

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridContext.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridContext.ts
@@ -7,6 +7,7 @@ DatagridContext.displayName = 'DatagridContext';
 
 export type DatagridContextValue = {
     isRowExpandable?: (record: RaRecord) => boolean;
+    expandSingle?: boolean;
 };
 
 export default DatagridContext;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -64,7 +64,11 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
         expand;
     const resource = useResourceContext(props);
     const createPath = useCreatePath();
-    const [expanded, toggleExpanded] = useExpanded(resource, id);
+    const [expanded, toggleExpanded] = useExpanded(
+        resource,
+        id,
+        context && context.expandSingle
+    );
     const [nbColumns, setNbColumns] = useState(() =>
         computeNbColumns(expandable, children, hasBulkActions)
     );


### PR DESCRIPTION
This prop forces the `Datagrid` to have one row expanded at a time

![chrome-capture (1)](https://user-images.githubusercontent.com/8268610/160950833-b8770c0d-02c6-4565-9ec9-e49d9b63dc24.gif)
