### PR TITLE
Make auth hooks use basename

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -381,7 +381,7 @@ import { createBrowserHistory } from 'history';
 
 const history = createBrowserHistory();
 const App = () => (
-    <Admin basename="admin" history={history}>
+    <Admin basename="/admin" history={history}>
         ...
     </Admin>
 );

--- a/examples/simple/src/index.tsx
+++ b/examples/simple/src/index.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Admin, Resource, CustomRoutes } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import { render } from 'react-dom';
-import { Route } from 'react-router-dom';
+import { Route, Routes, BrowserRouter, Link } from 'react-router-dom';
 
 import authProvider from './authProvider';
 import comments from './comments';
@@ -15,52 +15,79 @@ import posts from './posts';
 import users from './users';
 import tags from './tags';
 
+const App = () => (
+    <Admin
+        authProvider={authProvider}
+        dataProvider={dataProvider}
+        i18nProvider={i18nProvider}
+        title="Example Admin"
+        layout={Layout}
+        basename="admintest"
+    >
+        <CustomRoutes noLayout>
+            <Route
+                path="/custom"
+                element={<CustomRouteNoLayout title="Posts from /custom" />}
+            />
+        </CustomRoutes>
+        <Resource name="posts" {...posts} />
+        <Resource name="comments" {...comments} />
+        <Resource name="tags" {...tags} />
+        {permissions => (
+            <>
+                {permissions ? <Resource name="users" {...users} /> : null}
+                <CustomRoutes noLayout>
+                    <Route
+                        path="/custom1"
+                        element={
+                            <CustomRouteNoLayout title="Posts from /custom1" />
+                        }
+                    />
+                </CustomRoutes>
+                <CustomRoutes>
+                    <Route
+                        path="/custom2"
+                        element={
+                            <CustomRouteLayout title="Posts from /custom2" />
+                        }
+                    />
+                </CustomRoutes>
+            </>
+        )}
+        <CustomRoutes>
+            <Route
+                path="/custom3"
+                element={<CustomRouteLayout title="Posts from /custom3" />}
+            />
+        </CustomRoutes>
+    </Admin>
+);
+
+const Index = () => (
+    <nav>
+        <ul>
+            <li>
+                <Link to="/">Index</Link>
+            </li>
+            <li>
+                <Link to="/otherapp">OtherApp</Link>
+            </li>
+            <li>
+                <Link to="/admintest">Admintest</Link>
+            </li>
+        </ul>
+    </nav>
+);
+
 render(
     <React.StrictMode>
-        <Admin
-            authProvider={authProvider}
-            dataProvider={dataProvider}
-            i18nProvider={i18nProvider}
-            title="Example Admin"
-            layout={Layout}
-        >
-            <CustomRoutes noLayout>
-                <Route
-                    path="/custom"
-                    element={<CustomRouteNoLayout title="Posts from /custom" />}
-                />
-            </CustomRoutes>
-            <Resource name="posts" {...posts} />
-            <Resource name="comments" {...comments} />
-            <Resource name="tags" {...tags} />
-            {permissions => (
-                <>
-                    {permissions ? <Resource name="users" {...users} /> : null}
-                    <CustomRoutes noLayout>
-                        <Route
-                            path="/custom1"
-                            element={
-                                <CustomRouteNoLayout title="Posts from /custom1" />
-                            }
-                        />
-                    </CustomRoutes>
-                    <CustomRoutes>
-                        <Route
-                            path="/custom2"
-                            element={
-                                <CustomRouteLayout title="Posts from /custom2" />
-                            }
-                        />
-                    </CustomRoutes>
-                </>
-            )}
-            <CustomRoutes>
-                <Route
-                    path="/custom3"
-                    element={<CustomRouteLayout title="Posts from /custom3" />}
-                />
-            </CustomRoutes>
-        </Admin>
+        <BrowserRouter>
+            <Routes>
+                <Route path="/*" element={<Index />} />
+                <Route path="/otherapp" element={<h1>Other App</h1>} />
+                <Route path="/admintest/*" element={<App />} />
+            </Routes>
+        </BrowserRouter>
     </React.StrictMode>,
     document.getElementById('root')
 );

--- a/examples/simple/src/index.tsx
+++ b/examples/simple/src/index.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Admin, Resource, CustomRoutes } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import { render } from 'react-dom';
-import { Route, Routes, BrowserRouter, Link } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 import authProvider from './authProvider';
 import comments from './comments';
@@ -15,79 +15,52 @@ import posts from './posts';
 import users from './users';
 import tags from './tags';
 
-const App = () => (
-    <Admin
-        authProvider={authProvider}
-        dataProvider={dataProvider}
-        i18nProvider={i18nProvider}
-        title="Example Admin"
-        layout={Layout}
-        basename="admintest"
-    >
-        <CustomRoutes noLayout>
-            <Route
-                path="/custom"
-                element={<CustomRouteNoLayout title="Posts from /custom" />}
-            />
-        </CustomRoutes>
-        <Resource name="posts" {...posts} />
-        <Resource name="comments" {...comments} />
-        <Resource name="tags" {...tags} />
-        {permissions => (
-            <>
-                {permissions ? <Resource name="users" {...users} /> : null}
-                <CustomRoutes noLayout>
-                    <Route
-                        path="/custom1"
-                        element={
-                            <CustomRouteNoLayout title="Posts from /custom1" />
-                        }
-                    />
-                </CustomRoutes>
-                <CustomRoutes>
-                    <Route
-                        path="/custom2"
-                        element={
-                            <CustomRouteLayout title="Posts from /custom2" />
-                        }
-                    />
-                </CustomRoutes>
-            </>
-        )}
-        <CustomRoutes>
-            <Route
-                path="/custom3"
-                element={<CustomRouteLayout title="Posts from /custom3" />}
-            />
-        </CustomRoutes>
-    </Admin>
-);
-
-const Index = () => (
-    <nav>
-        <ul>
-            <li>
-                <Link to="/">Index</Link>
-            </li>
-            <li>
-                <Link to="/otherapp">OtherApp</Link>
-            </li>
-            <li>
-                <Link to="/admintest">Admintest</Link>
-            </li>
-        </ul>
-    </nav>
-);
-
 render(
     <React.StrictMode>
-        <BrowserRouter>
-            <Routes>
-                <Route path="/*" element={<Index />} />
-                <Route path="/otherapp" element={<h1>Other App</h1>} />
-                <Route path="/admintest/*" element={<App />} />
-            </Routes>
-        </BrowserRouter>
+        <Admin
+            authProvider={authProvider}
+            dataProvider={dataProvider}
+            i18nProvider={i18nProvider}
+            title="Example Admin"
+            layout={Layout}
+        >
+            <CustomRoutes noLayout>
+                <Route
+                    path="/custom"
+                    element={<CustomRouteNoLayout title="Posts from /custom" />}
+                />
+            </CustomRoutes>
+            <Resource name="posts" {...posts} />
+            <Resource name="comments" {...comments} />
+            <Resource name="tags" {...tags} />
+            {permissions => (
+                <>
+                    {permissions ? <Resource name="users" {...users} /> : null}
+                    <CustomRoutes noLayout>
+                        <Route
+                            path="/custom1"
+                            element={
+                                <CustomRouteNoLayout title="Posts from /custom1" />
+                            }
+                        />
+                    </CustomRoutes>
+                    <CustomRoutes>
+                        <Route
+                            path="/custom2"
+                            element={
+                                <CustomRouteLayout title="Posts from /custom2" />
+                            }
+                        />
+                    </CustomRoutes>
+                </>
+            )}
+            <CustomRoutes>
+                <Route
+                    path="/custom3"
+                    element={<CustomRouteLayout title="Posts from /custom3" />}
+                />
+            </CustomRoutes>
+        </Admin>
     </React.StrictMode>,
     document.getElementById('root')
 );

--- a/packages/ra-core/src/auth/useCheckAuth.spec.tsx
+++ b/packages/ra-core/src/auth/useCheckAuth.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import expect from 'expect';
-import { render, waitFor } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import { Route, MemoryRouter } from 'react-router-dom';
 
 import { useCheckAuth } from './useCheckAuth';
@@ -59,19 +59,6 @@ const authProvider: AuthProvider = {
     getPermissions: () => Promise.reject('not authenticated'),
 };
 
-const TestWrapper = ({ children }) => {
-    return (
-        <MemoryRouter>
-            <CoreAdminContext authProvider={authProvider}>
-                <CustomRoutes noLayout>
-                    <Route path="/login" element={<i>Login</i>} />
-                </CustomRoutes>
-                <Resource name="posts" list={() => <>{children}</>} />
-            </CoreAdminContext>
-        </MemoryRouter>
-    );
-};
-
 describe('useCheckAuth', () => {
     afterEach(() => {
         logout.mockClear();
@@ -79,7 +66,7 @@ describe('useCheckAuth', () => {
     });
 
     it('should not logout if has credentials', async () => {
-        const { queryByText } = render(
+        render(
             <AuthContext.Provider value={authProvider}>
                 <TestComponent params={{ token: true }} />
             </AuthContext.Provider>
@@ -87,28 +74,25 @@ describe('useCheckAuth', () => {
         await waitFor(() => {
             expect(logout).toHaveBeenCalledTimes(0);
             expect(notify).toHaveBeenCalledTimes(0);
-            expect(queryByText('authenticated')).not.toBeNull();
+            expect(screen.queryByText('authenticated')).not.toBeNull();
         });
     });
 
     it('should logout if has no credentials', async () => {
-        const { queryByText } = render(
-            <TestWrapper>
+        render(
+            <AuthContext.Provider value={authProvider}>
                 <TestComponent params={{ token: false }} />
-            </TestWrapper>
+            </AuthContext.Provider>
         );
         await waitFor(() => {
             expect(logout).toHaveBeenCalledTimes(1);
             expect(notify).toHaveBeenCalledTimes(1);
-            expect(queryByText('authenticated')).toBeNull();
-        });
-        await waitFor(() => {
-            expect(queryByText('Login')).not.toBeNull();
+            expect(screen.queryByText('authenticated')).toBeNull();
         });
     });
 
     it('should not logout if has no credentials and passed logoutOnFailure as false', async () => {
-        const { queryByText } = render(
+        render(
             <AuthContext.Provider value={authProvider}>
                 <TestComponent
                     params={{ token: false }}
@@ -119,12 +103,12 @@ describe('useCheckAuth', () => {
         await waitFor(() => {
             expect(logout).toHaveBeenCalledTimes(0);
             expect(notify).toHaveBeenCalledTimes(0);
-            expect(queryByText('not authenticated')).not.toBeNull();
+            expect(screen.queryByText('not authenticated')).not.toBeNull();
         });
     });
 
     it('should logout without showing a notification when disableNotification is true', async () => {
-        const { queryByText } = render(
+        render(
             <AuthContext.Provider value={authProvider}>
                 <TestComponent params={{ token: false }} disableNotification />
             </AuthContext.Provider>
@@ -132,12 +116,12 @@ describe('useCheckAuth', () => {
         await waitFor(() => {
             expect(logout).toHaveBeenCalledTimes(1);
             expect(notify).toHaveBeenCalledTimes(0);
-            expect(queryByText('authenticated')).toBeNull();
+            expect(screen.queryByText('authenticated')).toBeNull();
         });
     });
 
     it('should logout without showing a notification when authProvider returns error with message false', async () => {
-        const { queryByText } = render(
+        render(
             <AuthContext.Provider
                 value={{
                     ...authProvider,
@@ -150,7 +134,7 @@ describe('useCheckAuth', () => {
         await waitFor(() => {
             expect(logout).toHaveBeenCalledTimes(1);
             expect(notify).toHaveBeenCalledTimes(0);
-            expect(queryByText('authenticated')).toBeNull();
+            expect(screen.queryByText('authenticated')).toBeNull();
         });
     });
 });

--- a/packages/ra-core/src/auth/useCheckAuth.ts
+++ b/packages/ra-core/src/auth/useCheckAuth.ts
@@ -4,6 +4,7 @@ import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
 import useLogout from './useLogout';
 import { useNotify } from '../notification';
 import { useBasename } from '../routing';
+import { removeDoubleSlashes } from '../routing/useCreatePath';
 
 /**
  * Get a callback for calling the authProvider.checkAuth() method.
@@ -46,7 +47,9 @@ export const useCheckAuth = (): CheckAuth => {
     const notify = useNotify();
     const logout = useLogout();
     const basename = useBasename();
-    const loginUrl = `${basename ?? ''}${defaultAuthParams.loginUrl}`;
+    const loginUrl = removeDoubleSlashes(
+        `${basename}/${defaultAuthParams.loginUrl}`
+    );
 
     const checkAuth = useCallback(
         (

--- a/packages/ra-core/src/auth/useCheckAuth.ts
+++ b/packages/ra-core/src/auth/useCheckAuth.ts
@@ -46,7 +46,7 @@ export const useCheckAuth = (): CheckAuth => {
     const notify = useNotify();
     const logout = useLogout();
     const basename = useBasename();
-    const loginUrl = (basename ?? '') + defaultAuthParams.loginUrl;
+    const loginUrl = `${basename ?? ''}${defaultAuthParams.loginUrl}`;
 
     const checkAuth = useCallback(
         (

--- a/packages/ra-core/src/auth/useCheckAuth.ts
+++ b/packages/ra-core/src/auth/useCheckAuth.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
 import useLogout from './useLogout';
 import { useNotify } from '../notification';
+import { useBasename } from '../routing';
 
 /**
  * Get a callback for calling the authProvider.checkAuth() method.
@@ -44,12 +45,14 @@ export const useCheckAuth = (): CheckAuth => {
     const authProvider = useAuthProvider();
     const notify = useNotify();
     const logout = useLogout();
+    const basename = useBasename();
+    const loginUrl = (basename ?? '') + defaultAuthParams.loginUrl;
 
     const checkAuth = useCallback(
         (
             params: any = {},
             logoutOnFailure = true,
-            redirectTo = defaultAuthParams.loginUrl,
+            redirectTo = loginUrl,
             disableNotification = false
         ) =>
             authProvider.checkAuth(params).catch(error => {
@@ -71,7 +74,7 @@ export const useCheckAuth = (): CheckAuth => {
                 }
                 throw error;
             }),
-        [authProvider, logout, notify]
+        [authProvider, logout, notify, loginUrl]
     );
 
     return authProvider ? checkAuth : checkAuthWithoutAuthProvider;

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -37,7 +37,7 @@ const useLogin = (): Login => {
     const { resetNotifications } = useNotificationContext();
     const nextPathName = locationState && locationState.nextPathname;
     const nextSearch = locationState && locationState.nextSearch;
-    const afterLoginUrl = (basename ?? '') + defaultAuthParams.afterLoginUrl;
+    const afterLoginUrl = `${basename ?? ''}${defaultAuthParams.afterLoginUrl}`;
 
     const login = useCallback(
         (params: any = {}, pathName) =>

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useNotificationContext } from '../notification';
 import { useBasename } from '../routing';
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
+import { removeDoubleSlashes } from '../routing/useCreatePath';
 
 /**
  * Get a callback for calling the authProvider.login() method
@@ -37,7 +38,9 @@ const useLogin = (): Login => {
     const { resetNotifications } = useNotificationContext();
     const nextPathName = locationState && locationState.nextPathname;
     const nextSearch = locationState && locationState.nextSearch;
-    const afterLoginUrl = `${basename ?? ''}${defaultAuthParams.afterLoginUrl}`;
+    const afterLoginUrl = removeDoubleSlashes(
+        `${basename}/${defaultAuthParams.afterLoginUrl}`
+    );
 
     const login = useCallback(
         (params: any = {}, pathName) =>

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useNotificationContext } from '../notification';
+import { useBasename } from '../routing';
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
 
 /**
@@ -32,9 +33,11 @@ const useLogin = (): Login => {
     const location = useLocation();
     const locationState = location.state as any;
     const navigate = useNavigate();
+    const basename = useBasename();
     const { resetNotifications } = useNotificationContext();
     const nextPathName = locationState && locationState.nextPathname;
     const nextSearch = locationState && locationState.nextSearch;
+    const afterLoginUrl = (basename ?? '') + defaultAuthParams.afterLoginUrl;
 
     const login = useCallback(
         (params: any = {}, pathName) =>
@@ -42,21 +45,27 @@ const useLogin = (): Login => {
                 resetNotifications();
                 const redirectUrl = pathName
                     ? pathName
-                    : nextPathName + nextSearch ||
-                      defaultAuthParams.afterLoginUrl;
+                    : nextPathName + nextSearch || afterLoginUrl;
                 navigate(redirectUrl);
                 return ret;
             }),
-        [authProvider, navigate, nextPathName, nextSearch, resetNotifications]
+        [
+            authProvider,
+            navigate,
+            nextPathName,
+            nextSearch,
+            resetNotifications,
+            afterLoginUrl,
+        ]
     );
 
     const loginWithoutProvider = useCallback(
         (_, __) => {
             resetNotifications();
-            navigate(defaultAuthParams.afterLoginUrl);
+            navigate(afterLoginUrl);
             return Promise.resolve();
         },
-        [navigate, resetNotifications]
+        [navigate, resetNotifications, afterLoginUrl]
     );
 
     return authProvider ? login : loginWithoutProvider;

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
 import { useResetStore } from '../store';
+import { useBasename } from '../routing';
 import { useLocation, useNavigate, Path } from 'react-router-dom';
 
 /**
@@ -32,6 +33,8 @@ const useLogout = (): Logout => {
     const navigateRef = useRef(navigate);
     const location = useLocation();
     const locationRef = useRef(location);
+    const basename = useBasename();
+    const loginUrl = (basename ?? '') + defaultAuthParams.loginUrl;
 
     /*
      * We need the current location to pass in the router state
@@ -52,7 +55,7 @@ const useLogout = (): Logout => {
     const logout = useCallback(
         (
             params = {},
-            redirectTo = defaultAuthParams.loginUrl,
+            redirectTo = loginUrl,
             redirectToCurrentLocationAfterLogin = true
         ) =>
             authProvider.logout(params).then(redirectToFromProvider => {
@@ -91,14 +94,14 @@ const useLogout = (): Logout => {
 
                 return redirectToFromProvider;
             }),
-        [authProvider, resetStore]
+        [authProvider, resetStore, loginUrl]
     );
 
     const logoutWithoutProvider = useCallback(
         _ => {
             navigate(
                 {
-                    pathname: defaultAuthParams.loginUrl,
+                    pathname: loginUrl,
                 },
                 {
                     state: {
@@ -109,7 +112,7 @@ const useLogout = (): Logout => {
             resetStore();
             return Promise.resolve();
         },
-        [resetStore, location, navigate]
+        [resetStore, location, navigate, loginUrl]
     );
 
     return authProvider ? logout : logoutWithoutProvider;

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -34,7 +34,7 @@ const useLogout = (): Logout => {
     const location = useLocation();
     const locationRef = useRef(location);
     const basename = useBasename();
-    const loginUrl = (basename ?? '') + defaultAuthParams.loginUrl;
+    const loginUrl = `${basename ?? ''}${defaultAuthParams.loginUrl}`;
 
     /*
      * We need the current location to pass in the router state

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
 import { useResetStore } from '../store';
 import { useBasename } from '../routing';
+import { removeDoubleSlashes } from '../routing/useCreatePath';
 import { useLocation, useNavigate, Path } from 'react-router-dom';
 
 /**
@@ -34,7 +35,9 @@ const useLogout = (): Logout => {
     const location = useLocation();
     const locationRef = useRef(location);
     const basename = useBasename();
-    const loginUrl = `${basename ?? ''}${defaultAuthParams.loginUrl}`;
+    const loginUrl = removeDoubleSlashes(
+        `${basename}/${defaultAuthParams.loginUrl}`
+    );
 
     /*
      * We need the current location to pass in the router state
@@ -89,6 +92,7 @@ const useLogout = (): Logout => {
                 if (redirectToParts[1]) {
                     newLocation.search = redirectToParts[1];
                 }
+                console.log(`Redirecting to ${JSON.stringify(newLocation)}`);
                 navigateRef.current(newLocation, newLocationOptions);
                 resetStore();
 

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -92,7 +92,6 @@ const useLogout = (): Logout => {
                 if (redirectToParts[1]) {
                     newLocation.search = redirectToParts[1];
                 }
-                console.log(`Redirecting to ${JSON.stringify(newLocation)}`);
                 navigateRef.current(newLocation, newLocationOptions);
                 resetStore();
 

--- a/packages/ra-core/src/routing/useCreatePath.ts
+++ b/packages/ra-core/src/routing/useCreatePath.ts
@@ -70,4 +70,4 @@ export interface CreatePathParams {
     id?: Identifier;
 }
 
-const removeDoubleSlashes = (path: string) => path.replace('//', '/');
+export const removeDoubleSlashes = (path: string) => path.replace('//', '/');


### PR DESCRIPTION
## Content
Make the following auth hooks use basename in case of redirection:
- useLogin
- useLogout
- useCheckAuth

## Checklist
- [x] use basename to compute redirect url
- [x] cover with unit tests
- [x] test in real world example
- [x] check if doc needs to be updated