### PR TITLE
Input label proptypes and DatagridInput imports

### DIFF
--- a/packages/ra-ui-materialui/src/input/DatagridInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DatagridInput.tsx
@@ -10,7 +10,7 @@ import {
 } from 'ra-core';
 import { CommonInputProps } from './CommonInputProps';
 import { InputHelperText } from './InputHelperText';
-import {SupportCreateSuggestionOptions} from "./useSupportCreateSuggestion";
+import { SupportCreateSuggestionOptions } from './useSupportCreateSuggestion';
 import { Datagrid, DatagridProps } from '../list/datagrid';
 import { FilterButton, FilterForm } from '../list/filter';
 import { FilterContext } from '../list/FilterContext';

--- a/packages/ra-ui-materialui/src/input/DatagridInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DatagridInput.tsx
@@ -8,11 +8,9 @@ import {
     useChoicesContext,
     useInput,
 } from 'ra-core';
-import {
-    CommonInputProps,
-    InputHelperText,
-    SupportCreateSuggestionOptions,
-} from '.';
+import { CommonInputProps } from './CommonInputProps';
+import { InputHelperText } from './InputHelperText';
+import {SupportCreateSuggestionOptions} from "./useSupportCreateSuggestion";
 import { Datagrid, DatagridProps } from '../list/datagrid';
 import { FilterButton, FilterForm } from '../list/filter';
 import { FilterContext } from '../list/FilterContext';

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -95,7 +95,11 @@ export const DateInput = ({
 };
 
 DateInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     resource: PropTypes.string,
     source: PropTypes.string,
 };

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -95,7 +95,7 @@ export const DateInput = ({
 };
 
 DateInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     resource: PropTypes.string,
     source: PropTypes.string,
 };

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -83,7 +83,7 @@ export const DateTimeInput = ({
 };
 
 DateTimeInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     resource: PropTypes.string,
     source: PropTypes.string,
 };

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -83,7 +83,11 @@ export const DateTimeInput = ({
 };
 
 DateTimeInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     resource: PropTypes.string,
     source: PropTypes.string,
 };

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -214,7 +214,7 @@ FileInput.propTypes = {
     className: PropTypes.string,
     id: PropTypes.string,
     isRequired: PropTypes.bool,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     labelMultiple: PropTypes.string,
     labelSingle: PropTypes.string,
     maxSize: PropTypes.number,

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -214,7 +214,11 @@ FileInput.propTypes = {
     className: PropTypes.string,
     id: PropTypes.string,
     isRequired: PropTypes.bool,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     labelMultiple: PropTypes.string,
     labelSingle: PropTypes.string,
     maxSize: PropTypes.number,

--- a/packages/ra-ui-materialui/src/input/InputPropTypes.ts
+++ b/packages/ra-ui-materialui/src/input/InputPropTypes.ts
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types';
  * Common PropTypes for all react-admin inputs
  */
 export const InputPropTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     resource: PropTypes.string,
     source: PropTypes.string,
 };

--- a/packages/ra-ui-materialui/src/input/InputPropTypes.ts
+++ b/packages/ra-ui-materialui/src/input/InputPropTypes.ts
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
  * Common PropTypes for all react-admin inputs
  */
 export const InputPropTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     resource: PropTypes.string,
     source: PropTypes.string,
 };

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -89,7 +89,7 @@ export const NullableBooleanInput = (props: NullableBooleanInputProps) => {
 };
 
 NullableBooleanInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -89,7 +89,11 @@ export const NullableBooleanInput = (props: NullableBooleanInputProps) => {
 };
 
 NullableBooleanInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -152,7 +152,7 @@ export const NumberInput = ({
 };
 
 NumberInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -152,7 +152,11 @@ export const NumberInput = ({
 };
 
 NumberInput.propTypes = {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -202,7 +202,7 @@ export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
 
 RadioButtonGroupInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.any),
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -202,7 +202,11 @@ export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
 
 RadioButtonGroupInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.any),
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -302,7 +302,11 @@ SelectArrayInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
     className: PropTypes.string,
     children: PropTypes.node,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -302,7 +302,7 @@ SelectArrayInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
     className: PropTypes.string,
     children: PropTypes.node,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -311,7 +311,11 @@ SelectInput.propTypes = {
     emptyValue: PropTypes.any,
     choices: PropTypes.arrayOf(PropTypes.object),
     className: PropTypes.string,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -311,7 +311,7 @@ SelectInput.propTypes = {
     emptyValue: PropTypes.any,
     choices: PropTypes.arrayOf(PropTypes.object),
     className: PropTypes.string,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -89,7 +89,11 @@ export const TextInput = (props: TextInputProps) => {
 
 TextInput.propTypes = {
     className: PropTypes.string,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.element,
+    ]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -89,7 +89,7 @@ export const TextInput = (props: TextInputProps) => {
 
 TextInput.propTypes = {
     className: PropTypes.string,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.element]),
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,


### PR DESCRIPTION
- add element to label proptypes for inputs to eliminate browser console errors when passing an element as a label
- fix imports in DatagridInput (fixes https://github.com/marmelab/react-admin/issues/8018)