### PR TITLE
Fix the link to the ra-rbac module

### DIFF
--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -5,7 +5,7 @@ title: "RBAC"
 
 # Role-Based Access Control (RBAC)
 
-React-admin Enterprise Edition contains [the ra-rbac module](https://marmelab.com/ra-rbac)<img class="icon" src="./img/premium.svg" />, which adds fine-grained permissions to your admin. This module extends the `authProvider` and adds replacement for many react-admin components that use these permissions.
+React-admin Enterprise Edition contains [the ra-rbac module](https://marmelab.com/ra-enterprise/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, which adds fine-grained permissions to your admin. This module extends the `authProvider` and adds replacement for many react-admin components that use these permissions.
 
 <video controls="controls" style="max-width: 100%">
     <source src="./img/ra-rbac.mp4" type="video/mp4" />


### PR DESCRIPTION
Current link (https://marmelab.com/ra-rbac) leads to a page that doesn't exist.

`GET https://marmelab.com/ra-rbac 404`

**NOT FOUND**
You just hit a route that doesn't exist... the sadness.