### PR TITLE
Fix ReferenceOneField shows wrong sort order when used in a Datagrid

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
@@ -209,7 +209,8 @@ const ListWrapper = ({ children }) => (
                     {
                         total: 1,
                         data: [{ id: 1, title: 'War and Peace' }],
-                        sort: { field: 'title', order: 'ASC' },
+                        sort: { field: 'id', order: 'ASC' },
+                        setSort: () => {},
                     } as any
                 }
             >
@@ -222,6 +223,7 @@ const ListWrapper = ({ children }) => (
 export const InDatagrid = () => (
     <ListWrapper>
         <Datagrid>
+            <TextField source="id" />
             <TextField source="title" />
             <ReferenceOneField
                 label="ISBN"

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -123,4 +123,8 @@ ReferenceOneField.propTypes = {
 
 ReferenceOneField.defaultProps = {
     source: 'id',
+    // disable sorting on this field by default as its default source prop ('id')
+    // will match the default sort ({ field: 'id', order: 'DESC'})
+    // leading to an incorrect sort indicator in a datagrid header
+    sortable: false,
 };


### PR DESCRIPTION
Closes #8486