### PR TITLE
Use "strictNullChecks": true in `ra-core`

### DIFF
--- a/examples/demo/src/categories/CategoryList.tsx
+++ b/examples/demo/src/categories/CategoryList.tsx
@@ -32,7 +32,7 @@ const CategoryList = () => (
 
 const CategoryGrid = () => {
     const { data, isLoading } = useListContext<Category>();
-    if (isLoading) {
+    if (isLoading || !data) {
         return null;
     }
     return (

--- a/examples/demo/src/orders/MobileGrid.tsx
+++ b/examples/demo/src/orders/MobileGrid.tsx
@@ -23,7 +23,7 @@ interface MobileGridProps {
 const MobileGrid = (props: MobileGridProps) => {
     const { data, isLoading } = useListContext<Order>();
     const translate = useTranslate();
-    if (isLoading || data.length === 0) {
+    if (isLoading || !data || data.length === 0) {
         return null;
     }
     return (

--- a/examples/demo/src/products/ProductEdit.tsx
+++ b/examples/demo/src/products/ProductEdit.tsx
@@ -91,7 +91,7 @@ const ReviewsFormTab = (props: any) => {
         'reviews',
         {
             target: 'product_id',
-            id: record.id,
+            id: record?.id,
             pagination: { page: 1, perPage: 25 },
             sort: { field: 'id', order: 'DESC' },
         },

--- a/examples/demo/src/reviews/AcceptButton.tsx
+++ b/examples/demo/src/reviews/AcceptButton.tsx
@@ -22,7 +22,7 @@ const AcceptButton = () => {
 
     const [approve, { isLoading }] = useUpdate(
         'reviews',
-        { id: record.id, data: { status: 'accepted' }, previousData: record },
+        { id: record?.id, data: { status: 'accepted' }, previousData: record },
         {
             mutationMode: 'undoable',
             onSuccess: () => {

--- a/examples/demo/src/reviews/RejectButton.tsx
+++ b/examples/demo/src/reviews/RejectButton.tsx
@@ -22,7 +22,7 @@ const RejectButton = () => {
 
     const [reject, { isLoading }] = useUpdate(
         'reviews',
-        { id: record.id, data: { status: 'rejected' }, previousData: record },
+        { id: record?.id, data: { status: 'rejected' }, previousData: record },
         {
             mutationMode: 'undoable',
             onSuccess: () => {

--- a/examples/demo/src/reviews/ReviewListMobile.tsx
+++ b/examples/demo/src/reviews/ReviewListMobile.tsx
@@ -8,7 +8,7 @@ import { Review } from './../types';
 
 const ReviewListMobile = () => {
     const { data, isLoading, total } = useListContext<Review>();
-    if (isLoading || Number(total) === 0) {
+    if (isLoading || !data || Number(total) === 0) {
         return null;
     }
     return (

--- a/examples/demo/src/visitors/Aside.tsx
+++ b/examples/demo/src/visitors/Aside.tsx
@@ -51,12 +51,12 @@ const EventList = () => {
     const { data: orders } = useGetList<OrderRecord>('commands', {
         pagination: { page: 1, perPage: 100 },
         sort: { field: 'date', order: 'DESC' },
-        filter: { customer_id: record.id },
+        filter: { customer_id: record?.id },
     });
     const { data: reviews } = useGetList<ReviewRecord>('reviews', {
         pagination: { page: 1, perPage: 100 },
         sort: { field: 'date', order: 'DESC' },
-        filter: { customer_id: record.id },
+        filter: { customer_id: record?.id },
     });
     const events = mixOrdersAndReviews(orders, reviews);
 

--- a/examples/demo/src/visitors/MobileGrid.tsx
+++ b/examples/demo/src/visitors/MobileGrid.tsx
@@ -19,7 +19,7 @@ const MobileGrid = () => {
     const translate = useTranslate();
     const { data, isLoading } = useListContext<Customer>();
 
-    if (isLoading || data.length === 0) {
+    if (isLoading || !data || data.length === 0) {
         return null;
     }
 

--- a/packages/ra-core/src/auth/AuthContext.tsx
+++ b/packages/ra-core/src/auth/AuthContext.tsx
@@ -4,7 +4,7 @@ import { AuthProvider, UserIdentity } from '../types';
 
 const defaultIdentity: UserIdentity = { id: '' };
 
-const defaultProvider: AuthProvider = {
+export const defaultProvider: AuthProvider = {
     login: () => Promise.resolve(),
     logout: () => Promise.resolve(),
     checkAuth: () => Promise.resolve(),

--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -5,7 +5,6 @@ import { useSafeSetState } from '../util/hooks';
 
 const defaultIdentity = {
     id: '',
-    fullName: null,
 };
 
 /**
@@ -45,21 +44,20 @@ const useGetIdentity = () => {
     const authProvider = useAuthProvider();
     useEffect(() => {
         if (authProvider && typeof authProvider.getIdentity === 'function') {
-            const callAuthProvider = async () => {
-                try {
-                    const identity = await authProvider.getIdentity();
+            authProvider
+                .getIdentity()
+                .then(identity => {
                     setState({
                         isLoading: false,
                         identity: identity || defaultIdentity,
                     });
-                } catch (error) {
+                })
+                .catch(error => {
                     setState({
                         isLoading: false,
                         error,
                     });
-                }
-            };
-            callAuthProvider();
+                });
         } else {
             setState({
                 isLoading: false,

--- a/packages/ra-core/src/auth/usePermissionsOptimized.ts
+++ b/packages/ra-core/src/auth/usePermissionsOptimized.ts
@@ -12,6 +12,7 @@ interface State {
 const emptyParams = {};
 
 // keep a cache of already fetched permissions to initialize state for new
+
 // components and avoid a useless rerender if the permissions haven't changed
 const alreadyFetchedPermissions = { '{}': undefined };
 

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -169,7 +169,7 @@ export interface UseDeleteWithConfirmControllerParams<
     MutationOptionsError = unknown
 > {
     mutationMode?: MutationMode;
-    record?: RecordType;
+    record: RecordType;
     redirect?: RedirectionSideEffect;
     // @deprecated. This hook get the resource from the context
     resource?: string;

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -126,7 +126,7 @@ export interface UseDeleteWithUndoControllerParams<
     RecordType extends RaRecord = any,
     MutationOptionsError = unknown
 > {
-    record?: RecordType;
+    record: RecordType;
     redirect?: RedirectionSideEffect;
     // @deprecated. This hook get the resource from the context
     resource?: string;

--- a/packages/ra-core/src/controller/create/CreateContext.tsx
+++ b/packages/ra-core/src/controller/create/CreateContext.tsx
@@ -19,17 +19,6 @@ import { CreateControllerResult } from './useCreateController';
  *     );
  * };
  */
-export const CreateContext = createContext<CreateControllerResult>({
-    record: null,
-    defaultTitle: null,
-    isFetching: null,
-    isLoading: null,
-    redirect: null,
-    resource: null,
-    save: null,
-    saving: null,
-    registerMutationMiddleware: null,
-    unregisterMutationMiddleware: null,
-});
+export const CreateContext = createContext<CreateControllerResult>(undefined!);
 
 CreateContext.displayName = 'CreateContext';

--- a/packages/ra-core/src/controller/edit/EditContext.tsx
+++ b/packages/ra-core/src/controller/edit/EditContext.tsx
@@ -19,19 +19,6 @@ import { EditControllerResult } from './useEditController';
  *     );
  * };
  */
-export const EditContext = createContext<EditControllerResult>({
-    record: null,
-    defaultTitle: null,
-    isFetching: null,
-    isLoading: null,
-    mutationMode: null,
-    redirect: null,
-    refetch: null,
-    resource: null,
-    save: null,
-    saving: null,
-    registerMutationMiddleware: null,
-    unregisterMutationMiddleware: null,
-});
+export const EditContext = createContext<EditControllerResult>(undefined!);
 
 EditContext.displayName = 'EditContext';

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -66,7 +66,18 @@ export const useEditController = <
     const redirect = useRedirect();
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
-    const id = propsId != null ? propsId : decodeURIComponent(routeId);
+
+    const id =
+        propsId != null
+            ? propsId
+            : routeId
+            ? decodeURIComponent(routeId)
+            : null;
+
+    if (id === null) {
+        throw new Error(`useEditController: id param is not present`);
+    }
+
     const { meta: queryMeta, ...otherQueryOptions } = queryOptions;
     const {
         onSuccess,

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -18,7 +18,6 @@ export interface UseReferenceArrayFieldControllerParams {
 
 const emptyArray = [];
 const defaultFilter = {};
-const defaultSort = { field: null, order: null };
 
 /**
  * Hook that fetches records from another resource specified
@@ -52,7 +51,7 @@ export const useReferenceArrayFieldController = (
         perPage = 1000,
         record,
         reference,
-        sort = defaultSort,
+        sort,
         source,
     } = props;
     const notify = useNotify();
@@ -101,7 +100,6 @@ export const useReferenceArrayFieldController = (
 
     return {
         ...listProps,
-        defaultTitle: null,
         refetch,
         resource: reference,
     };

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import { useSafeSetState, removeEmpty } from '../../util';
 import { useGetManyReference } from '../../dataProvider';
 import { useNotify } from '../../notification';
-import { RaRecord, SortPayload } from '../../types';
+import { Optional, RaRecord, SortPayload } from '../../types';
 import { ListControllerResult } from '../list';
 import usePaginationState from '../usePaginationState';
 import { useRecordSelection } from '../list/useRecordSelection';
@@ -60,7 +60,10 @@ const defaultFilter = {};
  */
 export const useReferenceManyFieldController = (
     props: UseReferenceManyFieldControllerParams
-): ListControllerResult => {
+): Optional<
+    ListControllerResult,
+    'data' | 'hasNextPage' | 'hasPreviousPage' | 'total'
+> => {
     const {
         reference,
         record,
@@ -154,7 +157,7 @@ export const useReferenceManyFieldController = (
         reference,
         {
             target,
-            id: get(record, source),
+            id: source ? get(record, source) : undefined,
             pagination: { page, perPage },
             sort,
             filter: filterValues,
@@ -184,7 +187,6 @@ export const useReferenceManyFieldController = (
     return {
         sort,
         data,
-        defaultTitle: null,
         displayedFilters,
         error,
         filterValues,

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import { useSafeSetState, removeEmpty } from '../../util';
 import { useGetManyReference } from '../../dataProvider';
 import { useNotify } from '../../notification';
-import { Optional, RaRecord, SortPayload } from '../../types';
+import { RaRecord, SortPayload } from '../../types';
 import { ListControllerResult } from '../list';
 import usePaginationState from '../usePaginationState';
 import { useRecordSelection } from '../list/useRecordSelection';
@@ -60,10 +60,7 @@ const defaultFilter = {};
  */
 export const useReferenceManyFieldController = (
     props: UseReferenceManyFieldControllerParams
-): Optional<
-    ListControllerResult,
-    'data' | 'hasNextPage' | 'hasPreviousPage' | 'total'
-> => {
+): ListControllerResult => {
     const {
         reference,
         record,

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -117,7 +117,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         },
     });
     // add current value to possible sources
-    let finalData: RecordType[], finalTotal: number;
+    let finalData: RecordType[], finalTotal: number | undefined;
     if (
         !referenceRecord ||
         possibleValuesData.find(record => record.id === currentValue)
@@ -145,7 +145,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         sort: currentSort,
         allChoices: finalData,
         availableChoices: possibleValuesData,
-        selectedChoices: [referenceRecord],
+        selectedChoices: referenceRecord ? [referenceRecord] : [],
         displayedFilters: params.displayedFilters,
         error: referenceError || possibleValuesError,
         filter: params.filter,

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -183,7 +183,7 @@ export const useReferenceParams = ({
             filterValues,
             requestSignature,
             ...query,
-            displayedFilters: displayedFilterValues,
+            displayedFilters: query.displayedFilters ?? displayedFilterValues,
         },
         {
             changeParams,

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -92,10 +92,11 @@ export const useReferenceParams = ({
     const changeParams = useCallback(action => {
         if (!tempParams.current) {
             // no other changeParams action dispatched this tick
-            tempParams.current = queryReducer(query, action);
+            const nextParams = queryReducer(query, action);
+            tempParams.current = nextParams;
             // schedule side effects for next tick
             setTimeout(() => {
-                setParams(tempParams.current);
+                setParams(nextParams);
                 tempParams.current = undefined;
             }, 0);
         } else {
@@ -176,12 +177,13 @@ export const useReferenceParams = ({
             },
         });
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
+
     return [
         {
-            displayedFilters: displayedFilterValues,
             filterValues,
             requestSignature,
             ...query,
+            displayedFilters: displayedFilterValues,
         },
         {
             changeParams,
@@ -275,7 +277,9 @@ export const getNumberOrDefault = (
             ? parseInt(possibleNumber, 10)
             : possibleNumber;
 
-    return isNaN(parsedNumber) ? defaultValue : parsedNumber;
+    return parsedNumber === undefined || isNaN(parsedNumber)
+        ? defaultValue
+        : parsedNumber;
 };
 
 export interface ReferenceParamsOptions {

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -52,32 +52,6 @@ import { ListControllerResult } from './useListController';
  *     );
  * };
  */
-export const ListContext = createContext<ListControllerResult>({
-    sort: null,
-    data: null,
-    defaultTitle: null,
-    displayedFilters: null,
-    exporter: null,
-    filterValues: null,
-    hasNextPage: null,
-    hasPreviousPage: null,
-    hideFilter: null,
-    isFetching: null,
-    isLoading: null,
-    onSelect: null,
-    onToggleItem: null,
-    onUnselectItems: null,
-    page: null,
-    perPage: null,
-    refetch: null,
-    resource: null,
-    selectedIds: undefined,
-    setFilters: null,
-    setPage: null,
-    setPerPage: null,
-    setSort: null,
-    showFilter: null,
-    total: null,
-});
+export const ListContext = createContext<ListControllerResult>(undefined!);
 
 ListContext.displayName = 'ListContext';

--- a/packages/ra-core/src/controller/list/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/list/ListFilterContext.tsx
@@ -37,14 +37,9 @@ import { ListControllerResult } from './useListController';
  *     );
  * };
  */
-export const ListFilterContext = createContext<ListFilterContextValue>({
-    displayedFilters: null,
-    filterValues: null,
-    hideFilter: null,
-    setFilters: null,
-    showFilter: null,
-    resource: null,
-});
+export const ListFilterContext = createContext<ListFilterContextValue>(
+    undefined!
+);
 
 export type ListFilterContextValue = Pick<
     ListControllerResult,

--- a/packages/ra-core/src/controller/list/ListPaginationContext.tsx
+++ b/packages/ra-core/src/controller/list/ListPaginationContext.tsx
@@ -41,17 +41,9 @@ import { ListControllerResult } from './useListController';
  *     );
  * };
  */
-export const ListPaginationContext = createContext<ListPaginationContextValue>({
-    isLoading: null,
-    page: null,
-    perPage: null,
-    setPage: null,
-    setPerPage: null,
-    hasPreviousPage: null,
-    hasNextPage: null,
-    total: undefined,
-    resource: null,
-});
+export const ListPaginationContext = createContext<ListPaginationContextValue>(
+    undefined!
+);
 
 ListPaginationContext.displayName = 'ListPaginationContext';
 

--- a/packages/ra-core/src/controller/list/ListSortContext.tsx
+++ b/packages/ra-core/src/controller/list/ListSortContext.tsx
@@ -34,11 +34,7 @@ import { ListControllerResult } from './useListController';
  *     );
  * };
  */
-export const ListSortContext = createContext<ListSortContextValue>({
-    sort: null,
-    setSort: null,
-    resource: null,
-});
+export const ListSortContext = createContext<ListSortContextValue>(undefined!);
 
 export type ListSortContextValue = Pick<
     ListControllerResult,

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import { removeEmpty, useSafeSetState } from '../../util';
-import { FilterPayload, Optional, RaRecord, SortPayload } from '../../types';
+import { FilterPayload, RaRecord, SortPayload } from '../../types';
 import { useResourceContext } from '../../core';
 import usePaginationState from '../usePaginationState';
 import useSortState from '../useSortState';
@@ -233,7 +233,7 @@ export const useList = <RecordType extends RaRecord = any>(
 
     return {
         sort,
-        data: finalItems?.data ?? [],
+        data: finalItems?.data,
         defaultTitle: '',
         error,
         displayedFilters,
@@ -259,7 +259,7 @@ export const useList = <RecordType extends RaRecord = any>(
         setPerPage,
         setSort,
         showFilter,
-        total: finalItems?.total ?? 0,
+        total: finalItems?.total,
     };
 };
 
@@ -276,9 +276,8 @@ export interface UseListOptions<RecordType extends RaRecord = any> {
     filterCallback?: (record: RecordType) => boolean;
 }
 
-export type UseListValue<RecordType extends RaRecord = any> = Optional<
-    ListControllerResult<RecordType>,
-    'resource'
->;
+export type UseListValue<
+    RecordType extends RaRecord = any
+> = ListControllerResult<RecordType>;
 
 const defaultFilter = {};

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import { removeEmpty, useSafeSetState } from '../../util';
-import { FilterPayload, RaRecord, SortPayload } from '../../types';
+import { FilterPayload, Optional, RaRecord, SortPayload } from '../../types';
 import { useResourceContext } from '../../core';
 import usePaginationState from '../usePaginationState';
 import useSortState from '../useSortState';
@@ -233,7 +233,7 @@ export const useList = <RecordType extends RaRecord = any>(
 
     return {
         sort,
-        data: finalItems?.data,
+        data: finalItems?.data ?? [],
         defaultTitle: '',
         error,
         displayedFilters,
@@ -259,7 +259,7 @@ export const useList = <RecordType extends RaRecord = any>(
         setPerPage,
         setSort,
         showFilter,
-        total: finalItems?.total,
+        total: finalItems?.total ?? 0,
     };
 };
 
@@ -276,8 +276,9 @@ export interface UseListOptions<RecordType extends RaRecord = any> {
     filterCallback?: (record: RecordType) => boolean;
 }
 
-export type UseListValue<
-    RecordType extends RaRecord = any
-> = ListControllerResult<RecordType>;
+export type UseListValue<RecordType extends RaRecord = any> = Optional<
+    ListControllerResult<RecordType>,
+    'resource'
+>;
 
 const defaultFilter = {};

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -226,7 +226,7 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     page: number;
     perPage: number;
     refetch: (() => void) | UseGetListHookValue<RecordType>['refetch'];
-    resource: string;
+    resource?: string;
     selectedIds: RecordType['id'][];
     setFilters: (
         filters: any,

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -7,7 +7,13 @@ import { useNotify } from '../../notification';
 import { useGetList, UseGetListHookValue } from '../../dataProvider';
 import { SORT_ASC } from './queryReducer';
 import { defaultExporter } from '../../export';
-import { FilterPayload, SortPayload, RaRecord, Exporter } from '../../types';
+import {
+    FilterPayload,
+    SortPayload,
+    RaRecord,
+    Exporter,
+    Optional,
+} from '../../types';
 import { useResourceContext, useGetResourceLabel } from '../../core';
 import { useRecordSelection } from './useRecordSelection';
 import { useListParams } from './useListParams';
@@ -204,7 +210,7 @@ const defaultSort = {
 
 export interface ListControllerResult<RecordType extends RaRecord = any> {
     sort: SortPayload;
-    data: RecordType[];
+    data?: RecordType[];
     defaultTitle?: string;
     displayedFilters: any;
     error?: any;
@@ -231,9 +237,9 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     setPerPage: (page: number) => void;
     setSort: (sort: SortPayload) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
-    total: number;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
+    total?: number;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
 }
 
 export const injectedProps = [

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -7,13 +7,7 @@ import { useNotify } from '../../notification';
 import { useGetList, UseGetListHookValue } from '../../dataProvider';
 import { SORT_ASC } from './queryReducer';
 import { defaultExporter } from '../../export';
-import {
-    FilterPayload,
-    SortPayload,
-    RaRecord,
-    Exporter,
-    Optional,
-} from '../../types';
+import { FilterPayload, SortPayload, RaRecord, Exporter } from '../../types';
 import { useResourceContext, useGetResourceLabel } from '../../core';
 import { useRecordSelection } from './useRecordSelection';
 import { useListParams } from './useListParams';

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -137,22 +137,23 @@ export const useListParams = ({
 
             if (!tempParams.current) {
                 // no other changeParams action dispatched this tick
-                tempParams.current = queryReducer(query, action);
+                const nextLocalParams = queryReducer(query, action);
+                tempParams.current = nextLocalParams;
                 // schedule side effects for next tick
                 setTimeout(() => {
                     if (disableSyncWithLocation) {
-                        setLocalParams(tempParams.current);
+                        setLocalParams(nextLocalParams);
                     } else {
                         // the useEffect above will apply the changes to the params in the store
                         navigate(
                             {
                                 search: `?${stringify({
-                                    ...tempParams.current,
+                                    ...nextLocalParams,
                                     filter: JSON.stringify(
-                                        tempParams.current.filter
+                                        nextLocalParams.filter
                                     ),
                                     displayedFilters: JSON.stringify(
-                                        tempParams.current.displayedFilters
+                                        nextLocalParams.displayedFilters
                                     ),
                                 })}`,
                             },
@@ -245,10 +246,10 @@ export const useListParams = ({
 
     return [
         {
-            displayedFilters: displayedFilterValues,
             filterValues,
             requestSignature,
             ...query,
+            displayedFilters: query.displayedFilters ?? displayedFilterValues,
         },
         {
             changeParams,
@@ -363,7 +364,9 @@ export const getNumberOrDefault = (
             ? parseInt(possibleNumber, 10)
             : possibleNumber;
 
-    return isNaN(parsedNumber) ? defaultValue : parsedNumber;
+    return parsedNumber === undefined || isNaN(parsedNumber)
+        ? defaultValue
+        : parsedNumber;
 };
 
 export interface ListParamsOptions {

--- a/packages/ra-core/src/controller/list/useRecordSelection.ts
+++ b/packages/ra-core/src/controller/list/useRecordSelection.ts
@@ -58,4 +58,4 @@ export const useRecordSelection = (
     return [ids, selectionModifiers];
 };
 
-const defaultSelection = [];
+const defaultSelection: Identifier[] = [];

--- a/packages/ra-core/src/controller/record/RecordContext.tsx
+++ b/packages/ra-core/src/controller/record/RecordContext.tsx
@@ -8,9 +8,9 @@ import { RaRecord } from '../../types';
  * @see RecordContextProvider
  * @see useRecordContext
  */
-export const RecordContext = createContext<RaRecord | Omit<RaRecord, 'id'>>(
-    undefined
-);
+export const RecordContext = createContext<
+    RaRecord | Omit<RaRecord, 'id'> | undefined
+>(undefined);
 
 RecordContext.displayName = 'RecordContext';
 

--- a/packages/ra-core/src/controller/saveContext/SaveContext.ts
+++ b/packages/ra-core/src/controller/saveContext/SaveContext.ts
@@ -28,4 +28,4 @@ export type SaveHandler<RecordType> = (
     }
 ) => Promise<void | RecordType> | Record<string, string>;
 
-export const SaveContext = createContext<SaveContextValue>(undefined);
+export const SaveContext = createContext<SaveContextValue>(undefined!);

--- a/packages/ra-core/src/controller/saveContext/useRegisterMutationMiddleware.ts
+++ b/packages/ra-core/src/controller/saveContext/useRegisterMutationMiddleware.ts
@@ -17,9 +17,9 @@ export const useRegisterMutationMiddleware = <
     } = useSaveContext();
 
     useEffect(() => {
-        registerMutationMiddleware(callback);
+        registerMutationMiddleware?.(callback);
         return () => {
-            unregisterMutationMiddleware(callback);
+            unregisterMutationMiddleware?.(callback);
         };
     }, [callback, registerMutationMiddleware, unregisterMutationMiddleware]);
 };

--- a/packages/ra-core/src/controller/show/ShowContext.tsx
+++ b/packages/ra-core/src/controller/show/ShowContext.tsx
@@ -19,13 +19,6 @@ import { ShowControllerResult } from './useShowController';
  *     );
  * };
  */
-export const ShowContext = createContext<ShowControllerResult>({
-    record: null,
-    defaultTitle: null,
-    isFetching: null,
-    isLoading: null,
-    refetch: null,
-    resource: null,
-});
+export const ShowContext = createContext<ShowControllerResult>(undefined!);
 
 ShowContext.displayName = 'ShowContext';

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -57,7 +57,16 @@ export const useShowController = <RecordType extends RaRecord = any>(
     const redirect = useRedirect();
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
-    const id = propsId != null ? propsId : decodeURIComponent(routeId);
+    const id =
+        propsId != null
+            ? propsId
+            : routeId
+            ? decodeURIComponent(routeId)
+            : null;
+
+    if (id === null) {
+        throw new Error("useShowController: id can't be null");
+    }
     const { meta, ...otherQueryOptions } = queryOptions;
 
     const { data: record, error, isLoading, isFetching, refetch } = useGetOne<

--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -76,7 +76,7 @@ export default ({
             permanentFilterProp.current = permanentFilter;
             setFilterValue({
                 ...permanentFilter,
-                ...filterToQuery(latestValue.current),
+                ...filterToQuery(latestValue.current ?? ''),
             });
         }
     }, [permanentFilterSignature, permanentFilterProp, filterToQuery]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -23,6 +23,7 @@ import {
     DashboardComponent,
     LegacyDataProvider,
 } from '../types';
+import { defaultProvider as defaultAuthProvider } from '../auth/AuthContext';
 
 export interface CoreAdminContextProps {
     authProvider?: AuthProvider | LegacyAuthProvider;
@@ -42,7 +43,7 @@ export interface CoreAdminContextProps {
 
 export const CoreAdminContext = (props: CoreAdminContextProps) => {
     const {
-        authProvider,
+        authProvider = defaultAuthProvider,
         basename,
         dataProvider,
         i18nProvider,

--- a/packages/ra-core/src/core/CoreAdminRoutes.tsx
+++ b/packages/ra-core/src/core/CoreAdminRoutes.tsx
@@ -51,7 +51,7 @@ export const CoreAdminRoutes = (props: CoreAdminRoutesProps) => {
     }, [checkAuth, requireAuth]);
 
     if (status === 'empty') {
-        return <Ready />;
+        return Ready ? <Ready /> : null;
     }
 
     if (status === 'loading' || !canRender) {

--- a/packages/ra-core/src/core/ResourceContext.ts
+++ b/packages/ra-core/src/core/ResourceContext.ts
@@ -17,6 +17,6 @@ import { createContext } from 'react';
  *     );
  * };
  */
-export const ResourceContext = createContext<ResourceContextValue>(undefined);
+export const ResourceContext = createContext<ResourceContextValue>(undefined!);
 
 export type ResourceContextValue = string;

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -293,9 +293,9 @@ const getSingleChildFunction = (
 const getRoutesAndResourceFromNodes = (
     children: ReactNode
 ): RoutesAndResources => {
-    const customRoutesWithLayout = [];
-    const customRoutesWithoutLayout = [];
-    const resources = [];
+    const customRoutesWithLayout: CustomRouteWithLayout[] = [];
+    const customRoutesWithoutLayout: CustomRouteWithoutLayout[] = [];
+    const resources: Resource[] = [];
     Children.forEach(children, element => {
         if (!React.isValidElement(element)) {
             // Ignore non-elements. This allows people to more easily inline
@@ -322,13 +322,16 @@ const getRoutesAndResourceFromNodes = (
 
             if (customRoutesElement.props.noLayout) {
                 customRoutesWithoutLayout.push(
-                    customRoutesElement.props.children
+                    customRoutesElement.props
+                        .children as CustomRouteWithoutLayout
                 );
             } else {
-                customRoutesWithLayout.push(customRoutesElement.props.children);
+                customRoutesWithLayout.push(
+                    customRoutesElement.props.children as CustomRouteWithLayout
+                );
             }
         } else if ((element.type as any).raName === 'Resource') {
-            resources.push(element as ReactElement<ResourceProps>);
+            resources.push(element as Resource);
         }
     });
 
@@ -339,10 +342,14 @@ const getRoutesAndResourceFromNodes = (
     };
 };
 
+type CustomRouteWithLayout = ReactElement<CustomRoutesProps>;
+type CustomRouteWithoutLayout = ReactElement<CustomRoutesProps>;
+type Resource = ReactElement<ResourceProps> & ResourceWithRegisterFunction;
+
 type RoutesAndResources = {
-    customRoutesWithLayout: ReactElement<CustomRoutesProps>[];
-    customRoutesWithoutLayout: ReactElement<CustomRoutesProps>[];
-    resources: (ReactElement<ResourceProps> & ResourceWithRegisterFunction)[];
+    customRoutesWithLayout: CustomRouteWithLayout[];
+    customRoutesWithoutLayout: CustomRouteWithoutLayout[];
+    resources: Resource[];
 };
 
 type ResourceWithRegisterFunction = {

--- a/packages/ra-core/src/dataProvider/DataProviderContext.ts
+++ b/packages/ra-core/src/dataProvider/DataProviderContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 
 import { DataProvider } from '../types';
 
-const DataProviderContext = createContext<DataProvider>(null);
+const DataProviderContext = createContext<DataProvider>(undefined!);
 
 DataProviderContext.displayName = 'DataProviderContext';
 

--- a/packages/ra-core/src/dataProvider/HttpError.ts
+++ b/packages/ra-core/src/dataProvider/HttpError.ts
@@ -2,7 +2,7 @@ class HttpError extends Error {
     constructor(
         public readonly message,
         public readonly status,
-        public readonly body = null
+        public readonly body: any = null
     ) {
         super(message);
         Object.setPrototypeOf(this, HttpError.prototype);

--- a/packages/ra-core/src/dataProvider/combineDataProviders.ts
+++ b/packages/ra-core/src/dataProvider/combineDataProviders.ts
@@ -24,7 +24,7 @@ export type DataProviderMatcher = (resource: string) => DataProvider;
 export const combineDataProviders = (
     dataProviderMatcher: DataProviderMatcher
 ): DataProvider =>
-    new Proxy(defaultDataProvider, {
+    new Proxy(defaultDataProvider as DataProvider, {
         get: (target, name) => {
             return (resource, params) => {
                 if (typeof name === 'symbol' || name === 'then') {

--- a/packages/ra-core/src/dataProvider/convertLegacyDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/convertLegacyDataProvider.ts
@@ -65,7 +65,7 @@ const convertLegacyDataProvider = (
         },
     });
 
-    return proxy;
+    return (proxy as unknown) as ConvertedDataProvider;
 };
 
 export default convertLegacyDataProvider;

--- a/packages/ra-core/src/dataProvider/fetch.ts
+++ b/packages/ra-core/src/dataProvider/fetch.ts
@@ -75,7 +75,7 @@ const isValidObject = value => {
     return !isArray && !isBuffer && isObject && hasKeys;
 };
 
-export const flattenObject = (value, path = []) => {
+export const flattenObject = (value, path: string[] = []) => {
     if (isValidObject(value)) {
         return Object.assign(
             {},

--- a/packages/ra-core/src/dataProvider/testDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/testDataProvider.ts
@@ -3,9 +3,7 @@ import { DataProvider } from '../types';
 /**
  * A dataProvider meant to be used in tests only. You can override any of its methods by passing a partial dataProvider.
  */
-export const testDataProvider = (
-    overrides?: Partial<DataProvider>
-): DataProvider => {
+export const testDataProvider = (overrides?: Partial<DataProvider>) => {
     return {
         getList: () => Promise.resolve({ data: [], total: 0 }),
         getOne: () => Promise.resolve({ data: undefined }),

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -91,7 +91,7 @@ export const useCreate = <
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .create<RecordType>(callTimeResource, {
+                .create<RecordType>(callTimeResource as string, {
                     data: callTimeData,
                     meta: callTimeMeta,
                 })
@@ -117,8 +117,8 @@ export const useCreate = <
         }
     );
 
-    const create = (
-        callTimeResource: string = resource,
+    const create = async (
+        callTimeResource: string | undefined = resource,
         callTimeParams: Partial<CreateParams<RecordType>> = {},
         createOptions: MutateOptions<
             RecordType,

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -15,6 +15,7 @@ import {
     DeleteParams,
     MutationMode,
     GetListResult as OriginalGetListResult,
+    Identifier,
 } from '../types';
 
 /**
@@ -96,7 +97,6 @@ export const useDelete = <
         const updatedAt = mode.current === 'undoable' ? now + 5 * 1000 : now;
 
         const updateColl = (old: RecordType[]) => {
-            if (!old) return;
             const index = old.findIndex(
                 // eslint-disable-next-line eqeqeq
                 record => record.id == id
@@ -136,7 +136,7 @@ export const useDelete = <
         queryClient.setQueriesData(
             [resource, 'getManyReference'],
             (res: GetListResult) => {
-                if (!res || !res.data) return res;
+                if (!res || !res.data || !res.total) return res;
                 const newCollection = updateColl(res.data);
                 const recordWasFound = newCollection.length < res.data.length;
                 return recordWasFound
@@ -162,8 +162,8 @@ export const useDelete = <
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .delete<RecordType>(callTimeResource, {
-                    id: callTimeId,
+                .delete<RecordType>(callTimeResource as string, {
+                    id: callTimeId as Identifier,
                     previousData: callTimePreviousData,
                     meta: callTimeMeta,
                 })
@@ -265,7 +265,7 @@ export const useDelete = <
     );
 
     const mutate = async (
-        callTimeResource: string = resource,
+        callTimeResource: string | undefined = resource,
         callTimeParams: Partial<DeleteParams<RecordType>> = {},
         updateOptions: MutateOptions<
             RecordType,
@@ -341,7 +341,7 @@ export const useDelete = <
             setTimeout(
                 () =>
                     onSuccess(
-                        callTimePreviousData,
+                        callTimePreviousData as RecordType,
                         { resource: callTimeResource, ...callTimeParams },
                         { snapshot: snapshot.current }
                     ),
@@ -351,8 +351,8 @@ export const useDelete = <
         if (reactMutationOptions.onSuccess) {
             setTimeout(
                 () =>
-                    reactMutationOptions.onSuccess(
-                        callTimePreviousData,
+                    reactMutationOptions.onSuccess?.(
+                        callTimePreviousData as RecordType,
                         { resource: callTimeResource, ...callTimeParams },
                         { snapshot: snapshot.current }
                     ),

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -101,7 +101,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
         }
     );
 
-    return (result.data
+    return (!result.isLoading
         ? {
               ...result,
               data: result.data?.data,

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
@@ -117,7 +117,8 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
             ...options,
             getNextPageParam: lastLoadedPage => {
                 if (lastLoadedPage.pageInfo) {
-                    return lastLoadedPage.pageInfo.hasNextPage
+                    return lastLoadedPage.pageInfo.hasNextPage &&
+                        lastLoadedPage.pageParam
                         ? lastLoadedPage.pageParam + 1
                         : undefined;
                 }
@@ -125,18 +126,21 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
                     (lastLoadedPage.total || 0) / pagination.perPage
                 );
 
-                return lastLoadedPage.pageParam < totalPages
+                return lastLoadedPage.pageParam &&
+                    lastLoadedPage.pageParam < totalPages
                     ? Number(lastLoadedPage.pageParam) + 1
                     : undefined;
             },
             getPreviousPageParam: lastLoadedPage => {
                 if (lastLoadedPage.pageInfo) {
-                    return lastLoadedPage.pageInfo.hasPreviousPage
+                    return lastLoadedPage.pageInfo.hasPreviousPage &&
+                        lastLoadedPage.pageParam
                         ? lastLoadedPage.pageParam - 1
                         : undefined;
                 }
 
-                return lastLoadedPage.pageParam === 1
+                return lastLoadedPage.pageParam === 1 ||
+                    lastLoadedPage.pageParam === undefined
                     ? undefined
                     : lastLoadedPage.pageParam - 1;
             },

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -15,6 +15,7 @@ import {
     UpdateParams,
     MutationMode,
     GetListResult as OriginalGetListResult,
+    Identifier,
 } from '../types';
 
 /**
@@ -159,9 +160,9 @@ export const useUpdate = <
             previousData: callTimePreviousData = paramsRef.current.previousData,
         } = {}) =>
             dataProvider
-                .update<RecordType>(callTimeResource, {
-                    id: callTimeId,
-                    data: callTimeData,
+                .update<RecordType>(callTimeResource as string, {
+                    id: callTimeId as Identifier,
+                    data: callTimeData as Partial<RecordType>,
                     previousData: callTimePreviousData,
                     meta: callTimeMeta,
                 })
@@ -264,7 +265,7 @@ export const useUpdate = <
     );
 
     const update = async (
-        callTimeResource: string = resource,
+        callTimeResource: string | undefined = resource,
         callTimeParams: Partial<UpdateParams<RecordType>> = {},
         updateOptions: MutateOptions<
             RecordType,
@@ -372,7 +373,7 @@ export const useUpdate = <
             setTimeout(
                 () =>
                     onSuccess(
-                        { ...previousRecord, ...callTimeData },
+                        { ...previousRecord, ...callTimeData } as any,
                         { resource: callTimeResource, ...callTimeParams },
                         { snapshot: snapshot.current }
                     ),
@@ -382,8 +383,8 @@ export const useUpdate = <
         if (reactMutationOptions.onSuccess) {
             setTimeout(
                 () =>
-                    reactMutationOptions.onSuccess(
-                        { ...previousRecord, ...callTimeData },
+                    reactMutationOptions.onSuccess?.(
+                        { ...previousRecord, ...callTimeData } as any,
                         { resource: callTimeResource, ...callTimeParams },
                         { snapshot: snapshot.current }
                     ),

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -168,12 +168,12 @@ export const useUpdateMany = <
             meta: callTimeMeta = paramsRef.current.meta,
         } = {}) =>
             dataProvider
-                .updateMany(callTimeResource, {
-                    ids: callTimeIds,
+                .updateMany(callTimeResource as string, {
+                    ids: callTimeIds as Identifier[],
                     data: callTimeData,
                     meta: callTimeMeta,
                 })
-                .then(({ data }) => data),
+                .then(({ data }) => data as any[]),
         {
             ...reactMutationOptions,
             onMutate: async (
@@ -230,8 +230,8 @@ export const useUpdateMany = <
                         meta: callTimeMeta = meta,
                     } = variables;
                     updateCache({
-                        resource: callTimeResource,
-                        ids: callTimeIds,
+                        resource: callTimeResource as string,
+                        ids: callTimeIds as Identifier[],
                         data: callTimeData,
                         meta: callTimeMeta,
                     });
@@ -275,7 +275,7 @@ export const useUpdateMany = <
     );
 
     const updateMany = async (
-        callTimeResource: string = resource,
+        callTimeResource: string | undefined = resource,
         callTimeParams: Partial<UpdateManyParams<RecordType>> = {},
         updateOptions: MutateOptions<
             Array<RecordType['id']>,
@@ -363,8 +363,8 @@ export const useUpdateMany = <
 
         // Optimistically update to the new data
         await updateCache({
-            resource: callTimeResource,
-            ids: callTimeIds,
+            resource: callTimeResource as string,
+            ids: callTimeIds as Identifier[],
             data: callTimeData,
             meta: callTimeMeta,
         });
@@ -374,7 +374,7 @@ export const useUpdateMany = <
             setTimeout(
                 () =>
                     onSuccess(
-                        callTimeIds,
+                        callTimeIds as Identifier[],
                         { resource: callTimeResource, ...callTimeParams },
                         { snapshot: snapshot.current }
                     ),
@@ -384,8 +384,8 @@ export const useUpdateMany = <
         if (reactMutationOptions.onSuccess) {
             setTimeout(
                 () =>
-                    reactMutationOptions.onSuccess(
-                        callTimeIds,
+                    reactMutationOptions.onSuccess?.(
+                        callTimeIds as Identifier[],
                         { resource: callTimeResource, ...callTimeParams },
                         { snapshot: snapshot.current }
                     ),

--- a/packages/ra-core/src/form/FormGroupContext.ts
+++ b/packages/ra-core/src/form/FormGroupContext.ts
@@ -7,6 +7,8 @@ import { createContext } from 'react';
  *
  * This should only be used through a FormGroupContextProvider.
  */
-export const FormGroupContext = createContext<FormGroupContextValue>(undefined);
+export const FormGroupContext = createContext<FormGroupContextValue>(
+    undefined!
+);
 
 export type FormGroupContextValue = string;

--- a/packages/ra-core/src/form/choices/ChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/ChoicesContext.ts
@@ -12,22 +12,22 @@ export const ChoicesContext = createContext<ChoicesContextValue | undefined>(
 );
 
 export type ChoicesContextValue<RecordType extends RaRecord = any> = {
-    allChoices: RecordType[];
-    availableChoices: RecordType[];
+    allChoices?: RecordType[];
+    availableChoices?: RecordType[];
     displayedFilters: any;
     error?: any;
     filter?: FilterPayload;
     filterValues: any;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
     hideFilter: (filterName: string) => void;
     isFetching: boolean;
     isLoading: boolean;
     page: number;
     perPage: number;
     refetch: (() => void) | UseGetListHookValue<RecordType>['refetch'];
-    resource: string;
-    selectedChoices: RecordType[];
+    resource?: string;
+    selectedChoices?: RecordType[];
     setFilters: (
         filters: any,
         displayedFilters: any,
@@ -38,7 +38,7 @@ export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     setSort: (sort: SortPayload) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
     sort: SortPayload;
-    source: string;
-    total: number;
+    source?: string;
+    total?: number;
     isFromReference: boolean;
 };

--- a/packages/ra-core/src/form/useFormGroup.ts
+++ b/packages/ra-core/src/form/useFormGroup.ts
@@ -73,6 +73,7 @@ export const useFormGroup = (name: string): FormGroupState => {
     });
 
     const updateGroupState = useCallback(() => {
+        if (!formGroups) return;
         const fields = formGroups.getGroupFields(name);
         const fieldStates = fields
             .map<FieldState>(field => {
@@ -109,6 +110,7 @@ export const useFormGroup = (name: string): FormGroupState => {
     );
 
     useEffect(() => {
+        if (!formGroups) return;
         // Whenever the group content changes (input are added or removed)
         // we must update its state
         return formGroups.subscribe(name, () => {

--- a/packages/ra-core/src/i18n/I18nContextProvider.tsx
+++ b/packages/ra-core/src/i18n/I18nContextProvider.tsx
@@ -55,7 +55,7 @@ export const I18nContextProvider = ({
 };
 
 export interface I18nContextProviderProps {
-    value: I18nProvider;
+    value?: I18nProvider;
     children: ReactNode;
 }
 

--- a/packages/ra-core/src/routing/useRedirect.ts
+++ b/packages/ra-core/src/routing/useRedirect.ts
@@ -39,7 +39,7 @@ export const useRedirect = () => {
 
     return useCallback(
         (
-            redirectTo: RedirectionSideEffect,
+            redirectTo?: RedirectionSideEffect,
             resource: string = '',
             id?: Identifier,
             data?: Partial<RaRecord>,

--- a/packages/ra-core/src/store/StoreContext.tsx
+++ b/packages/ra-core/src/store/StoreContext.tsx
@@ -3,6 +3,6 @@ import { createContext } from 'react';
 import { Store } from './types';
 import { memoryStore } from './memoryStore';
 
-const defaultStore = memoryStore();
+export const defaultStore = memoryStore();
 
 export const StoreContext = createContext<Store>(defaultStore);

--- a/packages/ra-core/src/store/StoreContextProvider.tsx
+++ b/packages/ra-core/src/store/StoreContextProvider.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { useEffect } from 'react';
-import { StoreContext } from './StoreContext';
+import { StoreContext, defaultStore } from './StoreContext';
 import { Store } from './types';
 
 export const StoreContextProvider = ({
-    value: Store,
+    value: Store = defaultStore,
     children,
 }: StoreContextProviderProps) => {
     useEffect(() => {
@@ -20,6 +20,6 @@ export const StoreContextProvider = ({
 };
 
 export interface StoreContextProviderProps {
-    value: Store;
+    value?: Store;
     children: React.ReactNode;
 }

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -364,3 +364,5 @@ export type SetOnSave = (
 export type FormFunctions = {
     setOnSave?: SetOnSave;
 };
+
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -364,5 +364,3 @@ export type SetOnSave = (
 export type FormFunctions = {
     setOnSave?: SetOnSave;
 };
-
-export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/packages/ra-core/src/util/hooks.ts
+++ b/packages/ra-core/src/util/hooks.ts
@@ -5,8 +5,8 @@ import isEqual from 'lodash/isEqual';
 // thanks Kent C Dodds for the following helpers
 
 export function useSafeSetState<T>(
-    initialState?: T | (() => T)
-): [T | undefined, React.Dispatch<React.SetStateAction<T>>] {
+    initialState: T | (() => T)
+): [T, React.Dispatch<React.SetStateAction<T>>] {
     const [state, setState] = useState(initialState);
 
     const mountedRef = useRef(false);

--- a/packages/ra-core/tsconfig.json
+++ b/packages/ra-core/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": [
         "**/*.spec.ts",

--- a/packages/ra-ui-materialui/tsconfig.json
+++ b/packages/ra-ui-materialui/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src",
+        "rootDir": "src"
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js", "**/*.stories.tsx"],
     "include": ["src"]


### PR DESCRIPTION
This PR enables `strictNullChecks` mode in `ra-core`, which is required by many useful TypeScript packages (e.g. https://github.com/colinhacks/zod or https://trpc.io/)

The current implementation is just bare minimum to make it compile, and has a handful of ugly type casts. I submitted it to open a a discussion on the best approach to resolve issues - there are a few alternatives.

I added some comments which explain the issues and lists possible solutions.