### PR TITLE
`useRecordContext` may return `undefined`

### DIFF
--- a/packages/ra-core/src/controller/RecordContext.tsx
+++ b/packages/ra-core/src/controller/RecordContext.tsx
@@ -72,7 +72,7 @@ export const useRecordContext = <
     RecordType extends Record | Omit<Record, 'id'> = Record
 >(
     props?: UseRecordContextParams<RecordType>
-): RecordType => {
+): RecordType | undefined => {
     // Can't find a way to specify the RecordType when CreateContext is declared
     // @ts-ignore
     const context = useContext<RecordType>(RecordContext);


### PR DESCRIPTION
[The doc mentions it](https://marmelab.com/react-admin/doc/4.0/useRecordContext.html#optimistic-rendering) but TS doesn't enforce it. I believe it should.