### PR TITLE
fix: layout padding inconsistency on low resolution screens

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -134,7 +134,7 @@ const StyledLayout = styled('div', {
         flexBasis: 0,
         padding: 0,
         [theme.breakpoints.up('xs')]: {
-            paddingRight: theme.spacing(2),
+            paddingRight: theme.spacing(1),
             paddingLeft: theme.spacing(1),
         },
     },


### PR DESCRIPTION
# Summary

<details><summary>Before</summary>

![Screen Shot 2023-04-03 at 20 39 14](https://user-images.githubusercontent.com/1698357/229607286-00e2737b-c2f4-426b-ab93-f084bdeb6df5.png)


</details> 

<details><summary>After</summary>

![Screen Shot 2023-04-03 at 20 42 11](https://user-images.githubusercontent.com/1698357/229607320-7593ac79-4f59-4afa-b5bf-95ec8224bd62.png)

</details> 

Its a fix of the configuration introduced in 48e4a91f4fc85a68e7b4d9ce23fc4db387b1c96f.

I am not sure it was intended, but it make more sense to me.