### PR TITLE
[TypeScript] Fix `<ReferenceArrayInput>` props type marks children as required

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
@@ -122,7 +122,7 @@ ReferenceArrayInput.defaultProps = {
 export interface ReferenceArrayInputProps
     extends InputProps,
         UseReferenceArrayInputParams {
-    children: ReactElement;
+    children?: ReactElement;
     label?: string;
     [key: string]: any;
 }


### PR DESCRIPTION
Closes #8438