### PR TITLE
Proposal: add meta to EditProps

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -49,6 +49,7 @@ export const useEditController = <RecordType extends RaRecord = any>(
     const {
         disableAuthentication,
         id: propsId,
+        meta = {},
         mutationMode = 'undoable',
         mutationOptions = {},
         queryOptions = {},
@@ -69,7 +70,7 @@ export const useEditController = <RecordType extends RaRecord = any>(
         RecordType
     >(
         resource,
-        { id },
+        { id, meta },
         {
             onError: () => {
                 notify('ra.notification.item_doesnt_exist', {
@@ -201,6 +202,7 @@ export const useEditController = <RecordType extends RaRecord = any>(
 export interface EditControllerProps<RecordType extends RaRecord = any> {
     disableAuthentication?: boolean;
     id?: RecordType['id'];
+    meta?: Record<string, any>;
     mutationMode?: MutationMode;
     mutationOptions?: UseMutationOptions<
         RecordType,

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -15,6 +15,7 @@ export interface EditProps<RecordType extends RaRecord = any> {
     actions?: ReactElement | false;
     aside?: ReactElement;
     className?: string;
+    meta?: Record<string, any>;
     component?: ElementType;
     id?: Identifier;
     mutationMode?: MutationMode;


### PR DESCRIPTION
Hey!

I currently have the following changes in my own project, and I've had them for a while now. This is an example PR to share the diff.

I noticed that there was no nice way for me to pass meta through to the data provider without creating a lot of conditionals in the data provider.

An example of how I use this:

```tsx
export function TopicEdit(props: any) {
  return (
    <Edit meta={{ embed: 'media' }} {...props}>
      <TopicForm />
    </Edit>
  );
}
```

The change is relatively minor since everything after the controller already accepts meta.

Thoughts?