### PR TITLE
Allow label position config in CheckboxGroupInput

### DIFF
--- a/docs/CheckboxGroupInput.md
+++ b/docs/CheckboxGroupInput.md
@@ -29,6 +29,7 @@ import { CheckboxGroupInput } from 'react-admin';
 | `optionText`  | Optional | `string` &#124; `Function` | `name`  | Field name of record to display in the suggestion item or function which accepts the correct record as argument (`record => {string}`) |
 | `optionValue` | Optional | `string`                   | `id`    | Field name of record containing the value to use as input value                                                                        |
 | `row`         | Optional | `boolean`                  | `true`  | Display group of elements in a compact row.                                                                                            |
+| `labelPlacement` | Optional | `"bottom" `&#124;`"end"`&#124;`"start"`&#124;`"top" ` | `"end"` | The position of the checkbox label.                                                                                                    |
 
 Refer to [MUI Checkbox documentation](https://mui.com/api/checkbox/) for more details.
 

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -278,6 +278,7 @@ export type CheckboxGroupInputProps = Omit<CommonInputProps, 'source'> &
         row?: boolean;
         // Optional as this input can be used inside a ReferenceInput
         source?: string;
+        labelPlacement?: 'bottom' | 'end' | 'start' | 'top';
     };
 
 const PREFIX = 'RaCheckboxGroupInput';

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInputItem.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInputItem.tsx
@@ -16,6 +16,7 @@ export const CheckboxGroupInputItem = props => {
         options,
         translateChoice,
         value,
+        labelPlacement,
         ...rest
     } = props;
 
@@ -50,6 +51,7 @@ export const CheckboxGroupInputItem = props => {
                 />
             }
             label={choiceName}
+            labelPlacement={labelPlacement}
         />
     );
 };


### PR DESCRIPTION
Add `labelPlacement` props so that the CheckboxGroupInput can have labels on the top of checkboxes.  It is useful when there is limited width for a checkbox group. For example,  a weekday checkbox group squeezes in `xs={4}`.

<del>I will continue on this PR for RadioGroupInput if you think this change is desirable.</del> I find `labelPlacement` in RadioGroupInput looks weird.  I will keep this PR only for `CheckboxGroupInput`.