### PR TITLE
[Datagrid] Fix non clickable row can't be styled

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -676,25 +676,27 @@ export const PostList = () => (
 
 The `<Datagrid>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property. This property accepts the following subclasses:
 
-| Rule name                      | Description                                       |
-| ------------------------------ |---------------------------------------------------|
-| `& .RaDatagrid-tableWrapper`   | Applied to the div that wraps table element       |
-| `& .RaDatagrid-table`          | Applied to the table element                      |
-| `& .RaDatagrid-thead`          | Applied to the table header                       |
-| `& .RaDatagrid-tbody`          | Applied to the table body                         |
-| `& .RaDatagrid-headerCell`     | Applied to each header cell                       |
-| `& .RaDatagrid-headerRow`      | Applied to each header row                        |
-| `& .RaDatagrid-row`            | Applied to each row                               |
-| `& .RaDatagrid-rowEven`        | Applied to each even row                          |
-| `& .RaDatagrid-rowOdd`         | Applied to each odd row                           |
-| `& .RaDatagrid-rowCell`        | Applied to each row cell                          |
-| `& .RaDatagrid-expandHeader`   | Applied to each expandable header cell            |
-| `& .RaDatagrid-clickableRow`   | Applied to each row if `rowClick` prop is truthy  |
-| `& .RaDatagrid-expandIconCell` | Applied to each expandable cell                   |
-| `& .RaDatagrid-expandIcon`     | Applied to each expand icon                       |
-| `& .RaDatagrid-expanded`       | Applied to each expanded icon                     |
-| `& .RaDatagrid-expandedPanel`  | Applied to each expandable panel                  |
-| `& .RaDatagrid-checkbox`       | Applied to each checkbox cell                     |
+| Rule name                      | Description                                      |
+| ------------------------------ |--------------------------------------------------|
+| `& .RaDatagrid-tableWrapper`   | Applied to the div that wraps table element      |
+| `& .RaDatagrid-table`          | Applied to the table element                     |
+| `& .RaDatagrid-thead`          | Applied to the table header                      |
+| `& .RaDatagrid-tbody`          | Applied to the table body                        |
+| `& .RaDatagrid-headerCell`     | Applied to each header cell                      |
+| `& .RaDatagrid-headerRow`      | Applied to each header row                       |
+| `& .RaDatagrid-row`            | Applied to each row                              |
+| `& .RaDatagrid-rowEven`        | Applied to each even row                         |
+| `& .RaDatagrid-rowOdd`         | Applied to each odd row                          |
+| `& .RaDatagrid-rowCell`        | Applied to each row cell                         |
+| `& .RaDatagrid-selectable`     | Applied to each selectable row                   |
+| `& .RaDatagrid-expandHeader`   | Applied to each expandable header cell           |
+| `& .RaDatagrid-clickableRow`   | Applied to each row if `rowClick` prop is truthy |
+| `& .RaDatagrid-expandIconCell` | Applied to each expandable cell                  |
+| `& .RaDatagrid-expandIcon`     | Applied to each expand icon                      |
+| `& .RaDatagrid-expandable`     | Applied to each expandable row                   |
+| `& .RaDatagrid-expanded`       | Applied to each expanded icon                    |
+| `& .RaDatagrid-expandedPanel`  | Applied to each expandable panel                 |
+| `& .RaDatagrid-checkbox`       | Applied to each checkbox cell                    |
 
 For instance, here is how you can leverage these styles to implement zebra stripes (a.k.a. alternate row styles)
 

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -40,7 +40,6 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
                         className: clsx(DatagridClasses.row, {
                             [DatagridClasses.rowEven]: rowIndex % 2 === 0,
                             [DatagridClasses.rowOdd]: rowIndex % 2 !== 0,
-                            [DatagridClasses.clickableRow]: rowClick,
                         }),
                         expand,
                         hasBulkActions: hasBulkActions && !!selectedIds,

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -143,7 +143,7 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
                     [DatagridClasses.expandable]: expandable,
                     [DatagridClasses.selectable]: selectable,
                     [DatagridClasses.clickableRow]:
-                        typeof rowClick === 'function' ? false : rowClick,
+                        typeof rowClick === 'function' ? true : rowClick,
                 })}
                 key={id}
                 style={style}

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -139,7 +139,12 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
         <RecordContextProvider value={record}>
             <TableRow
                 ref={ref}
-                className={className}
+                className={clsx(className, {
+                    [DatagridClasses.expandable]: expandable,
+                    [DatagridClasses.selectable]: selectable,
+                    [DatagridClasses.clickableRow]:
+                        typeof rowClick === 'function' ? false : rowClick,
+                })}
                 key={id}
                 style={style}
                 hover={hover}

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
@@ -15,9 +15,11 @@ export const DatagridClasses = {
     rowEven: `${PREFIX}-rowEven`,
     rowOdd: `${PREFIX}-rowOdd`,
     rowCell: `${PREFIX}-rowCell`,
+    selectable: `${PREFIX}-selectable`,
     expandHeader: `${PREFIX}-expandHeader`,
     expandIconCell: `${PREFIX}-expandIconCell`,
     expandIcon: `${PREFIX}-expandIcon`,
+    expandable: `${PREFIX}-expandable`,
     expanded: `${PREFIX}-expanded`,
     expandedPanel: `${PREFIX}-expandedPanel`,
 };


### PR DESCRIPTION
We're adding classes to each datagrid row to let developers style them differently whether they're clickable, selectable, expandable, or not. 

Ideally, we should change the cursor by default when a row isn't clickable, selectable, or expandable, but this is for another PR.

Closes #7407