### PR TITLE
Fix preferenceKey definition in `<SelectColumnsButton>` 

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.stories.tsx
@@ -8,6 +8,7 @@ import { Inspector, InspectorButton } from '../../preferences';
 import { TextField } from '../../field';
 import { EditButton } from '../../button';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { SelectColumnsButton } from './SelectColumnsButton';
 
 export default { title: 'ra-ui-materialui/list/DatagridConfigurable' };
 
@@ -96,38 +97,44 @@ export const Omit = () => (
 );
 
 export const PreferenceKey = () => (
-    <PreferencesEditorContextProvider>
-        <MemoryRouter>
-            <Inspector />
-            <Box display="flex" justifyContent="flex-end">
-                <InspectorButton />
-            </Box>
-            <Box p={2} display="flex" justifyContent="space-between">
-                <DatagridConfigurable
-                    resource="books3"
-                    data={data}
-                    sort={{ field: 'title', order: 'ASC' }}
-                    bulkActionButtons={false}
-                    preferenceKey="pref1"
-                >
-                    <TextField source="id" />
-                    <TextField source="title" label="Original title" />
-                    <TextField source="author" />
-                    <TextField source="year" />
-                </DatagridConfigurable>
-                <DatagridConfigurable
-                    resource="books3"
-                    data={data}
-                    sort={{ field: 'title', order: 'ASC' }}
-                    bulkActionButtons={false}
-                    preferenceKey="pref2"
-                >
-                    <TextField source="id" />
-                    <TextField source="title" label="Original title" />
-                    <TextField source="author" />
-                    <TextField source="year" />
-                </DatagridConfigurable>
-            </Box>
-        </MemoryRouter>
-    </PreferencesEditorContextProvider>
+    <ThemeProvider theme={theme}>
+        <PreferencesEditorContextProvider>
+            <MemoryRouter>
+                <Inspector />
+                <Box display="flex" justifyContent="space-around">
+                    <SelectColumnsButton
+                        resource="books3"
+                        preferenceKey="pref1"
+                    />
+                    <InspectorButton color="primary" />
+                </Box>
+                <Box p={2} display="flex" justifyContent="space-between">
+                    <DatagridConfigurable
+                        resource="books3"
+                        data={data}
+                        sort={{ field: 'title', order: 'ASC' }}
+                        bulkActionButtons={false}
+                        preferenceKey="pref1"
+                    >
+                        <TextField source="id" />
+                        <TextField source="title" label="Original title" />
+                        <TextField source="author" />
+                        <TextField source="year" />
+                    </DatagridConfigurable>
+                    <DatagridConfigurable
+                        resource="books3"
+                        data={data}
+                        sort={{ field: 'title', order: 'ASC' }}
+                        bulkActionButtons={false}
+                        preferenceKey="pref2"
+                    >
+                        <TextField source="id" />
+                        <TextField source="title" label="Original title" />
+                        <TextField source="author" />
+                        <TextField source="year" />
+                    </DatagridConfigurable>
+                </Box>
+            </MemoryRouter>
+        </PreferencesEditorContextProvider>
+    </ThemeProvider>
 );

--- a/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.tsx
@@ -38,17 +38,22 @@ import { styled } from '@mui/material/styles';
  *   </List>
  * );
  */
-export const SelectColumnsButton = props => {
+export const SelectColumnsButton = (props: SelectColumnsButtonProps) => {
+    const { preferenceKey } = props;
+
     const resource = useResourceContext(props);
-    const preferenceKey =
-        props.preferenceKey || `preferences.${resource}.datagrid`;
+    const finalPreferenceKey = preferenceKey || `${resource}.datagrid`;
+
     const [anchorEl, setAnchorEl] = React.useState(null);
     const [availableColumns, setAvailableColumns] = useStore<
         ConfigurableDatagridColumn[]
-    >(`${preferenceKey}.availableColumns`, []);
-    const [omit] = useStore<string[]>(`${preferenceKey}.omit`, []);
+    >(`preferences.${finalPreferenceKey}.availableColumns`, []);
+    const [omit] = useStore<string[]>(
+        `preferences.${finalPreferenceKey}.omit`,
+        []
+    );
     const [columns, setColumns] = useStore<string[]>(
-        `${preferenceKey}.columns`,
+        `preferences.${preferenceKey}.columns`,
         availableColumns
             .filter(column => !omit?.includes(column.source))
             .map(column => column.index)
@@ -130,6 +135,7 @@ export const SelectColumnsButton = props => {
                         color="primary"
                         onClick={handleClick}
                         size="large"
+                        {...sanitizeRestProps(props)}
                     >
                         <ViewWeekIcon />
                     </IconButton>
@@ -139,6 +145,7 @@ export const SelectColumnsButton = props => {
                     size="small"
                     onClick={handleClick}
                     startIcon={<ViewWeekIcon />}
+                    {...sanitizeRestProps(props)}
                 >
                     {title}
                 </StyledButton>
@@ -184,6 +191,14 @@ const StyledButton = styled(Button, {
     },
 });
 
-export interface SelectColumnsButtonProps {
-    preferenceKey: string;
+const sanitizeRestProps = ({
+    resource = null,
+    preferenceKey = null,
+    ...rest
+}) => rest;
+
+export interface SelectColumnsButtonProps
+    extends React.HtmlHTMLAttributes<HTMLDivElement> {
+    resource?: string;
+    preferenceKey?: string;
 }

--- a/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.tsx
@@ -53,7 +53,7 @@ export const SelectColumnsButton = (props: SelectColumnsButtonProps) => {
         []
     );
     const [columns, setColumns] = useStore<string[]>(
-        `preferences.${preferenceKey}.columns`,
+        `preferences.${finalPreferenceKey}.columns`,
         availableColumns
             .filter(column => !omit?.includes(column.source))
             .map(column => column.index)


### PR DESCRIPTION
Duplicate of #8432 

- [x] Fix `preferenceKey`discrepencies between `<DatagridConfigurable>` and `<SelectColumnsButton>`
- [x] Add typescript support to `<SelectColumnsButton>`

