### PR TITLE
fix(menu): add unique key

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -46,7 +46,9 @@ export const Menu = (props: MenuProps) => {
     const {
         hasDashboard,
         children = [
-            hasDashboard ? <DashboardMenuItem /> : null,
+            hasDashboard ? (
+                <DashboardMenuItem key="default-dashboard-menu-item" />
+            ) : null,
             ...Object.keys(resources)
                 .filter(name => resources[name].hasList)
                 .map(name => (


### PR DESCRIPTION
Using the `dashboard` property of the `Admin` component results in an error with the `Menu` component.
The `DashboardMenuItem` does not have a `key` set, hence React complains about missing unique-keys.

This PR defines a key (`default-dashboard-menu-item`) for the dashboard's menu item.