### PR TITLE
[Doc] Document how to sanitize form values

### DIFF
--- a/docs/Create.md
+++ b/docs/Create.md
@@ -336,7 +336,27 @@ export const UserCreate = (props) => {
 
 The `transform` function can also return a `Promise`, which allows you to do all sorts of asynchronous calls (e.g. to the `dataProvider`) during the transformation.
 
-**Tip**: If you want to have different transformations based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save", and another to "save and notify other admins"), you can set the `transform` prop on [the `<SaveButton>` component](./SaveButton.md), too. 
+**Tip**: If you want to have different transformations based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save", and another to "save and notify other admins"), you can set the `transform` prop on [the `<SaveButton>` component](./SaveButton.md), too.
+
+**Tip**: A frequent usage of the `transform` function is to stripe empty string values returned by the form.
+
+```jsx
+export const UserCreate = (props) => {
+    const transform = (data) => {
+        const sanitizedData = {};
+        for (const key in data) {
+            if (typeof data[key] === "string" && data[key].length === 0) continue;
+            sanitizedData[key] = data[key]; 
+        }
+        return sanitizedData;
+    };
+    return (
+        <Create {...props} transform={transform}>
+            ...
+        </Create>
+    );
+}
+```
 
 ## Adding `meta` To The DataProvider Call
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -523,7 +523,7 @@ The `transform` function can also return a `Promise`, which allows you to do all
 
 **Tip**: If you want to have different transformations based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save", and another to "save and notify other admins"), you can set the `transform` prop on [the `<SaveButton>` component](./SaveButton.md), too.
 
-**Tip**: `<Edit>`’s transform prop function also get the `previousData` in its second argument:
+**Tip**: The `transform` function also get the `previousData` in its second argument:
 
 ```jsx
 export const UserEdit = (props) => {
@@ -531,6 +531,26 @@ export const UserEdit = (props) => {
         ...data,
         avoidChangeField: previousData.avoidChangeField
     });
+    return (
+        <Edit {...props} transform={transform}>
+            ...
+        </Edit>
+    );
+}
+```
+
+**Tip**: A frequent usage of the `transform` function is to stripe empty string values returned by the form.
+
+```jsx
+export const UserEdit = (props) => {
+    const transform = (data) => {
+        const sanitizedData = {};
+        for (const key in data) {
+            if (typeof data[key] === "string" && data[key].trim().length === 0) continue;
+            sanitizedData[key] = data[key]; 
+        }
+        return sanitizedData;
+    };
     return (
         <Edit {...props} transform={transform}>
             ...

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -376,6 +376,23 @@ const dateParser = value => {
 <DateInput source="isodate" format={dateFormatter} parse={dateParser} defaultValue={new Date()} />
 ```
 
+**Tip:** To spread a conversion behaviour to your whole application, you can import a `react-admin`component then re-export them with their `transform` and/or `parse` props set.
+
+```jsx
+import * as React from 'react';
+import { TextInput } from 'react-admin';
+
+const FilledOrNullTextInput = props => {
+    return (
+        <TextInput
+            {...props}
+            transform={ v => typeof v === 'string' && v.length === 0 ? null : v }
+            />
+    );
+};
+export default FilledOrNullTextInput;
+```
+
 ## Linking Two Inputs
 
 Edition forms often contain linked inputs, e.g. country and city (the choices of the latter depending on the value of the former).
@@ -513,7 +530,7 @@ import { FormDataConsumer } from 'react-admin';
 
 MUI offers [3 variants for text fields](https://mui.com/material-ui/react-text-field/#basic-textfield): `outlined`, `filled`, and `standard`. The default react-admin theme uses the `filled` variant.
 
-Most Input components pass their additional props down to the root component, which is often an MUI Field component. This means you can pass a `variant` prop to override the varaint of a single input:
+Most Input components pass their additional props down to the root component, which is often an MUI Field component. This means you can pass a `variant` prop to override the variant of a single input:
 
 ```jsx
 <TextInput source="name" variant="outlined" />


### PR DESCRIPTION
From Trello 753
Mention `transform` and `parse`. `parse` is important because you might want that an input always apply this sanitize in all forms. You could re-export some or all react-admin inputs or views to set their parse or transform by default to sanitize empty values.