### PR TITLE
Update `<Link>` to honor the `underline` prop

### DIFF
--- a/packages/ra-ui-materialui/src/Link.tsx
+++ b/packages/ra-ui-materialui/src/Link.tsx
@@ -16,6 +16,7 @@ export const Link = (props: LinkProps) => {
             component={RRLink}
             to={to}
             className={clsx(LinkClasses.link, className)}
+            underline="none"
             {...rest}
         >
             {children}
@@ -29,11 +30,7 @@ export const LinkClasses = {
     link: `${PREFIX}-link`,
 };
 
-const StyledMuiLink = styled(MuiLink)(({ theme }) => ({
-    [`&.${LinkClasses.link}`]: {
-        textDecoration: 'none',
-    },
-})) as typeof MuiLink; // @see https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop
+const StyledMuiLink = styled(MuiLink)({}) as typeof MuiLink; // @see https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop
 
 // @see https://mui.com/material-ui/guides/composition/#with-typescript
 export interface LinkProps


### PR DESCRIPTION
## Problem

We use a custom `<Link>` tag, which combines MUI and react-router Links. 

This tag uses a custom style to disable the underline. 

When users use the `underline` prop to force the underline, this fails. 

## Solution

Use the `underline` prop instead of custom styles
