### PR TITLE
Fix `Fields` doc reference to `getMany()` usage

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -863,7 +863,7 @@ You can also use a custom `link` function to get a custom path for the children.
 ]
 ```
 
-Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField>`, fetches the API for the related users in one call (`GET http://path.to.my.api/users?ids=[789,735]`), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.
+Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField>`, fetches the API for the related users in one call (`GET http://path.to.my.api/users?filter={"ids":[789,735]}`), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.
 
 ### `<ReferenceManyField>`
 


### PR DESCRIPTION
There's a statement at the end of the section on ReferenceFields [0] which says that ReferenceField will use `/users?ids=[]` to fetch source data:

> Then react-admin renders the <PostList> with a loader for the <ReferenceField>, fetches the API for the related users in one call (GET http://path.to.my.api/users?ids=[789,735]), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.

However, the beginning of the section on ReferenceFields [1] says ReferenceField will use `dataProvider.getMany()` to fetch source data:

> This component fetches a referenced record (using the dataProvider.getMany() method), and passes it to its child.

The DataProvider page [2] shows that `.getMany()` is 

> GET http://my.api.url/posts?filter={"id":[123,456,789]}

So I think the statement at the end of the section on ReferenceFields [0] should be updated!

I'll open PRs for 1.x and 2.x as well since those look wrong too.

[0] https://marmelab.com/react-admin/doc/3.12/Fields.html#usage-9
[1] https://marmelab.com/react-admin/doc/3.12/Fields.html#referencefield
[2] https://marmelab.com/react-admin/doc/3.12/DataProviders.html#usage