### PR TITLE
adjusted documentation for the `linkType` property found in `SimpleList` and `SingleFieldList` 

### DIFF
--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -75,9 +75,9 @@ export const PostList = () => (
 
 `linkType` accepts the following options:
 
-* `linkType="edit"`: links to the Edit page. This is the default behavior.
+* `linkType="edit"`: links to the edit page. This is the default behavior.
 * `linkType="show"`: links to the show page.
-* `linkType={false}`: disables clicking the item.
+* `linkType={false}`: removes the link.
 
 
 

--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -72,7 +72,14 @@ export const PostList = () => (
 );
 ```
 
-Setting the `linkType` prop to `false` (boolean, not string) removes the link in all list items.
+
+`linkType` accepts the following options:
+
+* `linkType="edit"`: links to the Edit page. This is the default behavior.
+* `linkType="show"`: links to the show page.
+* `linkType={false}`: disables clicking the item.
+
+
 
 ## `primaryText`
 

--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -73,7 +73,7 @@ export const PostList = () => (
 ```
 
 
-`linkType` accepts the following options:
+`linkType` accepts the following values:
 
 * `linkType="edit"`: links to the edit page. This is the default behavior.
 * `linkType="show"`: links to the show page.

--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -77,7 +77,7 @@ export const PostList = () => (
 
 * `linkType="edit"`: links to the edit page. This is the default behavior.
 * `linkType="show"`: links to the show page.
-* `linkType={false}`: removes the link.
+* `linkType={false}`: does not create any link.
 
 
 

--- a/docs/SingleFieldList.md
+++ b/docs/SingleFieldList.md
@@ -83,7 +83,7 @@ The `<SingleFieldList>` items link to the edition page by default. You can set t
 
 * `linkType="edit"`: links to the edit page. This is the default behavior.
 * `linkType="show"`: links to the show page.
-* `linkType={false}`: removes the link.
+* `linkType={false}`: does not create any link.
 
 
 ## `sx`: CSS API

--- a/docs/SingleFieldList.md
+++ b/docs/SingleFieldList.md
@@ -79,7 +79,7 @@ The `<SingleFieldList>` items link to the edition page by default. You can set t
 ```
 
 
-`linkType` accepts the following options:
+`linkType` accepts the following values:
 
 * `linkType="edit"`: links to the edit page. This is the default behavior.
 * `linkType="show"`: links to the show page.

--- a/docs/SingleFieldList.md
+++ b/docs/SingleFieldList.md
@@ -81,9 +81,9 @@ The `<SingleFieldList>` items link to the edition page by default. You can set t
 
 `linkType` accepts the following options:
 
-* `linkType="edit"`: reference links to the Edit page. This is the default behavior.
-* `linkType="show"`: reference links to the show page.
-* `linkType={false}`: reference has no link, and disables the item from being clickable.
+* `linkType="edit"`: links to the edit page. This is the default behavior.
+* `linkType="show"`: links to the show page.
+* `linkType={false}`: removes the link.
 
 
 ## `sx`: CSS API

--- a/docs/SingleFieldList.md
+++ b/docs/SingleFieldList.md
@@ -78,6 +78,14 @@ The `<SingleFieldList>` items link to the edition page by default. You can set t
 </ReferenceArrayField>
 ```
 
+
+`linkType` accepts the following options:
+
+* `linkType="edit"`: reference links to the Edit page. This is the default behavior.
+* `linkType="show"`: reference links to the show page.
+* `linkType={false}`: reference has no link, and disables the item from being clickable.
+
+
 ## `sx`: CSS API
 
 The `<SingleFieldList>` component accepts the usual `className` prop. You can also override the styles of the inner components thanks to the `sx` property. This property accepts the following subclasses:


### PR DESCRIPTION
There used to be documentation on the possible options with `linkType`, but this is from an [old PR](https://github.com/marmelab/react-admin/pull/490) and that part of the documentation changed with time since it's no longer a property in `ReferenceField`.

I have added documentation for the following options for `linkType`:
* `"show"`
* `"edit"`
* `false`

Though I did not add documentation for the empty string option `""`, because it has inconsistent behavior with `false` when used in `SimpleList`:
* `""` would not route to other pages, but the buttons will **still** be clickable.
* `false` would not route to other pages, and the buttons will **not** be clickable.