### PR TITLE
Fix ra-language-french package.json to avoid including tsconfig

### DIFF
--- a/packages/ra-language-french/package.json
+++ b/packages/ra-language-french/package.json
@@ -6,6 +6,11 @@
         "type": "git",
         "url": "git+https://github.com/marmelab/react-admin.git"
     },
+    "files": [
+        "*.md",
+        "dist",
+        "src"
+    ],
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
Some tools might use it even when not needed. Besides, that's the only misconfigured package