### PR TITLE
Fix dataProvider hooks do not handle `pageInfo` when updating 'getList' query cache

### DIFF
--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -18,6 +18,7 @@ import {
     ErrorCase as ErrorCaseUndoable,
     SuccessCase as SuccessCaseUndoable,
 } from './useDelete.undoable.stories';
+import { QueryClient } from 'react-query';
 
 describe('useDelete', () => {
     it('returns a callback that can be used with deleteOne arguments', async () => {
@@ -387,6 +388,111 @@ describe('useDelete', () => {
                 expect(screen.queryByText('Hello')).not.toBeNull();
                 expect(screen.queryByText('World')).not.toBeNull();
                 expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+    });
+
+    describe('query cache', () => {
+        it('updates getList query cache when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                ],
+                total: 2,
+            });
+            const dataProvider = {
+                delete: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1 } } as any)
+                ),
+            } as any;
+            let localDeleteOne;
+            const Dummy = () => {
+                const [deleteOne] = useDelete('foo', {
+                    id: 1,
+                    previousData: { id: 1, bar: 'bar' },
+                });
+                localDeleteOne = deleteOne;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localDeleteOne('foo', {
+                id: 1,
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [{ id: 2, bar: 'bar' }],
+                    total: 1,
+                });
+            });
+        });
+        it('updates getList query cache with pageInfo when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                ],
+                pageInfo: {
+                    hasPreviousPage: false,
+                    hasNextPage: true,
+                },
+            });
+            const dataProvider = {
+                delete: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1 } } as any)
+                ),
+            } as any;
+            let localDeleteOne;
+            const Dummy = () => {
+                const [deleteOne] = useDelete('foo', {
+                    id: 1,
+                    previousData: { id: 1, bar: 'bar' },
+                });
+                localDeleteOne = deleteOne;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localDeleteOne('foo', {
+                id: 1,
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [{ id: 2, bar: 'bar' }],
+                    pageInfo: {
+                        hasPreviousPage: false,
+                        hasNextPage: true,
+                    },
+                });
             });
         });
     });

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -10,7 +10,12 @@ import {
 
 import { useDataProvider } from './useDataProvider';
 import undoableEventEmitter from './undoableEventEmitter';
-import { RaRecord, DeleteParams, MutationMode } from '../types';
+import {
+    RaRecord,
+    DeleteParams,
+    MutationMode,
+    GetListResult as OriginalGetListResult,
+} from '../types';
 
 /**
  * Get a callback to call the dataProvider.delete() method, the result and the loading state.
@@ -102,7 +107,9 @@ export const useDelete = <
             return [...old.slice(0, index), ...old.slice(index + 1)];
         };
 
-        type GetListResult = { data?: RecordType[]; total?: number };
+        type GetListResult = Omit<OriginalGetListResult, 'data'> & {
+            data?: RecordType[];
+        };
 
         queryClient.setQueriesData(
             [resource, 'getList'],
@@ -113,7 +120,8 @@ export const useDelete = <
                 return recordWasFound
                     ? {
                           data: newCollection,
-                          total: res.total - 1,
+                          total: res.total ? res.total - 1 : undefined,
+                          pageInfo: res.pageInfo,
                       }
                     : res;
             },

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -5,6 +5,7 @@ import expect from 'expect';
 import { CoreAdminContext } from '../core';
 import { testDataProvider } from './testDataProvider';
 import { useDeleteMany } from './useDeleteMany';
+import { QueryClient } from 'react-query';
 
 describe('useDeleteMany', () => {
     it('returns a callback that can be used with update arguments', async () => {
@@ -100,6 +101,107 @@ describe('useDeleteMany', () => {
             expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
                 ids: [1, 2],
                 meta: { hello: 'world' },
+            });
+        });
+    });
+
+    describe('query cache', () => {
+        it('updates getList query cache when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                    { id: 3, bar: 'bar' },
+                    { id: 4, bar: 'bar' },
+                ],
+                total: 4,
+            });
+            const dataProvider = {
+                deleteMany: jest.fn(() =>
+                    Promise.resolve({ data: [1, 2] } as any)
+                ),
+            } as any;
+            let localDeleteMany;
+            const Dummy = () => {
+                const [deleteMany] = useDeleteMany();
+                localDeleteMany = deleteMany;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localDeleteMany('foo', { ids: [1, 2] });
+            await waitFor(() => {
+                expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
+                    ids: [1, 2],
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [
+                        { id: 3, bar: 'bar' },
+                        { id: 4, bar: 'bar' },
+                    ],
+                    total: 2,
+                });
+            });
+        });
+        it('updates getList query cache with pageInfo when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                    { id: 3, bar: 'bar' },
+                    { id: 4, bar: 'bar' },
+                ],
+                pageInfo: {
+                    hasPreviousPage: false,
+                    hasNextPage: true,
+                },
+            });
+            const dataProvider = {
+                deleteMany: jest.fn(() =>
+                    Promise.resolve({ data: [1, 2] } as any)
+                ),
+            } as any;
+            let localDeleteMany;
+            const Dummy = () => {
+                const [deleteMany] = useDeleteMany();
+                localDeleteMany = deleteMany;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localDeleteMany('foo', { ids: [1, 2] });
+            await waitFor(() => {
+                expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
+                    ids: [1, 2],
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [
+                        { id: 3, bar: 'bar' },
+                        { id: 4, bar: 'bar' },
+                    ],
+                    pageInfo: {
+                        hasPreviousPage: false,
+                        hasNextPage: true,
+                    },
+                });
             });
         });
     });

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -10,7 +10,12 @@ import {
 
 import { useDataProvider } from './useDataProvider';
 import undoableEventEmitter from './undoableEventEmitter';
-import { RaRecord, DeleteManyParams, MutationMode } from '../types';
+import {
+    RaRecord,
+    DeleteManyParams,
+    MutationMode,
+    GetListResult as OriginalGetListResult,
+} from '../types';
 
 /**
  * Get a callback to call the dataProvider.delete() method, the result and the loading state.
@@ -111,7 +116,9 @@ export const useDeleteMany = <
             return newCollection;
         };
 
-        type GetListResult = { data?: RecordType[]; total?: number };
+        type GetListResult = Omit<OriginalGetListResult, 'data'> & {
+            data?: RecordType[];
+        };
 
         queryClient.setQueriesData(
             [resource, 'getList'],
@@ -122,9 +129,11 @@ export const useDeleteMany = <
                 return recordWasFound
                     ? {
                           data: newCollection,
-                          total:
-                              res.total -
-                              (res.data.length - newCollection.length),
+                          total: res.total
+                              ? res.total -
+                                (res.data.length - newCollection.length)
+                              : undefined,
+                          pageInfo: res.pageInfo,
                       }
                     : res;
             },

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -222,100 +222,6 @@ describe('useUpdate', () => {
                 expect(screen.queryByText('mutating')).toBeNull();
             });
         });
-        it('when pessimistic, updates getList query cache when dataProvider promise resolves', async () => {
-            const queryClient = new QueryClient();
-            queryClient.setQueryData(['foo', 'getList'], {
-                data: [{ id: 1, bar: 'bar' }],
-                total: 1,
-            });
-            const dataProvider = {
-                update: jest.fn(() =>
-                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
-                ),
-            } as any;
-            let localUpdate;
-            const Dummy = () => {
-                const [update] = useUpdate();
-                localUpdate = update;
-                return <span />;
-            };
-            render(
-                <CoreAdminContext
-                    dataProvider={dataProvider}
-                    queryClient={queryClient}
-                >
-                    <Dummy />
-                </CoreAdminContext>
-            );
-            localUpdate('foo', {
-                id: 1,
-                data: { bar: 'baz' },
-                previousData: { id: 1, bar: 'bar' },
-            });
-            await waitFor(() => {
-                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
-                    id: 1,
-                    data: { bar: 'baz' },
-                    previousData: { id: 1, bar: 'bar' },
-                });
-            });
-            await waitFor(() => {
-                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
-                    data: [{ id: 1, bar: 'baz' }],
-                    total: 1,
-                });
-            });
-        });
-        it('when pessimistic, updates getList query cache with pageInfo when dataProvider promise resolves', async () => {
-            const queryClient = new QueryClient();
-            queryClient.setQueryData(['foo', 'getList'], {
-                data: [{ id: 1, bar: 'bar' }],
-                pageInfo: {
-                    hasPreviousPage: false,
-                    hasNextPage: true,
-                },
-            });
-            const dataProvider = {
-                update: jest.fn(() =>
-                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
-                ),
-            } as any;
-            let localUpdate;
-            const Dummy = () => {
-                const [update] = useUpdate();
-                localUpdate = update;
-                return <span />;
-            };
-            render(
-                <CoreAdminContext
-                    dataProvider={dataProvider}
-                    queryClient={queryClient}
-                >
-                    <Dummy />
-                </CoreAdminContext>
-            );
-            localUpdate('foo', {
-                id: 1,
-                data: { bar: 'baz' },
-                previousData: { id: 1, bar: 'bar' },
-            });
-            await waitFor(() => {
-                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
-                    id: 1,
-                    data: { bar: 'baz' },
-                    previousData: { id: 1, bar: 'bar' },
-                });
-            });
-            await waitFor(() => {
-                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
-                    data: [{ id: 1, bar: 'baz' }],
-                    pageInfo: {
-                        hasPreviousPage: false,
-                        hasNextPage: true,
-                    },
-                });
-            });
-        });
         it('when optimistic, displays result and success side effects right away', async () => {
             jest.spyOn(console, 'log').mockImplementation(() => {});
             render(<SuccessCaseOptimistic />);
@@ -406,6 +312,102 @@ describe('useUpdate', () => {
                 expect(screen.queryByText('success')).toBeNull();
                 expect(screen.queryByText('Hello World')).toBeNull();
                 expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+    });
+    describe('query cache', () => {
+        it('updates getList query cache when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [{ id: 1, bar: 'bar' }],
+                total: 1,
+            });
+            const dataProvider = {
+                update: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                ),
+            } as any;
+            let localUpdate;
+            const Dummy = () => {
+                const [update] = useUpdate();
+                localUpdate = update;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdate('foo', {
+                id: 1,
+                data: { bar: 'baz' },
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [{ id: 1, bar: 'baz' }],
+                    total: 1,
+                });
+            });
+        });
+        it('updates getList query cache with pageInfo when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [{ id: 1, bar: 'bar' }],
+                pageInfo: {
+                    hasPreviousPage: false,
+                    hasNextPage: true,
+                },
+            });
+            const dataProvider = {
+                update: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                ),
+            } as any;
+            let localUpdate;
+            const Dummy = () => {
+                const [update] = useUpdate();
+                localUpdate = update;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdate('foo', {
+                id: 1,
+                data: { bar: 'baz' },
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [{ id: 1, bar: 'baz' }],
+                    pageInfo: {
+                        hasPreviousPage: false,
+                        hasNextPage: true,
+                    },
+                });
             });
         });
     });

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -17,6 +17,7 @@ import {
     ErrorCase as ErrorCaseUndoable,
     SuccessCase as SuccessCaseUndoable,
 } from './useUpdate.undoable.stories';
+import { QueryClient } from 'react-query';
 
 describe('useUpdate', () => {
     describe('mutate', () => {
@@ -219,6 +220,100 @@ describe('useUpdate', () => {
                 ).not.toBeNull();
                 expect(screen.queryByText('Hello World')).toBeNull();
                 expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+        it('when pessimistic, updates getList query cache when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [{ id: 1, bar: 'bar' }],
+                total: 1,
+            });
+            const dataProvider = {
+                update: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                ),
+            } as any;
+            let localUpdate;
+            const Dummy = () => {
+                const [update] = useUpdate();
+                localUpdate = update;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdate('foo', {
+                id: 1,
+                data: { bar: 'baz' },
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [{ id: 1, bar: 'baz' }],
+                    total: 1,
+                });
+            });
+        });
+        it('when pessimistic, updates getList query cache with pageInfo when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [{ id: 1, bar: 'bar' }],
+                pageInfo: {
+                    hasPreviousPage: false,
+                    hasNextPage: true,
+                },
+            });
+            const dataProvider = {
+                update: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                ),
+            } as any;
+            let localUpdate;
+            const Dummy = () => {
+                const [update] = useUpdate();
+                localUpdate = update;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdate('foo', {
+                id: 1,
+                data: { bar: 'baz' },
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [{ id: 1, bar: 'baz' }],
+                    pageInfo: {
+                        hasPreviousPage: false,
+                        hasNextPage: true,
+                    },
+                });
             });
         });
         it('when optimistic, displays result and success side effects right away', async () => {

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -110,7 +110,14 @@ export const useUpdate = <
             ];
         };
 
-        type GetListResult = { data?: RecordType[]; total?: number };
+        type GetListResult = {
+            data?: RecordType[];
+            total?: number;
+            pageInfo?: {
+                hasNextPage?: boolean;
+                hasPreviousPage?: boolean;
+            };
+        };
 
         queryClient.setQueryData(
             [resource, 'getOne', { id: String(id), meta }],
@@ -120,9 +127,7 @@ export const useUpdate = <
         queryClient.setQueriesData(
             [resource, 'getList'],
             (res: GetListResult) =>
-                res && res.data
-                    ? { data: updateColl(res.data), total: res.total }
-                    : res,
+                res && res.data ? { ...res, data: updateColl(res.data) } : res,
             { updatedAt }
         );
         queryClient.setQueriesData(

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -10,7 +10,12 @@ import {
 
 import { useDataProvider } from './useDataProvider';
 import undoableEventEmitter from './undoableEventEmitter';
-import { RaRecord, UpdateParams, MutationMode } from '../types';
+import {
+    RaRecord,
+    UpdateParams,
+    MutationMode,
+    GetListResult as OriginalGetListResult,
+} from '../types';
 
 /**
  * Get a callback to call the dataProvider.update() method, the result and the loading state.
@@ -110,13 +115,8 @@ export const useUpdate = <
             ];
         };
 
-        type GetListResult = {
+        type GetListResult = Omit<OriginalGetListResult, 'data'> & {
             data?: RecordType[];
-            total?: number;
-            pageInfo?: {
-                hasNextPage?: boolean;
-                hasPreviousPage?: boolean;
-            };
         };
 
         queryClient.setQueryData(

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -10,7 +10,12 @@ import {
 
 import { useDataProvider } from './useDataProvider';
 import undoableEventEmitter from './undoableEventEmitter';
-import { RaRecord, UpdateManyParams, MutationMode } from '../types';
+import {
+    RaRecord,
+    UpdateManyParams,
+    MutationMode,
+    GetListResult as OriginalGetListResult,
+} from '../types';
 import { Identifier } from '..';
 
 /**
@@ -118,7 +123,9 @@ export const useUpdateMany = <
             return newCollection;
         };
 
-        type GetListResult = { data?: RecordType[]; total?: number };
+        type GetListResult = Omit<OriginalGetListResult, 'data'> & {
+            data?: RecordType[];
+        };
 
         ids.forEach(id =>
             queryClient.setQueryData(
@@ -130,9 +137,7 @@ export const useUpdateMany = <
         queryClient.setQueriesData(
             [resource, 'getList'],
             (res: GetListResult) =>
-                res && res.data
-                    ? { data: updateColl(res.data), total: res.total }
-                    : res,
+                res && res.data ? { ...res, data: updateColl(res.data) } : res,
             { updatedAt }
         );
         queryClient.setQueriesData(
@@ -221,12 +226,13 @@ export const useUpdateMany = <
                     const {
                         resource: callTimeResource = resource,
                         ids: callTimeIds = ids,
+                        data: callTimeData = data,
                         meta: callTimeMeta = meta,
                     } = variables;
                     updateCache({
                         resource: callTimeResource,
                         ids: callTimeIds,
-                        data,
+                        data: callTimeData,
                         meta: callTimeMeta,
                     });
 


### PR DESCRIPTION
**Problem:**
The dataProvider hooks `useUpdate`, `useUpdateMany`, `useDelete` and `useDeleteMany` directly updates the `'getList'` result when successful, but they did not handle the `pageInfo`. This lead to a pagination bug in EE module ra-editable-datagrid.

**Bonus problem:**
It also appears that the `'getList'` cache was incorrectly populated by `useUpdateMany`, because fed with the list of `ids` as data, instead of the record data.

This lead to having cached values like:
```js
{ id: 1, bar: 'baz', "0": 1, "1": 2 }
```
instead of:
```js
{ id: 1, bar: 'baz' }
```

**Solution:**
- All 4 hooks have been fixed to handle the `pageInfo` correctly
  - Notice: for now the value of this prop is determined in a very basic way: we just copy what was previously in cache. It might be doable to implement a more clever solution, but this seemed good enough to me for now...
- The 4 hooks now use the _real_ `GetListResult` type
-  `useUpdateMany` now calls `updateCache` with the proper `data`
- unit tests have been added to all 4 hooks to ensure the cache is set properly