### PR TITLE
Fix ArrayInput doesn't allow null as value

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -26,7 +26,7 @@
         "react": "^17.0.0",
         "react-admin": "^4.5.4",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.34.2",
+        "react-hook-form": "^7.38.0",
         "react-query": "^3.32.1",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0"

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -26,7 +26,7 @@
         "react": "^17.0.0",
         "react-admin": "^4.5.4",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.40.0",
         "react-query": "^3.32.1",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0"

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -39,7 +39,7 @@
         "ignore-styles": "~5.0.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.34.2",
+        "react-hook-form": "^7.38.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0",
         "react-test-renderer": "^16.9.0 || ^17.0.0",
@@ -51,7 +51,7 @@
         "history": "^5.1.0",
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react-hook-form": "^7.34.2",
+        "react-hook-form": "^7.38.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0"
     },

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -39,7 +39,7 @@
         "ignore-styles": "~5.0.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.40.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0",
         "react-test-renderer": "^16.9.0 || ^17.0.0",
@@ -51,7 +51,7 @@
         "history": "^5.1.0",
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.40.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0"
     },

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -53,7 +53,7 @@
         "ra-ui-materialui": "^4.5.4",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.40.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.0"
     }

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -53,7 +53,7 @@
         "ra-ui-materialui": "^4.5.4",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.34.2",
+        "react-hook-form": "^7.38.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.0"
     }

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -39,7 +39,7 @@
         "ra-language-english": "^4.5.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.40.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0",
         "react-test-renderer": "~16.8.6",

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -39,7 +39,7 @@
         "ra-language-english": "^4.5.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-hook-form": "^7.34.2",
+        "react-hook-form": "^7.38.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0",
         "react-test-renderer": "~16.8.6",

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -45,7 +45,7 @@
         "ra-i18n-polyglot": "^4.5.2",
         "ra-language-english": "^4.5.2",
         "ra-ui-materialui": "^4.5.4",
-        "react-hook-form": "^7.34.2",
+        "react-hook-form": "^7.38.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0"
     }

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -45,7 +45,7 @@
         "ra-i18n-polyglot": "^4.5.2",
         "ra-language-english": "^4.5.2",
         "ra-ui-materialui": "^4.5.4",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.40.0",
         "react-router": "^6.1.0",
         "react-router-dom": "^6.1.0"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21578,7 +21578,7 @@ __metadata:
     query-string: ^7.1.1
     react: ^17.0.0
     react-dom: ^17.0.0
-    react-hook-form: ^7.34.2
+    react-hook-form: ^7.38.0
     react-is: ^17.0.2
     react-query: ^3.32.1
     react-router: ^6.1.0
@@ -21591,7 +21591,7 @@ __metadata:
     history: ^5.1.0
     react: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
-    react-hook-form: ^7.34.2
+    react-hook-form: ^7.38.0
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
   languageName: unknown
@@ -21738,7 +21738,7 @@ __metadata:
     ra-ui-materialui: ^4.5.4
     react: ^17.0.0
     react-dom: ^17.0.0
-    react-hook-form: ^7.34.2
+    react-hook-form: ^7.38.0
     rimraf: ^3.0.2
     typescript: ^4.4.0
   peerDependencies:
@@ -21829,7 +21829,7 @@ __metadata:
     react-dom: ^17.0.0
     react-dropzone: ^12.0.4
     react-error-boundary: ^3.1.4
-    react-hook-form: ^7.34.2
+    react-hook-form: ^7.38.0
     react-query: ^3.32.1
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
@@ -22024,7 +22024,7 @@ __metadata:
     ra-i18n-polyglot: ^4.5.2
     ra-language-english: ^4.5.2
     ra-ui-materialui: ^4.5.4
-    react-hook-form: ^7.34.2
+    react-hook-form: ^7.38.0
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
     rimraf: ^3.0.2
@@ -22258,12 +22258,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.34.2":
-  version: 7.34.2
-  resolution: "react-hook-form@npm:7.34.2"
+"react-hook-form@npm:^7.38.0":
+  version: 7.40.0
+  resolution: "react-hook-form@npm:7.40.0"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18
-  checksum: da4f1c519ad4e365c7094166df638ed9d3f72579e6c7803c182567c51676e6fd16c84e5adb0a756a052be5850aa114403476d03fa694c6ae95c242983042aaed
+  checksum: 16e071ba3a11977948d7b0cbb6a84db80823465740210d3ea58d7cb93813e8771a585e4ffb82f53b24ac5ea43a6fe37da07b42d41aecda7b160dc68d68e50781
   languageName: node
   linkType: hard
 
@@ -24066,7 +24066,7 @@ __metadata:
     react-admin: ^4.5.4
     react-app-polyfill: ^1.0.4
     react-dom: ^17.0.0
-    react-hook-form: ^7.34.2
+    react-hook-form: ^7.38.0
     react-query: ^3.32.1
     react-router: ^6.1.0
     react-router-dom: ^6.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -21578,7 +21578,7 @@ __metadata:
     query-string: ^7.1.1
     react: ^17.0.0
     react-dom: ^17.0.0
-    react-hook-form: ^7.38.0
+    react-hook-form: ^7.40.0
     react-is: ^17.0.2
     react-query: ^3.32.1
     react-router: ^6.1.0
@@ -21591,7 +21591,7 @@ __metadata:
     history: ^5.1.0
     react: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
-    react-hook-form: ^7.38.0
+    react-hook-form: ^7.40.0
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
   languageName: unknown
@@ -21738,7 +21738,7 @@ __metadata:
     ra-ui-materialui: ^4.5.4
     react: ^17.0.0
     react-dom: ^17.0.0
-    react-hook-form: ^7.38.0
+    react-hook-form: ^7.40.0
     rimraf: ^3.0.2
     typescript: ^4.4.0
   peerDependencies:
@@ -21829,7 +21829,7 @@ __metadata:
     react-dom: ^17.0.0
     react-dropzone: ^12.0.4
     react-error-boundary: ^3.1.4
-    react-hook-form: ^7.38.0
+    react-hook-form: ^7.40.0
     react-query: ^3.32.1
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
@@ -22024,7 +22024,7 @@ __metadata:
     ra-i18n-polyglot: ^4.5.2
     ra-language-english: ^4.5.2
     ra-ui-materialui: ^4.5.4
-    react-hook-form: ^7.38.0
+    react-hook-form: ^7.40.0
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
     rimraf: ^3.0.2
@@ -22258,7 +22258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.38.0":
+"react-hook-form@npm:^7.40.0":
   version: 7.40.0
   resolution: "react-hook-form@npm:7.40.0"
   peerDependencies:
@@ -24066,7 +24066,7 @@ __metadata:
     react-admin: ^4.5.4
     react-app-polyfill: ^1.0.4
     react-dom: ^17.0.0
-    react-hook-form: ^7.38.0
+    react-hook-form: ^7.40.0
     react-query: ^3.32.1
     react-router: ^6.1.0
     react-router-dom: ^6.1.0


### PR DESCRIPTION
Fixes #7754

Reproduction case: https://stackblitz.com/edit/github-yb7hqu?file=package.json
1. Edit Post of id=1
Result: You get a `cannot read properties of null (reading 'map')` error.

To fix it, change `package.json` line 29 like so:

```diff
- "react-hook-form": "7.34.2",
+ "react-hook-form": "7.38.0",
```
and hard refresh the website
