### PR TITLE
Fix `<AutocompleteInput>` should not use `matchSuggestion` when in a `<ReferenceInput>`

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -17,6 +17,7 @@ import {
     DifferentShapeInGetMany,
     InsideReferenceInput,
     InsideReferenceInputDefaultValue,
+    InsideReferenceInputWithCustomizedItemRendering,
     Nullable,
     NullishValuesSupport,
     VeryLargeOptionsNumber,
@@ -1392,6 +1393,39 @@ describe('<AutocompleteInput />', () => {
             }
             expect(testFailed).toBe(false);
             expect(input.value).toBe('Leo Tolstoy test');
+        });
+
+        it('should not use getSuggestions to do client-side filtering', async () => {
+            // filtering should be done server-side only, and hence matchSuggestion should never be called
+            const matchSuggestion = jest.fn().mockReturnValue(true);
+            render(
+                <InsideReferenceInputWithCustomizedItemRendering
+                    matchSuggestion={matchSuggestion}
+                />
+            );
+            await waitFor(
+                () => {
+                    expect(
+                        (screen.getByRole('textbox') as HTMLInputElement).value
+                    ).toBe('Leo Tolstoy - Russian');
+                },
+                { timeout: 2000 }
+            );
+            screen.getByRole('textbox').focus();
+            fireEvent.click(screen.getByLabelText('Clear value'));
+            await waitFor(() => {
+                expect(screen.getByRole('listbox').children).toHaveLength(5);
+            });
+            fireEvent.change(screen.getByRole('textbox'), {
+                target: { value: 'French' },
+            });
+            await waitFor(
+                () => {
+                    screen.getByText('No options');
+                },
+                { timeout: 2000 }
+            );
+            expect(matchSuggestion).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -24,7 +24,7 @@ import fakeRestProvider from 'ra-data-fakerest';
 
 import { Edit } from '../detail';
 import { SimpleForm } from '../form';
-import { AutocompleteInput } from './AutocompleteInput';
+import { AutocompleteInput, AutocompleteInputProps } from './AutocompleteInput';
 import { ReferenceInput } from './ReferenceInput';
 import { TextInput } from './TextInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
@@ -686,6 +686,46 @@ export const InsideReferenceInputWithCreationSupport = () => (
     <Admin dataProvider={dataProviderWithAuthors} history={history}>
         <Resource name="authors" />
         <Resource name="books" edit={BookEditWithReferenceAndCreationSupport} />
+    </Admin>
+);
+
+const BookOptionText = () => {
+    const book = useRecordContext();
+    if (!book) return null;
+    return <div>{`${book.name} - ${book.language}`}</div>;
+};
+
+export const InsideReferenceInputWithCustomizedItemRendering = (
+    props: Partial<AutocompleteInputProps>
+) => (
+    <Admin dataProvider={dataProviderWithAuthors} history={history}>
+        <Resource name="authors" />
+        <Resource
+            name="books"
+            edit={() => (
+                <Edit
+                    mutationMode="pessimistic"
+                    mutationOptions={{
+                        onSuccess: data => {
+                            console.log(data);
+                        },
+                    }}
+                >
+                    <SimpleForm>
+                        <ReferenceInput reference="authors" source="author">
+                            <AutocompleteInput
+                                fullWidth
+                                optionText={<BookOptionText />}
+                                inputText={book =>
+                                    `${book.name} - ${book.language}`
+                                }
+                                {...props}
+                            />
+                        </ReferenceInput>
+                    </SimpleForm>
+                </Edit>
+            )}
+        />
     </Admin>
 );
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -276,8 +276,12 @@ export const AutocompleteInput = <
             throw new Error(`
 If you provided a React element for the optionText prop, you must also provide the inputText prop (used for the text input)`);
         }
-        // eslint-disable-next-line eqeqeq
-        if (isValidElement(optionText) && matchSuggestion == undefined) {
+        if (
+            isValidElement(optionText) &&
+            !isFromReference &&
+            // eslint-disable-next-line eqeqeq
+            matchSuggestion == undefined
+        ) {
             throw new Error(`
 If you provided a React element for the optionText prop, you must also provide the matchSuggestion prop (used to match the user input with a choice)`);
         }
@@ -515,7 +519,7 @@ If you provided a React element for the optionText prop, you must also provide t
     const oneSecondHasPassed = useTimeout(1000, filterValue);
 
     const suggestions = useMemo(() => {
-        if (matchSuggestion || limitChoicesToValue) {
+        if (!isFromReference && (matchSuggestion || limitChoicesToValue)) {
             return getSuggestions(filterValue);
         }
         return finalChoices?.slice(0, suggestionLimit) || [];
@@ -526,6 +530,7 @@ If you provided a React element for the optionText prop, you must also provide t
         limitChoicesToValue,
         matchSuggestion,
         suggestionLimit,
+        isFromReference,
     ]);
 
     const isOptionEqualToValue = (option, value) => {


### PR DESCRIPTION
**Problem**

When provided with a `matchSuggestion` and used in a `<ReferenceInput>`, `<AutocompleteInput>` does actually do the filtering twice: once immediately client-side, and then once server-side.
The client-side filtering does not make much sense because it's done only on a subset of the data, and besides it leads to UI flickering when the server-side results arrive.

**Solution**

Actually this is a bug, we shouldn't call `getSuggestions()` when used inside a reference, at all.
We already do this to disable MUI's Autocomplete default filtering fn, so I just extended this behavior to `getSuggestions()`.

I also had to adapt the error message warning the user that they can't use `optionText` without `matchSuggestion`, to only trigger when **not** used in a reference. Indeed, in a reference, `matchSuggestion` should never be called, as it is used for client-side filtering only.