### PR TITLE
Fix displaying texts in Loading in case of arguments are not passed

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Loading.tsx
+++ b/packages/ra-ui-materialui/src/layout/Loading.tsx
@@ -21,8 +21,8 @@ export const Loading = (props: LoadingProps) => {
                     className={LoadingClasses.icon}
                     color="primary"
                 />
-                <h1>{translate(loadingPrimary)}</h1>
-                <div>{translate(loadingSecondary)}</div>
+                {loadingPrimary ?? <h1>{translate(loadingPrimary)}</h1>}
+                {loadingSecondary ?? <div>{translate(loadingSecondary)}</div>}
             </div>
         </Root>
     );


### PR DESCRIPTION
Current behavior: 

If we omit the `loadingPrimary` and `loadingSecondary` props, the component still displays the translation keys (`ra.page.loading` and `ra.message.loading`) beneath the spinner. 

This fixes that. 