### PR TITLE
Remove unused TranslationMessage

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -177,7 +177,6 @@ export interface TranslationMessages extends StringMap {
         };
         configurable?: {
             customize: string;
-            templateError: string;
             configureMode: string;
             inspector: {
                 title: string;

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -178,7 +178,6 @@ const englishMessages: TranslationMessages = {
         },
         configurable: {
             customize: 'Customize',
-            templateError: '## Template error',
             configureMode: 'Configure this page',
             inspector: {
                 title: 'Inspector',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -184,7 +184,6 @@ const frenchMessages: TranslationMessages = {
         },
         configurable: {
             customize: 'Personnaliser',
-            templateError: '## Erreur de formule',
             configureMode: 'Configurer cette page',
             inspector: {
                 title: 'Inspecteur',


### PR DESCRIPTION
I noticed that `ra.configurable.templateError` was added in version 4.4.0 but is unused.
It seems that they deleted `translate(ra.configurable.templateError, ...)` when changed to translate instead of lodash.

https://github.com/marmelab/react-admin/commit/c4a6ac61599fe8dd48d74590a51a36f44205de13#diff-be8dc1889be155c57e45c5b1e0d96f8f05466f57a969429ef5cd766baedcde9aL22-L24
(deleted /packages/ra-core/src/preferences/useRenderTemplate.ts)