### PR TITLE
Fix DatagridConfigurable uses translation key with wrong case

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -179,7 +179,7 @@ export interface TranslationMessages extends StringMap {
         configurable?: {
             customize: string;
             configureMode: string;
-            Datagrid: {
+            datagrid: {
                 unlabeled: string;
             };
             inspector: {

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -180,7 +180,7 @@ const englishMessages: TranslationMessages = {
         configurable: {
             customize: 'Customize',
             configureMode: 'Configure this page',
-            Datagrid: {
+            datagrid: {
                 unlabeled: 'Unlabeled column #%{column}',
             },
             inspector: {

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -186,7 +186,7 @@ const frenchMessages: TranslationMessages = {
         configurable: {
             customize: 'Personnaliser',
             configureMode: 'Configurer cette page',
-            Datagrid: {
+            datagrid: {
                 unlabeled: 'Colonne sans label #%{column}',
             },
             inspector: {

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
@@ -67,7 +67,7 @@ export const DatagridConfigurable = ({
                           child.props.source || child.props.label
                               ? child.props.label
                               : translate(
-                                    'ra.configurable.Datagrid.unlabeled',
+                                    'ra.configurable.datagrid.unlabeled',
                                     {
                                         column: index,
                                         _: `Unlabeled column #%{column}`,


### PR DESCRIPTION
Follows #8376