### PR TITLE
[TypeScript] Fix UpdateParams id type doesn't use generic type

### DIFF
--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -196,8 +196,8 @@ export interface UpdateResult<RecordType extends RaRecord = any> {
     data: RecordType;
 }
 
-export interface UpdateManyParams<T extends RaRecord = any> {
-    ids: T['id'][];
+export interface UpdateManyParams<T = any> {
+    ids: Identifier[];
     data: T;
     meta?: any;
 }

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -186,8 +186,8 @@ export interface GetManyReferenceResult<RecordType extends RaRecord = any> {
     };
 }
 
-export interface UpdateParams<T = any> {
-    id: Identifier;
+export interface UpdateParams<T extends RaRecord = any> {
+    id: T['id'];
     data: Partial<T>;
     previousData: T;
     meta?: any;
@@ -196,8 +196,8 @@ export interface UpdateResult<RecordType extends RaRecord = any> {
     data: RecordType;
 }
 
-export interface UpdateManyParams<T = any> {
-    ids: Identifier[];
+export interface UpdateManyParams<T extends RaRecord = any> {
+    ids: T['id'][];
     data: T;
     meta?: any;
 }


### PR DESCRIPTION
Update a type definition to make `UpdateParams` is consistent with the definition in `GetOne` and `GetMany`. Similar to https://github.com/marmelab/react-admin/pull/8208

Because `UpdateParams` includes `previousData: T`. So I think we shall have `T extends RaRecord` to fit the type of `previousData`.