### PR TITLE
Fix `useReferenceInputController` all choices merge in case `id` is not a string

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -122,7 +122,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
     let finalData: RecordType[], finalTotal: number;
     if (
         !referenceRecord ||
-        possibleValuesData.find(record => record.id === currentValue)
+        possibleValuesData.find(record => record.id === referenceRecord.id)
     ) {
         finalData = possibleValuesData;
         finalTotal = total;


### PR DESCRIPTION
**Problem:** to merge the possible choices with the current choice, `useReferenceInputController` checks if the current value is already in the possible values or not (https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/controller/input/useReferenceInputController.ts#L125).
This check only works if `id` is of type string, because we check it against the current value coming straight from the form (with RHF's `useWatch`).
In the `/story/ra-ui-materialui-input-referenceinput--with-radio-button-group-input` story, we use ids that are number, which causes the merge to fail.

**Solution:** we should compare it with the id of the reference record fetched with `useReference`, which should be of the matching type

**Alternatives:**
- Replace `===` with `==` (but I was unsure if this could have undesired side effects)

This PR supersedes https://github.com/marmelab/react-admin/pull/8214