### PR TITLE
Fix code error in *Usage* example of ra-data-localstorage README

### DIFF
--- a/packages/ra-data-localstorage/README.md
+++ b/packages/ra-data-localstorage/README.md
@@ -17,9 +17,9 @@ npm install --save ra-data-local-storage
 import * as React from "react";
 import { Admin, Resource } from 'react-admin';
 import localStorageDataProvider from 'ra-data-local-storage';
+import { PostList } from './posts';
 
 const dataProvider = localStorageDataProvider();
-import { PostList } from './posts';
 
 const App = () => (
     <Admin dataProvider={dataProvider}>


### PR DESCRIPTION
This patch just corrects a minor code error in the README of ra-data-localstorage