### PR TITLE
Fix ToggleThemeButton behaviour

### DIFF
--- a/packages/ra-ui-materialui/src/button/ToggleThemeButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ToggleThemeButton.tsx
@@ -25,7 +25,7 @@ import { RaThemeOptions } from '..';
 export const ToggleThemeButton = (props: ToggleThemeButtonProps) => {
     const translate = useTranslate();
     const { darkTheme, lightTheme } = props;
-    const [theme, setTheme] = useTheme(lightTheme);
+    const [theme, setTheme] = useTheme();
 
     const handleTogglePaletteType = (): void => {
         setTheme(theme?.palette.mode === 'dark' ? lightTheme : darkTheme);


### PR DESCRIPTION
Leave the responsability of setting theme to ThemeProvider

Fix #8426 :Theme switching with dark being the default requires an extra initial click on the ToggleThemeButton to switch to light