### PR TITLE
enable passing meta to ExportButton/BulkExportButton dataProvider #8635

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -183,6 +183,7 @@ export const PostList = () => (
 | `label`      | Optional | `string`        | 'ra.action.export' | label or translation message to use |
 | `icon`       | Optional | `ReactElement`  | `<DownloadIcon>`   | iconElement, e.g. `<CommentIcon />` |
 | `exporter`   | Optional | `Function`      | -                  | Override the List exporter function |
+| `meta`       | Optional | `any`           | undefined          | Metadata passed to the dataProvider |
 
 ### `<BulkExportButton>`
 
@@ -216,6 +217,7 @@ export const PostList = () => (
 | `label`      | Optional | `string`        | 'ra.action.export' | label or translation message to use |
 | `icon`       | Optional | `ReactElement`  | `<DownloadIcon>`   | iconElement, e.g. `<CommentIcon />` |
 | `exporter`   | Optional | `Function`      | -                  | Override the List exporter function |
+| `meta`       | Optional | `any`           | undefined          | Metadata passed to the dataProvider |
 
 ### `<BulkDeleteButton>`
 

--- a/packages/ra-ui-materialui/src/button/BulkExportButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkExportButton.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+import expect from 'expect';
+import {
+    CoreAdminContext,
+    testDataProvider,
+    ListContextProvider,
+} from 'ra-core';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+import { BulkExportButton } from './BulkExportButton';
+
+const theme = createTheme();
+
+describe('<BulkExportButton />', () => {
+    it('should invoke dataProvider with meta', async () => {
+        const exporter = jest.fn().mockName('exporter');
+        const dataProvider = testDataProvider({
+            getMany: jest.fn().mockResolvedValueOnce({ data: [], total: 0 }),
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ThemeProvider theme={theme}>
+                    <ListContextProvider
+                        value={{ selectedIds: ['selectedId'] }}
+                    >
+                        <BulkExportButton
+                            resource="test"
+                            exporter={exporter}
+                            meta={{ pass: 'meta' }}
+                        />
+                    </ListContextProvider>
+                </ThemeProvider>
+            </CoreAdminContext>
+        );
+
+        fireEvent.click(screen.getByLabelText('ra.action.export'));
+
+        await waitFor(() => {
+            expect(dataProvider.getMany).toHaveBeenCalledWith('test', {
+                ids: ['selectedId'],
+                meta: { pass: 'meta' },
+            });
+
+            expect(exporter).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
@@ -42,6 +42,7 @@ export const BulkExportButton = (props: BulkExportButtonProps) => {
         label = 'ra.action.export',
         icon = defaultIcon,
         exporter: customExporter,
+        meta,
         ...rest
     } = props;
     const {
@@ -56,7 +57,7 @@ export const BulkExportButton = (props: BulkExportButtonProps) => {
         event => {
             exporter &&
                 dataProvider
-                    .getMany(resource, { ids: selectedIds })
+                    .getMany(resource, { ids: selectedIds, meta })
                     .then(({ data }) =>
                         exporter(
                             data,
@@ -75,7 +76,7 @@ export const BulkExportButton = (props: BulkExportButtonProps) => {
                 onClick(event);
             }
         },
-        [dataProvider, exporter, notify, onClick, resource, selectedIds]
+        [dataProvider, exporter, notify, onClick, resource, selectedIds, meta]
     );
 
     return (
@@ -96,7 +97,7 @@ const sanitizeRestProps = ({
     selectedIds,
     resource,
     ...rest
-}: Omit<BulkExportButtonProps, 'exporter' | 'label'>) => rest;
+}: Omit<BulkExportButtonProps, 'exporter' | 'label' | 'meta'>) => rest;
 
 interface Props {
     exporter?: Exporter;
@@ -106,6 +107,7 @@ interface Props {
     onClick?: (e: Event) => void;
     selectedIds?: Identifier[];
     resource?: string;
+    meta?: any;
 }
 
 export type BulkExportButtonProps = Props & ButtonProps;
@@ -116,4 +118,5 @@ BulkExportButton.propTypes = {
     resource: PropTypes.string,
     selectedIds: PropTypes.arrayOf(PropTypes.any),
     icon: PropTypes.element,
+    meta: PropTypes.any,
 };

--- a/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+import expect from 'expect';
+import { CoreAdminContext, testDataProvider } from 'ra-core';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+import { ExportButton } from './ExportButton';
+
+const theme = createTheme();
+
+describe('<ExportButton />', () => {
+    it('should invoke dataProvider with meta', async () => {
+        const exporter = jest.fn().mockName('exporter');
+        const dataProvider = testDataProvider({
+            getList: jest.fn().mockResolvedValueOnce({ data: [], total: 0 }),
+        });
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ThemeProvider theme={theme}>
+                    <ExportButton
+                        resource="test"
+                        filterValues={{ filters: 'override' }}
+                        exporter={exporter}
+                        meta={{ pass: 'meta' }}
+                    />
+                </ThemeProvider>
+            </CoreAdminContext>
+        );
+
+        fireEvent.click(screen.getByLabelText('ra.action.export'));
+
+        await waitFor(() => {
+            expect(dataProvider.getList).toHaveBeenCalledWith('test', {
+                sort: null,
+                filter: { filters: 'override' },
+                pagination: { page: 1, perPage: 1000 },
+                meta: { pass: 'meta' },
+            });
+
+            expect(exporter).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -13,7 +13,6 @@ import {
     useResourceContext,
 } from 'ra-core';
 import { Button, ButtonProps } from './Button';
-import { UseQueryOptions } from 'react-query';
 
 export const ExportButton = (props: ExportButtonProps) => {
     const {

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -13,6 +13,7 @@ import {
     useResourceContext,
 } from 'ra-core';
 import { Button, ButtonProps } from './Button';
+import { UseQueryOptions } from 'react-query';
 
 export const ExportButton = (props: ExportButtonProps) => {
     const {
@@ -21,6 +22,7 @@ export const ExportButton = (props: ExportButtonProps) => {
         label = 'ra.action.export',
         icon = defaultIcon,
         exporter: customExporter,
+        meta,
         ...rest
     } = props;
     const {
@@ -43,6 +45,7 @@ export const ExportButton = (props: ExportButtonProps) => {
                         ? { ...filterValues, ...filter }
                         : filterValues,
                     pagination: { page: 1, perPage: maxResults },
+                    meta,
                 })
                 .then(
                     ({ data }) =>
@@ -72,6 +75,7 @@ export const ExportButton = (props: ExportButtonProps) => {
             onClick,
             resource,
             sort,
+            meta,
         ]
     );
 
@@ -93,8 +97,10 @@ const sanitizeRestProps = ({
     filterValues,
     resource,
     ...rest
-}: Omit<ExportButtonProps, 'sort' | 'maxResults' | 'label' | 'exporter'>) =>
-    rest;
+}: Omit<
+    ExportButtonProps,
+    'sort' | 'maxResults' | 'label' | 'exporter' | 'meta'
+>) => rest;
 
 interface Props {
     exporter?: Exporter;
@@ -105,6 +111,7 @@ interface Props {
     onClick?: (e: Event) => void;
     resource?: string;
     sort?: SortPayload;
+    meta?: any;
 }
 
 export type ExportButtonProps = Props & ButtonProps;
@@ -120,4 +127,5 @@ ExportButton.propTypes = {
         order: PropTypes.string,
     }),
     icon: PropTypes.element,
+    meta: PropTypes.any,
 };


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/8635