### PR TITLE
[Typescript] Fix `FunctionField` generic typing restriction

### DIFF
--- a/packages/ra-ui-materialui/src/field/FunctionField.tsx
+++ b/packages/ra-ui-materialui/src/field/FunctionField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMemo } from 'react';
-import { RaRecord, useRecordContext } from 'ra-core';
+import { useRecordContext } from 'ra-core';
 import PropTypes from 'prop-types';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 

--- a/packages/ra-ui-materialui/src/field/FunctionField.tsx
+++ b/packages/ra-ui-materialui/src/field/FunctionField.tsx
@@ -17,7 +17,8 @@ import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
  *     render={record => record && `${record.first_name} ${record.last_name}`}
  * />
  */
-export const FunctionField = <RecordType extends RaRecord = any>(
+
+export const FunctionField = <RecordType extends unknown = any>(
     props: FunctionFieldProps<RecordType>
 ) => {
     const { className, source = '', render, ...rest } = props;
@@ -45,7 +46,7 @@ FunctionField.propTypes = {
     render: PropTypes.func.isRequired,
 };
 
-export interface FunctionFieldProps<RecordType extends RaRecord = any>
+export interface FunctionFieldProps<RecordType extends unknown = any>
     extends PublicFieldProps,
         InjectedFieldProps<RecordType>,
         Omit<TypographyProps, 'textAlign'> {

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -25,8 +25,7 @@ export interface PublicFieldProps {
     fullWidth?: boolean;
 }
 
-// Props injected by react-admin
-export interface InjectedFieldProps<RecordType extends RaRecord = any> {
+export interface InjectedFieldProps<RecordType = any> {
     record?: RecordType;
     resource?: string;
 }


### PR DESCRIPTION
Issue [https://github.com/marmelab/react-admin/issues/7702](https://github.com/marmelab/react-admin/issues/7702)
Type fix is based on [minimal resolution](https://github.com/marmelab/react-admin/issues/7702#issuecomment-1128936498) suggested by @fzaninotto 