### PR TITLE
Fix IntrospectionOptions exported type

### DIFF
--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -115,7 +115,7 @@ export type GetWatchQueryOptions = (
 export type Options = {
     client?: ApolloClient<unknown>;
     clientOptions?: Partial<ApolloClientOptions<unknown>>;
-    introspection?: false | IntrospectionOptions;
+    introspection?: false | Partial<IntrospectionOptions>;
     override?: {
         [key: string]: (params: any) => BuildQueryResult;
     };


### PR DESCRIPTION
operationNames is set by default https://github.com/marmelab/react-admin/blob/03a0980ad801d753faa92d3a74ed18be43b926ec/packages/ra-data-graphql/src/index.ts#L60