### PR TITLE
Fix `useGetList` default `onSuccess` throws when the query is disabled

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.spec.tsx
@@ -5,6 +5,7 @@ import { QueryClient } from 'react-query';
 
 import { CoreAdminContext } from '../core';
 import { useGetList } from './useGetList';
+import { DataProvider } from '../types';
 
 const UseGetList = ({
     resource = 'posts',
@@ -342,5 +343,35 @@ describe('useGetList', () => {
         expect(
             queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
         ).toEqual({ id: 1, title: 'live' });
+    });
+
+    it('should not fail when the query is disabled and the cache gets updated by another query', async () => {
+        const callback: any = jest.fn();
+        const onSuccess = jest.fn();
+        const queryClient = new QueryClient();
+        const dataProvider = ({
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
+            ),
+            delete: jest.fn(),
+        } as unknown) as DataProvider;
+        render(
+            <CoreAdminContext
+                queryClient={queryClient}
+                dataProvider={dataProvider}
+            >
+                <UseGetList
+                    options={{ enabled: false, onSuccess }}
+                    callback={callback}
+                />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalled();
+        });
+        queryClient.setQueriesData(['posts', 'getList'], res => res);
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ra-core/src/dataProvider/useGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.spec.tsx
@@ -353,7 +353,6 @@ describe('useGetList', () => {
             getList: jest.fn(() =>
                 Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
             ),
-            delete: jest.fn(),
         } as unknown) as DataProvider;
         render(
             <CoreAdminContext
@@ -369,7 +368,9 @@ describe('useGetList', () => {
         await waitFor(() => {
             expect(callback).toHaveBeenCalled();
         });
+        // Simulate the side-effect of e.g. a call to delete
         queryClient.setQueriesData(['posts', 'getList'], res => res);
+        // If we get this far without an error being thrown, the test passes
         await waitFor(() => {
             expect(onSuccess).toHaveBeenCalled();
         });

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -86,9 +86,8 @@ export const useGetList = <RecordType extends RaRecord = any>(
         {
             ...options,
             onSuccess: value => {
-                const { data } = value;
                 // optimistically populate the getOne cache
-                data.forEach(record => {
+                value?.data?.forEach(record => {
                     queryClient.setQueryData(
                         [resource, 'getOne', { id: String(record.id), meta }],
                         oldRecord => oldRecord ?? record


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/8940