### PR TITLE
Remove trailing dot from secondary loading text

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Loading.tsx
+++ b/packages/ra-ui-materialui/src/layout/Loading.tsx
@@ -22,7 +22,7 @@ export const Loading = (props: LoadingProps) => {
                     color="primary"
                 />
                 <h1>{translate(loadingPrimary)}</h1>
-                <div>{translate(loadingSecondary)}.</div>
+                <div>{translate(loadingSecondary)}</div>
             </div>
         </Root>
     );


### PR DESCRIPTION
The Loading component's secondary text has a trailing dot that prevents people from leaving empty that section.