### PR TITLE
Fix documentation for RichTextInputToolbar's LevelSelect

### DIFF
--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -59,7 +59,7 @@ Or to remove some prebuilt components like the `<AlignmentButtons>`:
 import {
 	RichTextInput,
 	RichTextInputToolbar,
-	RichTextInputLevelSelect,
+	LevelSelect,
 	FormatButtons,
 	ListButtons,
 	LinkButtons,
@@ -71,7 +71,7 @@ const MyRichTextInput = ({ size, ...props }) => (
 	<RichTextInput
 		toolbar={
 			<RichTextInputToolbar>
-				<RichTextInputLevelSelect size={size} />
+				<LevelSelect size={size} />
 				<FormatButtons size={size} />
 				<ListButtons size={size} />
 				<LinkButtons size={size} />
@@ -97,7 +97,7 @@ import {
 	DefaultEditorOptions,
 	RichTextInput,
 	RichTextInputToolbar,
-	RichTextInputLevelSelect,
+	LevelSelect,
 	FormatButtons,
 	AlignmentButtons,
 	ListButtons,
@@ -113,7 +113,7 @@ const MyRichTextInput = ({ size, ...props }) => (
 		editorOptions={MyEditorOptions}
 		toolbar={
 			<RichTextInputToolbar>
-				<RichTextInputLevelSelect size={size} />
+				<LevelSelect size={size} />
 				<FormatButtons size={size} />
 				<AlignmentButtons {size} />
 				<ListButtons size={size} />

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -2581,7 +2581,7 @@ import {
 	RichTextInput,
 +	DefaultEditorOptions,
 +	RichTextInputToolbar,
-+	RichTextInputLevelSelect,
++	LevelSelect,
 +	FormatButtons,
 +	AlignmentButtons,
 +	ListButtons,
@@ -2601,7 +2601,7 @@ const MyRichTextInput = (props) => (
 -        configureQuill={configureQuill}
 +        toolbar={
 +			<RichTextInputToolbar>
-+				<RichTextInputLevelSelect size={size} />
++				<LevelSelect size={size} />
 +				<FormatButtons size={size} />
 +				<AlignmentButtons {size} />
 +				<ListButtons size={size} />

--- a/packages/ra-input-rich-text/README.md
+++ b/packages/ra-input-rich-text/README.md
@@ -54,7 +54,7 @@ Or to remove some prebuilt components like the `<AlignmentButtons>`:
 import {
 	RichTextInput,
 	RichTextInputToolbar,
-	RichTextInputLevelSelect,
+	LevelSelect,
 	FormatButtons,
 	ListButtons,
 	LinkButtons,
@@ -66,7 +66,7 @@ const MyRichTextInput = ({ size, ...props }) => (
 	<RichTextInput
 		toolbar={
 			<RichTextInputToolbar>
-				<RichTextInputLevelSelect size={size} />
+				<LevelSelect size={size} />
 				<FormatButtons size={size} />
 				<ListButtons size={size} />
 				<LinkButtons size={size} />
@@ -92,7 +92,7 @@ import {
 	DefaultEditorOptions,
 	RichTextInput,
 	RichTextInputToolbar,
-	RichTextInputLevelSelect,
+	LevelSelect,
 	FormatButtons,
 	AlignmentButtons,
 	ListButtons,
@@ -108,7 +108,7 @@ const MyRichTextInput = ({ size, ...props }) => (
 		editorOptions={MyEditorOptions}
 		toolbar={
 			<RichTextInputToolbar>
-				<RichTextInputLevelSelect size={size} />
+				<LevelSelect size={size} />
 				<FormatButtons size={size} />
 				<AlignmentButtons {size} />
 				<ListButtons size={size} />

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -52,7 +52,7 @@ import { RichTextInputToolbar } from './RichTextInputToolbar';
  *     <RichTextInput
  *         toolbar={(
  *             <RichTextInputToolbar>
- *                 <RichTextInputLevelSelect size={size} />
+ *                 <LevelSelect size={size} />
  *                 <FormatButtons size={size} />
  *                 <ListButtons size={size} />
  *                 <LinkButtons size={size} />

--- a/packages/ra-input-rich-text/src/RichTextInputToolbar.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInputToolbar.tsx
@@ -34,7 +34,7 @@ import {
  *     <RichTextInput
  *         toolbar={(
  *             <RichTextInputToolbar>
- *                 <RichTextInputLevelSelect size={size} />
+ *                 <LevelSelect size={size} />
  *                 <FormatButtons size={size} />
  *                 <ListButtons size={size} />
  *                 <LinkButtons size={size} />


### PR DESCRIPTION
`ra-input-rich-text` doesn't export any `RichTextInputLevelSelect`. It should be just `LevelSelect`.