### PR TITLE
Fix custom input's onChange handlers should have access to updated context value

### DIFF
--- a/packages/ra-core/src/form/useInput.spec.tsx
+++ b/packages/ra-core/src/form/useInput.spec.tsx
@@ -20,8 +20,8 @@ const Input: FunctionComponent<
 const InputWithCustomOnChange: FunctionComponent<
     {
         children: (props: ReturnType<typeof useInput>) => ReactElement;
-    } & InputProps & { getContextValue?: (value: string) => void }
-> = ({ children, getContextValue, ...props }) => {
+    } & InputProps & { setContextValue?: (value: string) => void }
+> = ({ children, setContextValue, ...props }) => {
     const { getValues } = useFormContext();
 
     return (
@@ -29,7 +29,7 @@ const InputWithCustomOnChange: FunctionComponent<
             {...props}
             onChange={e => {
                 props.onChange(e);
-                getContextValue(getValues()[props.source]);
+                setContextValue(getValues()[props.source]);
             }}
         >
             {children}
@@ -131,7 +131,7 @@ describe('useInput', () => {
         const handleChange = e => {
             targetValue = e.target.value;
         };
-        const getContextValue = value => {
+        const setContextValue = value => {
             contextValue = value;
         };
 
@@ -142,7 +142,7 @@ describe('useInput', () => {
                         source="title"
                         resource="posts"
                         onChange={handleChange}
-                        getContextValue={getContextValue}
+                        setContextValue={setContextValue}
                         defaultValue=""
                     >
                         {({ id, field }) => (

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -87,21 +87,21 @@ export const useInput = <ValueType = any>(
     useApplyInputDefaultValues(props);
 
     const onBlur = useEvent((...event: any[]) => {
+        controllerField.onBlur();
         if (initialOnBlur) {
             initialOnBlur(...event);
         }
-        controllerField.onBlur();
     });
 
     const onChange = useEvent((...event: any[]) => {
-        if (initialOnChange) {
-            initialOnChange(...event);
-        }
         const eventOrValue = (props.type === 'checkbox' &&
         event[0]?.target?.value === 'on'
             ? event[0].target.checked
             : event[0]?.target?.value ?? event[0]) as any;
         controllerField.onChange(parse ? parse(eventOrValue) : eventOrValue);
+        if (initialOnChange) {
+            initialOnChange(...event);
+        }
     });
 
     const field = {


### PR DESCRIPTION
I'm updating a project from ra-v3 to ra-v4 where the value of change inputs is taken from the Form state within the onChange / onBlur event handler (instead of its `e.target.value` argument), and it doesn't have the updated value.

I found out that :
In react-admin **v3** inputs run custom event handlers **after** react-final-form ones.
In react-admin **v4** inputs run custom event handlers **before** react-hook-form ones.

So, changing this order of execution to match ra-v3 allows `useFormContext().getValues()` to have the latest value inside the custom event handlers.


Supersedes #8903