### PR TITLE
Fix NumberInput seems buggy when used in a FilterForm

### DIFF
--- a/docs/NumberInput.md
+++ b/docs/NumberInput.md
@@ -36,3 +36,30 @@ You can customize the `step` props (which defaults to "any"). For instance, to r
 ```jsx
 <NumberInput source="nb_views" step={1} />
 ```
+
+## Usage In Filter Form
+
+The [Filter Button/Form combo](https://marmelab.com/react-admin/FilteringTutorial.html#the-filter-buttonform-combo) changes the filter value as the user types. But, as explained earlier in this page, `<NumberInput>` converts the input value to a number on blur.
+
+This means that using `<NumberInput>` in a filter form will not work as expected. The filter will only change when the user presses the Enter key, which differs from the other input types.
+
+In a filter form, you should use a `<TextInput type="number">` instead:
+
+```jsx
+import { TextInput } from 'react-admin';
+
+const convertStringToNumber = value => {
+    const float = parseFloat(value);
+    return isNaN(float) ? null : float;
+};
+
+const productFilters = [
+    <TextInput label="Stock less than" source="stock_lte" type="number" parse={convertStringToNumber} />,
+];
+
+export const ProductList = (props) => (
+    <List {...props} filters={postFilters}>
+        ...
+    </List>
+);
+```

--- a/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
@@ -53,7 +53,7 @@ describe('<NumberInput />', () => {
         expect(input.step).toEqual('0.1');
     });
 
-    it('should change when the user types a number', () => {
+    it('should change when the user types a number and blurs', () => {
         render(
             <AdminContext>
                 <SimpleForm defaultValues={{ views: 12 }} onSubmit={jest.fn()}>
@@ -68,6 +68,24 @@ describe('<NumberInput />', () => {
         ) as HTMLInputElement;
         fireEvent.change(input, { target: { value: '3' } });
         fireEvent.blur(input);
+        screen.getByText('views:3');
+    });
+
+    it('should change when the user types a number and presses enter', () => {
+        render(
+            <AdminContext>
+                <SimpleForm defaultValues={{ views: 12 }} onSubmit={jest.fn()}>
+                    <NumberInput {...defaultProps} />
+                    <RecordWatcher />
+                </SimpleForm>
+            </AdminContext>
+        );
+        screen.getByText('views:12');
+        const input = screen.getByLabelText(
+            'resources.posts.fields.views'
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '3' } });
+        fireEvent.keyUp(input, { key: 'Enter', code: 'Enter', keyCode: 13 });
         screen.getByText('views:3');
     });
 

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -108,6 +108,12 @@ export const NumberInput = ({
         field.onChange(newValue);
     };
 
+    const handleKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            handleBlur(event);
+        }
+    };
+
     return (
         <TextField
             id={id}
@@ -116,6 +122,7 @@ export const NumberInput = ({
             value={value}
             onChange={handleChange}
             onBlur={handleBlur}
+            onKeyUp={handleKeyUp}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             type="number"
             size="small"


### PR DESCRIPTION
- [x] Add format on enter to `NumberInput`
- [x] Document usage gotcha in filter form

The [Filter Button/Form combo](https://marmelab.com/react-admin/FilteringTutorial.html#the-filter-buttonform-combo) changes the filter value as the user types. But, as explained earlier in this page, `<NumberInput>` converts the input value to a number on blur.

This means that using `<NumberInput>` in a filter form will not work as expected. The filter will only change when the user presses the Enter key, which differs from the other input types.

In a filter form, you should use a `<TextInput type="number">` instead:

```jsx
import { TextInput } from 'react-admin';

const convertStringToNumber = value => {
    const float = parseFloat(value);
    return isNaN(float) ? null : float;
};

const productFilters = [
    <TextInput label="Stock less than" source="stock_lte" type="number" parse={convertStringToNumber} />,
];

export const ProductList = (props) => (
    <List {...props} filters={postFilters}>
        ...
    </List>
);
```