### PR TITLE
[Doc] Add `global` definition to the Vite example, and offer to install the Roboto font locally

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -115,6 +115,8 @@ Lastly, add the `Roboto` font to the `index.html` file:
 </html>
 ```
 
+**Tip:** You can also install the `Roboto` font locally by following the instructions from the [MUI starter guide](https://mui.com/material-ui/getting-started/installation/#roboto-font).
+
 The `<App>` component renders an `<Admin>` component, which is the root component of a react-admin application. This component expects a `dataProvider` prop - a function capable of fetching data from an API. Since there is no standard for data exchanges between computers, you will probably have to write a custom provider to connect react-admin to your own APIs - but we'll dive into Data Providers later. For now, let's take advantage of the `ra-data-json-server` data provider, which speaks the same REST dialect as JSONPlaceholder.
 
 Now it's time to add features!

--- a/docs/Vite.md
+++ b/docs/Vite.md
@@ -70,7 +70,7 @@ body {
 }
 ```
 
-Finally, add the `Roboto` font to your `index.html` file:
+Next, add the `Roboto` font to your `index.html` file:
 
 ```diff
 // in ./index.html
@@ -91,6 +91,33 @@ Finally, add the `Roboto` font to your `index.html` file:
   </body>
 </html>
 ```
+
+**Tip:** You can also install the `Roboto` font locally by following the instructions from the [MUI starter guide](https://mui.com/material-ui/getting-started/installation/#roboto-font).
+
+Finally, add the following line to the `index.html` file:
+
+```diff
+// in ./index.html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Admin</title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
++   <script>window.global = window</script>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>
+```
+
+This helps increase the compatibility of some dependencies used by React Admin with Vite.
 
 Now, start the server with `yarn dev`, browse to `http://localhost:5173/`, and you should see the working admin:
 


### PR DESCRIPTION
- Adding `window.global = window` to the Vite example allows to fix errors with some libs, e.g. react-floater, that would throw errors such as `Uncaught ReferenceError: global is not defined`
- Offering to install the Roboto font locally can help with local legislation compliance, such as the GDPR in Europe