### PR TITLE
Fix `<NumberInput>` edge cases

### DIFF
--- a/docs/NumberInput.md
+++ b/docs/NumberInput.md
@@ -17,7 +17,7 @@ import { NumberInput } from 'react-admin';
 
 `<NumberInput>` converts the input value to a number (integer or float) *on blur*. This is because if the input updates the form value on every keystroke, it will prevent users from entering certain float values. For instance, to enter the number `1.02`, a user would type `1.0`, that JavaScript converts to the number `1`.
 
-If you need the form value to update on change instead of on blur (for instane to update another input based on the number input value), you can build your own number input using `<TextInput>`, and the `format` and `parse` props. But be aware that this only works for integer values. 
+If you need the form value to update on change instead of on blur (for instance to update another input based on the number input value), you can build your own number input using `<TextInput>`, and the `format` and `parse` props. But be aware that this only works for integer values. 
 
 ## Properties
 

--- a/docs/NumberInput.md
+++ b/docs/NumberInput.md
@@ -5,17 +5,19 @@ title: "The NumberInput Component"
 
 # `<NumberInput>`
 
-`<NumberInput>` translates to an HTML `<input type="number">`.
-
-![NumberInput](./img/number-input.gif)
-
-It is necessary for numeric values because of a [known React bug](https://github.com/facebook/react/issues/1425), which prevents using the more generic [`<TextInput>`](./TextInput.md) in that case.
+`<NumberInput>` translates to an HTML `<input type="number">`, and converts the user input to a number.
 
 ```jsx
 import { NumberInput } from 'react-admin';
 
 <NumberInput source="nb_views" />
 ```
+
+![NumberInput](./img/number-input.gif)
+
+`<NumberInput>` converts the input value to a number (integer or float) *on blur*. This is because if the input updates the form value on every keystroke, it will prevent users from entering certain float values. For instance, to enter the number `1.02`, a user would type `1.0`, that JavaScript converts to the number `1`.
+
+If you need the form value to update on change instead of on blur (for instane to update another input based on the number input value), you can build your own number input using `<TextInput>`, and the `format` and `parse` props. But be aware that this only works for integer values. 
 
 ## Properties
 

--- a/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
@@ -12,6 +12,12 @@ describe('<NumberInput />', () => {
         resource: 'posts',
     };
 
+    const MyToolbar = () => (
+        <Toolbar>
+            <SaveButton alwaysEnable />
+        </Toolbar>
+    );
+
     it('should use a mui TextField', () => {
         render(
             <AdminContext>
@@ -42,11 +48,6 @@ describe('<NumberInput />', () => {
     });
 
     describe('format and parse', () => {
-        const MyToolbar = () => (
-            <Toolbar>
-                <SaveButton alwaysEnable />
-            </Toolbar>
-        );
         it('should get the same value as injected value ', async () => {
             const onSubmit = jest.fn();
 
@@ -228,6 +229,7 @@ describe('<NumberInput />', () => {
             render(
                 <AdminContext>
                     <SimpleForm
+                        toolbar={<MyToolbar />}
                         defaultValues={{ views: 12 }}
                         onSubmit={jest.fn()}
                     >
@@ -238,6 +240,7 @@ describe('<NumberInput />', () => {
                     </SimpleForm>
                 </AdminContext>
             );
+            fireEvent.click(screen.getByText('ra.action.save'));
             const error = screen.queryByText('error');
             expect(error).toBeNull();
         });
@@ -246,6 +249,32 @@ describe('<NumberInput />', () => {
             render(
                 <AdminContext>
                     <SimpleForm
+                        toolbar={<MyToolbar />}
+                        defaultValues={{ views: 12 }}
+                        onSubmit={jest.fn()}
+                    >
+                        <NumberInput
+                            {...defaultProps}
+                            validate={value => undefined}
+                        />
+                    </SimpleForm>
+                </AdminContext>
+            );
+            const input = screen.getByLabelText('resources.posts.fields.views');
+            fireEvent.change(input, { target: { value: '3' } });
+            fireEvent.blur(input);
+
+            fireEvent.click(screen.getByText('ra.action.save'));
+
+            const error = screen.queryByText('error');
+            expect(error).toBeNull();
+        });
+
+        it('should be displayed if field has been touched and is invalid', async () => {
+            render(
+                <AdminContext>
+                    <SimpleForm
+                        toolbar={<MyToolbar />}
                         defaultValues={{ views: 12 }}
                         onSubmit={jest.fn()}
                     >
@@ -258,29 +287,9 @@ describe('<NumberInput />', () => {
             );
             const input = screen.getByLabelText('resources.posts.fields.views');
             fireEvent.change(input, { target: { value: '3' } });
-            input.blur();
-
-            const error = screen.queryByText('error');
-            expect(error).toBeNull();
-        });
-
-        it('should be displayed if field has been touched and is invalid', async () => {
-            render(
-                <AdminContext>
-                    <SimpleForm
-                        defaultValues={{ views: 12 }}
-                        onSubmit={jest.fn()}
-                        mode="onBlur"
-                    >
-                        <NumberInput
-                            {...defaultProps}
-                            validate={() => 'error'}
-                        />
-                    </SimpleForm>
-                </AdminContext>
-            );
-            const input = screen.getByLabelText('resources.posts.fields.views');
             fireEvent.blur(input);
+
+            fireEvent.click(screen.getByText('ra.action.save'));
 
             await waitFor(() => {
                 expect(screen.getByText('error')).not.toBeNull();

--- a/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
@@ -5,6 +5,7 @@ import { NumberInput } from './NumberInput';
 import { AdminContext } from '../AdminContext';
 import { SaveButton } from '../button';
 import { SimpleForm, Toolbar } from '../form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 describe('<NumberInput />', () => {
     const defaultProps = {
@@ -17,6 +18,11 @@ describe('<NumberInput />', () => {
             <SaveButton alwaysEnable />
         </Toolbar>
     );
+
+    const RecordWatcher = () => {
+        const views = useWatch({ name: 'views' });
+        return <code>views:{JSON.stringify(views)}</code>;
+    };
 
     it('should use a mui TextField', () => {
         render(
@@ -45,6 +51,47 @@ describe('<NumberInput />', () => {
             'resources.posts.fields.views'
         ) as HTMLInputElement;
         expect(input.step).toEqual('0.1');
+    });
+
+    it('should change when the user types a number', () => {
+        render(
+            <AdminContext>
+                <SimpleForm defaultValues={{ views: 12 }} onSubmit={jest.fn()}>
+                    <NumberInput {...defaultProps} />
+                    <RecordWatcher />
+                </SimpleForm>
+            </AdminContext>
+        );
+        screen.getByText('views:12');
+        const input = screen.getByLabelText(
+            'resources.posts.fields.views'
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '3' } });
+        fireEvent.blur(input);
+        screen.getByText('views:3');
+    });
+
+    it('should reinitialize when form values change', () => {
+        const UpdateViewsButton = () => {
+            const { setValue } = useFormContext();
+            return (
+                <button onClick={() => setValue('views', 45)}>
+                    Update views
+                </button>
+            );
+        };
+        render(
+            <AdminContext>
+                <SimpleForm defaultValues={{ views: 12 }} onSubmit={jest.fn()}>
+                    <NumberInput {...defaultProps} />
+                    <UpdateViewsButton />
+                    <RecordWatcher />
+                </SimpleForm>
+            </AdminContext>
+        );
+        screen.getByText('views:12');
+        fireEvent.click(screen.getByText('Update views'));
+        screen.getByText('views:45');
     });
 
     describe('format and parse', () => {

--- a/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { required } from 'ra-core';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 
 import { NumberInput } from './NumberInput';
 import { AdminContext } from '../AdminContext';

--- a/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
@@ -1,0 +1,272 @@
+import * as React from 'react';
+import { required } from 'ra-core';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { NumberInput } from './NumberInput';
+import { AdminContext } from '../AdminContext';
+import { Create } from '../detail';
+import { SimpleForm } from '../form';
+
+export default { title: 'ra-ui-materialui/input/NumberInput' };
+
+const FormInspector = ({ name = 'views' }) => {
+    const value = useWatch({ name });
+    return (
+        <div style={{ backgroundColor: 'lightgrey' }}>
+            {name} value in form:&nbsp;
+            <code>
+                {JSON.stringify(value)} ({typeof value})
+            </code>
+        </div>
+    );
+};
+
+export const Basic = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" />
+                <FormInspector />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Float = () => (
+    <AdminContext>
+        <Create
+            resource="poi"
+            record={{ id: 123, lat: 48.692054, long: 6.184417 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="lat" />
+                <NumberInput source="long" />
+                <FormInspector name="lat" />
+                <FormInspector name="long" />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const DefaultValue = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" defaultValue={26} />
+                <NumberInput
+                    source="views1"
+                    label="Default 6"
+                    defaultValue={6}
+                />
+                <NumberInput
+                    source="views2"
+                    label="Default 0"
+                    defaultValue={0}
+                />
+                <NumberInput source="views3" label="Default undefined" />
+                <FormInspector name="views" />
+                <FormInspector name="views1" />
+                <FormInspector name="views2" />
+                <FormInspector name="views3" />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const HelperText = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" />
+                <NumberInput source="views" helperText={false} />
+                <NumberInput
+                    source="views"
+                    helperText="Number of times the post was read"
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Label = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" />
+                <NumberInput source="views" label={false} />
+                <NumberInput source="views" label="Number of views" />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const FullWidth = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" label="default" />
+                <NumberInput source="views" label="Full Width" fullWidth />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Margin = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" label="default (dense)" />
+                <NumberInput source="views" label="none" margin="none" />
+                <NumberInput source="views" label="normal" margin="normal" />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Variant = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" label="default (filled)" />
+                <NumberInput
+                    source="views"
+                    label="outlined"
+                    variant="outlined"
+                />
+                <NumberInput
+                    source="views"
+                    label="standard"
+                    variant="standard"
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Step = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" label="No step" />
+                <NumberInput source="views" label="Step 0.1" step={0.1} />
+                <NumberInput source="views" label="Step 10" step={10} />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const MinMax = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" label="No min or max" />
+                <NumberInput
+                    source="views"
+                    label="Min 20, max 30"
+                    min={20}
+                    max={30}
+                />
+                <NumberInput source="views" label="Min 50" min={50} />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Required = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput source="views" />
+                <NumberInput source="views" required />
+                <NumberInput source="views" validate={required()} />
+                <NumberInput source="views" validate={[required()]} />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Error = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm
+                resolver={() => ({
+                    values: {},
+                    errors: {
+                        views: {
+                            type: 'custom',
+                            message: 'Special error message',
+                        },
+                    },
+                })}
+            >
+                <NumberInput source="views" />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const Sx = () => (
+    <AdminContext>
+        <Create
+            resource="posts"
+            record={{ id: 123, views: 23 }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <NumberInput
+                    source="views"
+                    sx={{
+                        border: 'solid 1px red',
+                        borderRadius: '5px',
+                        '& .MuiInputLabel-root': { fontWeight: 'bold' },
+                    }}
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -11,6 +11,9 @@ import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 /**
  * An Input component for a number
  *
+ * Due to limitations in React controlled components and number formatting,
+ * this input only updates the form value on blur.
+ *
  * @example
  * <NumberInput source="nb_views" />
  *
@@ -18,7 +21,6 @@ import { sanitizeInputRestProps } from './sanitizeInputRestProps';
  * @example
  * <NumberInput source="nb_views" step={1} />
  *
- * The object passed as `options` props is passed to the MUI <TextField> component
  */
 export const NumberInput = ({
     className,

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -48,8 +48,6 @@ export const NumberInput = ({
         isRequired,
     } = useInput({
         defaultValue,
-        format,
-        parse,
         resource,
         source,
         validate,

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -55,23 +55,27 @@ export const NumberInput = ({
         validate,
         ...rest,
     });
-    const [value, setValue] = React.useState(field.value);
-
-    // update the value when the record changes
-    React.useEffect(() => {
-        const stringValue = convertNumberToString(field.value);
-        setValue(value => (value !== stringValue ? stringValue : value));
-    }, [field.value]);
 
     const inputProps = { ...overrideInputProps, step, min, max };
 
-    // handle the text value manually
-    // to allow transitory values like '1.0' that will lead to '1.02'
+    // This is a controlled input that doesn't transform the user input on change.
+    // The user input is only turned into a number on blur.
+    // This is to allow transitory values like '1.0' that will lead to '1.02'
+
+    // text typed by the user and displayed in the input, unparsed
+    const [value, setValue] = React.useState(format(field.value));
+
+    // update the input text when the record changes
+    React.useEffect(() => {
+        const stringValue = format(field.value);
+        setValue(value => (value !== stringValue ? stringValue : value));
+    }, [field.value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // update the input text when the user types in the input
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
             onChange(event);
         }
-
         if (
             typeof event.target === 'undefined' ||
             typeof event.target.value === 'undefined'
@@ -108,6 +112,7 @@ export const NumberInput = ({
         <TextField
             id={id}
             {...field}
+            // override the react-hook-form value, onChange and onBlur props
             value={value}
             onChange={handleChange}
             onBlur={handleBlur}


### PR DESCRIPTION
## Problem

`<NumberInput>` does not handle zero after comma correctly (cf #7530)

## Solution

A controlled Number input cannot handle "transitive" values (e.g. "1.0" while typing "1.02") properly.

An uncontrolled input cannot handle reinitialization properly (this leads to problems e.g. when browsing from one record to the other in the same Edition view)

So the solution is to manage the string value locally, and only modify the form value on blur. This is the path taken by [react-aria's `useNumberField`](https://react-spectrum.adobe.com/react-aria/useNumberField.html#controlled), and I believe the only viable solution. 

Closes #7530, #7625
Supersedes #7537

## Tasks

- [x] Add storybook for `NumberInput` to test it locally
- [x] Use `event.target.valueAsNumber` instead of home-made `parse`
- [x] Manage string value with `useState`, and set form value on blur
- [x] Add more tests
- [x] Fix tests 
- [x] Update NumberInput doc to mention update in blur

Maybe we should also mention that `<input type="number" />` is problematic, [as pointed by this BBC study](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/). 