### PR TITLE
Sanitize source for default controller name

### DIFF
--- a/packages/ra-core/src/form/useInput.spec.tsx
+++ b/packages/ra-core/src/form/useInput.spec.tsx
@@ -106,6 +106,29 @@ describe('useInput', () => {
         expect(handleBlur).toHaveBeenCalled();
     });
 
+    it('sanitizes the source when using as the default name', () => {
+        let inputProps;
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
+                <Form onSubmit={jest.fn()}>
+                    <Input
+                        defaultValue="A title"
+                        source="title||ilike"
+                        resource="posts"
+                        validate={required()}
+                    >
+                        {props => {
+                            inputProps = props;
+                            return <div />;
+                        }}
+                    </Input>
+                </Form>
+            </CoreAdminContext>
+        );
+
+        expect(inputProps.field.name).toEqual('title__ilike');
+    });
+
     describe('defaultValue', () => {
         it('applies the defaultValue when input does not have a value', () => {
             const onSubmit = jest.fn();

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -22,6 +22,8 @@ import { useApplyInputDefaultValues } from './useApplyInputDefaultValues';
 const defaultFormat = (value: any) => (value == null ? '' : value);
 // parse empty string into null as it's more suitable for a majority of backends
 const defaultParse = (value: string) => (value === '' ? null : value);
+// A name with a pipe (|) in it can cause text controllers to break #8721
+const sanitizeName = (value: string) => value.replace(/\|/g, '_');
 
 export const useInput = (props: InputProps): UseInputValue => {
     const {
@@ -37,7 +39,7 @@ export const useInput = (props: InputProps): UseInputValue => {
         validate,
         ...options
     } = props;
-    const finalName = name || source;
+    const finalName = name || sanitizeName(source);
     const formGroupName = useFormGroupContext();
     const formGroups = useFormGroups();
     const record = useRecordContext();


### PR DESCRIPTION
Ensures that pipe characters in `source`s do not make it to controller names.

Closes #8721