### PR TITLE
Fix ArrayInput doesn't support scalar values

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -98,30 +98,33 @@ export const AutocompleteFirst = () => (
     </Admin>
 );
 
-const BookTagsEdit = () => {
-    return (
-        <Edit
-            mutationMode="pessimistic"
-            mutationOptions={{
-                onSuccess: data => {
-                    console.log(data);
-                },
-            }}
-        >
-            <SimpleForm>
-                <TextInput source="title" />
-                <ArrayInput source="tags" fullWidth>
-                    <SimpleFormIterator disableReordering>
-                        <TextInput source="" label="tag" helperText={false} />
-                    </SimpleFormIterator>
-                </ArrayInput>
-            </SimpleForm>
-        </Edit>
-    );
-};
-
 export const Scalar = () => (
     <Admin dataProvider={dataProvider} history={history}>
-        <Resource name="books" edit={BookTagsEdit} />
+        <Resource
+            name="books"
+            edit={() => (
+                <Edit
+                    mutationMode="pessimistic"
+                    mutationOptions={{
+                        onSuccess: data => {
+                            console.log(data);
+                        },
+                    }}
+                >
+                    <SimpleForm>
+                        <TextInput source="title" />
+                        <ArrayInput source="tags" fullWidth>
+                            <SimpleFormIterator disableReordering>
+                                <TextInput
+                                    source=""
+                                    label="tag"
+                                    helperText={false}
+                                />
+                            </SimpleFormIterator>
+                        </ArrayInput>
+                    </SimpleForm>
+                </Edit>
+            )}
+        />
     </Admin>
 );

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -28,6 +28,7 @@ const dataProvider = {
                         role: 'co_writer',
                     },
                 ],
+                tags: ['novel', 'war', 'classic'],
             },
         }),
     update: (resource, params) => Promise.resolve(params),
@@ -94,5 +95,33 @@ const BookEditWithAutocomplete = () => {
 export const AutocompleteFirst = () => (
     <Admin dataProvider={dataProvider} history={history}>
         <Resource name="books" edit={BookEditWithAutocomplete} />
+    </Admin>
+);
+
+const BookTagsEdit = () => {
+    return (
+        <Edit
+            mutationMode="pessimistic"
+            mutationOptions={{
+                onSuccess: data => {
+                    console.log(data);
+                },
+            }}
+        >
+            <SimpleForm>
+                <TextInput source="title" />
+                <ArrayInput source="tags" fullWidth>
+                    <SimpleFormIterator disableReordering>
+                        <TextInput source="" label="tag" helperText={false} />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        </Edit>
+    );
+};
+
+export const Scalar = () => (
+    <Admin dataProvider={dataProvider} history={history}>
+        <Resource name="books" edit={BookTagsEdit} />
     </Admin>
 );

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -59,16 +59,29 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
         (item: any = undefined) => {
             let defaultValue = item;
             if (item == null) {
-                defaultValue = {} as Record<string, unknown>;
-                Children.forEach(children, input => {
-                    if (
-                        React.isValidElement(input) &&
-                        input.type !== FormDataConsumer
-                    ) {
-                        defaultValue[input.props.source] =
-                            input.props.defaultValue ?? '';
-                    }
-                });
+                if (
+                    Children.count(children) === 1 &&
+                    React.isValidElement(Children.only(children)) &&
+                    // @ts-ignore
+                    !Children.only(children).props.source
+                ) {
+                    // ArrayInput used for an array of scalar values
+                    // (e.g. tags: ['foo', 'bar'])
+                    defaultValue = '';
+                } else {
+                    // ArrayInput used for an array of objects
+                    // (e.g. authors: [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Doe' }])
+                    defaultValue = {} as Record<string, unknown>;
+                    Children.forEach(children, input => {
+                        if (
+                            React.isValidElement(input) &&
+                            input.type !== FormDataConsumer
+                        ) {
+                            defaultValue[input.props.source] =
+                                input.props.defaultValue ?? '';
+                        }
+                    });
+                }
             }
             append(defaultValue);
         },


### PR DESCRIPTION
Closes #8069

I'm not documenting the feature as the user experience isn't ideal. We should instead offer an alternative based on MUI's Autocomplete, with creation support. But it's non trivial, so in the meantime, let's let ArrayInput support scalar values. 