### PR TITLE
Fixing textinput changing 'on' into 'false'

### DIFF
--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -59,11 +59,7 @@ export const useInput = (props: InputProps): UseInputValue => {
     // This ensures dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level defaultValues so that it works as it should in react-hook-form
     // (i.e. field level defaultValue override form level defaultValues for this field).
-    const {
-        field: controllerField,
-        fieldState,
-        formState,
-    } = useController({
+    const { field: controllerField, fieldState, formState } = useController({
         name: finalName,
         defaultValue: get(record, source, defaultValue),
         rules: {

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -97,8 +97,8 @@ export const useInput = (props: InputProps): UseInputValue => {
             if (onChange) {
                 onChange(...event);
             }
-            const eventOrValue = (typeof event[0]?.target?.checked ===
-                'boolean' && event[0]?.target?.value === 'on'
+            const eventOrValue = (props.type === "checkbox" 
+                && event[0]?.target?.value === 'on'
                 ? event[0].target.checked
                 : event[0]?.target?.value ?? event[0]) as any;
             controllerField.onChange(
@@ -132,6 +132,7 @@ export type InputProps<ValueType = any> = Omit<
         onBlur?: (...event: any[]) => void;
         onChange?: (...event: any[]) => void;
         parse?: (value: any) => ValueType;
+        type?: string;
         resource?: string;
         source: string;
         validate?: Validator | Validator[];

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -59,7 +59,11 @@ export const useInput = (props: InputProps): UseInputValue => {
     // This ensures dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level defaultValues so that it works as it should in react-hook-form
     // (i.e. field level defaultValue override form level defaultValues for this field).
-    const { field: controllerField, fieldState, formState } = useController({
+    const {
+        field: controllerField,
+        fieldState,
+        formState,
+    } = useController({
         name: finalName,
         defaultValue: get(record, source, defaultValue),
         rules: {
@@ -97,8 +101,8 @@ export const useInput = (props: InputProps): UseInputValue => {
             if (onChange) {
                 onChange(...event);
             }
-            const eventOrValue = (props.type === "checkbox" 
-                && event[0]?.target?.value === 'on'
+            const eventOrValue = (props.type === 'checkbox' &&
+            event[0]?.target?.value === 'on'
                 ? event[0].target.checked
                 : event[0]?.target?.value ?? event[0]) as any;
             controllerField.onChange(

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -161,7 +161,12 @@ export interface NumberInputProps
     extends CommonInputProps,
         Omit<
             TextFieldProps,
-            'label' | 'helperText' | 'defaultValue' | 'onChange' | 'onBlur'
+            | 'label'
+            | 'helperText'
+            | 'defaultValue'
+            | 'onChange'
+            | 'onBlur'
+            | 'type'
         > {
     step?: string | number;
     min?: string | number;


### PR DESCRIPTION
Hello,
I came across a bizarre issue while implementing the last version of react-admin. Indeed, if the content of a any Input containing text is "on" it will be replaced by "false" (the bug was case sensitive, it can be verified on the [demo login page](https://marmelab.com/react-admin-demo/#/login) for example).
I tried and fixed it in my personal repository, so i'm submitting this pull request to help other encoutering this issue.

