### PR TITLE
Fix `AutocompleteInput` should only add an empty option when there is an `emptyText`

### DIFF
--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -100,9 +100,7 @@ See [Using in a `ReferenceInput>`](#using-in-a-referenceinput) below for more in
 
 ## `emptyText`
 
-If the input isn't required (using `validate={required()}`), users can select an empty choice with an empty text `''` as label.
-
-You can override that label with the `emptyText` prop.
+If the input isn't required (using `validate={required()}`), and you need a choice to represent the empty value, set `emptyText` prop and a choice will be added at the top, with its value as label.
 
 ```jsx
 <AutocompleteInput

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -721,7 +721,7 @@ const BookEditWithEmptyText = () => {
         >
             <SimpleForm>
                 <AutocompleteInput
-                    label="emptyValue set to 'no-author', emptyText set to '' by default"
+                    label="emptyValue set to 'no-author', emptyText not set"
                     source="author"
                     choices={choices}
                     emptyValue="no-author"

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -218,6 +218,7 @@ export const AutocompleteInput = <
 
     const finalChoices = useMemo(
         () =>
+            // eslint-disable-next-line eqeqeq
             emptyText == undefined || isRequired || multiple
                 ? allChoices
                 : [

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -193,8 +193,6 @@ export const AutocompleteInput = <
 
     const translate = useTranslate();
 
-    const finalEmptyText = emptyText ?? '';
-
     const {
         id,
         field,
@@ -220,22 +218,22 @@ export const AutocompleteInput = <
 
     const finalChoices = useMemo(
         () =>
-            isRequired || multiple
+            emptyText == undefined || isRequired || multiple
                 ? allChoices
                 : [
                       {
                           [optionValue || 'id']: emptyValue,
                           [typeof optionText === 'string'
                               ? optionText
-                              : 'name']: translate(finalEmptyText, {
-                              _: finalEmptyText,
+                              : 'name']: translate(emptyText, {
+                              _: emptyText,
                           }),
                       },
                   ].concat(allChoices),
         [
             allChoices,
             emptyValue,
-            finalEmptyText,
+            emptyText,
             isRequired,
             multiple,
             optionText,


### PR DESCRIPTION
Fixes #8293