### PR TITLE
Fix improve SaveButton enable state

### DIFF
--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -12,7 +12,12 @@ import {
 import { SaveButton } from './SaveButton';
 import { SimpleForm, Toolbar } from '../form';
 import { Edit } from '../detail';
-import { TextInput } from '../input';
+import {
+    TextInput,
+    ArrayInput,
+    SimpleFormIterator,
+    NumberInput,
+} from '../input';
 import { AdminContext } from '../AdminContext';
 
 const invalidButtonDomProps = {
@@ -397,6 +402,60 @@ describe('<SaveButton />', () => {
         await waitFor(() =>
             expect(screen.getByLabelText('ra.action.save')['disabled']).toEqual(
                 false
+            )
+        );
+    });
+
+    it('should not be enabled if no inputs have changed', async () => {
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <SimpleForm
+                    resource="myresource"
+                    onSubmit={jest.fn}
+                    defaultValues={{
+                        test: 'test',
+                        arr: [
+                            {
+                                id: 123,
+                                foo: 'bar',
+                                nested: {
+                                    deep: '1',
+                                },
+                            },
+                            {
+                                id: 456,
+                                foo: 'baz',
+                                nested: {
+                                    deep: '2',
+                                },
+                            },
+                        ],
+                    }}
+                >
+                    <TextInput source="test" />
+                    <ArrayInput resource="foo" source="arr">
+                        <SimpleFormIterator>
+                            <NumberInput source="id" />
+                            <ArrayInput resource="bar" source="arr.nested">
+                                <SimpleFormIterator>
+                                    <NumberInput source="deep" />
+                                </SimpleFormIterator>
+                            </ArrayInput>
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                </SimpleForm>
+            </AdminContext>
+        );
+
+        const testInput = screen.getByLabelText(
+            'resources.myresource.fields.test'
+        );
+        fireEvent.focus(testInput);
+        fireEvent.blur(testInput);
+
+        await waitFor(() =>
+            expect(screen.getByLabelText('ra.action.save')['disabled']).toEqual(
+                true
             )
         );
     });

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -414,37 +414,12 @@ describe('<SaveButton />', () => {
                     onSubmit={jest.fn}
                     defaultValues={{
                         test: 'test',
-                        arr: [
-                            {
-                                id: 123,
-                                foo: 'bar',
-                                nested: [
-                                    {
-                                        deep: '1',
-                                    },
-                                ],
-                            },
-                            {
-                                id: 456,
-                                foo: 'baz',
-                                nested: [
-                                    {
-                                        deep: '2',
-                                    },
-                                ],
-                            },
-                        ],
                     }}
                 >
                     <TextInput source="test" />
                     <ArrayInput resource="foo" source="arr">
                         <SimpleFormIterator>
                             <NumberInput source="id" />
-                            <ArrayInput resource="bar" source="arr.nested">
-                                <SimpleFormIterator>
-                                    <NumberInput source="deep" />
-                                </SimpleFormIterator>
-                            </ArrayInput>
                         </SimpleFormIterator>
                     </ArrayInput>
                 </SimpleForm>

--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -418,16 +418,20 @@ describe('<SaveButton />', () => {
                             {
                                 id: 123,
                                 foo: 'bar',
-                                nested: {
-                                    deep: '1',
-                                },
+                                nested: [
+                                    {
+                                        deep: '1',
+                                    },
+                                ],
                             },
                             {
                                 id: 456,
                                 foo: 'baz',
-                                nested: {
-                                    deep: '2',
-                                },
+                                nested: [
+                                    {
+                                        deep: '2',
+                                    },
+                                ],
                             },
                         ],
                     }}

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -65,7 +65,8 @@ export const SaveButton = <RecordType extends RaRecord = any>(
     const translate = useTranslate();
     const form = useFormContext();
     const saveContext = useSaveContext();
-    const { isDirty, isValidating, isSubmitting } = useFormState();
+    const { dirtyFields, isValidating, isSubmitting } = useFormState();
+    const isDirty = Object.keys(dirtyFields).length;
     // Use form isDirty, isValidating and form context saving to enable or disable the save button
     // if alwaysEnable is undefined
     const disabled = valueOrDefault(

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -66,7 +66,8 @@ export const SaveButton = <RecordType extends RaRecord = any>(
     const form = useFormContext();
     const saveContext = useSaveContext();
     const { dirtyFields, isValidating, isSubmitting } = useFormState();
-    const isDirty = Object.keys(dirtyFields).length;
+    // useFormState().isDirty might differ from useFormState().dirtyFields (https://github.com/react-hook-form/react-hook-form/issues/4740)
+    const isDirty = Object.keys(dirtyFields).length > 0;
     // Use form isDirty, isValidating and form context saving to enable or disable the save button
     // if alwaysEnable is undefined
     const disabled = valueOrDefault(

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
@@ -223,7 +223,7 @@ describe('<DateTimeInput />', () => {
             const onSubmit = jest.fn();
             render(
                 <AdminContext dataProvider={testDataProvider()}>
-                    <SimpleForm onSubmit={onSubmit}>
+                    <SimpleForm mode="onBlur" onSubmit={onSubmit}>
                         <DateTimeInput
                             {...defaultProps}
                             validate={required()}
@@ -245,7 +245,6 @@ describe('<DateTimeInput />', () => {
                 target: { value: '' },
             });
             fireEvent.blur(input);
-            fireEvent.click(screen.getByText('ra.action.save'));
             await waitFor(() => {
                 expect(
                     screen.queryByText('ra.validation.required')

--- a/packages/ra-ui-materialui/src/input/TimeInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/TimeInput.spec.tsx
@@ -213,7 +213,7 @@ describe('<TimeInput />', () => {
             const onSubmit = jest.fn();
             render(
                 <AdminContext dataProvider={testDataProvider()}>
-                    <SimpleForm onSubmit={onSubmit}>
+                    <SimpleForm mode="onBlur" onSubmit={onSubmit}>
                         <TimeInput {...defaultProps} validate={required()} />
                     </SimpleForm>
                 </AdminContext>
@@ -232,7 +232,6 @@ describe('<TimeInput />', () => {
                 target: { value: '' },
             });
             fireEvent.blur(input);
-            fireEvent.click(screen.getByText('ra.action.save'));
             await waitFor(() => {
                 expect(
                     screen.queryByText('ra.validation.required')


### PR DESCRIPTION
Fixes #8258

**PROBLEM**

`SaveButton` enable state may be true, even though no inputs have been changed.

This is because `useFormState().isDirty` might differ from `useFormState().dirtyFields` (https://github.com/react-hook-form/react-hook-form/issues/4740)
This is the expected behavior of `react-hook-form` and it may happen when you have a missing `defaultValue` for one of the inputs

· `dirtyFields` will mark the field dirty or not individually.
· `isDirty` will always do a deep equal against your defaultValues to determined form is dirty or not.
https://github.com/react-hook-form/react-hook-form/discussions/7860#discussioncomment-2208434

This is key, since `defaultValue` prop might be `undefined`, and in some cases you end up with `isDirty` being `true` but `dirtyFields` being an empty object. Like in the test I've added in this PR, plus the ones I've fixed in this PR

**SOLUTION**

Use `useFormState().dirtyFields` to enable/disable `SaveButton` instead of `useFormState().isDirty`

