### PR TITLE
Fix `ReferenceManyCount` rendering link incorrectly

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
@@ -69,7 +69,6 @@ export const ReferenceManyCount = (props: ReferenceManyCountProps) => {
     );
 
     return link ? (
-        // @ts-ignore TypeScript complains that the props for <a> aren't the same as for <span>
         <Link
             to={{
                 pathname: createPath({ resource: reference, type: 'list' }),
@@ -79,7 +78,6 @@ export const ReferenceManyCount = (props: ReferenceManyCountProps) => {
                 })}`,
             }}
             variant="body2"
-            component="span"
             onClick={e => e.stopPropagation()}
             {...rest}
         >

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
@@ -79,7 +79,7 @@ export const ReferenceManyCount = (props: ReferenceManyCountProps) => {
             }}
             variant="body2"
             onClick={e => e.stopPropagation()}
-            {...rest}
+            {...sanitizeFieldRestProps(rest)}
         >
             {body}
         </Link>


### PR DESCRIPTION
Fixes #8750 

Tested on my local environment, and nothing has changed visually, while the link works properly now.