### PR TITLE
Show focus on clear buttons in `ResettableTextfield`

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -90,7 +90,6 @@ export const ResettableTextField = forwardRef(
                                     'ra.action.clear_input_value'
                                 )}
                                 title={translate('ra.action.clear_input_value')}
-                                disableRipple
                                 disabled={true}
                                 size="large"
                             >
@@ -135,7 +134,6 @@ export const ResettableTextField = forwardRef(
                                 'ra.action.clear_input_value'
                             )}
                             title={translate('ra.action.clear_input_value')}
-                            disableRipple
                             onClick={handleClickClearButton}
                             onMouseDown={handleMouseDownClearButton}
                             disabled={disabled}


### PR DESCRIPTION
Ripple effects had been disabled on resettable textfields, this removes the feedback during tabulation navigation.