### PR TITLE
Fix `DatagridConfigurable` column ordering feature does not work in Firefox

### DIFF
--- a/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
@@ -20,7 +20,7 @@ export const FieldToggle = props => {
     }, []);
 
     const handleDragStart = () => {
-        document.ondragover = handleDocumentDragOver;
+        document.addEventListener('dragover', handleDocumentDragOver);
     };
 
     const handleDrag = event => {
@@ -51,7 +51,7 @@ export const FieldToggle = props => {
         const selectedItem = event.target;
         onMove(selectedItem.dataset.index, dropIndex.current);
         selectedItem.classList.remove('drag-active');
-        document.ondragover = null;
+        document.removeEventListener('dragover', handleDocumentDragOver);
     };
 
     const handleDragOver = event => {

--- a/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
@@ -11,18 +11,27 @@ export const FieldToggle = props => {
     const { selected, label, onToggle, onMove, source, index } = props;
     const resource = useResourceContext();
     const dropIndex = React.useRef<number>(null);
+    const x = React.useRef<number>(null);
+    const y = React.useRef<number>(null);
+
+    const handleDocumentDragOver = React.useCallback(event => {
+        x.current = event.clientX;
+        y.current = event.clientY;
+    }, []);
+
+    const handleDragStart = () => {
+        document.ondragover = handleDocumentDragOver;
+    };
 
     const handleDrag = event => {
         // imperative DOM manipulations using the native Drag API
         const selectedItem = event.target;
         selectedItem.classList.add('drag-active');
         const list = selectedItem.parentNode;
-        const x = event.clientX;
-        const y = event.clientY;
         let dropItem =
-            document.elementFromPoint(x, y) === null
+            document.elementFromPoint(x.current, y.current) === null
                 ? selectedItem
-                : document.elementFromPoint(x, y);
+                : document.elementFromPoint(x.current, y.current);
         if (dropItem.classList.contains('dragIcon')) {
             dropItem = dropItem.parentNode;
         }
@@ -42,6 +51,7 @@ export const FieldToggle = props => {
         const selectedItem = event.target;
         onMove(selectedItem.dataset.index, dropIndex.current);
         selectedItem.classList.remove('drag-active');
+        document.ondragover = null;
     };
 
     const handleDragOver = event => {
@@ -54,6 +64,7 @@ export const FieldToggle = props => {
             key={source}
             draggable={onMove ? 'true' : undefined}
             onDrag={onMove ? handleDrag : undefined}
+            onDragStart={onMove ? handleDragStart : undefined}
             onDragEnd={onMove ? handleDragEnd : undefined}
             onDragOver={onMove ? handleDragOver : undefined}
             data-index={index}


### PR DESCRIPTION
Fix #8672

## Related readings
- [Issue description in stackoverflow](https://stackoverflow.com/questions/11656061/why-is-event-clientx-incorrectly-showing-as-0-in-firefox-for-dragend-event)
- [Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=505521#c80)
- [Implemented solution](https://stackoverflow.com/a/24137885/3975522)