### PR TITLE
feat(hooks): mutation error typing

### DIFF
--- a/docs/useCreate.md
+++ b/docs/useCreate.md
@@ -55,3 +55,17 @@ const LikeButton = ({ record }) => {
     return <button disabled={isLoading} onClick={handleClick}>Like</button>;
 };
 ```
+
+**Tip**: If you use TypeScript, you can specify the record and error types for more type safety:
+
+```tsx
+useCreate<Product, Error>(undefined, undefined, {
+    onError: (error) => {
+        // error is an instance of Error.
+    },
+    onSettled: (data, error) => {
+        // data is an instance of Product.
+        // error is an instance of Error.
+    },
+})
+```

--- a/docs/useCreate.md
+++ b/docs/useCreate.md
@@ -5,7 +5,7 @@ title: "useCreate"
 
 # `useCreate`
 
-This hook allows to call `dataProvider.create()` when the callback is executed. 
+This hook allows to call `dataProvider.create()` when the callback is executed.
 
 ```jsx
 // syntax

--- a/docs/useDelete.md
+++ b/docs/useDelete.md
@@ -5,7 +5,7 @@ title: "useDelete"
 
 # `useDelete`
 
-This hook allows calling `dataProvider.delete()` when the callback is executed and deleting a single record based on its `id`. 
+This hook allows calling `dataProvider.delete()` when the callback is executed and deleting a single record based on its `id`.
 
 ```jsx
 // syntax

--- a/docs/useDelete.md
+++ b/docs/useDelete.md
@@ -59,3 +59,17 @@ const DeleteButton = ({ record }) => {
     return <button disabled={isLoading} onClick={handleClick}>Delete</button>;
 };
 ```
+
+**Tip**: If you use TypeScript, you can specify the record and error types for more type safety:
+
+```tsx
+useDelete<Product, Error>(undefined, undefined, {
+    onError: (error) => {
+        // error is an instance of Error.
+    },
+    onSettled: (data, error) => {
+        // data is an instance of Product.
+        // error is an instance of Error.
+    },
+})
+```

--- a/docs/useDeleteMany.md
+++ b/docs/useDeleteMany.md
@@ -5,7 +5,7 @@ title: "useDeleteMany"
 
 # `useDeleteMany`
 
-This hook allows to call `dataProvider.deleteMany()` when the callback is executed, and delete an array of records based on their `ids`. 
+This hook allows to call `dataProvider.deleteMany()` when the callback is executed, and delete an array of records based on their `ids`.
 
 ```jsx
 // syntax

--- a/docs/useDeleteMany.md
+++ b/docs/useDeleteMany.md
@@ -59,3 +59,17 @@ const BulkDeletePostsButton = ({ selectedIds }) => {
     return <button disabled={isLoading} onClick={handleClick}>Delete selected posts</button>;
 };
 ```
+
+**Tip**: If you use TypeScript, you can specify the record and error types for more type safety:
+
+```tsx
+useDeleteMany<Product, Error>(undefined, undefined, {
+    onError: (error) => {
+        // error is an instance of Error.
+    },
+    onSettled: (data, error) => {
+        // data is an instance of Product.
+        // error is an instance of Error.
+    },
+})
+```

--- a/docs/useUpdate.md
+++ b/docs/useUpdate.md
@@ -5,7 +5,7 @@ title: "useUpdate"
 
 # `useUpdate`
 
-This hook allows to call `dataProvider.update()` when the callback is executed, and update a single record based on its `id` and a `data` argument. 
+This hook allows to call `dataProvider.update()` when the callback is executed, and update a single record based on its `id` and a `data` argument.
 
 ```jsx
 // syntax

--- a/docs/useUpdate.md
+++ b/docs/useUpdate.md
@@ -61,3 +61,17 @@ const IncreaseLikeButton = ({ record }) => {
     return <button disabled={isLoading} onClick={handleClick}>Like</button>;
 };
 ```
+
+**Tip**: If you use TypeScript, you can specify the record and error types for more type safety:
+
+```tsx
+useUpdate<Product, Error>(undefined, undefined, {
+    onError: (error) => {
+        // error is an instance of Error.
+    },
+    onSettled: (data, error) => {
+        // data is an instance of Product.
+        // error is an instance of Error.
+    },
+})
+```

--- a/docs/useUpdateMany.md
+++ b/docs/useUpdateMany.md
@@ -60,3 +60,17 @@ const BulkResetViewsButton = ({ selectedIds }) => {
     return <button disabled={isLoading} onClick={handleClick}>Reset views</button>;
 };
 ```
+
+**Tip**: If you use TypeScript, you can specify the record and error types for more type safety:
+
+```tsx
+useUpdateMany<Product, Error>(undefined, undefined, {
+    onError: (error) => {
+        // error is an instance of Error.
+    },
+    onSettled: (data, error) => {
+        // data is an instance of Product.
+        // error is an instance of Error.
+    },
+})
+```

--- a/docs/useUpdateMany.md
+++ b/docs/useUpdateMany.md
@@ -5,7 +5,7 @@ title: "useUpdateMany"
 
 # `useUpdateMany`
 
-This hook allows to call `dataProvider.updateMany()` when the callback is executed, and update an array of records based on their `ids` and a `data` argument. 
+This hook allows to call `dataProvider.updateMany()` when the callback is executed, and update an array of records based on their `ids` and a `data` argument.
 
 
 ```jsx

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -35,8 +35,11 @@ import {
  *     return <CreateView {...controllerProps} {...props} />;
  * }
  */
-export const useCreateController = <RecordType extends RaRecord = RaRecord>(
-    props: CreateControllerProps<RecordType> = {}
+export const useCreateController = <
+    RecordType extends RaRecord = RaRecord,
+    MutationOptionsError = unknown
+>(
+    props: CreateControllerProps<RecordType, MutationOptionsError> = {}
 ): CreateControllerResult<RecordType> => {
     const {
         disableAuthentication,
@@ -63,11 +66,10 @@ export const useCreateController = <RecordType extends RaRecord = RaRecord>(
         unregisterMutationMiddleware,
     } = useMutationMiddlewares();
 
-    const [create, { isLoading: saving }] = useCreate<RecordType>(
-        resource,
-        undefined,
-        otherMutationOptions
-    );
+    const [create, { isLoading: saving }] = useCreate<
+        RecordType,
+        MutationOptionsError
+    >(resource, undefined, otherMutationOptions);
 
     const save = useCallback(
         (
@@ -166,7 +168,10 @@ export const useCreateController = <RecordType extends RaRecord = RaRecord>(
     };
 };
 
-export interface CreateControllerProps<RecordType extends RaRecord = RaRecord> {
+export interface CreateControllerProps<
+    RecordType extends RaRecord = RaRecord,
+    MutationOptionsError = unknown
+> {
     disableAuthentication?: boolean;
     hasEdit?: boolean;
     hasShow?: boolean;
@@ -175,7 +180,7 @@ export interface CreateControllerProps<RecordType extends RaRecord = RaRecord> {
     resource?: string;
     mutationOptions?: UseMutationOptions<
         RecordType,
-        unknown,
+        MutationOptionsError,
         UseCreateMutateParams<RecordType>
     >;
     transform?: TransformData;

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -39,8 +39,11 @@ import { SaveContextValue, useMutationMiddlewares } from '../saveContext';
  *     return <EditView {...controllerProps} {...props} />;
  * }
  */
-export const useEditController = <RecordType extends RaRecord = any>(
-    props: EditControllerProps<RecordType> = {}
+export const useEditController = <
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+>(
+    props: EditControllerProps<RecordType, MutationOptionsError> = {}
 ): EditControllerResult<RecordType> => {
     const {
         disableAuthentication,
@@ -101,11 +104,10 @@ export const useEditController = <RecordType extends RaRecord = any>(
 
     const recordCached = { id, previousData: record };
 
-    const [update, { isLoading: saving }] = useUpdate<RecordType>(
-        resource,
-        recordCached,
-        { ...otherMutationOptions, mutationMode }
-    );
+    const [update, { isLoading: saving }] = useUpdate<
+        RecordType,
+        MutationOptionsError
+    >(resource, recordCached, { ...otherMutationOptions, mutationMode });
 
     const save = useCallback(
         (
@@ -211,13 +213,16 @@ export const useEditController = <RecordType extends RaRecord = any>(
     };
 };
 
-export interface EditControllerProps<RecordType extends RaRecord = any> {
+export interface EditControllerProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> {
     disableAuthentication?: boolean;
     id?: RecordType['id'];
     mutationMode?: MutationMode;
     mutationOptions?: UseMutationOptions<
         RecordType,
-        unknown,
+        MutationOptionsError,
         UseUpdateMutateParams<RecordType>
     >;
     queryOptions?: UseQueryOptions<RecordType>;

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -66,11 +66,14 @@ import { RaRecord, CreateParams } from '../types';
  * const [create, { data }] = useCreate<Product>('products', { data: product });
  *                    \-- data is Product
  */
-export const useCreate = <RecordType extends RaRecord = any>(
+export const useCreate = <
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+>(
     resource?: string,
     params: Partial<CreateParams<Partial<RecordType>>> = {},
-    options: UseCreateOptions<RecordType> = {}
-): UseCreateResult<RecordType> => {
+    options: UseCreateOptions<RecordType, MutationError> = {}
+): UseCreateResult<RecordType, boolean, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
     const paramsRef = useRef<Partial<CreateParams<Partial<RecordType>>>>(
@@ -79,7 +82,7 @@ export const useCreate = <RecordType extends RaRecord = any>(
 
     const mutation = useMutation<
         RecordType,
-        unknown,
+        MutationError,
         Partial<UseCreateMutateParams<RecordType>>
     >(
         ({
@@ -119,7 +122,7 @@ export const useCreate = <RecordType extends RaRecord = any>(
         callTimeParams: Partial<CreateParams<RecordType>> = {},
         createOptions: MutateOptions<
             RecordType,
-            unknown,
+            MutationError,
             Partial<UseCreateMutateParams<RecordType>>,
             unknown
         > & { returnPromise?: boolean } = {}
@@ -147,30 +150,32 @@ export interface UseCreateMutateParams<RecordType extends RaRecord = any> {
 }
 
 export type UseCreateOptions<
-    RecordType extends RaRecord = any
+    RecordType extends RaRecord = any,
+    MutationError = unknown
 > = UseMutationOptions<
     RecordType,
-    unknown,
+    MutationError,
     Partial<UseCreateMutateParams<RecordType>>
 >;
 
 export type UseCreateResult<
     RecordType extends RaRecord = any,
-    TReturnPromise extends boolean = boolean
+    TReturnPromise extends boolean = boolean,
+    MutationError = unknown
 > = [
     (
         resource?: string,
         params?: Partial<CreateParams<Partial<RecordType>>>,
         options?: MutateOptions<
             RecordType,
-            unknown,
+            MutationError,
             Partial<UseCreateMutateParams<RecordType>>,
             unknown
         > & { returnPromise?: TReturnPromise }
     ) => Promise<TReturnPromise extends true ? RecordType : void>,
     UseMutationResult<
         RecordType,
-        unknown,
+        MutationError,
         Partial<UseCreateMutateParams<RecordType>>,
         unknown
     >

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -68,11 +68,14 @@ import { RaRecord, DeleteParams, MutationMode } from '../types';
  * const [delete, { data }] = useDelete<Product>('products', { id, previousData: product });
  *                    \-- data is Product
  */
-export const useDelete = <RecordType extends RaRecord = any>(
+export const useDelete = <
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+>(
     resource?: string,
     params: Partial<DeleteParams<RecordType>> = {},
-    options: UseDeleteOptions<RecordType> = {}
-): UseDeleteResult<RecordType> => {
+    options: UseDeleteOptions<RecordType, MutationError> = {}
+): UseDeleteResult<RecordType, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
     const { id, previousData } = params;
@@ -141,7 +144,7 @@ export const useDelete = <RecordType extends RaRecord = any>(
 
     const mutation = useMutation<
         RecordType,
-        unknown,
+        MutationError,
         Partial<UseDeleteMutateParams<RecordType>>
     >(
         ({
@@ -176,7 +179,7 @@ export const useDelete = <RecordType extends RaRecord = any>(
                 }
             },
             onError: (
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseDeleteMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -227,7 +230,7 @@ export const useDelete = <RecordType extends RaRecord = any>(
             },
             onSettled: (
                 data: RecordType,
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseDeleteMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -258,7 +261,7 @@ export const useDelete = <RecordType extends RaRecord = any>(
         callTimeParams: Partial<DeleteParams<RecordType>> = {},
         updateOptions: MutateOptions<
             RecordType,
-            unknown,
+            MutationError,
             Partial<UseDeleteMutateParams<RecordType>>,
             unknown
         > & { mutationMode?: MutationMode } = {}
@@ -388,27 +391,31 @@ export interface UseDeleteMutateParams<RecordType extends RaRecord = any> {
 }
 
 export type UseDeleteOptions<
-    RecordType extends RaRecord = any
+    RecordType extends RaRecord = any,
+    MutationError = unknown
 > = UseMutationOptions<
     RecordType,
-    unknown,
+    MutationError,
     Partial<UseDeleteMutateParams<RecordType>>
 > & { mutationMode?: MutationMode };
 
-export type UseDeleteResult<RecordType extends RaRecord = any> = [
+export type UseDeleteResult<
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+> = [
     (
         resource?: string,
         params?: Partial<DeleteParams<RecordType>>,
         options?: MutateOptions<
             RecordType,
-            unknown,
+            MutationError,
             Partial<UseDeleteMutateParams<RecordType>>,
             unknown
         > & { mutationMode?: MutationMode }
     ) => Promise<void>,
     UseMutationResult<
         RecordType,
-        unknown,
+        MutationError,
         Partial<DeleteParams<RecordType> & { resource?: string }>,
         unknown
     >

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -70,11 +70,14 @@ import { RaRecord, DeleteManyParams, MutationMode } from '../types';
  * const [deleteMany, { data }] = useDeleteMany<Product>('products', { ids });
  *                        \-- data is Product
  */
-export const useDeleteMany = <RecordType extends RaRecord = any>(
+export const useDeleteMany = <
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+>(
     resource?: string,
     params: Partial<DeleteManyParams<RecordType>> = {},
-    options: UseDeleteManyOptions<RecordType> = {}
-): UseDeleteManyResult<RecordType> => {
+    options: UseDeleteManyOptions<RecordType, MutationError> = {}
+): UseDeleteManyResult<RecordType, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
     const { ids } = params;
@@ -154,7 +157,7 @@ export const useDeleteMany = <RecordType extends RaRecord = any>(
 
     const mutation = useMutation<
         RecordType['id'][],
-        unknown,
+        MutationError,
         Partial<UseDeleteManyMutateParams<RecordType>>
     >(
         ({
@@ -187,7 +190,7 @@ export const useDeleteMany = <RecordType extends RaRecord = any>(
                 }
             },
             onError: (
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseDeleteManyMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -238,7 +241,7 @@ export const useDeleteMany = <RecordType extends RaRecord = any>(
             },
             onSettled: (
                 data: RecordType['id'][],
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseDeleteManyMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -394,27 +397,31 @@ export interface UseDeleteManyMutateParams<RecordType extends RaRecord = any> {
 }
 
 export type UseDeleteManyOptions<
-    RecordType extends RaRecord = any
+    RecordType extends RaRecord = any,
+    MutationError = unknown
 > = UseMutationOptions<
     RecordType['id'][],
-    unknown,
+    MutationError,
     Partial<UseDeleteManyMutateParams<RecordType>>
 > & { mutationMode?: MutationMode };
 
-export type UseDeleteManyResult<RecordType extends RaRecord = any> = [
+export type UseDeleteManyResult<
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+> = [
     (
         resource?: string,
         params?: Partial<DeleteManyParams<RecordType>>,
         options?: MutateOptions<
             RecordType['id'][],
-            unknown,
+            MutationError,
             Partial<UseDeleteManyMutateParams<RecordType>>,
             unknown
         > & { mutationMode?: MutationMode }
     ) => Promise<void>,
     UseMutationResult<
         RecordType['id'][],
-        unknown,
+        MutationError,
         Partial<DeleteManyParams<RecordType> & { resource?: string }>,
         unknown
     >

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -72,11 +72,14 @@ import { RaRecord, UpdateParams, MutationMode } from '../types';
  * const [update, { data }] = useUpdate<Product>('products', { id, data: diff, previousData: product });
  *                    \-- data is Product
  */
-export const useUpdate = <RecordType extends RaRecord = any>(
+export const useUpdate = <
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+>(
     resource?: string,
     params: Partial<UpdateParams<RecordType>> = {},
-    options: UseUpdateOptions<RecordType> = {}
-): UseUpdateResult<RecordType> => {
+    options: UseUpdateOptions<RecordType, MutationError> = {}
+): UseUpdateResult<RecordType, boolean, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
     const { id, data, meta } = params;
@@ -140,7 +143,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
 
     const mutation = useMutation<
         RecordType,
-        unknown,
+        MutationError,
         Partial<UseUpdateMutateParams<RecordType>>
     >(
         ({
@@ -177,7 +180,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
                 }
             },
             onError: (
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseUpdateMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -229,7 +232,7 @@ export const useUpdate = <RecordType extends RaRecord = any>(
             },
             onSettled: (
                 data: RecordType,
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseUpdateMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -422,30 +425,32 @@ export interface UseUpdateMutateParams<RecordType extends RaRecord = any> {
 }
 
 export type UseUpdateOptions<
-    RecordType extends RaRecord = any
+    RecordType extends RaRecord = any,
+    MutationError = unknown
 > = UseMutationOptions<
     RecordType,
-    unknown,
+    MutationError,
     Partial<UseUpdateMutateParams<RecordType>>
 > & { mutationMode?: MutationMode };
 
 export type UseUpdateResult<
     RecordType extends RaRecord = any,
-    TReturnPromise extends boolean = boolean
+    TReturnPromise extends boolean = boolean,
+    MutationError = unknown
 > = [
     (
         resource?: string,
         params?: Partial<UpdateParams<RecordType>>,
         options?: MutateOptions<
             RecordType,
-            unknown,
+            MutationError,
             Partial<UseUpdateMutateParams<RecordType>>,
             unknown
         > & { mutationMode?: MutationMode; returnPromise?: TReturnPromise }
     ) => Promise<TReturnPromise extends true ? RecordType : void>,
     UseMutationResult<
         RecordType,
-        unknown,
+        MutationError,
         Partial<UpdateParams<RecordType> & { resource?: string }>,
         unknown
     >

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -66,11 +66,14 @@ import { Identifier } from '..';
  *     return <button disabled={isLoading} onClick={() => updateMany()}>Reset views</button>;
  * };
  */
-export const useUpdateMany = <RecordType extends RaRecord = any>(
+export const useUpdateMany = <
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+>(
     resource?: string,
     params: Partial<UpdateManyParams<Partial<RecordType>>> = {},
-    options: UseUpdateManyOptions<RecordType> = {}
-): UseUpdateManyResult<RecordType> => {
+    options: UseUpdateManyOptions<RecordType, MutationError> = {}
+): UseUpdateManyResult<RecordType, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
     const { ids, data, meta } = params;
@@ -150,7 +153,7 @@ export const useUpdateMany = <RecordType extends RaRecord = any>(
 
     const mutation = useMutation<
         Array<RecordType['id']>,
-        unknown,
+        MutationError,
         Partial<UseUpdateManyMutateParams<RecordType>>
     >(
         ({
@@ -185,7 +188,7 @@ export const useUpdateMany = <RecordType extends RaRecord = any>(
                 }
             },
             onError: (
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseUpdateManyMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -239,7 +242,7 @@ export const useUpdateMany = <RecordType extends RaRecord = any>(
             },
             onSettled: (
                 data: Array<RecordType['id']>,
-                error: unknown,
+                error: MutationError,
                 variables: Partial<UseUpdateManyMutateParams<RecordType>> = {},
                 context: { snapshot: Snapshot }
             ) => {
@@ -405,27 +408,31 @@ export interface UseUpdateManyMutateParams<RecordType extends RaRecord = any> {
 }
 
 export type UseUpdateManyOptions<
-    RecordType extends RaRecord = any
+    RecordType extends RaRecord = any,
+    MutationError = unknown
 > = UseMutationOptions<
     Array<RecordType['id']>,
-    unknown,
+    MutationError,
     Partial<UseUpdateManyMutateParams<RecordType>>
 > & { mutationMode?: MutationMode };
 
-export type UseUpdateManyResult<RecordType extends RaRecord = any> = [
+export type UseUpdateManyResult<
+    RecordType extends RaRecord = any,
+    MutationError = unknown
+> = [
     (
         resource?: string,
         params?: Partial<UpdateManyParams<RecordType>>,
         options?: MutateOptions<
             Array<RecordType['id']>,
-            unknown,
+            MutationError,
             Partial<UseUpdateManyMutateParams<RecordType>>,
             unknown
         > & { mutationMode?: MutationMode }
     ) => Promise<void>,
     UseMutationResult<
         Array<RecordType['id']>,
-        unknown,
+        MutationError,
         Partial<UpdateManyParams<Partial<RecordType>> & { resource?: string }>,
         unknown
     >

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -11,7 +11,10 @@ import {
 } from 'ra-core';
 import { UseQueryOptions, UseMutationOptions } from 'react-query';
 
-export interface EditProps<RecordType extends RaRecord = any> {
+export interface EditProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> {
     actions?: ReactElement | false;
     aside?: ReactElement;
     className?: string;
@@ -22,7 +25,7 @@ export interface EditProps<RecordType extends RaRecord = any> {
     queryOptions?: UseQueryOptions<RecordType>;
     mutationOptions?: UseMutationOptions<
         RecordType,
-        unknown,
+        MutationOptionsError,
         UseUpdateMutateParams<RecordType>
     >;
     redirect?: RedirectionSideEffect;
@@ -32,7 +35,10 @@ export interface EditProps<RecordType extends RaRecord = any> {
     sx?: SxProps;
 }
 
-export interface CreateProps<RecordType extends RaRecord = any> {
+export interface CreateProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> {
     actions?: ReactElement | false;
     aside?: ReactElement;
     className?: string;
@@ -45,7 +51,7 @@ export interface CreateProps<RecordType extends RaRecord = any> {
     resource?: string;
     mutationOptions?: UseMutationOptions<
         RecordType,
-        unknown,
+        MutationOptionsError,
         UseCreateMutateParams<RecordType>
     >;
     transform?: TransformData;


### PR DESCRIPTION
Provides a way to set the expected type of the error instance that will be propagated to the related functions.

closes #7653 