### PR TITLE
feat: add translate in emptyText on ra-ui-material fields

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -144,7 +144,7 @@ CSS class name passed to the root component.
 
 ## `emptyText`
 
-By default, a Field renders an empty string when the record has no value for that field. You can override this behavior by setting the `emptyText` prop.
+By default, a Field renders an empty string when the record has no value for that field. You can override this behavior by setting the `emptyText` prop. The emptyText supports i8nProvider translation, if the translation is not found it will display the value as default.
 
 ```jsx
 const PostList = () => (

--- a/packages/ra-ui-materialui/src/field/BooleanField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.spec.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import expect from 'expect';
 import { BooleanField } from './BooleanField';
 import { screen, render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 const defaultProps = {
     record: { id: 123, published: true },
@@ -10,6 +11,24 @@ const defaultProps = {
     resource: 'posts',
     classes: {},
 };
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<BooleanField />', () => {
     it('should display tick and truthy text if value is true', () => {
@@ -151,5 +170,19 @@ describe('<BooleanField />', () => {
             />
         );
         expect(screen.queryByLabelText('ra.boolean.true')).not.toBeNull();
+    });
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <BooleanField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -62,7 +62,7 @@ export const BooleanField: FunctionComponent<BooleanFieldProps> = memo(
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         );
     }

--- a/packages/ra-ui-materialui/src/field/ChipField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.spec.tsx
@@ -2,7 +2,26 @@ import * as React from 'react';
 import expect from 'expect';
 import { ChipField } from './ChipField';
 import { render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<ChipField />', () => {
     it('should display the record value added as source', () => {
@@ -54,4 +73,18 @@ describe('<ChipField />', () => {
             expect(getByText('NA')).not.toBeNull();
         }
     );
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <ChipField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
+    });
 });

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -5,7 +5,7 @@ import get from 'lodash/get';
 import Chip, { ChipProps } from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import clsx from 'clsx';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
@@ -13,8 +13,8 @@ import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 export const ChipField: FC<ChipFieldProps> = memo(props => {
     const { className, source, emptyText, ...rest } = props;
     const record = useRecordContext(props);
-
     const value = get(record, source);
+    const translate = useTranslate();
 
     if (value == null && emptyText) {
         return (
@@ -24,7 +24,7 @@ export const ChipField: FC<ChipFieldProps> = memo(props => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         );
     }

--- a/packages/ra-ui-materialui/src/field/DateField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.spec.tsx
@@ -1,9 +1,28 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { DateField } from './DateField';
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<DateField />', () => {
     it('should return null when the record is not set', () => {
@@ -161,4 +180,18 @@ describe('<DateField />', () => {
             expect(queryByText('NA')).not.toBeNull();
         }
     );
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <DateField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
+    });
 });

--- a/packages/ra-ui-materialui/src/field/DateField.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.tsx
@@ -3,7 +3,7 @@ import { memo, FC } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { Typography, TypographyProps } from '@mui/material';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
@@ -43,6 +43,7 @@ export const DateField: FC<DateFieldProps> = memo(props => {
         source,
         ...rest
     } = props;
+    const translate = useTranslate();
 
     if (!showTime && !showDate) {
         throw new Error(
@@ -54,6 +55,7 @@ export const DateField: FC<DateFieldProps> = memo(props => {
     if (!record) {
         return null;
     }
+
     const value = get(record, source);
     if (value == null || value === '') {
         return emptyText ? (
@@ -63,7 +65,7 @@ export const DateField: FC<DateFieldProps> = memo(props => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : null;
     }

--- a/packages/ra-ui-materialui/src/field/EmailField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/EmailField.spec.tsx
@@ -1,9 +1,28 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { EmailField } from './EmailField';
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 const url = 'foo@bar.com';
 
@@ -86,5 +105,19 @@ describe('<EmailField />', () => {
             <EmailField record={{ id: 123 }} source="foo" />
         );
         expect(container.firstChild).toBeNull();
+    });
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <EmailField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/EmailField.tsx
+++ b/packages/ra-ui-materialui/src/field/EmailField.tsx
@@ -3,7 +3,7 @@ import { memo, FC } from 'react';
 import get from 'lodash/get';
 import Typography from '@mui/material/Typography';
 import { Link, LinkProps } from '@mui/material';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
@@ -12,6 +12,7 @@ export const EmailField: FC<EmailFieldProps> = memo(props => {
     const { className, source, emptyText, ...rest } = props;
     const record = useRecordContext(props);
     const value = get(record, source);
+    const translate = useTranslate();
 
     if (value == null) {
         return emptyText ? (
@@ -21,7 +22,7 @@ export const EmailField: FC<EmailFieldProps> = memo(props => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : null;
     }

--- a/packages/ra-ui-materialui/src/field/FileField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/FileField.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { FileField } from './FileField';
 
@@ -9,6 +10,24 @@ const defaultProps = {
     classes: {},
     source: 'url',
 };
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<FileField />', () => {
     it('should return an empty div when record is not set', () => {
@@ -162,5 +181,19 @@ describe('<FileField />', () => {
             />
         );
         expect(container.children[0].classList.contains('foo')).toBe(true);
+    });
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <FileField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/FileField.tsx
+++ b/packages/ra-ui-materialui/src/field/FileField.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Typography from '@mui/material/Typography';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
@@ -38,6 +38,7 @@ export const FileField = (props: FileFieldProps) => {
     } = props;
     const record = useRecordContext(props);
     const sourceValue = get(record, source);
+    const translate = useTranslate();
 
     if (!sourceValue) {
         return emptyText ? (
@@ -47,7 +48,7 @@ export const FileField = (props: FileFieldProps) => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : (
             <Root className={className} {...sanitizeFieldRestProps(rest)} />

--- a/packages/ra-ui-materialui/src/field/ImageField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { ImageField } from './ImageField';
 
@@ -9,6 +10,24 @@ const defaultProps = {
     classes: {},
     source: 'url',
 };
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<ImageField />', () => {
     it('should return an empty div when record is not set', () => {
@@ -150,5 +169,19 @@ describe('<ImageField />', () => {
         );
 
         expect(container.children[0].classList.contains('foo')).toBe(true);
+    });
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <ImageField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles';
 import { Box, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
@@ -13,6 +13,7 @@ export const ImageField = (props: ImageFieldProps) => {
     const { className, emptyText, source, src, title, ...rest } = props;
     const record = useRecordContext(props);
     const sourceValue = get(record, source);
+    const translate = useTranslate();
 
     if (!sourceValue) {
         return emptyText ? (
@@ -22,7 +23,7 @@ export const ImageField = (props: ImageFieldProps) => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : (
             <div className={className} {...sanitizeFieldRestProps(rest)} />

--- a/packages/ra-ui-materialui/src/field/NumberField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/NumberField.spec.tsx
@@ -1,9 +1,28 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render } from '@testing-library/react';
-import { RecordContextProvider } from 'ra-core';
+import { RecordContextProvider, I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { NumberField } from './NumberField';
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<NumberField />', () => {
     it('should return null when the record is not set', () => {
@@ -92,5 +111,19 @@ describe('<NumberField />', () => {
         );
 
         expect(queryByText('2')).not.toBeNull();
+    });
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <NumberField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/NumberField.tsx
+++ b/packages/ra-ui-materialui/src/field/NumberField.tsx
@@ -3,7 +3,7 @@ import { memo, FC } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Typography, { TypographyProps } from '@mui/material/Typography';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
@@ -47,10 +47,13 @@ export const NumberField: FC<NumberFieldProps> = memo(props => {
         ...rest
     } = props;
     const record = useRecordContext(props);
+    const translate = useTranslate();
+
     if (!record) {
         return null;
     }
     const value = get(record, source);
+
     if (value == null) {
         return emptyText ? (
             <Typography
@@ -59,7 +62,7 @@ export const NumberField: FC<NumberFieldProps> = memo(props => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : null;
     }

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -12,7 +12,11 @@ import { QueryClient } from 'react-query';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { ReferenceField } from './ReferenceField';
-import { Children, MissingReference } from './ReferenceField.stories';
+import {
+    Children,
+    EmptyWithTranslate,
+    MissingReference,
+} from './ReferenceField.stories';
 import { TextField } from './TextField';
 
 const theme = createTheme({});
@@ -456,5 +460,11 @@ describe('<ReferenceField />', () => {
         render(<Children />);
         expect(screen.findByText('9780393966473')).not.toBeNull();
         expect(screen.findByText('novel')).not.toBeNull();
+    });
+
+    it('should translate emptyText', () => {
+        render(<EmptyWithTranslate />);
+
+        expect(screen.findByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
@@ -7,10 +7,13 @@ import {
     ResourceDefinitionContextProvider,
     ListContextProvider,
     useRecordContext,
+    I18nContextProvider,
 } from 'ra-core';
 import { createMemoryHistory } from 'history';
 import { ThemeProvider, Stack } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
 
 import { TextField } from '../field';
 import { ReferenceField } from './ReferenceField';
@@ -18,6 +21,25 @@ import { SimpleShowLayout } from '../detail/SimpleShowLayout';
 import { Datagrid } from '../list/datagrid/Datagrid';
 
 export default { title: 'ra-ui-materialui/fields/ReferenceField' };
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        ...englishMessages,
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 const history = createMemoryHistory({ initialEntries: ['/books/1/show'] });
 
@@ -78,6 +100,20 @@ export const Empty = () => (
         >
             <TextField source="ISBN" />
         </ReferenceField>
+    </Wrapper>
+);
+
+export const EmptyWithTranslate = () => (
+    <Wrapper record={{ id: 1, title: 'War and Peace' }}>
+        <I18nContextProvider value={i18nProvider}>
+            <ReferenceField
+                source="detail_id"
+                reference="book_details"
+                emptyText="resources.books.not_found"
+            >
+                <TextField source="ISBN" />
+            </ReferenceField>
+        </I18nContextProvider>
     </Wrapper>
 );
 

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -16,6 +16,7 @@ import {
     useCreatePath,
     Identifier,
     useGetRecordRepresentation,
+    useTranslate,
 } from 'ra-core';
 
 import { LinearProgress } from '../layout';
@@ -57,11 +58,12 @@ export const ReferenceField: FC<ReferenceFieldProps> = props => {
     const { source, emptyText, ...rest } = props;
     const record = useRecordContext(props);
     const id = get(record, source);
+    const translate = useTranslate();
 
     return id == null ? (
         emptyText ? (
             <Typography component="span" variant="body2">
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : null
     ) : (
@@ -164,6 +166,7 @@ export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
         sx,
     } = props;
     const getRecordRepresentation = useGetRecordRepresentation(reference);
+    const translate = useTranslate();
 
     if (error) {
         return (
@@ -181,7 +184,7 @@ export const ReferenceFieldView: FC<ReferenceFieldViewProps> = props => {
         return <LinearProgress />;
     }
     if (!referenceRecord) {
-        return emptyText ? <>{emptyText}</> : null;
+        return emptyText ? <>{translate(emptyText, { _: emptyText })}</> : null;
     }
 
     let child = children || (

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { RecordRepresentation, Basic } from './ReferenceOneField.stories';
+import {
+    RecordRepresentation,
+    Basic,
+    EmptyWithTranslate,
+} from './ReferenceOneField.stories';
 
 describe('ReferenceOneField', () => {
     it('should render the recordRepresentation of the related record', async () => {
@@ -11,5 +15,11 @@ describe('ReferenceOneField', () => {
     it('should render its child in the context of the related record', async () => {
         render(<Basic />);
         await screen.findByText('9780393966473');
+    });
+
+    it('should translate emptyText', () => {
+        render(<EmptyWithTranslate />);
+
+        expect(screen.findByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
@@ -7,10 +7,13 @@ import {
     ResourceDefinitionContextProvider,
     ListContextProvider,
     useRecordContext,
+    I18nContextProvider,
 } from 'ra-core';
 import { createMemoryHistory } from 'history';
 import { ThemeProvider, Stack } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
 
 import { TextField } from '../field';
 import { ReferenceOneField } from './ReferenceOneField';
@@ -18,6 +21,25 @@ import { SimpleShowLayout } from '../detail/SimpleShowLayout';
 import { Datagrid } from '../list/datagrid/Datagrid';
 
 export default { title: 'ra-ui-materialui/fields/ReferenceOneField' };
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        ...englishMessages,
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 const defaultDataProvider = {
     getManyReference: () =>
@@ -86,6 +108,20 @@ export const Empty = () => (
         >
             <TextField source="ISBN" />
         </ReferenceOneField>
+    </Wrapper>
+);
+
+export const EmptyWithTranslate = () => (
+    <Wrapper dataProvider={emptyDataProvider}>
+        <I18nContextProvider value={i18nProvider}>
+            <ReferenceOneField
+                reference="book_details"
+                target="book_id"
+                emptyText="resources.books.not_found"
+            >
+                <TextField source="ISBN" />
+            </ReferenceOneField>
+        </I18nContextProvider>
     </Wrapper>
 );
 

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -7,6 +7,7 @@ import {
     ResourceContextProvider,
     LinkToType,
     useCreatePath,
+    useTranslate,
 } from 'ra-core';
 
 import { PublicFieldProps, fieldPropTypes, InjectedFieldProps } from './types';
@@ -33,6 +34,7 @@ export const ReferenceOneField = (props: ReferenceOneFieldProps) => {
     } = props;
     const record = useRecordContext(props);
     const createPath = useCreatePath();
+    const translate = useTranslate();
 
     const {
         isLoading,
@@ -62,7 +64,7 @@ export const ReferenceOneField = (props: ReferenceOneFieldProps) => {
     return !record || (!isLoading && referenceRecord == null) ? (
         emptyText ? (
             <Typography component="span" variant="body2">
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : null
     ) : (

--- a/packages/ra-ui-materialui/src/field/SelectField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/SelectField.spec.tsx
@@ -5,9 +5,29 @@ import {
     RecordContextProvider,
     TestTranslationProvider,
     useRecordContext,
+    I18nContextProvider,
 } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { SelectField } from './SelectField';
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<SelectField />', () => {
     const defaultProps = {
@@ -159,5 +179,20 @@ describe('<SelectField />', () => {
         );
         expect(screen.queryAllByText('hello')).toHaveLength(1);
         expect(screen.queryAllByText('bonjour')).toHaveLength(0);
+    });
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <SelectField
+                    {...defaultProps}
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/field/SelectField.tsx
+++ b/packages/ra-ui-materialui/src/field/SelectField.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { memo, FC } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { ChoicesProps, useChoices, useRecordContext } from 'ra-core';
+import {
+    ChoicesProps,
+    useChoices,
+    useRecordContext,
+    useTranslate,
+} from 'ra-core';
 import { Typography, TypographyProps } from '@mui/material';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
@@ -85,6 +90,7 @@ export const SelectField: FC<SelectFieldProps> = memo(props => {
         optionValue,
         translateChoice,
     });
+    const translate = useTranslate();
 
     const choice = choices.find(choice => getChoiceValue(choice) === value);
 
@@ -96,7 +102,7 @@ export const SelectField: FC<SelectFieldProps> = memo(props => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         ) : null;
     }

--- a/packages/ra-ui-materialui/src/field/UrlField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/UrlField.spec.tsx
@@ -1,9 +1,30 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render } from '@testing-library/react';
+import { I18nContextProvider } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+
 import { UrlField } from './UrlField';
 
 const url = 'https://en.wikipedia.org/wiki/HAL_9000';
+
+const i18nProvider = polyglotI18nProvider(
+    _locale => ({
+        resources: {
+            books: {
+                name: 'Books',
+                fields: {
+                    id: 'Id',
+                    title: 'Title',
+                    author: 'Author',
+                    year: 'Year',
+                },
+                not_found: 'Not found',
+            },
+        },
+    }),
+    'en'
+);
 
 describe('<UrlField />', () => {
     it('should render a link', () => {
@@ -42,4 +63,18 @@ describe('<UrlField />', () => {
             expect(getByText('NA')).not.toEqual(null);
         }
     );
+
+    it('should translate emptyText', () => {
+        const { getByText } = render(
+            <I18nContextProvider value={i18nProvider}>
+                <UrlField
+                    record={{ id: 123 }}
+                    source="foo.bar"
+                    emptyText="resources.books.not_found"
+                />
+            </I18nContextProvider>
+        );
+
+        expect(getByText('Not found')).not.toBeNull();
+    });
 });

--- a/packages/ra-ui-materialui/src/field/UrlField.tsx
+++ b/packages/ra-ui-materialui/src/field/UrlField.tsx
@@ -3,13 +3,14 @@ import { AnchorHTMLAttributes, memo, FC } from 'react';
 import get from 'lodash/get';
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { Typography, Link } from '@mui/material';
-import { useRecordContext } from 'ra-core';
+import { useRecordContext, useTranslate } from 'ra-core';
 import { PublicFieldProps, InjectedFieldProps, fieldPropTypes } from './types';
 
 export const UrlField: FC<UrlFieldProps> = memo(props => {
     const { className, emptyText, source, ...rest } = props;
     const record = useRecordContext(props);
     const value = get(record, source);
+    const translate = useTranslate();
 
     if (value == null) {
         return (
@@ -19,7 +20,7 @@ export const UrlField: FC<UrlFieldProps> = memo(props => {
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             >
-                {emptyText}
+                {translate(emptyText, { _: emptyText })}
             </Typography>
         );
     }


### PR DESCRIPTION
Implementing the emptyTextt translation feature for issue #8044

I added useTranslate to always translate emptyText, if it doesn't find the translation it will display the text normally

- Code ✅ 
- Test ❌ 
- Documentation ❌ 


I was wondering what is expected of me to document and which test I should add. Can you help me @fzaninotto?

Closes #8044 