### PR TITLE
Fix prop-types validation for TabbedFormView's `toolbar` prop

### DIFF
--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.tsx
@@ -256,4 +256,29 @@ describe('<TabbedForm />', () => {
             )
         ).toEqual(true);
     });
+
+    it('should not warn for `toolbar` prop of type `false`', () => {
+        const history = createMemoryHistory({ initialEntries: ['/'] });
+
+        const consoleSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        render(
+            <AdminContext dataProvider={testDataProvider()} history={history}>
+                <ResourceContextProvider value="posts">
+                    <TabbedForm toolbar={false}>
+                        <FormTab label="tab1"></FormTab>
+                    </TabbedForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+
+        expect(consoleSpy).not.toBeCalledWith(
+            'Warning: Failed %s type: %s%s',
+            'prop',
+            expect.stringContaining('Invalid prop `toolbar` of type `boolean`'),
+            expect.stringContaining(`at ${TabbedForm.name}`)
+        );
+    });
 });

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -111,7 +111,7 @@ TabbedFormView.propTypes = {
     // @ts-ignore
     resource: PropTypes.string,
     tabs: PropTypes.element,
-    toolbar: PropTypes.element,
+    toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.oneOf([false])]),
     validate: PropTypes.func,
     value: PropTypes.number,
 };


### PR DESCRIPTION
Currently, when specifying the `toolbar` prop of the TabbedForm component `false`, React issues a warning:

```
Warning: Failed prop type: Invalid prop `toolbar` of type `boolean` supplied to `TabbedFormView`, expected a single ReactElement.
```

This PR fixes PropTypes validation for the `toolbar` prop, allowing the `false` value to be used like:

```jsx
<TabbedForm toolbar={false}>...</TabbedForm>
```