### PR TITLE
Remove support for warnWhenUnsavedChange when react-router doesn't allow it

### DIFF
--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -672,6 +672,8 @@ const Form = ({ onSubmit }) => {
 
 **Tip**: You can customize the message displayed in the confirm dialog by setting the `ra.message.unsaved_changes` message in your i18nProvider.
 
+**Warning**: This feature only works if you have a dependency on react-router 6.3.0 **at most**. The react-router team disabled this possibility in react-router 6.4, so `warnWhenUnsavedChanges` will silently fail with react-router 6.4 or later.
+
 ## Submit On Enter
 
 By default, pressing `ENTER` in any of the form inputs submits the form - this is the expected behavior in most cases. To disable the automated form submission on enter, set the `type` prop of the `SaveButton` component to `button`.

--- a/docs/Form.md
+++ b/docs/Form.md
@@ -230,3 +230,4 @@ export const TagEdit = () => (
 );
 ```
 
+**Warning**: This feature only works if you have a dependency on react-router 6.3.0 **at most**. The react-router team disabled this possibility in react-router 6.4, so `warnWhenUnsavedChanges` will silently fail with react-router 6.4 or later.

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -376,6 +376,8 @@ export const TagEdit = () => (
 );
 ```
 
+**Warning**: This feature only works if you have a dependency on react-router 6.3.0 **at most**. The react-router team disabled this possibility in react-router 6.4, so `warnWhenUnsavedChanges` will silently fail with react-router 6.4 or later.
+
 ## Using Fields As Children
 
 The basic usage of `<SimpleForm>` is to pass [Input components](./Inputs.md) as children. For non-editable fields, you can pass `disabled` inputs, or even [Field components](./Fields.md). But since `<Field>` components have no label by default, you'll have to wrap your inputs in a `<Labeled>` component in that case:

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -469,6 +469,8 @@ export const TagEdit = () => (
 );
 ```
 
+**Warning**: This feature only works if you have a dependency on react-router 6.3.0 **at most**. The react-router team disabled this possibility in react-router 6.4, so `warnWhenUnsavedChanges` will silently fail with react-router 6.4 or later.
+
 ## `<FormTab>`
 
 `<TabbedForm>` expect `<FormTab>` elements as children. `<FormTab>` elements accept four props:

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
@@ -28,6 +28,14 @@ export const useWarnWhenUnsavedChanges = (
 
     useEffect(() => {
         if (!enable || !isDirty) return;
+        if (!navigator.block) {
+            if (process.env.NODE_ENV !== 'production') {
+                console.warn(
+                    'warnWhenUnsavedChanged is not compatible with react-router >= 6.4. If you need this feature, please downgrade react-router to 6.3.0'
+                );
+            }
+            return;
+        }
 
         let unblock = navigator.block((tx: Transition) => {
             const newLocationIsInsideForm = tx.location.pathname.startsWith(


### PR DESCRIPTION
## Problem

React-router 6.4.0 removed support for `navigator.block`, which is necessary for the `warnWhenUnsavedChanges` feature (see https://github.com/remix-run/react-router/issues/9262).

This breaks existing applications using react-router >= 6.4 and a custom router. 

## Solution

The `warnWithUnsavedChanges` feature fails silently when using with react-router >= 6.4 

Closes #8163