### PR TITLE
Type downloadCSV function

### DIFF
--- a/packages/ra-core/src/export/downloadCSV.ts
+++ b/packages/ra-core/src/export/downloadCSV.ts
@@ -1,4 +1,4 @@
-export default (csv, filename) => {
+export default (csv: string, filename: string): void => {
     const fakeLink = document.createElement('a');
     fakeLink.style.display = 'none';
     document.body.appendChild(fakeLink);


### PR DESCRIPTION
Because `downloadCSV` function is exported by react-admin, it is good to make it typed rather than `any`.
