### PR TITLE
Change the definition of sort order to ASC|DESC

### DIFF
--- a/examples/demo/src/invoices/InvoiceList.tsx
+++ b/examples/demo/src/invoices/InvoiceList.tsx
@@ -22,7 +22,7 @@ const InvoiceList = () => (
     <List
         filters={listFilters}
         perPage={25}
-        sort={{ field: 'date', order: 'desc' }}
+        sort={{ field: 'date', order: 'DESC' }}
     >
         <Datagrid
             rowClick="expand"

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -290,7 +290,7 @@ export interface ReferenceParamsOptions {
 
 export interface ReferenceParams {
     sort: string;
-    order: string;
+    order: 'ASC' | 'DESC';
     page: number;
     perPage: number;
     filter: any;
@@ -320,6 +320,6 @@ const emptyObject = {};
 const defaultSort = {
     field: 'id',
     order: SORT_ASC,
-};
+} as const;
 
 const defaultParams = {};

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -205,7 +205,7 @@ export interface ListControllerProps<RecordType extends RaRecord = any> {
 const defaultSort = {
     field: 'id',
     order: SORT_ASC,
-};
+} as const;
 
 export interface ListControllerResult<RecordType extends RaRecord = any> {
     sort: SortPayload;

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -20,7 +20,7 @@ import { useIsMounted } from '../../util/hooks';
 
 export interface ListParams {
     sort: string;
-    order: string;
+    order: 'ASC' | 'DESC';
     page: number;
     perPage: number;
     filter: any;
@@ -419,6 +419,6 @@ const emptyObject = {};
 const defaultSort = {
     field: 'id',
     order: SORT_ASC,
-};
+} as const;
 
 const defaultParams = {};

--- a/packages/ra-core/src/controller/useSortState.ts
+++ b/packages/ra-core/src/controller/useSortState.ts
@@ -46,7 +46,7 @@ const sortReducer = (state: SortPayload, action: Action): SortPayload => {
     }
 };
 
-export const defaultSort = { field: '', order: 'ASC' };
+export const defaultSort = { field: '', order: 'ASC' } as const;
 
 /**
  * Set the sort { field, order }
@@ -123,7 +123,7 @@ const useSortState = (initialSort: SortPayload = defaultSort): SortProps => {
             [dispatch]
         ),
         setSortOrder: useCallback(
-            (order: string) =>
+            (order: 'ASC' | 'DESC') =>
                 dispatch({ type: 'SET_SORT_ORDER', payload: order }),
             [dispatch]
         ),

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -15,7 +15,7 @@ export interface RaRecord<IdentifierType extends Identifier = Identifier>
 
 export interface SortPayload {
     field: string;
-    order: string;
+    order: 'ASC' | 'DESC';
 }
 export interface FilterPayload {
     [k: string]: any;

--- a/packages/ra-data-simple-rest/src/index.spec.ts
+++ b/packages/ra-data-simple-rest/src/index.spec.ts
@@ -25,7 +25,7 @@ describe('Data Simple REST Client', () => {
             });
 
             expect(httpClient).toHaveBeenCalledWith(
-                'http://localhost:3000/posts?filter=%7B%7D&range=%5B0%2C9%5D&sort=%5B%22title%22%2C%22desc%22%5D',
+                'http://localhost:3000/posts?filter=%7B%7D&range=%5B0%2C9%5D&sort=%5B%22title%22%2C%22DESC%22%5D',
                 {
                     headers: {
                         map: {

--- a/packages/ra-data-simple-rest/src/index.spec.ts
+++ b/packages/ra-data-simple-rest/src/index.spec.ts
@@ -20,7 +20,7 @@ describe('Data Simple REST Client', () => {
                 },
                 sort: {
                     field: 'title',
-                    order: 'desc',
+                    order: 'DESC',
                 },
             });
 
@@ -61,7 +61,7 @@ describe('Data Simple REST Client', () => {
                 },
                 sort: {
                     field: 'title',
-                    order: 'desc',
+                    order: 'DESC',
                 },
             });
 

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -123,7 +123,7 @@ ExportButton.propTypes = {
     resource: PropTypes.string,
     sort: PropTypes.exact({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     icon: PropTypes.element,
     meta: PropTypes.any,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -131,7 +131,7 @@ ReferenceManyField.propTypes = {
     source: PropTypes.string,
     sort: PropTypes.exact({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     target: PropTypes.string.isRequired,
 };
@@ -166,7 +166,7 @@ ReferenceManyFieldView.propTypes = {
     className: PropTypes.string,
     sort: PropTypes.exact({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     data: PropTypes.any,
     isLoading: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -176,4 +176,4 @@ ReferenceManyFieldView.propTypes = {
 };
 
 const defaultFilter = {};
-const defaultSort = { field: 'id', order: 'DESC' };
+const defaultSort = { field: 'id', order: 'DESC' as const };

--- a/packages/ra-ui-materialui/src/list/InfiniteList.tsx
+++ b/packages/ra-ui-materialui/src/list/InfiniteList.tsx
@@ -123,7 +123,7 @@ InfiniteList.propTypes = {
     //@ts-ignore-line
     sort: PropTypes.shape({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     sx: PropTypes.any,
     title: TitlePropType,

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -112,7 +112,7 @@ List.propTypes = {
     //@ts-ignore-line
     sort: PropTypes.shape({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     sx: PropTypes.any,
     title: TitlePropType,

--- a/packages/ra-ui-materialui/src/list/ListActions.tsx
+++ b/packages/ra-ui-materialui/src/list/ListActions.tsx
@@ -108,7 +108,10 @@ export const ListActions = (props: ListActionsProps) => {
 
 ListActions.propTypes = {
     className: PropTypes.string,
-    sort: PropTypes.any,
+    sort: PropTypes.shape({
+        field: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
+    }),
     displayedFilters: PropTypes.object,
     exporter: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     filters: PropTypes.element,

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -301,7 +301,7 @@ Datagrid.propTypes = {
     className: PropTypes.string,
     sort: PropTypes.exact({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     data: PropTypes.arrayOf(PropTypes.any),
     empty: PropTypes.element,

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -157,7 +157,7 @@ DatagridHeader.propTypes = {
     className: PropTypes.string,
     sort: PropTypes.exact({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }),
     data: PropTypes.arrayOf(PropTypes.any),
     hasExpand: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -73,7 +73,7 @@ DatagridHeaderCell.propTypes = {
     field: PropTypes.element,
     sort: PropTypes.shape({
         field: PropTypes.string,
-        order: PropTypes.string,
+        order: PropTypes.oneOf(['ASC', 'DESC'] as const),
     }).isRequired,
     isSorting: PropTypes.bool,
     resource: PropTypes.string,


### PR DESCRIPTION
Currently `order` in `SortPayload` type definition is a general string, but it shall be `ASC` or `DESC` in accordance with the docs and sort clicks in `Datagrid`  This PR changes the definition of `order` to `ASC|DESC`

I also changed some `desc` in spec or demo files to `DESC`, because, if we use `Datagrid` from the react-admin, then our order would be predefined `DESC` or `ASC`, not the small cased `desc` or `asc`.