### PR TITLE
[Doc] Remove reference to `react-autosuggest` component

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -374,8 +374,6 @@ When dealing with a large amount of `choices` you may need to limit the number o
 />
 ```
 
-This prop is passed to the underlying `MUI Autocomplete` component and is documented [in their respository](https://mui.com/material-ui/api/autocomplete/#props).
-
 ## `suggestionLimit`
 
 The `choices` prop can be very large, and rendering all of them would be very slow. To limit the number of suggestions displayed at any time, set the `suggestionLimit` prop:

--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -374,7 +374,7 @@ When dealing with a large amount of `choices` you may need to limit the number o
 />
 ```
 
-This prop is passed to the underlying `react-autosuggest` component and is documented [in their respository](https://github.com/moroshko/react-autosuggest#should-render-suggestions-prop).
+This prop is passed to the underlying `MUI Autocomplete` component and is documented [in their respository](https://mui.com/material-ui/api/autocomplete/#props).
 
 ## `suggestionLimit`
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -366,8 +366,6 @@ When dealing with a large amount of `choices` you may need to limit the number o
 />
 ```
 
-This prop is passed to the underlying `MUI Autocomplete` component and is documented [in their respository](https://mui.com/material-ui/api/autocomplete/#props).
-
 ## `suggestionLimit`
 
 The `choices` prop can be very large, and rendering all of them would be very slow. To limit the number of suggestions displayed at any time, set the `suggestionLimit` prop:

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -366,7 +366,7 @@ When dealing with a large amount of `choices` you may need to limit the number o
 />
 ```
 
-This prop is passed to the underlying `react-autosuggest` component and is documented [in their respository](https://github.com/moroshko/react-autosuggest#should-render-suggestions-prop).
+This prop is passed to the underlying `MUI Autocomplete` component and is documented [in their respository](https://mui.com/material-ui/api/autocomplete/#props).
 
 ## `suggestionLimit`
 


### PR DESCRIPTION
I initially change the reference to point to `MUI Autocomplete` component, but the original reference was too specific of `react-autosuggest` `shouldRenderSuggestions` docs and becomes unnecessary to make that remark with `MUI Autocomplete` `options` prop.

Especially given the fact that it's mention later on in the docs that `AutocompleteInput`/`AutocompleteArrayInput` uses `MUI Autocomplete` underneath.

But I can add it back if that is what you want
