### PR TITLE
Fix `AutocompleteInput` displays empty choice when `validate={required()}`

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -14,7 +14,6 @@ import { SimpleForm } from '../form';
 import { AutocompleteInput } from './AutocompleteInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import {
-    Basic,
     InsideReferenceInput,
     InsideReferenceInputDefaultValue,
     Nullable,

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
     FormDataConsumer,
+    required,
     testDataProvider,
     TestTranslationProvider,
     useRecordContext,
@@ -13,6 +14,7 @@ import { SimpleForm } from '../form';
 import { AutocompleteInput } from './AutocompleteInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import {
+    Basic,
     InsideReferenceInput,
     InsideReferenceInputDefaultValue,
     Nullable,
@@ -120,6 +122,85 @@ describe('<AutocompleteInput />', () => {
             const input = screen.getByRole('textbox') as HTMLInputElement;
 
             expect(input.value).toEqual('Default');
+        });
+
+        it('should display the emptyText when input is not required', async () => {
+            const emptyText = 'Default';
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <SimpleForm
+                        onSubmit={jest.fn()}
+                        defaultValues={{ role: 1 }}
+                    >
+                        <AutocompleteInput
+                            emptyText={emptyText}
+                            {...defaultProps}
+                            choices={[]}
+                        />
+                    </SimpleForm>
+                </AdminContext>
+            );
+            fireEvent.click(
+                await screen.findByLabelText('resources.users.fields.role')
+            );
+            await waitFor(() => {
+                expect(screen.queryAllByRole('option').length).toEqual(1);
+            });
+            expect(screen.queryByText('Default')).not.toBeNull();
+        });
+
+        it('should not display the emptyText when validate equals required', async () => {
+            const emptyText = 'Default';
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <SimpleForm
+                        onSubmit={jest.fn()}
+                        defaultValues={{ role: 1 }}
+                    >
+                        <AutocompleteInput
+                            emptyText={emptyText}
+                            {...defaultProps}
+                            choices={[]}
+                            validate={required()}
+                        />
+                    </SimpleForm>
+                </AdminContext>
+            );
+            fireEvent.click(
+                await screen.findByLabelText('resources.users.fields.role *')
+            );
+            await waitFor(() => {
+                expect(screen.queryAllByRole('option').length).toEqual(0);
+            });
+            expect(screen.queryByText('Default')).toBeNull();
+            await screen.findByText('No options');
+        });
+
+        it('should not display the emptyText when isRequired is true', async () => {
+            const emptyText = 'Default';
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <SimpleForm
+                        onSubmit={jest.fn()}
+                        defaultValues={{ role: 1 }}
+                    >
+                        <AutocompleteInput
+                            emptyText={emptyText}
+                            {...defaultProps}
+                            choices={[]}
+                            isRequired
+                        />
+                    </SimpleForm>
+                </AdminContext>
+            );
+            fireEvent.click(
+                await screen.findByLabelText('resources.users.fields.role *')
+            );
+            await waitFor(() => {
+                expect(screen.queryAllByRole('option').length).toEqual(0);
+            });
+            expect(screen.queryByText('Default')).toBeNull();
+            await screen.findByText('No options');
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -538,11 +538,7 @@ If you provided a React element for the optionText prop, you must also provide t
                                 label={label}
                                 source={source}
                                 resource={resourceProp}
-                                isRequired={
-                                    typeof isRequiredOverride !== 'undefined'
-                                        ? isRequiredOverride
-                                        : isRequired
-                                }
+                                isRequired={isRequired}
                             />
                         }
                         error={

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -195,9 +195,32 @@ export const AutocompleteInput = <
 
     const finalEmptyText = emptyText ?? '';
 
+    const {
+        id,
+        field,
+        isRequired,
+        fieldState: { error, invalid, isTouched },
+        formState: { isSubmitted },
+    } = useInput({
+        defaultValue,
+        id: idOverride,
+        field: fieldOverride,
+        fieldState: fieldStateOverride,
+        formState: formStateOverride,
+        isRequired: isRequiredOverride,
+        onBlur,
+        onChange,
+        parse,
+        format,
+        resource,
+        source,
+        validate,
+        ...rest,
+    });
+
     const finalChoices = useMemo(
         () =>
-            isRequiredOverride || multiple
+            isRequired || multiple
                 ? allChoices
                 : [
                       {
@@ -213,35 +236,13 @@ export const AutocompleteInput = <
             allChoices,
             emptyValue,
             finalEmptyText,
-            isRequiredOverride,
+            isRequired,
             multiple,
             optionText,
             optionValue,
             translate,
         ]
     );
-
-    const {
-        id,
-        field,
-        isRequired,
-        fieldState: { error, invalid, isTouched },
-        formState: { isSubmitted },
-    } = useInput({
-        defaultValue,
-        id: idOverride,
-        field: fieldOverride,
-        fieldState: fieldStateOverride,
-        formState: formStateOverride,
-        onBlur,
-        onChange,
-        parse,
-        format,
-        resource,
-        source,
-        validate,
-        ...rest,
-    });
 
     const selectedChoice = useSelectedChoice<
         OptionType,


### PR DESCRIPTION
`AutocompleteInput` should not display the empty choice when `validate={required()}`