### PR TITLE
[Docs] Fix Creating New Choices examples

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -238,7 +238,7 @@ const CreateTag = () => {
                 },                
             },
             {
-                onSuccess: ({ data }) => {
+                onSuccess: (data) => {
                     setValue('');
                     onCreate(data);
                 },

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -224,7 +224,7 @@ const CreateCategory = () => {
                 },
             },
             {
-                onSuccess: ({ data }) => {
+                onSuccess: (data) => {
                     setValue('');
                     onCreate(data);
                 },

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -228,7 +228,7 @@ const CreateTag = () => {
               },
           },
           {
-              onSuccess: ({ data }) => {
+              onSuccess: (data) => {
                   setValue('');
                   onCreate(data);
               },

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -239,7 +239,7 @@ const CreateCategory = () => {
               },
           },
           {
-              onSuccess: ({ data }) => {
+              onSuccess: (data) => {
                   setValue('');
                   onCreate(data);
               },


### PR DESCRIPTION
This has been bugging me for a while now and I finally figured it out! The data passed to onSuccess should not be deconstructed from props.