### PR TITLE
Add imports to guesser output

### DIFF
--- a/packages/ra-ui-materialui/src/detail/EditGuesser.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.spec.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CoreAdminContext } from 'ra-core';
+
+import { EditGuesser } from './EditGuesser';
+import { ThemeProvider } from '../layout';
+
+describe('<EditGuesser />', () => {
+    it('should log the guessed Edit view based on the fetched record', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const dataProvider = {
+            getOne: () =>
+                Promise.resolve({
+                    data: {
+                        id: 123,
+                        author: 'john doe',
+                        post_id: 6,
+                        score: 3,
+                        body:
+                            "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
+                        created_at: new Date('2012-08-02'),
+                    },
+                }),
+            getMany: () => Promise.resolve({ data: [] }),
+        };
+        render(
+            <ThemeProvider theme={{}}>
+                <CoreAdminContext dataProvider={dataProvider as any}>
+                    <EditGuesser resource="comments" id={123} />
+                </CoreAdminContext>
+            </ThemeProvider>
+        );
+        await waitFor(() => {
+            screen.getByDisplayValue('john doe');
+        });
+        expect(logSpy).toHaveBeenCalledWith(`Guessed Edit:
+
+import { DateInput, Edit, NumberInput, ReferenceInput, SelectInput, SimpleForm, TextInput } from 'react-admin';
+
+export const CommentEdit = () => (
+    <Edit>
+        <SimpleForm>
+            <TextInput source="id" />
+            <TextInput source="author" />
+            <ReferenceInput source="post_id" reference="posts"><SelectInput optionText="id" /></ReferenceInput>
+            <NumberInput source="score" />
+            <TextInput source="body" />
+            <DateInput source="created_at" />
+        </SimpleForm>
+    </Edit>
+);`);
+    });
+});

--- a/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
@@ -44,9 +44,9 @@ export const EditGuesser = (props: EditProps) => {
 const EditViewGuesser = props => {
     const resource = useResourceContext(props);
     const { record } = useEditContext();
-    const [inferredChild, setInferredChild] = useState(null);
+    const [child, setChild] = useState(null);
     useEffect(() => {
-        if (record && !inferredChild) {
+        if (record && !child) {
             const inferredElements = getElementsFromRecords(
                 [record],
                 editFieldTypes
@@ -56,16 +56,17 @@ const EditViewGuesser = props => {
                 null,
                 inferredElements
             );
-            setInferredChild(inferredChild.getElement());
+            setChild(inferredChild.getElement());
 
             if (process.env.NODE_ENV === 'production') return;
 
             const representation = inferredChild.getRepresentation();
+
             const components = ['Edit']
                 .concat(
                     Array.from(
                         new Set(
-                            Array.from(representation.matchAll(/<([^\/\s>]+)/g))
+                            Array.from(representation.matchAll(/<([^/\s>]+)/g))
                                 .map(match => match[1])
                                 .filter(component => component !== 'span')
                         )
@@ -88,9 +89,9 @@ ${representation}
 );`
             );
         }
-    }, [record, inferredChild, resource]);
+    }, [record, child, resource]);
 
-    return <EditView {...props}>{inferredChild}</EditView>;
+    return <EditView {...props}>{child}</EditView>;
 };
 
 EditViewGuesser.propTypes = EditView.propTypes;

--- a/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
@@ -45,6 +45,11 @@ const EditViewGuesser = props => {
     const resource = useResourceContext(props);
     const { record } = useEditContext();
     const [child, setChild] = useState(null);
+
+    useEffect(() => {
+        setChild(null);
+    }, [resource]);
+
     useEffect(() => {
         if (record && !child) {
             const inferredElements = getElementsFromRecords(

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.spec.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CoreAdminContext } from 'ra-core';
+
+import { ShowGuesser } from './ShowGuesser';
+import { ThemeProvider } from '../layout';
+
+describe('<ShowGuesser />', () => {
+    it('should log the guessed Show view based on the fetched record', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const dataProvider = {
+            getOne: () =>
+                Promise.resolve({
+                    data: {
+                        id: 123,
+                        author: 'john doe',
+                        post_id: 6,
+                        score: 3,
+                        body:
+                            "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
+                        created_at: new Date('2012-08-02'),
+                    },
+                }),
+        };
+        render(
+            <ThemeProvider theme={{}}>
+                <CoreAdminContext dataProvider={dataProvider as any}>
+                    <ShowGuesser resource="comments" id={123} />
+                </CoreAdminContext>
+            </ThemeProvider>
+        );
+        await waitFor(() => {
+            screen.getByText('john doe');
+        });
+        expect(logSpy).toHaveBeenCalledWith(`Guessed Show:
+
+import { DateField, NumberField, ReferenceField, Show, SimpleShowLayout, TextField } from 'react-admin';
+
+export const CommentShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="id" />
+            <TextField source="author" />
+            <ReferenceField source="post_id" reference="posts"><TextField source="id" /></ReferenceField>
+            <NumberField source="score" />
+            <TextField source="body" />
+            <DateField source="created_at" />
+        </SimpleShowLayout>
+    </Show>
+);`);
+    });
+});

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
@@ -27,9 +27,9 @@ export const ShowGuesser = ({
 const ShowViewGuesser = props => {
     const resource = useResourceContext(props);
     const { record } = useShowContext();
-    const [inferredChild, setInferredChild] = useState(null);
+    const [child, setChild] = useState(null);
     useEffect(() => {
-        if (record && !inferredChild) {
+        if (record && !child) {
             const inferredElements = getElementsFromRecords(
                 [record],
                 showFieldTypes
@@ -39,7 +39,7 @@ const ShowViewGuesser = props => {
                 null,
                 inferredElements
             );
-            setInferredChild(inferredChild.getElement());
+            setChild(inferredChild.getElement());
 
             if (process.env.NODE_ENV === 'production') return;
 
@@ -48,7 +48,7 @@ const ShowViewGuesser = props => {
                 .concat(
                     Array.from(
                         new Set(
-                            Array.from(representation.matchAll(/<([^\/\s>]+)/g))
+                            Array.from(representation.matchAll(/<([^/\s>]+)/g))
                                 .map(match => match[1])
                                 .filter(component => component !== 'span')
                         )
@@ -71,9 +71,9 @@ ${inferredChild.getRepresentation()}
 );`
             );
         }
-    }, [record, inferredChild, resource]);
+    }, [record, child, resource]);
 
-    return <ShowView {...props}>{inferredChild}</ShowView>;
+    return <ShowView {...props}>{child}</ShowView>;
 };
 
 ShowViewGuesser.propTypes = ShowView.propTypes;

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
@@ -28,6 +28,11 @@ const ShowViewGuesser = props => {
     const resource = useResourceContext(props);
     const { record } = useShowContext();
     const [child, setChild] = useState(null);
+
+    useEffect(() => {
+        setChild(null);
+    }, [resource]);
+
     useEffect(() => {
         if (record && !child) {
             const inferredElements = getElementsFromRecords(

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
@@ -39,6 +39,7 @@ const ShowViewGuesser = props => {
                 null,
                 inferredElements
             );
+            setInferredChild(inferredChild.getElement());
 
             if (process.env.NODE_ENV === 'production') return;
 
@@ -69,7 +70,6 @@ ${inferredChild.getRepresentation()}
     </Show>
 );`
             );
-            setInferredChild(inferredChild.getElement());
         }
     }, [record, inferredChild, resource]);
 

--- a/packages/ra-ui-materialui/src/list/ListGuesser.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.spec.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CoreAdminContext } from 'ra-core';
+
+import { ListGuesser } from './ListGuesser';
+import { ThemeProvider } from '../layout';
+
+describe('<ListGuesser />', () => {
+    it('should log the guessed List view based on the fetched records', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const dataProvider = {
+            getList: () =>
+                Promise.resolve({
+                    data: [
+                        {
+                            id: 123,
+                            author: 'john doe',
+                            post_id: 6,
+                            score: 3,
+                            body:
+                                "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
+                            created_at: new Date('2012-08-02'),
+                        },
+                    ],
+                    total: 1,
+                }),
+        };
+        render(
+            <ThemeProvider theme={{}}>
+                <CoreAdminContext dataProvider={dataProvider as any}>
+                    <ListGuesser resource="comments" />
+                </CoreAdminContext>
+            </ThemeProvider>
+        );
+        await waitFor(() => {
+            screen.getByText('john doe');
+        });
+        expect(logSpy).toHaveBeenCalledWith(`Guessed List:
+
+import { Datagrid, DateField, List, NumberField, ReferenceField, TextField } from 'react-admin';
+
+export const CommentList = () => (
+    <List>
+        <Datagrid rowClick="edit">
+            <TextField source="id" />
+            <TextField source="author" />
+            <ReferenceField source="post_id" reference="posts"><TextField source="id" /></ReferenceField>
+            <NumberField source="score" />
+            <TextField source="body" />
+            <DateField source="created_at" />
+        </Datagrid>
+    </List>
+);`);
+    });
+});

--- a/packages/ra-ui-materialui/src/list/ListGuesser.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.tsx
@@ -71,14 +71,14 @@ export const ListGuesser = <RecordType extends RaRecord = any>(
 const ListViewGuesser = (props: Omit<ListViewProps, 'children'>) => {
     const { data } = useListContext(props);
     const resource = useResourceContext();
-    const [inferredChild, setInferredChild] = useState(null);
+    const [child, setChild] = useState(null);
 
     useEffect(() => {
-        setInferredChild(null);
+        setChild(null);
     }, [resource]);
 
     useEffect(() => {
-        if (data && data.length > 0 && !inferredChild) {
+        if (data && data.length > 0 && !child) {
             const inferredElements = getElementsFromRecords(
                 data,
                 listFieldTypes
@@ -88,7 +88,7 @@ const ListViewGuesser = (props: Omit<ListViewProps, 'children'>) => {
                 null,
                 inferredElements
             );
-            setInferredChild(inferredChild.getElement());
+            setChild(inferredChild.getElement());
 
             if (process.env.NODE_ENV === 'production') return;
 
@@ -120,9 +120,9 @@ ${inferredChild.getRepresentation()}
 );`
             );
         }
-    }, [data, inferredChild, resource]);
+    }, [data, child, resource]);
 
-    return <ListView {...props}>{inferredChild}</ListView>;
+    return <ListView {...props}>{child}</ListView>;
 };
 
 ListViewGuesser.propTypes = ListView.propTypes;

--- a/packages/ra-ui-materialui/src/list/ListGuesser.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.tsx
@@ -97,7 +97,7 @@ const ListViewGuesser = (props: Omit<ListViewProps, 'children'>) => {
                 .concat(
                     Array.from(
                         new Set(
-                            Array.from(representation.matchAll(/<([^\/\s>]+)/g))
+                            Array.from(representation.matchAll(/<([^/\s>]+)/g))
                                 .map(match => match[1])
                                 .filter(component => component !== 'span')
                         )

--- a/packages/ra-ui-materialui/src/list/ListGuesser.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.tsx
@@ -88,6 +88,7 @@ const ListViewGuesser = (props: Omit<ListViewProps, 'children'>) => {
                 null,
                 inferredElements
             );
+            setInferredChild(inferredChild.getElement());
 
             if (process.env.NODE_ENV === 'production') return;
 
@@ -118,7 +119,6 @@ ${inferredChild.getRepresentation()}
     </List>
 );`
             );
-            setInferredChild(inferredChild.getElement());
         }
     }, [data, inferredChild, resource]);
 


### PR DESCRIPTION
## Problem

Guesser output can't be copy/pasted directly, as it misses the import part.

## Solution

Add the imports

## Example output

```diff
Guessed Show:
+
+import { DateField, ReferenceField, Show, SimpleShowLayout, TextField } from 'react-admin';

export const CommentShow = () => (
    <Show>
        <SimpleShowLayout>
            <TextField source="id" />
            <DateField source="author.undefined" />
            <ReferenceField source="post_id" reference="posts"><TextField source="id" /></ReferenceField>
            <TextField source="body" />
            <DateField source="created_at" />
        </SimpleShowLayout>
    </Show>
);
```