### PR TITLE
Fix AutocompleteInput (Format and Parse)

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -223,9 +223,9 @@ export const AutocompleteInput = <
         formState: formStateOverride,
         onBlur,
         onChange,
-        parse: parse ?? isFromReference ? convertEmptyStringToNull : undefined,
+        parse: parse ?? (isFromReference ? convertEmptyStringToNull : undefined),
         format:
-            format ?? isFromReference ? convertNullToEmptyString : undefined,
+            format ?? (isFromReference ? convertNullToEmptyString : undefined),
         resource,
         source,
         validate,


### PR DESCRIPTION
## Fix AutocompleteInput - Format and Parse doesn't work

Right now there's no way to use `format` and `parse` in AutocompleteInput (and AutocompleteArrayInput)  because of ordering logical operations.
