### PR TITLE
Fix filter form reset effect deps

### DIFF
--- a/cypress/integration/list.js
+++ b/cypress/integration/list.js
@@ -88,7 +88,6 @@ describe('List Page', () => {
             // See https://github.com/marmelab/react-admin/pull/2019
             cy.get('[href="#/users"]').click();
             // Wait until the filter is actually applied (async because of hook-form)
-            cy.url().should('contain', 'role');
             cy.contains('1-2 of 2');
 
             cy.get('[href="#/posts"]').click();
@@ -119,7 +118,7 @@ describe('List Page', () => {
             );
             cy.get('[href="#/users"]').click();
             // Wait until the filter is actually applied (async because of hook-form)
-            cy.url().should('contain', 'role');
+            cy.contains('1-2 of 2');
             cy.get('[href="#/posts"]').click();
             cy.url().should('contain', '/posts');
             cy.get(ListPagePosts.elements.filter('title')).should(el =>
@@ -134,7 +133,6 @@ describe('List Page', () => {
             LoginPage.login('admin', 'password');
             ListPageUsers.navigate();
             // Wait until the filter is actually applied (async because of hook-form)
-            cy.url().should('contain', 'role');
             cy.contains('1-2 of 2');
             cy.get('button[title="Remove this filter"]').click();
             cy.contains('1-3 of 3');

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -48,7 +48,7 @@ export const FilterForm = (props: FilterFormProps) => {
     useEffect(() => {
         const newValues = getFilterFormValues(form.getValues(), filterValues);
         form.reset(newValues);
-    }, [filterValues, filters, form]);
+    }, [filterValues, form]);
 
     useEffect(() => {
         const subscription = form.watch(async (values, { name, type }) => {


### PR DESCRIPTION
Fix infinite rendering issues introduced after #7442

Fixes #7452

Remove superfluous dependency on `filters` in effect handling form reset in `FilterForm`

_Note :_ testing was done manually, didn't add a story for this case as declaring the filters inside the List component is not recommended by the docs