### PR TITLE
Fix authProvider hooks support for redirectTo: absolute URL

### DIFF
--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -70,11 +70,20 @@ const useLogout = (): Logout => {
                     // do not redirect
                     return;
                 }
-                // redirectTo can contain a query string, e.g. '/login?foo=bar'
-                // we must split the redirectTo to pass a structured location to navigate()
-                const redirectToParts = (
-                    redirectToFromProvider || redirectTo
-                ).split('?');
+
+                const finalRedirectTo = redirectToFromProvider || redirectTo;
+
+                if (finalRedirectTo.startsWith('http')) {
+                    // absolute link (e.g. https://my.oidc.server/login)
+                    resetStore();
+                    queryClient.clear();
+                    window.location.href = finalRedirectTo;
+                    return finalRedirectTo;
+                }
+
+                // redirectTo is an internal location that may contain a query string, e.g. '/login?foo=bar'
+                // we must split it to pass a structured location to navigate()
+                const redirectToParts = finalRedirectTo.split('?');
                 const newLocation: Partial<Path> = {
                     pathname: redirectToParts[0],
                 };

--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -73,7 +73,7 @@ const useLogout = (): Logout => {
 
                 const finalRedirectTo = redirectToFromProvider || redirectTo;
 
-                if (finalRedirectTo.startsWith('http')) {
+                if (finalRedirectTo?.startsWith('http')) {
                     // absolute link (e.g. https://my.oidc.server/login)
                     resetStore();
                     queryClient.clear();

--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
@@ -71,7 +71,7 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
                         disableNotification ||
                         (e && e.message === false) ||
                         (error && error.message === false) ||
-                        redirectTo.startsWith('http')
+                        redirectTo?.startsWith('http')
                     );
                     if (shouldNotify) {
                         // notify only if not yet logged out

--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
@@ -60,10 +60,18 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
                         timer = undefined;
                     }, 0);
 
+                    const redirectTo =
+                        e && e.redirectTo != null
+                            ? e.redirectTo
+                            : error && error.redirectTo
+                            ? error.redirectTo
+                            : undefined;
+
                     const shouldNotify = !(
                         disableNotification ||
                         (e && e.message === false) ||
-                        (error && error.message === false)
+                        (error && error.message === false) ||
+                        redirectTo.startsWith('http')
                     );
                     if (shouldNotify) {
                         // notify only if not yet logged out
@@ -90,12 +98,6 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
                             })
                             .catch(() => {});
                     }
-                    const redirectTo =
-                        e && e.redirectTo != null
-                            ? e.redirectTo
-                            : error && error.redirectTo
-                            ? error.redirectTo
-                            : undefined;
 
                     if (logoutUser) {
                         logout({}, redirectTo);

--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
@@ -100,7 +100,13 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
                     if (logoutUser) {
                         logout({}, redirectTo);
                     } else {
-                        navigate(redirectTo);
+                        if (redirectTo.startsWith('http')) {
+                            // absolute link (e.g. https://my.oidc.server/login)
+                            window.location.href = redirectTo;
+                        } else {
+                            // internal location
+                            navigate(redirectTo);
+                        }
                     }
 
                     return true;


### PR DESCRIPTION
This was possible in v3 since #6469, but it was broken when migrating to v4. 

It's necessary for OIDC / OAuth workflows. 