### PR TITLE
Use rowSx instead of rowStyle to style selected cell based on row record

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -19,7 +19,7 @@ import {
     RaRecord,
     SortPayload,
 } from 'ra-core';
-import { Table, TableProps } from '@mui/material';
+import { Table, TableProps, SxProps } from '@mui/material';
 import clsx from 'clsx';
 import union from 'lodash/union';
 import difference from 'lodash/difference';
@@ -50,6 +50,7 @@ const defaultBulkActionButtons = <BulkDeleteButton />;
  *  - isRowExpandable
  *  - isRowSelectable
  *  - optimized
+ *  - rowSx
  *  - rowStyle
  *  - rowClick
  *  - size
@@ -128,6 +129,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
         isRowExpandable,
         resource,
         rowClick,
+        rowSx,
         rowStyle,
         size = 'small',
         sx,
@@ -269,6 +271,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                                 onToggleItem: handleToggleItem,
                                 resource,
                                 rowStyle,
+                                rowSx,
                                 selectedIds,
                                 isRowSelectable,
                             },
@@ -309,6 +312,7 @@ Datagrid.propTypes = {
     onToggleItem: PropTypes.func,
     resource: PropTypes.string,
     rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    rowSx: PropTypes.func,
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     setSort: PropTypes.func,
@@ -338,6 +342,7 @@ export interface DatagridProps<RecordType extends RaRecord = any>
     optimized?: boolean;
     rowClick?: string | RowClickFunction;
     rowStyle?: (record: RecordType, index: number) => any;
+    rowSx?: (record: RecordType, index: number) => SxProps;
     size?: 'medium' | 'small';
     // can be injected when using the component without context
     sort?: SortPayload;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cloneElement, memo, FC, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { TableBody, TableBodyProps } from '@mui/material';
+import { SxProps, TableBody, TableBodyProps } from '@mui/material';
 import clsx from 'clsx';
 import { Identifier, RaRecord } from 'ra-core';
 
@@ -22,6 +22,7 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
             row,
             rowClick,
             rowStyle,
+            rowSx,
             selectedIds,
             isRowSelectable,
             ...rest
@@ -53,6 +54,7 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
                         selectable: !isRowSelectable || isRowSelectable(record),
                         selected: selectedIds?.includes(record.id),
                         style: rowStyle ? rowStyle(record, rowIndex) : null,
+                        sx: rowSx ? rowSx(record, rowIndex) : null,
                     },
                     children
                 )
@@ -75,6 +77,7 @@ DatagridBody.propTypes = {
     row: PropTypes.element,
     rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     rowStyle: PropTypes.func,
+    rowSx: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     styles: PropTypes.object,
     isRowSelectable: PropTypes.func,
@@ -107,6 +110,7 @@ export interface DatagridBodyProps extends Omit<TableBodyProps, 'classes'> {
     row?: ReactElement;
     rowClick?: string | RowClickFunction;
     rowStyle?: (record: RaRecord, index: number) => any;
+    rowSx?: (record: RaRecord, index: number) => SxProps;
     selectedIds?: Identifier[];
     isRowSelectable?: (record: RaRecord) => boolean;
 }


### PR DESCRIPTION
This PR intends to add `rowSx`instead of `rowStyle` for styling the Datagrid rows for two reasons:
1. `Sx` is more common in mui instead of `style` to style.
2. `rowStyle` will apply to the whole row. If one wants to highlight specific cells in the datagrid body, for example highlight duplicate phone numbers, they have to write their own `DatagridBody` and `DatagridBodyRow`. Meanwhile, `rowSx` can fix the problem.

`rowStyle` has been kept in this PR for compatibility.

I have not yet updated the spec and docs according to `rowSx'. If you think this change is good, I will update docs and spec in the same PR.