### PR TITLE
fix: valid value for prop `sx` on <div> tag using ImageField

### DIFF
--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -27,6 +27,7 @@ export const ImageField = (props: ImageFieldProps) => {
             </Typography>
         ) : (
             <Typography
+                component="div"
                 className={className}
                 {...sanitizeFieldRestProps(rest)}
             />

--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -26,7 +26,10 @@ export const ImageField = (props: ImageFieldProps) => {
                 {emptyText && translate(emptyText, { _: emptyText })}
             </Typography>
         ) : (
-            <div className={className} {...sanitizeFieldRestProps(rest)} />
+            <Typography
+                className={className}
+                {...sanitizeFieldRestProps(rest)}
+            />
         );
     }
 


### PR DESCRIPTION
If you have many menu items, navigating between them can produce temporary invalid records with empty sourceValue, in this case sometimes we received this error **valid value for prop `sx` on <div> tag** related to the usage of `ImageField` with specification of `sx` prop. 

To avoid this we replaced standard `div` with `Typography` that can accept sx without problems.