### PR TITLE
Fix example for BooleanInput

### DIFF
--- a/docs/BooleanInput.md
+++ b/docs/BooleanInput.md
@@ -24,7 +24,7 @@ You can use the `options` prop to pass any option supported by the MUI's `Switch
 import { BooleanInput } from 'react-admin';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 
-<BooleanInput source="favorite" checkedIcon={<FavoriteIcon />} />
+<BooleanInput source="favorite" options={{ checkedIcon: <FavoriteIcon /> }} />
 ```
 {% endraw %}
 


### PR DESCRIPTION
BooleanInput expects an options object to overwrite MUI component