### PR TITLE
[Doc] Fix `<AppBar>` example

### DIFF
--- a/docs/AppBar.md
+++ b/docs/AppBar.md
@@ -111,7 +111,7 @@ export const MyAppBar = () => (
 
 **Tip**: Whats the `<TitlePortal>`? It's a placeholder for the page title, that components in the page can fill using [the `<Title>` component](./Title.md). `<Title>` uses a [React Portal](https://reactjs.org/docs/portals.html) under the hood. `<TitlePortal>` takes all the available space in the app bar, so it "pushes" the following children to the right.
  
-If you omit `<PagePortal>`, `<AppBar>` will no longer display the page title. This can be done on purpose, e.g. if you want to render something completely different in the AppBar, like a company logo and a search engine:
+If you omit `<TitlePortal>`, `<AppBar>` will no longer display the page title. This can be done on purpose, e.g. if you want to render something completely different in the AppBar, like a company logo and a search engine:
 
 ```jsx
 // in src/MyAppBar.js

--- a/docs/AppBar.md
+++ b/docs/AppBar.md
@@ -203,7 +203,7 @@ export const MyAppBar = () => (
             <ToggleThemeButton lightTheme={defaultTheme} darkTheme={darkTheme} />
             <RefreshIconButton />
         </>
-    } >
+    }/>
 );
 ```
 

--- a/docs/AppBar.md
+++ b/docs/AppBar.md
@@ -203,7 +203,7 @@ export const MyAppBar = () => (
             <ToggleThemeButton lightTheme={defaultTheme} darkTheme={darkTheme} />
             <RefreshIconButton />
         </>
-    }/>
+    } />
 );
 ```
 


### PR DESCRIPTION
Fix typo in AppBar docs