### PR TITLE
Fix `useGetIdentity` throws an error when no `authProvider.getIdentity` is provided

### DIFF
--- a/packages/ra-core/src/auth/useGetIdentity.spec.tsx
+++ b/packages/ra-core/src/auth/useGetIdentity.spec.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import { Basic, ErrorCase, ResetIdentity } from './useGetIdentity.stories';
+import useGetIdentity from './useGetIdentity';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import AuthContext from './AuthContext';
 
 describe('useGetIdentity', () => {
     it('should return the identity', async () => {
@@ -21,5 +24,36 @@ describe('useGetIdentity', () => {
         fireEvent.click(screen.getByText('Save'));
         await screen.findByText('Jane Doe');
         expect(screen.queryByText('John Doe')).toBeNull();
+    });
+    it('should not throw errors when there is no authProvider.getIdentity', async () => {
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkAuth: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            getPermissions: () => Promise.resolve(),
+        };
+        const Identity = () => {
+            const { data, error, isLoading } = useGetIdentity({ retry: false });
+            return isLoading ? (
+                <>Loading</>
+            ) : error ? (
+                <>{`Error: ${error.message}`}</>
+            ) : (
+                <>{String(data)}</>
+            );
+        };
+        render(
+            <QueryClientProvider client={new QueryClient()}>
+                <AuthContext.Provider value={authProvider}>
+                    <Identity />
+                </AuthContext.Provider>
+            </QueryClientProvider>
+        );
+        await waitFor(() => {
+            expect(screen.queryByText('Loading')).toBeNull();
+        });
+        expect(screen.queryByText(/Error/)).toBeNull();
+        expect(screen.queryByText('undefined')).not.toBeNull();
     });
 });

--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -52,7 +52,7 @@ export const useGetIdentity = (
             ? () => authProvider.getIdentity()
             : async () => defaultIdentity,
         {
-            enabled: typeof authProvider.getIdentity === 'function',
+            enabled: typeof authProvider?.getIdentity === 'function',
             ...queryParams,
         }
     );

--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -51,7 +51,10 @@ export const useGetIdentity = (
         authProvider
             ? () => authProvider.getIdentity()
             : async () => defaultIdentity,
-        queryParams
+        {
+            enabled: typeof authProvider.getIdentity === 'function',
+            ...queryParams,
+        }
     );
 
     // @FIXME: return useQuery's result directly by removing identity prop (BC break - to be done in v5)


### PR DESCRIPTION
Issue raised by https://github.com/marmelab/react-admin/pull/8372#discussion_r1050404542