### PR TITLE
Fix: notifications with type 'warning' should use the warning text color from the MUI palette

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -145,7 +145,7 @@ const StyledSnackbar = styled(Snackbar, {
 
     [`& .${NotificationClasses.warning}`]: {
         backgroundColor: theme.palette.warning.main,
-        color: theme.palette.error.contrastText,
+        color: theme.palette.warning.contrastText,
     },
 
     [`& .${NotificationClasses.undo}`]: {


### PR DESCRIPTION
Related to
- PR : https://github.com/marmelab/react-admin/pull/8519 
- Issue : https://github.com/marmelab/react-admin/issues/8510

It would be better to follow the same field name for `color` as well.