### PR TITLE
Fix `useDataProvider` returning undefined value when unauthorized 401 error is thrown

### DIFF
--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -109,7 +109,7 @@ export const useDataProvider = <
                                 }
                                 return logoutIfAccessDenied(error).then(
                                     loggedOut => {
-                                        if (loggedOut) return;
+                                        if (loggedOut) return { data: {} };
                                         throw error;
                                     }
                                 );


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/7815