### PR TITLE
:bug: Fix DateTimeInput is not working correctly. #7661

### DIFF
--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -15,7 +15,7 @@ import { InputHelperText } from './InputHelperText';
  * @param {string} value Date string, formatted as yyyy-MM-ddThh:mm
  * @return {Date}
  */
-const parseDateTime = (value: string) => new Date(value);
+const parseDateTime = (value: string) => value ? new Date(value) : value;
 
 /**
  * Input component for entering a date and a time with timezone, using the browser locale


### PR DESCRIPTION
Return empty string if `parseDateTime` function receive empty string as value instead `Invalid Date`(`Date` object)

Reference #7661 