### PR TITLE
Fix `Notification` raises a MUI warning when `message` is a string

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -117,7 +117,7 @@ export const Notification = (props: NotificationProps) => {
             {...rest}
             {...options}
         >
-            {message && typeof message !== 'string' && message}
+            {message && typeof message !== 'string' ? message : null}
         </StyledSnackbar>
     );
 };


### PR DESCRIPTION
Fix #8664

### Notes

Didn't add a test cause I'm not sure it would make sense to have a test ensuring MUI does not raise any warning (as it's pretty specific). But I can add one if you guys think otherwise.

The fix can be tested with the `Basic` story of the `Notification` storybook.