### PR TITLE
fix: highlight error in red when form is submitted

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -235,7 +235,7 @@ export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = pr
                     />
                 ))}
             </FormGroup>
-            <FormHelperText error={fetchError || (isTouched && !!error)}>
+            <FormHelperText error={fetchError || ((isTouched || isSubmitted) && !!error)}>
                 <InputHelperText
                     touched={isTouched || isSubmitted || fetchError}
                     error={error?.message || fetchError?.message}


### PR DESCRIPTION
If the checkbox is required by the form but is touched then upon submit validation error is displayed, but not highlighted in red color.