### PR TITLE
fix: Avoid undefined data on disabled requests in useGetManyAggregate

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -127,6 +127,7 @@ export const useGetManyAggregate = <RecordType extends RaRecord = any>(
                     );
                 });
             },
+            initialData: [],
             retry: false,
             ...options,
         }


### PR DESCRIPTION
Fixes #8684 by setting the initial data prop, therefore avoiding data being undefined on disabled requests,