### PR TITLE
Add TabbedForm.Tab and TabbedShowLayout.Tab shortcuts

### DIFF
--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -630,7 +630,7 @@ const ProductShow = () => (
 
 ### `<Tab>`
 
-Replacement for the show `<Tab>` that only renders a tab if the user has the right permissions.
+Replacement for the `<TabbedShowLayout.Tab>` that only renders a tab if the user has the right permissions.
 
 Add a `name` prop to the Tab to define the resource on which the user needs to have the 'read' permissions for.
 

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -178,14 +178,14 @@ export const UserEdit = () => {
     return (
         <Edit title={<UserTitle />}>
             <TabbedForm defaultValue={{ role: 'user' }}>
-                <FormTab label="user.form.summary">
+                <TabbedForm.Tab label="user.form.summary">
                     {permissions === 'admin' && <TextInput disabled source="id" />}
                     <TextInput source="name" validate={required()} />
-                </FormTab>
+                </TabbedForm.Tab>
                 {permissions === 'admin' &&
-                    <FormTab label="user.form.security">
+                    <TabbedForm.Tab label="user.form.security">
                         <TextInput source="role" validate={required()} />
-                    </FormTab>}
+                    </TabbedForm.Tab>}
             </TabbedForm>
         </Edit>
     );

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -80,12 +80,12 @@ export const PostShow = () => (
     <Show>
 -       <SimpleShowLayout>
 +       <TabbedShowLayout>
-+           <Tab label="Main>
++           <TabbedShowLayout.Tab label="Main>
                 <TextField source="title" />
                 <TextField source="teaser" />
                 <RichTextField source="body" />
                 <DateField label="Publication date" source="created_at" />
-+           </Tab>
++           </TabbedShowLayout.Tab>
 -       </SimpleShowLayout>
 +       </TabbedShowLayout>
     </Show>
@@ -362,25 +362,25 @@ export const PostShow = () => {
 ```
 {% endraw %}
 
-This also works inside a `TabbedShowLayout`, and you can hide a `Tab` completely:
+This also works inside a `<TabbedShowLayout>`, and you can hide a `TabbedShowLayout.Tab` completely:
 
 {% raw %}
 ```jsx
-import { Show, TabbedShowLayout, Tab, TextField } from 'react-admin';
+import { Show, TabbedShowLayout, TextField } from 'react-admin';
 
 export const UserShow = () => {
     const { permissions } = usePermissions();
     return (
         <Show>
             <TabbedShowLayout>
-                <Tab label="user.form.summary">
+                <TabbedShowLayout.Tab label="user.form.summary">
                     {permissions === 'admin' && <TextField source="id" />}
                     <TextField source="name" />
-                </Tab>
+                </TabbedShowLayout.Tab>
                 {permissions === 'admin' &&
-                    <Tab label="user.form.security">
+                    <TabbedShowLayout.Tab label="user.form.security">
                         <TextField source="role" />
-                    </Tab>}
+                    </TabbedShowLayout.Tab>}
             </TabbedShowLayout>
         </Show>
     );

--- a/docs/ShowTutorial.md
+++ b/docs/ShowTutorial.md
@@ -358,7 +358,7 @@ const BookShow = () => (
 When a Show view has to display a lot of fields, the `<SimpleShowLayout>` component ends up in very long page that is not user-friendly. You can use [the `<TabbedShowLayout>` component](./TabbedShowLayout.md) instead, which is a variant of the `<SimpleShowLayout>` component that displays the fields in tabs. 
 
 ```jsx
-import { Show, TabbedShowLayout, Tab, TextField, DateField, WithRecord } from 'react-admin';
+import { Show, TabbedShowLayout, TextField, DateField, WithRecord } from 'react-admin';
 import StarIcon from '@mui/icons-material/Star';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import PersonPinIcon from '@mui/icons-material/PersonPin';
@@ -366,19 +366,19 @@ import PersonPinIcon from '@mui/icons-material/PersonPin';
 const BookShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="Description" icon={<FavoriteIcon />}>
+            <TabbedShowLayout.Tab label="Description" icon={<FavoriteIcon />}>
                 <TextField label="Title" source="title" />
                 <ReferenceField label="Author" source="author_id">
                     <TextField source="name" />
                 </ReferenceField>
                 <DateField label="Publication Date" source="published_at" />
-            </Tab>
-            <Tab label="User ratings" icon={<PersonPinIcon />}>
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="User ratings" icon={<PersonPinIcon />}>
                 <WithRecord label="Rating" render={record => <>
                     {[...Array(record.rating)].map((_, index) => <StarIcon key={index} />)}
                 </>} />
                 <DateField label="Last rating" source="last_rated_at" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -5,7 +5,7 @@ title: "TabbedForm"
 
 # `<TabbedForm>`
 
-`<TabbedForm>` creates a `<form>` to edit a record, and renders inputs grouped by tab. The tabs are set by using `<FormTab>` components. It is useful for forms with a lot of inputs, to reduce the time taken to change a subset of the fields.
+`<TabbedForm>` creates a `<form>` to edit a record, and renders inputs grouped by tab. The tabs are set by using `<TabbedForm.Tab>` components. It is useful for forms with a lot of inputs, to reduce the time taken to change a subset of the fields.
 
 ![tabbed form](./img/tabbed-form.gif)
 
@@ -13,14 +13,13 @@ title: "TabbedForm"
 
 `<TabbedForm>` reads the `record` from the `RecordContext`, uses it to initialize the defaultValues of a `<Form>`, renders its children in a MUI `<Stack>`, and renders a toolbar with a `<SaveButton>` that calls the `save` callback prepared by the edit or the create controller when pressed. 
 
-`<TabbedForm>` is often used as child of `<Create>` or `<Edit>`. It accepts `<FormTab>` elements as children. It relies on [react-hook-form](https://react-hook-form.com/) for form handling. It requires no prop by default.
+`<TabbedForm>` is often used as child of `<Create>` or `<Edit>`. It accepts `<TabbedForm.Tab>` elements as children. It relies on [react-hook-form](https://react-hook-form.com/) for form handling. It requires no prop by default.
 
 {% raw %}
 ```jsx
 import * as React from "react";
 import {
     TabbedForm,
-    FormTab,
     Edit,
     Datagrid,
     TextField,
@@ -36,22 +35,22 @@ import {
 export const PostEdit = () => (
     <Edit>
         <TabbedForm>
-            <FormTab label="summary">
+            <TabbedForm.Tab label="summary">
                 <TextInput disabled label="Id" source="id" />
                 <TextInput source="title" validate={required()} />
                 <TextInput multiline source="teaser" validate={required()} />
-            </FormTab>
-            <FormTab label="body">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="body">
                 <RichTextInput source="body" validate={required()} label={false} />
-            </FormTab>
-            <FormTab label="Miscellaneous">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="Miscellaneous">
                 <TextInput label="Password (if protected post)" source="password" type="password" />
                 <DateInput label="Publication date" source="published_at" />
                 <NumberInput source="average_note" validate={[ number(), minValue(0) ]} />
                 <BooleanInput label="Allow comments?" source="commentable" defaultValue />
                 <TextInput disabled label="Nb views" source="views" />
-            </FormTab>
-            <FormTab label="comments">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="comments">
                 <ReferenceManyField reference="comments" target="post_id" label={false}>
                     <Datagrid>
                         <TextField source="body" />
@@ -59,7 +58,7 @@ export const PostEdit = () => (
                         <EditButton />
                     </Datagrid>
                 </ReferenceManyField>
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Edit>
 );
@@ -187,7 +186,7 @@ export const PostCreate = () => (
 ```
 {% endraw %}
 
-**Tip:** If you want to customize the _content_ of the tabs instead, for example to limit the width of the form, you should rather add an `sx` prop to the [`<FormTab>` component](#formtab).
+**Tip:** If you want to customize the _content_ of the tabs instead, for example to limit the width of the form, you should rather add an `sx` prop to the [`<TabbedForm.Tab>` component](#formtab).
 
 ## `sanitizeEmptyValues`
 
@@ -241,22 +240,22 @@ However, this makes `<TabbedForm>` impossible to use in pages where the state is
 export const PostEdit = () => (
     <Edit>
         <TabbedForm syncWithLocation={false}>
-            <FormTab label="summary">
+            <TabbedForm.Tab label="summary">
                 <TextInput disabled label="Id" source="id" />
                 <TextInput source="title" validate={required()} />
                 <TextInput multiline source="teaser" validate={required()} />
-            </FormTab>
-            <FormTab label="body">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="body">
                 <RichTextInput source="body" validate={required()} label={false} />
-            </FormTab>
-            <FormTab label="Miscellaneous">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="Miscellaneous">
                 <TextInput label="Password (if protected post)" source="password" type="password" />
                 <DateInput label="Publication date" source="published_at" />
                 <NumberInput source="average_note" validate={[ number(), minValue(0) ]} />
                 <BooleanInput label="Allow comments?" source="commentable" defaultValue />
                 <TextInput disabled label="Nb views" source="views" />
-            </FormTab>
-            <FormTab label="comments">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="comments">
                 <ReferenceManyField reference="comments" target="post_id" label={false}>
                     <Datagrid>
                         <TextField source="body" />
@@ -264,18 +263,18 @@ export const PostEdit = () => (
                         <EditButton />
                     </Datagrid>
                 </ReferenceManyField>
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Edit>
 );
 ```
 {% endraw %}
 
-**Tip**: When `syncWithLocation` is `false`, the `path` prop of the `<FormTab>` components is ignored.
+**Tip**: When `syncWithLocation` is `false`, the `path` prop of the `<TabbedForm.Tab>` components is ignored.
 
 ## `tabs`
 
-By default, `<TabbedForm>` uses `<TabbedFormTabs>`, an internal react-admin component, to renders the tab headers. You can pass a custom component as the `tabs` prop to tweak th UX of these headers. Besides, props from `<TabbedFormTabs>` are passed down to MUI's `<Tabs>` component.
+By default, `<TabbedForm>` uses `<TabbedFormTabs>`, an internal react-admin component, to render the tab headers. You can pass a custom component as the `tabs` prop to tweak th UX of these headers. Besides, props from `<TabbedFormTabs>` are passed down to MUI's `<Tabs>` component.
 
 The following example shows how to make use of scrollable `<Tabs>`. Pass `variant="scrollable"` and `scrollButtons="auto"` props to `<TabbedFormTabs>` and use it in the `tabs` prop from `<TabbedForm>`.
 
@@ -470,16 +469,16 @@ export const TagEdit = () => (
 
 **Warning**: This feature only works if you have a dependency on react-router 6.3.0 **at most**. The react-router team disabled this possibility in react-router 6.4, so `warnWhenUnsavedChanges` will silently fail with react-router 6.4 or later.
 
-## `<FormTab>`
+## `<TabbedForm.Tab>`
 
-`<TabbedForm>` expect `<FormTab>` elements as children. `<FormTab>` elements accept four props:
+`<TabbedForm>` expect `<TabbedForm.Tab>` elements as children. `<TabbedForm.Tab>` elements accept four props:
 
 - `label`: the label of the tab
 - `path`: the path of the tab in the URL (ignored when `syncWithLocation={false}`)
 - `sx`: custom styles to apply to the tab
 - `children`: the content of the tab (usually a list of inputs)
 
-`<FormTab>` renders its children in a MUI `<Stack>` component, i.e. one child per row.
+`<TabbedForm.Tab>` renders its children in a MUI `<Stack>` component, i.e. one child per row.
 
 The `sx` prop allows to style the content of the tab, e.g. to limit its width:
 
@@ -488,12 +487,12 @@ The `sx` prop allows to style the content of the tab, e.g. to limit its width:
 const ProductEdit = () => (
     <Edit title={<ProductTitle />}>
         <TabbedForm>
-            <FormTab
+            <TabbedForm.Tab
                 label="resources.products.tabs.image"
                 sx={{ maxWidth: '40em' }}
             >
                 ...
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Edit>
 );
@@ -506,25 +505,25 @@ React-admin passes the `label` through the `translate()` function, so you can us
 const ProductEdit = () => (
     <Edit title={<ProductTitle />}>
         <TabbedForm>
-            <FormTab label="resources.products.tabs.image">
+            <TabbedForm.Tab label="resources.products.tabs.image">
                 ...
-            </FormTab>
-            <FormTab label="resources.products.tabs.details">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="resources.products.tabs.details">
                 ...
-            </FormTab>
-            <FormTab label="resources.products.tabs.description">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="resources.products.tabs.description">
                 ...
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Edit>
 );
 ```
 
-**Tip**: React-admin renders each tab *twice*: once to get the tab header, and once to get the tab content. If you use a custom component instead of a `<FormTab>`, make sure that it accepts an `intent` prop, and renders differently when the value of that prop is 'header' or 'content'.
+**Tip**: React-admin renders each tab *twice*: once to get the tab header, and once to get the tab content. If you use a custom component instead of a `<TabbedForm.Tab>`, make sure that it accepts an `intent` prop, and renders differently when the value of that prop is 'header' or 'content'.
 
-## Using Fields As FormTab Children
+## Using Fields As Children
 
-The basic usage of `<TabbedForm>` is to pass [Input components](./Inputs.md) as children of `<FormTab>`. For non-editable fields, you can pass `disabled` inputs, or even [Field components](./Fields.md). But since `<Field>` components have no label by default, you'll have to wrap your inputs in a `<Labeled>` component in that case:
+The basic usage of `<TabbedForm>` is to pass [Input components](./Inputs.md) as children of `<TabbedForm.Tab>`. For non-editable fields, you can pass `disabled` inputs, or even [Field components](./Fields.md). But since `<Field>` components have no label by default, you'll have to wrap your inputs in a `<Labeled>` component in that case:
 
 ```jsx
 import { Edit, TabbedForm, TextInput, Labeled, TextField } from 'react-admin';
@@ -532,13 +531,13 @@ import { Edit, TabbedForm, TextInput, Labeled, TextField } from 'react-admin';
 const PostEdit = () => (
     <Edit>
         <TabbedForm>
-            <FormTab label="main">
+            <TabbedForm.Tab label="main">
                 <TextInput source="id" />
                 <Labeled label="Title">
                     <TextField source="title" />
                 </Labeled>
                 <TextInput source="body" />
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Edit>
 );
@@ -550,25 +549,25 @@ const PostEdit = () => (
 
 ![complex form layout](./img/TabbedForm-layout.png)
 
-By default, `<FormTab>` renders one child per row. But a given child can be a layout element (e.g. `<Grid>`, `<Stack>`, `<Box>`) and contain several input elements. This lets you build form layouts of any complexity:
+By default, `<TabbedForm.Tab>` renders one child per row. But a given child can be a layout element (e.g. `<Grid>`, `<Stack>`, `<Box>`) and contain several input elements. This lets you build form layouts of any complexity:
 
 {% raw %}
 ```jsx
 const ProductEdit = () => (
     <Edit title={<ProductTitle />}>
         <TabbedForm>
-            <FormTab label="resources.products.tabs.image">
+            <TabbedForm.Tab label="resources.products.tabs.image">
                 ...
-            </FormTab>
-            <FormTab label="resources.products.tabs.details">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="resources.products.tabs.details">
                 <ProductEditDetails />
-            </FormTab>
-            <FormTab label="resources.products.tabs.description">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="resources.products.tabs.description">
                 ...
-            </FormTab>
-            <FormTab path="reviews">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab path="reviews">
                 ...
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Edit>
 );
@@ -637,7 +636,7 @@ const ProductEditDetails = () => (
 
 ![dynamic tab label](./img/FormTab-dynamic-label.png)
 
-To achieve that, create a custom commponent that renders a `<FormTab>` with a dynamic `label`:
+To achieve that, create a custom commponent that renders a `<TabbedForm.Tab>` with a dynamic `label`:
 
 ```jsx
 const ReviewsFormTab = props => {
@@ -657,7 +656,7 @@ const ReviewsFormTab = props => {
     if (!isLoading) {
         label += ` (${total})`;
     }
-    return <FormTab label={label} {...props} />;
+    return <TabbedForm.Tab label={label} {...props} />;
 };
 ```
 
@@ -668,15 +667,15 @@ Then, use this custom component in a `<TabbedForm>`:
 const ProductEdit = () => (
     <Edit title={<ProductTitle />}>
         <TabbedForm>
-            <FormTab label="resources.products.tabs.image">
+            <TabbedForm.Tab label="resources.products.tabs.image">
                 ...
-            </FormTab>
-            <FormTab label="resources.products.tabs.details">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="resources.products.tabs.details">
                 ...
-            </FormTab>
-            <FormTab label="resources.products.tabs.description">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="resources.products.tabs.description">
                 ...
-            </FormTab>
+            </TabbedForm.Tab>
             <ReviewsFormTab path="reviews">
                 <ReferenceManyField
                     reference="reviews"
@@ -724,13 +723,13 @@ const UserEdit = () => {
     return (
         <Edit>
             <TabbedForm>
-                <FormTab label="summary">
+                <TabbedForm.Tab label="summary">
                     ...
-                </FormTab>
+                </TabbedForm.Tab>
                 {permissions === 'admin' &&
-                    <FormTab label="Security">
+                    <TabbedForm.Tab label="Security">
                         ...
-                    </FormTab>
+                    </TabbedForm.Tab>
                 }
             </TabbedForm>
         </Edit>

--- a/docs/TabbedShowLayout.md
+++ b/docs/TabbedShowLayout.md
@@ -5,39 +5,39 @@ title: "TabbedShowLayout"
 
 # `<TabbedShowLayout>`
 
-The `<TabbedShowLayout>` pulls the `record` from the `RecordContext`. It renders a set of `<Tabs>`, each of which contains a list of record fields in a single-column layout (via MUI's `<Stack>` component). `<TabbedShowLayout>` delegates the actual rendering of fields to its children, which should be `<Tab>` components. `<Tab>`  wraps each field inside a `<Labeled>` component to add a label.
+The `<TabbedShowLayout>` pulls the `record` from the `RecordContext`. It renders a set of `<Tabs>`, each of which contains a list of record fields in a single-column layout (via MUI's `<Stack>` component). `<TabbedShowLayout>` delegates the actual rendering of fields to its children, which should be `<TabbedShowLayout.Tab>` elements. `<TabbedShowLayout.Tab>`  wraps each field inside a `<Labeled>` component to add a label.
 
-Switching tabs will update the current url. By default, it uses the tabs indexes and the first tab will be displayed at the root url. You can customize the path by providing a `path` prop to each `Tab` component. If you'd like the first one to act as an index page, just omit the `path` prop.
+Switching tabs will update the current url. By default, it uses the tabs indexes and the first tab will be displayed at the root url. You can customize the path by providing a `path` prop to each `<TabbedShowLayout.Tab>` component. If you'd like the first one to act as an index page, just omit the `path` prop.
 
 ![tabbed show](./img/tabbed-show.gif)
 
 ## Usage 
 
-Use `<TabbedShowLayout>` as descendant of a `<Show>` component (or any component creating a `<RecordContext>`), define the tabs via `<Tab>` children, and set the fields to be displayed as children of each tab:
+Use `<TabbedShowLayout>` as descendant of a `<Show>` component (or any component creating a `<RecordContext>`), define the tabs via `<TabbedShowLayout.Tab>` children, and set the fields to be displayed as children of each tab:
 
 {% raw %}
 ```jsx
-import { Show, TabbedShowLayout, Tab } from 'react-admin'
+import { Show, TabbedShowLayout } from 'react-admin'
 
 export const PostShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="summary">
+            <TabbedShowLayout.Tab label="summary">
                 <TextField label="Id" source="id" />
                 <TextField source="title" />
                 <TextField source="teaser" />
-            </Tab>
-            <Tab label="body" path="body">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="body" path="body">
                 <RichTextField source="body" label={false} />
-            </Tab>
-            <Tab label="Miscellaneous" path="miscellaneous">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="Miscellaneous" path="miscellaneous">
                 <TextField label="Password (if protected post)" source="password" type="password" />
                 <DateField label="Publication date" source="published_at" />
                 <NumberField source="average_note" />
                 <BooleanField label="Allow comments?" source="commentable" defaultValue />
                 <TextField label="Nb views" source="views" />
-            </Tab>
-            <Tab label="comments" path="comments">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="comments" path="comments">
                 <ReferenceManyField reference="comments" target="post_id" label={false}>
                     <Datagrid>
                         <TextField source="body" />
@@ -45,7 +45,7 @@ export const PostShow = () => (
                         <EditButton />
                     </Datagrid>
                 </ReferenceManyField>
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -67,9 +67,9 @@ Additional props are passed to the root component (`<div>`).
 
 ## Tabs
 
-Children of `<TabbedShowLayout>` must be `<Tab>` components.
+Children of `<TabbedShowLayout>` must be `<TabbedShowLayout.Tab>` components.
 
-The `<Tab>` component renders tabs headers and the active tab. It manages the tab change, either via the URL, or an internal state.
+The `<TabbedShowLayout.Tab>` component renders tabs headers and the active tab. It manages the tab change, either via the URL, or an internal state.
 
 It accepts the following props:
 
@@ -82,18 +82,18 @@ It accepts the following props:
 import * as React from "react";
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import PersonPinIcon from '@mui/icons-material/PersonPin';
-import { Show, TabbedShowLayout, Tab, TextField } from 'react-admin';
+import { Show, TabbedShowLayout, TextField } from 'react-admin';
 
 export const PostShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="Content" icon={<FavoriteIcon />}>
+            <TabbedShowLayout.Tab label="Content" icon={<FavoriteIcon />}>
                 <TextField source="title" />
                 <TextField source="subtitle" />
-            </Tab>
-            <Tab label="Metadata" icon={<PersonIcon />} path="metadata">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="Metadata" icon={<PersonIcon />} path="metadata">
                 <TextField source="category" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -101,15 +101,15 @@ export const PostShow = () => (
 
 ## Tab Fields
 
-`<Tab>` renders each child inside a `<Labeled>` component. This component uses the humanized source as label by default. You can customize it by passing a `label` prop to the fields:
+`<TabbedShowLayout.Tab>` renders each child inside a `<Labeled>` component. This component uses the humanized source as label by default. You can customize it by passing a `label` prop to the fields:
 
 ```jsx
 const PostShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="main">
+            <TabbedShowLayout.Tab label="main">
                 <TextField label="My Custom Title" source="title" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -122,10 +122,10 @@ The `<Labeled label>` uses the humanized source by default. You can customize it
 const PostShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="main">
+            <TabbedShowLayout.Tab label="main">
                 <TextField label="My Custom Title" source="title" />
                 <TextField label="my.custom.translationKey" source="description" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -151,15 +151,15 @@ You can disable the `<Labeled>` decoration by passing setting `label={false}` on
 const PostShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="main">
+            <TabbedShowLayout.Tab label="main">
                 <TextField label={false} source="title" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
 ```
 
-`<Tab>` children can be anything you want. Try passing your own components:
+`<TabbedShowLayout.Tab>` children can be anything you want. Try passing your own components:
 
 ```jsx
 const PostTitle = () => {
@@ -170,9 +170,9 @@ const PostTitle = () => {
 const PostShow = () => (
     <Show>
         <TabbedShowLayout>
-            <Tab label="main">
+            <TabbedShowLayout.Tab label="main">
                 <PostTitle label="title" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -189,22 +189,22 @@ import { TabbedShowLayout, Tab } from 'react-admin'
 export const PostShow = () => (
     <Show>
         <TabbedShowLayout syncWithLocation={false}>
-            <Tab label="summary">
+            <TabbedShowLayout.Tab label="summary">
                 <TextField label="Id" source="id" />
                 <TextField source="title" />
                 <TextField source="teaser" />
-            </Tab>
-            <Tab label="body" path="body">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="body" path="body">
                 <RichTextField source="body" label={false} />
-            </Tab>
-            <Tab label="Miscellaneous" path="miscellaneous">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="Miscellaneous" path="miscellaneous">
                 <TextField label="Password (if protected post)" source="password" type="password" />
                 <DateField label="Publication date" source="published_at" />
                 <NumberField source="average_note" />
                 <BooleanField label="Allow comments?" source="commentable" defaultValue />
                 <TextField label="Nb views" source="views" />
-            </Tab>
-            <Tab label="comments" path="comments">
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="comments" path="comments">
                 <ReferenceManyField reference="comments" target="post_id" label={false}>
                     <Datagrid>
                         <TextField source="body" />
@@ -212,26 +212,26 @@ export const PostShow = () => (
                         <EditButton />
                     </Datagrid>
                 </ReferenceManyField>
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
 ```
 {% endraw %}
 
-**Tip**: When `syncWithLocation` is `false`, the `path` prop of the `<Tab>` components is ignored.
+**Tip**: When `syncWithLocation` is `false`, the `path` prop of the `<TabbedShowLayout.Tab>` components is ignored.
 
 ## Spacing
 
-`<Tab>` renders a MUI `<Stack>`. You can customize the spacing of each row by passing a `spacing` prop:
+`<TabbedShowLayout.Tab>` renders a MUI `<Stack>`. You can customize the spacing of each row by passing a `spacing` prop:
 
 ```jsx
 const PostShow = () => (
     <Show>
         <TabbedShowLayout spacing={2}>
-            <Tab label="main">
+            <TabbedShowLayout.Tab label="main">
                 <PostTitle label="title" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -249,9 +249,9 @@ import { Divider } from '@mui/material';
 const PostShow = () => (
     <Show>
         <TabbedShowLayout divider={<Divider flexItem />}>
-            <Tab label="main">
+            <TabbedShowLayout.Tab label="main">
                 <PostTitle label="title" />
-            </Tab>
+            </TabbedShowLayout.Tab>
         </TabbedShowLayout>
     </Show>
 );
@@ -289,9 +289,9 @@ By default, `<TabbedShowLayout>` reads the record from the `ResourceContext`. Bu
 ```jsx
 const StaticPostShow = () => (
     <TabbedShowLayout record={{ id: 123, title: 'Hello world' }}>
-        <Tab label="main">
+        <TabbedShowLayout.Tab label="main">
             <TextField source="title" />
-        </Tab>
+        </TabbedShowLayout.Tab>
     </TabbedShowLayout>
 );
 ```
@@ -309,7 +309,7 @@ The `<TabbedShowLayout>` component accepts the usual `className` prop but you ca
 
 To override the style of all instances of `<TabbedShowLayout>` using the [MUI style overrides](https://mui.com/customization/theme-components/), use the `RaTabbedShowLayout` key.
 
-To style the tabs, the `<Tab>` component accepts two props:
+To style the tabs, the `<TabbedShowLayout.Tab>` component accepts two props:
 
 - `className` is passed to the tab *header*
 - `contentClassName` is passed to the tab *content*
@@ -318,16 +318,16 @@ To style the tabs, the `<Tab>` component accepts two props:
 
 * [Field components](./Fields.md)
 * [Show Guesser](./ShowGuesser.md) guesses the fields based on the record type
-* [SimpleShowLayout](./SimpleShowLayout.md) provides a simpler layout with no tabs
+* [SimpleShowLayout](./TabbedShowLayout.md) provides a simpler layout with no tabs
 
 ## API
 
 * [`<TabbedShowLayout>`]
-* [`<Tab>`]
+* [`<TabbedShowLayout.Tab>`]
 * [`<Labeled>`]
 * [`useRecordContext`]
 
 [`<Labeled>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/Labeled.tsx
 [`<TabbedShowLayout>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
-[`<Tab>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/Tab.tsx
+[`<TabbedShowLayout.Tab>`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/detail/Tab.tsx
 [`useRecordContext`]: https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/controller/record/useRecordContext.ts

--- a/examples/demo/src/products/ProductCreate.tsx
+++ b/examples/demo/src/products/ProductCreate.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Create, FormTab, TabbedForm, TextInput, required } from 'react-admin';
+import { Create, TabbedForm, TextInput, required } from 'react-admin';
 import { RichTextInput } from 'ra-input-rich-text';
 
 import { ProductEditDetails } from './ProductEditDetails';
@@ -8,7 +8,7 @@ const ProductCreate = () => {
     return (
         <Create>
             <TabbedForm defaultValues={{ sales: 0 }}>
-                <FormTab
+                <TabbedForm.Tab
                     label="resources.products.tabs.image"
                     sx={{ maxWidth: '40em' }}
                 >
@@ -23,20 +23,20 @@ const ProductCreate = () => {
                         fullWidth
                         validate={required()}
                     />
-                </FormTab>
-                <FormTab
+                </TabbedForm.Tab>
+                <TabbedForm.Tab
                     label="resources.products.tabs.details"
                     path="details"
                     sx={{ maxWidth: '40em' }}
                 >
                     <ProductEditDetails />
-                </FormTab>
-                <FormTab
+                </TabbedForm.Tab>
+                <TabbedForm.Tab
                     label="resources.products.tabs.description"
                     path="description"
                 >
                     <RichTextInput source="description" label="" />
-                </FormTab>
+                </TabbedForm.Tab>
             </TabbedForm>
         </Create>
     );

--- a/examples/demo/src/products/ProductEdit.tsx
+++ b/examples/demo/src/products/ProductEdit.tsx
@@ -4,7 +4,6 @@ import {
     DateField,
     Edit,
     EditButton,
-    FormTab,
     Pagination,
     ReferenceManyField,
     required,
@@ -31,28 +30,28 @@ const ProductTitle = () => {
 const ProductEdit = () => (
     <Edit title={<ProductTitle />}>
         <TabbedForm>
-            <FormTab
+            <TabbedForm.Tab
                 label="resources.products.tabs.image"
                 sx={{ maxWidth: '40em' }}
             >
                 <Poster />
                 <TextInput source="image" fullWidth validate={req} />
                 <TextInput source="thumbnail" fullWidth validate={req} />
-            </FormTab>
-            <FormTab
+            </TabbedForm.Tab>
+            <TabbedForm.Tab
                 label="resources.products.tabs.details"
                 path="details"
                 sx={{ maxWidth: '40em' }}
             >
                 <ProductEditDetails />
-            </FormTab>
-            <FormTab
+            </TabbedForm.Tab>
+            <TabbedForm.Tab
                 label="resources.products.tabs.description"
                 path="description"
                 sx={{ maxWidth: '40em' }}
             >
                 <RichTextInput source="description" label="" validate={req} />
-            </FormTab>
+            </TabbedForm.Tab>
             <ReviewsFormTab path="reviews">
                 <ReferenceManyField
                     reference="reviews"
@@ -104,7 +103,7 @@ const ReviewsFormTab = (props: any) => {
     if (!isLoading) {
         label += ` (${total})`;
     }
-    return <FormTab label={label} {...props} />;
+    return <TabbedForm.Tab label={label} {...props} />;
 };
 
 export default ProductEdit;

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -14,7 +14,6 @@ import {
     CreateButton,
     ShowButton,
     EditButton,
-    FormTab,
     ImageField,
     ImageInput,
     NumberInput,
@@ -107,7 +106,7 @@ const PostEdit = () => {
                 defaultValues={{ average_note: 0 }}
                 warnWhenUnsavedChanges
             >
-                <FormTab label="post.form.summary">
+                <TabbedForm.Tab label="post.form.summary">
                     <SanitizedBox
                         display="flex"
                         flexDirection="column"
@@ -189,16 +188,16 @@ const PostEdit = () => {
                             </SimpleFormIterator>
                         </ArrayInput>
                     )}
-                </FormTab>
-                <FormTab label="post.form.body">
+                </TabbedForm.Tab>
+                <TabbedForm.Tab label="post.form.body">
                     <RichTextInput
                         source="body"
                         label=""
                         validate={required()}
                         fullWidth
                     />
-                </FormTab>
-                <FormTab label="post.form.miscellaneous">
+                </TabbedForm.Tab>
+                <TabbedForm.Tab label="post.form.miscellaneous">
                     <TagReferenceInput
                         reference="tags"
                         source="tags"
@@ -239,8 +238,8 @@ const PostEdit = () => {
                             </ArrayInput>
                         </SimpleFormIterator>
                     </ArrayInput>
-                </FormTab>
-                <FormTab label="post.form.comments">
+                </TabbedForm.Tab>
+                <TabbedForm.Tab label="post.form.comments">
                     <ReferenceManyField
                         reference="comments"
                         target="post_id"
@@ -253,7 +252,7 @@ const PostEdit = () => {
                             <EditButton />
                         </Datagrid>
                     </ReferenceManyField>
-                </FormTab>
+                </TabbedForm.Tab>
             </TabbedForm>
         </Edit>
     );

--- a/examples/simple/src/posts/PostShow.tsx
+++ b/examples/simple/src/posts/PostShow.tsx
@@ -43,7 +43,7 @@ const PostShow = () => {
         <ShowContextProvider value={controllerProps}>
             <ShowView title={<PostTitle />}>
                 <TabbedShowLayout>
-                    <Tab label="post.form.summary">
+                    <TabbedShowLayout.Tab label="post.form.summary">
                         <TextField source="id" />
                         <TextField source="title" />
                         {controllerProps.record &&
@@ -57,15 +57,15 @@ const PostShow = () => {
                                 <UrlField source="url" />
                             </Datagrid>
                         </ArrayField>
-                    </Tab>
-                    <Tab label="post.form.body">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="post.form.body">
                         <RichTextField
                             source="body"
                             stripTags={false}
                             label={false}
                         />
-                    </Tab>
-                    <Tab label="post.form.miscellaneous">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="post.form.miscellaneous">
                         <ReferenceArrayField
                             reference="tags"
                             source="tags"
@@ -87,8 +87,8 @@ const PostShow = () => {
                         <BooleanField source="commentable" />
                         <TextField source="views" />
                         <CloneButton />
-                    </Tab>
-                    <Tab label="post.form.comments">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="post.form.comments">
                         <ReferenceManyField
                             reference="comments"
                             target="post_id"
@@ -102,7 +102,7 @@ const PostShow = () => {
                             </Datagrid>
                         </ReferenceManyField>
                         <CreateRelatedComment />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </ShowView>
         </ShowContextProvider>

--- a/examples/simple/src/posts/PostShow.tsx
+++ b/examples/simple/src/posts/PostShow.tsx
@@ -15,7 +15,6 @@ import {
     ShowContextProvider,
     ShowView,
     SingleFieldList,
-    Tab,
     TabbedShowLayout,
     TextField,
     UrlField,

--- a/examples/simple/src/users/UserCreate.tsx
+++ b/examples/simple/src/users/UserCreate.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useFormContext } from 'react-hook-form';
 import {
     Create,
-    FormTab,
     SaveButton,
     AutocompleteInput,
     TabbedForm,
@@ -61,16 +60,16 @@ const UserCreate = () => {
                 warnWhenUnsavedChanges
                 toolbar={<UserEditToolbar permissions={permissions} />}
             >
-                <FormTab label="user.form.summary" path="">
+                <TabbedForm.Tab label="user.form.summary" path="">
                     <TextInput
                         source="name"
                         defaultValue="Slim Shady"
                         autoFocus
                         validate={[required(), isValidName]}
                     />
-                </FormTab>
+                </TabbedForm.Tab>
                 {permissions === 'admin' && (
-                    <FormTab label="user.form.security" path="security">
+                    <TabbedForm.Tab label="user.form.security" path="security">
                         <AutocompleteInput
                             source="role"
                             choices={[
@@ -81,7 +80,7 @@ const UserCreate = () => {
                             ]}
                             validate={[required()]}
                         />
-                    </FormTab>
+                    </TabbedForm.Tab>
                 )}
             </TabbedForm>
         </Create>

--- a/examples/simple/src/users/UserEdit.tsx
+++ b/examples/simple/src/users/UserEdit.tsx
@@ -4,7 +4,6 @@ import {
     CloneButton,
     DeleteWithConfirmButton,
     Edit,
-    FormTab,
     required,
     SaveButton,
     SelectInput,
@@ -64,16 +63,16 @@ const UserEditForm = ({ save, ...props }: { save?: any }) => {
             {...props}
             onSubmit={newSave}
         >
-            <FormTab label="user.form.summary" path="">
+            <TabbedForm.Tab label="user.form.summary" path="">
                 {permissions === 'admin' && <TextInput disabled source="id" />}
                 <TextInput
                     source="name"
                     defaultValue="slim shady"
                     validate={required()}
                 />
-            </FormTab>
+            </TabbedForm.Tab>
             {permissions === 'admin' && (
-                <FormTab label="user.form.security" path="security">
+                <TabbedForm.Tab label="user.form.security" path="security">
                     <SelectInput
                         source="role"
                         validate={required()}
@@ -84,7 +83,7 @@ const UserEditForm = ({ save, ...props }: { save?: any }) => {
                         ]}
                         defaultValue={'user'}
                     />
-                </FormTab>
+                </TabbedForm.Tab>
             )}
         </TabbedForm>
     );

--- a/examples/simple/src/users/UserShow.tsx
+++ b/examples/simple/src/users/UserShow.tsx
@@ -1,12 +1,6 @@
 /* eslint react/jsx-key: off */
 import * as React from 'react';
-import {
-    Show,
-    Tab,
-    TabbedShowLayout,
-    TextField,
-    usePermissions,
-} from 'react-admin';
+import { Show, TabbedShowLayout, TextField, usePermissions } from 'react-admin';
 
 import Aside from './Aside';
 

--- a/examples/simple/src/users/UserShow.tsx
+++ b/examples/simple/src/users/UserShow.tsx
@@ -15,14 +15,17 @@ const UserShow = () => {
     return (
         <Show>
             <TabbedShowLayout>
-                <Tab label="user.form.summary">
+                <TabbedShowLayout.Tab label="user.form.summary">
                     <TextField source="id" />
                     <TextField source="name" />
-                </Tab>
+                </TabbedShowLayout.Tab>
                 {permissions === 'admin' && (
-                    <Tab label="user.form.security" path="security">
+                    <TabbedShowLayout.Tab
+                        label="user.form.security"
+                        path="security"
+                    >
                         <TextField source="role" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 )}
             </TabbedShowLayout>
             <Aside />

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -18,23 +18,25 @@ import { Labeled } from '../Labeled';
  * - icon: The icon to show before the label (optional). Must be a component.
  * - path: The string used for custom urls
  *
+ * It is also available as TabbedShowLayout.Tab.
+ *
  * @example
  *     // in src/posts.js
  *     import * as React from "react";
  *     import FavoriteIcon from '@mui/icons-material/Favorite';
  *     import PersonPinIcon from '@mui/icons-material/PersonPin';
- *     import { Show, TabbedShowLayout, Tab, TextField } from 'react-admin';
+ *     import { Show, TabbedShowLayout, TextField } from 'react-admin';
  *
  *     export const PostShow = (props) => (
  *         <Show {...props}>
  *             <TabbedShowLayout>
- *                 <Tab label="Content" icon={<FavoriteIcon />}>
+ *                 <TabbedShowLayout.Tab label="Content" icon={<FavoriteIcon />}>
  *                     <TextField source="title" />
  *                     <TextField source="subtitle" />
- *                </Tab>
- *                 <Tab label="Metadata" icon={<PersonIcon />} path="metadata">
+ *                </TabbedShowLayout.Tab>
+ *                 <TabbedShowLayout.Tab label="Metadata" icon={<PersonIcon />} path="metadata">
  *                     <TextField source="category" />
- *                </Tab>
+ *                </TabbedShowLayout.Tab>
  *             </TabbedShowLayout>
  *         </Show>
  *     );

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.spec.tsx
@@ -5,7 +5,6 @@ import { createMemoryHistory } from 'history';
 import { CoreAdminContext, testDataProvider } from 'ra-core';
 
 import { TabbedShowLayout } from './TabbedShowLayout';
-import { Tab } from './Tab';
 import { TextField } from '../field';
 
 describe('<TabbedShowLayout />', () => {
@@ -17,12 +16,12 @@ describe('<TabbedShowLayout />', () => {
                 history={history}
             >
                 <TabbedShowLayout record={{ id: 123 }}>
-                    <Tab label="Tab1">
+                    <TabbedShowLayout.Tab label="Tab1">
                         <TextField label="Field On Tab1" source="field1" />
-                    </Tab>
-                    <Tab label="Tab2">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="Tab2">
                         <TextField label="Field On Tab2" source="field2" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </CoreAdminContext>
         );
@@ -40,12 +39,12 @@ describe('<TabbedShowLayout />', () => {
             >
                 <TabbedShowLayout record={{ id: 123 }}>
                     {null}
-                    <Tab label="Tab1">
+                    <TabbedShowLayout.Tab label="Tab1">
                         <TextField label="Field On Tab1" source="field1" />
-                    </Tab>
-                    <Tab label="Tab2">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="Tab2">
                         <TextField label="Field On Tab2" source="field2" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </CoreAdminContext>
         );
@@ -64,12 +63,12 @@ describe('<TabbedShowLayout />', () => {
             >
                 <TabbedShowLayout record={{ id: 123 }}>
                     {null}
-                    <Tab label="Tab1">
+                    <TabbedShowLayout.Tab label="Tab1">
                         <TextField label="Field On Tab1" source="field1" />
-                    </Tab>
-                    <Tab label="Tab2">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="Tab2">
                         <TextField label="Field On Tab2" source="field2" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </CoreAdminContext>
         );
@@ -94,12 +93,12 @@ describe('<TabbedShowLayout />', () => {
             >
                 <TabbedShowLayout record={{ id: 123 }}>
                     {null}
-                    <Tab label="Tab1">
+                    <TabbedShowLayout.Tab label="Tab1">
                         <TextField label="Field On Tab1" source="field1" />
-                    </Tab>
-                    <Tab label="Tab2" path="second">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="Tab2" path="second">
                         <TextField label="Field On Tab2" source="field2" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </CoreAdminContext>
         );
@@ -124,12 +123,12 @@ describe('<TabbedShowLayout />', () => {
             >
                 <TabbedShowLayout record={record} syncWithLocation={false}>
                     {null}
-                    <Tab label="Tab1">
+                    <TabbedShowLayout.Tab label="Tab1">
                         <TextField label="Field On Tab1" source="field1" />
-                    </Tab>
-                    <Tab label="Tab2">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="Tab2">
                         <TextField label="Field On Tab2" source="field2" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </CoreAdminContext>
         );

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.stories.tsx
@@ -10,7 +10,6 @@ import {
 import { Labeled } from '../Labeled';
 import { TextField, NumberField } from '../field';
 import { TabbedShowLayout } from './TabbedShowLayout';
-import { Tab } from './Tab';
 
 export default { title: 'ra-ui-materialui/detail/TabbedShowLayout' };
 
@@ -28,15 +27,15 @@ export const Basic = () => (
         <ResourceContext.Provider value="books">
             <RecordContextProvider value={record}>
                 <TabbedShowLayout>
-                    <Tab label="First">
+                    <TabbedShowLayout.Tab label="First">
                         <TextField source="id" />
                         <TextField source="title" />
-                    </Tab>
-                    <Tab label="Second">
+                    </TabbedShowLayout.Tab>
+                    <TabbedShowLayout.Tab label="Second">
                         <TextField source="author" />
                         <TextField source="summary" />
                         <NumberField source="year" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </RecordContextProvider>
         </ResourceContext.Provider>
@@ -53,12 +52,12 @@ export const CustomChild = () => (
         <ResourceContext.Provider value="books">
             <RecordContextProvider value={record}>
                 <TabbedShowLayout>
-                    <Tab label="First">
+                    <TabbedShowLayout.Tab label="First">
                         <BookTitle />
                         <WithRecord
                             render={record => <span>{record.author}</span>}
                         />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </RecordContextProvider>
         </ResourceContext.Provider>
@@ -70,7 +69,7 @@ export const CustomLabel = () => (
         <ResourceContext.Provider value="books">
             <RecordContextProvider value={record}>
                 <TabbedShowLayout>
-                    <Tab label="First">
+                    <TabbedShowLayout.Tab label="First">
                         <TextField label="Identifier" source="id" />
                         <TextField source="title" />
                         <Labeled label="Author name">
@@ -78,7 +77,7 @@ export const CustomLabel = () => (
                         </Labeled>
                         <TextField label={false} source="summary" />
                         <NumberField source="year" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </RecordContextProvider>
         </ResourceContext.Provider>
@@ -90,13 +89,13 @@ export const Spacing = () => (
         <ResourceContext.Provider value="books">
             <RecordContextProvider value={record}>
                 <TabbedShowLayout spacing={3}>
-                    <Tab label="First">
+                    <TabbedShowLayout.Tab label="First">
                         <TextField source="id" />
                         <TextField source="title" />
                         <TextField source="author" />
                         <TextField source="summary" />
                         <NumberField source="year" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </RecordContextProvider>
         </ResourceContext.Provider>
@@ -108,13 +107,13 @@ export const Divider = () => (
         <ResourceContext.Provider value="books">
             <RecordContextProvider value={record}>
                 <TabbedShowLayout divider={<MuiDivider />}>
-                    <Tab label="First">
+                    <TabbedShowLayout.Tab label="First">
                         <TextField source="id" />
                         <TextField source="title" />
                         <TextField source="author" />
                         <TextField source="summary" />
                         <NumberField source="year" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </RecordContextProvider>
         </ResourceContext.Provider>
@@ -132,13 +131,13 @@ export const SX = () => (
                         bgcolor: 'text.disabled',
                     }}
                 >
-                    <Tab label="First">
+                    <TabbedShowLayout.Tab label="First">
                         <TextField source="id" />
                         <TextField source="title" />
                         <TextField source="author" />
                         <TextField source="summary" />
                         <NumberField source="year" />
-                    </Tab>
+                    </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </RecordContextProvider>
         </ResourceContext.Provider>

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
@@ -23,6 +23,7 @@ import {
     TabbedShowLayoutTabs,
     getShowLayoutTabFullPath,
 } from './TabbedShowLayoutTabs';
+import { Tab } from './Tab';
 
 /**
  * Layout for a Show view showing fields grouped in tabs and laid out in a single column.
@@ -31,24 +32,24 @@ import {
  * each of which contains a list of record fields in a single-column layout
  * (via MUI's `<Stack>` component).
  * `<TabbedShowLayout>` delegates the actual rendering of fields to its children,
- * which should be `<Tab>` components.
- * `<Tab>` wraps each field inside a <Labeled> component to add a label.
+ * which should be `<TabbedShowLayout.Tab>` components.
+ * `<TabbedShowLayout.Tab>` wraps each field inside a `<Labeled>` component to add a label.
  *
  * @example
  * // in src/posts.js
  * import * as React from "react";
- * import { Show, TabbedShowLayout, Tab, TextField } from 'react-admin';
+ * import { Show, TabbedShowLayout, TextField } from 'react-admin';
  *
  * export const PostShow = () => (
  *     <Show>
  *         <TabbedShowLayout>
- *             <Tab label="Content">
+ *             <TabbedShowLayout.Tab label="Content">
  *                 <TextField source="title" />
  *                 <TextField source="subtitle" />
- *            </Tab>
- *             <Tab label="Metadata">
+ *            </TabbedShowLayout.Tab>
+ *             <TabbedShowLayout.Tab label="Metadata">
  *                 <TextField source="category" />
- *            </Tab>
+ *            </TabbedShowLayout.Tab>
  *         </TabbedShowLayout>
  *     </Show>
  * );
@@ -179,6 +180,8 @@ export const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
         </OptionalRecordContextProvider>
     );
 };
+
+TabbedShowLayout.Tab = Tab;
 
 export interface TabbedShowLayoutProps {
     children: ReactNode;

--- a/packages/ra-ui-materialui/src/form/FormTab.spec.tsx
+++ b/packages/ra-ui-materialui/src/form/FormTab.spec.tsx
@@ -3,19 +3,18 @@ import expect from 'expect';
 import { testDataProvider } from 'ra-core';
 import { render, screen, waitFor } from '@testing-library/react';
 import { TabbedForm } from './TabbedForm';
-import { FormTab } from './FormTab';
 import { TextInput } from '../input';
 import { AdminContext } from '../AdminContext';
 
-describe('<FormTab label="foo" />', () => {
+describe('<TabbedForm.Tab label="foo" />', () => {
     it('should display <Toolbar />', async () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
                 <TabbedForm>
-                    <FormTab label="foo">
+                    <TabbedForm.Tab label="foo">
                         <TextInput source="name" />
                         <TextInput source="city" />
-                    </FormTab>
+                    </TabbedForm.Tab>
                 </TabbedForm>
             </AdminContext>
         );
@@ -24,7 +23,7 @@ describe('<FormTab label="foo" />', () => {
         });
     });
 
-    it('should render a TabbedForm with FormTabs having custom props without warnings', async () => {
+    it('should render a TabbedForm with TabbedForm.Tabs having custom props without warnings', async () => {
         let countWarnings = 0;
         const spy = jest
             .spyOn(console, 'error')
@@ -39,7 +38,7 @@ describe('<FormTab label="foo" />', () => {
         const { container } = render(
             <AdminContext dataProvider={testDataProvider()}>
                 <TabbedForm>
-                    <FormTab
+                    <TabbedForm.Tab
                         label="First"
                         resource="posts"
                         record={record}
@@ -47,8 +46,8 @@ describe('<FormTab label="foo" />', () => {
                         variant="standard"
                     >
                         <TextInput source="name" />
-                    </FormTab>
-                    <FormTab
+                    </TabbedForm.Tab>
+                    <TabbedForm.Tab
                         label="Second"
                         resource="posts"
                         record={record}
@@ -56,8 +55,8 @@ describe('<FormTab label="foo" />', () => {
                         variant="filled"
                     >
                         <TextInput source="name" />
-                    </FormTab>
-                    <FormTab
+                    </TabbedForm.Tab>
+                    <TabbedForm.Tab
                         label="Third"
                         resource="posts"
                         record={record}
@@ -65,7 +64,7 @@ describe('<FormTab label="foo" />', () => {
                         variant="outlined"
                     >
                         <TextInput source="name" />
-                    </FormTab>
+                    </TabbedForm.Tab>
                 </TabbedForm>
             </AdminContext>
         );

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.tsx
@@ -17,7 +17,6 @@ import {
 import { AdminContext } from '../AdminContext';
 import { TabbedForm } from './TabbedForm';
 import { TabbedFormClasses } from './TabbedFormView';
-import { FormTab } from './FormTab';
 import { TextInput } from '../input';
 
 describe('<TabbedForm />', () => {
@@ -26,8 +25,8 @@ describe('<TabbedForm />', () => {
         render(
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <TabbedForm>
-                    <FormTab label="tab1" />
-                    <FormTab label="tab2" />
+                    <TabbedForm.Tab label="tab1" />
+                    <TabbedForm.Tab label="tab2" />
                 </TabbedForm>
             </AdminContext>
         );
@@ -42,20 +41,20 @@ describe('<TabbedForm />', () => {
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <ResourceContextProvider value="posts">
                     <TabbedForm mode="onBlur">
-                        <FormTab label="tab1">
+                        <TabbedForm.Tab label="tab1">
                             <TextInput
                                 defaultValue=""
                                 source="title"
                                 validate={required()}
                             />
-                        </FormTab>
-                        <FormTab label="tab2">
+                        </TabbedForm.Tab>
+                        <TabbedForm.Tab label="tab2">
                             <TextInput
                                 defaultValue=""
                                 source="description"
                                 validate={minLength(10)}
                             />
-                        </FormTab>
+                        </TabbedForm.Tab>
                     </TabbedForm>
                 </ResourceContextProvider>
             </AdminContext>
@@ -87,20 +86,20 @@ describe('<TabbedForm />', () => {
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <ResourceContextProvider value="posts">
                     <TabbedForm mode="onBlur">
-                        <FormTab label="tab1">
+                        <TabbedForm.Tab label="tab1">
                             <TextInput
                                 defaultValue=""
                                 source="title"
                                 validate={required()}
                             />
-                        </FormTab>
-                        <FormTab label="tab2">
+                        </TabbedForm.Tab>
+                        <TabbedForm.Tab label="tab2">
                             <TextInput
                                 defaultValue=""
                                 source="description"
                                 validate={required()}
                             />
-                        </FormTab>
+                        </TabbedForm.Tab>
                     </TabbedForm>
                 </ResourceContextProvider>
             </AdminContext>
@@ -128,20 +127,20 @@ describe('<TabbedForm />', () => {
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <ResourceContextProvider value="posts">
                     <TabbedForm mode="onBlur">
-                        <FormTab label="tab1">
+                        <TabbedForm.Tab label="tab1">
                             <TextInput
                                 defaultValue=""
                                 source="title"
                                 validate={required()}
                             />
-                        </FormTab>
-                        <FormTab label="tab2">
+                        </TabbedForm.Tab>
+                        <TabbedForm.Tab label="tab2">
                             <TextInput
                                 defaultValue=""
                                 source="description"
                                 validate={minLength(10)}
                             />
-                        </FormTab>
+                        </TabbedForm.Tab>
                     </TabbedForm>
                 </ResourceContextProvider>
             </AdminContext>
@@ -171,20 +170,20 @@ describe('<TabbedForm />', () => {
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <ResourceContextProvider value="posts">
                     <TabbedForm>
-                        <FormTab label="tab1">
+                        <TabbedForm.Tab label="tab1">
                             <TextInput
                                 defaultValue=""
                                 source="title"
                                 validate={required()}
                             />
-                        </FormTab>
-                        <FormTab label="tab2">
+                        </TabbedForm.Tab>
+                        <TabbedForm.Tab label="tab2">
                             <TextInput
                                 defaultValue=""
                                 source="description"
                                 validate={minLength(10)}
                             />
-                        </FormTab>
+                        </TabbedForm.Tab>
                     </TabbedForm>
                 </ResourceContextProvider>
             </AdminContext>
@@ -220,15 +219,15 @@ describe('<TabbedForm />', () => {
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <ResourceContextProvider value="posts">
                     <TabbedForm syncWithLocation={false}>
-                        <FormTab label="tab1">
+                        <TabbedForm.Tab label="tab1">
                             <TextInput source="title" validate={required()} />
-                        </FormTab>
-                        <FormTab label="tab2">
+                        </TabbedForm.Tab>
+                        <TabbedForm.Tab label="tab2">
                             <TextInput
                                 source="description"
                                 validate={minLength(10)}
                             />
-                        </FormTab>
+                        </TabbedForm.Tab>
                     </TabbedForm>
                 </ResourceContextProvider>
             </AdminContext>
@@ -268,7 +267,7 @@ describe('<TabbedForm />', () => {
             <AdminContext dataProvider={testDataProvider()} history={history}>
                 <ResourceContextProvider value="posts">
                     <TabbedForm toolbar={false}>
-                        <FormTab label="tab1"></FormTab>
+                        <TabbedForm.Tab label="tab1"></TabbedForm.Tab>
                     </TabbedForm>
                 </ResourceContextProvider>
             </AdminContext>

--- a/packages/ra-ui-materialui/src/form/TabbedForm.stories.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.stories.tsx
@@ -5,7 +5,6 @@ import { AdminContext } from '../AdminContext';
 import { Edit } from '../detail';
 import { NumberInput, TextInput } from '../input';
 import { TabbedForm } from './TabbedForm';
-import { FormTab } from './FormTab';
 import { Stack } from '@mui/material';
 
 export default { title: 'ra-ui-materialui/forms/TabbedForm' };
@@ -41,11 +40,11 @@ const Wrapper = ({ children }) => (
 export const Basic = () => (
     <Wrapper>
         <TabbedForm>
-            <FormTab label="main">
+            <TabbedForm.Tab label="main">
                 <TextInput source="title" fullWidth />
                 <TextInput source="author" />
                 <NumberInput source="year" />
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Wrapper>
 );
@@ -53,14 +52,14 @@ export const Basic = () => (
 export const MultipleTabs = () => (
     <Wrapper>
         <TabbedForm>
-            <FormTab label="main">
+            <TabbedForm.Tab label="main">
                 <TextInput source="title" fullWidth />
                 <TextInput source="author" />
                 <NumberInput source="year" />
-            </FormTab>
-            <FormTab label="details">
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="details">
                 <TextInput multiline source="bio" fullWidth />
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Wrapper>
 );
@@ -68,13 +67,13 @@ export const MultipleTabs = () => (
 export const CustomLayout = () => (
     <Wrapper>
         <TabbedForm>
-            <FormTab label="main">
+            <TabbedForm.Tab label="main">
                 <TextInput source="title" fullWidth />
                 <Stack direction="row" gap={1} width="100%">
                     <TextInput source="author" sx={{ width: '50%' }} />
                     <NumberInput source="year" sx={{ width: '50%' }} />
                 </Stack>
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Wrapper>
 );
@@ -82,11 +81,11 @@ export const CustomLayout = () => (
 export const NoToolbar = () => (
     <Wrapper>
         <TabbedForm toolbar={false}>
-            <FormTab label="main">
+            <TabbedForm.Tab label="main">
                 <TextInput source="title" fullWidth />
                 <TextInput source="author" sx={{ width: '50%' }} />
                 <NumberInput source="year" sx={{ width: '50%' }} />
-            </FormTab>
+            </TabbedForm.Tab>
         </TabbedForm>
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -12,11 +12,12 @@ import get from 'lodash/get';
 
 import { TabbedFormView, TabbedFormViewProps } from './TabbedFormView';
 import { useFormRootPath } from './useFormRootPath';
+import { FormTab } from './FormTab';
 
 /**
  * Form layout where inputs are divided by tab, one input per line.
  *
- * Pass FormTab components as children.
+ * Pass <TabbedForm.Tab> components as children.
  *
  * @example
  *
@@ -24,7 +25,6 @@ import { useFormRootPath } from './useFormRootPath';
  * import {
  *     Edit,
  *     TabbedForm,
- *     FormTab,
  *     Datagrid,
  *     TextField,
  *     DateField,
@@ -39,22 +39,22 @@ import { useFormRootPath } from './useFormRootPath';
  * export const PostEdit = (props) => (
  *     <Edit {...props}>
  *         <TabbedForm>
- *             <FormTab label="summary">
+ *             <TabbedForm.Tab label="summary">
  *                 <TextInput disabled label="Id" source="id" />
  *                 <TextInput source="title" validate={required()} />
  *                 <TextInput multiline source="teaser" validate={required()} />
- *             </FormTab>
- *             <FormTab label="body">
+ *             </TabbedForm.Tab>
+ *             <TabbedForm.Tab label="body">
  *                 <RichTextInput source="body" validate={required()} label={false} />
- *             </FormTab>
- *             <FormTab label="Miscellaneous">
+ *             </TabbedForm.Tab>
+ *             <TabbedForm.Tab label="Miscellaneous">
  *                 <TextInput label="Password (if protected post)" source="password" type="password" />
  *                 <DateInput label="Publication date" source="published_at" />
  *                 <NumberInput source="average_note" validate={[ number(), minValue(0) ]} />
  *                 <BooleanInput label="Allow comments?" source="commentable" defaultValue />
  *                 <TextInput disabled label="Nb views" source="views" />
- *             </FormTab>
- *             <FormTab label="comments">
+ *             </TabbedForm.Tab>
+ *             <TabbedForm.Tab label="comments">
  *                 <ReferenceManyField reference="comments" target="post_id" label={false}>
  *                     <Datagrid>
  *                         <TextField source="body" />
@@ -62,7 +62,7 @@ import { useFormRootPath } from './useFormRootPath';
  *                         <EditButton />
  *                     </Datagrid>
  *                 </ReferenceManyField>
- *             </FormTab>
+ *             </TabbedForm.Tab>
  *         </TabbedForm>
  *     </Edit>
  * );
@@ -87,6 +87,8 @@ export const TabbedForm = (props: TabbedFormProps) => {
         </Form>
     );
 };
+
+TabbedForm.Tab = FormTab;
 
 const sanitizeRestProps = ({
     criteriaMode,

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -5,7 +5,7 @@ import { createMemoryHistory } from 'history';
 import { InputAdornment } from '@mui/material';
 
 import { Edit, Create } from '../../detail';
-import { SimpleForm, TabbedForm, FormTab } from '../../form';
+import { SimpleForm, TabbedForm } from '../../form';
 import { ArrayInput } from './ArrayInput';
 import { SimpleFormIterator } from './SimpleFormIterator';
 import { TextInput } from '../TextInput';
@@ -442,7 +442,7 @@ const CreateGlobalValidationInFormTab = () => {
                   We still need `validate={required()}` to indicate fields are required 
                   with a '*' symbol after the label, but the real validation happens in `globalValidator`
                 */}
-                <FormTab label="Main">
+                <TabbedForm.Tab label="Main">
                     <TextInput source="title" />
                     <ArrayInput
                         source="authors"
@@ -454,7 +454,7 @@ const CreateGlobalValidationInFormTab = () => {
                             <TextInput source="role" validate={required()} />
                         </SimpleFormIterator>
                     </ArrayInput>
-                </FormTab>
+                </TabbedForm.Tab>
             </TabbedForm>
         </Create>
     );


### PR DESCRIPTION
## Problem 

`<Tab>` and `<FormTab>` aren't easy to remember. 

## Solution

Expose the tab component as a sub component of the tabbed components, just like we do with the `<Menu.Item>`. This introduces two components:

- `<TabbedForm.Tab>`
- `<TabbedShowLayout.Tab>`

```diff
-import { Show, TabbedShowLayout, Tab, TextField } from 'react-admin';
+import { Show, TabbedShowLayout, TextField } from 'react-admin';
export const UserShow = () => {
    const { permissions } = usePermissions();
    return (
        <Show>
            <TabbedShowLayout>
-               <Tab label="user.form.summary">
+               <TabbedShowLayout.Tab label="user.form.summary">
                    {permissions === 'admin' && <TextField source="id" />}
                    <TextField source="name" />
-               </Tab>
+               </TabbedShowLayout.Tab>
                {permissions === 'admin' &&
-                   <Tab label="user.form.security">
+                   <TabbedShowLayout.Tab label="user.form.security">
                        <TextField source="role" />
-                   </Tab>}
+                   </TabbedShowLayout.Tab>}
            </TabbedShowLayout>
        </Show>
    );
};
```