### PR TITLE
Fix redirectTo returned by `useEditController`

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -109,6 +109,31 @@ describe('useEditController', () => {
         });
     });
 
+    it('should return the `redirect` provided through props or the default', async () => {
+        const getOne = jest
+            .fn()
+            .mockImplementationOnce(() =>
+                Promise.resolve({ data: { id: 12, title: 'hello' } })
+            );
+        const dataProvider = ({ getOne } as unknown) as DataProvider;
+        const Component = ({ redirect = undefined }) => (
+            <CoreAdminContext dataProvider={dataProvider}>
+                <EditController {...defaultProps} redirect={redirect}>
+                    {({ redirect }) => <div>{redirect}</div>}
+                </EditController>
+            </CoreAdminContext>
+        );
+        const { rerender } = render(<Component />);
+        await waitFor(() => {
+            expect(screen.queryAllByText('list')).toHaveLength(1);
+        });
+
+        rerender(<Component redirect="show" />);
+        await waitFor(() => {
+            expect(screen.queryAllByText('show')).toHaveLength(1);
+        });
+    });
+
     describe('queryOptions', () => {
         it('should accept custom client query options', async () => {
             const mock = jest

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -220,7 +220,7 @@ export const useEditController = <
         isLoading,
         mutationMode,
         record,
-        redirect: DefaultRedirect,
+        redirect: redirectTo,
         refetch,
         registerMutationMiddleware,
         resource,


### PR DESCRIPTION
`useEditController` should return the redirectTo used to redirect (if any) or the default, just like `useCreateController` does it, not the default