### PR TITLE
enable endAdornment for SelectInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -111,6 +111,7 @@ export const SelectInput = (props: SelectInputProps) => {
         choices: choicesProp,
         className,
         create,
+        createAlwaysVisible,
         createLabel,
         createValue,
         defaultValue,

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -111,7 +111,7 @@ export const SelectInput = (props: SelectInputProps) => {
         choices: choicesProp,
         className,
         create,
-        createAlwaysVisible,
+        clearAlwaysVisible,
         createLabel,
         createValue,
         defaultValue,

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ReactElement, useCallback, useEffect, ChangeEvent } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { MenuItem, TextFieldProps } from '@mui/material';
+import { MenuItem } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import {
     useChoicesContext,
@@ -18,6 +18,7 @@ import {
 import { CommonInputProps } from './CommonInputProps';
 import {
     ResettableTextField,
+    ResettableTextFieldProps,
     ResettableTextFieldStyles,
 } from './ResettableTextField';
 import { InputHelperText } from './InputHelperText';
@@ -428,7 +429,10 @@ const StyledResettableTextField = styled(ResettableTextField, {
 export type SelectInputProps = Omit<CommonInputProps, 'source'> &
     ChoicesProps &
     Omit<SupportCreateSuggestionOptions, 'handleChange'> &
-    Omit<TextFieldProps, 'label' | 'helperText' | 'classes' | 'onChange'> & {
+    Omit<
+        ResettableTextFieldProps,
+        'label' | 'helperText' | 'classes' | 'onChange'
+    > & {
         disableValue?: string;
         emptyText?: string | ReactElement;
         emptyValue?: any;


### PR DESCRIPTION
Fix #8615.

Slightly changed SelectInput.
- Changed OmitTextProps to ResettableTextFieldProps.
- Added clearAlwaysVisible to the props that SelectInput receives.

Originally, the StyledResettableTextField inside SelectInput received clearAlwaysVisible, but it was set to true, so it can now be edited as desired.
That way, we can add endAdornment to SelectInput as well!