### PR TITLE
Fix `<Button>` accepts user defined MUI color palettes as `color` property

### DIFF
--- a/packages/ra-ui-materialui/src/button/Button.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.stories.tsx
@@ -10,9 +10,15 @@ export default { title: 'ra-ui-materialui/button/Button' };
 export const Basic = () => (
     <ThemeProvider theme={theme}>
         <UIWrapper>
-            <Button label="button" />
-            <Button label="button" variant="outlined" />
-            <Button label="button" variant="contained" />
+            <Button label="default" />
+            <Button label="outlined" variant="outlined" />
+            <Button label="contained" variant="contained" />
+            <Button label="error contained" color="error" variant="contained" />
+            <Button
+                label="secondary contained"
+                color="secondary"
+                variant="contained"
+            />
         </UIWrapper>
     </ThemeProvider>
 );
@@ -50,7 +56,14 @@ export const WithUserDefinedPalette = () => (
 );
 
 const UIWrapper = ({ children }: { children: ReactNode }) => (
-    <Stack sx={{ alignItems: 'flex-start', gap: 1, margin: 1 }}>
+    <Stack
+        sx={{
+            gap: 1,
+            alignItems: 'flex-start',
+            margin: 2,
+            padding: 2,
+        }}
+    >
         {children}
     </Stack>
 );

--- a/packages/ra-ui-materialui/src/button/Button.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.stories.tsx
@@ -1,23 +1,82 @@
 import * as React from 'react';
-import { ThemeProvider } from '@mui/material';
-import { createTheme } from '@mui/material/styles';
+import { createTheme, ThemeProvider, Stack } from '@mui/material';
+import type { PaletteColor } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { Button } from './Button';
-
-const theme = createTheme();
+import { ReactNode } from 'react';
 
 export default { title: 'ra-ui-materialui/button/Button' };
 
 export const Basic = () => (
     <ThemeProvider theme={theme}>
-        <Button label="button" />
+        <UIWrapper>
+            <Button label="button" />
+            <Button label="button" variant="outlined" />
+            <Button label="button" variant="contained" />
+        </UIWrapper>
     </ThemeProvider>
 );
 
 export const WithIcon = () => (
     <ThemeProvider theme={theme}>
-        <Button label="button">
-            <AddIcon />
-        </Button>
+        <UIWrapper>
+            <Button label="button">
+                <AddIcon />
+            </Button>
+            <Button label="button" variant="outlined">
+                <AddIcon />
+            </Button>
+            <Button label="button" variant="contained">
+                <AddIcon />
+            </Button>
+        </UIWrapper>
     </ThemeProvider>
 );
+
+export const WithUserDefinedPalette = () => (
+    <ThemeProvider theme={theme}>
+        <UIWrapper>
+            <Button label="button" color="userDefined">
+                <AddIcon />
+            </Button>
+            <Button label="button" color="userDefined" variant="outlined">
+                <AddIcon />
+            </Button>
+            <Button label="button" color="userDefined" variant="contained">
+                <AddIcon />
+            </Button>
+        </UIWrapper>
+    </ThemeProvider>
+);
+
+const UIWrapper = ({ children }: { children: ReactNode }) => (
+    <Stack sx={{ alignItems: 'flex-start', gap: 1, margin: 1 }}>
+        {children}
+    </Stack>
+);
+
+const theme = createTheme({
+    palette: {
+        userDefined: {
+            light: '#18DBAD',
+            main: '#07CC9D',
+            dark: '#07BA8F',
+            contrastText: '#ffffff',
+        },
+    },
+});
+
+declare module '@mui/material/styles' {
+    interface Palette {
+        userDefined: PaletteColor;
+    }
+    interface PaletteOptions {
+        userDefined: PaletteColor;
+    }
+}
+
+declare module '@mui/material/Button' {
+    interface ButtonPropsColorOverrides {
+        userDefined: true;
+    }
+}

--- a/packages/ra-ui-materialui/src/button/Button.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.stories.tsx
@@ -68,6 +68,10 @@ const UIWrapper = ({ children }: { children: ReactNode }) => (
     </Stack>
 );
 
+/**
+ * Adding new theme tokens to the palette
+ * @see https://mui.com/material-ui/experimental-api/css-theme-variables/customization/#typescript
+ */
 const theme = createTheme({
     palette: {
         userDefined: {
@@ -88,6 +92,10 @@ declare module '@mui/material/styles' {
     }
 }
 
+/**
+ * Adding new theme tokens to the Button
+ * https://mui.com/joy-ui/customization/themed-components/#theme-style-overrides
+ */
 declare module '@mui/material/Button' {
     interface ButtonPropsColorOverrides {
         userDefined: true;

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -7,7 +7,6 @@ import {
     Tooltip,
     IconButton,
     useMediaQuery,
-    PropTypes as MuiPropTypes,
     Theme,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -94,7 +94,6 @@ interface Props {
     alignIcon?: 'left' | 'right';
     children?: ReactElement;
     className?: string;
-    color?: MuiPropTypes.Color;
     component?: ElementType;
     to?: string | LocationDescriptor;
     disabled?: boolean;

--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -47,6 +47,7 @@ const CreateButton = (props: CreateButtonProps) => {
             component={Link}
             to={createPath({ resource, type: 'create' })}
             state={scrollStates[String(scrollToTop)]}
+            // @ts-ignore FabProps ships its own runtime palette `FabPropsColorOverrides` provoking an overlap error with `ButtonProps`
             color="primary"
             className={clsx(CreateButtonClasses.floating, className)}
             aria-label={label && translate(label)}


### PR DESCRIPTION
Fix #8831 

### Storybook snapshot

![Screenshot from 2023-04-12 18-30-17](https://user-images.githubusercontent.com/102964006/231522690-6f272dc1-6f7c-42dc-be21-e2d707713cba.png)
