### PR TITLE
Fix `<AutocompleteInput>` storybook does not select newly created option

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -353,7 +353,7 @@ const CreateAuthor = () => {
                 },
             },
             {
-                onSuccess: ({ data }) => {
+                onSuccess: data => {
                     setName('');
                     setLanguage('');
                     onCreate(data);


### PR DESCRIPTION
Fix `<AutocompleteInput>` storybook does not select newly created option.

Applies the same fix as https://github.com/marmelab/react-admin/pull/7833 in the storybook.