### PR TITLE
[Doc] Missing import in custom routes documentation

### DIFF
--- a/docs/CustomRoutes.md
+++ b/docs/CustomRoutes.md
@@ -61,6 +61,8 @@ If you want a custom route to render without the layout (without the menu and th
 // in src/App.js
 import * as React from "react";
 import { Admin, CustomRoutes } from 'react-admin';
+import { Route } from "react-router-dom";
+
 import Settings from './Settings';
 import Register from './register';
 

--- a/docs/CustomRoutes.md
+++ b/docs/CustomRoutes.md
@@ -11,6 +11,7 @@ To register your own routes, pass one or several `<CustomRoutes>` elements as ch
 // in src/App.js
 import * as React from "react";
 import { Admin, Resource, CustomRoutes } from 'react-admin';
+import { Route } from "react-router-dom";
 import posts from './posts';
 import comments from './comments';
 import Settings from './Settings';

--- a/docs/CustomRoutes.md
+++ b/docs/CustomRoutes.md
@@ -62,7 +62,6 @@ If you want a custom route to render without the layout (without the menu and th
 import * as React from "react";
 import { Admin, CustomRoutes } from 'react-admin';
 import { Route } from "react-router-dom";
-
 import Settings from './Settings';
 import Register from './register';
 


### PR DESCRIPTION
Adding an import from "react-router-dom"