### PR TITLE
Rich text as json

### DIFF
--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -144,3 +144,22 @@ export const MyEditorOptions = {
 	],
 };
 ```
+
+## Changing the content type
+
+By default the RichTextInput will store and load the content as html. You can change this to json instead by passing in a prop `contentType` set to `json` if you prefer. This will export the input data as json instead. You can read more about this in the [tiptap docs](https://tiptap.dev/guide/output#option-1-json).
+
+Example:
+
+```jsx
+export function NewsForm() {
+  return (
+    <SimpleForm>
+      <TextInput source='title' />
+      <RichTextInput source='body' contentType="json" />
+    </SimpleForm>
+  );
+}
+```
+
+**Note:** Setting the contentType to json will make the value of this field incompatible with `RichTextField`. You can use tiptap's [generateHTML utility](https://tiptap.dev/api/utilities/html#generate-html-from-json) for this instead.

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -128,7 +128,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const newContent = 
+            const newContent =
                 contentType === 'json' ? editor.getJSON() : editor.getHTML();
 
             field.onChange(newContent);

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -128,7 +128,9 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const newContent = contentType === 'json' ? editor.getJSON() : editor.getHTML();
+            const newContent = contentType === 'json' 
+                ? editor.getJSON() 
+                : editor.getHTML();
 
             field.onChange(newContent);
             field.onBlur();

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -128,8 +128,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const newContent = contentType === 'json' 
-                ? editor.getJSON() 
+            const newContent = contentType === 'json' ? editor.getJSON() 
                 : editor.getHTML();
 
             field.onChange(newContent);

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -72,6 +72,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
         defaultValue = '',
         disabled = false,
         editorOptions = DefaultEditorOptions,
+        contentType = 'html',
         fullWidth,
         helperText,
         label,
@@ -127,8 +128,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const html = editor.getHTML();
-            field.onChange(html);
+            field.onChange(contentType === 'html' ? editor.getHTML() : editor.getJSON());
             field.onBlur();
         };
 
@@ -265,6 +265,7 @@ export type RichTextInputProps = CommonInputProps &
     Omit<LabeledProps, 'children'> & {
         disabled?: boolean;
         readOnly?: boolean;
+        contentType?: 'json' | 'html';
         editorOptions?: Partial<EditorOptions>;
         toolbar?: ReactNode;
     };

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -136,7 +136,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
         return () => {
             editor.off('update', handleEditorUpdate);
         };
-    }, [editor, field]);
+    }, [editor, field, contentType]);
 
     return (
         <Labeled

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -128,7 +128,9 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            field.onChange(contentType === 'json' ? editor.getJSON() : editor.getHTML());
+            const newContent = contentType === 'json' ? editor.getJSON() : editor.getHTML();
+
+            field.onChange(newContent);
             field.onBlur();
         };
 

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -128,7 +128,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            field.onChange(contentType === 'html' ? editor.getHTML() : editor.getJSON());
+            field.onChange(contentType === 'json' ? editor.getJSON() : editor.getHTML());
             field.onBlur();
         };
 

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -128,8 +128,8 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const newContent = contentType === 'json' ? editor.getJSON() 
-                : editor.getHTML();
+            const newContent = 
+                contentType === 'json' ? editor.getJSON() : editor.getHTML();
 
             field.onChange(newContent);
             field.onBlur();


### PR DESCRIPTION
Hello again, I wanted to share another suggestion! I have this change locally and it works.

**Context**

The reason I use this:

Our front end (api consumer) is a mobile app. Instead of a webview (which looks kind of lame on a mobile phone) I use json to parse it into native components. To do this I need json instead of html.

Luckily, tiptap supports this! This tiny change allows me to store json instead of html.

**BC**

I made it backwards compatible by defaulting to html and explicitly requiring `json` to activate the new behaviour. Even if someone uses this prop it won't break.

Thoughts?