### PR TITLE
Fix SSR Support

### DIFF
--- a/packages/ra-core/src/routing/AdminRouter.tsx
+++ b/packages/ra-core/src/routing/AdminRouter.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { useInRouterContext } from 'react-router-dom';
 import { createHashHistory, History } from 'history';
 
-import { HistoryRouter } from './HistoryRouter';
+import { HistoryRouter, HistoryRouterProps } from './HistoryRouter';
 import { BasenameContextProvider } from './BasenameContextProvider';
 
 /**
@@ -16,13 +16,11 @@ export const AdminRouter = ({
     children,
 }: AdminRouterProps) => {
     const isInRouter = useInRouterContext();
-    const Router = isInRouter ? DummyRouter : HistoryRouter;
-    const finalHistory = useMemo(() => history || createHashHistory(), [
-        history,
-    ]);
+    const Router = isInRouter ? DummyRouter : InternalRouter;
+
     return (
         <BasenameContextProvider basename={isInRouter ? basename : ''}>
-            <Router basename={basename} history={finalHistory}>
+            <Router basename={basename} history={history}>
                 {children}
             </Router>
         </BasenameContextProvider>
@@ -35,4 +33,17 @@ export interface AdminRouterProps {
     children: React.ReactNode;
 }
 
-const DummyRouter = ({ children }) => children;
+const DummyRouter = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+const InternalRouter = ({
+    children,
+    history,
+}: {
+    history?: History;
+} & Omit<HistoryRouterProps, 'history'>) => {
+    const finalHistory = useMemo(() => history || createHashHistory(), [
+        history,
+    ]);
+
+    return <HistoryRouter history={finalHistory}>{children}</HistoryRouter>;
+};


### PR DESCRIPTION
# The problem

Even though you wrapped your API with a Router, react-admin will still instantiate an history if you didn't provide one.

# The solution

Extract the history instantiation in an internal router component.

I tested this on a local remix project with success