### PR TITLE
Add ability to pass multiple children to `<List>` and `<Create>`

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Create.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.spec.tsx
@@ -25,4 +25,19 @@ describe('<Create />', () => {
         );
         expect(screen.queryAllByText('Hello')).toHaveLength(1);
     });
+
+    it('should accept more than one child', () => {
+        const Form = () => <div>form</div>;
+        const HelpText = () => <div>help</div>;
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
+                <Create {...defaultCreateProps}>
+                    <Form />
+                    <HelpText />
+                </Create>
+            </CoreAdminContext>
+        );
+        expect(screen.queryAllByText('form')).toHaveLength(1);
+        expect(screen.queryAllByText('help')).toHaveLength(1);
+    });
 });

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { RaRecord, useCheckMinimumRequiredProps } from 'ra-core';
 
@@ -51,7 +51,7 @@ import { CreateBase } from 'ra-core';
  * export default App;
  */
 export const Create = <RecordType extends RaRecord = any>(
-    props: CreateProps<RecordType> & { children: ReactElement }
+    props: CreateProps<RecordType> & { children: ReactNode }
 ): ReactElement => {
     useCheckMinimumRequiredProps('Create', ['children'], props);
     const {
@@ -84,7 +84,7 @@ export const Create = <RecordType extends RaRecord = any>(
 Create.propTypes = {
     actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     aside: PropTypes.element,
-    children: PropTypes.element,
+    children: PropTypes.node,
     className: PropTypes.string,
     disableAuthentication: PropTypes.bool,
     hasEdit: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -48,13 +48,13 @@ export const CreateView = (props: CreateViewProps) => {
 interface CreateViewProps<RecordType extends RaRecord = any>
     extends CreateProps<RecordType>,
         Omit<CreateControllerProps<RecordType>, 'resource'> {
-    children: ReactElement;
+    children: ReactNode;
 }
 
 CreateView.propTypes = {
     actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     aside: PropTypes.element,
-    children: PropTypes.element,
+    children: PropTypes.node,
     className: PropTypes.string,
     defaultTitle: PropTypes.any,
     hasList: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/list/List.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/List.spec.tsx
@@ -50,6 +50,23 @@ describe('<List />', () => {
         expect(screen.queryAllByText('datagrid')).toHaveLength(1);
     });
 
+    it('should accept more than one child', () => {
+        const Filter = () => <div>filter</div>;
+        const Datagrid = () => <div>datagrid</div>;
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
+                <ThemeProvider theme={theme}>
+                    <List resource="posts">
+                        <Filter />
+                        <Datagrid />
+                    </List>
+                </ThemeProvider>
+            </CoreAdminContext>
+        );
+        expect(screen.queryAllByText('filter')).toHaveLength(1);
+        expect(screen.queryAllByText('datagrid')).toHaveLength(1);
+    });
+
     it('should display aside component', () => {
         const Dummy = () => <div />;
         const Aside = () => <div id="aside">Hello</div>;

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -97,7 +97,7 @@ List.propTypes = {
     // @ts-ignore-line
     actions: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
     aside: PropTypes.element,
-    children: PropTypes.element.isRequired,
+    children: PropTypes.node.isRequired,
     className: PropTypes.string,
     emptyWhileLoading: PropTypes.bool,
     filter: PropTypes.object,

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { Children, cloneElement, ReactElement, ElementType } from 'react';
+import {
+    Children,
+    cloneElement,
+    ReactElement,
+    ReactNode,
+    ElementType,
+} from 'react';
 import PropTypes from 'prop-types';
 import { SxProps } from '@mui/system';
 import Card from '@mui/material/Card';
@@ -61,8 +67,11 @@ export const ListView = <RecordType extends RaRecord = any>(
                 />
             )}
             <Content className={ListClasses.content}>
-                {bulkActionButtons && children
-                    ? cloneElement(Children.only(children), {
+                {bulkActionButtons &&
+                children &&
+                React.isValidElement<any>(children)
+                    ? // FIXME remove in 5.0
+                      cloneElement(children, {
                           bulkActionButtons,
                       })
                     : children}
@@ -101,7 +110,7 @@ ListView.propTypes = {
     // @ts-ignore-line
     actions: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
     aside: PropTypes.element,
-    children: PropTypes.element,
+    children: PropTypes.node,
     className: PropTypes.string,
     component: ComponentPropType,
     // @ts-ignore-line
@@ -152,7 +161,7 @@ export interface ListViewProps {
      */
     bulkActionButtons?: ReactElement | false;
     className?: string;
-    children: ReactElement;
+    children: ReactNode;
     component?: ElementType;
     empty?: ReactElement | false;
     emptyWhileLoading?: boolean;


### PR DESCRIPTION
## Problem

It's not possible to pass utility components as children of `<List>` in addition to a `<Datagrid>`. In particular, I need to pass a `<ListLiveUpdate>` component to watch for real-time changes in the list, and it needs access to the `ListContext`. 

## Solution

Change the accepted type and proptype

```jsx
const PostList = () => (
  <List>
    <ListLiveUpdate />
    <Datagrid>
      // ...
    </Datagrid>
  </List>
);
```

Other page components (`<Edit>` and `<Show>`) already allow that. 

