### PR TITLE
Update docs for new third party color input / field

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -597,3 +597,4 @@ You can find components for react-admin in third-party repositories.
 
 - [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): a quick and customizable copy-to-clipboard field.
 - [MrHertal/react-admin-json-view](https://github.com/MrHertal/react-admin-json-view): JSON field and input for react-admin.
+- [alexgschwend/react-admin-color-picker](https://github.com/alexgschwend/react-admin-color-picker): a color field

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -832,7 +832,7 @@ const PersonEdit = () => (
 
 You can find components for react-admin in third-party repositories.
 
-- [vascofg/react-admin-color-input](https://github.com/vascofg/react-admin-color-input): a color input using [React Color](https://casesandberg.github.io/react-color/), a collection of color pickers.
+- [alexgschwend/react-admin-color-picker](https://github.com/alexgschwend/react-admin-color-picker): a color input using [React Color](https://casesandberg.github.io/react-color/), a collection of color pickers.
 - [vascofg/react-admin-date-inputs](https://github.com/vascofg/react-admin-date-inputs): a collection of Date Inputs, based on [material-ui-pickers](https://material-ui-pickers.firebaseapp.com/)
 - [MrHertal/react-admin-json-view](https://github.com/MrHertal/react-admin-json-view): JSON field and input for react-admin.
 - [@bb-tech/ra-components](https://github.com/bigbasket/ra-components): `JsonInput` which allows only valid JSON as input, `JsonField` to view JSON properly on show card and `TrimField` to trim the fields while showing in `Datagrid` in `List` component.


### PR DESCRIPTION
This [third-party color input] (https://github.com/vascofg/react-admin-color-input) no longer works with react-admin v4 and is no longer maintained. So I ported the library and updated the react-admin documentation.