### PR TITLE
Fix `AutocompleteInput` when record has a different shape between `getList` and  `getMany`

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -14,6 +14,7 @@ import { SimpleForm } from '../form';
 import { AutocompleteInput } from './AutocompleteInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import {
+    DifferentShapeInGetMany,
     InsideReferenceInput,
     InsideReferenceInputDefaultValue,
     Nullable,
@@ -1368,6 +1369,29 @@ describe('<AutocompleteInput />', () => {
                     expect.anything()
                 );
             });
+        });
+
+        it('should not reset the filter when typing when getMany returns a different record shape than getList', async () => {
+            render(<DifferentShapeInGetMany />);
+            await screen.findByDisplayValue('Leo Tolstoy');
+            const input = (await screen.findByLabelText(
+                'Author'
+            )) as HTMLInputElement;
+            expect(input.value).toBe('Leo Tolstoy');
+            fireEvent.mouseDown(input);
+            fireEvent.change(input, { target: { value: 'Leo Tolstoy test' } });
+            // Make sure that 'Leo Tolstoy' did not reappear
+            let testFailed = false;
+            try {
+                await waitFor(() => {
+                    expect(input.value).toBe('Leo Tolstoy');
+                });
+                testFailed = true;
+            } catch {
+                // This is expected, nothing to do
+            }
+            expect(testFailed).toBe(false);
+            expect(input.value).toBe('Leo Tolstoy test');
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -727,7 +727,14 @@ const useSelectedChoice = <
             multiple
         );
 
-        if (!isEqual(selectedChoiceRef.current, newSelectedItems)) {
+        if (
+            !areSelectedItemsEqual(
+                selectedChoiceRef.current,
+                newSelectedItems,
+                optionValue,
+                multiple
+            )
+        ) {
             selectedChoiceRef.current = newSelectedItems;
             setSelectedChoice(newSelectedItems);
         }
@@ -754,6 +761,31 @@ const getSelectedItems = (
         choices.find(
             choice => String(get(choice, optionValue)) === String(value)
         ) || ''
+    );
+};
+
+const areSelectedItemsEqual = (
+    selectedChoice: RaRecord | RaRecord[],
+    newSelectedChoice: RaRecord | RaRecord[],
+    optionValue = 'id',
+    multiple: boolean
+) => {
+    if (multiple) {
+        const selectedChoiceArray = (selectedChoice as RaRecord[]) ?? [];
+        const newSelectedChoiceArray = (newSelectedChoice as RaRecord[]) ?? [];
+        if (selectedChoiceArray.length !== newSelectedChoiceArray.length) {
+            return false;
+        }
+        const equalityArray = selectedChoiceArray.map(choice =>
+            newSelectedChoiceArray.some(
+                newChoice =>
+                    get(newChoice, optionValue) === get(choice, optionValue)
+            )
+        );
+        return !equalityArray.some(item => item === false);
+    }
+    return (
+        get(selectedChoice, optionValue) === get(newSelectedChoice, optionValue)
     );
 };
 


### PR DESCRIPTION
**Issue**

`AutocompleteInput` uses `getMany` to fetch the records matching the already selected choices, and `getList` to fetch the other available choices.

If both methods do not render exactly the same record shape (e.g. if `getMany` records have extra fields compared to `getList` records), then when fetching for additional choices (e.g. while filtering), `AutocompleteInput` gets confused because it thinks the selected choice has changed, and ends up resetting the filterValue.

**Solution**

Instead of comparing the full records, only compare their `id` (or the field chosen as `optionValue`)