### PR TITLE
[Feat] add 'children' prop to Resources

### DIFF
--- a/docs/CustomRoutes.md
+++ b/docs/CustomRoutes.md
@@ -5,21 +5,24 @@ title: "The CustomRoutes Component"
 
 # `<CustomRoutes>`
 
-To register your own routes, pass one or several `<CustomRoutes>` elements as children of `<Admin>`. Declare as many [react-router-dom](https://reactrouter.com/docs/en/v6/api#routes-and-route) `<Route>` as you want inside them:
+To register your own routes, pass one or several `<CustomRoutes>` elements as children of `<Admin>`. Declare as many [react-router-dom](https://reactrouter.com/docs/en/v6/api#routes-and-route) `<Route>` as you want inside them.
+Alternatively, you can add your custom routes to resources. They will be available under the resource prefix.
 
 ```jsx
 // in src/App.js
 import * as React from "react";
 import { Admin, Resource, CustomRoutes } from 'react-admin';
 import { Route } from "react-router-dom";
-import posts from './posts';
+import posts, {PostAnalytics} from './posts';
 import comments from './comments';
 import Settings from './Settings';
 import Profile from './Profile';
 
 const App = () => (
     <Admin dataProvider={simpleRestProvider('http://path.to.my.api')}>
-        <Resource name="posts" {...posts} />
+        <Resource name="posts" {...posts}>
+            <Route path="analytics" element={<PostAnalytics/>}>
+        </Resource>
         <Resource name="comments" {...comments} />
         <CustomRoutes>
             <Route path="/settings" element={<Settings />} />

--- a/docs/CustomRoutes.md
+++ b/docs/CustomRoutes.md
@@ -13,7 +13,8 @@ Alternatively, you can add your custom routes to resources. They will be availab
 import * as React from "react";
 import { Admin, Resource, CustomRoutes } from 'react-admin';
 import { Route } from "react-router-dom";
-import posts, {PostAnalytics} from './posts';
+import simpleRestProvider from 'ra-data-simple-rest';
+import posts, { PostAnalytics } from './posts';
 import comments from './comments';
 import Settings from './Settings';
 import Profile from './Profile';
@@ -21,7 +22,7 @@ import Profile from './Profile';
 const App = () => (
     <Admin dataProvider={simpleRestProvider('http://path.to.my.api')}>
         <Resource name="posts" {...posts}>
-            <Route path="analytics" element={<PostAnalytics/>}>
+            <Route path="analytics" element={<PostAnalytics/>} />
         </Resource>
         <Resource name="comments" {...comments} />
         <CustomRoutes>
@@ -64,6 +65,7 @@ If you want a custom route to render without the layout (without the menu and th
 // in src/App.js
 import * as React from "react";
 import { Admin, CustomRoutes } from 'react-admin';
+import simpleRestProvider from 'ra-data-simple-rest';
 import { Route } from "react-router-dom";
 import Settings from './Settings';
 import Register from './register';

--- a/packages/ra-core/src/core/Resource.spec.tsx
+++ b/packages/ra-core/src/core/Resource.spec.tsx
@@ -5,12 +5,15 @@ import { createMemoryHistory } from 'history';
 
 import { CoreAdminContext } from './CoreAdminContext';
 import { Resource } from './Resource';
+import { Route } from 'react-router';
 
 const PostList = () => <div>PostList</div>;
 const PostEdit = () => <div>PostEdit</div>;
 const PostCreate = () => <div>PostCreate</div>;
 const PostShow = () => <div>PostShow</div>;
 const PostIcon = () => <div>PostIcon</div>;
+
+const PostCustomRoute = () => <div>PostCustomRoute</div>;
 
 const resource = {
     name: 'posts',
@@ -20,6 +23,7 @@ const resource = {
     create: PostCreate,
     show: PostShow,
     icon: PostIcon,
+    children: <Route path="customroute" element={<PostCustomRoute />} />,
 };
 
 describe('<Resource>', () => {
@@ -40,5 +44,7 @@ describe('<Resource>', () => {
         expect(screen.getByText('PostShow')).not.toBeNull();
         history.push('/create');
         expect(screen.getByText('PostCreate')).not.toBeNull();
+        history.push('/customroute');
+        expect(screen.getByText('PostCustomRoute')).not.toBeNull();
     });
 });

--- a/packages/ra-core/src/core/Resource.tsx
+++ b/packages/ra-core/src/core/Resource.tsx
@@ -35,6 +35,7 @@ export const Resource = (props: ResourceProps) => {
                         element={isValidElement(List) ? List : <List />}
                     />
                 )}
+                {props.children}
             </Routes>
         </ResourceContextProvider>
     );

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -339,7 +339,7 @@ export interface ResourceProps {
     icon?: ComponentType<any>;
     recordRepresentation?: ReactElement | RecordToStringFunction | string;
     options?: ResourceOptions;
-    children?: ReactNode; 
+    children?: ReactNode;
 }
 
 export type Exporter = (

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -339,6 +339,7 @@ export interface ResourceProps {
     icon?: ComponentType<any>;
     recordRepresentation?: ReactElement | RecordToStringFunction | string;
     options?: ResourceOptions;
+    children?: ReactNode; 
 }
 
 export type Exporter = (


### PR DESCRIPTION
React admin makes it fast to develop admin-interfaces with react.
However, when resources get more and more functions it is a bit unhandy to pass CustomRoutes to <Admin/>

This PR adds children as a property of resources and makes it possible to define the whole resource with custom sub-routes in a seperate typescript module:

``` tsx
import ListView from "./list";
import CustomRoute from "./customroute";

const MyResource = () => {
    return {
        list: ListView,
        children: <CustomRoute/>
    }
}
```
