### PR TITLE
Fix delete contexts don't send mutation `meta`

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -244,11 +244,11 @@ export const PostList = () => (
 
 ![Bulk Delete button](./img/bulk-delete-button.png)
 
-| Prop         | Required | Type            | Default            | Description                         |
-| ------------ | -------- | --------------- | ------------------ | ----------------------------------- |
-| `label`      | Optional | `string`        | 'ra.action.delete' | label or translation message to use |
-| `icon`       | Optional | `ReactElement`  | `<DeleteIcon>`     | iconElement, e.g. `<CommentIcon />` |
-| `exporter`   | Optional | `Function`      | -                  | Override the List exporter function |
+| Prop                | Required | Type            | Default            | Description                                        |
+| --------------------| -------- | --------------- | ------------------ | ---------------------------------------------------|
+| `label`             | Optional | `string`        | 'ra.action.delete' | label or translation message to use                |
+| `icon`              | Optional | `ReactElement`  | `<DeleteIcon>`     | iconElement, e.g. `<CommentIcon />`                |
+| `mutationOptions`   | Optional | `object`        | null               | options for react-query `useMutation` hook         |
 
 ### `<FilterButton>`
 
@@ -277,6 +277,7 @@ Delete the current record after a confirm dialog has been accepted. To be used i
 | `confirmContent`                                           | Optional | `ReactNode`                      | 'ra.message.delete_content' | Message or React component to be used as the body of the confirm dialog |
 | `redirect`                                                 | Optional | `string | false | Function`      | 'list'                      | Custom redirection after success side effect                            |
 | `translateOptions`                                         | Optional | `{ id?: string, name?: string }` | {}                          | Custom id and name to be used in the confirm dialog's title             |
+| `mutationOptions`                                          | Optional |                                  | null                        | options for react-query `useMutation` hook                              |
 
 {% raw %}
 ```jsx

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import expect from 'expect';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { fireEvent, screen, render, waitFor } from '@testing-library/react';
+
+import { testDataProvider } from '../../dataProvider';
+import { CoreAdminContext } from '../../core';
+import useDeleteWithConfirmController, {
+    UseDeleteWithConfirmControllerParams,
+} from './useDeleteWithConfirmController';
+
+describe('useDeleteWithConfirmController', () => {
+    it('should call the dataProvider.delete() function with the meta param', async () => {
+        let receivedMeta = null;
+        const dataProvider = testDataProvider({
+            delete: jest.fn((ressource, params) => {
+                receivedMeta = params?.meta?.key;
+                console.log(receivedMeta);
+                return Promise.resolve({ data: params?.meta?.key });
+            }),
+        });
+
+        const MockComponent = () => {
+            const { handleDelete } = useDeleteWithConfirmController({
+                record: { id: 1 },
+                resource: 'posts',
+                mutationMode: 'pessimistic',
+                mutationOptions: { meta: { key: 'metadata' } },
+            } as UseDeleteWithConfirmControllerParams);
+            return <button onClick={handleDelete}>Delete</button>;
+        };
+
+        render(
+            <MemoryRouter>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Routes>
+                        <Route path="/" element={<MockComponent />} />
+                    </Routes>
+                </CoreAdminContext>
+            </MemoryRouter>
+        );
+
+        await screen.getByText('Delete');
+        fireEvent.click(screen.getByText('Delete'));
+        waitFor(() => expect(receivedMeta).toEqual('metadata'), {
+            timeout: 1000,
+        });
+    });
+});

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.spec.tsx
@@ -15,7 +15,6 @@ describe('useDeleteWithConfirmController', () => {
         const dataProvider = testDataProvider({
             delete: jest.fn((ressource, params) => {
                 receivedMeta = params?.meta?.key;
-                console.log(receivedMeta);
                 return Promise.resolve({ data: params?.meta?.key });
             }),
         });
@@ -40,8 +39,8 @@ describe('useDeleteWithConfirmController', () => {
             </MemoryRouter>
         );
 
-        await screen.getByText('Delete');
-        fireEvent.click(screen.getByText('Delete'));
+        const button = await screen.findByText('Delete');
+        fireEvent.click(button);
         waitFor(() => expect(receivedMeta).toEqual('metadata'), {
             timeout: 1000,
         });

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -98,7 +98,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
                 {
                     id: record.id,
                     previousData: record,
-                    meta: mutationOptions.meta,
+                    meta: mutationOptions?.meta,
                 },
                 {
                     onSuccess: () => {

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -71,8 +71,9 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
         redirect: redirectTo,
         mutationMode,
         onClick,
-        mutationOptions,
+        mutationOptions = {},
     } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
     const resource = useResourceContext(props);
     const [open, setOpen] = useState(false);
     const notify = useNotify();
@@ -98,7 +99,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
                 {
                     id: record.id,
                     previousData: record,
-                    meta: mutationOptions?.meta,
+                    meta: mutationMeta,
                 },
                 {
                     onSuccess: () => {
@@ -132,7 +133,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
                         );
                     },
                     mutationMode,
-                    ...mutationOptions,
+                    ...otherMutationOptions,
                 }
             );
             if (typeof onClick === 'function') {
@@ -141,8 +142,9 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
         },
         [
             deleteOne,
+            mutationMeta,
             mutationMode,
-            mutationOptions,
+            otherMutationOptions,
             notify,
             onClick,
             record,

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -95,7 +95,11 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
             event.stopPropagation();
             deleteOne(
                 resource,
-                { id: record.id, previousData: record },
+                {
+                    id: record.id,
+                    previousData: record,
+                    meta: mutationOptions.meta,
+                },
                 {
                     onSuccess: () => {
                         setOpen(false);

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.spec.tsx
@@ -15,7 +15,6 @@ describe('useDeleteWithUndoController', () => {
         const dataProvider = testDataProvider({
             delete: jest.fn((ressource, params) => {
                 receivedMeta = params?.meta?.key;
-                console.log(receivedMeta);
                 return Promise.resolve({ data: params?.meta?.key });
             }),
         });
@@ -40,8 +39,8 @@ describe('useDeleteWithUndoController', () => {
             </MemoryRouter>
         );
 
-        await screen.getByText('Delete');
-        fireEvent.click(screen.getByText('Delete'));
+        const button = await screen.findByText('Delete');
+        fireEvent.click(button);
         waitFor(() => expect(receivedMeta).toEqual('metadata'), {
             timeout: 1000,
         });

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import expect from 'expect';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { fireEvent, screen, render, waitFor } from '@testing-library/react';
+
+import { testDataProvider } from '../../dataProvider';
+import { CoreAdminContext } from '../../core';
+import useDeleteWithUndoController, {
+    UseDeleteWithConfirmControllerParams,
+} from './useDeleteWithConfirmController';
+
+describe('useDeleteWithUndoController', () => {
+    it('should call the dataProvider.delete() function with the meta param', async () => {
+        let receivedMeta = null;
+        const dataProvider = testDataProvider({
+            delete: jest.fn((ressource, params) => {
+                receivedMeta = params?.meta?.key;
+                console.log(receivedMeta);
+                return Promise.resolve({ data: params?.meta?.key });
+            }),
+        });
+
+        const MockComponent = () => {
+            const { handleDelete } = useDeleteWithUndoController({
+                record: { id: 1 },
+                resource: 'posts',
+                mutationMode: 'undoable',
+                mutationOptions: { meta: { key: 'metadata' } },
+            } as UseDeleteWithConfirmControllerParams);
+            return <button onClick={handleDelete}>Delete</button>;
+        };
+
+        render(
+            <MemoryRouter>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Routes>
+                        <Route path="/" element={<MockComponent />} />
+                    </Routes>
+                </CoreAdminContext>
+            </MemoryRouter>
+        );
+
+        await screen.getByText('Delete');
+        fireEvent.click(screen.getByText('Delete'));
+        waitFor(() => expect(receivedMeta).toEqual('metadata'), {
+            timeout: 1000,
+        });
+    });
+});

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -66,7 +66,7 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
                 {
                     id: record.id,
                     previousData: record,
-                    meta: mutationOptions.meta,
+                    meta: mutationOptions?.meta,
                 },
                 {
                     onSuccess: () => {

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -63,7 +63,11 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
             event.stopPropagation();
             deleteOne(
                 resource,
-                { id: record.id, previousData: record },
+                {
+                    id: record.id,
+                    previousData: record,
+                    meta: mutationOptions.meta,
+                },
                 {
                     onSuccess: () => {
                         notify('ra.notification.deleted', {

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -50,8 +50,9 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
         record,
         redirect: redirectTo = 'list',
         onClick,
-        mutationOptions,
+        mutationOptions = {},
     } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
     const resource = useResourceContext(props);
     const notify = useNotify();
     const unselect = useUnselect(resource);
@@ -66,7 +67,7 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
                 {
                     id: record.id,
                     previousData: record,
-                    meta: mutationOptions?.meta,
+                    meta: mutationMeta,
                 },
                 {
                     onSuccess: () => {
@@ -97,7 +98,7 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
                         );
                     },
                     mutationMode: 'undoable',
-                    ...mutationOptions,
+                    ...otherMutationOptions,
                 }
             );
             if (typeof onClick === 'function') {
@@ -106,7 +107,8 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
         },
         [
             deleteOne,
-            mutationOptions,
+            mutationMeta,
+            otherMutationOptions,
             notify,
             onClick,
             record,

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -32,10 +32,11 @@ export const BulkDeleteWithConfirmButton = (
         icon = defaultIcon,
         label = 'ra.action.delete',
         mutationMode = 'pessimistic',
-        mutationOptions = null,
+        mutationOptions = {},
         onClick,
         ...rest
     } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
     const { selectedIds } = useListContext(props);
     const [isOpen, setOpen] = useSafeSetState(false);
     const notify = useNotify();
@@ -45,7 +46,7 @@ export const BulkDeleteWithConfirmButton = (
     const translate = useTranslate();
     const [deleteMany, { isLoading }] = useDeleteMany(
         resource,
-        { ids: selectedIds, meta: mutationOptions?.meta },
+        { ids: selectedIds, meta: mutationMeta },
         {
             onSuccess: () => {
                 refresh();
@@ -77,6 +78,7 @@ export const BulkDeleteWithConfirmButton = (
                 setOpen(false);
             },
             mutationMode,
+            ...otherMutationOptions,
         }
     );
 
@@ -158,7 +160,7 @@ export interface BulkDeleteWithConfirmButtonProps<
         RecordType,
         MutationOptionsError,
         DeleteManyParams<RecordType>
-    >;
+    > & { meta?: any };
 }
 
 const PREFIX = 'RaBulkDeleteWithConfirmButton';

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -14,11 +14,14 @@ import {
     useTranslate,
     useUnselectAll,
     useSafeSetState,
+    RaRecord,
+    DeleteManyParams,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
 import { Button, ButtonProps } from './Button';
 import { BulkActionProps } from '../types';
+import { UseMutationOptions } from 'react-query';
 
 export const BulkDeleteWithConfirmButton = (
     props: BulkDeleteWithConfirmButtonProps
@@ -29,6 +32,7 @@ export const BulkDeleteWithConfirmButton = (
         icon = defaultIcon,
         label = 'ra.action.delete',
         mutationMode = 'pessimistic',
+        mutationOptions = null,
         onClick,
         ...rest
     } = props;
@@ -41,7 +45,7 @@ export const BulkDeleteWithConfirmButton = (
     const translate = useTranslate();
     const [deleteMany, { isLoading }] = useDeleteMany(
         resource,
-        { ids: selectedIds },
+        { ids: selectedIds, meta: mutationOptions?.meta },
         {
             onSuccess: () => {
                 refresh();
@@ -141,13 +145,20 @@ const sanitizeRestProps = ({
     'resource' | 'icon' | 'mutationMode'
 >) => rest;
 
-export interface BulkDeleteWithConfirmButtonProps
-    extends BulkActionProps,
+export interface BulkDeleteWithConfirmButtonProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> extends BulkActionProps,
         ButtonProps {
     confirmContent?: React.ReactNode;
     confirmTitle?: string;
     icon?: ReactElement;
     mutationMode: MutationMode;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        MutationOptionsError,
+        DeleteManyParams<RecordType>
+    >;
 }
 
 const PREFIX = 'RaBulkDeleteWithConfirmButton';

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -11,10 +11,13 @@ import {
     useUnselectAll,
     useResourceContext,
     useListContext,
+    RaRecord,
+    DeleteManyParams,
 } from 'ra-core';
 
 import { Button, ButtonProps } from './Button';
 import { BulkActionProps } from '../types';
+import { UseMutationOptions } from 'react-query';
 
 export const BulkDeleteWithUndoButton = (
     props: BulkDeleteWithUndoButtonProps
@@ -23,6 +26,7 @@ export const BulkDeleteWithUndoButton = (
         label = 'ra.action.delete',
         icon = defaultIcon,
         onClick,
+        mutationOptions = null,
         ...rest
     } = props;
     const { selectedIds } = useListContext(props);
@@ -36,7 +40,7 @@ export const BulkDeleteWithUndoButton = (
     const handleClick = e => {
         deleteMany(
             resource,
-            { ids: selectedIds },
+            { ids: selectedIds, meta: mutationOptions?.meta },
             {
                 onSuccess: () => {
                     notify('ra.notification.deleted', {
@@ -95,10 +99,17 @@ const sanitizeRestProps = ({
     ...rest
 }: Omit<BulkDeleteWithUndoButtonProps, 'resource' | 'icon'>) => rest;
 
-export interface BulkDeleteWithUndoButtonProps
-    extends BulkActionProps,
+export interface BulkDeleteWithUndoButtonProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> extends BulkActionProps,
         ButtonProps {
     icon?: ReactElement;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        MutationOptionsError,
+        DeleteManyParams<RecordType>
+    >;
 }
 
 const PREFIX = 'RaBulkDeleteWithUndoButton';

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -26,9 +26,10 @@ export const BulkDeleteWithUndoButton = (
         label = 'ra.action.delete',
         icon = defaultIcon,
         onClick,
-        mutationOptions = null,
+        mutationOptions = {},
         ...rest
     } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
     const { selectedIds } = useListContext(props);
 
     const notify = useNotify();
@@ -40,7 +41,7 @@ export const BulkDeleteWithUndoButton = (
     const handleClick = e => {
         deleteMany(
             resource,
-            { ids: selectedIds, meta: mutationOptions?.meta },
+            { ids: selectedIds, meta: mutationMeta },
             {
                 onSuccess: () => {
                     notify('ra.notification.deleted', {
@@ -70,6 +71,7 @@ export const BulkDeleteWithUndoButton = (
                     refresh();
                 },
                 mutationMode: 'undoable',
+                ...otherMutationOptions,
             }
         );
         if (typeof onClick === 'function') {
@@ -109,7 +111,7 @@ export interface BulkDeleteWithUndoButtonProps<
         RecordType,
         MutationOptionsError,
         DeleteManyParams<RecordType>
-    >;
+    > & { meta?: any };
 }
 
 const PREFIX = 'RaBulkDeleteWithUndoButton';


### PR DESCRIPTION
Fix #8016
Kudos to @carlos-duran

- [x] Fix delete contexts don't send mutation meta
- [x] Fix settings `mutationOptions` on `<BulkDeleteWithConfirmButton>`and `<BulkDeleteWithUndoButton>` generates an error
- [x] Add `mutationOptions` prop description on delete buttons documentation

[useMutation documentation](https://react-query-v3.tanstack.com/reference/useMutation).