### PR TITLE
Fix bugs in SearchInput and TextField related to the `label` property

### DIFF
--- a/packages/ra-ui-materialui/src/input/SearchInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.spec.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { testDataProvider } from 'ra-core';
+
+import { AdminContext } from '../AdminContext';
+import { SearchInput } from '.';
+import { FilterForm } from '../list';
+
+describe('<SearchInput />', () => {
+    it('should not render label if passed explicit `undefined` value', async () => {
+        const source = 'test';
+
+        const filters = [<SearchInput source={source} label={undefined} />];
+        const displayedFilters = {
+            [source]: true,
+        };
+
+        const { container } = render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <FilterForm
+                    setFilters={jest.fn()}
+                    filters={filters}
+                    displayedFilters={displayedFilters}
+                />
+            </AdminContext>
+        );
+
+        expect(container.querySelector(`label`)).toBeNull();
+    });
+});

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -8,9 +8,11 @@ import { CommonInputProps } from './CommonInputProps';
 import { TextInput, TextInputProps } from './TextInput';
 
 export const SearchInput = (props: SearchInputProps) => {
+    const { label, ...rest } = props;
+
     const translate = useTranslate();
 
-    if (props.label) {
+    if (label) {
         throw new Error(
             "<SearchInput> isn't designed to be used with a label prop. Use <TextInput> if you need a label."
         );
@@ -18,7 +20,6 @@ export const SearchInput = (props: SearchInputProps) => {
 
     return (
         <StyledTextInput
-            hiddenLabel
             label=""
             resettable
             placeholder={translate('ra.action.search')}
@@ -30,7 +31,7 @@ export const SearchInput = (props: SearchInputProps) => {
                 ),
             }}
             size="small"
-            {...props}
+            {...rest}
         />
     );
 };

--- a/packages/ra-ui-materialui/src/input/TextInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.spec.tsx
@@ -166,4 +166,36 @@ describe('<TextInput />', () => {
             expect(input.value).toEqual('bar');
         });
     });
+
+    describe('label', () => {
+        it('should not render label when `label` prop is `false`', () => {
+            const { container } = render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <SimpleForm
+                        defaultValues={{ title: 'hello' }}
+                        onSubmit={jest.fn}
+                    >
+                        <TextInput {...defaultProps} label={false} />
+                    </SimpleForm>
+                </AdminContext>
+            );
+
+            expect(container.querySelector(`label`)).toBeNull();
+        });
+
+        it('should not render label when `label` prop is empty string', () => {
+            const { container } = render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <SimpleForm
+                        defaultValues={{ title: 'hello' }}
+                        onSubmit={jest.fn}
+                    >
+                        <TextInput {...defaultProps} label="" />
+                    </SimpleForm>
+                </AdminContext>
+            );
+
+            expect(container.querySelector(`label`)).toBeNull();
+        });
+    });
 });

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -64,15 +64,14 @@ export const TextInput = (props: TextInputProps) => {
             {...field}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             label={
-                label !== '' &&
-                label !== false && (
+                label !== '' && label !== false ? (
                     <FieldTitle
                         label={label}
                         source={source}
                         resource={resource}
                         isRequired={isRequired}
                     />
-                )
+                ) : undefined
             }
             error={(isTouched || isSubmitted) && invalid}
             helperText={


### PR DESCRIPTION
Starting with MUI 5.4.0, they changed the way of displaying the label for TextField. Now the label will not be rendered only if `null`, `undefined` or `""` value is provided, but react-admin passes `false` as the label (so it will be rendered). This often affects the SearchInput component, which doesn't (and shouldn't) have label: placeholder is shown only when SearchInput is active (because the label replaces the placeholder when the input is not active).

Also, I fixed a bug, where when providing an explicit `undefined` value to the SearchInput's `label` property, the default label (based on `source`) was shown:
```jsx
<SearchInput source="q" label={undefined} />
```