### PR TITLE
[Fix] Validation errors don't show on `Edit` page

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
@@ -165,7 +165,7 @@ describe('useReferenceInputController', () => {
         );
 
         await waitFor(() => {
-            expect(children).toBeCalledTimes(4);
+            expect(children).toBeCalledTimes(3);
         });
         expect(children).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/ra-core/src/form/useIsFormInvalid.ts
+++ b/packages/ra-core/src/form/useIsFormInvalid.ts
@@ -11,7 +11,7 @@ import { useFormState, Control } from 'react-hook-form';
  */
 export const useIsFormInvalid = (control?: Control) => {
     const [isInvalid, setIsInvalid] = useState(false);
-    const { isValid, submitCount, errors } = useFormState(
+    const { submitCount, errors } = useFormState(
         control ? { control } : undefined
     );
     const submitCountRef = useRef(submitCount);
@@ -22,15 +22,13 @@ export const useIsFormInvalid = (control?: Control) => {
         if (submitCount > submitCountRef.current) {
             submitCountRef.current = submitCount;
 
-            // For some reason, the validation state might not be sync yet on first submit
-            // so we need to check if there are actually some errors even though the isValid is false
-            if (Object.keys(errors).length > 0 && !isValid) {
+            if (Object.keys(errors).length > 0) {
                 setIsInvalid(true);
             } else {
                 setIsInvalid(false);
             }
         }
-    }, [errors, isValid, submitCount]);
+    }, [errors, submitCount]);
 
     return isInvalid;
 };


### PR DESCRIPTION
Fix #8049


`useIsFormInvalid` will only check if `useFormState` has errors.
Because `useFormState`does not return `isValid` state if `useForm` mode is null ([read more](https://react-hook-form.com/api/useformstate
))

https://user-images.githubusercontent.com/18294269/183671325-34926bf2-a8e6-46c3-80f6-734c1d744e40.mp4


