### PR TITLE
Add lifecycle callbacks to facilitate dataProvider customization

### DIFF
--- a/cypress/e2e/edit.cy.js
+++ b/cypress/e2e/edit.cy.js
@@ -8,6 +8,7 @@ describe('Edit Page', () => {
     const ListPagePosts = listPageFactory('/#/posts');
     const CreatePostPage = createPageFactory('/#/posts/create');
     const EditCommentPage = editPageFactory('/#/comments/5');
+    const ListCommentPage = listPageFactory('/#/comments');
     const LoginPage = loginPageFactory('/#/login');
     const EditUserPage = editPageFactory('/#/users/3');
     const CreateUserPage = createPageFactory('/#/users/create');
@@ -285,8 +286,7 @@ describe('Edit Page', () => {
         );
     });
 
-    // FIXME unskip me when useGetList uses the react-query API
-    it.skip('should refresh the list when the update fails', () => {
+    it('should refresh the list when the update fails', () => {
         ListPagePosts.navigate();
         ListPagePosts.nextPage(); // Ensure the record is visible in the table
 
@@ -327,5 +327,26 @@ describe('Edit Page', () => {
         // If the update succeeded without display a warning about unsaved changes,
         // we should have been redirected to the list
         cy.url().then(url => expect(url).to.contain('/#/posts'));
+    });
+
+    describe('lifecycle callbacks', () => {
+        it('should delete related comments when deleting a post', () => {
+            ListCommentPage.navigate();
+            ListCommentPage.waitUntilDataLoaded();
+            cy.get('[data-testid="postLink"]').should('have.length', 6);
+            ListCommentPage.nextPage();
+            ListCommentPage.waitUntilDataLoaded();
+            cy.get('[data-testid="postLink"]').should('have.length', 5);
+
+            EditPostPage.navigate();
+            EditPostPage.delete();
+
+            ListCommentPage.navigate(); // go back to the list, on page 2
+            ListCommentPage.waitUntilDataLoaded();
+            cy.get('[data-testid="postLink"]').should('have.length', 3);
+            ListCommentPage.previousPage();
+            ListCommentPage.waitUntilDataLoaded();
+            cy.get('[data-testid="postLink"]').should('have.length', 6);
+        });
     });
 });

--- a/cypress/support/ListPage.js
+++ b/cypress/support/ListPage.js
@@ -34,6 +34,7 @@ export default url => ({
         headroomUnfixed: '.headroom--unfixed',
         headroomUnpinned: '.headroom--unpinned',
         skipNavButton: '.skip-nav-button',
+        mainContent: '#main-content',
     },
 
     navigate() {

--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -848,7 +848,7 @@ export const dataProvider = {
 If you need to add custom business logic to a generic `dataProvider` for a specific resource, you can use the `withLifecycleCallbacks` helper:
 
 ```jsx
-// in scr/dataProvider.js
+// in src/dataProvider.js
 import { withLifecycleCallbacks } from 'react-admin';
 import simpleRestProvider from 'ra-data-simple-rest';
 

--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -843,3 +843,35 @@ export const dataProvider = {
 };
 ```
 
+## Resource-Specific Business Logic
+
+If you need to add custom business logic to a generic `dataProvider` for a specific resource, you can use the `withLifecycleCallbacks` helper:
+
+```jsx
+// in scr/dataProvider.js
+import { withLifecycleCallbacks } from 'react-admin';
+import simpleRestProvider from 'ra-data-simple-rest';
+
+const baseDataProvider = simpleRestProvider('http://path.to.my.api/');
+
+export const dataProvider = withLifecycleCallbacks(baseDataProvider, [
+    {
+        resource: 'posts',
+        beforeDelete: async (params, dataProvider) => {
+            // delete all comments related to the post
+            // first, fetch the comments
+            const { data: comments } = await dataProvider.getList('comments', {
+                filter: { post_id: params.id },
+                pagination: { page: 1, perPage: 1000 },
+                sort: { field: 'id', order: 'DESC' },
+            });
+            // then, delete them
+            await dataProvider.deleteMany('comments', { ids: comments.map(comment => comment.id) });
+
+            return params;
+        },
+    },
+]);
+```
+
+Check the [withLifecycleCallbacks](./withLifecycleCallbacks.md) documentation for more details.

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -242,6 +242,8 @@ const dataProvider = {
 But the `dataProvider` code quickly becomes hard to read and maintain. React-admin provides a helper function to make it easier to add lifecycle callbacks to the dataProvider: `withLifecycleCallbacks`:
 
 ```jsx
+import { withLifecycleCallbacks } from 'react-admin';
+
 const dataProvider = withLifecycleCallbacks(baseDataProvider, [
     {
         resource: 'posts',
@@ -262,68 +264,7 @@ const dataProvider = withLifecycleCallbacks(baseDataProvider, [
 ]);
 ```
 
-The `withLifecycleCallbacks` function takes two arguments:
-
-- The base dataProvider
-- An array of lifecycle callbacks
-
-A lifecycle callback object can have the following properties:
-
-```jsx
-const myLifecycleCallback = {
-  resource: /* resource name (required) */,
-  // before callbacks
-  beforeGetList: /* async (params, dataProvider) => params */,
-  beforeGetOne: /* async (params, dataProvider) => params */,
-  beforeGetMany : /* async (params, dataProvider) => params */,
-  beforeGetManyReference: /* async (params, dataProvider) => params */,
-  beforeCreate: /* async (params, dataProvider) => params */,
-  beforeUpdate: /* async (params, dataProvider) => params */,
-  beforeUpdateMany: /* async (params, dataProvider) => params */,
-  beforeDelete: /* async (params, dataProvider) => params */,
-  beforeDeleteMany: /* async (params, dataProvider) => params */,
-  // after callbacks
-  afterGetList: /* async (result, dataProvider) => result */,
-  afterGetOne: /* async (result, dataProvider) => result */,
-  afterGetMany: /* async (result, dataProvider) => result */,
-  afterGetManyReference: /* async (result, dataProvider) => result */,
-  afterCreate: /* async (result, dataProvider) => result */,
-  afterUpdate: /* async (result, dataProvider) => result */,
-  afterUpdateMany: /* async (result, dataProvider) => result */,
-  afterDelete: /* async (result, dataProvider) => result */,
-  afterDeleteMany: /* async (result, dataProvider) => result */,
-  // special callbacks
-  afterRead: /* async (record, dataProvider) => record */,
-  beforeSave: /* async (data, dataProvider) => data */,
-  afterSave: /* async (record, dataProvider) => record */,
-}
-```
-
-The callbacks have different parameters:
-
-- before callbacks receive the following arguments:
-    - `params`: the parameters passed to the dataProvider method
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- after callbacks receive the following arguments:
-    - `response`: the response returned by the dataProvider method
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `afterRead` is called after any dataProvider method that reads data (`getList`, `getOne`, `getMany`, `getManyReference`), letting you modify the records before react-admin uses them. It receives the following arguments:
-    - `record`: the record returned by the backend 
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `beforeSave` is called before any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you modify the records before they are sent to the backend. It receives the following arguments:
-    - `data`: the record update to be sent to the backend (often, a diff of the record)
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `afterSave` is called after any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you updte related records. It receives the following arguments:
-    - `record`: the record returned by the backend 
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-
-Use lifecycle callbacks with caution:
-
-- They execute outside of the React context, and therefore cannot use hooks. 
-- As queries issued in the callbacks are not done through react-query, any change in the data will not be automatically reflected in the UI. If you need to update the UI, prefer putting the logic in the `onSuccess` property of the mutation. 
-- The callbacks are not executed in a transaction. In case of error, the backend may be left in an inconsistent state.
-- When another client than react-admin calls the API, the callbacks will not be executed, leaving the backend in a possiblly inconsistent state.
-- If a callback triggers the query it's listening to, this will lead to a infinite loop.
+Check the [withLifecycleCallbacks](./withLifecycleCallbacks.md) documentation for more details.
 
 ## Handling File Uploads
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -231,9 +231,11 @@ const dataProvider = {
             })));
         }
         // fallback to the default implementation
-        return httpClient(`${apiUrl}/${resource}/${params.id}`, {
+        const { data } = await httpClient(`${apiUrl}/${resource}/${params.id}`, {
             method: 'DELETE',
         });
+
+        return { data };
     },
     // ...
 }

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -226,5 +226,6 @@ title: "Reference"
 * [`useUnselect`](./useUnselect.md)
 * [`useUnselectAll`](./useUnselectAll.md)
 * [`useWarnWhenUnsavedChanges`](./EditTutorial.md#warning-about-unsaved-changes)
+* [ `withLifecycleCallbacks`](./withLifecycleCallbacks.md)
 
 </div>

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -35,6 +35,7 @@
   <li {% if page.path == 'useDeleteMany.md' %} class="active" {% endif %}><a class="nav-link" href="./useDeleteMany.html"><code>useDeleteMany</code></a></li>
   <li><a class="nav-link external" href="https://marmelab.com/ra-enterprise/modules/ra-realtime#real-time-hooks.html" target="_blank"><code>useSubscribe</code><img class="premium" src="./img/premium.svg" /></a></li>
   <li {% if page.path == 'useGetTree.md' %} class="active" {% endif %}><a class="nav-link" href="./useGetTree.html"><code>useGetTree</code><img class="premium" src="./img/premium.svg" /></a></li>
+  <li {% if page.path == 'withLifecycleCallbacks.md' %} class="active" {% endif %}><a class="nav-link" href="./withLifecycleCallbacks.html"><code>withLifecycleCallbacks</code></a></li>
 </ul>
 
 <ul><div>Auth Provider and Security</div>

--- a/docs/withLifecycleCallbacks.md
+++ b/docs/withLifecycleCallbacks.md
@@ -16,7 +16,7 @@ Use `withLifecycleCallbacks` to decorate an existing data provider. In addition 
 For instance, to delete the comments related to a post before deleting the post itself:
 
 ```jsx
-// in scr/dataProvider.js
+// in src/dataProvider.js
 import { withLifecycleCallbacks } from 'react-admin';
 import simpleRestProvider from 'ra-data-simple-rest';
 

--- a/docs/withLifecycleCallbacks.md
+++ b/docs/withLifecycleCallbacks.md
@@ -1,0 +1,298 @@
+---
+layout: default
+title: "withLifecycleCallbacks"
+---
+
+# `withLifecycleCallbacks`
+
+This helper function adds logic to an existing [`dataProvider`](./DataProviderIntroduction.md) for particular resources, using pre- and post- event handlers like `beforeGetOne` and `afterSave`.
+
+**Note**: It's always preferable to **define custom business logic on the server side**. This helper is useful when you can't alter the underlying API, but has some serious [limitations](#limitations).
+
+## Usage
+
+Use `withLifecycleCallbacks` to decorate an existing data provider. In addition to the base data provider, this function takes an array of objects that define the callbacks for one resource.
+
+For instance, to delete the comments related to a post before deleting the post itself:
+
+```jsx
+// in scr/dataProvider.js
+import { withLifecycleCallbacks } from 'react-admin';
+import simpleRestProvider from 'ra-data-simple-rest';
+
+const baseDataProvider = simpleRestProvider('http://path.to.my.api/');
+
+export const dataProvider = withLifecycleCallbacks(baseDataProvider, [
+    {
+        resource: 'posts',
+        beforeDelete: async (params, dataProvider) => {
+            // delete all comments related to the post
+            // first, fetch the comments
+            const { data: comments } = await dataProvider.getList('comments', {
+                filter: { post_id: params.id },
+                pagination: { page: 1, perPage: 1000 },
+                sort: { field: 'id', order: 'DESC' },
+            });
+            // then, delete them
+            await dataProvider.deleteMany('comments', { ids: comments.map(comment => comment.id) });
+
+            return params;
+        },
+    },
+]);
+```
+
+Then, inject the decorated data provider in the `<Admin>` component:
+
+```jsx
+// in src/App.js
+import { Admin } from 'react-admin';
+import { dataProvider } from './dataProvider';
+
+export const App = () => (
+    <Admin dataProvider={dataProvider}>
+        {/* ... */}
+    </Admin>
+)
+```
+
+Lifecycle callbacks are a good way to:
+
+- Add custom parameters before a `dataProvider` method is called (e.g. to set the query `meta` parameter based on the user profile),
+- Clean up the data before it's sent to the API (e.g. to transform two `lat` and `long` values into a single `location` field),
+- Add or rename fields in the data returned by the API before using it in react-dmin (e.g. to add a `fullName` field based on the `firstName` and `lastName` fields),
+- Update related records when a record is created, updated or deleted (e.g. update the `post.nb_comments` field after a `comment` is created or deleted)
+- Remove related records when a record is deleted (similar to a server-side `ON DELETE CASCADE`)
+
+Here is another usage example:
+
+```jsx
+const dataProvider = withLifecycleCallbacks(
+  jsonServerProvider("http://localhost:3000"),
+  [
+    {
+      resource: "posts",
+      afterRead: async (data, dataProvider) => {
+        // rename field to the record
+        data.user_id = data.userId;
+        return data;
+      },
+      // executed after create, update and updateMany
+      afterSave: async (record, dataProvider) => {
+        // update the author's nb_posts
+        const { total } = await dataProvider.getList("users", {
+          filter: { id: record.user_id },
+          pagination: { page: 1, perPage: 1 },
+        });
+        await dataProvider.update("users", {
+          id: user.id,
+          data: { nb_posts: total },
+          previousData: user,
+        });
+        return record;
+      },
+      beforeDelete: async (params, dataProvider) => {
+        // delete all comments linked to the post
+        const { data: comments } = await dataProvider.getManyReference(
+          "comments",
+          {
+            target: "post_id",
+            id: params.id,
+          }
+        );
+        if (comments.length > 0) {
+          await dataProvider.deleteMany("comments", {
+            ids: comments.map((comment) => comment.id),
+          });
+        }
+        // update the author's nb_posts
+        const { data: post } = await dataProvider.getOne("posts", {
+          id: params.id,
+        });
+        const { total } = await dataProvider.getList("users", {
+          filter: { id: post.user_id },
+          pagination: { page: 1, perPage: 1 },
+        });
+        await dataProvider.update("users", {
+          id: user.id,
+          data: { nb_posts: total - 1 },
+          previousData: user,
+        });
+        return params;
+      },
+    },
+  ]
+);
+```
+
+## `dataProvider`
+
+The first argument must be a valid `dataProvider` object - for instance, [any third-party data provider](./DataProviderList.md). 
+
+```jsx
+// in src/dataProvider.js
+import { withLifecycleCallbacks } from 'react-admin';
+import simpleRestProvider from 'ra-data-simple-rest';
+
+const baseDataProvider = simpleRestProvider('http://path.to.my.api/');
+
+export const dataProvider = withLifecycleCallbacks(baseDataProvider, [ /* lifecycle callbacks */ ]);
+```
+
+## `lifecycleCallbacks`
+
+The second argument is an array of objects that define the callbacks to execute. One lifecycle callback object is required for each resource that needs to be decorated. One lifecycle callback object can define callbacks for multiple events.
+
+```jsx
+import jsonServerProvider from "ra-data-json-server";
+
+export const dataProvider = withLifecycleCallbacks(
+  jsonServerProvider("http://localhost:3000"),
+  [
+    {
+        resource: "posts",
+        afterRead: async (data, dataProvider) => { /* ... */ },
+        afterSave: async (record, dataProvider) => { /* ... */ },
+        beforeDelete: async (params, dataProvider) => { /* ... */ },
+    },
+    {
+        resource: "comments",
+        beforeRead: async (data, dataProvider) => { /* ... */ },
+        afterCreate: async (resul, dataProvider) => { /* ... */ },
+    },
+    {
+        resource: "users",
+        beforeGetList: async (params, dataProvider) => { /* ... */ },
+        afterGetList: async (result, dataProvider) => { /* ... */ },
+    }
+  ]
+);
+```
+
+A lifecycle callback object can have the following properties:
+
+```jsx
+const fooLifecycleCallback = {
+  resource: /* resource name (required) */,
+  // before callbacks
+  beforeGetList: /* async (params, dataProvider) => params */,
+  beforeGetOne: /* async (params, dataProvider) => params */,
+  beforeGetMany : /* async (params, dataProvider) => params */,
+  beforeGetManyReference: /* async (params, dataProvider) => params */,
+  beforeCreate: /* async (params, dataProvider) => params */,
+  beforeUpdate: /* async (params, dataProvider) => params */,
+  beforeUpdateMany: /* async (params, dataProvider) => params */,
+  beforeDelete: /* async (params, dataProvider) => params */,
+  beforeDeleteMany: /* async (params, dataProvider) => params */,
+  // after callbacks
+  afterGetList: /* async (result, dataProvider) => result */,
+  afterGetOne: /* async (result, dataProvider) => result */,
+  afterGetMany: /* async (result, dataProvider) => result */,
+  afterGetManyReference: /* async (result, dataProvider) => result */,
+  afterCreate: /* async (result, dataProvider) => result */,
+  afterUpdate: /* async (result, dataProvider) => result */,
+  afterUpdateMany: /* async (result, dataProvider) => result */,
+  afterDelete: /* async (result, dataProvider) => result */,
+  afterDeleteMany: /* async (result, dataProvider) => result */,
+  // special callbacks
+  afterRead: /* async (record, dataProvider) => record */,
+  beforeSave: /* async (data, dataProvider) => data */,
+  afterSave: /* async (record, dataProvider) => record */,
+}
+```
+
+The callbacks have different parameters:
+
+- before callbacks receive the following arguments:
+    - `params`: the parameters passed to the dataProvider method
+    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+- after callbacks receive the following arguments:
+    - `response`: the response returned by the dataProvider method
+    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+- `afterRead` is called after any dataProvider method that reads data (`getList`, `getOne`, `getMany`, `getManyReference`), letting you modify the records before react-admin uses them. It receives the following arguments:
+    - `record`: the record returned by the backend 
+    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+- `beforeSave` is called before any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you modify the records before they are sent to the backend. It receives the following arguments:
+    - `data`: the record update to be sent to the backend (often, a diff of the record)
+    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+- `afterSave` is called after any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you updte related records. It receives the following arguments:
+    - `record`: the record returned by the backend 
+    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+
+## Limitations
+
+As explained above, lifecycle callbacks are a fallback for business logic that you can't put on the server-side. But they have some serious limitations:
+
+- They execute outside of the React context, and therefore cannot use hooks. 
+- As queries issued in the callbacks are not done through `react-query`, any change in the data will not be automatically reflected in the UI. If you need to update the UI, prefer putting the logic in [the `onSuccess` property of the mutation](./Actions.md#success-and-error-side-effects). 
+- The callbacks are not executed in a transaction. In case of error, the backend may be left in an inconsistent state.
+- When another client than react-admin calls the API, the callbacks will not be executed. If you depend on these callbacks for data consistency, this prevents you from exposing the API to other clients
+- If a callback triggers the event it's listening to (e.g. if you update the record received in an `afterSave`), this will lead to a infinite loop.
+- Do not use lifecycle callbacks to implement authorization logic, as the JS code can be altered in the browser using development tools. Check this [tutorial on multi-tenant single page apps](https://marmelab.com/blog/2022/12/14/multitenant-spa.html) for more details.
+
+In short: use lifecycle callbacks with caution!
+
+## Code Organization
+
+Lifecycle callbacks receive the `dataProvider` as second argument, so you don't actually neeed to define them in the same file as the main data provider code. In fact, it's a good practice to put the lifecycle callbacks for a resource in the same directory as the other business logic code for that resource.  
+
+```jsx
+// in src/posts/index.js
+export const postLifecycleCallbacks = {
+    resource: 'posts',
+    beforeDelete: async (params, dataProvider) => {
+        // delete all comments related to the post
+        // first, fetch the comments
+        const { data: comments } = await dataProvider.getList('comments', {
+            filter: { post_id: params.id },
+            pagination: { page: 1, perPage: 1000 },
+            sort: { field: 'id', order: 'DESC' },
+        });
+        // then, delete them
+        await dataProvider.deleteMany('comments', { ids: comments.map(comment => comment.id) });
+
+        return params;
+    },
+};
+```
+
+Then, import the callbacks in your data provider:
+
+```jsx
+// in scr/dataProvider.js
+import simpleRestProvider from 'ra-data-simple-rest';
+
+import { postLifecycleCallbacks } from './posts';
+import { commentLifecycleCallbacks } from './comments';
+import { userLifecycleCallbacks } from './users';
+
+const baseDataProvider = simpleRestProvider('http://path.to.my.api/');
+
+export const dataProvider = withLifecycleCallbacks(baseDataProvider, [
+    postLifecycleCallbacks,
+    commentLifecycleCallbacks,
+    userLifecycleCallbacks,
+]);
+```
+
+You can test isolated lifecycle callbacks by mocking the `dataProvider`:
+
+```jsx
+// in src/posts/index.test.js
+import { withLifecycleCallbacks } from 'react-admin';
+
+import { postLifecycleCallbacks } from './index';
+
+describe('postLifecycleCallbacks', () => {
+    it('should delete related comments when deleting a post', async () => {
+        const dataProvider = {
+            getList: jest.fn().mockResolvedValue({ data: [{ id: 1, post_id: 123 }, { id: 2, post_id: 123 }], total: 2 }),
+            delete: jest.fn().mockResolvedValue({ data: { id: 123 } }),
+            deleteMany: jest.fn().mockResolvedValue({ data: [{ id: 1 }, { id: 2 }] }),
+        };
+        const wrappedDataProvider = withLifecycleCallbacks(dataProvider, [postLifecycleCallbacks]);
+        await wrappedDataProvider.delete('posts', { id: 123 });
+        expect(dataProvider.deleteMany).toHaveBeenCalledWith('comments', { ids: [1, 2] });
+    });
+});
+```

--- a/docs/withLifecycleCallbacks.md
+++ b/docs/withLifecycleCallbacks.md
@@ -203,21 +203,85 @@ const fooLifecycleCallback = {
 
 The callbacks have different parameters:
 
-- before callbacks receive the following arguments:
-    - `params`: the parameters passed to the dataProvider method
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- after callbacks receive the following arguments:
-    - `response`: the response returned by the dataProvider method
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `afterRead` is called after any dataProvider method that reads data (`getList`, `getOne`, `getMany`, `getManyReference`), letting you modify the records before react-admin uses them. It receives the following arguments:
-    - `record`: the record returned by the backend 
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `beforeSave` is called before any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you modify the records before they are sent to the backend. It receives the following arguments:
-    - `data`: the record update to be sent to the backend (often, a diff of the record)
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `afterSave` is called after any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you update related records. It receives the following arguments:
-    - `record`: the record returned by the backend 
-    - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+### Before callbacks
+
+The `beforeGetList`, `beforeGetOne`, `beforeGetMany `, `beforeGetManyReference`, `beforeCreate`, `beforeUpdate`, `beforeUpdateMany`, `beforeDelete`, and `beforeDeleteMany` callbacks receive the following arguments:
+
+- `params`: the parameters passed to the dataProvider method
+- `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+
+### After callbacks 
+
+The `afterGetList`, `afterGetOne`, `afterGetMany `, `afterGetManyReference`, `afterCreate`, `afterUpdate`, `afterUpdateMany`, `afterDelete`, and `afterDeleteMany` callbacks receive the following arguments:
+
+- `response`: the response returned by the dataProvider method
+- `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+
+### `afterRead` 
+
+Called after any dataProvider method that reads data (`getList`, `getOne`, `getMany`, `getManyReference`), letting you modify the records before react-admin uses them. It receives the following arguments:
+
+- `record`: the record returned by the backend 
+- `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+
+For methods that return many records (`getList`, `getMany`, `getManyReference`), the callback is called once for each record.
+
+```jsx
+const postLifecycleCallbacls = {
+  resource: "posts",
+  afterRead: async (record, dataProvider) => {
+    // rename field to the record
+    record.user_id = record.userId;
+    return data;
+  },
+};
+```
+
+### `beforeSave`
+
+Called before any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you modify the records before they are sent to the backend. It receives the following arguments:
+
+- `data`: the record update to be sent to the backend (often, a diff of the record)
+- `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+
+```jsx
+const postLifecycleCallbacls = {
+  resource: "posts",
+  beforeSave: async (data, dataProvider) => {
+    data.update_at = Date.now();
+    return data;
+  },
+};
+```
+
+### `afterSave`
+
+Called after any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you update related records. It receives the following arguments:
+
+- `record`: the record returned by the backend 
+- `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
+
+```jsx
+const postLifecycleCallback = {
+  resource: "posts",
+  // executed after create, update and updateMany
+  afterSave: async (record, dataProvider) => {
+    // update the author's nb_posts
+    const { total } = await dataProvider.getList("users", {
+      filter: { id: record.user_id },
+      pagination: { page: 1, perPage: 1 },
+    });
+    await dataProvider.update("users", {
+      id: user.id,
+      data: { nb_posts: total },
+      previousData: user,
+    });
+    return record;
+  },
+}
+```
+
+For methods that return many records (`updateMany`), the callback is called once for each record.
 
 ## Limitations
 

--- a/docs/withLifecycleCallbacks.md
+++ b/docs/withLifecycleCallbacks.md
@@ -259,7 +259,7 @@ export const postLifecycleCallbacks = {
 Then, import the callbacks into your data provider:
 
 ```jsx
-// in scr/dataProvider.js
+// in src/dataProvider.js
 import simpleRestProvider from 'ra-data-simple-rest';
 
 import { postLifecycleCallbacks } from './posts';

--- a/docs/withLifecycleCallbacks.md
+++ b/docs/withLifecycleCallbacks.md
@@ -60,8 +60,8 @@ Lifecycle callbacks are a good way to:
 
 - Add custom parameters before a `dataProvider` method is called (e.g. to set the query `meta` parameter based on the user profile),
 - Clean up the data before it's sent to the API (e.g. to transform two `lat` and `long` values into a single `location` field),
-- Add or rename fields in the data returned by the API before using it in react-dmin (e.g. to add a `fullName` field based on the `firstName` and `lastName` fields),
-- Update related records when a record is created, updated or deleted (e.g. update the `post.nb_comments` field after a `comment` is created or deleted)
+- Add or rename fields in the data returned by the API before using it in react-admin (e.g. to add a `fullName` field based on the `firstName` and `lastName` fields),
+- Update related records when a record is created, updated, or deleted (e.g. update the `post.nb_comments` field after a `comment` is created or deleted)
 - Remove related records when a record is deleted (similar to a server-side `ON DELETE CASCADE`)
 
 Here is another usage example:
@@ -158,7 +158,7 @@ export const dataProvider = withLifecycleCallbacks(
     {
         resource: "comments",
         beforeRead: async (data, dataProvider) => { /* ... */ },
-        afterCreate: async (resul, dataProvider) => { /* ... */ },
+        afterCreate: async (result, dataProvider) => { /* ... */ },
     },
     {
         resource: "users",
@@ -215,26 +215,26 @@ The callbacks have different parameters:
 - `beforeSave` is called before any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you modify the records before they are sent to the backend. It receives the following arguments:
     - `data`: the record update to be sent to the backend (often, a diff of the record)
     - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
-- `afterSave` is called after any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you updte related records. It receives the following arguments:
+- `afterSave` is called after any dataProvider method that saves data (`create`, `update`, `updateMany`), letting you update related records. It receives the following arguments:
     - `record`: the record returned by the backend 
     - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
 
 ## Limitations
 
-As explained above, lifecycle callbacks are a fallback for business logic that you can't put on the server-side. But they have some serious limitations:
+As explained above, lifecycle callbacks are a fallback for business logic that you can't put on the server side. But they have some serious limitations:
 
 - They execute outside of the React context, and therefore cannot use hooks. 
 - As queries issued in the callbacks are not done through `react-query`, any change in the data will not be automatically reflected in the UI. If you need to update the UI, prefer putting the logic in [the `onSuccess` property of the mutation](./Actions.md#success-and-error-side-effects). 
-- The callbacks are not executed in a transaction. In case of error, the backend may be left in an inconsistent state.
+- The callbacks are not executed in a transaction. In case of an error, the backend may be left in an inconsistent state.
 - When another client than react-admin calls the API, the callbacks will not be executed. If you depend on these callbacks for data consistency, this prevents you from exposing the API to other clients
-- If a callback triggers the event it's listening to (e.g. if you update the record received in an `afterSave`), this will lead to a infinite loop.
-- Do not use lifecycle callbacks to implement authorization logic, as the JS code can be altered in the browser using development tools. Check this [tutorial on multi-tenant single page apps](https://marmelab.com/blog/2022/12/14/multitenant-spa.html) for more details.
+- If a callback triggers the event it's listening to (e.g. if you update the record received in an `afterSave`), this will lead to an infinite loop.
+- Do not use lifecycle callbacks to implement authorization logic, as the JS code can be altered in the browser using development tools. Check this [tutorial on multi-tenant single-page apps](https://marmelab.com/blog/2022/12/14/multitenant-spa.html) for more details.
 
 In short: use lifecycle callbacks with caution!
 
 ## Code Organization
 
-Lifecycle callbacks receive the `dataProvider` as second argument, so you don't actually neeed to define them in the same file as the main data provider code. In fact, it's a good practice to put the lifecycle callbacks for a resource in the same directory as the other business logic code for that resource.  
+Lifecycle callbacks receive the `dataProvider` as the second argument, so you don't actually need to define them in the same file as the main data provider code. It's a good practice to put the lifecycle callbacks for a resource in the same directory as the other business logic code for that resource.  
 
 ```jsx
 // in src/posts/index.js
@@ -256,7 +256,7 @@ export const postLifecycleCallbacks = {
 };
 ```
 
-Then, import the callbacks in your data provider:
+Then, import the callbacks into your data provider:
 
 ```jsx
 // in scr/dataProvider.js
@@ -279,7 +279,7 @@ You can test isolated lifecycle callbacks by mocking the `dataProvider`:
 
 ```jsx
 // in src/posts/index.test.js
-import { withLifecycleCallbacks } from 'react-admin';
+import { withLifecycleCallbacks } from 'react-admin';
 
 import { postLifecycleCallbacks } from './index';
 

--- a/docs/withLifecycleCallbacks.md
+++ b/docs/withLifecycleCallbacks.md
@@ -227,7 +227,7 @@ Called after any dataProvider method that reads data (`getList`, `getOne`, `getM
 For methods that return many records (`getList`, `getMany`, `getManyReference`), the callback is called once for each record.
 
 ```jsx
-const postLifecycleCallbacls = {
+const postLifecycleCallbacks = {
   resource: "posts",
   afterRead: async (record, dataProvider) => {
     // rename field to the record
@@ -245,7 +245,7 @@ Called before any dataProvider method that saves data (`create`, `update`, `upda
 - `dataProvider`: the dataProvider itself, so you can call other dataProvider methods
 
 ```jsx
-const postLifecycleCallbacls = {
+const postLifecycleCallbacks = {
   resource: "posts",
   beforeSave: async (data, dataProvider) => {
     data.update_at = Date.now();

--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -111,7 +111,11 @@ const CommentGrid = () => {
                             />
                         </CardContent>
                         <CardContent sx={{ flexGrow: 1 }}>
-                            <Typography component="span" variant="body2">
+                            <Typography
+                                component="span"
+                                variant="body2"
+                                data-testid="postLink"
+                            >
                                 {translate('comment.list.about')}&nbsp;
                             </Typography>
                             <ReferenceField

--- a/examples/simple/src/dataProvider.tsx
+++ b/examples/simple/src/dataProvider.tsx
@@ -4,22 +4,17 @@ import get from 'lodash/get';
 import data from './data';
 import addUploadFeature from './addUploadFeature';
 
-const baseDataProvider = fakeRestProvider(data, true);
-
-const dataProvider = withLifecycleCallbacks(baseDataProvider, [
+const dataProvider = withLifecycleCallbacks(fakeRestProvider(data, true), [
     {
         resource: 'posts',
-        beforeDelete: async ({ id }) => {
+        beforeDelete: async ({ id }, dp) => {
             // delete related comments
-            const { data: comments } = await baseDataProvider.getList(
-                'comments',
-                {
-                    filter: { post_id: id },
-                    pagination: { page: 1, perPage: 100 },
-                    sort: { field: 'id', order: 'DESC' },
-                }
-            );
-            await baseDataProvider.deleteMany('comments', {
+            const { data: comments } = await dp.getList('comments', {
+                filter: { post_id: id },
+                pagination: { page: 1, perPage: 100 },
+                sort: { field: 'id', order: 'DESC' },
+            });
+            await dp.deleteMany('comments', {
                 ids: comments.map(comment => comment.id),
             });
             return { id };

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -8,6 +8,7 @@ export * from './combineDataProviders';
 export * from './dataFetchActions';
 export * from './defaultDataProvider';
 export * from './testDataProvider';
+export * from './withLifecycleCallbacks';
 export * from './useDataProvider';
 export * from './useIsDataLoaded';
 export * from './useLoading';

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.spec.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.spec.ts
@@ -1,0 +1,854 @@
+import expect from 'expect';
+import { testDataProvider } from './testDataProvider';
+
+import { withLifecycleCallbacks } from './withLifecycleCallbacks';
+
+describe('withLifecycleCallbacks', () => {
+    it('should be called when the resource matches', async () => {
+        const resourceCallback = {
+            resource: 'posts',
+            beforeGetOne: jest.fn(params => Promise.resolve(params)),
+        };
+        const dataProvider = withLifecycleCallbacks(testDataProvider(), [
+            resourceCallback,
+        ]);
+        dataProvider.getOne('posts', { id: 1 });
+        expect(resourceCallback.beforeGetOne).toHaveBeenCalled();
+    });
+    it('should not be called when the resource does not match', async () => {
+        const resourceCallback = {
+            resource: 'posts',
+            beforeGetOne: jest.fn(params => Promise.resolve(params)),
+        };
+        const dataProvider = withLifecycleCallbacks(testDataProvider(), [
+            resourceCallback,
+        ]);
+        dataProvider.getOne('comments', { id: 1 });
+        expect(resourceCallback.beforeGetOne).not.toHaveBeenCalled();
+    });
+    it('should allow more than one callback per resource', async () => {
+        const resourceCallback = {
+            resource: 'posts',
+            beforeGetOne: jest.fn(params => Promise.resolve(params)),
+            beforeGetMany: jest.fn(params => Promise.resolve(params)),
+        };
+        const dataProvider = withLifecycleCallbacks(testDataProvider(), [
+            resourceCallback,
+        ]);
+
+        dataProvider.getOne('posts', { id: 1 });
+        expect(resourceCallback.beforeGetOne).toHaveBeenCalled();
+
+        dataProvider.getMany('posts', { ids: [1, 2] });
+        expect(resourceCallback.beforeGetMany).toHaveBeenCalled();
+    });
+
+    describe('beforeGetList', () => {
+        it('should update the getList parameters', async () => {
+            const params = {
+                filter: { q: 'foo' },
+                sort: { field: 'id', order: 'DESC' },
+                pagination: { page: 1, perPage: 10 },
+            };
+            const base = {
+                getList: jest.fn(() => Promise.resolve({ data: [], total: 0 })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeGetList: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.getList('posts', params);
+
+            expect(base.getList).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+
+    describe('afterGetList', () => {
+        it('should update the getList result', async () => {
+            const base = {
+                getList: jest.fn(() =>
+                    Promise.resolve({
+                        data: [{ id: 1, title: 'foo' }],
+                        total: 1,
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterGetList: jest.fn(() =>
+                        Promise.resolve({
+                            data: [{ id: 1, title: 'bar' }],
+                            total: 1,
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getList('posts', {});
+
+            expect(result).toEqual({
+                data: [{ id: 1, title: 'bar' }],
+                total: 1,
+            });
+        });
+    });
+
+    describe('beforeGetOne', () => {
+        it('should update the getOne parameters', async () => {
+            const params = { id: 1 };
+            const base = {
+                getOne: jest.fn(() => Promise.resolve({ data: {} })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeGetOne: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.getOne('posts', params);
+
+            expect(base.getOne).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+    describe('afterGetOne', () => {
+        it('should update the getOne result', async () => {
+            const base = {
+                getOne: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, title: 'foo' } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterGetOne: jest.fn(result =>
+                        Promise.resolve({
+                            data: { ...result.data, title: 'bar' },
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getOne('posts', { id: 1 });
+
+            expect(result).toEqual({
+                data: { id: 1, title: 'bar' },
+            });
+        });
+    });
+
+    describe('beforeGetMany', () => {
+        it('should update the getMany parameters', async () => {
+            const params = { ids: [1, 2] };
+            const base = {
+                getMany: jest.fn(() => Promise.resolve({ data: [] })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeGetMany: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.getMany('posts', params);
+
+            expect(base.getMany).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+
+    describe('afterGetMany', () => {
+        it('should update the getMany result', async () => {
+            const base = {
+                getMany: jest.fn(() =>
+                    Promise.resolve({
+                        data: [{ id: 1, title: 'foo' }],
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterGetMany: jest.fn(() =>
+                        Promise.resolve({
+                            data: [{ id: 1, title: 'bar' }],
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getMany('posts', { ids: [1] });
+
+            expect(result).toEqual({
+                data: [{ id: 1, title: 'bar' }],
+            });
+        });
+    });
+
+    describe('beforeGetManyReference', () => {
+        it('should update the getManyReference parameters', async () => {
+            const params = {
+                target: '1',
+                id: '1',
+                pagination: { page: 1, perPage: 1 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: {},
+            };
+            const base = {
+                getManyReference: jest.fn(() =>
+                    Promise.resolve({ data: [], total: 0 })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeGetManyReference: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.getManyReference('posts', params);
+
+            expect(base.getManyReference).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+
+    describe('afterGetManyReference', () => {
+        it('should update the getManyReference result', async () => {
+            const base = {
+                getManyReference: jest.fn(() =>
+                    Promise.resolve({
+                        data: [{ id: 1, title: 'foo' }],
+                        total: 1,
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterGetManyReference: jest.fn(() =>
+                        Promise.resolve({
+                            data: [{ id: 1, title: 'bar' }],
+                            total: 1,
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getManyReference('posts', {
+                target: '1',
+                id: '1',
+                pagination: { page: 1, perPage: 1 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: {},
+            });
+
+            expect(result).toEqual({
+                data: [{ id: 1, title: 'bar' }],
+                total: 1,
+            });
+        });
+    });
+
+    describe('afterRead', () => {
+        it('should update the getOne result', async () => {
+            const base = {
+                getOne: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, title: 'foo' } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterRead: jest.fn(record =>
+                        Promise.resolve({
+                            ...record,
+                            title: 'bar',
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getOne('posts', { id: 1 });
+
+            expect(result).toEqual({
+                data: { id: 1, title: 'bar' },
+            });
+        });
+
+        it('should update the getList result', async () => {
+            const base = {
+                getList: jest.fn(() =>
+                    Promise.resolve({
+                        data: [
+                            { id: 1, title: 'foo' },
+                            { id: 2, title: 'foo' },
+                        ],
+                        total: 2,
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterRead: jest.fn(record =>
+                        Promise.resolve({
+                            ...record,
+                            title: 'bar',
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getList('posts', {
+                filter: { q: 'foo' },
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+            });
+
+            expect(result).toEqual({
+                data: [
+                    { id: 1, title: 'bar' },
+                    { id: 2, title: 'bar' },
+                ],
+                total: 2,
+            });
+        });
+
+        it('should update the getMany result', async () => {
+            const base = {
+                getMany: jest.fn(() =>
+                    Promise.resolve({
+                        data: [
+                            { id: 1, title: 'foo' },
+                            { id: 2, title: 'foo' },
+                        ],
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterRead: jest.fn(record =>
+                        Promise.resolve({
+                            ...record,
+                            title: 'bar',
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getMany('posts', { ids: [1, 2] });
+
+            expect(result).toEqual({
+                data: [
+                    { id: 1, title: 'bar' },
+                    { id: 2, title: 'bar' },
+                ],
+            });
+        });
+
+        it('should update the getManyReference result', async () => {
+            const base = {
+                getManyReference: jest.fn(() =>
+                    Promise.resolve({
+                        data: [
+                            { id: 1, title: 'foo' },
+                            { id: 2, title: 'foo' },
+                        ],
+                        total: 2,
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterRead: jest.fn(record =>
+                        Promise.resolve({
+                            ...record,
+                            title: 'bar',
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.getManyReference('posts', {
+                target: 'author_id',
+                id: 1,
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: {},
+            });
+
+            expect(result).toEqual({
+                data: [
+                    { id: 1, title: 'bar' },
+                    { id: 2, title: 'bar' },
+                ],
+                total: 2,
+            });
+        });
+    });
+
+    describe('beforeCreate', () => {
+        it('should update the create parameters', async () => {
+            const params = {
+                data: { title: 'foo' },
+            };
+            const base = {
+                create: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeCreate: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.create('posts', params);
+
+            expect(base.create).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+
+    describe('afterCreate', () => {
+        it('should update the create result', async () => {
+            const base = {
+                create: jest.fn((resource, { data }) =>
+                    Promise.resolve({ data: { id: 1, ...data } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterCreate: jest.fn(result =>
+                        Promise.resolve({
+                            data: { ...result.data, foo: 'bar' },
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.create('posts', {
+                data: { title: 'foo' },
+            });
+
+            expect(result).toEqual({
+                data: { id: 1, title: 'foo', foo: 'bar' },
+            });
+        });
+    });
+
+    describe('beforeUpdate', () => {
+        it('should update the update parameters', async () => {
+            const params = {
+                id: 1,
+                data: { title: 'foo' },
+                previousData: { title: 'bar' },
+            };
+            const base = {
+                update: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeUpdate: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.update('posts', params);
+
+            expect(base.update).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+
+    describe('afterUpdate', () => {
+        it('should update the update result', async () => {
+            const base = {
+                update: jest.fn((resource, { id, data }) =>
+                    Promise.resolve({ data: { id, ...data } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterUpdate: jest.fn(result =>
+                        Promise.resolve({
+                            data: { ...result.data, foo: 'bar' },
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.update('posts', {
+                id: 1,
+                data: { title: 'foo' },
+                previousData: { title: 'bar' },
+            });
+
+            expect(result).toEqual({
+                data: { id: 1, title: 'foo', foo: 'bar' },
+            });
+        });
+    });
+
+    describe('beforeUpdateMany', () => {
+        it('should update the updateMany parameters', async () => {
+            const params = {
+                ids: [1, 2],
+                data: { title: 'foo' },
+            };
+            const base = {
+                updateMany: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeUpdateMany: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'foo' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.updateMany('posts', params);
+
+            expect(base.updateMany).toHaveBeenCalledWith('posts', {
+                ...params,
+                meta: 'foo',
+            });
+        });
+    });
+
+    describe('afterUpdateMany', () => {
+        it('should update the updateMany result', async () => {
+            const base = {
+                updateMany: jest.fn((resource, { ids, data }) =>
+                    Promise.resolve({ data: ids })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterUpdateMany: jest.fn(result =>
+                        Promise.resolve({
+                            data: [...result.data, 'foo', 'bar'],
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.updateMany('posts', {
+                ids: [1, 2],
+                data: { title: 'foo' },
+            });
+
+            expect(result).toEqual({
+                data: [1, 2, 'foo', 'bar'],
+            });
+        });
+    });
+
+    describe('beforeSave', () => {
+        it('should update the create data parameter', async () => {
+            const params = {
+                data: { title: 'foo' },
+            };
+            const base = {
+                create: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeSave: jest.fn(data =>
+                        Promise.resolve({ ...data, foo: 'bar' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.create('posts', params);
+
+            expect(base.create).toHaveBeenCalledWith('posts', {
+                data: { ...params.data, foo: 'bar' },
+            });
+        });
+        it('should update the update data parameter', async () => {
+            const params = {
+                id: 1,
+                data: { title: 'foo' },
+                previousData: { title: 'bar' },
+            };
+            const base = {
+                update: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeSave: jest.fn(data =>
+                        Promise.resolve({ ...data, foo: 'bar' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.update('posts', params);
+
+            expect(base.update).toHaveBeenCalledWith('posts', {
+                id: 1,
+                data: { ...params.data, foo: 'bar' },
+                previousData: params.previousData,
+            });
+        });
+        it('should update the updateMany data parameter', async () => {
+            const params = {
+                ids: [1, 2],
+                data: { title: 'foo' },
+            };
+            const base = {
+                updateMany: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeSave: jest.fn(data =>
+                        Promise.resolve({ ...data, foo: 'bar' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.updateMany('posts', params);
+
+            expect(base.updateMany).toHaveBeenCalledWith('posts', {
+                ids: params.ids,
+                data: { title: 'foo', foo: 'bar' },
+            });
+        });
+    });
+    describe('afterSave', () => {
+        it('should alter the create result data', async () => {
+            const base = {
+                create: jest.fn((resource, { data }) =>
+                    Promise.resolve({ data: { id: 1, ...data } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterSave: jest.fn(record =>
+                        Promise.resolve({
+                            ...record,
+                            foo: 'bar',
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.create('posts', {
+                data: { title: 'foo' },
+            });
+
+            expect(result).toEqual({
+                data: { id: 1, title: 'foo', foo: 'bar' },
+            });
+        });
+        it('should alter the update result data', async () => {
+            const base = {
+                update: jest.fn((resource, { id, data }) =>
+                    Promise.resolve({ data: { id, ...data } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterSave: jest.fn(record =>
+                        Promise.resolve({
+                            ...record,
+                            foo: 'bar',
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.update('posts', {
+                id: 1,
+                data: { title: 'foo' },
+                previousData: { title: 'bar' },
+            });
+
+            expect(result).toEqual({
+                data: { id: 1, title: 'foo', foo: 'bar' },
+            });
+        });
+        it('should be called on the updateMany', async () => {
+            const base = {
+                getMany: jest.fn((resource, { ids }) =>
+                    Promise.resolve({
+                        data: ids.map(id => ({ id })),
+                    })
+                ),
+                updateMany: jest.fn((resource, { ids, data }) =>
+                    Promise.resolve({ data: ids })
+                ),
+            };
+            const resourceCallback = {
+                resource: 'posts',
+                afterSave: jest.fn(record =>
+                    Promise.resolve({
+                        ...record,
+                        foo: 'bar',
+                    })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                resourceCallback,
+            ]);
+
+            const result = await dataProvider.updateMany('posts', {
+                ids: [1, 2],
+                data: { title: 'foo' },
+            });
+
+            expect(result).toEqual({
+                data: [1, 2],
+            });
+            expect(resourceCallback.afterSave).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('beforeDelete', () => {
+        it('should update the delete params', async () => {
+            const params = {
+                id: 1,
+            };
+            const base = {
+                delete: jest.fn(() => Promise.resolve({ data: { id: 1 } })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeDelete: jest.fn(params =>
+                        Promise.resolve({ ...params, foo: 'bar' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.delete('posts', params);
+
+            expect(base.delete).toHaveBeenCalledWith('posts', {
+                id: 1,
+                foo: 'bar',
+            });
+        });
+    });
+    describe('afterDelete', () => {
+        it('should alter the delete result', async () => {
+            const base = {
+                delete: jest.fn((resource, { id }) =>
+                    Promise.resolve({ data: { id } })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterDelete: jest.fn(result =>
+                        Promise.resolve({
+                            data: { ...result.data, foo: 'bar' },
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.delete('posts', {
+                id: 1,
+            });
+
+            expect(result).toEqual({
+                data: { id: 1, foo: 'bar' },
+            });
+        });
+    });
+
+    describe('beforeDeleteMany', () => {
+        it('should update the deleteMany params', async () => {
+            const params = {
+                ids: [1, 2],
+            };
+            const base = {
+                deleteMany: jest.fn(() => Promise.resolve({ data: [1, 2] })),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    beforeDeleteMany: jest.fn(params =>
+                        Promise.resolve({ ...params, meta: 'bar' })
+                    ),
+                },
+            ]);
+
+            await dataProvider.deleteMany('posts', params);
+
+            expect(base.deleteMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2],
+                meta: 'bar',
+            });
+        });
+    });
+
+    describe('afterDeleteMany', () => {
+        it('should alter the deleteMany result', async () => {
+            const base = {
+                deleteMany: jest.fn((resource, { ids }) =>
+                    Promise.resolve({ data: ids })
+                ),
+            };
+            const dataProvider = withLifecycleCallbacks(base, [
+                {
+                    resource: 'posts',
+                    afterDeleteMany: jest.fn(result =>
+                        Promise.resolve({
+                            data: [...result.data, 'foo', 'bar'],
+                        })
+                    ),
+                },
+            ]);
+
+            const result = await dataProvider.deleteMany('posts', {
+                ids: [1, 2],
+            });
+
+            expect(result).toEqual({
+                data: [1, 2, 'foo', 'bar'],
+            });
+        });
+    });
+});

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.spec.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.spec.ts
@@ -187,9 +187,9 @@ describe('withLifecycleCallbacks', () => {
             const dataProvider = withLifecycleCallbacks(base, [
                 {
                     resource: 'posts',
-                    afterGetMany: jest.fn(() =>
+                    afterGetMany: jest.fn(result =>
                         Promise.resolve({
-                            data: [{ id: 1, title: 'bar' }],
+                            data: [{ ...result.data[0], title: 'bar' }],
                         })
                     ),
                 },
@@ -248,9 +248,9 @@ describe('withLifecycleCallbacks', () => {
             const dataProvider = withLifecycleCallbacks(base, [
                 {
                     resource: 'posts',
-                    afterGetManyReference: jest.fn(() =>
+                    afterGetManyReference: jest.fn(result =>
                         Promise.resolve({
-                            data: [{ id: 1, title: 'bar' }],
+                            data: [{ ...result.data[0], title: 'bar' }],
                             total: 1,
                         })
                     ),

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
@@ -582,7 +582,7 @@ export type ResourceCallbacks<T extends RaRecord = any> = {
      */
     afterRead?: (record: T, dataProvider: DataProvider) => Promise<T>;
     /**
-     * Modify the record after it is returned by the dataProvider.
+     * Use the record after it is returned by the dataProvider.
      *
      * Used in create, update, and updateMany
      */

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
@@ -489,131 +489,80 @@ export const withLifecycleCallbacks = (
     };
 };
 
-export type BeforteGetListCallback = (
-    params: GetListParams,
-    dataProvider: DataProvider
-) => Promise<GetListParams>;
-
-export type AfterGetListCallback<T extends RaRecord = any> = (
-    result: GetListResult<T>,
-    dataProvider: DataProvider
-) => Promise<GetListResult<T>>;
-
-export type BeforeGetOneCallback<T extends RaRecord = any> = (
-    params: GetOneParams<T>,
-    dataProvider: DataProvider
-) => Promise<GetOneParams<T>>;
-
-export type AfterGetOneCallback<T extends RaRecord = any> = (
-    result: GetOneResult<T>,
-    dataProvider: DataProvider
-) => Promise<GetOneResult<T>>;
-
-export type BeforeGetManyCallback = (
-    params: GetManyParams,
-    dataProvider: DataProvider
-) => Promise<GetManyParams>;
-
-export type AfterGetManyCallback<T extends RaRecord = any> = (
-    result: GetManyResult<T>,
-    dataProvider: DataProvider
-) => Promise<GetManyResult<T>>;
-
-export type BeforeGetManyReferenceCallback = (
-    params: GetManyReferenceParams,
-    dataProvider: DataProvider
-) => Promise<GetManyReferenceParams>;
-
-export type AfterGetManyReferenceCallback<T extends RaRecord = any> = (
-    result: GetManyReferenceResult<T>,
-    dataProvider: DataProvider
-) => Promise<GetManyReferenceResult<T>>;
-
-export type BeforeUpdateCallback<T extends RaRecord = any> = (
-    params: UpdateParams<T>,
-    dataProvider: DataProvider
-) => Promise<UpdateParams<T>>;
-
-export type BeforeUpdateManyCallback<T extends RaRecord = any> = (
-    params: UpdateManyParams<T>,
-    dataProvider: DataProvider
-) => Promise<UpdateManyParams<T>>;
-
-export type AfterUpdateManyCallback<T extends RaRecord = any> = (
-    result: UpdateManyResult<T>,
-    dataProvider: DataProvider
-) => Promise<UpdateManyResult<T>>;
-
-export type AfterUpdateCallback<T extends RaRecord = any> = (
-    result: UpdateResult<T>,
-    dataProvider: DataProvider
-) => Promise<UpdateResult<T>>;
-
-export type BeforeCreateCallback<T extends RaRecord = any> = (
-    params: CreateParams<T>,
-    dataProvider: DataProvider
-) => Promise<CreateParams<T>>;
-
-export type AfterCreateCallback<T extends RaRecord = any> = (
-    result: CreateResult<T>,
-    dataProvider: DataProvider
-) => Promise<CreateResult<T>>;
-
-export type BeforeDeleteCallback<T extends RaRecord = any> = (
-    params: DeleteParams<T>,
-    dataProvider: DataProvider
-) => Promise<DeleteParams<T>>;
-
-export type AfterDeleteCallback<T extends RaRecord = any> = (
-    result: DeleteResult<T>,
-    dataProvider: DataProvider
-) => Promise<DeleteResult<T>>;
-
-export type BeforeDeleteManyCallback<T extends RaRecord = any> = (
-    params: DeleteManyParams<T>,
-    dataProvider: DataProvider
-) => Promise<DeleteManyParams<T>>;
-
-export type AfterDeleteManyCallback<T extends RaRecord = any> = (
-    result: DeleteManyResult<T>,
-    dataProvider: DataProvider
-) => Promise<DeleteManyResult<T>>;
-
-export type AfterReadCallback<T extends RaRecord = any> = (
-    record: T,
-    dataProvider: DataProvider
-) => Promise<T>;
-
-export type BeforeSaveCallback<T extends RaRecord = any> = (
-    data: Partial<T>,
-    dataProvider: DataProvider
-) => Promise<T>;
-
-export type AfterSaveCallback<T extends RaRecord = any> = (
-    record: T,
-    dataProvider: DataProvider
-) => Promise<T>;
-
 export type ResourceCallbacks<T extends RaRecord = any> = {
     resource: string;
-    afterCreate?: AfterCreateCallback<T>;
-    afterDelete?: AfterDeleteCallback<T>;
-    afterDeleteMany?: AfterDeleteManyCallback<T>;
-    afterGetList?: AfterGetListCallback<T>;
-    afterGetMany?: AfterGetManyCallback<T>;
-    afterGetManyReference?: AfterGetManyReferenceCallback<T>;
-    afterGetOne?: AfterGetOneCallback<T>;
-    afterUpdate?: AfterUpdateCallback<T>;
-    afterUpdateMany?: AfterUpdateManyCallback<T>;
-    beforeCreate?: BeforeCreateCallback<T>;
-    beforeDelete?: BeforeDeleteCallback<T>;
-    beforeDeleteMany?: BeforeDeleteManyCallback<T>;
-    beforeGetList?: BeforteGetListCallback;
-    beforeGetMany?: BeforeGetManyCallback;
-    beforeGetManyReference?: BeforeGetManyReferenceCallback;
-    beforeGetOne?: BeforeGetOneCallback<T>;
-    beforeUpdate?: BeforeUpdateCallback<T>;
-    beforeUpdateMany?: BeforeUpdateManyCallback<T>;
+    afterCreate?: (
+        result: CreateResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<CreateResult<T>>;
+    afterDelete?: (
+        result: DeleteResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<DeleteResult<T>>;
+    afterDeleteMany?: (
+        result: DeleteManyResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<DeleteManyResult<T>>;
+    afterGetList?: (
+        result: GetListResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<GetListResult<T>>;
+    afterGetMany?: (
+        result: GetManyResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<GetManyResult<T>>;
+    afterGetManyReference?: (
+        result: GetManyReferenceResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<GetManyReferenceResult<T>>;
+    afterGetOne?: (
+        result: GetOneResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<GetOneResult<T>>;
+    afterUpdate?: (
+        result: UpdateResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<UpdateResult<T>>;
+    afterUpdateMany?: (
+        result: UpdateManyResult<T>,
+        dataProvider: DataProvider
+    ) => Promise<UpdateManyResult<T>>;
+    beforeCreate?: (
+        params: CreateParams<T>,
+        dataProvider: DataProvider
+    ) => Promise<CreateParams<T>>;
+    beforeDelete?: (
+        params: DeleteParams<T>,
+        dataProvider: DataProvider
+    ) => Promise<DeleteParams<T>>;
+    beforeDeleteMany?: (
+        params: DeleteManyParams<T>,
+        dataProvider: DataProvider
+    ) => Promise<DeleteManyParams<T>>;
+    beforeGetList?: (
+        params: GetListParams,
+        dataProvider: DataProvider
+    ) => Promise<GetListParams>;
+    beforeGetMany?: (
+        params: GetManyParams,
+        dataProvider: DataProvider
+    ) => Promise<GetManyParams>;
+    beforeGetManyReference?: (
+        params: GetManyReferenceParams,
+        dataProvider: DataProvider
+    ) => Promise<GetManyReferenceParams>;
+    beforeGetOne?: (
+        params: GetOneParams<T>,
+        dataProvider: DataProvider
+    ) => Promise<GetOneParams<T>>;
+    beforeUpdate?: (
+        params: UpdateParams<T>,
+        dataProvider: DataProvider
+    ) => Promise<UpdateParams<T>>;
+    beforeUpdateMany?: (
+        params: UpdateManyParams<T>,
+        dataProvider: DataProvider
+    ) => Promise<UpdateManyParams<T>>;
 
     // The following hooks don't match a dataProvider method
 
@@ -625,17 +574,17 @@ export type ResourceCallbacks<T extends RaRecord = any> = {
      * Note: This callback doesn't modify the record itself, but the data argument
      * (which may be a diff, especially when called with updateMany).
      */
-    beforeSave?: BeforeSaveCallback<T>;
+    beforeSave?: (data: Partial<T>, dataProvider: DataProvider) => Promise<T>;
     /**
      * Update a record after it has been read from the dataProvider
      *
      * Used in getOne, getList, getMany, and getManyReference
      */
-    afterRead?: AfterReadCallback<T>;
+    afterRead?: (record: T, dataProvider: DataProvider) => Promise<T>;
     /**
      * Modify the record after it is returned by the dataProvider.
      *
      * Used in create, update, and updateMany
      */
-    afterSave?: AfterSaveCallback<T>;
+    afterSave?: (record: T, dataProvider: DataProvider) => Promise<T>;
 };

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
@@ -1,0 +1,641 @@
+import {
+    CreateParams,
+    CreateResult,
+    DataProvider,
+    DeleteManyParams,
+    DeleteManyResult,
+    DeleteParams,
+    DeleteResult,
+    GetListParams,
+    GetListResult,
+    GetManyParams,
+    GetManyReferenceParams,
+    GetManyReferenceResult,
+    GetManyResult,
+    GetOneParams,
+    GetOneResult,
+    RaRecord,
+    UpdateManyParams,
+    UpdateManyResult,
+    UpdateParams,
+    UpdateResult,
+} from '../types';
+
+/**
+ * Extend a dataProvider to execute callbacks before and after read and write calls.
+ *
+ * @param {DataProvider} dataProvider The dataProvider to wrap
+ * @param {ResourceCallbacks[]} handlers An array of ResourceCallbacks
+ *
+ * @typedef {Object} ResourceCallbacks
+ * @property {string} resource The resource name
+ * @property {AfterCreate} [afterCreate] A callback executed after create
+ * @property {AfterDelete} [afterDelete] A callback executed after delete
+ * @property {AfterDeleteMany} [afterDeleteMany] A callback executed after deleteMany
+ * @property {AfterGetList} [afterGetList] A callback executed after getList
+ * @property {AfterGetMany} [afterGetMany] A callback executed after getMany
+ * @property {AfterGetManyReference} [afterGetManyReference] A callback executed after getManyReference
+ * @property {AfterGetOne} [afterGetOne] A callback executed after getOne
+ * @property {AfterRead} [afterRead] A callback executed after read (getList, getMany, getManyReference, getOne)
+ * @property {AfterSave} [afterSave] A callback executed after save (create, update, updateMany)
+ * @property {AfterUpdate} [afterUpdate] A callback executed after update
+ * @property {AfterUpdateMany} [afterUpdateMany] A callback executed after updateMany
+ * @property {BeforeCreate} [beforeCreate] A callback executed before create
+ * @property {BeforeDelete} [beforeDelete] A callback executed before delete
+ * @property {BeforeDeleteMany} [beforeDeleteMany] A callback executed before deleteMany
+ * @property {BeforeGetList} [beforeGetList] A callback executed before getList
+ * @property {BeforeGetMany} [beforeGetMany] A callback executed before getMany
+ * @property {BeforeGetManyReference} [beforeGetManyReference] A callback executed before getManyReference
+ * @property {BeforeGetOne} [beforeGetOne] A callback executed before getOne
+ * @property {BeforeSave} [beforeSave] A callback executed before save (create, update, updateMany)
+ * @property {BeforeUpdate} [beforeUpdate] A callback executed before update
+ * @property {BeforeUpdateMany} [beforeUpdateMany] A callback executed before updateMany
+ *
+ * Warnings:
+ * - As queries issued in the callbacks are not done through react-query,
+ *   any change in the data will not be automatically reflected in the UI.
+ * - The callbacks are not executed in a transaction. In case of error,
+ *   the backend may be left in an inconsistent state.
+ * - When calling the API directly using fetch or another client,
+ *   the callbacks will not be executed, leaving the backend in a possiblly inconsistent state.
+ * - If a callback triggers the query it's listening to, this will lead to a infinite loop.
+ *
+ * @example
+ *
+ * const dataProvider = withLifecycleCallbacks(
+ *   jsonServerProvider("http://localhost:3000"),
+ *   [
+ *     {
+ *       resource: "posts",
+ *       afterRead: async (data, dataProvider) => {
+ *         // rename field to the record
+ *         data.user_id = data.userId;
+ *         return data;
+ *       },
+ *       // executed after create, update and updateMany
+ *       afterSave: async (record, dataProvider) => {
+ *         // update the author's nb_posts
+ *         const { total } = await dataProvider.getList("users", {
+ *           filter: { id: record.user_id },
+ *           pagination: { page: 1, perPage: 1 },
+ *         });
+ *         await dataProvider.update("users", {
+ *           id: user.id,
+ *           data: { nb_posts: total },
+ *           previousData: user,
+ *         });
+ *         return record;
+ *       },
+ *       beforeDelete: async (params, dataProvider) => {
+ *         // delete all comments linked to the post
+ *         const { data: comments } = await dataProvider.getManyReference(
+ *           "comments",
+ *           {
+ *             target: "post_id",
+ *             id: params.id,
+ *           }
+ *         );
+ *         if (comments.length > 0) {
+ *           await dataProvider.deleteMany("comments", {
+ *             ids: comments.map((comment) => comment.id),
+ *           });
+ *         }
+ *         // update the author's nb_posts
+ *         const { data: post } = await dataProvider.getOne("posts", {
+ *           id: params.id,
+ *         });
+ *         const { total } = await dataProvider.getList("users", {
+ *           filter: { id: post.user_id },
+ *           pagination: { page: 1, perPage: 1 },
+ *         });
+ *         await dataProvider.update("users", {
+ *           id: user.id,
+ *           data: { nb_posts: total - 1 },
+ *           previousData: user,
+ *         });
+ *         return params;
+ *       },
+ *     },
+ *   ]
+ * );
+ */
+export const withLifecycleCallbacks = (
+    dataProvider: DataProvider,
+    handlers: ResourceCallbacks[]
+): DataProvider => {
+    return {
+        ...dataProvider,
+
+        getList: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: GetListParams
+        ) {
+            let newParams = params;
+            const beforeGetListHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeGetList
+            );
+            for (let handler of beforeGetListHandlers) {
+                newParams = await handler.beforeGetList(
+                    newParams,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.getList<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterGetListHandlers = handlers.filter(
+                h => h.resource === resource && h.afterGetList
+            );
+            for (let handler of afterGetListHandlers) {
+                result = await handler.afterGetList(result, dataProvider);
+            }
+            const afterReadHandlers = handlers.filter(
+                h => h.resource === resource && h.afterRead
+            );
+            for (let handler of afterReadHandlers) {
+                result.data = await Promise.all(
+                    result.data.map(record =>
+                        handler.afterRead(record, dataProvider)
+                    )
+                );
+            }
+
+            return result;
+        },
+
+        getOne: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: GetOneParams<RecordType>
+        ) {
+            let newParams = params;
+            const beforeGetOneHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeGetOne
+            );
+            for (let handler of beforeGetOneHandlers) {
+                newParams = await handler.beforeGetOne(newParams, dataProvider);
+            }
+
+            let result = await dataProvider.getOne<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterGetOneHandlers = handlers.filter(
+                h => h.resource === resource && h.afterGetOne
+            );
+            for (let handler of afterGetOneHandlers) {
+                result = await handler.afterGetOne(result, dataProvider);
+            }
+            const afterReadHandlers = handlers.filter(
+                h => h.resource === resource && h.afterRead
+            );
+            for (let handler of afterReadHandlers) {
+                result.data = await handler.afterRead(
+                    result.data,
+                    dataProvider
+                );
+            }
+
+            return result;
+        },
+
+        getMany: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: GetManyParams
+        ) {
+            let newParams = params;
+            const beforeGetManyHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeGetMany
+            );
+            for (let handler of beforeGetManyHandlers) {
+                newParams = await handler.beforeGetMany(
+                    newParams,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.getMany<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterGetManyHandlers = handlers.filter(
+                h => h.resource === resource && h.afterGetMany
+            );
+            for (let handler of afterGetManyHandlers) {
+                result = await handler.afterGetMany(result, dataProvider);
+            }
+            const afterReadHandlers = handlers.filter(
+                h => h.resource === resource && h.afterRead
+            );
+            for (let handler of afterReadHandlers) {
+                result.data = await Promise.all(
+                    result.data.map(record =>
+                        handler.afterRead(record, dataProvider)
+                    )
+                );
+            }
+
+            return result;
+        },
+
+        getManyReference: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: GetManyReferenceParams
+        ) {
+            let newParams = params;
+            const beforeGetManyReferenceHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeGetManyReference
+            );
+            for (let handler of beforeGetManyReferenceHandlers) {
+                newParams = await handler.beforeGetManyReference(
+                    newParams,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.getManyReference<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterGetManyReferenceHandlers = handlers.filter(
+                h => h.resource === resource && h.afterGetManyReference
+            );
+            for (let handler of afterGetManyReferenceHandlers) {
+                result = await handler.afterGetManyReference(
+                    result,
+                    dataProvider
+                );
+            }
+            const afterReadHandlers = handlers.filter(
+                h => h.resource === resource && h.afterRead
+            );
+            for (let handler of afterReadHandlers) {
+                result.data = await Promise.all(
+                    result.data.map(record =>
+                        handler.afterRead(record, dataProvider)
+                    )
+                );
+            }
+
+            return result;
+        },
+
+        update: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: UpdateParams<RecordType>
+        ) {
+            let newParams = params;
+            const beforeUpdateHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeUpdate
+            );
+            for (let handler of beforeUpdateHandlers) {
+                newParams = await handler.beforeUpdate(newParams, dataProvider);
+            }
+            const beforeSaveHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeSave
+            );
+            for (let handler of beforeSaveHandlers) {
+                newParams.data = await handler.beforeSave(
+                    newParams.data,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.update<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterUpdateHandlers = handlers.filter(
+                h => h.resource === resource && h.afterUpdate
+            );
+            for (let handler of afterUpdateHandlers) {
+                result = await handler.afterUpdate(result, dataProvider);
+            }
+            const afterSaveHandlers = handlers.filter(
+                h => h.resource === resource && h.afterSave
+            );
+            for (let handler of afterSaveHandlers) {
+                result.data = await handler.afterSave(
+                    result.data,
+                    dataProvider
+                );
+            }
+
+            return result;
+        },
+
+        create: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: CreateParams<RecordType>
+        ) {
+            let newParams = params;
+            const beforeCreateHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeCreate
+            );
+            for (let handler of beforeCreateHandlers) {
+                newParams = await handler.beforeCreate(newParams, dataProvider);
+            }
+            const beforeSaveHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeSave
+            );
+            for (let handler of beforeSaveHandlers) {
+                newParams.data = await handler.beforeSave(
+                    newParams.data,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.create<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterCreateHandlers = handlers.filter(
+                h => h.resource === resource && h.afterCreate
+            );
+            for (let handler of afterCreateHandlers) {
+                result = await handler.afterCreate(result, dataProvider);
+            }
+            const afterSaveHandlers = handlers.filter(
+                h => h.resource === resource && h.afterSave
+            );
+            for (let handler of afterSaveHandlers) {
+                result.data = await handler.afterSave(
+                    result.data,
+                    dataProvider
+                );
+            }
+
+            return result;
+        },
+
+        delete: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: DeleteParams<RecordType>
+        ) {
+            let newParams = params;
+            const beforeDeleteHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeDelete
+            );
+            for (let handler of beforeDeleteHandlers) {
+                newParams = await handler.beforeDelete(newParams, dataProvider);
+            }
+
+            let result = await dataProvider.delete<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterDeleteHandlers = handlers.filter(
+                h => h.resource === resource && h.afterDelete
+            );
+            for (let handler of afterDeleteHandlers) {
+                result = await handler.afterDelete(result, dataProvider);
+            }
+
+            return result;
+        },
+
+        updateMany: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: UpdateManyParams<RecordType>
+        ) {
+            let newParams = params;
+            const beforeUpdateManyHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeUpdateMany
+            );
+            for (let handler of beforeUpdateManyHandlers) {
+                newParams = await handler.beforeUpdateMany(
+                    newParams,
+                    dataProvider
+                );
+            }
+            const beforeSaveHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeSave
+            );
+            for (let handler of beforeSaveHandlers) {
+                newParams.data = await handler.beforeSave(
+                    newParams.data,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.updateMany<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterUpdateManyHandlers = handlers.filter(
+                h => h.resource === resource && h.afterUpdateMany
+            );
+            for (let handler of afterUpdateManyHandlers) {
+                result = await handler.afterUpdateMany(result, dataProvider);
+            }
+            const afterSaveHandlers = handlers.filter(
+                h => h.resource === resource && h.afterSave
+            );
+            if (afterSaveHandlers.length > 0) {
+                const { data: records } = await dataProvider.getMany(resource, {
+                    ids: result.data,
+                });
+
+                for (let handler of afterSaveHandlers) {
+                    await Promise.all(
+                        records.map(record =>
+                            handler.afterSave(record, dataProvider)
+                        )
+                    );
+                }
+            }
+
+            return result;
+        },
+
+        deleteMany: async function <RecordType extends RaRecord = any>(
+            resource: string,
+            params: DeleteManyParams<RecordType>
+        ) {
+            let newParams = params;
+            const beforeDeleteManyHandlers = handlers.filter(
+                h => h.resource === resource && h.beforeDeleteMany
+            );
+            for (let handler of beforeDeleteManyHandlers) {
+                newParams = await handler.beforeDeleteMany(
+                    newParams,
+                    dataProvider
+                );
+            }
+
+            let result = await dataProvider.deleteMany<RecordType>(
+                resource,
+                newParams
+            );
+
+            const afterDeleteManyHandlers = handlers.filter(
+                h => h.resource === resource && h.afterDeleteMany
+            );
+            for (let handler of afterDeleteManyHandlers) {
+                result = await handler.afterDeleteMany(result, dataProvider);
+            }
+
+            return result;
+        },
+    };
+};
+
+export type BeforteGetListCallback = (
+    params: GetListParams,
+    dataProvider: DataProvider
+) => Promise<GetListParams>;
+
+export type AfterGetListCallback<T extends RaRecord = any> = (
+    result: GetListResult<T>,
+    dataProvider: DataProvider
+) => Promise<GetListResult<T>>;
+
+export type BeforeGetOneCallback<T extends RaRecord = any> = (
+    params: GetOneParams<T>,
+    dataProvider: DataProvider
+) => Promise<GetOneParams<T>>;
+
+export type AfterGetOneCallback<T extends RaRecord = any> = (
+    result: GetOneResult<T>,
+    dataProvider: DataProvider
+) => Promise<GetOneResult<T>>;
+
+export type BeforeGetManyCallback = (
+    params: GetManyParams,
+    dataProvider: DataProvider
+) => Promise<GetManyParams>;
+
+export type AfterGetManyCallback<T extends RaRecord = any> = (
+    result: GetManyResult<T>,
+    dataProvider: DataProvider
+) => Promise<GetManyResult<T>>;
+
+export type BeforeGetManyReferenceCallback = (
+    params: GetManyReferenceParams,
+    dataProvider: DataProvider
+) => Promise<GetManyReferenceParams>;
+
+export type AfterGetManyReferenceCallback<T extends RaRecord = any> = (
+    result: GetManyReferenceResult<T>,
+    dataProvider: DataProvider
+) => Promise<GetManyReferenceResult<T>>;
+
+export type BeforeUpdateCallback<T extends RaRecord = any> = (
+    params: UpdateParams<T>,
+    dataProvider: DataProvider
+) => Promise<UpdateParams<T>>;
+
+export type BeforeUpdateManyCallback<T extends RaRecord = any> = (
+    params: UpdateManyParams<T>,
+    dataProvider: DataProvider
+) => Promise<UpdateManyParams<T>>;
+
+export type AfterUpdateManyCallback<T extends RaRecord = any> = (
+    result: UpdateManyResult<T>,
+    dataProvider: DataProvider
+) => Promise<UpdateManyResult<T>>;
+
+export type AfterUpdateCallback<T extends RaRecord = any> = (
+    result: UpdateResult<T>,
+    dataProvider: DataProvider
+) => Promise<UpdateResult<T>>;
+
+export type BeforeCreateCallback<T extends RaRecord = any> = (
+    params: CreateParams<T>,
+    dataProvider: DataProvider
+) => Promise<CreateParams<T>>;
+
+export type AfterCreateCallback<T extends RaRecord = any> = (
+    result: CreateResult<T>,
+    dataProvider: DataProvider
+) => Promise<CreateResult<T>>;
+
+export type BeforeDeleteCallback<T extends RaRecord = any> = (
+    params: DeleteParams<T>,
+    dataProvider: DataProvider
+) => Promise<DeleteParams<T>>;
+
+export type AfterDeleteCallback<T extends RaRecord = any> = (
+    result: DeleteResult<T>,
+    dataProvider: DataProvider
+) => Promise<DeleteResult<T>>;
+
+export type BeforeDeleteManyCallback<T extends RaRecord = any> = (
+    params: DeleteManyParams<T>,
+    dataProvider: DataProvider
+) => Promise<DeleteManyParams<T>>;
+
+export type AfterDeleteManyCallback<T extends RaRecord = any> = (
+    result: DeleteManyResult<T>,
+    dataProvider: DataProvider
+) => Promise<DeleteManyResult<T>>;
+
+export type AfterReadCallback<T extends RaRecord = any> = (
+    record: T,
+    dataProvider: DataProvider
+) => Promise<T>;
+
+export type BeforeSaveCallback<T extends RaRecord = any> = (
+    data: Partial<T>,
+    dataProvider: DataProvider
+) => Promise<T>;
+
+export type AfterSaveCallback<T extends RaRecord = any> = (
+    record: T,
+    dataProvider: DataProvider
+) => Promise<T>;
+
+export type ResourceCallbacks<T extends RaRecord = any> = {
+    resource: string;
+    afterCreate?: AfterCreateCallback<T>;
+    afterDelete?: AfterDeleteCallback<T>;
+    afterDeleteMany?: AfterDeleteManyCallback<T>;
+    afterGetList?: AfterGetListCallback<T>;
+    afterGetMany?: AfterGetManyCallback<T>;
+    afterGetManyReference?: AfterGetManyReferenceCallback<T>;
+    afterGetOne?: AfterGetOneCallback<T>;
+    afterUpdate?: AfterUpdateCallback<T>;
+    afterUpdateMany?: AfterUpdateManyCallback<T>;
+    beforeCreate?: BeforeCreateCallback<T>;
+    beforeDelete?: BeforeDeleteCallback<T>;
+    beforeDeleteMany?: BeforeDeleteManyCallback<T>;
+    beforeGetList?: BeforteGetListCallback;
+    beforeGetMany?: BeforeGetManyCallback;
+    beforeGetManyReference?: BeforeGetManyReferenceCallback;
+    beforeGetOne?: BeforeGetOneCallback<T>;
+    beforeUpdate?: BeforeUpdateCallback<T>;
+    beforeUpdateMany?: BeforeUpdateManyCallback<T>;
+
+    // The following hooks don't match a dataProvider method
+
+    /**
+     * Modify the data before it is sent to the dataProvider.
+     *
+     * Used in create, update, and updateMany
+     *
+     * Note: This callback doesn't modify the record itself, but the data argument
+     * (which may be a diff, especially when called with updateMany).
+     */
+    beforeSave?: BeforeSaveCallback<T>;
+    /**
+     * Update a record after it has been read from the dataProvider
+     *
+     * Used in getOne, getList, getMany, and getManyReference
+     */
+    afterRead?: AfterReadCallback<T>;
+    /**
+     * Modify the record after it is returned by the dataProvider.
+     *
+     * Used in create, update, and updateMany
+     */
+    afterSave?: AfterSaveCallback<T>;
+};


### PR DESCRIPTION
## Problem

Developers must put their data handling / domain logic in the dataProvider, but that isn't very practical. The dataProvider quickly becomes a mess of `if(resource ==='...')` that is hard to read and to maintain. 

## Solution

Allow developers to decorate an existing `dataProvider` with lifecycle callbacks.

```jsx
const dataProvider = withLifecycleCallbacks(baseDataProvider, [
    {
        resource: 'posts',
        beforeDelete: async ({ id }) => {
            // delete related comments
            const { data: comments } = await baseDataProvider.getList(
                'comments',
                {
                    filter: { post_id: id },
                    pagination: { page: 1, perPage: 100 },
                    sort: { field: 'id', order: 'DESC' },
                }
            );
            await baseDataProvider.deleteMany('comments', {
                ids: comments.map(comment => comment.id),
            });
            return { id };
        },
    },
]);
```

- [x] Add code
- [x] Add unit tests
- [x] Use in simple example
- [x] Add e2e test
- [x] Add documentation