### PR TITLE
Fix show custom empty component on <ListView>

### DIFF
--- a/packages/ra-ui-materialui/src/list/List.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/List.spec.tsx
@@ -128,6 +128,33 @@ describe('<List />', () => {
         });
     });
 
+    it('should render custom empty component when data is empty', async () => {
+        const Dummy = () => null;
+        const CustomEmpty = () => <div>Custom Empty</div>;
+
+        const dataProvider = {
+            getList: jest.fn(() =>
+                Promise.resolve({
+                    data: [],
+                    pageInfo: { hasNextPage: false, hasPreviousPage: false },
+                })
+            ),
+        } as any;
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ThemeProvider theme={theme}>
+                    <List resource="posts" empty={<CustomEmpty />}>
+                        <Dummy />
+                    </List>
+                </ThemeProvider>
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(screen.queryByText('resources.posts.empty')).toBeNull();
+            screen.getByText('Custom Empty');
+        });
+    });
+
     it('should not render an invite when a filter is active', async () => {
         const Dummy = () => {
             const { isLoading } = useListContext();

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -41,7 +41,6 @@ export const ListView = <RecordType extends RaRecord = any>(
         defaultTitle,
         data,
         error,
-        total,
         isLoading,
         filterValues,
         resource,
@@ -83,7 +82,7 @@ export const ListView = <RecordType extends RaRecord = any>(
 
     const shouldRenderEmptyPage =
         !isLoading &&
-        total === 0 &&
+        data?.length === 0 &&
         !Object.keys(filterValues).length &&
         empty !== false;
 
@@ -144,7 +143,6 @@ ListView.propTypes = {
     setSort: PropTypes.func,
     showFilter: PropTypes.func,
     title: TitlePropType,
-    total: PropTypes.number,
 };
 
 export interface ListViewProps {


### PR DESCRIPTION
The logic that checks whether the custom empty component should be shown relies on the `total` value. Since react-admin supports partial pagination, it should handle that case too. This PR fixes that.