### PR TITLE
[WIP] Use normal store instead of React state with disabled location sync

### DIFF
--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -83,7 +83,7 @@ export const useListParams = ({
     perPage = 10,
     resource,
     sort = defaultSort,
-    storeKey = `${resource}.listParams`,
+    storeKey = disableSyncWithLocation ? '' : `${resource}.listParams`,
 }: ListParamsOptions): [Parameters, Modifiers] => {
     const location = useLocation();
     const navigate = useNavigate();

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -96,7 +96,7 @@ export const useListParams = ({
         location.search,
         resource,
         storeKey,
-        JSON.stringify(disableSyncWithLocation ? localParams : params),
+        JSON.stringify(disableSyncWithLocation && storeKey === '' ? localParams : params),
         JSON.stringify(filterDefaultValues),
         JSON.stringify(sort),
         perPage,
@@ -111,7 +111,7 @@ export const useListParams = ({
         () =>
             getQuery({
                 queryFromLocation,
-                params: disableSyncWithLocation ? localParams : params,
+                params: disableSyncWithLocation && storeKey === '' ? localParams : params,
                 filterDefaultValues,
                 sort,
                 perPage,
@@ -141,8 +141,10 @@ export const useListParams = ({
                 tempParams.current = queryReducer(query, action);
                 // schedule side effects for next tick
                 setTimeout(() => {
-                    if (disableSyncWithLocation) {
+                    if (disableSyncWithLocation && storeKey === '') {
                         setLocalParams(tempParams.current);
+                    } else if (disableSyncWithLocation && storeKey !== '') {
+                        setParams(tempParams.current);
                     } else {
                         // the useEffect above will apply the changes to the params in the store
                         navigate(

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect, useRef } from 'react';
+import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
 import { parse, stringify } from 'query-string';
 import lodashDebounce from 'lodash/debounce';
 import pickBy from 'lodash/pickBy';
@@ -87,6 +87,7 @@ export const useListParams = ({
 }: ListParamsOptions): [Parameters, Modifiers] => {
     const location = useLocation();
     const navigate = useNavigate();
+    const [localParams, setLocalParams] = useState(defaultParams);
     const [params, setParams] = useStore(storeKey, defaultParams);
     const tempParams = useRef<ListParams>();
     const isMounted = useIsMounted();
@@ -95,7 +96,7 @@ export const useListParams = ({
         location.search,
         resource,
         storeKey,
-        JSON.stringify(params),
+        JSON.stringify(disableSyncWithLocation ? localParams : params),
         JSON.stringify(filterDefaultValues),
         JSON.stringify(sort),
         perPage,
@@ -110,7 +111,7 @@ export const useListParams = ({
         () =>
             getQuery({
                 queryFromLocation,
-                params,
+                params: disableSyncWithLocation ? localParams : params,
                 filterDefaultValues,
                 sort,
                 perPage,
@@ -141,7 +142,7 @@ export const useListParams = ({
                 // schedule side effects for next tick
                 setTimeout(() => {
                     if (disableSyncWithLocation) {
-                        setParams(tempParams.current);
+                        setLocalParams(tempParams.current);
                     } else {
                         // the useEffect above will apply the changes to the params in the store
                         navigate(

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
+import { useCallback, useMemo, useEffect, useRef } from 'react';
 import { parse, stringify } from 'query-string';
 import lodashDebounce from 'lodash/debounce';
 import pickBy from 'lodash/pickBy';
@@ -87,7 +87,6 @@ export const useListParams = ({
 }: ListParamsOptions): [Parameters, Modifiers] => {
     const location = useLocation();
     const navigate = useNavigate();
-    const [localParams, setLocalParams] = useState(defaultParams);
     const [params, setParams] = useStore(storeKey, defaultParams);
     const tempParams = useRef<ListParams>();
     const isMounted = useIsMounted();
@@ -96,7 +95,7 @@ export const useListParams = ({
         location.search,
         resource,
         storeKey,
-        JSON.stringify(disableSyncWithLocation ? localParams : params),
+        JSON.stringify(params),
         JSON.stringify(filterDefaultValues),
         JSON.stringify(sort),
         perPage,
@@ -111,7 +110,7 @@ export const useListParams = ({
         () =>
             getQuery({
                 queryFromLocation,
-                params: disableSyncWithLocation ? localParams : params,
+                params,
                 filterDefaultValues,
                 sort,
                 perPage,
@@ -142,7 +141,7 @@ export const useListParams = ({
                 // schedule side effects for next tick
                 setTimeout(() => {
                     if (disableSyncWithLocation) {
-                        setLocalParams(tempParams.current);
+                        setParams(tempParams.current);
                     } else {
                         // the useEffect above will apply the changes to the params in the store
                         navigate(


### PR DESCRIPTION
This change is to continue using the normal React Admin store (local storage by default) when `disableSyncWithLocation` is used, this enables filters, sort, and pagination to be persisted across navigation and component mount/unmount.

In order for this behavior to work, the `storeKey` default value is left blank when `disableSyncWithLocation` is `true`.

`storeKey` is then checked (if blank) in `changeParams`, if blank, old behavior remains, uses `localParams` that do not persist, if `storeKey` is set, then it uses store as normal.

[WIP] [TODO] Documentation and tests updated to reflect this additional behavior

I feel this meets the design choice that filter values are persisted in application state as stated at the bottom of [this section](https://marmelab.com/react-admin/FilteringTutorial.html#filter-query-parameter) even if you need to not sync those values with the location due to have multiple `List` components on one page.

Implements https://github.com/marmelab/react-admin/issues/9100