### PR TITLE
Fix #7593, choices should indeed be `any[]`

### DIFF
--- a/packages/ra-core/src/form/useChoices.tsx
+++ b/packages/ra-core/src/form/useChoices.tsx
@@ -13,7 +13,7 @@ export type OptionTextFunc = (choice: any) => string | OptionTextElement;
 export type OptionText = OptionTextElement | OptionTextFunc | string;
 
 export interface ChoicesProps {
-    choices?: RaRecord[];
+    choices?: any[];
     isFetching?: boolean;
     isLoading?: boolean;
     optionValue?: string;


### PR DESCRIPTION
See #7593 