### PR TITLE
Fix ReferenceInput generated label in FilterForm

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -9,6 +9,7 @@ import {
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import {
+    LabelPrefixContextProvider,
     ListFilterContextValue,
     useListContext,
     useResourceContext,
@@ -118,21 +119,23 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
     );
 
     return (
-        <StyledForm
-            className={className}
-            {...sanitizeRestProps(rest)}
-            onSubmit={handleSubmit}
-        >
-            {getShownFilters().map((filterElement: JSX.Element) => (
-                <FilterFormInput
-                    key={filterElement.props.source}
-                    filterElement={filterElement}
-                    handleHide={handleHide}
-                    resource={resource}
-                />
-            ))}
-            <div className={FilterFormClasses.clearFix} />
-        </StyledForm>
+        <LabelPrefixContextProvider prefix={`resources.${resource}.fields`}>
+            <StyledForm
+                className={className}
+                {...sanitizeRestProps(rest)}
+                onSubmit={handleSubmit}
+            >
+                {getShownFilters().map((filterElement: JSX.Element) => (
+                    <FilterFormInput
+                        key={filterElement.props.source}
+                        filterElement={filterElement}
+                        handleHide={handleHide}
+                        resource={resource}
+                    />
+                ))}
+                <div className={FilterFormClasses.clearFix} />
+            </StyledForm>
+        </LabelPrefixContextProvider>
     );
 };
 


### PR DESCRIPTION
Fix [7817](https://github.com/marmelab/react-admin/issues/7817)
Add missing `LabelPrefixContextProvider` in `FiltersForm` / kudos to @slax57 