### PR TITLE
Fix `useTheme` returns undefined as value

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Theme/useTheme.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Theme/useTheme.spec.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { CoreAdminContext, useStore } from 'ra-core';
 import expect from 'expect';
 import { render, screen } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { useTheme } from './useTheme';
-import { CoreAdminContext } from 'ra-core';
+import { SimplePaletteColorOptions } from '@mui/material';
 
 const authProvider = {
     login: jest.fn().mockResolvedValueOnce(''),
@@ -25,5 +27,17 @@ describe('useTheme', () => {
             </CoreAdminContext>
         );
         expect(screen.getByLabelText('has-theme')).not.toBeNull();
+    });
+
+    it('should return theme from settings when available', () => {
+        const { result: storeResult } = renderHook(() => useStore('theme'));
+        storeResult.current[1]({ palette: { primary: { main: 'red' } } });
+
+        const { result: themeResult } = renderHook(() => useTheme());
+
+        expect(storeResult.current[0].palette.primary.main).toEqual(
+            (themeResult.current[0].palette
+                ?.primary as SimplePaletteColorOptions).main
+        );
     });
 });

--- a/packages/ra-ui-materialui/src/layout/Theme/useTheme.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Theme/useTheme.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen } from '@testing-library/react';
+import { useTheme } from './useTheme';
+import { CoreAdminContext } from 'ra-core';
+
+const authProvider = {
+    login: jest.fn().mockResolvedValueOnce(''),
+    logout: jest.fn().mockResolvedValueOnce(''),
+    checkAuth: jest.fn().mockResolvedValueOnce(''),
+    checkError: jest.fn().mockResolvedValueOnce(''),
+    getPermissions: jest.fn().mockResolvedValueOnce(''),
+};
+
+const Foo = () => {
+    const [theme] = useTheme();
+    return theme !== undefined ? <div aria-label="has-theme" /> : <></>;
+};
+
+describe('useTheme', () => {
+    it('should return current theme', () => {
+        render(
+            <CoreAdminContext authProvider={authProvider}>
+                <Foo />
+            </CoreAdminContext>
+        );
+        expect(screen.getByLabelText('has-theme')).not.toBeNull();
+    });
+});

--- a/packages/ra-ui-materialui/src/layout/Theme/useTheme.ts
+++ b/packages/ra-ui-materialui/src/layout/Theme/useTheme.ts
@@ -1,8 +1,12 @@
 import { useStore } from 'ra-core';
-import { ThemeOptions } from '@mui/material';
+import { ThemeOptions, useTheme as useThemeMUI } from '@mui/material';
 
 export type ThemeSetter = (theme: ThemeOptions) => void;
 
 export const useTheme = (
     themeOverride?: ThemeOptions
-): [ThemeOptions, ThemeSetter] => useStore('theme', themeOverride);
+): [ThemeOptions, ThemeSetter] => {
+    const themeMUI = useThemeMUI();
+    const [theme, setter] = useStore('theme', themeOverride);
+    return [theme || themeMUI, setter];
+};


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/7805

React-Admin `useTheme` hook use the store, and when no data is available there, returns the default value specified as hook parameter.  As this default theme parameter is not available in theme data consumption, the best solution was to use MUI `useTheme` hook for reading purpose. This PR aims at automating this process and avoid misuses.