### PR TITLE
Fix `Fields` doc reference to `getMany()` usage in v1.x

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -429,7 +429,7 @@ You can also prevent `<ReferenceField>` from adding link to children by setting 
 ]
 ```
 
-Then admin-on-rest renders the `<CommentList>` with a loader for the `<ReferenceField>`, fetches the API for the related posts in one call (`GET http://path.to.my.api/posts?ids=[789,735]`), and re-renders the list once the data arrives. This accelerates the rendering, and minimizes network load.
+Then admin-on-rest renders the `<CommentList>` with a loader for the `<ReferenceField>`, fetches the API for the related posts in one call (`GET http://path.to.my.api/posts?filter={"ids":[789,735]}`), and re-renders the list once the data arrives. This accelerates the rendering, and minimizes network load.
 
 ## `<ReferenceManyField>`
 


### PR DESCRIPTION
Same issue as https://github.com/marmelab/react-admin/pull/7773 

GET_MANY is [0] `posts?filter={"ids":[123,124,125]}` and ReferenceField uses GET_MANY, so the ReferenceField doc [1] shouldn't `posts?ids=[789,735]`

[0] https://github.com/marmelab/react-admin/blob/1.x/docs/RestClients.md?plain=1#L68
[1] https://github.com/marmelab/react-admin/blob/1.x/docs/Fields.md?plain=1#L432