### PR TITLE
Missing css class in ListView, cannot style List actions

### DIFF
--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -55,6 +55,7 @@ export const ListView = <RecordType extends RaRecord = any>(
         <div className={ListClasses.main}>
             {(filters || actions) && (
                 <ListToolbar
+                    className={ListClasses.actions}         
                     filters={filters}
                     actions={actions}
                     hasCreate={hasCreate}


### PR DESCRIPTION
As mentioned by the documentation:

https://marmelab.com/react-admin/List.html#sx-css-api

there have to be a class for actions: _& .RaList-actions_ 
but ListToolbar component never got it. 

I don't know this was a mistake or deliberate.