### PR TITLE
[TypeScript] Add `resettable` prop to `SelectInputProps`

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -395,6 +395,7 @@ export type SelectInputProps = Omit<CommonInputProps, 'source'> &
         disableValue?: string;
         emptyText?: string | ReactElement;
         emptyValue?: any;
+        resettable?: boolean;
         // Source is optional as AutocompleteInput can be used inside a ReferenceInput that already defines the source
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;


### PR DESCRIPTION
 - [x] Document the fact (in DOC and in TS) that SelectInput can handle the "resettable" prop => already done in doc (https://marmelab.com/react-admin/SelectInput.html#properties)