### PR TITLE
Fix simple dataProvider create does not return server data

### DIFF
--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -159,9 +159,7 @@ export default (
         httpClient(`${apiUrl}/${resource}`, {
             method: 'POST',
             body: JSON.stringify(params.data),
-        }).then(({ json }) => ({
-            data: { ...params.data, id: json.id },
-        })),
+        }).then(({ json }) => ({ data: json })),
 
     delete: (resource, params) =>
         httpClient(`${apiUrl}/${resource}/${params.id}`, {


### PR DESCRIPTION
Update useCreateResult in the Simple REST Provider to return the API response data.

Fixes #7912