### PR TITLE
Fix type of Button's "component" prop

### DIFF
--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ElementType } from 'react';
 import PropTypes from 'prop-types';
 import {
     Button as MuiButton,
@@ -107,7 +107,7 @@ interface Props {
     children?: ReactElement;
     className?: string;
     color?: MuiPropTypes.Color;
-    component?: ReactNode;
+    component?: ElementType;
     to?: string | LocationDescriptor;
     disabled?: boolean;
     label?: string;


### PR DESCRIPTION
The "component" prop allows passing the tag or component that will be rendered as a button
`ReactNode` refers to a string, number, null, undefined, boolean, React element, fragment, or portal
`ElementType` refers to an HTML tag name, React class or functional component