### PR TITLE
chore: bump `ra-data-graphql-simple/graphql` from 15.6.0 to 16.6.0

### DIFF
--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -40,12 +40,12 @@
         "ra-data-graphql": "^4.10.1"
     },
     "peerDependencies": {
-        "graphql": "^15.6.0",
+        "graphql": "^16.6.0",
         "ra-core": "^4.0.0"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",
-        "graphql": "^15.6.0",
+        "graphql": "^16.6.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.0"
     },


### PR DESCRIPTION
It updates `graphql` dependency to the last version.
This change follows version 16 declared in the package `ra-data-graphql` 
https://github.com/marmelab/react-admin/blob/37663821958abef6ec4df553cc50d8d93a2862f6/packages/ra-data-graphql/package.json#L41
that is a direct dependency of this package