### PR TITLE
Fix `useGetList`'s `onSuccess` side effect overriding internal one

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.spec.tsx
@@ -285,4 +285,62 @@ describe('useGetList', () => {
             expect(onError.mock.calls.pop()[0]).toEqual(new Error('failed'));
         });
     });
+
+    it('should pre-populate getOne Query Cache', async () => {
+        const callback = jest.fn();
+        const queryClient = new QueryClient();
+        const dataProvider = {
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
+            ),
+        };
+        render(
+            <CoreAdminContext
+                queryClient={queryClient}
+                dataProvider={dataProvider}
+            >
+                <UseGetList callback={callback} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+        expect(
+            queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
+        ).toEqual({ id: 1, title: 'live' });
+    });
+
+    it('should still pre-populate getOne Query Cache with custom onSuccess', async () => {
+        const callback = jest.fn();
+        const onSuccess = jest.fn();
+        const queryClient = new QueryClient();
+        const dataProvider = {
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
+            ),
+        };
+        render(
+            <CoreAdminContext
+                queryClient={queryClient}
+                dataProvider={dataProvider}
+            >
+                <UseGetList callback={callback} options={{ onSuccess }} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+        expect(
+            queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
+        ).toEqual({ id: 1, title: 'live' });
+    });
 });

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -84,7 +84,8 @@ export const useGetList = <RecordType extends RaRecord = any>(
                 })),
         {
             ...options,
-            onSuccess: ({ data }) => {
+            onSuccess: value => {
+                const { data } = value;
                 // optimistically populate the getOne cache
                 data.forEach(record => {
                     queryClient.setQueryData(
@@ -94,7 +95,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
                 });
                 // execute call-time onSuccess if provided
                 if (options?.onSuccess) {
-                    options.onSuccess({ data });
+                    options.onSuccess(value);
                 }
             },
         }

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -83,6 +83,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
                     pageInfo,
                 })),
         {
+            ...options,
             onSuccess: ({ data }) => {
                 // optimistically populate the getOne cache
                 data.forEach(record => {
@@ -91,8 +92,11 @@ export const useGetList = <RecordType extends RaRecord = any>(
                         oldRecord => oldRecord ?? record
                     );
                 });
+                // execute call-time onSuccess if provided
+                if (options?.onSuccess) {
+                    options.onSuccess({ data });
+                }
             },
-            ...options,
         }
     );
 


### PR DESCRIPTION
**Problem:** Providing a `onSuccess` side effect to `useGetList` overrides the default one set by react-admin. This results in the `'getOne'` react-query cache data not being populated as they should be (and causes bugs in some EE components).

**Solution:** Execute both the `onSuccess` side effects, as it is done in other hooks like `useUpdate` for instance