### PR TITLE
Fix race condition in useUpdate.ts

### DIFF
--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -136,7 +136,7 @@ export const useUpdate = <
         queryClient.setQueriesData(
             [resource, 'getMany'],
             (coll: RecordType[]) =>
-                coll && coll.length > 0 ? updateColl(coll) : coll,
+                coll && coll.length > 0 ? updateColl(coll) : coll ?? [],
             { updatedAt }
         );
         queryClient.setQueriesData(


### PR DESCRIPTION
Fixes #8684 by defaulting coll to [] if it's undefined.

Now before you ask me to write a test for this:
I don't know how :D

I'm not proficient enough in jest testing to do this since it seems to be related to a race condition in which react query doesn't set the initial cache entry before you try to update it, so I have no idea how to test against that.