### PR TITLE
Add CSSBaseline to the default layout for better UI

### DIFF
--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { memo } from 'react';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { AppBar, Layout, InspectorButton } from 'react-admin';
-import { CssBaseline, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 const MyAppBar = memo(props => (
     <AppBar {...props}>
@@ -13,7 +13,6 @@ const MyAppBar = memo(props => (
 
 export default props => (
     <>
-        <CssBaseline />
         <Layout {...props} appBar={MyAppBar} />
         <ReactQueryDevtools
             initialIsOpen={false}

--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import clsx from 'clsx';
+import { ScopedCssBaseline } from '@mui/material';
 import { styled, SxProps } from '@mui/material/styles';
 import { CoreLayoutProps } from 'ra-core';
 
@@ -39,34 +40,42 @@ export const Layout = (props: LayoutProps) => {
     };
 
     return (
-        <StyledLayout className={clsx('layout', className)} {...rest}>
-            <SkipNavigationButton />
-            <div className={LayoutClasses.appFrame}>
-                <AppBar open={open} title={title} />
-                <main className={LayoutClasses.contentWithSidebar}>
-                    <Sidebar>
-                        <Menu hasDashboard={!!dashboard} />
-                    </Sidebar>
-                    <div id="main-content" className={LayoutClasses.content}>
-                        <ErrorBoundary
-                            onError={handleError}
-                            fallbackRender={({ error, resetErrorBoundary }) => (
-                                <Error
-                                    error={error}
-                                    errorComponent={errorComponent}
-                                    errorInfo={errorInfo}
-                                    resetErrorBoundary={resetErrorBoundary}
-                                    title={title}
-                                />
-                            )}
+        <ScopedCssBaseline enableColorScheme>
+            <StyledLayout className={clsx('layout', className)} {...rest}>
+                <SkipNavigationButton />
+                <div className={LayoutClasses.appFrame}>
+                    <AppBar open={open} title={title} />
+                    <main className={LayoutClasses.contentWithSidebar}>
+                        <Sidebar>
+                            <Menu hasDashboard={!!dashboard} />
+                        </Sidebar>
+                        <div
+                            id="main-content"
+                            className={LayoutClasses.content}
                         >
-                            {children}
-                        </ErrorBoundary>
-                    </div>
-                </main>
-                <Inspector />
-            </div>
-        </StyledLayout>
+                            <ErrorBoundary
+                                onError={handleError}
+                                fallbackRender={({
+                                    error,
+                                    resetErrorBoundary,
+                                }) => (
+                                    <Error
+                                        error={error}
+                                        errorComponent={errorComponent}
+                                        errorInfo={errorInfo}
+                                        resetErrorBoundary={resetErrorBoundary}
+                                        title={title}
+                                    />
+                                )}
+                            >
+                                {children}
+                            </ErrorBoundary>
+                        </div>
+                    </main>
+                    <Inspector />
+                </div>
+            </StyledLayout>
+        </ScopedCssBaseline>
     );
 };
 


### PR DESCRIPTION
## Problem

MUI's `<CSSBaseline>` is crucial to get a good UI with react-admin, yet we never mention it in the documentation.

We do our tests with the Simple example, which uses CSSBaselaine, without realizing that for most users, without CSS Baseline, the UI is degraded.

## Solution

Enable it by default 

## Before

Note the top margin between the AppBar and the content

![image](https://user-images.githubusercontent.com/99944/193309866-b54db287-7f84-434e-8b1f-764b94f4fefd.png)

## After

![image](https://user-images.githubusercontent.com/99944/193309546-46008db6-17ba-49c0-8081-99070b5999be.png)
