### PR TITLE
fix autocomplete warning in google console for issue #8549

### DIFF
--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -60,6 +60,7 @@ export const LoginForm = (props: LoginFormProps) => {
                     autoFocus
                     source="username"
                     label={translate('ra.auth.username')}
+                    autoComplete="username"
                     validate={required()}
                     fullWidth
                 />


### PR DESCRIPTION
Set autoComplete attribute to username, which fixed the warning in the developer console.
reference : [Chromium Projects](https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/)