### PR TITLE
add chinese(zh) locale

### DIFF
--- a/docs/TranslationLocales.md
+++ b/docs/TranslationLocales.md
@@ -14,7 +14,6 @@ You can find translation packages for the following languages:
 - Bulgarian (`bg`): [ptodorov0/ra-language-bulgarian](https://github.com/ptodorov0/ra-language-bulgarian)
 - Catalan (`ca`): [joshf/ra-language-catalan](https://github.com/joshf/ra-language-catalan)
 - Chinese (`zh-TW`): [areyliu6/ra-language-chinese-traditional](https://github.com/areyliu6/ra-language-chinese-traditional)
-- Chinese (`zh`): [chen4w/ra-language-chinese](https://github.com/chen4w/ra-language-chinese)
 - Chinese (`zh`): [haxqer/ra-language-chinese](https://github.com/haxqer/ra-language-chinese)
 - Czech (`cs`): [binao/ra-language-czech](https://github.com/binao/ra-language-czech)
 - Danish (`da`): [nikri/ra-language-danish](https://github.com/nikri/ra-language-danish)

--- a/docs/TranslationLocales.md
+++ b/docs/TranslationLocales.md
@@ -15,6 +15,7 @@ You can find translation packages for the following languages:
 - Catalan (`ca`): [joshf/ra-language-catalan](https://github.com/joshf/ra-language-catalan)
 - Chinese (`zh-TW`): [areyliu6/ra-language-chinese-traditional](https://github.com/areyliu6/ra-language-chinese-traditional)
 - Chinese (`zh`): [chen4w/ra-language-chinese](https://github.com/chen4w/ra-language-chinese)
+- Chinese (`zh`): [haxqer/ra-language-chinese](https://github.com/haxqer/ra-language-chinese)
 - Czech (`cs`): [binao/ra-language-czech](https://github.com/binao/ra-language-czech)
 - Danish (`da`): [nikri/ra-language-danish](https://github.com/nikri/ra-language-danish)
 - Dutch (`nl`): [nickwaelkens/ra-language-dutch](https://github.com/nickwaelkens/ra-language-dutch)


### PR DESCRIPTION
`chen4w/ra-language-chinese` unable to support the latest ReactAdmin version.
The new version of RA has added some fields.

`haxqer/ra-language-chinese` support the latest ReactAdmin version.