### PR TITLE
Fix guesser for of ReferenceField and ReferenceArrayField

### DIFF
--- a/packages/ra-core/src/inference/InferredElement.ts
+++ b/packages/ra-core/src/inference/InferredElement.ts
@@ -6,7 +6,11 @@ class InferredElement {
         private type?: InferredType,
         private props?: any,
         private children?: any
-    ) {}
+    ) {
+        this.type = type;
+        this.props = props;
+        this.children = children;
+    }
 
     getElement(props = {}) {
         if (!this.type || !this.type.component) {

--- a/packages/ra-core/src/inference/inferElementFromValues.spec.tsx
+++ b/packages/ra-core/src/inference/inferElementFromValues.spec.tsx
@@ -59,7 +59,6 @@ describe('inferElementFromValues', () => {
         const types = {
             referenceArray: { component: Good },
             string: { component: Bad },
-            referenceArrayChild: { component: Dummy },
         };
         expect(
             inferElementFromValues(
@@ -67,25 +66,16 @@ describe('inferElementFromValues', () => {
                 ['foo', 'bar'],
                 types
             ).getElement()
-        ).toEqual(
-            <Good source="foo_ids" reference="foos">
-                <Dummy />
-            </Good>
-        );
+        ).toEqual(<Good source="foo_ids" reference="foos" />);
     });
     it('should return a reference array field for field named *Ids', () => {
         const types = {
             referenceArray: { component: Good },
             string: { component: Bad },
-            referenceArrayChild: { component: Dummy },
         };
         expect(
             inferElementFromValues('fooIds', ['foo', 'bar'], types).getElement()
-        ).toEqual(
-            <Good source="fooIds" reference="foos">
-                <Dummy />
-            </Good>
-        );
+        ).toEqual(<Good source="fooIds" reference="foos" />);
     });
     it('should return a string field for no values', () => {
         const types = {

--- a/packages/ra-core/src/inference/inferElementFromValues.tsx
+++ b/packages/ra-core/src/inference/inferElementFromValues.tsx
@@ -89,28 +89,20 @@ const inferElementFromValues = (
         const reference = inflection.pluralize(name.substr(0, name.length - 3));
         return (
             types.reference &&
-            new InferredElement(
-                types.reference,
-                {
-                    source: name,
-                    reference,
-                },
-                new InferredElement(types.referenceChild)
-            )
+            new InferredElement(types.reference, {
+                source: name,
+                reference,
+            })
         );
     }
     if (name.substr(name.length - 2) === 'Id' && hasType('reference', types)) {
         const reference = inflection.pluralize(name.substr(0, name.length - 2));
         return (
             types.reference &&
-            new InferredElement(
-                types.reference,
-                {
-                    source: name,
-                    reference,
-                },
-                new InferredElement(types.referenceChild)
-            )
+            new InferredElement(types.reference, {
+                source: name,
+                reference,
+            })
         );
     }
     if (
@@ -120,14 +112,10 @@ const inferElementFromValues = (
         const reference = inflection.pluralize(name.substr(0, name.length - 4));
         return (
             types.referenceArray &&
-            new InferredElement(
-                types.referenceArray,
-                {
-                    source: name,
-                    reference,
-                },
-                new InferredElement(types.referenceArrayChild)
-            )
+            new InferredElement(types.referenceArray, {
+                source: name,
+                reference,
+            })
         );
     }
     if (
@@ -137,14 +125,10 @@ const inferElementFromValues = (
         const reference = inflection.pluralize(name.substr(0, name.length - 3));
         return (
             types.referenceArray &&
-            new InferredElement(
-                types.referenceArray,
-                {
-                    source: name,
-                    reference,
-                },
-                new InferredElement(types.referenceArrayChild)
-            )
+            new InferredElement(types.referenceArray, {
+                source: name,
+                reference,
+            })
         );
     }
     if (values.length === 0) {

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -175,7 +175,7 @@ export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props =
 
 ReferenceArrayFieldView.propTypes = {
     className: PropTypes.string,
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
     reference: PropTypes.string.isRequired,
 };
 

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -144,18 +144,20 @@ export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props =
     const { recordRepresentation } = useResourceDefinition({
         resource: reference,
     });
-    let child =
-        typeof recordRepresentation === 'string' ? (
-            <SingleFieldList>
-                <ChipField source={recordRepresentation} size="small" />
-            </SingleFieldList>
-        ) : recordRepresentation == null ? (
-            <SingleFieldList>
-                <ChipField source="id" size="small" />
-            </SingleFieldList>
-        ) : (
-            children
-        );
+    let child = children ? (
+        children
+    ) : (
+        <SingleFieldList>
+            <ChipField
+                source={
+                    typeof recordRepresentation === 'string'
+                        ? recordRepresentation
+                        : 'id'
+                }
+                size="small"
+            />
+        </SingleFieldList>
+    );
 
     return (
         <Root className={className} sx={sx}>

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -10,12 +10,15 @@ import {
     FilterPayload,
     ResourceContextProvider,
     useRecordContext,
+    useResourceDefinition,
 } from 'ra-core';
+import { styled } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
 
 import { fieldPropTypes, PublicFieldProps, InjectedFieldProps } from './types';
 import { LinearProgress } from '../layout';
-import { styled } from '@mui/material/styles';
-import { SxProps } from '@mui/system';
+import { SingleFieldList } from '../list/SingleFieldList';
+import { ChipField } from './ChipField';
 
 /**
  * A container component that fetches records from another resource specified
@@ -106,7 +109,7 @@ export const ReferenceArrayField: FC<ReferenceArrayFieldProps> = props => {
 ReferenceArrayField.propTypes = {
     ...fieldPropTypes,
     className: PropTypes.string,
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
     label: fieldPropTypes.label,
     record: PropTypes.any,
     reference: PropTypes.string.isRequired,
@@ -119,7 +122,7 @@ ReferenceArrayField.propTypes = {
 export interface ReferenceArrayFieldProps
     extends PublicFieldProps,
         InjectedFieldProps {
-    children: ReactNode;
+    children?: ReactNode;
     filter?: FilterPayload;
     page?: number;
     pagination?: ReactElement;
@@ -135,8 +138,24 @@ export interface ReferenceArrayFieldViewProps
         ListControllerProps {}
 
 export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props => {
-    const { children, pagination, className, sx } = props;
+    const { children, pagination, reference, className, sx } = props;
     const { isLoading, total } = useListContext(props);
+
+    const { recordRepresentation } = useResourceDefinition({
+        resource: reference,
+    });
+    let child =
+        typeof recordRepresentation === 'string' ? (
+            <SingleFieldList>
+                <ChipField source={recordRepresentation} size="small" />
+            </SingleFieldList>
+        ) : recordRepresentation == null ? (
+            <SingleFieldList>
+                <ChipField source="id" size="small" />
+            </SingleFieldList>
+        ) : (
+            children
+        );
 
     return (
         <Root className={className} sx={sx}>
@@ -146,7 +165,7 @@ export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props =
                 />
             ) : (
                 <span>
-                    {children}
+                    {child}
                     {pagination && total !== undefined ? pagination : null}
                 </span>
             )}

--- a/packages/ra-ui-materialui/src/input/index.ts
+++ b/packages/ra-ui-materialui/src/input/index.ts
@@ -18,6 +18,7 @@ export * from './NumberInput';
 export * from './PasswordInput';
 export * from './RadioButtonGroupInput';
 export * from './ReferenceArrayInput';
+export * from './ReferenceError';
 export * from './ReferenceInput';
 export * from './ResettableTextField';
 export * from './sanitizeInputRestProps';

--- a/packages/ra-ui-materialui/src/list/ListGuesser.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.stories.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Resource } from 'ra-core';
+import fakeRestProvider from 'ra-data-fakerest';
+import defaultMessages from 'ra-language-english';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+
+import { ListGuesser } from './ListGuesser';
+import { AdminUI } from '../AdminUI';
+import { AdminContext } from '../AdminContext';
+
+export default {
+    title: 'ra-ui-materialui/list/ListGuesser',
+};
+
+const data = {
+    products: [
+        {
+            id: 1,
+            name: 'Office jeans',
+            price: 45.99,
+            category_id: 1,
+            tags_ids: [1],
+        },
+        {
+            id: 2,
+            name: 'Black elegance jeans',
+            price: 69.99,
+            category_id: 1,
+            tags_ids: [2, 3],
+        },
+        {
+            id: 3,
+            name: 'Slim fit jeans',
+            price: 55.99,
+            category_id: 1,
+            tags_ids: [2, 4],
+        },
+        {
+            id: 4,
+            name: 'Basic T-shirt',
+            price: 15.99,
+            category_id: 2,
+            tags_ids: [1, 4, 3],
+        },
+        {
+            id: 5,
+            name: 'Basic cap',
+            price: 19.99,
+            category_id: 6,
+            tags_ids: [1, 4, 3],
+        },
+    ],
+    categories: [
+        { id: 1, name: 'Jeans' },
+        { id: 2, name: 'T-Shirts' },
+        { id: 3, name: 'Jackets' },
+        { id: 4, name: 'Shoes' },
+        { id: 5, name: 'Accessories' },
+        { id: 6, name: 'Hats' },
+        { id: 7, name: 'Socks' },
+        { id: 8, name: 'Shirts' },
+        { id: 9, name: 'Sweaters' },
+        { id: 10, name: 'Trousers' },
+        { id: 11, name: 'Coats' },
+        { id: 12, name: 'Dresses' },
+        { id: 13, name: 'Skirts' },
+        { id: 14, name: 'Swimwear' },
+        { id: 15, name: 'Bags' },
+    ],
+    tags: [
+        { id: 1, name: 'top seller' },
+        { id: 2, name: 'new' },
+        { id: 3, name: 'sale' },
+        { id: 4, name: 'promotion' },
+    ],
+};
+
+const dataProvider = fakeRestProvider(data, process.env.NODE_ENV !== 'test');
+
+export const Basic = () => (
+    <AdminContext
+        dataProvider={dataProvider}
+        i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+    >
+        <AdminUI>
+            <Resource
+                name="products"
+                list={ListGuesser}
+                recordRepresentation="name"
+            />
+            <Resource name="categories" recordRepresentation="name" />
+            <Resource name="tags" recordRepresentation="name" />
+        </AdminUI>
+    </AdminContext>
+);

--- a/packages/ra-ui-materialui/src/list/listFieldTypes.tsx
+++ b/packages/ra-ui-materialui/src/list/listFieldTypes.tsx
@@ -65,17 +65,22 @@ ${children.map(child => `            ${child.getRepresentation()}`).join('\n')}
             `<ReferenceField source="${props.source}" reference="${props.reference}" />`,
     },
     referenceChild: {
-        component: props => <TextField source="id" {...props} />, // eslint-disable-line react/display-name
+        component: () => <TextField source="id" />, // eslint-disable-line react/display-name
         representation: () => `<TextField source="id" />`,
     },
     referenceArray: {
         component: ReferenceArrayField,
         representation: props =>
-            `<ReferenceArrayField source="${props.source}" reference="${props.reference}"><TextField source="id" /></ReferenceArrayField>`,
+            `<ReferenceArrayField source="${props.source}" reference="${props.reference}" />`,
     },
     referenceArrayChild: {
-        component: props => <TextField source="id" {...props} />, // eslint-disable-line react/display-name
-        representation: () => `<TextField source="id" />`,
+        component: () => (
+            <SingleFieldList>
+                <ChipField source="id" />
+            </SingleFieldList>
+        ), // eslint-disable-line react/display-name
+        representation: () =>
+            `<SingleFieldList><ChipField source="id" /></SingleFieldList>`,
     },
     richText: undefined, // never display a rich text field in a datagrid
     string: {


### PR DESCRIPTION
The guessers couldn't take advantage of the recordRepresentation introduced in 4.3 due to an override at the listTypes level. 

## Before

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/99944/186729309-774d6e63-0357-46fb-8948-d35e80a415df.png">


## After

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/99944/186729033-04a6105e-0abf-4b6b-9d14-44766a08f194.png">
