### PR TITLE
[fix] TabbedForm passes invalid props to its root element

### DIFF
--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -87,7 +87,10 @@ export const TabbedForm = (props: TabbedFormProps) => {
 
     return (
         <Form formRootPathname={formRootPathname} {...props}>
-            <TabbedFormView formRootPathname={formRootPathname} {...props} />
+            <TabbedFormView
+                formRootPathname={formRootPathname}
+                {...sanitizeRestProps(props)}
+            />
         </Form>
     );
 };
@@ -153,3 +156,12 @@ export const findTabsWithErrors = (children, errors) => {
         return acc;
     }, []);
 };
+
+const sanitizeRestProps = ({
+    record,
+    resource,
+    warnWhenUnsavedChanges,
+    defaultChecked,
+    defaultValues,
+    ...rest
+}: TabbedFormProps) => rest;

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -149,4 +149,4 @@ const Root = styled('div', {
     },
 }));
 
-const sanitizeRestProps = ({ record, resource, ...rest }: any) => rest;
+const sanitizeRestProps = ({ resource, ...rest }: TabbedFormViewProps) => rest;


### PR DESCRIPTION
closes #7871 

This resolves the issue where `TabbedForm` props like `warnWhenUnsavedChanges` end up on a styled div within `TabbedForm`, which leads to react errors.

I fixed it by sanitizing the props that get passed to the `TabbedFormView`. 
I also removed the sanitizing of the `record` prop within the `TabbedFormView` because from my understanding this should never appear here now anymore (it was already sanitized on the level above).

How to test:
- Run the simple example
- Open the Edit view of a Post
- There should be no console errors anymore