### PR TITLE
Fix parsed date/date-time filter resets component

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -152,10 +152,12 @@ describe('<FilterForm />', () => {
                 nestedToClear: { nestedValue: 'def' },
                 classicUpdated: 'ghi',
                 nestedUpdated: { nestedValue: 'jkl' },
+                published_at: new Date('2022-01-01T03:00:00.000Z'),
             };
             const newFilterValues = {
                 classicUpdated: 'ghi2',
                 nestedUpdated: { nestedValue: 'jkl2' },
+                published_at: '2022-01-01T03:00:00.000Z',
             };
 
             expect(
@@ -165,6 +167,7 @@ describe('<FilterForm />', () => {
                 nestedToClear: { nestedValue: '' },
                 classicUpdated: 'ghi2',
                 nestedUpdated: { nestedValue: 'jkl2' },
+                published_at: '2022-01-01T03:00:00.000Z',
             });
         });
     });

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -153,6 +153,7 @@ describe('<FilterForm />', () => {
                 classicUpdated: 'ghi',
                 nestedUpdated: { nestedValue: 'jkl' },
                 published_at: new Date('2022-01-01T03:00:00.000Z'),
+                clearedDateValue: null,
             };
             const newFilterValues = {
                 classicUpdated: 'ghi2',
@@ -168,6 +169,7 @@ describe('<FilterForm />', () => {
                 classicUpdated: 'ghi2',
                 nestedUpdated: { nestedValue: 'jkl2' },
                 published_at: '2022-01-01T03:00:00.000Z',
+                clearedDateValue: '',
             });
         });
     });

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -237,7 +237,13 @@ const getInputValue = (
     key: string,
     filterValues: Record<string, any>
 ) => {
+    if (formValues[key] === undefined || formValues[key] === null) {
+        return '';
+    }
     if (Array.isArray(formValues[key])) {
+        return lodashGet(filterValues, key, '');
+    }
+    if (formValues[key] instanceof Date) {
         return lodashGet(filterValues, key, '');
     }
     if (typeof formValues[key] === 'object') {


### PR DESCRIPTION
Fixes #7540

The problem is in the `getFilterFormValues` return value, if a field is a Date, and has a `parse` function that returns a date (this is why it happens by default in DateTimeInputs and not in DateInputs), its value gets treated like a regular object, and ends up returning an empty object for that field, instead of the string representation of the date