### PR TITLE
chg: :memo: Remove label from ReferenceArrayInput

### DIFF
--- a/docs/ReferenceArrayInput.md
+++ b/docs/ReferenceArrayInput.md
@@ -97,7 +97,6 @@ You can tweak how this component fetches the possible values using the `page`, `
 
 ```jsx
 <ReferenceArrayInput
-    label="Tags"
     reference="tags"
     source="tags"
     enableGetChoices={({ q }) => (q ? q.length >= 2 : false)}


### PR DESCRIPTION
ReferenceArrayInput does not have a "label" props anymore as stated above on that same file.