### PR TITLE
[TypeScript] Add missing types for TranslationMessages

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -12,6 +12,7 @@ export interface TranslationMessages extends StringMap {
             back: string;
             bulk_actions: string;
             cancel: string;
+            clear_array_input: string;
             clear_input_value: string;
             clone: string;
             confirm: string;
@@ -95,6 +96,7 @@ export interface TranslationMessages extends StringMap {
             bulk_delete_title: string;
             bulk_update_content: string;
             bulk_update_title: string;
+            clear_array_input: string;
             delete_content: string;
             delete_title: string;
             details: string;


### PR DESCRIPTION
https://github.com/marmelab/react-admin/commit/d72a583a8a7067bbb0d301d3e20cac3b1d2b65b5#diff-d55e636245f2994de4a9a74002cca1fec0a6a2e68d1805a5439a0c885f37263b