### PR TITLE
Add OutlinedInput for correct label handling in SelectArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -22,6 +22,7 @@ import {
 } from 'ra-core';
 import { InputHelperText } from './InputHelperText';
 import { FormControlProps } from '@mui/material/FormControl';
+import OutlinedInput from '@mui/material/OutlinedInput';
 
 import { LinearProgress } from '../layout';
 import { CommonInputProps } from './CommonInputProps';
@@ -253,6 +254,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                 <Select
                     autoWidth
                     labelId={`${label}-outlined-label`}
+                    input={<OutlinedInput label={label} />}
                     multiple
                     error={
                         !!fetchError || ((isTouched || isSubmitted) && invalid)


### PR DESCRIPTION
Currently, the label of the `SelectArrayInput` is not handled correctly when pushed upwards:
![image](https://user-images.githubusercontent.com/42775578/205499979-d2e7789e-6a18-4087-896c-7d2ca820c91a.png)
I used the example code from the react-admin docs: https://marmelab.com/react-admin/SelectArrayInput.html#usage

According to this [SO answer](https://stackoverflow.com/questions/53916720/label-of-multiple-select-is-crossed-out-by-the-outline-of-the-input-field/74049905#74049905) this can be fixed directly by MUI: https://mui.com/material-ui/react-select/#MultipleSelectCheckmarks.js

However, I could not test it locally as I was not able to include this fix in my project. I believe I don't properly understand the structure of the react-admin repo in order to consume my fix. I tried it with `yarn add https://gitpkg.now.sh/sebastianbuechler/react-admin/packages/react-admin`, but on startup, my project can't find react-admin.