### PR TITLE
Fix Datagrid with expand element expands ALL rows when used as a child of ArrayField

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -44,7 +44,7 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
                         expand,
                         hasBulkActions: hasBulkActions && !!selectedIds,
                         hover,
-                        id: record.id,
+                        id: record.id ?? `row${rowIndex}`,
                         key: record.id ?? `row${rowIndex}`,
                         onToggleItem,
                         record,


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/7814
