### PR TITLE
Export register resource hook

### DIFF
--- a/packages/ra-core/src/core/index.ts
+++ b/packages/ra-core/src/core/index.ts
@@ -8,6 +8,7 @@ export * from './ResourceContext';
 export * from './ResourceContextProvider';
 export * from './ResourceDefinitionContext';
 export * from './useGetResourceLabel';
+export * from './useRegisterResource';
 export * from './useResourceContext';
 export * from './useResourceDefinition';
 export * from './useResourceDefinitions';


### PR DESCRIPTION
Some of CRM is able to create resource schema definitions dynamically

We sometimes will need to manually register resource under different components so it would be best to export this hook