### PR TITLE
Add <Admin requireAuth> to hide the app until auth is checked

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -43,6 +43,7 @@ Here are all the props accepted by the component:
 - [`history`](#history)
 - [`basename`](#basename)
 - [`ready`](#ready)
+- [`requireAuth`](#requireAuth)
 - [`store`](#store)
 
 ## `dataProvider`
@@ -408,6 +409,20 @@ const Ready = () => (
 const App = () => (
     <Admin ready={Ready}>
         ...
+    </Admin>
+);
+```
+
+## `requireAuth`
+
+Some pages in react-admin apps may allow anonymous access. For that reason, react-admin starts rendering the page layout before knowing if the user is logged in. If all the pages require authentication, this default behaviour creates an unwanted "flash of UI" for users who never logged in, before the `authProvider` redirects them to the login page.
+
+If you know your app will never accept anonymous access, you can force the app to wait for the `authProvider.checkAuth()` to resolve before rendering the page layout, by setting the `<Admin requireAuth>` prop.
+
+```jsx
+const App = () => (
+    <Admin dataProvider={dataProvider} authProvider={authProvider} requireAuth>
+        <Resource name="posts" list={PostList} />
     </Admin>
 );
 ```

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -111,6 +111,20 @@ const App = () => (
 - `<List>`, `<ListBase>`, `<ListController>` and `useListController`
 - `<Show>`, `<ShowBase>`, `<ShowController>` and `useShowController`
 
+## Disabling Anonymous Access
+
+Some pages in react-admin apps may allow anonymous access. For that reason, react-admin starts rendering the page layout before knowing if the user is logged in. If all the pages require authentication, this default behaviour creates an unwanted "flash of UI" for users who never logged in, before the `authProvider` redirects them to the login page.
+
+If you know your app will never accept anonymous access, you can force the app to wait for the `authProvider.checkAuth()` to resolve before rendering the page layout, by setting the `<Admin requireAuth>` prop.
+
+```jsx
+const App = () => (
+    <Admin dataProvider={dataProvider} authProvider={authProvider} requireAuth>
+        <Resource name="posts" list={PostList} />
+    </Admin>
+);
+```
+
 ## Restricting Access To Custom Pages
 
 When you add custom pages, they are accessible to anonymous users by default. To make them only accessible to authenticated users, call [the `useAuthenticated` hook](./useAuthenticated.md) in the custom page:

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -98,6 +98,7 @@ export const CoreAdmin = (props: CoreAdminProps) => {
         loading,
         loginPage,
         menu, // deprecated, use a custom layout instead
+        requireAuth,
         title = 'React Admin',
     } = props;
     return (
@@ -118,6 +119,7 @@ export const CoreAdmin = (props: CoreAdminProps) => {
                 title={title}
                 loading={loading}
                 loginPage={loginPage}
+                requireAuth={requireAuth}
             >
                 {children}
             </CoreAdminUI>

--- a/packages/ra-core/src/core/CoreAdminRoutes.tsx
+++ b/packages/ra-core/src/core/CoreAdminRoutes.tsx
@@ -1,7 +1,8 @@
-import React, { Children, ComponentType } from 'react';
+import * as React from 'react';
+import { useState, useEffect, Children, ComponentType } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { WithPermissions } from '../auth';
+import { WithPermissions, useCheckAuth } from '../auth';
 import { useTimeout } from '../util';
 import { useScrollToTop, useCreatePath } from '../routing';
 import {
@@ -31,15 +32,27 @@ export const CoreAdminRoutes = (props: CoreAdminRoutesProps) => {
         dashboard,
         loading: LoadingPage,
         menu,
+        requireAuth,
         ready: Ready,
         title,
     } = props;
+
+    const [canRender, setCanRender] = useState(!requireAuth);
+    const checkAuth = useCheckAuth();
+
+    useEffect(() => {
+        checkAuth()
+            .then(() => {
+                setCanRender(true);
+            })
+            .catch(() => {});
+    }, [checkAuth]);
 
     if (status === 'empty') {
         return <Ready />;
     }
 
-    if (status === 'loading') {
+    if (status === 'loading' || !canRender) {
         return (
             <Routes>
                 {customRoutesWithoutLayout}
@@ -113,6 +126,7 @@ export interface CoreAdminRoutesProps extends CoreLayoutProps {
     catchAll: CatchAllComponent;
     children?: AdminChildren;
     loading: LoadingComponent;
+    requireAuth?: boolean;
     ready?: ComponentType;
 }
 

--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -27,7 +27,11 @@ export interface CoreAdminUIProps {
     layout?: LayoutComponent;
     loading?: LoadingComponent;
     loginPage?: LoginComponent | boolean;
+    /**
+     * @deprecated use a custom layout instead
+     */
     menu?: ComponentType;
+    requireAuth?: boolean;
     ready?: ComponentType;
     title?: TitleComponent;
 }
@@ -44,6 +48,7 @@ export const CoreAdminUI = (props: CoreAdminUIProps) => {
         menu, // deprecated, use a custom layout instead
         ready = Ready,
         title = 'React Admin',
+        requireAuth = false,
     } = props;
 
     useEffect(() => {
@@ -74,6 +79,7 @@ export const CoreAdminUI = (props: CoreAdminUIProps) => {
                         layout={layout}
                         loading={loading}
                         menu={menu}
+                        requireAuth={requireAuth}
                         ready={ready}
                         title={title}
                     >

--- a/packages/react-admin/src/Admin.tsx
+++ b/packages/react-admin/src/Admin.tsx
@@ -101,6 +101,7 @@ export const Admin = (props: AdminProps) => {
         loginPage,
         menu, // deprecated, use a custom layout instead
         notification,
+        requireAuth,
         store,
         ready,
         theme,
@@ -133,6 +134,7 @@ export const Admin = (props: AdminProps) => {
                 loading={loading}
                 loginPage={loginPage}
                 notification={notification}
+                requireAuth={requireAuth}
                 ready={ready}
             >
                 {children}


### PR DESCRIPTION
## Problem

Auth check is optimistic by default.  In v3, one could turn auth check to pessimistic (i.e. display nothing until `dataProvider.checkAuth()` resolves) by implementing a custom `<Resource>`. But in v4, the authentication isn't in `<Resource>` anymore, but in the page controllers. As a consequence, it is not possible to make auth pessimistic. 

## Solution

Add an option to `<Admin>` to make the app require authentication. 

This is something we must do before releasing v4, because otherwise it would prevent an entire class of features (and break ra-rbac).

Closes #5229