### PR TITLE
[ra-core] use react-query useQuery for permissions fetching

### DIFF
--- a/packages/ra-core/src/auth/usePermissions.spec.tsx
+++ b/packages/ra-core/src/auth/usePermissions.spec.tsx
@@ -6,10 +6,10 @@ import { CoreAdminContext } from '../core/CoreAdminContext';
 import usePermissions from './usePermissions';
 
 const UsePermissions = ({ children }: any) => {
-    const authParams = {
+    const permissionQueryParams = {
         retry: false,
     };
-    const res = usePermissions({}, authParams);
+    const res = usePermissions({}, permissionQueryParams);
     return children(res);
 };
 

--- a/packages/ra-core/src/auth/usePermissions.spec.tsx
+++ b/packages/ra-core/src/auth/usePermissions.spec.tsx
@@ -9,7 +9,7 @@ const UsePermissions = ({ children }: any) => {
     const authParams = {
         retry: false,
     };
-    const res = usePermissions(authParams);
+    const res = usePermissions({}, authParams);
     return children(res);
 };
 

--- a/packages/ra-core/src/auth/usePermissions.spec.tsx
+++ b/packages/ra-core/src/auth/usePermissions.spec.tsx
@@ -5,7 +5,10 @@ import { CoreAdminContext } from '../core/CoreAdminContext';
 
 import usePermissions from './usePermissions';
 
-const UsePermissions = ({ children, authParams }: any) => {
+const UsePermissions = ({ children }: any) => {
+    const authParams = {
+        retry: false,
+    };
     const res = usePermissions(authParams);
     return children(res);
 };

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import useGetPermissions from './useGetPermissions';
 import { useQuery, UseQueryOptions } from 'react-query';
+import { reactAdminFetchActions } from '../dataProvider';
 
 const emptyParams = {};
 /**
@@ -40,17 +42,19 @@ const usePermissions = <Permissions = any, Error = any>(
 ) => {
     const getPermissions = useGetPermissions();
 
-    const { data, isLoading, error } = useQuery(
+    const result = useQuery(
         ['auth', 'getPermissions', params],
         () => getPermissions(params),
         queryParams
     );
 
-    return {
-        permissions: data,
-        isLoading,
-        error,
-    };
+    return useMemo(() => {
+        return {
+            permissions: result.data,
+            isLoading: result.isLoading,
+            error: result.error,
+        };
+    }, [result]);
 };
 
 export default usePermissions;

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import useGetPermissions from './useGetPermissions';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { reactAdminFetchActions } from '../dataProvider';
+import useAuthProvider from './useAuthProvider';
 
 const emptyParams = {};
 /**
@@ -40,11 +41,13 @@ const usePermissions = <Permissions = any, Error = any>(
         refetchOnMount: false,
     }
 ) => {
-    const getPermissions = useGetPermissions();
+    const authProvider = useAuthProvider();
 
     const result = useQuery(
         ['auth', 'getPermissions', params],
-        () => getPermissions(params),
+        authProvider
+            ? () => authProvider.getPermissions(params)
+            : async () => [],
         queryParams
     );
 

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -1,6 +1,7 @@
 import useGetPermissions from './useGetPermissions';
 import { useQuery, UseQueryOptions } from 'react-query';
 
+const emptyParams = {};
 /**
  * Hook for getting user permissions
  *
@@ -32,16 +33,17 @@ import { useQuery, UseQueryOptions } from 'react-query';
  *     };
  */
 const usePermissions = <Permissions = any, Error = any>(
-    params: UseQueryOptions<Permissions, Error> = {
+    params = emptyParams,
+    useQueryParams: UseQueryOptions<Permissions, Error> = {
         refetchOnMount: false,
     }
 ) => {
     const getPermissions = useGetPermissions();
 
     const { data, isLoading, error } = useQuery(
-        ['ra-Permissions'],
-        getPermissions,
-        params
+        ['auth', 'getPermissions', params],
+        () => getPermissions(params),
+        useQueryParams
     );
 
     return {

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
-import useGetPermissions from './useGetPermissions';
 import { useQuery, UseQueryOptions } from 'react-query';
-import { reactAdminFetchActions } from '../dataProvider';
 import useAuthProvider from './useAuthProvider';
 
 const emptyParams = {};

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -36,7 +36,7 @@ const emptyParams = {};
 const usePermissions = <Permissions = any, Error = any>(
     params = emptyParams,
     queryParams: UseQueryOptions<Permissions, Error> = {
-        refetchOnMount: false,
+        staleTime: 5 * 60 * 1000,
     }
 ) => {
     const authProvider = useAuthProvider();

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -1,20 +1,11 @@
-import { useEffect } from 'react';
-
 import useGetPermissions from './useGetPermissions';
-import { useSafeSetState } from '../util/hooks';
-
-interface State<Permissions, Error> {
-    isLoading: boolean;
-    permissions?: Permissions;
-    error?: Error;
-}
-
-const emptyParams = {};
+import { useQuery, UseQueryOptions } from 'react-query';
+import useAuthState from './useAuthState';
 
 /**
  * Hook for getting user permissions
  *
- * Calls the authProvider.getPermissions() method asynchronously.
+ * Calls the authProvider.getPermissions() method using react-query.
  * If the authProvider returns a rejected promise, returns empty permissions.
  *
  * The return value updates according to the request state:
@@ -42,25 +33,23 @@ const emptyParams = {};
  *     };
  */
 const usePermissions = <Permissions = any, Error = any>(
-    params = emptyParams
-): State<Permissions, Error> => {
-    const [state, setState] = useSafeSetState<State<Permissions, Error>>({
-        isLoading: true,
-    });
+    params: UseQueryOptions<Permissions[], Error> = {
+        refetchOnMount: false,
+        initialData: [],
+    }
+) => {
     const getPermissions = useGetPermissions();
-    useEffect(() => {
-        getPermissions(params)
-            .then(permissions => {
-                setState({ isLoading: false, permissions });
-            })
-            .catch(error => {
-                setState({
-                    isLoading: false,
-                    error,
-                });
-            });
-    }, [getPermissions, params, setState]);
-    return state;
+
+    const { data: permissions, isLoading } = useQuery(
+        'ra-Permissions',
+        getPermissions,
+        params
+    );
+
+    return {
+        permissions,
+        isLoading,
+    };
 };
 
 export default usePermissions;

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -34,7 +34,7 @@ const emptyParams = {};
  */
 const usePermissions = <Permissions = any, Error = any>(
     params = emptyParams,
-    useQueryParams: UseQueryOptions<Permissions, Error> = {
+    queryParams: UseQueryOptions<Permissions, Error> = {
         refetchOnMount: false,
     }
 ) => {
@@ -43,7 +43,7 @@ const usePermissions = <Permissions = any, Error = any>(
     const { data, isLoading, error } = useQuery(
         ['auth', 'getPermissions', params],
         () => getPermissions(params),
-        useQueryParams
+        queryParams
     );
 
     return {

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -1,6 +1,5 @@
 import useGetPermissions from './useGetPermissions';
 import { useQuery, UseQueryOptions } from 'react-query';
-import useAuthState from './useAuthState';
 
 /**
  * Hook for getting user permissions
@@ -33,22 +32,22 @@ import useAuthState from './useAuthState';
  *     };
  */
 const usePermissions = <Permissions = any, Error = any>(
-    params: UseQueryOptions<Permissions[], Error> = {
+    params: UseQueryOptions<Permissions, Error> = {
         refetchOnMount: false,
-        initialData: [],
     }
 ) => {
     const getPermissions = useGetPermissions();
 
-    const { data: permissions, isLoading } = useQuery(
-        'ra-Permissions',
+    const { data, isLoading, error } = useQuery(
+        ['ra-Permissions'],
         getPermissions,
         params
     );
 
     return {
-        permissions,
+        permissions: data,
         isLoading,
+        error,
     };
 };
 


### PR DESCRIPTION
I wanted to hook up the builtin permission system from react-admin and I experienced a ton of queries: one per permission check.
the docs have a hidden (pro/paid flagged) hint on how to solve this:
https://marmelab.com/react-admin/AuthRBAC.html#performance

since we are using react-query already all-over why don't we use it for the permission-fetching?
This adds a lot of sane defaults: re-fetch on window focus, cache invalidation on logout, retries with back-off, ...

I think the same could be applied to `useCheckAuth`, `useGetIdentity`,... but I'd like to hear your comments first.