### PR TITLE
[doc] Fix: Incorrect example code block of ReferenceInput

### DIFF
--- a/docs/ReferenceInput.md
+++ b/docs/ReferenceInput.md
@@ -14,8 +14,8 @@ The component expects a `source` and a `reference` attributes. For instance, to 
 ```jsx
 import { ReferenceInput, SelectInput } from 'react-admin';
 
-<ReferenceInput label="Post" source="post_id" reference="posts">
-    <SelectInput optionText="title" />
+<ReferenceInput source="post_id" reference="posts">
+    <SelectInput label="Post" optionText="title" />
 </ReferenceInput>
 ```
 


### PR DESCRIPTION
+  Providing prop `label` to ReferenceInput doesn't take any effect. It should be passed to its child *Input component.