### PR TITLE
[Minor BC] Fix `<Datagrid>` does not apply `className` to its root element

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -9,7 +9,7 @@ import {
     useGetList,
     useList,
 } from 'ra-core';
-import { Box } from '@mui/material';
+import { Box, styled } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { TextField } from '../../field';
@@ -379,5 +379,35 @@ export const IsRowExpandable = () => (
             <TextField source="author" />
             <TextField source="year" />
         </Datagrid>
+    </Wrapper>
+);
+
+const StyledDatagrid = styled(Datagrid, {
+    name: 'MyStyledDatagrid',
+    overridesResolver: (props, styles) => styles.root,
+})(() => ({
+    width: '70%',
+    backgroundColor: '#ffb',
+}));
+
+export const StyledComponent = () => (
+    <Wrapper>
+        <Datagrid
+            sx={{
+                width: '70%',
+                backgroundColor: '#ffb',
+            }}
+        >
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+        <StyledDatagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </StyledDatagrid>
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -228,7 +228,10 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
      */
     return (
         <DatagridContextProvider value={contextValue}>
-            <DatagridRoot sx={sx} className={DatagridClasses.root}>
+            <DatagridRoot
+                sx={sx}
+                className={clsx(DatagridClasses.root, className)}
+            >
                 {bulkActionButtons !== false ? (
                     <BulkActionsToolbar selectedIds={selectedIds}>
                         {isValidElement(bulkActionButtons)
@@ -239,7 +242,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                 <div className={DatagridClasses.tableWrapper}>
                     <Table
                         ref={ref}
-                        className={clsx(DatagridClasses.table, className)}
+                        className={DatagridClasses.table}
                         size={size}
                         {...sanitizeRestProps(rest)}
                     >


### PR DESCRIPTION
## Problem

`<Datagrid>` does not apply `className` to its root element, but rather to its nested `Table` element.

This creates a discrepancy between styles applied via `sx` and styles applied via `styled`.

This is among others visible with the (EE) `<EditableDatagrid>` component.

## Solution

`sx` and `className` should be applied to the same component, i.e. `<DatagridRoot>`.

:warning: :warning: :warning: **Breaking change** :warning: :warning: :warning: 

This change is technically a BC. But it should be really minor as it would affect only people that use `styled` to apply styles to the `Datagrid` component. People applying styles via `sx` shouldn't be affected.

## Screenshots (of the added story)

Before

![Capture d’écran du 2023-04-04 16-56-52](https://user-images.githubusercontent.com/14542336/229834846-9af9d5d9-718d-4c74-bfea-f0032f6eb949.png)


After

![Capture d’écran du 2023-04-04 16-56-26](https://user-images.githubusercontent.com/14542336/229834874-a0093578-0425-4e5e-836e-dc2d02b69459.png)

