### PR TITLE
Fix `<ResourceMenuItem>` throws an error when used with only `<Resource>` as `<Admin>` children

### DIFF
--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.spec.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Resource, testDataProvider } from 'ra-core';
+import { Layout, LayoutProps, Menu } from '.';
+import { AdminContext } from '../AdminContext';
+import { AdminUI } from '../AdminUI';
+import { ListGuesser } from '../list';
+
+describe('ResourceMenuItem', () => {
+    it('should not throw when used with only <Resource> as <Admin> child', async () => {
+        const dataProvider = testDataProvider();
+        const CustomMenu = () => (
+            <Menu>
+                <Menu.ResourceItem name="users" />
+            </Menu>
+        );
+        const CustomLayout = (props: LayoutProps) => (
+            <Layout {...props} menu={CustomMenu} />
+        );
+        const App = () => (
+            <AdminContext dataProvider={dataProvider}>
+                <AdminUI layout={CustomLayout}>
+                    <Resource name="users" list={ListGuesser} />
+                </AdminUI>
+            </AdminContext>
+        );
+        render(<App />);
+    });
+    it('should not throw when used with a Function as <Admin> child', async () => {
+        const dataProvider = testDataProvider();
+        const authProvider: any = {
+            getPermissions: () => Promise.resolve([]),
+            checkAuth: () => Promise.resolve(),
+        };
+        const CustomMenu = () => (
+            <Menu>
+                <Menu.ResourceItem name="users" />
+            </Menu>
+        );
+        const CustomLayout = (props: LayoutProps) => (
+            <Layout {...props} menu={CustomMenu} />
+        );
+        const App = () => (
+            <AdminContext
+                dataProvider={dataProvider}
+                authProvider={authProvider}
+            >
+                <AdminUI layout={CustomLayout}>
+                    <Resource name="users" list={ListGuesser} />
+                    {permissions => (
+                        <Resource name="posts" list={ListGuesser} />
+                    )}
+                </AdminUI>
+            </AdminContext>
+        );
+        render(<App />);
+    });
+});

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
@@ -14,6 +14,7 @@ export const ResourceMenuItem = ({ name }: { name: string }) => {
     const resources = useResourceDefinitions();
     const getResourceLabel = useGetResourceLabel();
     const createPath = useCreatePath();
+    if (!resources || !resources[name]) return null;
     return (
         <MenuItemLink
             to={createPath({


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/8469

Without the fix:
- `should not throw when used with a Function as <Admin> child` passes :heavy_check_mark: 
- `should not throw when used with only <Resource> as <Admin> child` fails :negative_squared_cross_mark: 

With the fix, both tests pass. :heavy_check_mark: 