### PR TITLE
Feat: move remove filter button and display it on hover

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
@@ -64,10 +64,25 @@ const Root = styled('div', {
     display: 'flex',
     alignItems: 'flex-end',
     pointerEvents: 'auto',
+    position: 'relative',
+    '@media (hover: hover)': {
+        '&:hover': {
+            [`& .${FilterFormInputClasses.hideButton}`]: {
+                display: 'flex',
+            },
+        },
+    },
 
     [`& .${FilterFormInputClasses.spacer}`]: { width: theme.spacing(2) },
     [`& .${FilterFormInputClasses.hideButton}`]: {
         marginBottom: theme.spacing(1),
+        position: 'absolute',
+        right: 0,
+        top: 0,
+        zIndex: 10,
+        '@media (hover: hover)': {
+            display: 'none',
+        },
     },
 }));
 


### PR DESCRIPTION
- [x] Display the close button only when hovering the input
- [x] Move the close button to the top right of the input


https://user-images.githubusercontent.com/41492953/193309603-13fc866b-f0b6-4714-a391-10f974638e8a.mov

