### PR TITLE
Allow GraphQL v16

### DIFF
--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -38,7 +38,7 @@
         "pluralize": "~7.0.0"
     },
     "peerDependencies": {
-        "graphql": "^15.6.0",
+        "graphql": "^15.6.0 || ^16",
         "ra-core": "^4.0.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21642,7 +21642,7 @@ __metadata:
     rimraf: ^3.0.2
     typescript: ^4.4.0
   peerDependencies:
-    graphql: ^15.6.0
+    graphql: ^15.6.0 || ^16
     ra-core: ^4.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Allow ra-data-graphql to use graphql v16.

In ra-data-hasura we wanted to use graphql v16 but were getting the error "Conflicting peer dependency". I ran all the tests in the ra-data-graphql with v16 and they passed. Thank you!