### PR TITLE
Expose setNotifications methods in notification contexts

### DIFF
--- a/packages/ra-core/src/notification/NotificationContext.ts
+++ b/packages/ra-core/src/notification/NotificationContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, Dispatch, SetStateAction } from 'react';
 
 import { NotificationPayload } from './types';
 
@@ -7,6 +7,7 @@ export type NotificationContextType = {
     addNotification: (notification: NotificationPayload) => void;
     takeNotification: () => NotificationPayload | void;
     resetNotifications: () => void;
+    setNotifications: Dispatch<SetStateAction<NotificationPayload[]>>;
 };
 
 /**
@@ -41,4 +42,5 @@ export const NotificationContext = createContext<NotificationContextType>({
     addNotification: () => {},
     takeNotification: () => {},
     resetNotifications: () => {},
+    setNotifications: () => {},
 });

--- a/packages/ra-core/src/notification/NotificationContextProvider.tsx
+++ b/packages/ra-core/src/notification/NotificationContextProvider.tsx
@@ -30,6 +30,7 @@ export const NotificationContextProvider = ({ children }) => {
             addNotification,
             takeNotification,
             resetNotifications,
+            setNotifications,
         }),
         [notifications] // eslint-disable-line react-hooks/exhaustive-deps
     );


### PR DESCRIPTION
In our use case, we have a customized notification center.

We would like to let users acknowledge some of the notifications, so that would require us to expose the setNotifications method in order to rewrite some of the values stored in the notification context