### PR TITLE
Fix `<Datagrid>` `rowClick` type and documentation

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -655,9 +655,10 @@ export const PostList = () => (
 * "show" to redirect to the show vue
 * "expand" to open the `expand` panel
 * "toggleSelection" to trigger the `onToggleItem` function
-* a function `(id, resource, record) => path` to redirect to a custom path
+* `false` to do nothing
+* a function `(id, resource, record) => path` that may return any of the above values or a custom path
 
-**Tip**: If you pass a function, it can return `edit`, `show`; or a router path. This allows to redirect to either `edit` or `show` after checking a condition on the record. For example:
+**Tip**: If you pass a function, it can return `edit`, `show`; `false` or a router path. This allows to redirect to either `edit` or `show` after checking a condition on the record. For example:
 
 ```js
 const postRowClick = (id, resource, record) => record.editable ? 'edit' : 'show';

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -658,7 +658,7 @@ export const PostList = () => (
 * `false` to do nothing
 * a function `(id, resource, record) => path` that may return any of the above values or a custom path
 
-**Tip**: If you pass a function, it can return `edit`, `show`; `false` or a router path. This allows to redirect to either `edit` or `show` after checking a condition on the record. For example:
+**Tip**: If you pass a function, it can return `'edit'`, `'show'`, `false` or a router path. This allows to redirect to either the Edit or Show view after checking a condition on the record. For example:
 
 ```js
 const postRowClick = (id, resource, record) => record.editable ? 'edit' : 'show';

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -337,7 +337,7 @@ export interface DatagridProps<RecordType extends RaRecord = any>
     isRowSelectable?: (record: RecordType) => boolean;
     isRowExpandable?: (record: RecordType) => boolean;
     optimized?: boolean;
-    rowClick?: string | RowClickFunction;
+    rowClick?: string | RowClickFunction | false;
     rowStyle?: (record: RecordType, index: number) => any;
     size?: 'medium' | 'small';
     // can be injected when using the component without context

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -105,7 +105,7 @@ export interface DatagridBodyProps extends Omit<TableBodyProps, 'classes'> {
     record?: RaRecord;
     resource?: string;
     row?: ReactElement;
-    rowClick?: string | RowClickFunction;
+    rowClick?: string | RowClickFunction | false;
     rowStyle?: (record: RaRecord, index: number) => any;
     selectedIds?: Identifier[];
     isRowSelectable?: (record: RaRecord) => boolean;


### PR DESCRIPTION
The TS definition didn't accept `false` as a vaild value.
The documentation did not mention you can pass `false`.