### PR TITLE
Fix incorrect `<Ready>` page when dynamically load routes with no resources

### DIFF
--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -129,7 +129,9 @@ const useRoutesAndResourcesFromChildren = (
             setStatus(
                 !!functionChild
                     ? 'loading'
-                    : newRoutesAndResources.resources.length > 0
+                    : newRoutesAndResources.resources.length > 0 ||
+                      newRoutesAndResources.customRoutesWithLayout.length > 0 ||
+                      newRoutesAndResources.customRoutesWithoutLayout.length > 0
                     ? 'ready'
                     : 'empty'
             );

--- a/packages/ra-no-code/src/Admin.tsx
+++ b/packages/ra-no-code/src/Admin.tsx
@@ -12,7 +12,7 @@ import {
     ResourceConfigurationPage,
     ResourceConfigurationProvider,
 } from './ResourceConfiguration';
-import { Layout, Ready } from './ui';
+import { Layout } from './ui';
 import { Route } from 'react-router';
 import { useApplication } from './ApplicationContext';
 

--- a/packages/ra-no-code/src/ui/Layout.tsx
+++ b/packages/ra-no-code/src/ui/Layout.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { Layout as RaLayout, LayoutProps } from 'react-admin';
+import { useResourcesConfiguration } from '../ResourceConfiguration';
 import { Menu } from './Menu';
 import { AppBar } from './Appbar';
+import { Ready } from './Ready';
 
-export const Layout = (props: LayoutProps) => (
-    <RaLayout {...props} appBar={AppBar} menu={Menu} />
-);
+export const Layout = (props: LayoutProps) => {
+    const [resources] = useResourcesConfiguration();
+    const hasResources = !!resources && Object.keys(resources).length > 0;
+
+    if (!hasResources) {
+        return <Ready />;
+    }
+
+    return <RaLayout {...props} appBar={AppBar} menu={Menu} />;
+};


### PR DESCRIPTION
As a follow up of feature https://github.com/marmelab/react-admin/pull/7609 under the use case of defining an admin without resources but routes,

There seems to be a bug if additional routes are _lazily_ added to the list of child routes when user navigates in the app.

It triggers a rerender https://github.com/marmelab/react-admin/blame/master/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx#L123 and it incorrectly redirects the user to `<Ready />` component

This pull requests adds additional checks similar to https://github.com/marmelab/react-admin/blame/master/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx#L253