### PR TITLE
[Doc] Improve usage examples for `<ReferenceInput>` and `<ReferenceArrayInput>`

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -436,7 +436,7 @@ In that case, set the `translateChoice` prop to `false`.
 
 **Tip**: To use the `disableCloseOnSelect` prop, you must also set `blurOnSelect={false}`, since this is enabled by default.
 
-## Using In A ReferenceArrayInput
+## Fetching Choices
 
 If you want to populate the `choices` attribute with a list of related records, you should decorate `<AutocompleteArrayInput>` with [`<ReferenceArrayInput>`](./ReferenceArrayInput.md), and leave the `choices` empty:
 
@@ -447,6 +447,8 @@ import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin';
     <AutocompleteArrayInput />
 </ReferenceArrayInput>
 ```
+
+Check [the `<ReferenceArrayInput>` documentation](./ReferenceArrayInput.md) for more details.
 
 ## Working With Object Values
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -61,6 +61,7 @@ The form value for the source must be the selected value, e.g.
 | `emptyText`                | Optional | `string`              | `''`                                                                | The text to use for the empty element                                                                                                                                                                               |
 | `emptyValue`               | Optional | `any`                 | `''`                                                                | The value to use for the empty element                                                                                                                                                                              |
 | `filterToQuery`            | Optional | `string` => `Object`  | `q => ({ q })`                                                      | How to transform the searchText into a parameter for the data provider                                                                                                                                              |
+| `isLoading`                | Optional | `boolean`             | `false`                                                             | If `true`, the component will display a loading indicator.                                                                                                                                                          |
 | `inputText`                | Optional | `Function`            | `-`                                                                 | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                                                                             |
 | `matchSuggestion`          | Optional | `Function`            | `-`                                                                 | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                             |
 | `onCreate`                 | Optional | `Function`            | `-`                                                                 | A function called with the current filter value when users choose to create a new choice.                                                                                                                           |
@@ -70,7 +71,6 @@ The form value for the source must be the selected value, e.g.
 | `shouldRender Suggestions` | Optional | `Function`            | `() => true`                                                        | A function that returns a `boolean` to determine whether or not suggestions are rendered.                                                                                                                           |
 | `suggestionLimit`          | Optional | `number`              | `null`                                                              | Limits the numbers of suggestions that are shown in the dropdown list                                                                                                                                               |
 | `translateChoice`          | Optional | `boolean`             | `true`                                                              | Whether the choices should be translated                                                                                                                                                                            |
-
 
 `<AutocompleteInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
@@ -263,6 +263,28 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
 <ReferenceInput label="Author" source="author_id" reference="authors">
     <AutocompleteInput filterToQuery={filterToQuery} />
 </ReferenceInput>
+```
+
+## `isLoading`
+
+When [fetching choices from a remote API](#fetching-choices), the `<AutocompleteInput>` can't be used until the choices are fetched. To let the user know, you can pass the `isLoading` prop to `<AutocompleteInput>`. This displays a loading message in the autocomplete box while the choices are being fetched.
+
+```jsx
+import { useGetList, AutocompleteInput } from 'react-admin';
+
+const UserCountry = () => {
+    const { data, isLoading } = useGetList('countries');
+    // data is an array of { id: 123, code: 'FR', name: 'France' }
+    return (
+        <AutocompleteInput 
+            source="country"
+            choices={data}
+            optionText="name"
+            optionValue="code"
+            isLoading={isLoading}
+        />
+    );
+}
 ```
 
 ## `onCreate`

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -116,7 +116,7 @@ const choices = [
 
 You can opt-out of this translation by setting [the `translateChoice` prop](#translatechoice) to `false`.
 
-If you need to *fetch* the options from another resource, you're actually editing a many-to-one or a one-to-one relationship. In this case, wrap the `<AutocompleteInput>` in a [`<ReferenceInput>`](./ReferenceInput.md). You don't need to specify the `choices` prop - the parent component injects it based on the possible values of the related resource.
+If you need to *fetch* the options from another resource, you're usually editing a many-to-one or a one-to-one relationship. In this case, wrap the `<AutocompleteInput>` in a [`<ReferenceInput>`](./ReferenceInput.md). You don't need to specify the `choices` prop - the parent component injects it based on the possible values of the related resource.
 
 ```jsx
 <ReferenceInput label="Author" source="author_id" reference="authors">
@@ -124,7 +124,7 @@ If you need to *fetch* the options from another resource, you're actually editin
 </ReferenceInput>
 ```
 
-See [Using in a `ReferenceInput>`](#using-in-a-referenceinput) below for more information.
+See [Selecting a foreign key](#selecting-a-foreign-key) below for more information.
 
 If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -590,7 +590,7 @@ const CompanyInput = () => (
 
 This is the recommended approach for using `<AutocompleteInput>` to select a foreign key. This not only signifies that the input is a `<AutocompleteInput>` but also highlights its function in fetching choices from another resource, ultimately enhancing the code's readability.
 
-**Tip**: `<ReferenceInput>` is much more powerful than the initial snippet. It optimizes and caches API calls, enables refetching of both API calls with a single command, and stores supplementary data in the `<ChoicesContext>`. `<ReferenceInput>` can provide choices to `<AutocompleteInput>`, but also to [`<RadioButtonInput>`](./RadioButtonInput.md) and [`<SelectInput>`](./SelectInput.md). For further information, refer to [the `<ReferenceInput>` documentation](./ReferenceInput.md).
+**Tip**: `<ReferenceInput>` is much more powerful than the initial snippet. It optimizes and caches API calls, enables refetching of both API calls with a single command, and stores supplementary data in the `<ChoicesContext>`. `<ReferenceInput>` can provide choices to `<AutocompleteInput>`, but also to [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md) and [`<SelectInput>`](./SelectInput.md). For further information, refer to [the `<ReferenceInput>` documentation](./ReferenceInput.md).
 
 `<AutocompleteInput>` uses [the `filterToQuery` prop](#filtertoquery) to determine how to map the input string into a filter. You may want to customize that function to match the filtering capabilities of your API:
 

--- a/docs/CheckboxGroupInput.md
+++ b/docs/CheckboxGroupInput.md
@@ -246,3 +246,17 @@ However, in some cases (e.g. inside a `<ReferenceArrayInput>`), you may not want
 ```jsx
 <CheckboxGroupInput source="roles" choices={choices} translateChoice={false}/>
 ```
+
+## Fetching Choices
+
+If you want to populate the `choices` attribute with a list of related records, you should decorate `<CheckboxGroupInput>` with [`<ReferenceArrayInput>`](./ReferenceArrayInput.md), and leave the `choices` empty:
+
+```jsx
+import { AutocompleteArrayInput, ReferenceArrayInput } from 'react-admin';
+
+<ReferenceArrayInput label="Tags" reference="tags" source="tags">
+    <CheckboxGroupInput />
+</ReferenceArrayInput>
+```
+
+Check [the `<ReferenceArrayInput>` documentation](./ReferenceArrayInput.md) for more details.

--- a/docs/RadioButtonGroupInput.md
+++ b/docs/RadioButtonGroupInput.md
@@ -109,7 +109,7 @@ If you need to *fetch* the options from another resource, you're actually editin
 </ReferenceInput>
 ```
 
-See [Using in a `<ReferenceInput>`](#using-in-a-referenceinput) below for more information.
+See [Selecting a foreign key](#selecting-a-foreign-key) below for more information.
 
 If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
 

--- a/docs/RadioButtonGroupInput.md
+++ b/docs/RadioButtonGroupInput.md
@@ -50,7 +50,8 @@ The form value for the source must be the selected value, e.g.
 
 | Prop              | Required | Type                       | Default | Description                                                                                                                            |
 | ----------------- | -------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `choices`         | Optional | `Object[]`                 | -       | List of items to show as options. Required unless inside a ReferenceInput.                                                                                                        |
+| `choices`         | Optional | `Object[]`                 | -       | List of items to show as options. Required unless inside a ReferenceInput.                                                             |
+| `isLoading`       | Optional | `boolean`                  | `false` | If `true`, the component will display a loading indicator.                                                                             |
 | `options`         | Optional | `Object`                   | -       | Props to pass to the underlying `<RadioButtonGroup>` element                                                                           |
 | `optionText`      | Optional | `string` &#124; `Function` | `name`  | Field name of record to display in the suggestion item or function which accepts the current record as argument (`record => {string}`) |
 | `optionValue`     | Optional | `string`                   | `id`    | Field name of record containing the value to use as input value                                                                        |

--- a/docs/RadioButtonGroupInput.md
+++ b/docs/RadioButtonGroupInput.md
@@ -275,13 +275,13 @@ Note that `translateChoice` is set to `false` when `<RadioButtonGroupInput>` is 
 You can use [`useGetList`](./useGetList.md) to fetch choices. For example, to fetch a list of countries for a user profile:
 
 ```jsx
-import { useGetList, RadioButtonInput } from 'react-admin';
+import { useGetList, RadioButtonGroupInput } from 'react-admin';
 
 const CountryInput = () => {
     const { data, isLoading } = useGetList('countries');
     // data is an array of { id: 123, code: 'FR', name: 'France' }
     return (
-        <RadioButtonInput 
+        <RadioButtonGroupInput 
             source="country"
             choices={data}
             optionText="name"
@@ -294,16 +294,16 @@ const CountryInput = () => {
 
 The `isLoading` prop is used to display a loading indicator while the data is being fetched.
 
-However, most of the time, if you need to populate a `<RadioButtonInput>` with choices fetched from another resource, it's because you are trying to set a foreign key. In that case, you should use [`<ReferenceInput>`](./ReferenceInput.md) to fetch the choices instead (see next section). 
+However, most of the time, if you need to populate a `<RadioButtonGroupInput>` with choices fetched from another resource, it's because you are trying to set a foreign key. In that case, you should use [`<ReferenceInput>`](./ReferenceInput.md) to fetch the choices instead (see next section). 
 
 ## Selecting a Foreign Key
 
-If you use `<RadioButtonInput>` to set a foreign key for a many-to-one or a one-to-one relationship, you'll have to [fetch choices](#fetching-choices), as explained in the previous section. You'll also have to fetch the record corresponding to the current value of the foreign key, as it may not be in the list of choices. 
+If you use `<RadioButtonGroupInput>` to set a foreign key for a many-to-one or a one-to-one relationship, you'll have to [fetch choices](#fetching-choices), as explained in the previous section. You'll also have to fetch the record corresponding to the current value of the foreign key, as it may not be in the list of choices. 
 
 For example, if a `contact` has one `company` via the `company_id` foreign key, a contact form can let users select a company as follows:
 
 ```jsx
-import { useGetList, useGetOne, RadioButtonInput } from 'react-admin';
+import { useGetList, useGetOne, RadioButtonGroupInput } from 'react-admin';
 import { useWatch } from 'react-hook-form';
 
 const CompanyInput = () => {
@@ -321,7 +321,7 @@ const CompanyInput = () => {
             : [...choices, currentCompany]
         : [];
     return (
-        <RadioButtonInput 
+        <RadioButtonGroupInput 
             label="Company"
             source="company_id"
             choices={choicesWithCurrentCompany}
@@ -335,11 +335,11 @@ const CompanyInput = () => {
 As this is a common task, react-admin provides a shortcut to do the same in a declarative way: [`<ReferenceInput>`](./ReferenceInput.md):
 
 ```jsx
-import { ReferenceInput, RadioButtonInput } from 'react-admin';
+import { ReferenceInput, RadioButtonGroupInput } from 'react-admin';
 
 const CompanyInput = () => (
     <ReferenceInput reference="companies" source="company_id">
-        <RadioButtonInput 
+        <RadioButtonGroupInput 
             label="Company"
             source="company_id"
             optionText="name"
@@ -354,26 +354,26 @@ const CompanyInput = () => (
  - puts the result of the fetch in the `ChoiceContext` as the `choices` prop, as well as the `isLoading` state,
  - and renders its child component
 
-When rendered as a child of `<ReferenceInput>`, `<RadioButtonInput>` reads that `ChoiceContext` to populate its own `choices` and `isLoading` props.
+When rendered as a child of `<ReferenceInput>`, `<RadioButtonGroupInput>` reads that `ChoiceContext` to populate its own `choices` and `isLoading` props.
 
 In fact, you can simplify the code even further:
 
-- `<ReferenceInput>` puts all its props inside the `ChoiceContext`, including `source`, so `<RadioButtonInput>` doesn't need to repeat it.
-- You can also put the `label` prop on the `<ReferenceInput>` rather than `<RadioButtonInput>` so that it looks just like [`<ReferenceField>`](./ReferenceField.md) (for easier memorization). 
-- `<RadioButtonInput>` uses the [`recordRepresentation`](./Resource.md#recordrepresentation) to determine how to represent the related choices. In the example above, the `companies` resource uses `name` as its `recordRepresentation`, so `<RadioButtonInput>` will default to `optionText="name"`. 
+- `<ReferenceInput>` puts all its props inside the `ChoiceContext`, including `source`, so `<RadioButtonGroupInput>` doesn't need to repeat it.
+- You can also put the `label` prop on the `<ReferenceInput>` rather than `<RadioButtonGroupInput>` so that it looks just like [`<ReferenceField>`](./ReferenceField.md) (for easier memorization). 
+- `<RadioButtonGroupInput>` uses the [`recordRepresentation`](./Resource.md#recordrepresentation) to determine how to represent the related choices. In the example above, the `companies` resource uses `name` as its `recordRepresentation`, so `<RadioButtonGroupInput>` will default to `optionText="name"`. 
 
 The code for the `<CompanyInput>` component can be reduced to:
 
 ```jsx
-import { ReferenceInput, RadioButtonInput } from 'react-admin';
+import { ReferenceInput, RadioButtonGroupInput } from 'react-admin';
 
 const CompanyInput = () => (
     <ReferenceInput reference="companies" source="company_id" label="Company">
-        <RadioButtonInput />
+        <RadioButtonGroupInput />
     </ReferenceInput>
 );
 ```
 
-This is the recommended approach for using `<RadioButtonInput>` to select a foreign key. This not only signifies that the input is a `<RadioButtonInput>` but also highlights its function in fetching choices from another resource, ultimately enhancing the code's readability.
+This is the recommended approach for using `<RadioButtonGroupInput>` to select a foreign key. This not only signifies that the input is a `<RadioButtonGroupInput>` but also highlights its function in fetching choices from another resource, ultimately enhancing the code's readability.
 
-**Tip**: `<ReferenceInput>` is much more powerful than the initial snippet. It optimizes and caches API calls, enables refetching of both API calls with a single command, and stores supplementary data in the `<ChoicesContext>`. `<ReferenceInput>` can provide choices to `<RadioButtonInput>`, but also to [`<AutocompleteInput>`](./AutocompleteInput.md) and [`<SelectInput>`](./SelectInput.md). For further information, refer to [the `<ReferenceInput>` documentation](./ReferenceInput.md).
+**Tip**: `<ReferenceInput>` is much more powerful than the initial snippet. It optimizes and caches API calls, enables refetching of both API calls with a single command, and stores supplementary data in the `<ChoicesContext>`. `<ReferenceInput>` can provide choices to `<RadioButtonGroupInput>`, but also to [`<AutocompleteInput>`](./AutocompleteInput.md) and [`<SelectInput>`](./SelectInput.md). For further information, refer to [the `<ReferenceInput>` documentation](./ReferenceInput.md).

--- a/docs/RadioButtonGroupInput.md
+++ b/docs/RadioButtonGroupInput.md
@@ -121,6 +121,28 @@ const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }
 <RadioButtonGroupInput source="category" choices={choices} />
 ```
 
+## `isLoading`
+
+When [fetching choices from a remote API](#fetching-choices), the `<RadioButtonGroupInput>` can't be used until the choices are fetched. To let the user know, you can pass the `isLoading` prop to `<RadioButtonGroupInput>`. This displays a loading indicator while the choices are being fetched.
+
+```jsx
+import { useGetList, RadioButtonGroupInput } from 'react-admin';
+
+const UserCountry = () => {
+    const { data, isLoading } = useGetList('countries');
+    // data is an array of { id: 123, code: 'FR', name: 'France' }
+    return (
+        <RadioButtonGroupInput 
+            source="country"
+            choices={data}
+            optionText="name"
+            optionValue="code"
+            isLoading={isLoading}
+        />
+    );
+}
+```
+
 ## `options`
 
 Use the `options` attribute if you want to override any of MUI's `<RadioGroup>` attributes:

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -383,7 +383,7 @@ In that case, set the `translateChoice` prop to `false`.
 <SelectArrayInput source="roles" choices={choices} translateChoice={false}/>
 ```
 
-## Using in a ReferenceArrayInput
+## Fetching Choices
 
 If you want to populate the `choices` attribute with a list of related records, you should decorate `<SelectArrayInput>` with [`<ReferenceArrayInput>`](./ReferenceArrayInput.md), and leave the `choices` empty:
 
@@ -413,6 +413,8 @@ export const PostCreate = () => (
 ```
 
 **Tip**: As it does not provide autocompletion, `<SelectArrayInput>` might not be suited when the reference resource has a lot of items.
+
+Check [the `<ReferenceArrayInput>` documentation](./ReferenceArrayInput.md) for more details.
 
 ## Creating New Choices
 

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -41,8 +41,8 @@ The form value for the source must be the selected value, e.g.
 
 **Tip**: React-admin includes other components to edit such values:
 
- - [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md) renders a list of radio buttons
  - [`<AutocompleteInput>`](./AutocompleteInput.md) renders a list of suggestions in an autocomplete input
+ - [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md) renders a list of radio buttons
 
 **Tip**: If you need to let users select more than one item in the list, check out the [`<SelectArrayInput>`](./SelectArrayInput.md) component.
 
@@ -506,7 +506,7 @@ const UserCountry = () => {
 
 The `isLoading` prop is used to display a loading indicator while the data is being fetched.
 
-But most of the time, if you need to populate a `<SelectInput>` with choices fetched from another resource, it's because you're trying to set a foreign key. In that case, you should use [`<ReferenceInput>`](./ReferenceInput.md) to fetch the choices instead (see next section). 
+However, most of the time, if you need to populate a `<SelectInput>` with choices fetched from another resource, it's because you are trying to set a foreign key. In that case, you should use [`<ReferenceInput>`](./ReferenceInput.md) to fetch the choices instead (see next section). 
 
 ## Selecting a Foreign Key
 
@@ -568,7 +568,13 @@ const CompanyInput = () => (
 
 When rendered as a child of `<ReferenceInput>`, `<SelectInput>` reads that `ChoiceContext` to populate its own `choices` and `isLoading` props.
 
-In fact, `<ReferenceInput>` puts all its props inside the `ChoiceContext`, ready for its children to use. And `<SelectInput>` uses the [`recordRepresentation`](./Resource.md#recordrepresentation) to determine how to represent the related choices. In the example above, the `companies` resource uses `name` as its `recordRepresentation`, so `<SelectInput>` will default to `optionText="name"`. This means that you can simplify the previous example even further by lifting the `label` prop to the `<ReferenceInput>`, and removing the `source` and `optionText` props from `<SelectInput>`:
+In fact, you can simplify the code even further:
+
+- `<ReferenceInput>` puts all its props inside the `ChoiceContext`, including `source`, so `<SelectInput>` doesn't need to repeat it.
+- You can also put the `label` prop on the `<ReferenceInput>` rather than `<SelectInput>` so that it looks just like [`<ReferenceField>`](./ReferenceField.md) (for easier memorization). 
+- `<SelectInput>` uses the [`recordRepresentation`](./Resource.md#recordrepresentation) to determine how to represent the related choices. In the example above, the `companies` resource uses `name` as its `recordRepresentation`, so `<SelectInput>` will default to `optionText="name"`. 
+
+The code for the `<CompanyInput>` component can be reduced to:
 
 ```jsx
 import { ReferenceInput, SelectInput } from 'react-admin';
@@ -580,9 +586,9 @@ const CompanyInput = () => (
 );
 ```
 
-This is the recommended way to use `<SelectInput>` to select a foreign key. `<ReferenceInput>` expresses that the input is not just a `<SelectInput>`, but a `<SelectInput>` that fetches choices from another resource. It also makes the code more readable.
+This is the recommended approach for using `<SelectInput>` to select a foreign key. This not only signifies that the input is a `<SelectInput>` but also highlights its function in fetching choices from another resource, ultimately enhancing the code's readability.
 
-**Tip**: `<ReferenceInput>` is much more powerful than the initial snippet. It optimizes and caches API calls, allows to refetch both API calls in one command, and stores additional data in the `<ChoicesContext>`. It can provide choices to `<SelectInput>`, but also to [`<AutocompleteInput>`](./AutocompleteInput.md) and [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md). See [the `<ReferenceInput>` documentation](./ReferenceInput.md) for more details.
+**Tip**: `<ReferenceInput>` is much more powerful than the initial snippet. It optimizes and caches API calls, enables refetching of both API calls with a single command, and stores supplementary data in the `<ChoicesContext>`. `<ReferenceInput>` can provide choices to `<SelectInput>`, but also to [`<AutocompleteInput>`](./AutocompleteInput.md) and [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md). For further information, refer to [the `<ReferenceInput>` documentation](./ReferenceInput.md).
 
 ## Creating New Choices
 

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -489,7 +489,7 @@ You can use [`useGetList`](./useGetList.md) to fetch choices. For example, to fe
 ```jsx
 import { useGetList, SelectInput } from 'react-admin';
 
-const UserCountry = () => {
+const CountryInput = () => {
     const { data, isLoading } = useGetList('countries');
     // data is an array of { id: 123, code: 'FR', name: 'France' }
     return (

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -134,7 +134,7 @@ If you need to *fetch* the options from another resource, you're actually editin
 </ReferenceInput>
 ```
 
-See [Using in a `ReferenceInput>`](#using-in-a-referenceinput) below for more information.
+See [Selecting a foreign key](#selecting-a-foreign-key) below for more information.
 
 If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
 

--- a/packages/ra-core/src/dataProvider/useGetList.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.stories.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { CoreAdminContext } from '../core';
+import { useGetList } from './useGetList';
+
+export default {
+    title: 'ra-core/dataProvider/useGetList',
+};
+
+const UseGetList = () => {
+    const hookValue = useGetList('posts');
+    return <pre>{JSON.stringify(hookValue, undefined, '  ')}</pre>;
+};
+export const NoArgs = () => {
+    return (
+        <CoreAdminContext
+            dataProvider={{
+                getList: async () => ({
+                    data: [{ id: 1, title: 'foo' }],
+                    total: 1,
+                }),
+            }}
+        >
+            <UseGetList />
+        </CoreAdminContext>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -134,6 +134,23 @@ export const Nullable = ({ onSuccess = console.log }) => {
     );
 };
 
+export const IsLoading = () => {
+    return (
+        <Admin dataProvider={dataProvider} history={history}>
+            <Resource
+                name="books"
+                edit={() => (
+                    <Edit>
+                        <SimpleForm>
+                            <AutocompleteInput source="author" isLoading />
+                        </SimpleForm>
+                    </Edit>
+                )}
+            />
+        </Admin>
+    );
+};
+
 const BookEditCustomText = () => {
     const choices = [
         { id: 1, fullName: 'Leo Tolstoy' },

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CircularProgress } from '@mui/material';
+import { CircularProgress, InputAdornment } from '@mui/material';
 import { styled, SxProps } from '@mui/material/styles';
 import { useTimeout } from 'ra-core';
 
@@ -34,11 +34,15 @@ export const LoadingInput = ({
             disabled
             onChange={() => {}}
             InputProps={{
-                endAdornment: oneSecondHasPassed ? (
-                    <CircularProgress color="inherit" size={20} />
-                ) : (
-                    // use an adornment of the same size to avoid visual jumps
-                    <span style={{ width: 20 }}>&nbsp;</span>
+                endAdornment: (
+                    <InputAdornment position="end">
+                        {oneSecondHasPassed ? (
+                            <CircularProgress color="inherit" size={20} />
+                        ) : (
+                            // use an adornment of the same size to avoid visual jumps
+                            <span style={{ width: 20 }}>&nbsp;</span>
+                        )}
+                    </InputAdornment>
                 ),
             }}
         />

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.stories.tsx
@@ -60,6 +60,12 @@ export const Invalid = () => (
     </Wrapper>
 );
 
+export const IsLoading = () => (
+    <Wrapper>
+        <RadioButtonGroupInput source="category" isLoading />
+    </Wrapper>
+);
+
 const dataProvider = testDataProvider({
     getList: () => Promise.resolve({ data: choices, total: choices.length }),
     getMany: (resource, params) =>

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -78,6 +78,12 @@ export const Disabled = () => (
     </Wrapper>
 );
 
+export const IsLoading = () => (
+    <Wrapper>
+        <SelectInput source="gender" isLoading />
+    </Wrapper>
+);
+
 export const Validate = () => (
     <Wrapper>
         <SelectInput

--- a/packages/ra-ui-materialui/src/layout/LinearProgress.tsx
+++ b/packages/ra-ui-materialui/src/layout/LinearProgress.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import Progress, {
+import {
+    Box,
+    LinearProgress as MuiLinearProgress,
     LinearProgressProps as ProgressProps,
-} from '@mui/material/LinearProgress';
+} from '@mui/material';
 import PropTypes from 'prop-types';
 import { useTimeout } from 'ra-core';
 
@@ -31,7 +33,9 @@ export const LinearProgress = ({
 
     return oneSecondHasPassed ? (
         <StyledProgress className={className} {...rest} />
-    ) : null;
+    ) : (
+        <Box my={1} height={4} />
+    );
 };
 
 LinearProgress.propTypes = {
@@ -48,7 +52,7 @@ export interface LinearProgressProps extends ProgressProps {
 
 const PREFIX = 'RaLinearProgress';
 
-const StyledProgress = styled(Progress, {
+const StyledProgress = styled(MuiLinearProgress, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({


### PR DESCRIPTION
## Problem

For `<SelectInput>` and other selection inputs, we document fetching related records by advertising the solution ("using in `<ReferenceInput>` rather than the problem ("Fetching choices"). 

As a consequence, newcomers struggle to understand that `ReferenceInput` thing. 

## Solution

Write the doc the other way around. 