### PR TITLE
Modifiable size prop for SelectArrayInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -127,3 +127,50 @@ export const DifferentIdTypes = () => {
         </AdminContext>
     );
 };
+
+export const DifferentSizes = () => {
+    const fakeData = {
+        bands: [{ id: 1, name: 'band_1', members: [1, '2'] }],
+        artists: [
+            { id: 1, name: 'artist_1' },
+            { id: 2, name: 'artist_2' },
+            { id: 3, name: 'artist_3' },
+        ],
+    };
+    const dataProvider = fakeRestProvider(fakeData, false);
+    return (
+        <AdminContext dataProvider={dataProvider}>
+            <Edit resource="bands" id={1} sx={{ width: 600 }}>
+                <SimpleForm>
+                    <TextInput source="name" fullWidth />
+                    <SelectArrayInput
+                        fullWidth
+                        source="members"
+                        choices={fakeData.artists}
+                        size="small"
+                    />
+                    <SelectArrayInput
+                        fullWidth
+                        source="members"
+                        choices={fakeData.artists}
+                        size="medium"
+                    />
+                    <SelectArrayInput
+                        fullWidth
+                        source="members"
+                        choices={fakeData.artists}
+                        size="small"
+                        variant="outlined"
+                    />
+                    <SelectArrayInput
+                        fullWidth
+                        source="members"
+                        choices={fakeData.artists}
+                        size="medium"
+                        variant="outlined"
+                    />
+                </SimpleForm>
+            </Edit>
+        </AdminContext>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -11,6 +11,7 @@ import {
     FormHelperText,
     FormControl,
     Chip,
+    OutlinedInput,
 } from '@mui/material';
 import {
     ChoicesProps,
@@ -108,6 +109,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         optionValue,
         parse,
         resource: resourceProp,
+        size = 'small',
         source: sourceProp,
         translateChoice,
         validate,
@@ -254,6 +256,25 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         ? [field.value]
         : [];
 
+    const outlinedInputProps =
+        variant === 'outlined'
+            ? {
+                  input: (
+                      <OutlinedInput
+                          id="select-multiple-chip"
+                          label={
+                              <FieldTitle
+                                  label={label}
+                                  source={source}
+                                  resource={resource}
+                                  isRequired={isRequired}
+                              />
+                          }
+                      />
+                  ),
+              }
+            : {};
+
     return (
         <>
             <StyledFormControl
@@ -299,11 +320,12 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                         </div>
                     )}
                     data-testid="selectArray"
-                    size="small"
+                    size={size}
                     {...field}
                     {...options}
                     onChange={handleChangeWithCreateSupport}
                     value={finalValue}
+                    {...outlinedInputProps}
                 >
                     {finalChoices.map(renderMenuItem)}
                 </Select>


### PR DESCRIPTION
fixes #8515 

This PR fixes 2 issues with `SelectArrayInput`:

- Removes hardcoded value for `size` prop
- Fixes label display issue when variant is set to `outlined`

`size` prop on `SelectArrayInput` was hardcoded to `small` which was preventing modifying size of the input through MUI's theming system. 

Additionally, when setting `SelectArrayInput` variant to `outlined` label of the input wasn't showing correctly. This is fixed by adding `input` prop with `OutlinedInput` component when variant is set to `outlined`.

Before:
![Screenshot 2023-01-09 at 4 33 31 PM](https://user-images.githubusercontent.com/2817572/211359050-4fa610be-a59e-4908-a1d1-fa84fc5d56bb.png)

After:
![Screenshot 2023-01-09 at 4 34 12 PM](https://user-images.githubusercontent.com/2817572/211359156-d4fa4a67-6687-4d24-a96b-58fceabdbd33.png)

