### PR TITLE
[SimpleFormIterator] default to null instead of empty string

### DIFF
--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import FormDataConsumer, { FormDataConsumerView } from './FormDataConsumer';
 import { testDataProvider } from '../dataProvider';
 import {
     AdminContext,
+    ArrayInput,
     BooleanInput,
     SimpleForm,
-    TextInput,
     SimpleFormIterator,
-    ArrayInput,
+    TextInput,
 } from 'ra-ui-materialui';
 import expect from 'expect';
 
@@ -146,7 +146,7 @@ describe('FormDataConsumerView', () => {
 
         fireEvent.click(screen.getByLabelText('ra.action.add'));
 
-        expect(globalScopedFormData).toEqual({ name: '' });
+        expect(globalScopedFormData).toEqual({ name: null });
 
         fireEvent.change(
             screen.getByLabelText('resources.undefined.fields.authors.name'),

--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+
 import FormDataConsumer, { FormDataConsumerView } from './FormDataConsumer';
 import { testDataProvider } from '../dataProvider';
 import {

--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -4,11 +4,11 @@ import FormDataConsumer, { FormDataConsumerView } from './FormDataConsumer';
 import { testDataProvider } from '../dataProvider';
 import {
     AdminContext,
-    ArrayInput,
     BooleanInput,
     SimpleForm,
-    SimpleFormIterator,
     TextInput,
+    SimpleFormIterator,
+    ArrayInput,
 } from 'ra-ui-materialui';
 import expect from 'expect';
 

--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import FormDataConsumer, { FormDataConsumerView } from './FormDataConsumer';
 import { testDataProvider } from '../dataProvider';
 import {

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {
-    screen,
-    render,
     fireEvent,
-    waitFor,
     getByLabelText,
+    render,
+    screen,
+    waitFor,
 } from '@testing-library/react';
 import expect from 'expect';
 import { FormDataConsumer, testDataProvider } from 'ra-core';
@@ -770,7 +770,7 @@ describe('<SimpleFormIterator />', () => {
         await waitFor(() => {
             expect(save).toHaveBeenCalledWith(
                 {
-                    emails: [{ email: '' }],
+                    emails: [{ email: null }],
                 },
                 expect.anything()
             );
@@ -853,7 +853,7 @@ describe('<SimpleFormIterator />', () => {
             expect(save).toHaveBeenCalledWith(
                 {
                     id: 1,
-                    emails: [{ email: '', role: '' }],
+                    emails: [{ email: null, role: null }],
                 },
                 expect.anything()
             );

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {
-    fireEvent,
-    getByLabelText,
-    render,
     screen,
+    render,
+    fireEvent,
     waitFor,
+    getByLabelText,
 } from '@testing-library/react';
 import expect from 'expect';
 import { FormDataConsumer, testDataProvider } from 'ra-core';

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -75,7 +75,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
         const { id, ...rest } = fields[0];
         initialDefaultValue.current = rest;
         for (const k in initialDefaultValue.current)
-            initialDefaultValue.current[k] = '';
+            initialDefaultValue.current[k] = null;
     }
 
     const addField = useCallback(
@@ -104,7 +104,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
                             input.props.source
                         ) {
                             defaultValue[input.props.source] =
-                                input.props.defaultValue ?? '';
+                                input.props.defaultValue ?? null;
                         }
                     });
                 }


### PR DESCRIPTION
This is a copy of this one: https://github.com/marmelab/react-admin/pull/8787

The `SimpleFormIterator` actually is defaulting every input inside a `FormDataConsumer` to an empty string. So if I have some arrays, objects, or numbers inside, they default to the empty strings when I add new elements to the array.

I propose to make the default equal to null instead. I know this is a kind of breaking change but I think is more consistent, in case we don't have enough information to determine the right return type null should be better.

This should also solve this issue: https://github.com/marmelab/react-admin/issues/8785 because it will default to null when no default value will be provided.

Let me know what you think about it!