### PR TITLE
feat: add ctrl(command)+click open on a new tab to DatagridRow

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -114,7 +114,11 @@ const DatagridRow: FC<DatagridRowProps> = React.forwardRef((props, ref) => {
                 return;
             }
             if (['edit', 'show'].includes(type)) {
-                navigate(createPath({ resource, id, type }));
+                if(event.ctrlKey || event.metaKey) {
+                    window.open(`#${createPath({ resource, id, type })}`);
+                } else {
+                    navigate(createPath({ resource, id, type }));
+                }
                 return;
             }
             if (type === 'expand') {
@@ -241,7 +245,11 @@ DatagridRow.propTypes = {
     record: PropTypes.object,
     resource: PropTypes.string,
     // @ts-ignore
-    rowClick: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    rowClick: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.bool,
+    ]),
     selected: PropTypes.bool,
     style: PropTypes.object,
     selectable: PropTypes.bool,


### PR DESCRIPTION
It's a common use case to be able to open links on a new tab using ctrl+click. These changes are supposed to add such a feature to the List's DatagridRow component.

relates to:
- https://github.com/marmelab/react-admin/pull/6051
- https://github.com/marmelab/react-admin/issues/3347