### PR TITLE
Add Support For resetable Prop in SelectArrayInput

### DIFF
--- a/examples/demo/src/visitors/SegmentsInput.tsx
+++ b/examples/demo/src/visitors/SegmentsInput.tsx
@@ -9,6 +9,7 @@ const SegmentsInput = (props: SelectArrayInputProps) => (
         source="groups"
         translateChoice
         choices={segments}
+        resettable
     />
 );
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -29,6 +29,7 @@ import {
     SupportCreateSuggestionOptions,
     useSupportCreateSuggestion,
 } from './useSupportCreateSuggestion';
+import { ResettableTextField } from './ResettableTextField';
 
 /**
  * An Input component for a select box allowing multiple selections, using an array of objects for the options
@@ -102,6 +103,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         optionText,
         optionValue,
         parse,
+        resettable,
         resource: resourceProp,
         source: sourceProp,
         translateChoice,
@@ -273,6 +275,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                     {...field}
                     onChange={handleChangeWithCreateSupport}
                     value={field.value || []}
+                    input={<ResettableTextField resettable={resettable} />}
                 >
                     {finalChoices.map(renderMenuItem)}
                 </Select>
@@ -296,6 +299,7 @@ export type SelectArrayInputProps = ChoicesProps &
         disableValue?: string;
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
+        resettable?: boolean;
     };
 
 SelectArrayInput.propTypes = {
@@ -354,6 +358,7 @@ const sanitizeRestProps = ({
     perPage,
     record,
     reference,
+    resettable,
     resource,
     setFilter,
     setPagination,


### PR DESCRIPTION
Fixes #7718

Like for or others inputs, it only appear on hover
![image](https://user-images.githubusercontent.com/1122076/169814493-5ac17bb9-2bc2-4436-be56-0f59b564240e.png)
