### PR TITLE
Bugifx: Allow style overrides for SimpleFormIterator

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -16,7 +16,10 @@ import { RaRecord } from 'ra-core';
 import { UseFieldArrayReturn } from 'react-hook-form';
 
 import { useArrayInput } from './useArrayInput';
-import { SimpleFormIteratorClasses } from './useSimpleFormIteratorStyles';
+import {
+    SimpleFormIteratorClasses,
+    SimpleFormIteratorPrefix,
+} from './useSimpleFormIteratorStyles';
 import { SimpleFormIteratorContext } from './SimpleFormIteratorContext';
 import {
     DisableRemoveFunction,
@@ -176,7 +179,10 @@ export interface SimpleFormIteratorProps extends Partial<UseFieldArrayReturn> {
     source?: string;
 }
 
-const Root = styled('ul')(({ theme }) => ({
+const Root = styled('ul', {
+    name: SimpleFormIteratorPrefix,
+    overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
     padding: 0,
     marginBottom: 0,
     '& > li:last-child': {


### PR DESCRIPTION
Resolves: https://github.com/marmelab/react-admin/issues/7629

Adding the following theme to the simple repo:

```js
const theme = merge({}, defaultTheme, {
    components: {
        RaSimpleFormIterator: {
            styleOverrides: {
                root: {
                    border: '1px solid red',
                    [`& .${SimpleFormIteratorClasses.indexContainer}`]: {
                        border: '1px solid hotpink',
                    },
                    [`& .${SimpleFormIteratorClasses.action}`]: {
                        border: '1px solid blue',
                    },
                },
            },
        },
    },
});
```

Results in the following (Mondrian-inspired 👩🏼‍🎨🖌🎨) appearance 😅 : 

<img width="880" alt="image" src="https://user-images.githubusercontent.com/17087167/166646167-eb36df09-75ba-4031-9fca-35eb99b8008a.png">
