### PR TITLE
allow -0 at NumberInput filling

### DIFF
--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -197,7 +197,7 @@ const convertStringToNumber = value => {
         return value;
     }
     
-    const float = value === '-0' ? '-0' : parseFloat(value);
+    const float = parseFloat(value);
 
     return isNaN(float) ? 0 : float;
 };

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -192,7 +192,7 @@ const convertStringToNumber = value => {
     if (value == null || value === '') {
         return null;
     }
-    const float = value === "-0" ? "-0" : parseFloat(value);
+    const float = value === '-0' ? '-0' : parseFloat(value);
 
     return isNaN(float) ? 0 : float;
 };

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -192,7 +192,7 @@ const convertStringToNumber = value => {
     if (value == null || value === '') {
         return null;
     }
-    const float = parseFloat(value);
+    const float = value === "-0" ? "-0" : parseFloat(value);
 
     return isNaN(float) ? 0 : float;
 };

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -192,6 +192,11 @@ const convertStringToNumber = value => {
     if (value == null || value === '') {
         return null;
     }
+    
+    if (value === '-0') {
+        return value;
+    }
+    
     const float = value === '-0' ? '-0' : parseFloat(value);
 
     return isNaN(float) ? 0 : float;

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -192,11 +192,11 @@ const convertStringToNumber = value => {
     if (value == null || value === '') {
         return null;
     }
-    
+
     if (value === '-0') {
         return value;
     }
-    
+
     const float = parseFloat(value);
 
     return isNaN(float) ? 0 : float;


### PR DESCRIPTION
### Problem

If you want to enter a negative number <1 (e.g. -0.14) `<NumberInput/>`-`onChange` automagically corrects `-0` to `0` while typing. You can add the `-` after a not-0-number (e.g. 0.14) is filled in <NumberInput/>.

### Solution

Adding special `-0` input treatment in `convertStringToNumber`.