### PR TITLE
[Doc] Make custom headers example compatible with TS

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -189,7 +189,7 @@ const fetchJson = (url, options = {}) => {
         options.headers = new Headers({ Accept: 'application/json' });
     }
     // add your own headers here
-    options.headers.set('X-Custom-Header', 'foobar');
+    options.headers['X-Custom-Header'] = 'foobar';
     return fetchUtils.fetchJson(url, options);
 }
 const dataProvider = simpleRestProvider('http://path.to.my.api/', fetchJson);


### PR DESCRIPTION
When you try to apply the instructions of [this section of the docs](https://marmelab.com/react-admin/DataProviders.html#adding-custom-headers) with TypeScript, after typing `options` to the provided `Options` type, you get the following error:

![Capture d’écran du 2023-01-09 10-28-47](https://user-images.githubusercontent.com/14542336/211280283-5373ac73-7ab1-49af-8bce-812d03960453.png)


This PR fixes the example to avoid the error:

![Capture d’écran du 2023-01-09 10-29-08](https://user-images.githubusercontent.com/14542336/211280304-da48614a-f6ee-4281-8b9c-e3d2530a4115.png)
