### PR TITLE
Add missing props in docs layout examples

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -280,7 +280,7 @@ const MyUserMenu = () => <UserMenu><MyLogoutButton /></UserMenu>;
 
 const MyAppBar = () => <AppBar userMenu={<MyUserMenu />} />;
 
-const MyLayout = () => <Layout appBar={MyAppBar} />;
+const MyLayout = (props) => <Layout {...props} appBar={MyAppBar} />;
 
 const App = () => (
     <Admin layout={MyLayout}>

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -970,7 +970,7 @@ const MyUserMenu = () => <UserMenu><MyLogoutButton /></UserMenu>;
 
 const MyAppBar = () => <AppBar userMenu={<MyUserMenu />} />;
 
-const MyLayout = () => <Layout appBar={MyAppBar} />;
+const MyLayout = (props) => <Layout {...props} appBar={MyAppBar} />;
 
 const App = () => (
     <Admin layout={MyLayout}>

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -2924,7 +2924,7 @@ const MyCustomLogout = () => <Logout className="my-class-name" />;
 
 + const MyAppBar = () => <AppBar userMenu={<MyUserMenu />} />;
 
-+ const MyLayout = () => <Layout appBar={MyAppBar} />;
++ const MyLayout = (props) => <Layout {...props} appBar={MyAppBar} />;
 
 const MyAdmin = () => (
     <Admin

--- a/docs/useLogout.md
+++ b/docs/useLogout.md
@@ -38,8 +38,8 @@ const MyAppBar = () => (
     <AppBar userMenu={<UserMenu />} />
 );
 
-const MyLayout = () => (
-    <Layout appBar={MyAppBar} />
+const MyLayout = (props) => (
+    <Layout {...props} appBar={MyAppBar} />
 );
 
 export default MyLayout;


### PR DESCRIPTION
Brings the examples in sync with the rest, e.g. https://marmelab.com/react-admin/Layout.html#appbar
This also seems to be needed to avoid rendering errors about components not rendering anything / missing returns