### PR TITLE
Fix `<SelectInput>` loading UI to avoid visual jump

### DIFF
--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { CircularProgress } from '@mui/material';
+import { styled, SxProps } from '@mui/material/styles';
+import { useInput, FieldTitle, useTimeout } from 'ra-core';
+
+import { ResettableTextField } from './ResettableTextField';
+
+/**
+ * An input placeholder with a loading indicator
+ *
+ * Avoids visual jumps when replaced by a form input
+ */
+export const LoadingInput = ({
+    label,
+    resource,
+    source,
+    timeout = 1000,
+    validate,
+    sx,
+}: LoadingInputProps) => {
+    const oneSecondHasPassed = useTimeout(timeout);
+
+    const { isRequired } = useInput({
+        resource,
+        source,
+        validate,
+    });
+
+    return (
+        <StyledResettableTextField
+            sx={sx}
+            label={
+                label !== '' &&
+                label !== false && (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                )
+            }
+            disabled
+            onChange={() => {}}
+            InputProps={{
+                endAdornment: oneSecondHasPassed ? (
+                    <CircularProgress color="inherit" size={20} />
+                ) : (
+                    // use an adornment of the same size to avoid visual jumps
+                    <span style={{ width: 20 }}>&nbsp;</span>
+                ),
+            }}
+        />
+    );
+};
+
+const PREFIX = 'RaLoadingInput';
+
+// make it look just like a regular input, even though it's disabled
+// because the loading indicator is enough
+const StyledResettableTextField = styled(ResettableTextField, {
+    name: PREFIX,
+    overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
+    '& .MuiInputLabel-root.Mui-disabled': {
+        color: theme.palette.text.secondary,
+    },
+    '& .MuiFilledInput-root.Mui-disabled': {
+        background:
+            theme.palette.mode === 'light'
+                ? 'rgba(0, 0, 0, 0.04)'
+                : 'rgba(255, 255, 255, 0.09)',
+    },
+    '& .MuiFilledInput-root.Mui-disabled:before': {
+        borderBottomStyle: 'solid',
+    },
+}));
+
+export interface LoadingInputProps {
+    label?: string | React.ReactElement | false;
+    resource?: string;
+    source?: string;
+    timeout?: number;
+    validate?: any;
+    sx?: SxProps;
+}

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -13,6 +13,7 @@ import { ResettableTextField } from './ResettableTextField';
 export const LoadingInput = ({
     label,
     helperText,
+    margin,
     size,
     sx,
     timeout = 1000,
@@ -26,6 +27,7 @@ export const LoadingInput = ({
             label={label}
             helperText={helperText}
             variant={variant}
+            margin={margin}
             size={size}
             disabled
             onChange={() => {}}
@@ -65,6 +67,7 @@ const StyledResettableTextField = styled(ResettableTextField, {
 
 export interface LoadingInputProps {
     helperText?: React.ReactNode;
+    margin?: 'normal' | 'none' | 'dense';
     label?: string | React.ReactElement | false;
     sx?: SxProps;
     size?: 'medium' | 'small';

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -15,6 +15,7 @@ export const LoadingInput = ({
     helperText,
     sx,
     timeout = 1000,
+    variant,
 }: LoadingInputProps) => {
     const oneSecondHasPassed = useTimeout(timeout);
 
@@ -23,6 +24,7 @@ export const LoadingInput = ({
             sx={sx}
             label={label}
             helperText={helperText}
+            variant={variant}
             disabled
             onChange={() => {}}
             InputProps={{
@@ -64,4 +66,5 @@ export interface LoadingInputProps {
     timeout?: number;
     sx?: SxProps;
     helperText?: React.ReactNode;
+    variant?: 'standard' | 'filled' | 'outlined';
 }

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -13,6 +13,7 @@ import { ResettableTextField } from './ResettableTextField';
 export const LoadingInput = ({
     label,
     helperText,
+    size,
     sx,
     timeout = 1000,
     variant,
@@ -25,6 +26,7 @@ export const LoadingInput = ({
             label={label}
             helperText={helperText}
             variant={variant}
+            size={size}
             disabled
             onChange={() => {}}
             InputProps={{
@@ -62,9 +64,10 @@ const StyledResettableTextField = styled(ResettableTextField, {
 }));
 
 export interface LoadingInputProps {
-    label?: string | React.ReactElement | false;
-    timeout?: number;
-    sx?: SxProps;
     helperText?: React.ReactNode;
+    label?: string | React.ReactElement | false;
+    sx?: SxProps;
+    size?: 'medium' | 'small';
+    timeout?: number;
     variant?: 'standard' | 'filled' | 'outlined';
 }

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CircularProgress } from '@mui/material';
 import { styled, SxProps } from '@mui/material/styles';
-import { useInput, FieldTitle, useTimeout } from 'ra-core';
+import { useTimeout } from 'ra-core';
 
 import { ResettableTextField } from './ResettableTextField';
 
@@ -12,34 +12,17 @@ import { ResettableTextField } from './ResettableTextField';
  */
 export const LoadingInput = ({
     label,
-    resource,
-    source,
-    timeout = 1000,
-    validate,
+    helperText,
     sx,
+    timeout = 1000,
 }: LoadingInputProps) => {
     const oneSecondHasPassed = useTimeout(timeout);
-
-    const { isRequired } = useInput({
-        resource,
-        source,
-        validate,
-    });
 
     return (
         <StyledResettableTextField
             sx={sx}
-            label={
-                label !== '' &&
-                label !== false && (
-                    <FieldTitle
-                        label={label}
-                        source={source}
-                        resource={resource}
-                        isRequired={isRequired}
-                    />
-                )
-            }
+            label={label}
+            helperText={helperText}
             disabled
             onChange={() => {}}
             InputProps={{
@@ -78,9 +61,7 @@ const StyledResettableTextField = styled(ResettableTextField, {
 
 export interface LoadingInputProps {
     label?: string | React.ReactElement | false;
-    resource?: string;
-    source?: string;
     timeout?: number;
-    validate?: any;
     sx?: SxProps;
+    helperText?: React.ReactNode;
 }

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.stories.tsx
@@ -31,20 +31,16 @@ const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 export const WithDatagridChild = () => (
     <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
-        <Form
-            onSubmit={() => {}}
-            defaultValues={{ tag_ids: [5] }}
-            render={() => (
-                <ReferenceArrayInput
-                    reference="tags"
-                    resource="posts"
-                    source="tag_ids"
-                >
-                    <DatagridInput rowClick="toggleSelection" sx={{ mt: 6 }}>
-                        <TextField source="name" />
-                    </DatagridInput>
-                </ReferenceArrayInput>
-            )}
-        />
+        <Form onSubmit={() => {}} defaultValues={{ tag_ids: [5] }}>
+            <ReferenceArrayInput
+                reference="tags"
+                resource="posts"
+                source="tag_ids"
+            >
+                <DatagridInput rowClick="toggleSelection" sx={{ mt: 6 }}>
+                    <TextField source="name" />
+                </DatagridInput>
+            </ReferenceArrayInput>
+        </Form>
     </AdminContext>
 );

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
@@ -41,15 +41,37 @@ const i18nProvider = polyglotI18nProvider(() => englishMessages);
 export const Loading = () => (
     <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
         <Form onSubmit={() => {}} defaultValues={{ tag_ids: [5] }}>
-            <Stack sx={{ width: 200 }}>
-                <ReferenceInput
-                    reference="tags"
-                    resource="posts"
-                    source="tag_ids"
-                >
-                    <SelectInput optionText="name" />
-                </ReferenceInput>
-                <TextInput source="foo" />
+            <Stack direction="row" spacing={2}>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput optionText="name" />
+                    </ReferenceInput>
+                    <TextInput source="foo" />
+                </Stack>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput optionText="name" variant="standard" />
+                    </ReferenceInput>
+                    <TextInput source="foo" variant="standard" />
+                </Stack>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput optionText="name" variant="outlined" />
+                    </ReferenceInput>
+                    <TextInput source="foo" variant="outlined" />
+                </Stack>
             </Stack>
         </Form>
     </AdminContext>

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Form, testDataProvider } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import { Stack, Divider } from '@mui/material';
+import { Stack, Divider, Typography } from '@mui/material';
 
 import { AdminContext } from '../AdminContext';
 import { SelectInput, TextInput } from '../input';
@@ -42,6 +42,22 @@ export const Loading = () => (
     <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
         <Form onSubmit={() => {}} defaultValues={{ tag_ids: [5] }}>
             <Stack direction="row" spacing={2}>
+                <Typography gutterBottom sx={{ width: 200 }}></Typography>
+                <Typography gutterBottom sx={{ width: 200 }}>
+                    Variant Default
+                </Typography>
+                <Typography gutterBottom sx={{ width: 200 }}>
+                    Variant Standard
+                </Typography>
+                <Typography gutterBottom sx={{ width: 200 }}>
+                    Variant Outlined
+                </Typography>
+            </Stack>
+            <Divider />
+            <Stack direction="row" spacing={2}>
+                <Typography gutterBottom sx={{ width: 200 }}>
+                    Default
+                </Typography>
                 <Stack sx={{ width: 200 }}>
                     <ReferenceInput
                         reference="tags"
@@ -75,6 +91,9 @@ export const Loading = () => (
             </Stack>
             <Divider />
             <Stack direction="row" spacing={2}>
+                <Typography gutterBottom sx={{ width: 200 }}>
+                    size
+                </Typography>
                 <Stack sx={{ width: 200 }}>
                     <ReferenceInput
                         reference="tags"
@@ -112,6 +131,58 @@ export const Loading = () => (
                         />
                     </ReferenceInput>
                     <TextInput source="foo" variant="outlined" size="medium" />
+                </Stack>
+            </Stack>
+            <Divider />
+            <Stack direction="row" spacing={2}>
+                <Typography gutterBottom sx={{ width: 200 }}>
+                    margin
+                </Typography>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput optionText="name" margin="normal" />
+                    </ReferenceInput>
+                    <TextInput source="foo" margin="normal" />
+                </Stack>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput
+                            optionText="name"
+                            variant="standard"
+                            margin="normal"
+                        />
+                    </ReferenceInput>
+                    <TextInput
+                        source="foo"
+                        variant="standard"
+                        margin="normal"
+                    />
+                </Stack>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput
+                            optionText="name"
+                            variant="outlined"
+                            margin="normal"
+                        />
+                    </ReferenceInput>
+                    <TextInput
+                        source="foo"
+                        variant="outlined"
+                        margin="normal"
+                    />
                 </Stack>
             </Stack>
         </Form>

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Form, testDataProvider } from 'ra-core';
+import { AdminContext } from '../AdminContext';
+
+import { SelectInput } from '../input';
+import { ReferenceInput } from './ReferenceInput';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
+
+export default { title: 'ra-ui-materialui/input/ReferenceInput' };
+
+const tags = [
+    { id: 5, name: 'lorem' },
+    { id: 6, name: 'ipsum' },
+];
+
+const dataProvider = testDataProvider({
+    getList: () =>
+        new Promise(resolve => {
+            setTimeout(
+                () =>
+                    resolve({
+                        // @ts-ignore
+                        data: tags,
+                        total: tags.length,
+                    }),
+                1500
+            );
+        }),
+    // @ts-ignore
+    getMany: (resource, params) => {
+        return Promise.resolve({
+            data: tags.filter(tag => params.ids.includes(tag.id)),
+        });
+    },
+});
+
+const i18nProvider = polyglotI18nProvider(() => englishMessages);
+
+export const Loading = () => (
+    <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+        <Form onSubmit={() => {}} defaultValues={{ tag_ids: [5] }}>
+            <ReferenceInput reference="tags" resource="posts" source="tag_ids">
+                <SelectInput optionText="name" />
+            </ReferenceInput>
+        </Form>
+    </AdminContext>
+);

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Form, testDataProvider } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import { Stack } from '@mui/material';
+import { Stack, Divider } from '@mui/material';
 
 import { AdminContext } from '../AdminContext';
 import { SelectInput, TextInput } from '../input';
@@ -71,6 +71,47 @@ export const Loading = () => (
                         <SelectInput optionText="name" variant="outlined" />
                     </ReferenceInput>
                     <TextInput source="foo" variant="outlined" />
+                </Stack>
+            </Stack>
+            <Divider />
+            <Stack direction="row" spacing={2}>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput optionText="name" size="medium" />
+                    </ReferenceInput>
+                    <TextInput source="foo" size="medium" />
+                </Stack>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput
+                            optionText="name"
+                            variant="standard"
+                            size="medium"
+                        />
+                    </ReferenceInput>
+                    <TextInput source="foo" variant="standard" size="medium" />
+                </Stack>
+                <Stack sx={{ width: 200 }}>
+                    <ReferenceInput
+                        reference="tags"
+                        resource="posts"
+                        source="tag_ids"
+                    >
+                        <SelectInput
+                            optionText="name"
+                            variant="outlined"
+                            size="medium"
+                        />
+                    </ReferenceInput>
+                    <TextInput source="foo" variant="outlined" size="medium" />
                 </Stack>
             </Stack>
         </Form>

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Form, testDataProvider } from 'ra-core';
-import { AdminContext } from '../AdminContext';
-
-import { SelectInput } from '../input';
-import { ReferenceInput } from './ReferenceInput';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
+import { Stack } from '@mui/material';
+
+import { AdminContext } from '../AdminContext';
+import { SelectInput, TextInput } from '../input';
+import { ReferenceInput } from './ReferenceInput';
 
 export default { title: 'ra-ui-materialui/input/ReferenceInput' };
 
@@ -40,9 +41,16 @@ const i18nProvider = polyglotI18nProvider(() => englishMessages);
 export const Loading = () => (
     <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
         <Form onSubmit={() => {}} defaultValues={{ tag_ids: [5] }}>
-            <ReferenceInput reference="tags" resource="posts" source="tag_ids">
-                <SelectInput optionText="name" />
-            </ReferenceInput>
+            <Stack sx={{ width: 200 }}>
+                <ReferenceInput
+                    reference="tags"
+                    resource="posts"
+                    source="tag_ids"
+                >
+                    <SelectInput optionText="name" />
+                </ReferenceInput>
+                <TextInput source="foo" />
+            </Stack>
         </Form>
     </AdminContext>
 );

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -255,6 +255,7 @@ export const SelectInput = (props: SelectInputProps) => {
                 }
                 variant={props.variant}
                 size={props.size}
+                margin={props.margin}
             />
         );
     }

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -254,6 +254,7 @@ export const SelectInput = (props: SelectInputProps) => {
                     />
                 }
                 variant={props.variant}
+                size={props.size}
             />
         );
     }

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -234,10 +234,25 @@ export const SelectInput = (props: SelectInputProps) => {
     if (isLoading) {
         return (
             <LoadingInput
-                label={label}
-                resource={resource}
-                source={source}
+                label={
+                    label !== '' &&
+                    label !== false && (
+                        <FieldTitle
+                            label={label}
+                            source={source}
+                            resource={resourceProp}
+                            isRequired={isRequired}
+                        />
+                    )
+                }
                 sx={props.sx}
+                helperText={
+                    <InputHelperText
+                        touched={isTouched || isSubmitted}
+                        error={error?.message}
+                        helperText={helperText}
+                    />
+                }
             />
         );
     }

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -253,6 +253,7 @@ export const SelectInput = (props: SelectInputProps) => {
                         helperText={helperText}
                     />
                 }
+                variant={props.variant}
             />
         );
     }

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ReactElement, useCallback, ChangeEvent } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { MenuItem, CircularProgress, TextFieldProps } from '@mui/material';
+import { MenuItem, TextFieldProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import {
     useChoicesContext,

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { ReactElement, useCallback, ChangeEvent } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import MenuItem from '@mui/material/MenuItem';
-import { TextFieldProps } from '@mui/material/TextField';
+import { MenuItem, CircularProgress, TextFieldProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import {
     useChoicesContext,
@@ -22,12 +21,11 @@ import {
 } from './ResettableTextField';
 import { InputHelperText } from './InputHelperText';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
-import { Labeled } from '../Labeled';
-import { LinearProgress } from '../layout';
 import {
     useSupportCreateSuggestion,
     SupportCreateSuggestionOptions,
 } from './useSupportCreateSuggestion';
+import { LoadingInput } from './LoadingInput';
 
 /**
  * An Input component for a select box, using an array of objects for the options
@@ -235,15 +233,12 @@ export const SelectInput = (props: SelectInputProps) => {
 
     if (isLoading) {
         return (
-            <Labeled
+            <LoadingInput
                 label={label}
+                resource={resource}
                 source={source}
-                resource={resourceProp}
-                className={clsx('ra-input', `ra-input-${source}`, className)}
-                isRequired={isRequired}
-            >
-                <LinearProgress />
-            </Labeled>
+                sx={props.sx}
+            />
         );
     }
 

--- a/packages/ra-ui-materialui/src/input/index.ts
+++ b/packages/ra-ui-materialui/src/input/index.ts
@@ -11,6 +11,7 @@ export * from './FileInput';
 export * from './ImageInput';
 export * from './InputHelperText';
 export * from './InputPropTypes';
+export * from './LoadingInput';
 export * from './NullableBooleanInput';
 export * from './NumberInput';
 export * from './PasswordInput';


### PR DESCRIPTION
Closes #7975

## Before

https://user-images.githubusercontent.com/99944/180303089-c9d9620d-5cd6-471c-a777-be1ad5975622.mov

## After

https://user-images.githubusercontent.com/99944/180305200-47dcbdf0-bd7e-4689-a757-72e39298fc8c.mov