### PR TITLE
[TypeScript] Fix `useReferenceManyFieldController` argument type

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -18,7 +18,7 @@ export interface UseReferenceManyFieldControllerParams {
     perPage?: number;
     record?: RaRecord;
     reference: string;
-    resource: string;
+    resource?: string;
     sort?: SortPayload;
     source?: string;
     target: string;
@@ -29,33 +29,26 @@ const defaultFilter = {};
 /**
  * Fetch reference records, and return them when available
  *
- * The reference prop should be the name of one of the <Resource> components
- * added as <Admin> child.
+ * Uses dataProvider.getManyReference() internally.
  *
- * @example
- *
+ * @example // fetch the comments related to the current post
  * const { isLoading, data } = useReferenceManyFieldController({
- *     resource
- *     reference: 'users',
- *     record: {
- *         userId: 7
- *     }
- *     target: 'comments',
- *     source: 'userId',
- *     page: 1,
- *     perPage: 25,
+ *     reference: 'comments',
+ *     target: 'post_id',
+ *     record: { id: 123, title: 'hello, world' },
+ *     resource: 'posts',
  * });
  *
  * @param {Object} props
- * @param {string} props.resource The current resource name
- * @param {string} props.reference The linked resource name
- * @param {Object} props.record The current resource record
- * @param {string} props.target The target resource key
+ * @param {string} props.reference The linked resource name. Required.
+ * @param {string} props.target The target resource key. Required.
  * @param {Object} props.filter The filter applied on the recorded records list
- * @param {string} props.source The key of the linked resource identifier
  * @param {number} props.page the page number
  * @param {number} props.perPage the number of item per page
+ * @param {Object} props.record The current resource record
+ * @param {string} props.resource The current resource name
  * @param {Object} props.sort the sort to apply to the referenced records
+ * @param {string} props.source The key of the linked resource identifier
  *
  * @returns {ListControllerResult} The reference many props
  */

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -58,7 +58,7 @@ import { PublicFieldProps, fieldPropTypes, InjectedFieldProps } from './types';
  *    ...
  * </ReferenceManyField>
  */
-export const ReferenceManyField: FC<ReferenceManyFieldProps> = props => {
+export const ReferenceManyField = (props: ReferenceManyFieldProps) => {
     const {
         children,
         filter,


### PR DESCRIPTION
`resource` isn't required as the controller uses the `ResourceContext` to fetch it. We didn't catch this before because `strictNullchecks` is off.