### PR TITLE
[TypeScript] Fix return type of `useShowContext`, `useEditContext`, and `useCreateContext`

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/create/useCreateContext.tsx
@@ -24,7 +24,7 @@ import { CreateControllerResult } from './useCreateController';
  */
 export const useCreateContext = <RecordType extends RaRecord = RaRecord>(
     props?: Partial<CreateControllerResult<RecordType>>
-): Partial<CreateControllerResult<RecordType>> => {
+): CreateControllerResult<RecordType> => {
     const context = useContext<CreateControllerResult<RecordType>>(
         // Can't find a way to specify the RecordType when CreateContext is declared
         // @ts-ignore

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -24,7 +24,7 @@ import { EditControllerResult } from './useEditController';
  */
 export const useEditContext = <RecordType extends RaRecord = any>(
     props?: Partial<EditControllerResult<RecordType>>
-): Partial<EditControllerResult<RecordType>> => {
+): EditControllerResult<RecordType> => {
     // Can't find a way to specify the RecordType when EditContext is declared
     // @ts-ignore
     const context = useContext<EditControllerResult<RecordType>>(EditContext);

--- a/packages/ra-core/src/controller/show/useShowContext.tsx
+++ b/packages/ra-core/src/controller/show/useShowContext.tsx
@@ -24,7 +24,7 @@ import { ShowControllerResult } from './useShowController';
  */
 export const useShowContext = <RecordType extends RaRecord = any>(
     props?: Partial<ShowControllerResult<RecordType>>
-): Partial<ShowControllerResult<RecordType>> => {
+): ShowControllerResult<RecordType> => {
     // Can't find a way to specify the RecordType when ShowContext is declared
     // @ts-ignore
     const context = useContext<ShowControllerResult<RecordType>>(ShowContext);


### PR DESCRIPTION
The Partial doesn't exist in useListContext, and is wrong. It leads to TypeScript error when accessing any property from the context without testing its existence first.