### PR TITLE
Avoid double translations

### DIFF
--- a/packages/ra-ui-materialui/src/button/SkipNavigationButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SkipNavigationButton.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { styled } from '@mui/material/styles';
 import { Button } from './Button';
-import { useTranslate } from 'ra-core';
 
 export const SkipNavigationButton = () => {
-    const translate = useTranslate();
-
     return (
         <StyledButton
             onClick={skipToContent}
             className={'skip-nav-button'}
-            label={translate('ra.navigation.skip_nav')}
+            label="ra.navigation.skip_nav"
             variant="contained"
         />
     );

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -1,26 +1,41 @@
 import * as React from 'react';
 import { isValidElement, ReactElement } from 'react';
-import { useTranslate, ValidationError, ValidationErrorMessage } from 'ra-core';
+import {
+    useTranslate,
+    ValidationError,
+    ValidationErrorMessage,
+    ValidationErrorMessageWithArgs,
+} from 'ra-core';
 
 export const InputHelperText = (props: InputHelperTextProps) => {
     const { helperText, touched, error } = props;
     const translate = useTranslate();
 
-    return touched && error ? (
-        <ValidationError error={error} />
-    ) : isValidElement(helperText) ? (
-        helperText
-    ) : typeof helperText === 'string' ? (
-        <>{translate(helperText, { _: helperText })}</>
-    ) : helperText !== false ? (
-        // MUI's HelperText cannot reserve space unless we pass a single
-        // space as child, which isn't possible when the child is a component.
-        // Therefore, we must reserve the space ourselves by passing the same
-        // markup as MUI.
-        // @see https://github.com/mui-org/material-ui/blob/62e439b7022d519ab638d65201e204b59b77f8da/packages/material-ui/src/FormHelperText/FormHelperText.js#L85-L90
-        // eslint-disable-next-line react/no-danger
-        <span dangerouslySetInnerHTML={defaultInnerHTML} />
-    ) : null;
+    if (touched && error) {
+        if ((error as ValidationErrorMessageWithArgs).message) {
+            return <ValidationError error={error} />;
+        }
+        return error;
+    }
+
+    if (helperText === false) {
+        return null;
+    }
+
+    if (isValidElement(helperText)) {
+        return helperText;
+    }
+
+    if (typeof helperText === 'string') {
+        return <>{translate(helperText, { _: helperText })}</>;
+    }
+
+    // MUI's HelperText cannot reserve space unless we pass a single
+    // space as child, which isn't possible when the child is a component.
+    // Therefore, we must reserve the space ourselves by passing the same
+    // markup as MUI.
+    // @see https://github.com/mui-org/material-ui/blob/62e439b7022d519ab638d65201e204b59b77f8da/packages/material-ui/src/FormHelperText/FormHelperText.js#L85-L90
+    return <span dangerouslySetInnerHTML={defaultInnerHTML} />;
 };
 
 const defaultInnerHTML = { __html: '&#8203;' };

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -15,7 +15,7 @@ export const InputHelperText = (props: InputHelperTextProps) => {
         if ((error as ValidationErrorMessageWithArgs).message) {
             return <ValidationError error={error} />;
         }
-        return error;
+        return <>{error}</>;
     }
 
     if (helperText === false) {

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
@@ -6,7 +6,6 @@ import {
     useResourceDefinitions,
     useGetResourceLabel,
     useCreatePath,
-    useTranslate,
 } from 'ra-core';
 
 import { MenuItemLink } from './MenuItemLink';
@@ -14,7 +13,6 @@ import { MenuItemLink } from './MenuItemLink';
 export const ResourceMenuItem = ({ name }: { name: string }) => {
     const resources = useResourceDefinitions();
     const getResourceLabel = useGetResourceLabel();
-    const translate = useTranslate();
     const createPath = useCreatePath();
     if (!resources || !resources[name]) return null;
     return (

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
@@ -6,6 +6,7 @@ import {
     useResourceDefinitions,
     useGetResourceLabel,
     useCreatePath,
+    useTranslate,
 } from 'ra-core';
 
 import { MenuItemLink } from './MenuItemLink';
@@ -13,6 +14,7 @@ import { MenuItemLink } from './MenuItemLink';
 export const ResourceMenuItem = ({ name }: { name: string }) => {
     const resources = useResourceDefinitions();
     const getResourceLabel = useGetResourceLabel();
+    const translate = useTranslate();
     const createPath = useCreatePath();
     if (!resources || !resources[name]) return null;
     return (
@@ -22,7 +24,14 @@ export const ResourceMenuItem = ({ name }: { name: string }) => {
                 type: 'list',
             })}
             state={{ _scrollToTop: true }}
-            primaryText={getResourceLabel(name, 2)}
+            primaryText={
+                <>
+                    {translate(`resources.${name}.name`, {
+                        smart_count: 2,
+                        _: getResourceLabel(name, 2),
+                    })}
+                </>
+            }
             leftIcon={
                 resources[name].icon ? (
                     createElement(resources[name].icon)

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
@@ -25,12 +25,7 @@ export const ResourceMenuItem = ({ name }: { name: string }) => {
             })}
             state={{ _scrollToTop: true }}
             primaryText={
-                <>
-                    {translate(`resources.${name}.name`, {
-                        smart_count: 2,
-                        _: getResourceLabel(name, 2),
-                    })}
-                </>
+                <>{getResourceLabel(name, 2)}</>
             }
             leftIcon={
                 resources[name].icon ? (

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
@@ -24,9 +24,7 @@ export const ResourceMenuItem = ({ name }: { name: string }) => {
                 type: 'list',
             })}
             state={{ _scrollToTop: true }}
-            primaryText={
-                <>{getResourceLabel(name, 2)}</>
-            }
+            primaryText={<>{getResourceLabel(name, 2)}</>}
             leftIcon={
                 resources[name].icon ? (
                     createElement(resources[name].icon)


### PR DESCRIPTION
Some components were translating labels twice. Besides the validation messages were translated twice as well. Fixing this requires a potential breaking change: when using the `InputHelperText` directly, the error message isn't translated anymore unless it's an object with a `message` property. I believe this is a very rare usage if it even exists.

FIxes #8662