### PR TITLE
[Doc] Fix react-query links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A frontend Framework for building data-driven applications running in the browse
 
 * ☂️ **Opt-In Types**: Develop either in TypeScript or JavaScript
 
-* 👨‍👩‍👧‍👦 Powered by [MUI](https://mui.com/), [react-hook-form](https://react-hook-form.com), [react-router](https://reacttraining.com/react-router/), [react-query](https://react-query.tanstack.com/), [TypeScript](https://www.typescriptlang.org/) and a few more
+* 👨‍👩‍👧‍👦 Powered by [MUI](https://mui.com/), [react-hook-form](https://react-hook-form.com), [react-router](https://reacttraining.com/react-router/), [react-query](https://react-query-v3.tanstack.com/), [TypeScript](https://www.typescriptlang.org/) and a few more
 
 ## Installation
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -5,7 +5,7 @@ title: "Querying the API"
 
 # Querying the API
 
-React-admin provides special hooks to emit read and write queries to the [`dataProvider`](./DataProviders.md), which in turn sends requests to your API. Under the hood, it uses [react-query](https://react-query.tanstack.com/) to call the `dataProvider` and cache the results.
+React-admin provides special hooks to emit read and write queries to the [`dataProvider`](./DataProviders.md), which in turn sends requests to your API. Under the hood, it uses [react-query](https://react-query-v3.tanstack.com/) to call the `dataProvider` and cache the results.
 
 ## Getting The `dataProvider` Instance
 
@@ -118,7 +118,7 @@ It's up to the Data Provider to interpret this parameter.
 
 ## `useQuery` and `useMutation`
 
-Internally, react-admin uses [react-query](https://react-query.tanstack.com/) to call the dataProvider. When fetching data from the dataProvider in your components, if you can't use any of the dataProvider method hooks, you should use that library, too. It brings several benefits:
+Internally, react-admin uses [react-query](https://react-query-v3.tanstack.com/) to call the dataProvider. When fetching data from the dataProvider in your components, if you can't use any of the dataProvider method hooks, you should use that library, too. It brings several benefits:
 
 1. It triggers the loader in the AppBar when the query is running.
 2. It reduces the boilerplate code since you don't need to use `useState`.
@@ -127,8 +127,8 @@ Internally, react-admin uses [react-query](https://react-query.tanstack.com/) to
 
 React-query offers 2 main hooks to interact with the dataProvider:
 
-* [`useQuery`](https://react-query.tanstack.com/reference/useQuery): fetches the dataProvider on mount. This is for *read* queries.
-* [`useMutation`](https://react-query.tanstack.com/reference/useMutation): fetches the dataProvider when you call a callback. This is for *write* queries, and *read* queries that execute on user interaction.
+* [`useQuery`](https://react-query-v3.tanstack.com/reference/useQuery): fetches the dataProvider on mount. This is for *read* queries.
+* [`useMutation`](https://react-query-v3.tanstack.com/reference/useMutation): fetches the dataProvider when you call a callback. This is for *write* queries, and *read* queries that execute on user interaction.
 
 Both these hooks accept a query *key* (identifying the query in the cache), and a query *function* (executing the query and returning a Promise). Internally, react-admin uses an array of arguments as the query key.
 
@@ -176,7 +176,7 @@ const ApproveButton = ({ record }) => {
 };
 ```
 
-If you want to go beyond data provider method hooks, we recommend that you read [the react-query documentation](https://react-query.tanstack.com/overview).
+If you want to go beyond data provider method hooks, we recommend that you read [the react-query documentation](https://react-query-v3.tanstack.com/overview).
 
 ## `isLoading` vs `isFetching`
 
@@ -184,7 +184,7 @@ Data fetching hooks return two loading state variables: `isLoading` and `isFetch
 
 The short answer is: use `isLoading`. Read on to understand why.
 
-The source of these two variables is [react-query](https://react-query.tanstack.com/guides/queries#query-basics). Here is how they defined these two variables:
+The source of these two variables is [react-query](https://react-query-v3.tanstack.com/guides/queries#query-basics). Here is how they defined these two variables:
 
 - `isLoading`:  The query has no data and is currently fetching
 - `isFetching`: In any state, if the query is fetching at any time (including background refetching) isFetching will be true.
@@ -253,7 +253,7 @@ const BanUserButton = ({ userId }) => {
 
 ## Query Options
 
-The data provider method hooks (like `useGetOne`) and react-query's hooks (like `useQuery`) accept a query options object as the last argument. This object can be used to modify the way the query is executed. There are many options, all documented [in the react-query documentation](https://react-query.tanstack.com/reference/useQuery):
+The data provider method hooks (like `useGetOne`) and react-query's hooks (like `useQuery`) accept a query options object as the last argument. This object can be used to modify the way the query is executed. There are many options, all documented [in the react-query documentation](https://react-query-v3.tanstack.com/reference/useQuery):
 
 - `cacheTime`
 - `enabled`

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -120,7 +120,7 @@ The [Translation Documentation](./Translation.md) details this process.
 
 ## `queryClient`
 
-React-admin uses [react-query](https://react-query.tanstack.com/) to fetch, cache and update data. Internally, the `<Admin>` component creates a react-query [`QueryClient`](https://react-query.tanstack.com/reference/QueryClient) on mount, using [react-query's "aggressive but sane" defaults](https://react-query.tanstack.com/guides/important-defaults):
+React-admin uses [react-query](https://react-query-v3.tanstack.com/) to fetch, cache and update data. Internally, the `<Admin>` component creates a react-query [`QueryClient`](https://react-query-v3.tanstack.com/reference/QueryClient) on mount, using [react-query's "aggressive but sane" defaults](https://react-query-v3.tanstack.com/guides/important-defaults):
 
 * Queries consider cached data as stale
 * Stale queries are refetched automatically in the background when:
@@ -158,7 +158,7 @@ const App = () => (
 );
 ```
 
-To know which options you can pass to the `QueryClient` constructor, check the [react-query documentation](https://react-query.tanstack.com/reference/QueryClient) and the [query options](https://react-query.tanstack.com/reference/useQuery) and [mutation options](https://react-query.tanstack.com/reference/useMutation) sections.
+To know which options you can pass to the `QueryClient` constructor, check the [react-query documentation](https://react-query-v3.tanstack.com/reference/QueryClient) and the [query options](https://react-query-v3.tanstack.com/reference/useQuery) and [mutation options](https://react-query-v3.tanstack.com/reference/useMutation) sections.
 
 The common settings that react-admin developers often overwrite are:
 

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -110,7 +110,7 @@ const App = () => {
 
 With this setting, all queries will be considered valid for 5 minutes. That means that react-admin *won't refetch* data from the API if the data is already in the cache and younger than 5 minutes.
 
-Check the details about this cache [in the react-query documentation](https://react-query.tanstack.com/guides/caching).
+Check the details about this cache [in the react-query documentation](https://react-query-v3.tanstack.com/guides/caching).
 
 It especially fits admins for API backends with a small number of users (because with a large number of users, there is a high chance that a record kept in the client-side cache for a few minutes may be updated on the backend by another user). It also works with GraphQL APIs. 
 

--- a/docs/Create.md
+++ b/docs/Create.md
@@ -168,7 +168,7 @@ const PostCreate = () => (
 ```
 {% endraw %}
 
-You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
+You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query-v3.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
 
 Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to the new record edit page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -68,7 +68,7 @@ Access-Control-Expose-Headers: Content-Range
 
 ## Enabling Query Logs
 
-React-admin uses `react-query` to call the dataProvider. You can see all the calls made by react-query in the browser thanks to [the react-query devtools](https://react-query.tanstack.com/devtools).
+React-admin uses `react-query` to call the dataProvider. You can see all the calls made by react-query in the browser thanks to [the react-query devtools](https://react-query-v3.tanstack.com/devtools).
 
 ![React-Query DevTools](./img/react-query-devtools.png)
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -281,7 +281,7 @@ const PostEdit = () => (
 ```
 {% endraw %}
 
-You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
+You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://react-query-v3.tanstack.com/reference/useMutation) in the react-query website for a list of the possible options.
 
 Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to the list page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
 
@@ -431,7 +431,7 @@ const PostEdit = () => (
 ```
 {% endraw %}
 
-Refer to the [useQuery documentation](https://react-query.tanstack.com/reference/useQuery) in the react-query website for a list of the possible options.
+Refer to the [useQuery documentation](https://react-query-v3.tanstack.com/reference/useQuery) in the react-query website for a list of the possible options.
 
 ## `redirect`
 

--- a/docs/Layout.md
+++ b/docs/Layout.md
@@ -304,7 +304,7 @@ export const MyLayout = (props) => (
 
 ## Adding Developer Tools
 
-A custom layout is also the ideal place to add debug tools, e.g. [react-query devtools](https://react-query.tanstack.com/devtools):
+A custom layout is also the ideal place to add debug tools, e.g. [react-query devtools](https://react-query-v3.tanstack.com/devtools):
 
 ```jsx
 // in src/MyLayout.js

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -19,7 +19,7 @@ React-admin v4 uses MUI (Material-UI) v5. The MUI team has written an upgrade gu
 
 ## Redux Is Gone
 
-React-admin no longer relies on Redux. Instead, it relies on [React context](https://reactjs.org/docs/context.html) and third-party libraries (e.g. [react-query](https://react-query.tanstack.com/)). 
+React-admin no longer relies on Redux. Instead, it relies on [React context](https://reactjs.org/docs/context.html) and third-party libraries (e.g. [react-query](https://react-query-v3.tanstack.com/)). 
 
 You will need to update your code if it contains any of the following keywords:
 
@@ -665,7 +665,7 @@ To upgrade, check every instance of your code of the following hooks:
 
 And update the calls. If you're using TypeScript, your code won't compile until you properly upgrade the calls. 
 
-These hooks are now powered by react-query, so the state argument contains way more than just `isLoading` (`reset`, `status`, `refetch`, etc.). Check the [`useQuery`](https://react-query.tanstack.com/reference/useQuery) and the [`useMutation`](https://react-query.tanstack.com/reference/useMutation) documentation on the react-query website for more details. 
+These hooks are now powered by react-query, so the state argument contains way more than just `isLoading` (`reset`, `status`, `refetch`, etc.). Check the [`useQuery`](https://react-query-v3.tanstack.com/reference/useQuery) and the [`useMutation`](https://react-query-v3.tanstack.com/reference/useMutation) documentation on the react-query website for more details. 
 
 ### `useQuery`, `useMutation`, and `useQueryWithStore` Have Been Removed
 
@@ -738,7 +738,7 @@ const BanUserButton = ({ userId }) => {
 };
 ```
 
-Refer to [the react-query documentation](https://react-query.tanstack.com/overview) for more information.
+Refer to [the react-query documentation](https://react-query-v3.tanstack.com/overview) for more information.
 
 ### `<Query>` and `<Mutation>` Have Been Removed
 
@@ -804,7 +804,7 @@ const BanUserButton = ({ userId }) => {
 };
 ```
 
-Refer to [the react-query documentation](https://react-query.tanstack.com/overview) for more information.
+Refer to [the react-query documentation](https://react-query-v3.tanstack.com/overview) for more information.
 
 
 ### Application Cache No Longer Uses `validUntil`
@@ -981,7 +981,7 @@ const BookDetail = ({ id }) => {
 
 In general, you should use `isLoading`. It's false as long as the data has never been loaded (whether from the dataProvider or from the cache).
 
-The new props are actually returned by react-query's `useQuery` hook. Check [their documentation](https://react-query.tanstack.com/reference/useQuery) for more information.
+The new props are actually returned by react-query's `useQuery` hook. Check [their documentation](https://react-query-v3.tanstack.com/reference/useQuery) for more information.
 
 
 ## Auth Provider
@@ -1612,7 +1612,7 @@ export const PostList = () => (
 
 ### `useGetMainList` Was Removed
 
-`useGetMainList` was a modified version of `useGetList` designed to keep previous data on screen upon navigation. As [this is now supported natively by react-query](https://react-query.tanstack.com/guides/paginated-queries#better-paginated-queries-with-keeppreviousdata), this hook is no longer necessary and has been removed. Use `useGetList()` instead.
+`useGetMainList` was a modified version of `useGetList` designed to keep previous data on screen upon navigation. As [this is now supported natively by react-query](https://react-query-v3.tanstack.com/guides/paginated-queries#better-paginated-queries-with-keeppreviousdata), this hook is no longer necessary and has been removed. Use `useGetList()` instead.
 
 ### `useUnselectAll` Syntax Changed
 

--- a/docs/useGetOne.md
+++ b/docs/useGetOne.md
@@ -19,7 +19,7 @@ const { data, isLoading, error, refetch } = useGetOne(
 
 The `meta` argument is optional. It can be anything you want to pass to the data provider, e.g. a list of fields to show in the result.
 
-The `options` parameter is optional, and is passed to [react-query's `useQuery` hook](https://react-query.tanstack.com/reference/useQuery). It may contain the following options:
+The `options` parameter is optional, and is passed to [react-query's `useQuery` hook](https://react-query-v3.tanstack.com/reference/useQuery). It may contain the following options:
 
 * `cacheTime`
 * `enabled`
@@ -49,9 +49,9 @@ The `options` parameter is optional, and is passed to [react-query's `useQuery` 
 * `suspense`
 * `useErrorBoundary`
 
-Check [react-query's `useQuery` hook documentation](https://react-query.tanstack.com/reference/useQuery) for details on each of these options.
+Check [react-query's `useQuery` hook documentation](https://react-query-v3.tanstack.com/reference/useQuery) for details on each of these options.
 
-The react-query [query key](https://react-query.tanstack.com/guides/query-keys) for this hook is `[resource, 'getOne', { id: String(id), meta }]`.
+The react-query [query key](https://react-query-v3.tanstack.com/guides/query-keys) for this hook is `[resource, 'getOne', { id: String(id), meta }]`.
 
 ## Usage
 

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -35,7 +35,7 @@ import { RaRecord, CreateParams } from '../types';
  * This hook uses react-query useMutation under the hood.
  * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * @see https://react-query.tanstack.com/reference/useMutation
+ * @see https://react-query-v3.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the create callback
  *

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -39,7 +39,7 @@ import { RaRecord, DeleteParams, MutationMode } from '../types';
  * This hook uses react-query useMutation under the hood.
  * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * @see https://react-query.tanstack.com/reference/useMutation
+ * @see https://react-query-v3.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the deleteOne callback
  *
@@ -289,7 +289,7 @@ export const useDelete = <
             previousData: callTimePreviousData = previousData,
         } = callTimeParams;
 
-        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // optimistic update as documented in https://react-query-v3.tanstack.com/guides/optimistic-updates
         // except we do it in a mutate wrapper instead of the onMutate callback
         // to have access to success side effects
 
@@ -310,7 +310,7 @@ export const useDelete = <
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]
          *
-         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         * @see https://react-query-v3.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
          */
         snapshot.current = queryKeys.reduce(
             (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -38,7 +38,7 @@ import { RaRecord, DeleteManyParams, MutationMode } from '../types';
  * This hook uses react-query useMutation under the hood.
  * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * @see https://react-query.tanstack.com/reference/useMutation
+ * @see https://react-query-v3.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the deleteMany callback
  *
@@ -297,7 +297,7 @@ export const useDeleteMany = <
 
         const { ids: callTimeIds = ids } = callTimeParams;
 
-        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // optimistic update as documented in https://react-query-v3.tanstack.com/guides/optimistic-updates
         // except we do it in a mutate wrapper instead of the onMutate callback
         // to have access to success side effects
 
@@ -318,7 +318,7 @@ export const useDeleteMany = <
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]
          *
-         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         * @see https://react-query-v3.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
          */
         snapshot.current = queryKeys.reduce(
             (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -41,7 +41,7 @@ import { RaRecord, UpdateParams, MutationMode } from '../types';
  * This hook uses react-query useMutation under the hood.
  * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * @see https://react-query.tanstack.com/reference/useMutation
+ * @see https://react-query-v3.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the update callback
  *
@@ -310,7 +310,7 @@ export const useUpdate = <
             meta: callTimeMeta = meta,
         } = callTimeParams;
 
-        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // optimistic update as documented in https://react-query-v3.tanstack.com/guides/optimistic-updates
         // except we do it in a mutate wrapper instead of the onMutate callback
         // to have access to success side effects
 
@@ -343,7 +343,7 @@ export const useUpdate = <
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]
          *
-         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         * @see https://react-query-v3.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
          */
         snapshot.current = queryKeys.reduce(
             (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -41,7 +41,7 @@ import { Identifier } from '..';
  * This hook uses react-query useMutation under the hood.
  * This means the state object contains mutate, isIdle, reset and other react-query methods.
  *
- * @see https://react-query.tanstack.com/reference/useMutation
+ * @see https://react-query-v3.tanstack.com/reference/useMutation
  *
  * @example // set params when calling the updateMany callback
  *
@@ -320,7 +320,7 @@ export const useUpdateMany = <
             meta: callTimeMeta = meta,
         } = callTimeParams;
 
-        // optimistic update as documented in https://react-query.tanstack.com/guides/optimistic-updates
+        // optimistic update as documented in https://react-query-v3.tanstack.com/guides/optimistic-updates
         // except we do it in a mutate wrapper instead of the onMutate callback
         // to have access to success side effects
 
@@ -343,7 +343,7 @@ export const useUpdateMany = <
          *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
          * ]
          *
-         * @see https://react-query.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         * @see https://react-query-v3.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
          */
         snapshot.current = queryKeys.reduce(
             (prev, curr) => prev.concat(queryClient.getQueriesData(curr)),

--- a/packages/react-admin/README.md
+++ b/packages/react-admin/README.md
@@ -9,7 +9,7 @@ A frontend Framework for building data-driven applications running in the browse
 ## Features
 
 * Adapts to any backend (REST, GraphQL, SOAP, etc.)
-* Powered by [material-ui](https://mui.com/), [react-query](https://react-query.tanstack.com/), [react-hook-form](https://react-hook-form.com), [react-router](https://reacttraining.com/react-router/) and a few more
+* Powered by [material-ui](https://mui.com/), [react-query](https://react-query-v3.tanstack.com/), [react-hook-form](https://react-hook-form.com), [react-router](https://reacttraining.com/react-router/) and a few more
 * Super-fast UI thanks to optimistic rendering (renders before the server returns)
 * Undo updates and deletes for a few seconds
 * Relationships (many to one, one to many)


### PR DESCRIPTION
React Query new major version induced a change in their documentation, current PR fix all links pointing toward it.