### PR TITLE
Add ability to set `meta` in page components

### DIFF
--- a/docs/Create.md
+++ b/docs/Create.md
@@ -152,7 +152,23 @@ const PostCreate = () => (
 
 ## `mutationOptions`
 
-You can customize the options you pass to react-query's `useMutation` hook, e.g. to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
+You can customize the options you pass to react-query's `useMutation` hook, e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.create()` call.
+
+{% raw %}
+```jsx
+import { Create, SimpleForm } from 'react-admin';
+
+const PostCreate = () => (
+    <Create mutationOptions={{ meta: { foo: 'bar' } }}>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </Create>
+);
+```
+{% endraw %}
+
+You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
 
 Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to the new record edit page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
 
@@ -321,6 +337,24 @@ export const UserCreate = (props) => {
 The `transform` function can also return a `Promise`, which allows you to do all sorts of asynchronous calls (e.g. to the `dataProvider`) during the transformation.
 
 **Tip**: If you want to have different transformations based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save", and another to "save and notify other admins"), you can set the `transform` prop on [the `<SaveButton>` component](./SaveButton.md), too. 
+
+## Adding `meta` To The DataProvider Call
+
+Use [the `mutationOptions` prop](#mutationoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.create()` call.
+
+{% raw %}
+```jsx
+import { Create, SimpleForm } from 'react-admin';
+
+const PostCreate = () => (
+    <Create mutationOptions={{ meta: { foo: 'bar' } }}>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </Create>
+);
+```
+{% endraw %}
 
 ## Changing The Notification Message
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -265,7 +265,23 @@ const PostEdit = () => (
 
 ## `mutationOptions`
 
-`<Edit>` calls `dataProvider.update()` via react-query's `useMutation` hook. You can customize the options you pass to this hook, e.g. to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
+`<Edit>` calls `dataProvider.update()` via react-query's `useMutation` hook. You can customize the options you pass to this hook, e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.update()` call.
+
+{% raw %}
+```jsx
+import { Edit, SimpleForm } from 'react-admin';
+
+const PostEdit = () => (
+    <Edit mutationOptions={{ meta: { foo: 'bar' } }}>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+{% endraw %}
+
+You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
 
 Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to the list page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
 
@@ -387,7 +403,23 @@ The default `onError` function is:
 
 `<Edit>` calls `dataProvider.getOne()` on mount via react-query's `useQuery` hook. You can customize the options you pass to this hook by setting the `queryOptions` prop.
 
-For instance, you can force a refetch on reconnect:
+This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getOne()` call.
+
+{% raw %}
+```jsx
+import { Edit, SimpleForm } from 'react-admin';
+
+export const PostShow = () => (
+    <Edit queryOptions={{ meta: { foo: 'bar' } }}>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+{% endraw %}
+
+You can also use `queryOptions` to force a refetch on reconnect:
 
 {% raw %}
 ```jsx
@@ -506,6 +538,27 @@ export const UserEdit = (props) => {
     );
 }
 ```
+
+## Adding `meta` To The DataProvider Call
+
+You can pass a custom `meta` to the `dataProvider` call, using either `queryOptions`, or `mutationOptions`:
+
+- Use [the `queryOptions` prop](#queryoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getOne()` call.
+- Use [the `mutationOptions` prop](#mutationoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.update()` call.
+
+{% raw %}
+```jsx
+import { Edit, SimpleForm } from 'react-admin';
+
+const PostEdit = () => (
+    <Edit mutationOptions={{ meta: { foo: 'bar' } }}>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+{% endraw %}
 
 ## Changing The Notification Message
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -602,7 +602,23 @@ export const PostList = () => (
 
 `<List>` accepts a `queryOptions` prop to pass options to the react-query client. 
 
-This can be useful e.g. to override the default error side effect. By default, when the `dataProvider.getList()` call fails, react-admin shows an error notification.
+This can be useful e.g. to pass a custom `meta` to the `dataProvider.getList()` call.
+
+{% raw %}
+```jsx
+import { List } from 'react-admin';
+
+const PostList = () => (
+    <List queryOptions={{ meta: { foo: 'bar' } }}>
+        ...
+    </List>
+);
+```
+{% endraw %}
+
+With this option, react-admin will call the `dataProvider.getList()` on mount with the ` meta: { foo: 'bar' }` option.
+
+You can also use the `queryOptions` prop to override the default error side effect. By default, when the `dataProvider.getList()` call fails, react-admin shows an error notification.
 
 You can override this behavior and pass custom side effects by providing a `queryOptions` prop:
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -602,7 +602,7 @@ export const PostList = () => (
 
 `<List>` accepts a `queryOptions` prop to pass options to the react-query client. 
 
-This can be useful e.g. to pass a custom `meta` to the `dataProvider.getList()` call.
+This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getList()` call.
 
 {% raw %}
 ```jsx
@@ -616,7 +616,7 @@ const PostList = () => (
 ```
 {% endraw %}
 
-With this option, react-admin will call the `dataProvider.getList()` on mount with the ` meta: { foo: 'bar' }` option.
+With this option, react-admin will call `dataProvider.getList()` on mount with the ` meta: { foo: 'bar' }` option.
 
 You can also use the `queryOptions` prop to override the default error side effect. By default, when the `dataProvider.getList()` call fails, react-admin shows an error notification.
 
@@ -721,3 +721,19 @@ const PostList = () => (
 {% endraw %}
 
 **Tip**: The `List` component `classes` can also be customized for all instances of the component with its global css name `RaList` as [describe here](https://marmelab.com/blog/2019/12/18/react-admin-3-1.html#theme-overrides)
+
+## Adding `meta` To The DataProvider Call
+
+Use [the `queryOptions` prop](#queryoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getList()` call.
+
+{% raw %}
+```jsx
+import { List } from 'react-admin';
+
+const PostList = () => (
+    <List queryOptions={{ meta: { foo: 'bar' } }}>
+        ...
+    </List>
+);
+```
+{% endraw %}

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -154,7 +154,23 @@ export const PostShow = () => (
 
 `<Show>` accepts a `queryOptions` prop to pass options to the react-query client. 
 
-This can be useful e.g. to override the default error side effect. By default, when the `dataProvider.getOne()` call fails at the dataProvider level, react-admin shows an error notification and refreshes the page.
+This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getOne()` call.
+
+{% raw %}
+```jsx
+import { Show } from 'react-admin';
+
+export const PostShow = () => (
+    <Show queryOptions={{ meta: { foo: 'bar' }}}>
+        ...
+    </Show>
+);
+```
+{% endraw %}
+
+With this option, react-admin will call `dataProvider.getOne()` on mount with the ` meta: { foo: 'bar' }` option.
+
+You can also use the `queryOptions` prop to override the default error side effect. By default, when the `dataProvider.getOne()` call fails at the dataProvider level, react-admin shows an error notification and refreshes the page.
 
 You can override this behavior and pass custom side effects by providing a custom `queryOptions` prop:
 
@@ -373,6 +389,22 @@ export const UserShow = () => {
 {% endraw %}
 
 For more details about permissions, check out the [authProvider documentation](./Authentication.md#authorization).
+
+## Adding `meta` To The DataProvider Call
+
+Use [the `queryOptions` prop](#queryoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getOne()` call.
+
+{% raw %}
+```jsx
+import { Show } from 'react-admin';
+
+export const PostShow = () => (
+    <Show queryOptions={{ meta: { foo: 'bar' }}}>
+        ...
+    </Show>
+);
+```
+{% endraw %}
 
 ## API
 

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -58,11 +58,11 @@ That's enough to display the post show view:
 * [`actions`](#actions): override the actions toolbar with a custom component
 * `className`: passed to the root component
 * [`children`](#layout): the components that render the record fields
-* [`component`](#root-component): overrides the root component
+* [`component`](#component): overrides the root component
 * [`emptyWhileLoading`](#loading-state)
-* [`queryOptions`](#client-query-options): options to pass to the react-query client
+* [`queryOptions`](#queryoptions): options to pass to the react-query client
 * [`sx`](#sx-css-api): Override the styles
-* [`title`](#page-title)
+* [`title`](#title)
 
 ## Layout
 
@@ -94,7 +94,7 @@ export const PostShow = () => (
 
 You can also pass a React element as child, to build a custom layout. Check [Building a custom Show Layout](./ShowTutorial.md#building-a-custom-layout) for more details.
 
-## Page Title
+## `title`
 
 By default, the title for the Show view is "[resource_name] #[record_id]".
 
@@ -127,7 +127,7 @@ export const PostShow = () => (
 );
 ```
 
-## Actions
+## `actions`
 
 By default, `<Show>` includes an action toolbar with an `<EditButton>` if the `<Resource>` declared an `edit` component. You can replace the list of default actions by your own component using the `actions` prop:
 
@@ -150,7 +150,7 @@ export const PostShow = () => (
 );
 ```
 
-## Client Query Options
+## `queryOptions`
 
 `<Show>` accepts a `queryOptions` prop to pass options to the react-query client. 
 
@@ -194,6 +194,61 @@ The default `onError` function is:
     refresh();
 }
 ```
+
+## `component`
+
+By default, the Show view renders the main content area inside a MUI `<Card>`. The actual layout of the record fields depends on the Show Layout component you're using (`<SimpleShowLayout>`, `<TabbedShowLayout>`, or a custom layout component).
+
+You can override the main area container by passing a `component` prop:
+
+{% raw %}
+```jsx
+import { Box } from '@mui/material';
+
+const ShowWrapper = ({ children }) => (
+    <Box sx={{ margin: 2, border: 'solid 1px grey' }}>
+        {children}
+    </Box>
+);
+
+// use a ShowWrapper as root component
+const PostShow = props => (
+    <Show component={ShowWrapper} {...props}>
+        ...
+    </Show>
+);
+```
+{% endraw %}
+
+## `sx`: CSS API
+
+The `<Show>` component accepts the usual `className` prop but you can override many class names injected to the inner components by React-admin thanks to the `sx` property (as most MUI components, see their [documentation about it](https://mui.com/customization/how-to-customize/#overriding-nested-component-styles)). This property accepts the following subclasses:
+
+| Rule name        | Description                                                   |
+|------------------| ------------------------------------------------------------- |
+| `& .RaShow-main` | Applied to the main container                                 |
+| `& .RaShow-card` | Applied to the `<Card>` element                               |
+
+Here's an example of how to override the default styles:
+
+{% raw %}
+```jsx
+const PostShow = () => (
+    <Show 
+        sx={{
+            backgroundColor: 'yellow',
+            '& .RaShow-main': {
+                backgroundColor: 'red',
+            },
+        }}
+    >
+            ...
+    </Show>
+);
+```
+{% endraw %}
+
+To override the style of all instances of `<Show>` using the [MUI style overrides](https://mui.com/customization/theme-components/), use the `RaShow` key.
 
 ## Loading State
 
@@ -251,61 +306,6 @@ const PostShow = () => (
     </Show>
 );
 ```
-
-## Root Component
-
-By default, the Show view renders the main content area inside a MUI `<Card>`. The actual layout of the record fields depends on the Show Layout component you're using (`<SimpleShowLayout>`, `<TabbedShowLayout>`, or a custom layout component).
-
-You can override the main area container by passing a `component` prop:
-
-{% raw %}
-```jsx
-import { Box } from '@mui/material';
-
-const ShowWrapper = ({ children }) => (
-    <Box sx={{ margin: 2, border: 'solid 1px grey' }}>
-        {children}
-    </Box>
-);
-
-// use a ShowWrapper as root component
-const PostShow = props => (
-    <Show component={ShowWrapper} {...props}>
-        ...
-    </Show>
-);
-```
-{% endraw %}
-
-## `sx`: CSS API
-
-The `<Show>` component accepts the usual `className` prop but you can override many class names injected to the inner components by React-admin thanks to the `sx` property (as most MUI components, see their [documentation about it](https://mui.com/customization/how-to-customize/#overriding-nested-component-styles)). This property accepts the following subclasses:
-
-| Rule name        | Description                                                   |
-|------------------| ------------------------------------------------------------- |
-| `& .RaShow-main` | Applied to the main container                                 |
-| `& .RaShow-card` | Applied to the `<Card>` element                               |
-
-Here's an example of how to override the default styles:
-
-{% raw %}
-```jsx
-const PostShow = () => (
-    <Show 
-        sx={{
-            backgroundColor: 'yellow',
-            '& .RaShow-main': {
-                backgroundColor: 'red',
-            },
-        }}
-    >
-            ...
-    </Show>
-);
-```
-{% endraw %}
-
-To override the style of all instances of `<Show>` using the [MUI style overrides](https://mui.com/customization/theme-components/), use the `RaShow` key.
 
 ## Displaying Fields Depending On User Permissions
 

--- a/packages/ra-core/src/controller/create/useCreateController.spec.tsx
+++ b/packages/ra-core/src/controller/create/useCreateController.spec.tsx
@@ -284,6 +284,38 @@ describe('useCreateController', () => {
         expect(notificationsSpy).toEqual([]);
     });
 
+    it('should accept meta in mutationOptions', async () => {
+        let saveCallback;
+        const create = jest
+            .fn()
+            .mockImplementationOnce((_, { data }) =>
+                Promise.resolve({ data: { id: 123, ...data } })
+            );
+        const dataProvider = testDataProvider({
+            getOne: () => Promise.resolve({ data: { id: 12 } } as any),
+            create,
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <CreateController
+                    {...defaultProps}
+                    mutationOptions={{ meta: { lorem: 'ipsum' } }}
+                >
+                    {({ save }) => {
+                        saveCallback = save;
+                        return null;
+                    }}
+                </CreateController>
+            </CoreAdminContext>
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        expect(create).toHaveBeenCalledWith('posts', {
+            data: { foo: 'bar' },
+            meta: { lorem: 'ipsum' },
+        });
+    });
+
     it('should allow the save onError option to override the failure side effects override', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         let saveCallback;

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -59,7 +59,12 @@ export const useCreateController = <
     const notify = useNotify();
     const redirect = useRedirect();
     const recordToUse = record ?? getRecordFromLocation(location) ?? undefined;
-    const { onSuccess, onError, ...otherMutationOptions } = mutationOptions;
+    const {
+        onSuccess,
+        onError,
+        meta,
+        ...otherMutationOptions
+    } = mutationOptions;
     const {
         registerMutationMiddleware,
         getMutateWithMiddlewares,
@@ -90,7 +95,7 @@ export const useCreateController = <
                 const mutate = getMutateWithMiddlewares(create);
                 mutate(
                     resource,
-                    { data },
+                    { data, meta },
                     {
                         onSuccess: async (data, variables, context) => {
                             if (onSuccessFromSave) {
@@ -182,7 +187,7 @@ export interface CreateControllerProps<
         RecordType,
         MutationOptionsError,
         UseCreateMutateParams<RecordType>
-    >;
+    > & { meta?: any };
     transform?: TransformData;
 }
 

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -145,6 +145,7 @@ export const useCreateController = <
             create,
             finalRedirectTo,
             getMutateWithMiddlewares,
+            meta,
             notify,
             onError,
             onSuccess,

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -189,6 +189,7 @@ export const useEditController = <
         [
             id,
             getMutateWithMiddlewares,
+            mutationMeta,
             mutationMode,
             notify,
             onError,

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -62,7 +62,13 @@ export const useEditController = <
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
     const id = propsId != null ? propsId : decodeURIComponent(routeId);
-    const { onSuccess, onError, ...otherMutationOptions } = mutationOptions;
+    const { meta: queryMeta, ...otherQueryOptions } = queryOptions;
+    const {
+        onSuccess,
+        onError,
+        meta: mutationMeta,
+        ...otherMutationOptions
+    } = mutationOptions;
     const {
         registerMutationMiddleware,
         getMutateWithMiddlewares,
@@ -72,7 +78,7 @@ export const useEditController = <
         RecordType
     >(
         resource,
-        { id },
+        { id, meta: queryMeta },
         {
             onError: () => {
                 notify('ra.notification.item_doesnt_exist', {
@@ -84,7 +90,7 @@ export const useEditController = <
             refetchOnReconnect: false,
             refetchOnWindowFocus: false,
             retry: false,
-            ...queryOptions,
+            ...otherQueryOptions,
         }
     );
 
@@ -132,7 +138,7 @@ export const useEditController = <
                 const mutate = getMutateWithMiddlewares(update);
                 return mutate(
                     resource,
-                    { id, data },
+                    { id, data, meta: mutationMeta },
                     {
                         onSuccess: async (data, variables, context) => {
                             if (onSuccessFromSave) {
@@ -224,8 +230,8 @@ export interface EditControllerProps<
         RecordType,
         MutationOptionsError,
         UseUpdateMutateParams<RecordType>
-    >;
-    queryOptions?: UseQueryOptions<RecordType>;
+    > & { meta?: any };
+    queryOptions?: UseQueryOptions<RecordType> & { meta?: any };
     redirect?: RedirectionSideEffect;
     resource?: string;
     transform?: TransformData;

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -28,25 +28,56 @@ describe('useListController', () => {
         debounce: 200,
     };
 
-    it('should accept custom client query options', async () => {
-        const mock = jest.spyOn(console, 'error').mockImplementation(() => {});
-        const getList = jest
-            .fn()
-            .mockImplementationOnce(() => Promise.reject(new Error()));
-        const onError = jest.fn();
-        const dataProvider = testDataProvider({ getList });
-        render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <ListController resource="posts" queryOptions={{ onError }}>
-                    {() => <div />}
-                </ListController>
-            </CoreAdminContext>
-        );
-        await waitFor(() => {
-            expect(getList).toHaveBeenCalled();
-            expect(onError).toHaveBeenCalled();
+    describe('queryOptions', () => {
+        it('should accept custom client query options', async () => {
+            const mock = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const getList = jest
+                .fn()
+                .mockImplementationOnce(() => Promise.reject(new Error()));
+            const onError = jest.fn();
+            const dataProvider = testDataProvider({ getList });
+            render(
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <ListController resource="posts" queryOptions={{ onError }}>
+                        {() => <div />}
+                    </ListController>
+                </CoreAdminContext>
+            );
+            await waitFor(() => {
+                expect(getList).toHaveBeenCalled();
+                expect(onError).toHaveBeenCalled();
+            });
+            mock.mockRestore();
         });
-        mock.mockRestore();
+
+        it('should accept meta in queryOptions', async () => {
+            const getList = jest
+                .fn()
+                .mockImplementationOnce(() =>
+                    Promise.resolve({ data: [], total: 25 })
+                );
+            const dataProvider = testDataProvider({ getList });
+            render(
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <ListController
+                        resource="posts"
+                        queryOptions={{ meta: { foo: 'bar' } }}
+                    >
+                        {() => <div />}
+                    </ListController>
+                </CoreAdminContext>
+            );
+            await waitFor(() => {
+                expect(getList).toHaveBeenCalledWith('posts', {
+                    filter: {},
+                    pagination: { page: 1, perPage: 10 },
+                    sort: { field: 'id', order: 'ASC' },
+                    meta: { foo: 'bar' },
+                });
+            });
+        });
     });
 
     describe('setFilters', () => {

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -41,10 +41,11 @@ export const useListController = <RecordType extends RaRecord = any>(
         filter,
         debounce = 500,
         disableSyncWithLocation,
-        queryOptions,
+        queryOptions = {},
     } = props;
     useAuthenticated({ enabled: !disableAuthentication });
     const resource = useResourceContext(props);
+    const { meta, ...otherQueryOptions } = queryOptions;
 
     if (!resource) {
         throw new Error(
@@ -88,6 +89,7 @@ export const useListController = <RecordType extends RaRecord = any>(
             },
             sort: { field: query.sort, order: query.order },
             filter: { ...query.filter, ...filter },
+            meta,
         },
         {
             keepPreviousData: true,
@@ -99,7 +101,7 @@ export const useListController = <RecordType extends RaRecord = any>(
                         _: error?.message,
                     },
                 }),
-            ...queryOptions,
+            ...otherQueryOptions,
         }
     );
 
@@ -190,7 +192,7 @@ export interface ListControllerProps<RecordType extends RaRecord = any> {
             hasNextPage?: boolean;
             hasPreviousPage?: boolean;
         };
-    }>;
+    }> & { meta?: any };
     resource?: string;
     sort?: SortPayload;
 }

--- a/packages/ra-core/src/controller/show/useShowController.spec.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.spec.tsx
@@ -142,4 +142,42 @@ describe('useShowController', () => {
         });
         mock.mockRestore();
     });
+
+    it('should accept meta in queryOptions', async () => {
+        const getOne = jest
+            .fn()
+            .mockImplementationOnce(() =>
+                Promise.resolve({ data: { id: 0, title: 'hello' } })
+            );
+
+        const dataProvider = ({ getOne } as unknown) as DataProvider;
+        render(
+            <CoreAdminContext
+                dataProvider={dataProvider}
+                history={createMemoryHistory({
+                    initialEntries: ['/posts/1'],
+                })}
+            >
+                <Routes>
+                    <Route
+                        path="posts/:id"
+                        element={
+                            <ShowController
+                                resource="posts"
+                                queryOptions={{ meta: { foo: 'bar' } }}
+                            >
+                                {() => <div />}
+                            </ShowController>
+                        }
+                    />
+                </Routes>
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(getOne).toHaveBeenCalledWith('posts', {
+                id: '1',
+                meta: { foo: 'bar' },
+            });
+        });
+    });
 });

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -55,12 +55,13 @@ export const useShowController = <RecordType extends RaRecord = any>(
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
     const id = propsId != null ? propsId : decodeURIComponent(routeId);
+    const { meta, ...otherQueryOptions } = queryOptions;
 
     const { data: record, error, isLoading, isFetching, refetch } = useGetOne<
         RecordType
     >(
         resource,
-        { id },
+        { id, meta },
         {
             onError: () => {
                 notify('ra.notification.item_doesnt_exist', {
@@ -70,7 +71,7 @@ export const useShowController = <RecordType extends RaRecord = any>(
                 refresh();
             },
             retry: false,
-            ...queryOptions,
+            ...otherQueryOptions,
         }
     );
 
@@ -102,7 +103,7 @@ export const useShowController = <RecordType extends RaRecord = any>(
 export interface ShowControllerProps<RecordType extends RaRecord = any> {
     disableAuthentication?: boolean;
     id?: RecordType['id'];
-    queryOptions?: UseQueryOptions<RecordType>;
+    queryOptions?: UseQueryOptions<RecordType> & { meta?: any };
     resource?: string;
 }
 

--- a/packages/ra-ui-materialui/src/detail/Show.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.stories.tsx
@@ -163,6 +163,25 @@ const DefaultPostShow = () => (
     </Show>
 );
 
+const dataProviderWithLog = {
+    getOne: (resource, params) => {
+        console.log('getOne', resource, params);
+        return dataProvider.getOne(resource, params);
+    },
+} as any;
+
+const PostShowWithMeta = () => (
+    <Show queryOptions={{ meta: { foo: 'bar ' } }}>
+        <BookTitle />
+    </Show>
+);
+
+export const Meta = () => (
+    <Admin dataProvider={dataProviderWithLog} history={history}>
+        <Resource name="books" show={PostShowWithMeta} />
+    </Admin>
+);
+
 export const Default = () => (
     <Admin dataProvider={dataProvider} history={history}>
         <Resource name="books" show={DefaultPostShow} edit={() => <span />} />

--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -248,6 +248,31 @@ export const SX = () => (
     </Admin>
 );
 
+const dataProviderWithLog = {
+    ...dataProvider,
+    getList: (resource, params) => {
+        console.log('getList', resource, params);
+        return dataProvider.getList(resource, params);
+    },
+} as any;
+
+const BookListWithMeta = () => (
+    <List queryOptions={{ meta: { foo: 'bar' } }}>
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+    </List>
+);
+
+export const Meta = () => (
+    <Admin dataProvider={dataProviderWithLog} history={history}>
+        <Resource name="books" list={BookListWithMeta} />
+    </Admin>
+);
+
 const BookListWithDatagrid = () => (
     <List filters={[<SearchInput source="q" alwaysOn />]}>
         <Datagrid>

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -22,7 +22,7 @@ export interface EditProps<
     disableAuthentication?: boolean;
     id?: Identifier;
     mutationMode?: MutationMode;
-    queryOptions?: UseQueryOptions<RecordType>;
+    queryOptions?: UseQueryOptions<RecordType> & { meta?: any };
     mutationOptions?: UseMutationOptions<
         RecordType,
         MutationOptionsError,
@@ -53,7 +53,7 @@ export interface CreateProps<
         RecordType,
         MutationOptionsError,
         UseCreateMutateParams<RecordType>
-    >;
+    > & { meta?: any };
     transform?: TransformData;
     title?: string | ReactElement;
     sx?: SxProps;
@@ -67,7 +67,7 @@ export interface ShowProps<RecordType extends RaRecord = any> {
     component?: ElementType;
     emptyWhileLoading?: boolean;
     id?: Identifier;
-    queryOptions?: UseQueryOptions<RecordType>;
+    queryOptions?: UseQueryOptions<RecordType> & { meta?: any };
     resource?: string;
     title?: string | ReactElement;
     sx?: SxProps;


### PR DESCRIPTION
- [x] Add support for `meta` in `<Create>`
- [x] Add support for `meta` in `<Show>`
- [x] Add support for `meta` in `<List>`
- [x] Add support for `meta` in `<Edit>`
- [x] Add documentation
- [x] Add tests

```jsx
import { Edit, SimpleForm } from 'react-admin';

const PostEdit = () => (
    <Edit mutationOptions={{ meta: { foo: 'bar' } }}>
        <SimpleForm>
            ...
        </SimpleForm>
    </Edit>
);
```

Closes #7357
Refs #7785, #7665