### PR TITLE
Fix `getList` and `getManyReference` error to take partial pagination into account.

### DIFF
--- a/packages/ra-core/src/dataProvider/validateResponseFormat.ts
+++ b/packages/ra-core/src/dataProvider/validateResponseFormat.ts
@@ -55,7 +55,7 @@ function validateResponseFormat(
         !response.hasOwnProperty('pageInfo')
     ) {
         logger(
-            `The response to '${type}' must be like  { data: [...], total: 123 }, but the received response does not have a 'total' key. The dataProvider is probably wrong for '${type}'`
+            `The response to '${type}' must be like { data: [...], total: 123 } or { data: [...], pageInfo: {...} }, but the received response has neither a 'total' nor a 'pageInfo' key. The dataProvider is probably wrong for '${type}'`
         );
         throw new Error('ra.notification.data_provider_error');
     }


### PR DESCRIPTION
The error displayed when `total` and `pageInfo` properties are missing in the response does not accurately say correct solution. This PR fixes that