### PR TITLE
Fix `<SelectInput emptyValue>` accepts null value

### DIFF
--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -146,7 +146,7 @@ You can override this value with the `emptyValue` prop.
 />
 ```
 
-You can furthermore customize the empty choice by using [the `emptyText` prop](#emptytext).
+**Tip**: While you can set `emptyValue` to a non-string value (e.g. `0`), you cannot use `null` or `undefined`, as it would turn the `<AutocompleteInput>` into an [uncontrolled component](https://reactjs.org/docs/uncontrolled-components.html). If you need the empty choice to be stored as `null` or `undefined`, use [the `parse` prop](./Inputs.md#parse) to convert the default empty value ('') to `null` or `undefined`, or use [the `sanitizeEmptyValues` prop](./SimpleForm.md#sanitizeemptyvalues) on the Form component. 
 
 ## `optionText`
 

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -157,6 +157,8 @@ You can override this value with the `emptyValue` prop.
     ]} />
 ```
 
+**Tip**: While you can set `emptyValue` to a non-string value (e.g. `0`), you cannot use `null` or `undefined`, as it would turn the `<SelectInput>` into an [uncontrolled component](https://reactjs.org/docs/uncontrolled-components.html). If you need the empty choice to be stored as `null` or `undefined`, use [the `parse` prop](./Inputs.md#parse) to convert the default empty value ('') to `null` or `undefined`, or use [the `sanitizeEmptyValues` prop](./SimpleForm.md#sanitizeemptyvalues) on the Form component. 
+
 ## `options`
 
 Use the `options` attribute if you want to override any of MUI's `<SelectField>` attributes:

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -248,9 +248,12 @@ export const AutocompleteInput = <
         // eslint-disable-next-line eqeqeq
         if (emptyValue == null) {
             throw new Error(
-                `emptyValue being set to null or undefined is not supported`
+                `emptyValue being set to null or undefined is not supported. Use parse to turn the empty string into null.`
             );
         }
+    }, [emptyValue]);
+
+    useEffect(() => {
         // eslint-disable-next-line eqeqeq
         if (isValidElement(optionText) && emptyText != undefined) {
             throw new Error(
@@ -267,7 +270,7 @@ If you provided a React element for the optionText prop, you must also provide t
             throw new Error(`
 If you provided a React element for the optionText prop, you must also provide the matchSuggestion prop (used to match the user input with a choice)`);
         }
-    }, [optionText, inputText, matchSuggestion, emptyText, emptyValue]);
+    }, [optionText, inputText, matchSuggestion, emptyText]);
 
     useEffect(() => {
         warning(

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -9,6 +9,8 @@ import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { SelectInput } from './SelectInput';
 import { ReferenceInput } from './ReferenceInput';
+import { SaveButton } from '../button//SaveButton';
+import { Toolbar } from '../form/Toolbar';
 
 export default { title: 'ra-ui-materialui/input/SelectInput' };
 
@@ -112,6 +114,32 @@ export const EmptyText = () => (
     </Wrapper>
 );
 
+export const EmptyValue = ({ emptyValue = 'foo' }) => (
+    <Wrapper>
+        <SelectInput
+            source="gender"
+            choices={[
+                { id: 'M', name: 'Male ' },
+                { id: 'F', name: 'Female' },
+            ]}
+            emptyValue={emptyValue}
+        />
+    </Wrapper>
+);
+EmptyValue.argTypes = {
+    emptyValue: {
+        options: ['foo', '0', 'null', 'undefined', 'empty string'],
+        mapping: {
+            foo: 'foo',
+            0: 0,
+            null: null,
+            undefined: undefined,
+            'empty string': '',
+        },
+        control: { type: 'select' },
+    },
+};
+
 export const Sort = () => (
     <Wrapper>
         <SelectInput
@@ -131,9 +159,23 @@ export const Sort = () => (
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({ children }) => (
-    <AdminContext i18nProvider={i18nProvider}>
-        <Create resource="posts">
-            <SimpleForm>{children}</SimpleForm>
+    <AdminContext
+        i18nProvider={i18nProvider}
+        dataProvider={{
+            create: (resource, params) =>
+                Promise.resolve({ data: { id: 1, ...params.data } }),
+        }}
+    >
+        <Create resource="posts" mutationOptions={{ onSuccess: console.log }}>
+            <SimpleForm
+                toolbar={
+                    <Toolbar>
+                        <SaveButton alwaysEnable />
+                    </Toolbar>
+                }
+            >
+                {children}
+            </SimpleForm>
         </Create>
     </AdminContext>
 );

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement, useCallback, ChangeEvent } from 'react';
+import { ReactElement, useCallback, useEffect, ChangeEvent } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { MenuItem, TextFieldProps } from '@mui/material';
@@ -136,6 +136,16 @@ export const SelectInput = (props: SelectInputProps) => {
         ...rest
     } = props;
     const translate = useTranslate();
+
+    useEffect(() => {
+        // eslint-disable-next-line eqeqeq
+        if (emptyValue == null) {
+            throw new Error(
+                `emptyValue being set to null or undefined is not supported. Use parse to turn the empty string into null.`
+            );
+        }
+    }, [emptyValue]);
+
     const {
         allChoices,
         isLoading,


### PR DESCRIPTION
- [x] Document that `null` isn't a possible value for `emptyValue`
- [x] Throw an error if a developer tries to use it. 

Refs #8060