### PR TITLE
Fix `<NumberInput>` parses 0 as string when used with a custom `parse` prop

### DIFF
--- a/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.spec.tsx
@@ -290,6 +290,50 @@ describe('<NumberInput />', () => {
             });
             expect(onSubmit.mock.calls[0][0].views).toBeNull();
         });
+
+        it('should cast value to a numeric with a custom parse function', async () => {
+            const onSubmit = jest.fn();
+
+            render(
+                <AdminContext>
+                    <SimpleForm toolbar={<MyToolbar />} onSubmit={onSubmit}>
+                        <NumberInput {...defaultProps} parse={value => value} />
+                    </SimpleForm>
+                </AdminContext>
+            );
+            const input = screen.getByLabelText('resources.posts.fields.views');
+            fireEvent.change(input, { target: { value: '12' } });
+            fireEvent.click(screen.getByText('ra.action.save'));
+            await waitFor(() => {
+                expect(onSubmit).toHaveBeenCalledWith(
+                    { views: 12 },
+                    expect.anything()
+                );
+            });
+            expect(typeof onSubmit.mock.calls[0][0].views).toEqual('number');
+        });
+
+        it('should cast 0 to a numeric with a custom parse function', async () => {
+            const onSubmit = jest.fn();
+
+            render(
+                <AdminContext>
+                    <SimpleForm toolbar={<MyToolbar />} onSubmit={onSubmit}>
+                        <NumberInput {...defaultProps} parse={value => value} />
+                    </SimpleForm>
+                </AdminContext>
+            );
+            const input = screen.getByLabelText('resources.posts.fields.views');
+            fireEvent.change(input, { target: { value: '0' } });
+            fireEvent.click(screen.getByText('ra.action.save'));
+            await waitFor(() => {
+                expect(onSubmit).toHaveBeenCalledWith(
+                    { views: 0 },
+                    expect.anything()
+                );
+            });
+            expect(typeof onSubmit.mock.calls[0][0].views).toEqual('number');
+        });
     });
 
     describe('onChange event', () => {

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -83,7 +83,6 @@ export const NumberInput = ({
         }
         const target = event.target;
         setValue(target.value);
-        console.log(target.valueAsNumber);
         const newValue =
             target.valueAsNumber !== undefined &&
             target.valueAsNumber !== null &&

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -83,8 +83,11 @@ export const NumberInput = ({
         }
         const target = event.target;
         setValue(target.value);
+        console.log(target.valueAsNumber);
         const newValue =
-            target.valueAsNumber !== undefined
+            target.valueAsNumber !== undefined &&
+            target.valueAsNumber !== null &&
+            !isNaN(target.valueAsNumber)
                 ? parse
                     ? parse(target.valueAsNumber)
                     : target.valueAsNumber

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -83,13 +83,14 @@ export const NumberInput = ({
         }
         const target = event.target;
         setValue(target.value);
-        const newValue = target.valueAsNumber
-            ? parse
-                ? parse(target.valueAsNumber)
-                : target.valueAsNumber
-            : parse
-            ? parse(target.value)
-            : convertStringToNumber(target.value);
+        const newValue =
+            target.valueAsNumber !== undefined
+                ? parse
+                    ? parse(target.valueAsNumber)
+                    : target.valueAsNumber
+                : parse
+                ? parse(target.value)
+                : convertStringToNumber(target.value);
         field.onChange(newValue);
     };
 


### PR DESCRIPTION
Fixes #8451