### PR TITLE
[Doc] Fix installation instructions in tutorial project

### DIFF
--- a/examples/tutorial/README.md
+++ b/examples/tutorial/README.md
@@ -9,5 +9,7 @@ After having cloned the react-admin repository, run the following commands:
 ```sh
 make install
 
+make build
+
 make run-tutorial
 ```


### PR DESCRIPTION
users get an error when they run without the make build command