### PR TITLE
fix: `<BooleanInput helperText={false} />` displays `FormHelperText` anyway

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -91,13 +91,15 @@ export const BooleanInput = (props: BooleanInputProps) => {
                     />
                 }
             />
-            <FormHelperText error={(isTouched || isSubmitted) && invalid}>
-                <InputHelperText
-                    touched={isTouched || isSubmitted}
-                    error={error?.message}
-                    helperText={helperText}
-                />
-            </FormHelperText>
+            {helperText !== false && (
+                <FormHelperText error={(isTouched || isSubmitted) && invalid}>
+                    <InputHelperText
+                        touched={isTouched || isSubmitted}
+                        error={error?.message}
+                        helperText={helperText}
+                    />
+                </FormHelperText>
+            )}
         </FormGroup>
     );
 };


### PR DESCRIPTION
Fix #8829
