### PR TITLE
Docs: fix small typo in Create.md

### DIFF
--- a/docs/Create.md
+++ b/docs/Create.md
@@ -27,7 +27,7 @@ export const PostCreate = () => (
     <Create>
         <SimpleForm>
             <TextInput source="title" validate={[required()]} fullWidth />
-            <TextInput source="teaser" multiLine={true} label="Short description" />
+            <TextInput source="teaser" multiline={true} label="Short description" />
             <RichTextInput source="body" />
             <DateInput label="Publication date" source="published_at" defaultValue={new Date()} />
         </SimpleForm>


### PR DESCRIPTION
The `TextInput` component expects the `multiline` prop to be lowercase while the `Create` docs have it written as 'multiLine`.