### PR TITLE
Prevent call to dataProvider.getMany from useGetManyAggregate if ids is empty

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -61,7 +61,6 @@ export const useReferenceArrayFieldController = (
         reference,
         { ids },
         {
-            enabled: ids.length > 0,
             onError: error =>
                 notify(
                     typeof error === 'string'

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -61,6 +61,7 @@ export const useReferenceArrayFieldController = (
         reference,
         { ids },
         {
+            enabled: ids.length > 0,
             onError: error =>
                 notify(
                     typeof error === 'string'

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
@@ -85,7 +85,7 @@ describe('useGetManyAggregate', () => {
         expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
     });
 
-    it.only('should not call dataProvider.getMany() if ids is empty', async () => {
+    it('should not call dataProvider.getMany() if ids is empty', async () => {
         const { rerender } = render(
             <CoreAdminContext dataProvider={dataProvider}>
                 <UseGetManyAggregate resource="posts" ids={[]} />

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
@@ -85,6 +85,23 @@ describe('useGetManyAggregate', () => {
         expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
     });
 
+    it.only('should not call dataProvider.getMany() if ids is empty', async () => {
+        const { rerender } = render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyAggregate resource="posts" ids={[]} />
+            </CoreAdminContext>
+        );
+        await new Promise(resolve => setTimeout(resolve));
+        expect(dataProvider.getMany).toHaveBeenCalledTimes(0);
+        rerender(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyAggregate resource="posts" ids={[]} />
+            </CoreAdminContext>
+        );
+        await new Promise(resolve => setTimeout(resolve));
+        expect(dataProvider.getMany).toHaveBeenCalledTimes(0);
+    });
+
     it('should recall dataProvider.getMany() when ids changes', async () => {
         const { rerender } = render(
             <CoreAdminContext dataProvider={dataProvider}>

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -73,6 +73,7 @@ export const useGetManyAggregate = <RecordType extends RaRecord = any>(
     const queryClient = useQueryClient();
     const queryCache = queryClient.getQueryCache();
     const { ids, meta } = params;
+    const { enabled = ids.length > 0, ...restOptions } = options;
     const placeholderData = useMemo(() => {
         const records = ids.map(id => {
             const queryHash = hashQueryKey([
@@ -116,7 +117,8 @@ export const useGetManyAggregate = <RecordType extends RaRecord = any>(
                 });
             },
             retry: false,
-            ...options,
+            enabled,
+            ...restOptions,
         }
     );
 };


### PR DESCRIPTION
Fixes #7458