### PR TITLE
`sort` in <ReferenceArrayInput> doesn't work

### DIFF
--- a/examples/simple/src/posts/PostList.tsx
+++ b/examples/simple/src/posts/PostList.tsx
@@ -24,6 +24,8 @@ import {
     TextField,
     TextInput,
     useTranslate,
+    ReferenceArrayInput,
+    SelectArrayInput,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
 import ResetViewsButton from './ResetViewsButton';
@@ -36,6 +38,14 @@ const QuickFilter = ({ label, source, defaultValue }) => {
 
 const postFilter = [
     <SearchInput source="q" alwaysOn />,
+    <ReferenceArrayInput
+        reference="tags"
+        source="tags"
+        sort={{ field: 'name.en', order: 'ASC' }}
+        alwaysOn
+    >
+        <SelectArrayInput optionText="name.en" />
+    </ReferenceArrayInput>,
     <TextInput source="title" defaultValue="Qui tempore rerum et voluptates" />,
     <QuickFilter
         label="resources.posts.fields.commentable"


### PR DESCRIPTION
Whatever I put in the `sort` props of the `<ReferenceArrayInput>` component is not taken into account, and it still filters the content by id.

The only difference I noticed is that by default, it sorts the referenced content by `id` DESC, and when I use the sort option it sorts by `id` ASC.

Reading the source code, it seems that the `useReferenceArrayInputController` doesn't do its job properly, but from a quick glance I didn't find the problem.

AFAIK, the bug exists in both the latest 3.x and 4.x versions.