### PR TITLE
Fix infinite redirection loop in useHandleCallback

### DIFF
--- a/packages/ra-core/src/auth/useHandleAuthCallback.spec.tsx
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.spec.tsx
@@ -98,50 +98,6 @@ describe('useHandleAuthCallback', () => {
         });
     });
 
-    it('should logout and not redirect to any page when the callback was not successfully handled', async () => {
-        const history = createMemoryHistory({ initialEntries: ['/'] });
-        render(
-            <HistoryRouter history={history}>
-                <AuthContext.Provider
-                    value={{
-                        ...authProvider,
-                        handleCallback: () => Promise.reject(),
-                    }}
-                >
-                    <QueryClientProvider client={queryClient}>
-                        <TestComponent />
-                    </QueryClientProvider>
-                </AuthContext.Provider>
-            </HistoryRouter>
-        );
-        await waitFor(() => {
-            expect(logout).toHaveBeenCalled();
-            expect(redirect).not.toHaveBeenCalled();
-        });
-    });
-
-    it('should redirect to the provided route when the callback was not successfully handled', async () => {
-        const history = createMemoryHistory({ initialEntries: ['/'] });
-        render(
-            <HistoryRouter history={history}>
-                <AuthContext.Provider
-                    value={{
-                        ...authProvider,
-                        handleCallback: () =>
-                            Promise.reject({ redirectTo: '/test' }),
-                    }}
-                >
-                    <QueryClientProvider client={queryClient}>
-                        <TestComponent />
-                    </QueryClientProvider>
-                </AuthContext.Provider>
-            </HistoryRouter>
-        );
-        await waitFor(() => {
-            expect(redirect).toHaveBeenCalledWith('/test');
-        });
-    });
-
     it('should use custom useQuery options such as onError', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] });
         render(

--- a/packages/ra-core/src/auth/useHandleAuthCallback.ts
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.ts
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router';
 import { useRedirect } from '../routing';
 import { AuthProvider, AuthRedirectResult } from '../types';
 import useAuthProvider from './useAuthProvider';
-import useLogout from './useLogout';
 
 /**
  * This hook calls the `authProvider.handleCallback()` method on mount. This is meant to be used in a route called
@@ -17,7 +16,6 @@ export const useHandleAuthCallback = (
 ) => {
     const authProvider = useAuthProvider();
     const redirect = useRedirect();
-    const logout = useLogout();
     const location = useLocation();
     const locationState = location.state as any;
     const nextPathName = locationState && locationState.nextPathname;
@@ -45,19 +43,6 @@ export const useHandleAuthCallback = (
                 }
 
                 redirect(redirectTo ?? defaultRedirectUrl);
-            },
-            onError: err => {
-                const { redirectTo = false, logoutOnFailure = true } = (err ??
-                    {}) as AuthRedirectResult;
-
-                if (logoutOnFailure) {
-                    logout({}, redirectTo);
-                }
-                if (redirectTo === false) {
-                    return;
-                }
-
-                redirect(redirectTo);
             },
             ...options,
         }


### PR DESCRIPTION
The default `AuthCallback` handles the error by showing a message.
The previous `onError` was preventing that and triggered an infinite loop