### PR TITLE
Fix `<CoreAdmin store>` prop is ignored

### DIFF
--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -100,6 +100,7 @@ export const CoreAdmin = (props: CoreAdminProps) => {
         menu, // deprecated, use a custom layout instead
         ready,
         requireAuth,
+        store,
         title = 'React Admin',
     } = props;
     return (
@@ -110,6 +111,7 @@ export const CoreAdmin = (props: CoreAdminProps) => {
             i18nProvider={i18nProvider}
             queryClient={queryClient}
             history={history}
+            store={store}
         >
             <CoreAdminUI
                 layout={layout}


### PR DESCRIPTION
`<CoreAdmin>` doesn't allow to override the default `store`. Only `<Admin>` does. 