### PR TITLE
[TypeScript] Fix MenuItemLink prop type isn't exported

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -65,7 +65,7 @@ import { useTranslate, useBasename } from 'ra-core';
  *     </Admin>
  * );
  */
-export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
+export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
     const {
         className,
         primaryText,
@@ -101,8 +101,8 @@ export const MenuItemLink = forwardRef((props: MenuItemLinkProps, ref) => {
                 className={clsx(className, {
                     [MenuItemLinkClasses.active]: !!match,
                 })}
-                component={LinkRef}
                 // @ts-ignore
+                component={LinkRef}
                 ref={ref}
                 tabIndex={0}
                 {...rest}


### PR DESCRIPTION
When trying to export a component based on MenuItemLink, TypeScript complains with:

> Exported variable 'MenuItemLink' has or is using name 'Props$1' from external module 'a/file/path/node_modules/ra-ui-materialui/dist/index' but cannot be named. ts(4023)

I believe this is due to the `React.forwardRef` not being properly typed in that component. 