### PR TITLE
[Fix] Can't un-toggle filter through secondary action button in aside list

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -189,14 +189,13 @@ export const FilterListItem = memo((props: FilterListItemProps) => {
                     data-selected={isSelected ? 'true' : 'false'}
                 />
                 {isSelected && (
-                    <ListItemSecondaryAction>
-                        <IconButton
-                            size="small"
-                            onClick={event => {
-                                event.stopPropagation();
-                                toggleFilter();
-                            }}
-                        >
+                    <ListItemSecondaryAction
+                        onClick={event => {
+                            event.stopPropagation();
+                            toggleFilter();
+                        }}
+                    >
+                        <IconButton size="small">
                             <CancelIcon />
                         </IconButton>
                     </ListItemSecondaryAction>


### PR DESCRIPTION
## Buggy behaviour capture

Note that on macOS, button is unreachable only when parent group list is unfocused but this behaviour will always occur on Linux and Windows Firefox versions.

https://user-images.githubusercontent.com/102964006/179513159-5d0b1296-b179-4de5-8e3f-9f4ff9dc0e23.mov



