### PR TITLE
Add `requireAuth` to <Authenticated /> component

### DIFF
--- a/docs/Authenticated.md
+++ b/docs/Authenticated.md
@@ -5,7 +5,7 @@ title: "The Authenticated Component"
 
 # `<Authenticated>`
 
-The `<Authenticated>` component calls [the `useAuthenticated()` hook](./useAuthenticated.md), and renders its child component - unless the authentication check fails. Use it as an alternative to the `useAuthenticated()` hook when you can't use a hook, e.g. inside a `<Route element>` commponent:
+The `<Authenticated>` component calls [the `useAuthState()` hook](./useAuthState.md), and renders its child component - unless the authentication check fails. Use it as an alternative to the `useAuthenticated()` hook when you can't use a hook, e.g. inside a `<Route element>` commponent:
 
 ```jsx
 import { Admin, CustomRoutes, Authenticated } from 'react-admin';

--- a/docs/Authenticated.md
+++ b/docs/Authenticated.md
@@ -5,7 +5,7 @@ title: "The Authenticated Component"
 
 # `<Authenticated>`
 
-The `<Authenticated>` component calls [the `useAuthState()` hook](./useAuthState.md), and renders its child component - unless the authentication check fails. Use it as an alternative to the `useAuthenticated()` hook when you can't use a hook, e.g. inside a `<Route element>` commponent:
+The `<Authenticated>` component calls [the `useAuthState()` hook](./useAuthState.md), and by default optimistically renders its child component - unless the authentication check fails. Use it as an alternative to the `useAuthenticated()` hook when you can't use a hook, or you want to support pessimistic mode, e.g. inside a `<Route element>` commponent:
 
 ```jsx
 import { Admin, CustomRoutes, Authenticated } from 'react-admin';
@@ -15,7 +15,7 @@ const App = () => (
     <Admin authProvider={authProvider}>
         <CustomRoutes>
             <Route path="/foo" element={<Authenticated><Foo /></Authenticated>} />
-            <Route path="/bar" element={<Authenticated><Bar /></Authenticated>} />
+            <Route path="/bar" element={<Authenticated pessimistic><Bar /></Authenticated>} />
             <Route path="/anoonymous" element={<Baz />} />
         </CustomRoutes>
     </Admin>

--- a/docs/Authenticated.md
+++ b/docs/Authenticated.md
@@ -5,7 +5,7 @@ title: "The Authenticated Component"
 
 # `<Authenticated>`
 
-The `<Authenticated>` component calls [the `useAuthState()` hook](./useAuthState.md), and by default optimistically renders its child component - unless the authentication check fails. Use it as an alternative to the `useAuthenticated()` hook when you can't use a hook, or you want to support pessimistic mode, e.g. inside a `<Route element>` commponent:
+The `<Authenticated>` component calls [the `useAuthState()` hook](./useAuthState.md), and by default optimistically renders its child component - unless the authentication check fails. Use it as an alternative to the `useAuthenticated()` hook when you can't use a hook, or you want to support pessimistic mode by setting `requireAuth` prop, e.g. inside a `<Route element>` commponent:
 
 ```jsx
 import { Admin, CustomRoutes, Authenticated } from 'react-admin';
@@ -15,7 +15,7 @@ const App = () => (
     <Admin authProvider={authProvider}>
         <CustomRoutes>
             <Route path="/foo" element={<Authenticated><Foo /></Authenticated>} />
-            <Route path="/bar" element={<Authenticated pessimistic><Bar /></Authenticated>} />
+            <Route path="/bar" element={<Authenticated requireAuth><Bar /></Authenticated>} />
             <Route path="/anoonymous" element={<Baz />} />
         </CustomRoutes>
     </Admin>

--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -12,7 +12,7 @@ import useAuthState from './useAuthState';
  *
  * By default this component is optimistic: it does not block
  * rendering children when checking authentication, but this mode
- * can be turned off by setting `pessimistic` to true.
+ * can be turned off by setting `requireAuth` to true.
  *
  * You can set additional `authParams` at will if your authProvider
  * requires it.
@@ -39,13 +39,13 @@ import useAuthState from './useAuthState';
  *     );
  */
 export const Authenticated = (props: AuthenticatedProps) => {
-    const { authParams, children, pessimistic = false } = props;
+    const { authParams, children, requireAuth = false } = props;
 
     // this hook will log out if the authProvider doesn't validate that the user is authenticated
     const { isLoading, authenticated } = useAuthState(authParams, true);
 
     // in pessimistic mode don't render the children until authenticated
-    if ((pessimistic && isLoading) || !authenticated) {
+    if ((requireAuth && isLoading) || !authenticated) {
         return null;
     }
 
@@ -56,5 +56,5 @@ export const Authenticated = (props: AuthenticatedProps) => {
 export interface AuthenticatedProps {
     children: ReactNode;
     authParams?: object;
-    pessimistic?: boolean;
+    requireAuth?: boolean;
 }

--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ReactNode } from 'react';
 
-import { useAuthenticated } from './useAuthenticated';
+import { useAuthState } from './useAuthState';
 
 /**
  * Restrict access to children to authenticated users.
@@ -13,33 +13,42 @@ import { useAuthenticated } from './useAuthenticated';
  * You can set additional `authParams` at will if your authProvider
  * requires it.
  *
- * @see useAuthenticated
+ * @see useAuthState
  *
  * @example
  *     import { Authenticated } from 'react-admin';
  *
  *     const CustomRoutes = [
- *         <Route path="/foo" render={() =>
+ *         <Route path="/foo" element={
  *             <Authenticated authParams={{ foo: 'bar' }}>
  *                 <Foo />
  *             </Authenticated>
  *         } />
  *     ];
  *     const App = () => (
- *         <Admin customRoutes={customRoutes}>
- *             ...
+ *         <Admin>
+ *             {CustomRoutes}
  *         </Admin>
  *     );
  */
 export const Authenticated = (props: AuthenticatedProps) => {
-    const { authParams, children } = props;
-    useAuthenticated({ params: authParams });
-    // render the child even though the useAuthenticated() call isn't finished (optimistic rendering)
-    // the above hook will log out if the authProvider doesn't validate that the user is authenticated
+    const { authParams, children, pessimistic = false } = props;
+
+    // this hook will log out if the authProvider doesn't validate that the user is authenticated
+    const { isLoading, authenticated } = useAuthState(authParams, true);
+
+    // to prevent flash of UI, we don't render the children
+    // in pessimistic mode until the authProvider has validated the user
+    if (!authenticated || (pessimistic && isLoading)) {
+        return null;
+    }
+
+    // render the children when authenticated or when in optimistic mode (default)
     return <>{children}</>;
 };
 
 export interface AuthenticatedProps {
     children: ReactNode;
     authParams?: object;
+    pessimistic?: boolean;
 }

--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -16,18 +16,21 @@ import { useAuthState } from './useAuthState';
  * @see useAuthState
  *
  * @example
- *     import { Authenticated } from 'react-admin';
+ *     import { Admin, CustomRoutes, Authenticated } from 'react-admin';
  *
- *     const CustomRoutes = [
- *         <Route path="/foo" element={
- *             <Authenticated authParams={{ foo: 'bar' }}>
- *                 <Foo />
- *             </Authenticated>
- *         } />
+ *     const customRoutes = [
+ *         <Route
+ *             path="/foo"
+ *             element={
+ *                 <Authenticated authParams={{ foo: 'bar' }}>
+ *                     <Foo />
+ *                 </Authenticated>
+ *             }
+ *         />
  *     ];
  *     const App = () => (
  *         <Admin>
- *             {CustomRoutes}
+ *             <CustomRoutes>{customRoutes}</CustomRoutes>
  *         </Admin>
  *     );
  */

--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ReactNode } from 'react';
 
-import { useAuthState } from './useAuthState';
+import useAuthState from './useAuthState';
 
 /**
  * Restrict access to children to authenticated users.
@@ -9,6 +9,10 @@ import { useAuthState } from './useAuthState';
  *
  * Use it to decorate your custom page components to require
  * authentication.
+ *
+ * By default this component is optimistic: it does not block
+ * rendering children when checking authentication, but this mode
+ * can be turned off by setting `pessimistic` to true.
  *
  * You can set additional `authParams` at will if your authProvider
  * requires it.
@@ -40,13 +44,12 @@ export const Authenticated = (props: AuthenticatedProps) => {
     // this hook will log out if the authProvider doesn't validate that the user is authenticated
     const { isLoading, authenticated } = useAuthState(authParams, true);
 
-    // to prevent flash of UI, we don't render the children
-    // in pessimistic mode until the authProvider has validated the user
-    if (!authenticated || (pessimistic && isLoading)) {
+    // in pessimistic mode don't render the children until authenticated
+    if ((pessimistic && isLoading) || !authenticated) {
         return null;
     }
 
-    // render the children when authenticated or when in optimistic mode (default)
+    // render the children in optimistic rendering or after authenticated
     return <>{children}</>;
 };
 

--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -28,6 +28,8 @@ const emptyParams = {};
  * @see useAuthenticated()
  *
  * @param {Object} params Any params you want to pass to the authProvider
+ * 
+ * @param {Boolean} logoutOnFailure: Optional. Whether the user should be logged out if the authProvider fails to authenticate them. False by default.
  *
  * @returns The current auth check state. Destructure as { authenticated, error, isLoading }.
  *

--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -45,14 +45,17 @@ const emptyParams = {};
  *     return <AnonymousContent />;
  * };
  */
-const useAuthState = (params: any = emptyParams): State => {
+const useAuthState = (
+    params: any = emptyParams,
+    logoutOnFailure: boolean = false
+): State => {
     const [state, setState] = useSafeSetState({
         isLoading: true,
         authenticated: true, // optimistic
     });
     const checkAuth = useCheckAuth();
     useEffect(() => {
-        checkAuth(params, false)
+        checkAuth(params, logoutOnFailure)
             .then(() => setState({ isLoading: false, authenticated: true }))
             .catch(() => setState({ isLoading: false, authenticated: false }));
     }, [checkAuth, params, setState]);

--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -28,7 +28,7 @@ const emptyParams = {};
  * @see useAuthenticated()
  *
  * @param {Object} params Any params you want to pass to the authProvider
- * 
+ *
  * @param {Boolean} logoutOnFailure: Optional. Whether the user should be logged out if the authProvider fails to authenticate them. False by default.
  *
  * @returns The current auth check state. Destructure as { authenticated, error, isLoading }.
@@ -60,7 +60,7 @@ const useAuthState = (
         checkAuth(params, logoutOnFailure)
             .then(() => setState({ isLoading: false, authenticated: true }))
             .catch(() => setState({ isLoading: false, authenticated: false }));
-    }, [checkAuth, params, setState]);
+    }, [checkAuth, params, logoutOnFailure, setState]);
     return state;
 };
 

--- a/packages/ra-core/src/auth/useAuthenticated.ts
+++ b/packages/ra-core/src/auth/useAuthenticated.ts
@@ -12,17 +12,17 @@ import { useCheckAuth } from './useCheckAuth';
  * requires it.
  *
  * @example
- *     import { useAuthenticated } from 'react-admin';
+ *     import { Admin, CustomRoutes, useAuthenticated } from 'react-admin';
  *     const FooPage = () => {
  *         useAuthenticated();
  *         return <Foo />;
  *     }
- *     const CustomRoutes = [
- *         <Route path="/foo" render={() => <FooPage />} />
+ *     const customRoutes = [
+ *         <Route path="/foo" element={<FooPage />} />
  *     ];
  *     const App = () => (
- *         <Admin customRoutes={customRoutes}>
- *             ...
+ *         <Admin>
+ *             <CustomRoutes>{customRoutes}</CustomRoutes>
  *         </Admin>
  *     );
  */


### PR DESCRIPTION
The `useAuthenticated()` hook and old `<Authenticated />` component is always optimistic, other auth hooks cannot be used directly inside `<Route element>` and causes boilerplate, and `<Admin requireAuth>` completely disallows anonymous access to all the pages.

This feature gives user finer granularity of control of which custom routes can be anonymously accessed, which can be optimistically rendered, and which should not leak the UI and does not have flash of UI.