### PR TITLE
[Demo] Fix Datagrid style: remove last row gutter

### DIFF
--- a/examples/demo/src/layout/themes.ts
+++ b/examples/demo/src/layout/themes.ts
@@ -99,5 +99,12 @@ export const lightTheme = {
                 },
             },
         },
+        MuiTableRow: {
+            styleOverrides: {
+                root: {
+                    '&:last-child td': { border: 0 },
+                },
+            },
+        },
     },
 };


### PR DESCRIPTION
With the 'rounded' style of the MUI components (especially Cards) in the demo, having a bottom gutter on the latest row of the Datagrids is ugly.

Similar to [what they did in their own demo](https://mui.com/material-ui/react-table/#basic-table), this PR changes the style of the MuiTableRow to disable bottom border on the last row.

## Screenshots

Before

![2023-02-16_10-24](https://user-images.githubusercontent.com/14542336/219325294-cae1a440-193d-4eee-ad7e-e6749f0627ab.png)


After

![2023-02-16_10-25](https://user-images.githubusercontent.com/14542336/219325324-99ebfaf6-99d0-4d28-b6be-df1ee87b57d8.png)
