### PR TITLE
Fix custom input's onChange handlers should have access to updated context value

### DIFF
--- a/packages/ra-core/src/form/useInput.spec.tsx
+++ b/packages/ra-core/src/form/useInput.spec.tsx
@@ -17,6 +17,25 @@ const Input: FunctionComponent<
     return children(inputProps);
 };
 
+const InputWithCustomOnChange: FunctionComponent<
+    {
+        children: (props: ReturnType<typeof useInput>) => ReactElement;
+    } & InputProps
+> = ({ children, ...props }) => {
+    const { getValues } = useFormContext();
+
+    return (
+        <Input
+            {...props}
+            onChange={e => {
+                props.onChange(e, getValues()[props.source]);
+            }}
+        >
+            {children}
+        </Input>
+    );
+};
+
 describe('useInput', () => {
     it('returns the props needed for an input', () => {
         let inputProps;
@@ -104,6 +123,43 @@ describe('useInput', () => {
 
         fireEvent.blur(input);
         expect(handleBlur).toHaveBeenCalled();
+    });
+
+    it('custom onChange handler should have access to updated context input value', () => {
+        let targetValue, contextValue;
+        const handleChange = (e, formContextValue) => {
+            targetValue = e.target.value;
+            contextValue = formContextValue;
+        };
+
+        render(
+            <CoreAdminContext dataProvider={testDataProvider()}>
+                <Form onSubmit={jest.fn()}>
+                    <InputWithCustomOnChange
+                        source="title"
+                        resource="posts"
+                        onChange={handleChange}
+                        defaultValue=""
+                    >
+                        {({ id, field }) => (
+                            <input
+                                type="text"
+                                id={id}
+                                aria-label="Title"
+                                {...field}
+                            />
+                        )}
+                    </InputWithCustomOnChange>
+                </Form>
+            </CoreAdminContext>
+        );
+        const input = screen.getByLabelText('Title');
+
+        fireEvent.change(input, {
+            target: { value: 'Changed title' },
+        });
+        expect(targetValue).toBe('Changed title');
+        expect(contextValue).toBe('Changed title');
     });
 
     describe('defaultValue', () => {

--- a/packages/ra-core/src/form/useInput.spec.tsx
+++ b/packages/ra-core/src/form/useInput.spec.tsx
@@ -20,15 +20,16 @@ const Input: FunctionComponent<
 const InputWithCustomOnChange: FunctionComponent<
     {
         children: (props: ReturnType<typeof useInput>) => ReactElement;
-    } & InputProps
-> = ({ children, ...props }) => {
+    } & InputProps & { getContextValue?: (value: string) => void }
+> = ({ children, getContextValue, ...props }) => {
     const { getValues } = useFormContext();
 
     return (
         <Input
             {...props}
             onChange={e => {
-                props.onChange(e, getValues()[props.source]);
+                props.onChange(e);
+                getContextValue(getValues()[props.source]);
             }}
         >
             {children}
@@ -127,9 +128,11 @@ describe('useInput', () => {
 
     it('custom onChange handler should have access to updated context input value', () => {
         let targetValue, contextValue;
-        const handleChange = (e, formContextValue) => {
+        const handleChange = e => {
             targetValue = e.target.value;
-            contextValue = formContextValue;
+        };
+        const getContextValue = value => {
+            contextValue = value;
         };
 
         render(
@@ -139,6 +142,7 @@ describe('useInput', () => {
                         source="title"
                         resource="posts"
                         onChange={handleChange}
+                        getContextValue={getContextValue}
                         defaultValue=""
                     >
                         {({ id, field }) => (

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -93,21 +93,21 @@ export const useInput = <ValueType = any>(
     useApplyInputDefaultValues(props);
 
     const onBlur = useEvent((...event: any[]) => {
+        controllerField.onBlur();
         if (initialOnBlur) {
             initialOnBlur(...event);
         }
-        controllerField.onBlur();
     });
 
     const onChange = useEvent((...event: any[]) => {
-        if (initialOnChange) {
-            initialOnChange(...event);
-        }
         const eventOrValue = (props.type === 'checkbox' &&
         event[0]?.target?.value === 'on'
             ? event[0].target.checked
             : event[0]?.target?.value ?? event[0]) as any;
         controllerField.onChange(parse ? parse(eventOrValue) : eventOrValue);
+        if (initialOnChange) {
+            initialOnChange(...event);
+        }
     });
 
     const field = {


### PR DESCRIPTION
I'm updating a project from ra-v3 to ra-v4 where the value of change inputs is taken from the Form state within the onChange / onBlur event handler (instead of its `e.target.value` argument), and it doesn't have the updated value.

I found out that :
In react-admin **v3** inputs run custom event handlers **after** react-final-form ones.
In react-admin **v4** inputs run custom event handlers **before** react-hook-form ones.

So, changing this order of execution to match ra-v3 allows `useFormContext().getValues()` to have the latest value inside the custom event handlers.
