### PR TITLE
[TypeScript] Fix regression in type of `<FunctionField>` `render`

### DIFF
--- a/packages/ra-ui-materialui/src/field/FunctionField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/FunctionField.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { RecordContextProvider } from 'ra-core';
+import { FunctionField } from './FunctionField';
+
+export default { title: 'ra-ui-materialui/fields/FunctionField' };
+
+export const Basic = () => (
+    <RecordContextProvider value={{ firstName: 'John', lastName: 'Doe' }}>
+        <FunctionField
+            render={record => `${record.firstName} ${record.lastName}`}
+        />
+    </RecordContextProvider>
+);
+
+type User = {
+    id: number;
+    firstName: string;
+    lastName: string;
+};
+
+export const Typed = () => (
+    <RecordContextProvider<User>
+        value={{ id: 123, firstName: 'John', lastName: 'Doe' }}
+    >
+        <FunctionField<User>
+            render={record => `${record?.firstName} ${record?.lastName}`}
+        />
+    </RecordContextProvider>
+);
+
+export const NonRegression = () => (
+    <RecordContextProvider value={{ firstName: 'John', lastName: 'Doe' }}>
+        <FunctionField
+            render={(record?: User) =>
+                `${record?.firstName} ${record?.lastName}`
+            }
+        />
+    </RecordContextProvider>
+);

--- a/packages/ra-ui-materialui/src/field/FunctionField.tsx
+++ b/packages/ra-ui-materialui/src/field/FunctionField.tsx
@@ -18,9 +18,7 @@ import { FieldProps, fieldPropTypes } from './types';
  * />
  */
 
-export const FunctionField = <
-    RecordType extends Record<string, unknown> = Record<string, any>
->(
+export const FunctionField = <RecordType extends Record<string, unknown> = any>(
     props: FunctionFieldProps<RecordType>
 ) => {
     const { className, source = '', render, ...rest } = props;
@@ -49,7 +47,7 @@ FunctionField.propTypes = {
 };
 
 export interface FunctionFieldProps<
-    RecordType extends Record<string, unknown> = Record<string, any>
+    RecordType extends Record<string, unknown> = any
 > extends FieldProps<RecordType>,
         Omit<TypographyProps, 'textAlign'> {
     render: (record?: RecordType, source?: string) => any;


### PR DESCRIPTION
Fixes https://github.com/marmelab/react-admin/issues/8960

I originally intended to fix the types properly, by setting the type to be `Record<string, any>` in case `RecordType` was not provided, but couldn't find a way to do so. :frowning: 
So I had to resort to using `any` as the default type.

Nevertheless, autocompletion works when setting the type either to `<FunctionField>` or to `render`'s `record` param, and TS no longer throws an error. :slightly_smiling_face: 