### PR TITLE
Fix in Typescript definitions

### DIFF
--- a/packages/ra-core/src/util/FieldTitle.tsx
+++ b/packages/ra-core/src/util/FieldTitle.tsx
@@ -7,12 +7,18 @@ export interface FieldTitleProps {
     isRequired?: boolean;
     resource?: string;
     source?: string;
-    label?: string | ReactElement | false;
+    label?: string | ReactElement | boolean;
 }
 
 export const FieldTitle = (props: FieldTitleProps) => {
     const { source, label, resource, isRequired } = props;
     const translateLabel = useTranslateLabel();
+
+    if (label === true) {
+        throw new Error(
+            'Label parameter must be a string, a ReactElement or false'
+        );
+    }
 
     if (label === false || label === '') {
         return null;

--- a/packages/ra-ui-materialui/src/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/Labeled.tsx
@@ -75,7 +75,7 @@ export interface LabeledProps extends StackProps {
     fullWidth?: boolean;
     htmlFor?: string;
     isRequired?: boolean;
-    label?: string | ReactElement | false;
+    label?: string | ReactElement | boolean;
     resource?: string;
     source?: string;
 }

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -14,7 +14,7 @@ export interface PublicFieldProps {
     sortBy?: string;
     sortByOrder?: SortOrder;
     source?: string;
-    label?: string | ReactElement | boolean;
+    label?: string | ReactElement | false;
     sortable?: boolean;
     className?: string;
     cellClassName?: string;

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -14,7 +14,7 @@ export interface PublicFieldProps {
     sortBy?: string;
     sortByOrder?: SortOrder;
     source?: string;
-    label?: string | ReactElement | false;
+    label?: string | ReactElement | boolean;
     sortable?: boolean;
     className?: string;
     cellClassName?: string;

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -22,64 +22,61 @@ import { TextInput } from '../../input';
  *     </Card>
  * );
  */
-export const FilterLiveSearch = memo(
-    (props: {
-        source?: string;
-        sx?: SxProps;
-        fullWidth?: boolean;
-        variant?: 'filled' | 'outlined';
-    }) => {
-        const { source = 'q', variant, ...rest } = props;
-        const { filterValues, setFilters } = useListFilterContext();
-        const translate = useTranslate();
+export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
+    const { source = 'q', variant, ...rest } = props;
+    const { filterValues, setFilters } = useListFilterContext();
+    const translate = useTranslate();
 
-        const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-            if (event.target) {
-                setFilters(
-                    { ...filterValues, [source]: event.target.value },
-                    null
-                );
-            } else {
-                const { [source]: _, ...filters } = filterValues;
-                setFilters(filters, null);
-            }
-        };
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        if (event.target) {
+            setFilters({ ...filterValues, [source]: event.target.value }, null);
+        } else {
+            const { [source]: _, ...filters } = filterValues;
+            setFilters(filters, null);
+        }
+    };
 
-        const initialValues = useMemo(
-            () => ({
-                [source]: filterValues[source],
-            }),
-            [filterValues, source]
-        );
+    const initialValues = useMemo(
+        () => ({
+            [source]: filterValues[source],
+        }),
+        [filterValues, source]
+    );
 
-        const onSubmit = () => undefined;
-        let label = translate('ra.action.search');
+    const onSubmit = () => undefined;
+    let label = translate('ra.action.search');
 
-        return (
-            <Form defaultValues={initialValues} onSubmit={onSubmit}>
-                <TextInput
-                    resettable
-                    helperText={false}
-                    source={source}
-                    InputProps={{
-                        endAdornment: (
-                            <InputAdornment position="end">
-                                <SearchIcon color="disabled" />
-                            </InputAdornment>
-                        ),
-                    }}
-                    onChange={handleChange}
-                    size="small"
-                    {...(variant === 'outlined'
-                        ? { variant: 'outlined', label }
-                        : {
-                              placeholder: label,
-                              label: false,
-                              hiddenLabel: true,
-                          })}
-                    {...rest}
-                />
-            </Form>
-        );
-    }
-);
+    return (
+        <Form defaultValues={initialValues} onSubmit={onSubmit}>
+            <TextInput
+                resettable
+                helperText={false}
+                source={source}
+                InputProps={{
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <SearchIcon color="disabled" />
+                        </InputAdornment>
+                    ),
+                }}
+                onChange={handleChange}
+                size="small"
+                {...(variant === 'outlined'
+                    ? { variant: 'outlined', label }
+                    : {
+                          placeholder: label,
+                          label: false,
+                          hiddenLabel: true,
+                      })}
+                {...rest}
+            />
+        </Form>
+    );
+});
+
+export interface FilterLiveSearchProps {
+    source?: string;
+    sx?: SxProps;
+    fullWidth?: boolean;
+    variant?: 'filled' | 'outlined';
+}

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -26,6 +26,7 @@ export const FilterLiveSearch = memo(
     (props: {
         source?: string;
         sx?: SxProps;
+        fullWidth?: boolean;
         variant?: 'filled' | 'outlined';
     }) => {
         const { source = 'q', variant, ...rest } = props;


### PR DESCRIPTION
Fixes [Component <FilterLiveSearch> definition is missing the fullWidth parameter · Issue #7755 · marmelab/react-admin](https://github.com/marmelab/react-admin/issues/7755)

Harmonization of the `label` parameter type between `CommonInputProps` and `LabeledProps`

