### PR TITLE
[chore] CI: update CodeQL-Build permissions following github token permissions change

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   CodeQL-Build:
 
+    permissions:
+      security-events: write  # for github/codeql-action/autobuild to send a status report
+
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Updates the build permissions for the CodeQL job, now that the github token default permission has been reduced to read-only.

Supersedes https://github.com/marmelab/react-admin/pull/8225

Credits go to [boahc077](https://github.com/boahc077) for raising the issue in the first place.