### PR TITLE
Fix useStore internal state reset when key changes

### DIFF
--- a/packages/ra-core/src/store/useStore.spec.tsx
+++ b/packages/ra-core/src/store/useStore.spec.tsx
@@ -116,4 +116,35 @@ describe('useStore', () => {
         expect(innerValue).toBe('hello');
         expect(result.current[0]).toBe('world');
     });
+
+    it('should clear its value when the key changes', () => {
+        const StoreConsumer = ({ storeKey }: { storeKey: string }) => {
+            const [value, setValue] = useStore(storeKey);
+            return (
+                <>
+                    <p>{value}</p>
+                    <button onClick={() => setValue('hello')}>
+                        change value
+                    </button>
+                </>
+            );
+        };
+        const MyComponent = () => {
+            const [storeKey, setStoreKey] = React.useState('list1');
+            return (
+                <StoreContextProvider value={memoryStore({})}>
+                    <StoreConsumer storeKey={storeKey} />
+                    <button onClick={() => setStoreKey('list2')}>
+                        change key
+                    </button>
+                </StoreContextProvider>
+            );
+        };
+        render(<MyComponent />);
+        expect(screen.queryByText('hello')).toBeNull();
+        fireEvent.click(screen.getByText('change value'));
+        screen.getByText('hello');
+        fireEvent.click(screen.getByText('change key'));
+        expect(screen.queryByText('hello')).toBeNull();
+    });
 });

--- a/packages/ra-core/src/store/useStore.ts
+++ b/packages/ra-core/src/store/useStore.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import isEqual from 'lodash/isEqual';
 
 import { useEventCallback } from '../util';
 import { useStoreContext } from './useStoreContext';
@@ -53,12 +54,15 @@ export const useStore = <T = any>(
 
     // subscribe to changes on this key, and change the state when they happen
     useEffect(() => {
-        setValue(getItem(key, defaultValue));
+        const storedValue = getItem(key, defaultValue);
+        if (!isEqual(value, storedValue)) {
+            setValue(storedValue);
+        }
         const unsubscribe = subscribe(key, newValue => {
             setValue(typeof newValue === 'undefined' ? defaultValue : newValue);
         });
         return () => unsubscribe();
-    }, [key, subscribe, defaultValue, getItem]);
+    }, [key, subscribe, defaultValue, getItem, value]);
 
     const set = useEventCallback(
         (valueParam: T, runtimeDefaultValue: T) => {

--- a/packages/ra-core/src/store/useStore.ts
+++ b/packages/ra-core/src/store/useStore.ts
@@ -53,11 +53,12 @@ export const useStore = <T = any>(
 
     // subscribe to changes on this key, and change the state when they happen
     useEffect(() => {
+        setValue(getItem(key, defaultValue));
         const unsubscribe = subscribe(key, newValue => {
             setValue(typeof newValue === 'undefined' ? defaultValue : newValue);
         });
         return () => unsubscribe();
-    }, [key, subscribe, defaultValue]);
+    }, [key, subscribe, defaultValue, getItem]);
 
     const set = useEventCallback(
         (valueParam: T, runtimeDefaultValue: T) => {


### PR DESCRIPTION
Fix `useStore` hook not resetting its internal state when the key changes.

Issue identified while working on https://github.com/marmelab/react-admin/pull/8042

- [x] Fix `useStore` hook
- [x] Unit test
- [x] Fix E2E tests