### PR TITLE
feat: add prevent validateResponseFormat() from validating custom routes

### DIFF
--- a/packages/ra-core/src/dataProvider/dataFetchActions.ts
+++ b/packages/ra-core/src/dataProvider/dataFetchActions.ts
@@ -21,6 +21,11 @@ export const fetchActionsWithArrayOfRecordsResponse = [
 ];
 export const fetchActionsWithTotalResponse = ['getList', 'getManyReference'];
 
+export const fetchActions = [
+    ...fetchActionsWithRecordResponse,
+    ...fetchActionsWithArrayOfRecordsResponse,
+];
+
 export const sanitizeFetchType = (fetchType: string) => {
     switch (fetchType) {
         case GET_LIST:

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -5,6 +5,7 @@ import { defaultDataProvider } from './defaultDataProvider';
 import validateResponseFormat from './validateResponseFormat';
 import { DataProvider } from '../types';
 import useLogoutIfAccessDenied from '../auth/useLogoutIfAccessDenied';
+import { fetchActions } from './dataFetchActions';
 
 /**
  * Hook for getting a dataProvider
@@ -98,7 +99,10 @@ export const useDataProvider = <
                         return dataProvider[type]
                             .apply(dataProvider, args)
                             .then(response => {
-                                if (process.env.NODE_ENV !== 'production') {
+                                if (
+                                    process.env.NODE_ENV !== 'production' &&
+                                    fetchActions.includes(type)
+                                ) {
                                     validateResponseFormat(response, type);
                                 }
                                 return response;


### PR DESCRIPTION
This pr makes an adjustment so that validateResponseFormat() is not used in dataProvider custom routes

- Code ✔️ 
- Test ❌ 
- Documentation ❌ 

---
Closes #8083


Obs: I need to understand what is needed to document and test