### PR TITLE
Fix RowClickFunction type to accept false.

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -284,7 +284,7 @@ export type RowClickFunction = (
     id: Identifier,
     resource: string,
     record: RaRecord
-) => string | Promise<string>;
+) => string | false | Promise<string | false>;
 
 const areEqual = (prevProps, nextProps) => {
     const { children: _1, expand: _2, ...prevPropsWithoutChildren } = prevProps;


### PR DESCRIPTION
`DatagridRow`'s `rowClick` property may be provided with a function, that may return a string (to trigger navigation) or `false` (in order to skip navigation).  At least the code would allow to do that, see https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx#L113

However typing restricts this (via `RowClickFunction`) to just support string return types (or promises there of).

This PR changes the type to allow `false` to be returned as well (both directly or with promise).

----

Please note that there are further inconsistencies with typing of `rowClick` on `Datagrid` itself and `DatagridBody`, which both disallow `rowClick={false}` (opposed to `DatagridRow`). Furthermore `DatagridRow.propTypes.rowClick` does not allow `false` value (i.e. conflicts with typing).  
This PR ignores this so far, since I'm not directly affected by that and I wasn't sure whether to fix that.  Let me know if I should.