### PR TITLE
export useReferenceParams

### DIFF
--- a/packages/ra-core/src/controller/input/index.ts
+++ b/packages/ra-core/src/controller/input/index.ts
@@ -6,6 +6,7 @@ import {
 
 export * from './useReferenceArrayInputController';
 export * from './useReferenceInputController';
+export * from './useReferenceParams';
 
 export {
     getStatusForInput,


### PR DESCRIPTION
I need to disable the getMany done by ReferenceArrayInput.

I couldn't find a way to do that and finally decided to create my own. The challenge with that is that this export is missing.