### PR TITLE
docs: repeated information

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -849,22 +849,6 @@ const PostList = () => (
 
 **Tip**: The `List` component `classes` can also be customized for all instances of the component with its global css name `RaList` as [describe here](https://marmelab.com/blog/2019/12/18/react-admin-3-1.html#theme-overrides)
 
-## Adding `meta` To The DataProvider Call
-
-Use [the `queryOptions` prop](#queryoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getList()` call.
-
-{% raw %}
-```jsx
-import { List } from 'react-admin';
-
-const PostList = () => (
-    <List queryOptions={{ meta: { foo: 'bar' } }}>
-        ...
-    </List>
-);
-```
-{% endraw %}
-
 ## Live Updates
 
 If you want to subscribe to live updates on the list of records (topic: `resource/[resource]`), use [the `<ListLive>` component](./ListLive.md) instead.


### PR DESCRIPTION
Adding meta to dataProvider call is already mentioned in `queryOptions` section.