### PR TITLE
Fix `SimpleForm` and `TabbedForm` do not sanitize the `resetOptions` prop

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -91,6 +91,7 @@ const DefaultComponent = styled(CardContent, {
 
 const DefaultToolbar = <Toolbar />;
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 const sanitizeRestProps = ({
     children,
     className,
@@ -105,6 +106,7 @@ const sanitizeRestProps = ({
     sx,
     toolbar,
     validate,
+    resetOptions,
     resolver,
     sanitizeEmptyValues,
     shouldFocusError,
@@ -113,3 +115,4 @@ const sanitizeRestProps = ({
     warnWhenUnsavedChanges,
     ...props
 }: SimpleFormProps) => props;
+/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -90,6 +90,7 @@ export const TabbedForm = (props: TabbedFormProps) => {
 
 TabbedForm.Tab = FormTab;
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 const sanitizeRestProps = ({
     criteriaMode,
     defaultValues,
@@ -99,6 +100,7 @@ const sanitizeRestProps = ({
     noValidate,
     onSubmit,
     record,
+    resetOptions,
     resolver,
     reValidateMode,
     sanitizeEmptyValues,
@@ -109,6 +111,7 @@ const sanitizeRestProps = ({
     warnWhenUnsavedChanges,
     ...rest
 }: TabbedFormProps) => rest;
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 TabbedForm.propTypes = {
     children: PropTypes.node,


### PR DESCRIPTION
Necessary since https://github.com/marmelab/react-admin/pull/8911 which allows the new `resetOptions` prop