### PR TITLE
Clarify DateField types

### DIFF
--- a/packages/ra-ui-materialui/src/field/DateField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.spec.tsx
@@ -107,7 +107,7 @@ describe('<DateField />', () => {
 
     it('should pass the options prop to toLocaleString', () => {
         const date = new Date('2017-04-23');
-        const options = {
+        const options: Intl.DateTimeFormatOptions = {
             weekday: 'long',
             year: 'numeric',
             month: 'long',

--- a/packages/ra-ui-materialui/src/field/DateField.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.tsx
@@ -129,7 +129,7 @@ export interface DateFieldProps
     extends PublicFieldProps,
         InjectedFieldProps,
         Omit<TypographyProps, 'textAlign'> {
-    locales?: string | string[];
+    locales?: Intl.LocalesArgument;
     options?: Intl.DateTimeFormatOptions;
     showTime?: boolean;
     showDate?: boolean;

--- a/packages/ra-ui-materialui/src/field/DateField.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.tsx
@@ -130,7 +130,7 @@ export interface DateFieldProps
         InjectedFieldProps,
         Omit<TypographyProps, 'textAlign'> {
     locales?: string | string[];
-    options?: object;
+    options?: Intl.DateTimeFormatOptions;
     showTime?: boolean;
     showDate?: boolean;
 }


### PR DESCRIPTION
Clarifies the types for `DateField`. Both `locales` and `options` are expected to be used in `.toLocaleDateString`, which has more specific (and built-in/native) types we can leverage. Setting to more explicit types provides useful auto-correct and documentation.