### PR TITLE
Fix CheckboxGroupInput helperText placement and color

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
@@ -3,13 +3,14 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import { Typography } from '@mui/material';
 import { FavoriteBorder, Favorite } from '@mui/icons-material';
-import { testDataProvider, useRecordContext } from 'ra-core';
+import { required, testDataProvider, useRecordContext } from 'ra-core';
 
 import { AdminContext } from '../AdminContext';
 import { Create } from '../detail';
 import { SimpleForm } from '../form';
 import { CheckboxGroupInput } from './CheckboxGroupInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
+import { TextInput } from './TextInput';
 
 export default { title: 'ra-ui-materialui/input/CheckboxGroupInput' };
 
@@ -47,7 +48,9 @@ export const Basic = () => (
 );
 
 const dataProvider = testDataProvider({
+    // @ts-ignore
     getList: () => Promise.resolve({ data: choices, total: choices.length }),
+    // @ts-ignore
     getMany: (resource, params) =>
         Promise.resolve({
             data: choices.filter(choice => params.ids.includes(choice.id)),
@@ -181,3 +184,33 @@ const OptionText = () => {
         </>
     );
 };
+
+export const Validate = () => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <Create resource="posts" sx={{ width: 600 }}>
+            <SimpleForm>
+                <CheckboxGroupInput
+                    source="options"
+                    choices={choices}
+                    validate={[required()]}
+                />
+                <TextInput source="foo" />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
+export const HelperText = () => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <Create resource="posts" sx={{ width: 600 }}>
+            <SimpleForm>
+                <CheckboxGroupInput
+                    source="options"
+                    choices={choices}
+                    validate={[required()]}
+                    helperText="Helper text"
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -235,7 +235,10 @@ export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = pr
                     />
                 ))}
             </FormGroup>
-            <FormHelperText error={fetchError || (isTouched && !!error)}>
+            <FormHelperText
+                error={fetchError || ((isTouched || isSubmitted) && !!error)}
+                className={CheckboxGroupInputClasses.helperText}
+            >
                 <InputHelperText
                     touched={isTouched || isSubmitted || fetchError}
                     error={error?.message || fetchError?.message}
@@ -286,6 +289,7 @@ const PREFIX = 'RaCheckboxGroupInput';
 
 export const CheckboxGroupInputClasses = {
     label: `${PREFIX}-label`,
+    helperText: `${PREFIX}-helperText`,
 };
 
 const StyledFormControl = styled(FormControl, {
@@ -295,5 +299,9 @@ const StyledFormControl = styled(FormControl, {
     [`& .${CheckboxGroupInputClasses.label}`]: {
         transform: 'translate(0, 4px) scale(0.75)',
         transformOrigin: `top ${theme.direction === 'ltr' ? 'left' : 'right'}`,
+    },
+    [`& .${CheckboxGroupInputClasses.helperText}`]: {
+        marginLeft: 0,
+        marginRight: 0,
     },
 }));


### PR DESCRIPTION
## Problems

- CheckboxGroupInput helperText has a left margin that shows a wrong alignment with the label
- When required but not touched, the error message appears in grey instead of red

Supersedes #8627

![image](https://user-images.githubusercontent.com/99944/218691687-5990607d-3da3-4d64-9046-3cd5aa1afb24.png)
