### PR TITLE
Fix useReferenceInputController to pass meta to useReference

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -116,6 +116,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         reference,
         options: {
             enabled: currentValue != null && currentValue !== '',
+            meta,
         },
     });
     // add current value to possible sources

--- a/packages/ra-core/src/controller/useReference.ts
+++ b/packages/ra-core/src/controller/useReference.ts
@@ -46,11 +46,12 @@ export interface UseReferenceResult<RecordType extends RaRecord = any> {
 export const useReference = <RecordType extends RaRecord = any>({
     reference,
     id,
-    options,
+    options = {},
 }: UseReferenceProps<RecordType>): UseReferenceResult<RecordType> => {
+    const { meta, ...otherQueryOptions } = options;
     const { data, error, isLoading, isFetching, refetch } = useGetManyAggregate<
         RecordType
-    >(reference, { ids: [id] }, options);
+    >(reference, { ids: [id], meta }, otherQueryOptions);
     return {
         referenceRecord: error ? undefined : data ? data[0] : undefined,
         refetch,

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
@@ -131,6 +131,29 @@ describe('<ReferenceInput />', () => {
         });
     });
 
+    it('should use meta when fetching current value', async () => {
+        const getMany = jest
+            .fn()
+            .mockImplementationOnce(() => Promise.resolve({ data: [] }));
+        const dataProvider = testDataProvider({ getMany });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Form record={{ post_id: 23 }}>
+                    <ReferenceInput
+                        {...defaultProps}
+                        queryOptions={{ meta: { foo: 'bar' } }}
+                    />
+                </Form>
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(getMany).toHaveBeenCalledWith('posts', {
+                ids: [23],
+                meta: { foo: 'bar' },
+            });
+        });
+    });
+
     it('should convert empty values to null with AutocompleteInput', async () => {
         jest.spyOn(console, 'log').mockImplementationOnce(() => {});
         const dataProvider = {


### PR DESCRIPTION
This relates to #8191, reporting that meta isn't passed on with `ReferenceInput`.  The issue mentions `useGetList` only, however it also uses `useReference` (which in turn calls `getMany` on the data provider).

So #8192 changed `ReferenceInput` to pass meta to the `getList` call.  However still not using it with the `getMany` call which is triggered to resolve an already assigned value.