### PR TITLE
Fix <Button/> type

### DIFF
--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -112,7 +112,6 @@ interface Props {
     disabled?: boolean;
     label?: string;
     size?: 'small' | 'medium' | 'large';
-    icon?: ReactElement;
     redirect?: RedirectionSideEffect;
     variant?: string;
     // May be injected by Toolbar


### PR DESCRIPTION
Per MUI documentation https://mui.com/material-ui/api/button/#props `icon` is no longer a prop

Also we are passing icon as children