### PR TITLE
fix ra-data-graphql-simple response parser for embedded arrays and objects

### DIFF
--- a/packages/ra-data-graphql-simple/src/getResponseParser.ts
+++ b/packages/ra-data-graphql-simple/src/getResponseParser.ts
@@ -37,7 +37,12 @@ const sanitizeResource = (data: any) => {
         }
 
         if (Array.isArray(dataForKey)) {
-            if (typeof dataForKey[0] === 'object' && dataForKey[0] !== null) {
+            if (
+                typeof dataForKey[0] === 'object' &&
+                dataForKey[0] != null &&
+                // If there is no id, it's not a reference but an embedded array
+                dataForKey[0].id != null
+            ) {
                 return {
                     ...acc,
                     [key]: dataForKey.map(sanitizeResource),
@@ -48,7 +53,12 @@ const sanitizeResource = (data: any) => {
             }
         }
 
-        if (typeof dataForKey === 'object' && dataForKey !== null) {
+        if (
+            typeof dataForKey === 'object' &&
+            dataForKey != null &&
+            // If there is no id, it's not a reference but an embedded object
+            dataForKey.id != null
+        ) {
             return {
                 ...acc,
                 ...(dataForKey &&


### PR DESCRIPTION
## Problem

When a record has embedded arrays or objects that are not references, `ra-data-graphql-simple` still generates fields to handle references for them. This leads to invalid payloads sent to the backend when updating for instance

## Solution

Check that embedded arrays and objects have identifiers before generating the field required for references. This is still not perfect but `ra-data-graphql-simple` shouldn't be used for real applications anyway