### PR TITLE
fix: credentials and headers belong to HttpLink

### DIFF
--- a/packages/ra-data-graphql/src/buildApolloClient.ts
+++ b/packages/ra-data-graphql/src/buildApolloClient.ts
@@ -15,7 +15,9 @@ export default (options: Partial<ApolloClientOptions<unknown>>) => {
     const {
         cache = new InMemoryCache().restore({}),
         uri,
-        link = !!uri ? new HttpLink({ uri }) : undefined,
+        credentials,
+        headers,
+        link = !!uri ? new HttpLink({ uri, credentials, headers }) : undefined,
         ...otherOptions
     } = options;
 


### PR DESCRIPTION
We need to pass credentials and headers to HttpLink to correctly build a fetch instance

CoAuthored with @dgopsq