### PR TITLE
Add possibility to disable redirect in useCreateController

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -50,7 +50,7 @@ export const useCreateController = <RecordType extends RaRecord = RaRecord>(
     const resource = useResourceContext(props);
     const { hasEdit, hasShow } = useResourceDefinition(props);
     const finalRedirectTo =
-        redirectTo || getDefaultRedirectRoute(hasShow, hasEdit);
+        redirectTo ?? getDefaultRedirectRoute(hasShow, hasEdit);
     const location = useLocation();
     const translate = useTranslate();
     const notify = useNotify();


### PR DESCRIPTION
Currently if `redirect` prop of useCreateController is set to false, it is ignored. This is probably not intentional and it makes difficult to disable redirects.