### PR TITLE
Fix typo in RichTextInput Docs

### DIFF
--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -115,7 +115,7 @@ const MyRichTextInput = ({ size, ...props }) => (
 			<RichTextInputToolbar>
 				<LevelSelect size={size} />
 				<FormatButtons size={size} />
-				<AlignmentButtons {size} />
+				<AlignmentButtons size={size} />
 				<ListButtons size={size} />
 				<LinkButtons size={size} />
 				<QuoteButtons size={size} />


### PR DESCRIPTION
Title is self-explanatory - this PR fixes a minor typo in the RichTextInput docs.