### PR TITLE
Fix `<Appbar>` buttons don't have consistent spacing

### DIFF
--- a/docs/LocalesMenuButton.md
+++ b/docs/LocalesMenuButton.md
@@ -71,11 +71,7 @@ The `locale` will be passed to `setLocale` when the user selects the language, a
 
 ## `sx`: CSS API
 
-The `<LocalesMenuButton>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property (as most MUI components, see their [documentation about it](https://mui.com/customization/how-to-customize/#overriding-nested-component-styles)). This property accepts the following subclasses:
-
-| Rule name                 | Description                                             |
-|---------------------------|---------------------------------------------------------|
-| `& .RaLocalesMenuButton-selectedLanguage`      | Applied to the current language element |
+The `<LocalesMenuButton>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property (as most MUI components, see their [documentation about it](https://mui.com/customization/how-to-customize/#overriding-nested-component-styles)).
 
 To override the style of all instances of `<LocalesMenuButton>` using the [MUI style overrides](https://mui.com/customization/globals/#css), use the `RaLocalesMenuButton` key.
 

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -54,9 +54,9 @@ export const Button = (props: ButtonProps) => {
                     aria-label={translatedLabel}
                     className={className}
                     color={color}
+                    size="large"
                     {...rest}
                     {...linkParams}
-                    size="large"
                 >
                     {children}
                 </IconButton>
@@ -66,9 +66,9 @@ export const Button = (props: ButtonProps) => {
                 className={className}
                 color={color}
                 disabled={disabled}
+                size="large"
                 {...rest}
                 {...linkParams}
-                size="large"
             >
                 {children}
             </IconButton>

--- a/packages/ra-ui-materialui/src/button/LocalesMenuButton.tsx
+++ b/packages/ra-ui-materialui/src/button/LocalesMenuButton.tsx
@@ -56,12 +56,10 @@ export const LocalesMenuButton = (props: LocalesMenuButtonProps) => {
                 aria-label=""
                 aria-haspopup="true"
                 onClick={handleLanguageClick}
+                startIcon={<LanguageIcon />}
+                endIcon={<ExpandMoreIcon fontSize="small" />}
             >
-                <LanguageIcon />
-                <div className={LocalesMenuButtonClasses.selectedLanguage}>
-                    {getNameForLocale(locale)}
-                </div>
-                <ExpandMoreIcon fontSize="small" />
+                {getNameForLocale(locale)}
             </Button>
             <Menu
                 id="simple-menu"
@@ -86,18 +84,12 @@ export const LocalesMenuButton = (props: LocalesMenuButtonProps) => {
 
 const PREFIX = 'RaLocalesMenuButton';
 
-export const LocalesMenuButtonClasses = {
-    selectedLanguage: `${PREFIX}-selectedLanguage`,
-};
+export const LocalesMenuButtonClasses = {};
 
 const Root = styled(Box, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
-})(({ theme }) => ({
-    [`& .${LocalesMenuButtonClasses.selectedLanguage}`]: {
-        marginLeft: theme.spacing(1),
-    },
-}));
+})({});
 
 export interface LocalesMenuButtonProps {
     languages?: { locale: string; name: string }[];

--- a/packages/ra-ui-materialui/src/button/RefreshIconButton.tsx
+++ b/packages/ra-ui-materialui/src/button/RefreshIconButton.tsx
@@ -35,7 +35,6 @@ export const RefreshIconButton = (props: RefreshIconButtonProps) => {
                 color="inherit"
                 onClick={handleClick}
                 {...rest}
-                size="large"
             >
                 {icon}
             </IconButton>

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -153,13 +153,12 @@ const StyledAppBar = styled(MuiAppBar, {
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
     [`& .${AppBarClasses.toolbar}`]: {
-        padding: `0 ${theme.spacing(1.5)} 0 0`,
+        padding: `0 ${theme.spacing(1)}`,
         [theme.breakpoints.down('md')]: {
             minHeight: theme.spacing(6),
         },
     },
     [`& .${AppBarClasses.menuButton}`]: {
-        marginLeft: '0.2em',
         marginRight: '0.2em',
     },
     [`& .${AppBarClasses.title}`]: {

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
@@ -59,8 +59,8 @@ const Root = styled('div', {
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
     [`& .${LoadingIndicatorClasses.loader}`]: {
-        marginLeft: theme.spacing(2),
-        marginRight: theme.spacing(2),
+        marginLeft: theme.spacing(1.5),
+        marginRight: theme.spacing(1.5),
     },
 
     [`& .${LoadingIndicatorClasses.loadedIcon}`]: {},

--- a/packages/ra-ui-materialui/src/layout/SidebarToggleButton.tsx
+++ b/packages/ra-ui-materialui/src/layout/SidebarToggleButton.tsx
@@ -10,7 +10,6 @@ import { useSidebarState } from './useSidebarState';
  * A button that toggles the sidebar. Used by default in the <AppBar>.
  * @param props The component props
  * @param {String} props.className An optional class name to apply to the button
-
  */
 export const SidebarToggleButton = (props: SidebarToggleButtonProps) => {
     const translate = useTranslate();
@@ -23,9 +22,7 @@ export const SidebarToggleButton = (props: SidebarToggleButtonProps) => {
             className={className}
             title={translate(
                 open ? 'ra.action.close_menu' : 'ra.action.open_menu',
-                {
-                    _: 'Open/Close menu',
-                }
+                { _: 'Open/Close menu' }
             )}
             enterDelay={500}
         >

--- a/packages/ra-ui-materialui/src/layout/SidebarToggleButton.tsx
+++ b/packages/ra-ui-materialui/src/layout/SidebarToggleButton.tsx
@@ -29,11 +29,7 @@ export const SidebarToggleButton = (props: SidebarToggleButtonProps) => {
             )}
             enterDelay={500}
         >
-            <StyledIconButton
-                color="inherit"
-                onClick={() => setOpen(!open)}
-                size="large"
-            >
+            <StyledIconButton color="inherit" onClick={() => setOpen(!open)}>
                 <MenuIcon
                     classes={{
                         root: open

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -110,7 +110,6 @@ export const UserMenu = (props: UserMenuProps) => {
                         aria-haspopup={true}
                         color="inherit"
                         onClick={handleMenu}
-                        size="large"
                     >
                         {!isLoading && identity?.avatar ? (
                             <Avatar


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/99944/199946850-003e3556-d052-4054-990f-246dc428eb5c.png)

## After

![image](https://user-images.githubusercontent.com/99944/199946755-345345ec-2682-4f9e-a2b6-c526105160e3.png)


Closes #8347