### PR TITLE
Fix `<FileInput>` label color

### DIFF
--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -152,7 +152,7 @@ export const FileInput = (props: FileInputProps) => {
             source={source}
             resource={resource}
             isRequired={isRequired}
-            color={(isTouched || isSubmitted) && invalid && 'error'}
+            color={(isTouched || isSubmitted) && invalid ? 'error' : undefined}
             {...sanitizeInputRestProps(rest)}
         >
             <>


### PR DESCRIPTION
## Problem

The label of the `<FileField>` is darker than the other input labels. 

## Before

<img width="684" alt="image" src="https://user-images.githubusercontent.com/99944/217164763-2f23aab6-759f-423a-9414-6400770acf08.png">


## After

<img width="684" alt="image" src="https://user-images.githubusercontent.com/99944/217164684-dab66c36-5a9d-40aa-b344-fce1ffbac93c.png">
