### PR TITLE
[Doc] Fix links to react-hook-form's doc

### DIFF
--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -90,7 +90,7 @@ Here are all the props you can set on the `<AccordionForm>` component:
 | `warnWhen UnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
 
-Additional props are passed to `react-hook-form`'s [`useForm` hook](https://www.react-hook-form.com/api/useform).
+Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/docs/useform).
 
 ## `autoClose`
 

--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -90,7 +90,7 @@ Here are all the props you can set on the `<AccordionForm>` component:
 | `warnWhen UnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
 
-Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/api/useform).
+Additional props are passed to `react-hook-form`'s [`useForm` hook](https://www.react-hook-form.com/api/useform).
 
 ## `autoClose`
 

--- a/docs/ArrayInput.md
+++ b/docs/ArrayInput.md
@@ -43,7 +43,7 @@ To edit arrays of data embedded inside a record, `<ArrayInput>` creates a list o
 
 ## Usage
 
-`<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component rendering a field array (the object returned by react-hook-form's [`useFieldArray`](https://www.react-hook-form.com/api/usefieldarray)). For instance, [the `<SimpleFormIterator>` component](./SimpleFormIterator.md) displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record.
+`<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component rendering a field array (the object returned by react-hook-form's [`useFieldArray`](https://react-hook-form.com/docs/usefieldarray)). For instance, [the `<SimpleFormIterator>` component](./SimpleFormIterator.md) displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record.
 
 ```jsx
 import { 

--- a/docs/ArrayInput.md
+++ b/docs/ArrayInput.md
@@ -43,7 +43,7 @@ To edit arrays of data embedded inside a record, `<ArrayInput>` creates a list o
 
 ## Usage
 
-`<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component rendering a field array (the object returned by react-hook-form's [`useFieldArray`](https://react-hook-form.com/api/usefieldarray)). For instance, [the `<SimpleFormIterator>` component](./SimpleFormIterator.md) displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record.
+`<ArrayInput>` expects a single child, which must be a *form iterator* component. A form iterator is a component rendering a field array (the object returned by react-hook-form's [`useFieldArray`](https://www.react-hook-form.com/api/usefieldarray)). For instance, [the `<SimpleFormIterator>` component](./SimpleFormIterator.md) displays an array of react-admin Inputs in an unordered list (`<ul>`), one sub-form by list item (`<li>`). It also provides controls for adding and removing a sub-record.
 
 ```jsx
 import { 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -517,7 +517,7 @@ Inside forms, you can use specialize [input components](./Inputs.md), designed f
 
 ### Dependent Inputs 
 
-You can build dependent inputs, using the [react-hook-form's `useWatch` hook](https://react-hook-form.com/api/usewatch). For instance, here is a `CityInput` that displays the cities of the selected country:
+You can build dependent inputs, using the [react-hook-form's `useWatch` hook](https://www.react-hook-form.com/api/usewatch). For instance, here is a `CityInput` that displays the cities of the selected country:
 
 ```jsx
 import * as React from 'react';

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -517,7 +517,7 @@ Inside forms, you can use specialize [input components](./Inputs.md), designed f
 
 ### Dependent Inputs 
 
-You can build dependent inputs, using the [react-hook-form's `useWatch` hook](https://www.react-hook-form.com/api/usewatch). For instance, here is a `CityInput` that displays the cities of the selected country:
+You can build dependent inputs, using the [react-hook-form's `useWatch` hook](https://react-hook-form.com/docs/usewatch). For instance, here is a `CityInput` that displays the cities of the selected country:
 
 ```jsx
 import * as React from 'react';

--- a/docs/Form.md
+++ b/docs/Form.md
@@ -39,7 +39,7 @@ export const PostCreate = () => (
 );
 ```
 
-`<Form>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://react-hook-form.com/api/useformcontext) and [`useFormState`](https://react-hook-form.com/api/useformstate) hooks to access the form state.
+`<Form>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://www.react-hook-form.com/api/useformcontext) and [`useFormState`](https://www.react-hook-form.com/api/useformstate) hooks to access the form state.
 
 ## Props
 
@@ -55,7 +55,7 @@ Here are all the props you can set on the `<Form>` component:
 | `validate`               | Optional | `function`        | -       | A function to validate the form values.                    |
 | `warnWhenUnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
-Additional props are passed to [the `useForm` hook](https://react-hook-form.com/api/useform).
+Additional props are passed to [the `useForm` hook](https://www.react-hook-form.com/api/useform).
 
 ## `defaultValues`
 
@@ -239,7 +239,7 @@ export const TagEdit = () => (
 
 `<Form>` relies on [react-hook-form's `useForm`](https://react-hook-form.com/docs/useform) to manage the form state and validation. You can subscribe to form changes using the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks.
  
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/Form.md
+++ b/docs/Form.md
@@ -39,7 +39,7 @@ export const PostCreate = () => (
 );
 ```
 
-`<Form>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://www.react-hook-form.com/api/useformcontext) and [`useFormState`](https://www.react-hook-form.com/api/useformstate) hooks to access the form state.
+`<Form>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks to access the form state.
 
 ## Props
 
@@ -55,7 +55,7 @@ Here are all the props you can set on the `<Form>` component:
 | `validate`               | Optional | `function`        | -       | A function to validate the form values.                    |
 | `warnWhenUnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
-Additional props are passed to [the `useForm` hook](https://www.react-hook-form.com/api/useform).
+Additional props are passed to [the `useForm` hook](https://react-hook-form.com/docs/useform).
 
 ## `defaultValues`
 
@@ -239,7 +239,7 @@ export const TagEdit = () => (
 
 `<Form>` relies on [react-hook-form's `useForm`](https://react-hook-form.com/docs/useform) to manage the form state and validation. You can subscribe to form changes using the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks.
  
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -52,7 +52,7 @@ All input components accept the following props:
 | `sx`            | Optional | `SxProps`                 | -       | Material UI shortcut for defining custom styles                                                                                                                             |
 | `validate`      | Optional | `Function` &#124; `array` | -       | Validation rules for the current property. See the [Validation Documentation](./Validation.md#per-input-validation-built-in-field-validators) for details.          |
 
-React-admin uses [react-hook-form](https://react-hook-form.com/) to control form inputs. Each input component also accepts all react-hook-form [useController](https://www.react-hook-form.com/api/usecontroller) hook options.
+React-admin uses [react-hook-form](https://react-hook-form.com/) to control form inputs. Each input component also accepts all react-hook-form [useController](https://react-hook-form.com/docs/usecontroller) hook options.
 
 Additional props are passed down to the underlying component (usually an Material UI component). For instance, when setting the `variant` prop on a `<TextInput>` component, the underlying Material UI `<TextField>` receives it, and renders it with a different variant. Refer to the documentation of each Input component to see the underlying Material UI component and its props.
 
@@ -438,7 +438,7 @@ import { TextInput, required } from 'react-admin';
 
 Edition forms often contain linked inputs, e.g. country and city (the choices of the latter depending on the value of the former).
 
-React-admin relies on [react-hook-form](https://react-hook-form.com/) for form handling. You can grab the current form values using react-hook-form's [useWatch](https://www.react-hook-form.com/api/usewatch) hook.
+React-admin relies on [react-hook-form](https://react-hook-form.com/) for form handling. You can grab the current form values using react-hook-form's [useWatch](https://react-hook-form.com/docs/usewatch) hook.
 
 ```jsx
 import * as React from 'react';
@@ -635,7 +635,7 @@ const theme = {
 
 ## Writing Your Own Input Component
 
-If you need a more specific input type, you can write it directly in React. You'll have to rely on react-hook-form's [useController](https://www.react-hook-form.com/api/usecontroller) hook, to handle the value update cycle.
+If you need a more specific input type, you can write it directly in React. You'll have to rely on react-hook-form's [useController](https://react-hook-form.com/docs/usecontroller) hook, to handle the value update cycle.
 
 ### Using `useController`
 
@@ -773,7 +773,7 @@ const LatLngInput = () => (
 
 **Tip**: Notice that we have added `defaultValue: ''` as one of the `useController` params. This is a good practice to avoid getting console warnings about controlled/uncontrolled components, that may arise if the value of `record.lat` or `record.lng` is `undefined` or `null`.
 
-`useController()` returns three values: `field`, `fieldState`, and `formState`. To learn more about these props, please refer to the [useController](https://www.react-hook-form.com/api/usecontroller) hook documentation.
+`useController()` returns three values: `field`, `fieldState`, and `formState`. To learn more about these props, please refer to the [useController](https://react-hook-form.com/docs/usecontroller) hook documentation.
 
 Instead of HTML `input` elements or Material UI components, you can use react-admin input components, like `<NumberInput>` for instance. React-admin components already use `useController()`, and already include a label, so you don't need either `useController()` or `<Labeled>` when using them:
 
@@ -892,7 +892,7 @@ const PersonEdit = () => (
 );
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -52,7 +52,7 @@ All input components accept the following props:
 | `sx`            | Optional | `SxProps`                 | -       | Material UI shortcut for defining custom styles                                                                                                                             |
 | `validate`      | Optional | `Function` &#124; `array` | -       | Validation rules for the current property. See the [Validation Documentation](./Validation.md#per-input-validation-built-in-field-validators) for details.          |
 
-React-admin uses [react-hook-form](https://react-hook-form.com/) to control form inputs. Each input component also accepts all react-hook-form [useController](https://react-hook-form.com/api/usecontroller) hook options.
+React-admin uses [react-hook-form](https://react-hook-form.com/) to control form inputs. Each input component also accepts all react-hook-form [useController](https://www.react-hook-form.com/api/usecontroller) hook options.
 
 Additional props are passed down to the underlying component (usually an Material UI component). For instance, when setting the `variant` prop on a `<TextInput>` component, the underlying Material UI `<TextField>` receives it, and renders it with a different variant. Refer to the documentation of each Input component to see the underlying Material UI component and its props.
 
@@ -438,7 +438,7 @@ import { TextInput, required } from 'react-admin';
 
 Edition forms often contain linked inputs, e.g. country and city (the choices of the latter depending on the value of the former).
 
-React-admin relies on [react-hook-form](https://react-hook-form.com/) for form handling. You can grab the current form values using react-hook-form's [useWatch](https://react-hook-form.com/api/usewatch) hook.
+React-admin relies on [react-hook-form](https://react-hook-form.com/) for form handling. You can grab the current form values using react-hook-form's [useWatch](https://www.react-hook-form.com/api/usewatch) hook.
 
 ```jsx
 import * as React from 'react';
@@ -635,7 +635,7 @@ const theme = {
 
 ## Writing Your Own Input Component
 
-If you need a more specific input type, you can write it directly in React. You'll have to rely on react-hook-form's [useController](https://react-hook-form.com/api/usecontroller) hook, to handle the value update cycle.
+If you need a more specific input type, you can write it directly in React. You'll have to rely on react-hook-form's [useController](https://www.react-hook-form.com/api/usecontroller) hook, to handle the value update cycle.
 
 ### Using `useController`
 
@@ -773,7 +773,7 @@ const LatLngInput = () => (
 
 **Tip**: Notice that we have added `defaultValue: ''` as one of the `useController` params. This is a good practice to avoid getting console warnings about controlled/uncontrolled components, that may arise if the value of `record.lat` or `record.lng` is `undefined` or `null`.
 
-`useController()` returns three values: `field`, `fieldState`, and `formState`. To learn more about these props, please refer to the [useController](https://react-hook-form.com/api/usecontroller) hook documentation.
+`useController()` returns three values: `field`, `fieldState`, and `formState`. To learn more about these props, please refer to the [useController](https://www.react-hook-form.com/api/usecontroller) hook documentation.
 
 Instead of HTML `input` elements or Material UI components, you can use react-admin input components, like `<NumberInput>` for instance. React-admin components already use `useController()`, and already include a label, so you don't need either `useController()` or `<Labeled>` when using them:
 
@@ -892,7 +892,7 @@ const PersonEdit = () => (
 );
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/LongForm.md
+++ b/docs/LongForm.md
@@ -100,7 +100,7 @@ Here are all the props you can set on the `<LongForm>` component:
 | `warnWhenUnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
 
-Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/api/useform).
+Additional props are passed to `react-hook-form`'s [`useForm` hook](https://www.react-hook-form.com/api/useform).
 
 ## `children`
 

--- a/docs/LongForm.md
+++ b/docs/LongForm.md
@@ -100,7 +100,7 @@ Here are all the props you can set on the `<LongForm>` component:
 | `warnWhenUnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
 
-Additional props are passed to `react-hook-form`'s [`useForm` hook](https://www.react-hook-form.com/api/useform).
+Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/docs/useform).
 
 ## `children`
 

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -29,7 +29,7 @@ export const PostCreate = () => (
 );
 ```
 
-`<SimpleForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://www.react-hook-form.com/api/useformcontext) and [`useFormState`](https://www.react-hook-form.com/api/useformstate) hooks to access the form state.
+`<SimpleForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks to access the form state.
 
 ## Props
 
@@ -49,7 +49,7 @@ Here are all the props you can set on the `<SimpleForm>` component:
 | `validate`                | Optional | `function`         | -       | A function to validate the form values.                    |
 | `warnWhen UnsavedChanges` | Optional | `boolean`          | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
-Additional props are passed to [the `useForm` hook](https://www.react-hook-form.com/api/useform) and to [the material-ui `<Stack>` component](https://mui.com/material-ui/react-stack/).
+Additional props are passed to [the `useForm` hook](https://react-hook-form.com/docs/useform) and to [the material-ui `<Stack>` component](https://mui.com/material-ui/react-stack/).
 
 ## `children`
 
@@ -509,7 +509,7 @@ Before building your own custom layout, take a look at the existing form layout 
 
 `<SimpleForm>` relies on [react-hook-form's `useForm`](https://react-hook-form.com/docs/useform) to manage the form state and validation. You can subscribe to form changes using the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks.
  
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -29,7 +29,7 @@ export const PostCreate = () => (
 );
 ```
 
-`<SimpleForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://react-hook-form.com/api/useformcontext) and [`useFormState`](https://react-hook-form.com/api/useformstate) hooks to access the form state.
+`<SimpleForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://www.react-hook-form.com/api/useformcontext) and [`useFormState`](https://www.react-hook-form.com/api/useformstate) hooks to access the form state.
 
 ## Props
 
@@ -49,7 +49,7 @@ Here are all the props you can set on the `<SimpleForm>` component:
 | `validate`                | Optional | `function`         | -       | A function to validate the form values.                    |
 | `warnWhen UnsavedChanges` | Optional | `boolean`          | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
-Additional props are passed to [the `useForm` hook](https://react-hook-form.com/api/useform) and to [the material-ui `<Stack>` component](https://mui.com/material-ui/react-stack/).
+Additional props are passed to [the `useForm` hook](https://www.react-hook-form.com/api/useform) and to [the material-ui `<Stack>` component](https://mui.com/material-ui/react-stack/).
 
 ## `children`
 
@@ -509,7 +509,7 @@ Before building your own custom layout, take a look at the existing form layout 
 
 `<SimpleForm>` relies on [react-hook-form's `useForm`](https://react-hook-form.com/docs/useform) to manage the form state and validation. You can subscribe to form changes using the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks.
  
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/SimpleFormIterator.md
+++ b/docs/SimpleFormIterator.md
@@ -14,7 +14,7 @@ This component provides a UI for editing arrays of objects, one row per object.
 </video>
 
 
-`<SimpleFormIterator>` lets users edit, add, remove and reorder sub-records. It is designed to be used as a child of [`<ArrayInput>`](./ArrayInput.md) or [`<ReferenceManyInput>`](./ReferenceManyInput.md). You can also use it within an `ArrayInputContext` containing a *field array*, i.e. the value returned by [react-hook-form's `useFieldArray` hook](https://www.react-hook-form.com/api/usefieldarray).
+`<SimpleFormIterator>` lets users edit, add, remove and reorder sub-records. It is designed to be used as a child of [`<ArrayInput>`](./ArrayInput.md) or [`<ReferenceManyInput>`](./ReferenceManyInput.md). You can also use it within an `ArrayInputContext` containing a *field array*, i.e. the value returned by [react-hook-form's `useFieldArray` hook](https://react-hook-form.com/docs/usefieldarray).
 
 ## Usage
 

--- a/docs/SimpleFormIterator.md
+++ b/docs/SimpleFormIterator.md
@@ -14,7 +14,7 @@ This component provides a UI for editing arrays of objects, one row per object.
 </video>
 
 
-`<SimpleFormIterator>` lets users edit, add, remove and reorder sub-records. It is designed to be used as a child of [`<ArrayInput>`](./ArrayInput.md) or [`<ReferenceManyInput>`](./ReferenceManyInput.md). You can also use it within an `ArrayInputContext` containing a *field array*, i.e. the value returned by [react-hook-form's `useFieldArray` hook](https://react-hook-form.com/api/usefieldarray).
+`<SimpleFormIterator>` lets users edit, add, remove and reorder sub-records. It is designed to be used as a child of [`<ArrayInput>`](./ArrayInput.md) or [`<ReferenceManyInput>`](./ReferenceManyInput.md). You can also use it within an `ArrayInputContext` containing a *field array*, i.e. the value returned by [react-hook-form's `useFieldArray` hook](https://www.react-hook-form.com/api/usefieldarray).
 
 ## Usage
 

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -70,7 +70,7 @@ export const PostEdit = () => (
 ```
 {% endraw %}
 
-`<TabbedForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://www.react-hook-form.com/api/useformcontext) and [`useFormState`](https://www.react-hook-form.com/api/useformstate) hooks to access the form state.
+`<TabbedForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks to access the form state.
 
 React-admin highlights the tabs containing validation errors to help users locate incorrect input values. 
 
@@ -92,7 +92,7 @@ Here are all the props you can set on the `<TabbedForm>` component:
 | `validate`                | Optional | `function`         | -       | A function to validate the form values.                    |
 | `warnWhen UnsavedChanges` | Optional | `boolean`          | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
-Additional props are passed to [the `useForm` hook](https://www.react-hook-form.com/api/useform) and to the wrapper `<div>` component.
+Additional props are passed to [the `useForm` hook](https://react-hook-form.com/docs/useform) and to the wrapper `<div>` component.
 
 ## `children`
 
@@ -669,7 +669,7 @@ const ProductEditDetails = () => (
 
 `<TabbedForm>` relies on [react-hook-form's `useForm`](https://react-hook-form.com/docs/useform) to manage the form state and validation. You can subscribe to form changes using the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks.
  
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -70,7 +70,7 @@ export const PostEdit = () => (
 ```
 {% endraw %}
 
-`<TabbedForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://react-hook-form.com/api/useformcontext) and [`useFormState`](https://react-hook-form.com/api/useformstate) hooks to access the form state.
+`<TabbedForm>` calls react-hook-form's `useForm` hook, and places the result in a `FormProvider` component. This means you can take advantage of the [`useFormContext`](https://www.react-hook-form.com/api/useformcontext) and [`useFormState`](https://www.react-hook-form.com/api/useformstate) hooks to access the form state.
 
 React-admin highlights the tabs containing validation errors to help users locate incorrect input values. 
 
@@ -92,7 +92,7 @@ Here are all the props you can set on the `<TabbedForm>` component:
 | `validate`                | Optional | `function`         | -       | A function to validate the form values.                    |
 | `warnWhen UnsavedChanges` | Optional | `boolean`          | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
-Additional props are passed to [the `useForm` hook](https://react-hook-form.com/api/useform) and to the wrapper `<div>` component.
+Additional props are passed to [the `useForm` hook](https://www.react-hook-form.com/api/useform) and to the wrapper `<div>` component.
 
 ## `children`
 
@@ -669,7 +669,7 @@ const ProductEditDetails = () => (
 
 `<TabbedForm>` relies on [react-hook-form's `useForm`](https://react-hook-form.com/docs/useform) to manage the form state and validation. You can subscribe to form changes using the [`useFormContext`](https://react-hook-form.com/docs/useformcontext) and [`useFormState`](https://react-hook-form.com/docs/useformstate) hooks.
  
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -1638,7 +1638,7 @@ const UnselectAllButton = () => {
 
 ### `initialValues` Is Now `defaultValues`
 
-`<FormWithRedirect>` used to accept [`react-final-form` `<Form>` props](https://final-form.org/docs/react-final-form/types/FormProps). It now accepts [`react-hook-form` `useForm` props](https://react-hook-form.com/api/useform). This also affects the other form components (`<SimpleForm>`, `<TabbedForm>`, etc.)
+`<FormWithRedirect>` used to accept [`react-final-form` `<Form>` props](https://final-form.org/docs/react-final-form/types/FormProps). It now accepts [`react-hook-form` `useForm` props](https://www.react-hook-form.com/api/useform). This also affects the other form components (`<SimpleForm>`, `<TabbedForm>`, etc.)
 
 The most commonly used prop is probably `initialValues`, which is now named `defaultValues`:
 
@@ -1657,13 +1657,13 @@ const PostCreate = () => (
 ```
 {% endraw %}
 
-We kept the `validate` function prop, which we automatically translate to a custom [`react-hook-form` `resolver`](https://react-hook-form.com/api/useform#validationResolver). So even if it's not technically a react-hook-form prop, you can still use `validate` as before.
+We kept the `validate` function prop, which we automatically translate to a custom [`react-hook-form` `resolver`](https://www.react-hook-form.com/api/useform#validationResolver). So even if it's not technically a react-hook-form prop, you can still use `validate` as before.
 
-This also means you can now use [`yup`](https://github.com/jquense/yup), [`zod`](https://github.com/colinhacks/zod), [`joi`](https://github.com/sideway/joi), [superstruct](https://github.com/ianstormtaylor/superstruct), [vest](https://github.com/ealush/vest) or any [resolver](https://react-hook-form.com/api/useform#validationResolver) supported by `react-hook-form` to apply schema validation.
+This also means you can now use [`yup`](https://github.com/jquense/yup), [`zod`](https://github.com/colinhacks/zod), [`joi`](https://github.com/sideway/joi), [superstruct](https://github.com/ianstormtaylor/superstruct), [vest](https://github.com/ealush/vest) or any [resolver](https://www.react-hook-form.com/api/useform#validationResolver) supported by `react-hook-form` to apply schema validation.
 
 ### Input-Level Validation Now Triggers on Submit
 
-With `react-hook-form`, the default mode for form validation is 'onSubmit'. This means the validation errors only appear once the user submits the form. If you want to have input level validation triggered before submission (e.g. on blur), you can try a different [validation strategy](https://react-hook-form.com/api/useform/) by passing a `mode` prop to the form:
+With `react-hook-form`, the default mode for form validation is 'onSubmit'. This means the validation errors only appear once the user submits the form. If you want to have input level validation triggered before submission (e.g. on blur), you can try a different [validation strategy](https://www.react-hook-form.com/api/useform/) by passing a `mode` prop to the form:
 
 ```jsx
 // This will trigger input validation onBlur
@@ -1674,7 +1674,7 @@ With `react-hook-form`, the default mode for form validation is 'onSubmit'. This
 
 ### Validation: Form Level & Input Level Are Mutually Exclusive
 
-With `react-hook-form`, you can't have both form level validation and input level validation. This is because form level validation is meant to be used for [schema based validation](https://react-hook-form.com/api/useform#validationResolver).
+With `react-hook-form`, you can't have both form level validation and input level validation. This is because form level validation is meant to be used for [schema based validation](https://www.react-hook-form.com/api/useform#validationResolver).
 
 If you used form level validation to run complex checks for multiple input values combinations, you can use a schema library such as [yup](https://github.com/jquense/yup):
 
@@ -1858,7 +1858,7 @@ export const MyForm = () => (
 );
 ```
 
-If you need to access the form state (`valid`, `invalid`, `pristine`, `dirty`), you can call [the react-hook-form `useFormState` hook](https://react-hook-form.com/api/useformstate) instead:
+If you need to access the form state (`valid`, `invalid`, `pristine`, `dirty`), you can call [the react-hook-form `useFormState` hook](https://www.react-hook-form.com/api/useformstate) instead:
 
 ```diff
 import { FormWithRedirect } from 'react-admin';
@@ -1891,7 +1891,7 @@ const MyCustomForm = () => {
 }
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
@@ -1973,7 +1973,7 @@ const ReviewEditToolbar = (props: ToolbarProps<Review>) => {
 };
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
@@ -2508,7 +2508,7 @@ export default LatLngInput;
 
 Just like all inputs, `useInput` now only accept `defaultValue` and will ignore `initialValue`.
 
-Besides, `useInput` used to return `final-form` properties such as `input` and `meta`. It now returns `field`, `fieldState` and `formState` (see https://react-hook-form.com/api/usecontroller).
+Besides, `useInput` used to return `final-form` properties such as `input` and `meta`. It now returns `field`, `fieldState` and `formState` (see https://www.react-hook-form.com/api/usecontroller).
 
 Note that the `error` returned by `fieldState` is not just a simple string anymore but an object with a `message` property.
 
@@ -2549,7 +2549,7 @@ const UserForm = () => (
 )
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -1638,7 +1638,7 @@ const UnselectAllButton = () => {
 
 ### `initialValues` Is Now `defaultValues`
 
-`<FormWithRedirect>` used to accept [`react-final-form` `<Form>` props](https://final-form.org/docs/react-final-form/types/FormProps). It now accepts [`react-hook-form` `useForm` props](https://www.react-hook-form.com/api/useform). This also affects the other form components (`<SimpleForm>`, `<TabbedForm>`, etc.)
+`<FormWithRedirect>` used to accept [`react-final-form` `<Form>` props](https://final-form.org/docs/react-final-form/types/FormProps). It now accepts [`react-hook-form` `useForm` props](https://react-hook-form.com/docs/useform). This also affects the other form components (`<SimpleForm>`, `<TabbedForm>`, etc.)
 
 The most commonly used prop is probably `initialValues`, which is now named `defaultValues`:
 
@@ -1657,13 +1657,13 @@ const PostCreate = () => (
 ```
 {% endraw %}
 
-We kept the `validate` function prop, which we automatically translate to a custom [`react-hook-form` `resolver`](https://www.react-hook-form.com/api/useform#validationResolver). So even if it's not technically a react-hook-form prop, you can still use `validate` as before.
+We kept the `validate` function prop, which we automatically translate to a custom [`react-hook-form` `resolver`](https://react-hook-form.com/docs/useform#validationResolver). So even if it's not technically a react-hook-form prop, you can still use `validate` as before.
 
-This also means you can now use [`yup`](https://github.com/jquense/yup), [`zod`](https://github.com/colinhacks/zod), [`joi`](https://github.com/sideway/joi), [superstruct](https://github.com/ianstormtaylor/superstruct), [vest](https://github.com/ealush/vest) or any [resolver](https://www.react-hook-form.com/api/useform#validationResolver) supported by `react-hook-form` to apply schema validation.
+This also means you can now use [`yup`](https://github.com/jquense/yup), [`zod`](https://github.com/colinhacks/zod), [`joi`](https://github.com/sideway/joi), [superstruct](https://github.com/ianstormtaylor/superstruct), [vest](https://github.com/ealush/vest) or any [resolver](https://react-hook-form.com/docs/useform#validationResolver) supported by `react-hook-form` to apply schema validation.
 
 ### Input-Level Validation Now Triggers on Submit
 
-With `react-hook-form`, the default mode for form validation is 'onSubmit'. This means the validation errors only appear once the user submits the form. If you want to have input level validation triggered before submission (e.g. on blur), you can try a different [validation strategy](https://www.react-hook-form.com/api/useform/) by passing a `mode` prop to the form:
+With `react-hook-form`, the default mode for form validation is 'onSubmit'. This means the validation errors only appear once the user submits the form. If you want to have input level validation triggered before submission (e.g. on blur), you can try a different [validation strategy](https://react-hook-form.com/docs/useform/) by passing a `mode` prop to the form:
 
 ```jsx
 // This will trigger input validation onBlur
@@ -1674,7 +1674,7 @@ With `react-hook-form`, the default mode for form validation is 'onSubmit'. This
 
 ### Validation: Form Level & Input Level Are Mutually Exclusive
 
-With `react-hook-form`, you can't have both form level validation and input level validation. This is because form level validation is meant to be used for [schema based validation](https://www.react-hook-form.com/api/useform#validationResolver).
+With `react-hook-form`, you can't have both form level validation and input level validation. This is because form level validation is meant to be used for [schema based validation](https://react-hook-form.com/docs/useform#validationResolver).
 
 If you used form level validation to run complex checks for multiple input values combinations, you can use a schema library such as [yup](https://github.com/jquense/yup):
 
@@ -1858,7 +1858,7 @@ export const MyForm = () => (
 );
 ```
 
-If you need to access the form state (`valid`, `invalid`, `pristine`, `dirty`), you can call [the react-hook-form `useFormState` hook](https://www.react-hook-form.com/api/useformstate) instead:
+If you need to access the form state (`valid`, `invalid`, `pristine`, `dirty`), you can call [the react-hook-form `useFormState` hook](https://react-hook-form.com/docs/useformstate) instead:
 
 ```diff
 import { FormWithRedirect } from 'react-admin';
@@ -1891,7 +1891,7 @@ const MyCustomForm = () => {
 }
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
@@ -1973,7 +1973,7 @@ const ReviewEditToolbar = (props: ToolbarProps<Review>) => {
 };
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
@@ -2508,7 +2508,7 @@ export default LatLngInput;
 
 Just like all inputs, `useInput` now only accept `defaultValue` and will ignore `initialValue`.
 
-Besides, `useInput` used to return `final-form` properties such as `input` and `meta`. It now returns `field`, `fieldState` and `formState` (see https://www.react-hook-form.com/api/usecontroller).
+Besides, `useInput` used to return `final-form` properties such as `input` and `meta`. It now returns `field`, `fieldState` and `formState` (see https://react-hook-form.com/docs/usecontroller).
 
 Note that the `error` returned by `fieldState` is not just a simple string anymore but an object with a `message` property.
 
@@ -2549,7 +2549,7 @@ const UserForm = () => (
 )
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -20,7 +20,7 @@ You can’t use both form level validation and input level validation - this is 
 
 By default, the validation mode is `onSubmit`, and the re-validation mode is `onChange`.
 
-Since [`<Form>`](./Form.md) actually passes all additional props to react-hook-form's [`useForm` hook](https://react-hook-form.com/api/useform/), this can easily be changed by setting the `mode` and `reValidateMode` props.
+Since [`<Form>`](./Form.md) actually passes all additional props to react-hook-form's [`useForm` hook](https://www.react-hook-form.com/api/useform/), this can easily be changed by setting the `mode` and `reValidateMode` props.
 
 ```jsx
 export const UserCreate = () => (
@@ -91,7 +91,7 @@ export const UserCreate = () => (
 );
 ```
 
-**Tip**: The props you pass to `<SimpleForm>` and `<TabbedForm>` are passed to the [useForm hook](https://react-hook-form.com/api/useform) of `react-hook-form`.
+**Tip**: The props you pass to `<SimpleForm>` and `<TabbedForm>` are passed to the [useForm hook](https://www.react-hook-form.com/api/useform) of `react-hook-form`.
 
 **Tip**: The `validate` function can return a promise for asynchronous validation. See [the Server-Side Validation section](#server-side-validation) below.
 
@@ -257,7 +257,7 @@ export const ProductEdit = () => (
 ```
 {% endraw %}
 
-**Tip**: The props of your Input components are passed to a `react-hook-form` [useController](https://react-hook-form.com/api/usecontroller) hook.
+**Tip**: The props of your Input components are passed to a `react-hook-form` [useController](https://www.react-hook-form.com/api/usecontroller) hook.
 
 **Tip**: The custom validator function can return a promise, e.g. to use server-side validation. See next section for details.
 
@@ -337,7 +337,7 @@ export const UserCreate = () => (
 
 ## Schema Validation
 
-`react-hook-form` supports schema validation with many libraries through its [`resolver` props](https://react-hook-form.com/api/useform#validationResolver). To use it, follow their [resolvers documentation](https://github.com/react-hook-form/resolvers). Here's an example using `yup`:
+`react-hook-form` supports schema validation with many libraries through its [`resolver` props](https://www.react-hook-form.com/api/useform#validationResolver). To use it, follow their [resolvers documentation](https://github.com/react-hook-form/resolvers). Here's an example using `yup`:
 
 ```jsx
 import { yupResolver } from '@hookform/resolvers/yup';

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -20,7 +20,7 @@ You can’t use both form level validation and input level validation - this is 
 
 By default, the validation mode is `onSubmit`, and the re-validation mode is `onChange`.
 
-Since [`<Form>`](./Form.md) actually passes all additional props to react-hook-form's [`useForm` hook](https://www.react-hook-form.com/api/useform/), this can easily be changed by setting the `mode` and `reValidateMode` props.
+Since [`<Form>`](./Form.md) actually passes all additional props to react-hook-form's [`useForm` hook](https://react-hook-form.com/docs/useform/), this can easily be changed by setting the `mode` and `reValidateMode` props.
 
 ```jsx
 export const UserCreate = () => (
@@ -91,7 +91,7 @@ export const UserCreate = () => (
 );
 ```
 
-**Tip**: The props you pass to `<SimpleForm>` and `<TabbedForm>` are passed to the [useForm hook](https://www.react-hook-form.com/api/useform) of `react-hook-form`.
+**Tip**: The props you pass to `<SimpleForm>` and `<TabbedForm>` are passed to the [useForm hook](https://react-hook-form.com/docs/useform) of `react-hook-form`.
 
 **Tip**: The `validate` function can return a promise for asynchronous validation. See [the Server-Side Validation section](#server-side-validation) below.
 
@@ -257,7 +257,7 @@ export const ProductEdit = () => (
 ```
 {% endraw %}
 
-**Tip**: The props of your Input components are passed to a `react-hook-form` [useController](https://www.react-hook-form.com/api/usecontroller) hook.
+**Tip**: The props of your Input components are passed to a `react-hook-form` [useController](https://react-hook-form.com/docs/usecontroller) hook.
 
 **Tip**: The custom validator function can return a promise, e.g. to use server-side validation. See next section for details.
 
@@ -337,7 +337,7 @@ export const UserCreate = () => (
 
 ## Schema Validation
 
-`react-hook-form` supports schema validation with many libraries through its [`resolver` props](https://www.react-hook-form.com/api/useform#validationResolver). To use it, follow their [resolvers documentation](https://github.com/react-hook-form/resolvers). Here's an example using `yup`:
+`react-hook-form` supports schema validation with many libraries through its [`resolver` props](https://react-hook-form.com/docs/useform#validationResolver). To use it, follow their [resolvers documentation](https://github.com/react-hook-form/resolvers). Here's an example using `yup`:
 
 ```jsx
 import { yupResolver } from '@hookform/resolvers/yup';

--- a/docs/WizardForm.md
+++ b/docs/WizardForm.md
@@ -58,7 +58,7 @@ The `<WizardForm>` component accepts the following props:
 | `warnWhen UnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
 
-Additional props are passed to `react-hook-form`'s [`useForm` hook](https://www.react-hook-form.com/api/useform).
+Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/docs/useform).
 
 ## `children`
 
@@ -405,7 +405,7 @@ const PostCreate = () => (
 
 ## Adding a Summary Final Step
 
-In order to add a final step with a summary of the form values before submit, you can leverage `react-hook-form` [`useWatch`](https://www.react-hook-form.com/api/usewatch) hook:
+In order to add a final step with a summary of the form values before submit, you can leverage `react-hook-form` [`useWatch`](https://react-hook-form.com/docs/usewatch) hook:
 
 ```tsx
 const FinalStepContent = () => {

--- a/docs/WizardForm.md
+++ b/docs/WizardForm.md
@@ -58,7 +58,7 @@ The `<WizardForm>` component accepts the following props:
 | `warnWhen UnsavedChanges` | Optional | `boolean`         | -       | Set to `true` to warn the user when leaving the form with unsaved changes. |
 
 
-Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/api/useform).
+Additional props are passed to `react-hook-form`'s [`useForm` hook](https://www.react-hook-form.com/api/useform).
 
 ## `children`
 
@@ -405,7 +405,7 @@ const PostCreate = () => (
 
 ## Adding a Summary Final Step
 
-In order to add a final step with a summary of the form values before submit, you can leverage `react-hook-form` [`useWatch`](https://react-hook-form.com/api/usewatch) hook:
+In order to add a final step with a summary of the form values before submit, you can leverage `react-hook-form` [`useWatch`](https://www.react-hook-form.com/api/usewatch) hook:
 
 ```tsx
 const FinalStepContent = () => {

--- a/docs/useInput.md
+++ b/docs/useInput.md
@@ -5,7 +5,7 @@ title: "useInput"
 
 # `useInput`
 
-This hook lets you build custom inputs for react-admin. It's a wrapper around [react-hook-form's `useController`](https://react-hook-form.com/api/usecontroller).
+This hook lets you build custom inputs for react-admin. It's a wrapper around [react-hook-form's `useController`](https://www.react-hook-form.com/api/usecontroller).
 
 React-admin adds functionality to react-hook-form:
 
@@ -52,7 +52,7 @@ const TitleInput = ({ source, label }) => {
 | `onChange`     | Optional | `Function`                     | -       | A function to call when the input value changes                   |
 | `onBlur`       | Optional | `Function`                     | -       | A function to call when the input is blurred                      |
 
-Additional props are passed to [react-hook-form's `useController` hook](https://react-hook-form.com/api/usecontroller).
+Additional props are passed to [react-hook-form's `useController` hook](https://www.react-hook-form.com/api/usecontroller).
 
 ## Usage with Material UI `<TextField>`
 
@@ -100,7 +100,7 @@ const LatLngInput = props => {
 };
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
@@ -154,7 +154,7 @@ const PersonEdit = () => (
 );
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/useInput.md
+++ b/docs/useInput.md
@@ -5,7 +5,7 @@ title: "useInput"
 
 # `useInput`
 
-This hook lets you build custom inputs for react-admin. It's a wrapper around [react-hook-form's `useController`](https://www.react-hook-form.com/api/usecontroller).
+This hook lets you build custom inputs for react-admin. It's a wrapper around [react-hook-form's `useController`](https://react-hook-form.com/docs/usecontroller).
 
 React-admin adds functionality to react-hook-form:
 
@@ -52,7 +52,7 @@ const TitleInput = ({ source, label }) => {
 | `onChange`     | Optional | `Function`                     | -       | A function to call when the input value changes                   |
 | `onBlur`       | Optional | `Function`                     | -       | A function to call when the input is blurred                      |
 
-Additional props are passed to [react-hook-form's `useController` hook](https://www.react-hook-form.com/api/usecontroller).
+Additional props are passed to [react-hook-form's `useController` hook](https://react-hook-form.com/docs/usecontroller).
 
 ## Usage with Material UI `<TextField>`
 
@@ -100,7 +100,7 @@ const LatLngInput = props => {
 };
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
@@ -154,7 +154,7 @@ const PersonEdit = () => (
 );
 ```
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://www.react-hook-form.com/api/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅

--- a/docs/useRecordContext.md
+++ b/docs/useRecordContext.md
@@ -64,7 +64,7 @@ As soon as there is a record available, react-admin puts it in a `RecordContext`
 
 Inside `<Edit>` and `<Create>`, `useRecordContext` returns the *initial* record, used to set the initial form values. 
 
-If you want to react to the data entered by the user, use [react-hook-form's `useWatch`](https://www.react-hook-form.com/api/usewatch/) instead of `useRecordContext`. It returns the current form values, including the changes made by the user.
+If you want to react to the data entered by the user, use [react-hook-form's `useWatch`](https://react-hook-form.com/docs/usewatch/) instead of `useRecordContext`. It returns the current form values, including the changes made by the user.
 
 For instance if you want to display an additional input when a user marks an order as returned, you can do the following:
 

--- a/docs/useRecordContext.md
+++ b/docs/useRecordContext.md
@@ -64,7 +64,7 @@ As soon as there is a record available, react-admin puts it in a `RecordContext`
 
 Inside `<Edit>` and `<Create>`, `useRecordContext` returns the *initial* record, used to set the initial form values. 
 
-If you want to react to the data entered by the user, use [react-hook-form's `useWatch`](https://react-hook-form.com/api/usewatch/) instead of `useRecordContext`. It returns the current form values, including the changes made by the user.
+If you want to react to the data entered by the user, use [react-hook-form's `useWatch`](https://www.react-hook-form.com/api/usewatch/) instead of `useRecordContext`. It returns the current form values, including the changes made by the user.
 
 For instance if you want to display an additional input when a user marks an order as returned, you can do the following:
 

--- a/packages/ra-core/src/form/Form.tsx
+++ b/packages/ra-core/src/form/Form.tsx
@@ -40,7 +40,7 @@ import { useAugmentedForm } from './useAugmentedForm';
  * @see useForm
  * @see FormGroupContext
  *
- * @link https://www.react-hook-form.com/api/useformcontext
+ * @link https://react-hook-form.com/docs/useformcontext
  */
 export const Form = (props: FormProps) => {
     const { children, id, className, noValidate = false } = props;

--- a/packages/ra-core/src/form/Form.tsx
+++ b/packages/ra-core/src/form/Form.tsx
@@ -40,7 +40,7 @@ import { useAugmentedForm } from './useAugmentedForm';
  * @see useForm
  * @see FormGroupContext
  *
- * @link https://react-hook-form.com/api/useformcontext
+ * @link https://www.react-hook-form.com/api/useformcontext
  */
 export const Form = (props: FormProps) => {
     const { children, id, className, noValidate = false } = props;

--- a/packages/ra-core/src/form/useFormValues.ts
+++ b/packages/ra-core/src/form/useFormValues.ts
@@ -1,6 +1,6 @@
 import { FieldValues, useFormContext, useWatch } from 'react-hook-form';
 
-// hook taken from https://react-hook-form.com/api/usewatch/#rules
+// hook taken from https://www.react-hook-form.com/api/usewatch/#rules
 export const useFormValues = <
     TFieldValues extends FieldValues = FieldValues
 >() => {

--- a/packages/ra-core/src/form/useFormValues.ts
+++ b/packages/ra-core/src/form/useFormValues.ts
@@ -1,6 +1,6 @@
 import { FieldValues, useFormContext, useWatch } from 'react-hook-form';
 
-// hook taken from https://www.react-hook-form.com/api/usewatch/#rules
+// hook taken from https://react-hook-form.com/docs/usewatch/#rules
 export const useFormValues = <
     TFieldValues extends FieldValues = FieldValues
 >() => {

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -66,7 +66,7 @@ import { ArrayInputContext } from './ArrayInputContext';
  * list item (<li>). It also provides controls for adding and removing
  * a sub-record (a backlink in this example).
  *
- * @see {@link https://www.react-hook-form.com/api/usefieldarray}
+ * @see {@link https://react-hook-form.com/docs/usefieldarray}
  */
 export const ArrayInput = (props: ArrayInputProps) => {
     const {
@@ -188,7 +188,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
                         touched={isDirty || isSubmitted}
                         // root property is applicable to built-in validation only,
                         // Resolvers are yet to support useFieldArray root level validation.
-                        // Reference: https://www.react-hook-form.com/api/usefieldarray
+                        // Reference: https://react-hook-form.com/docs/usefieldarray
                         error={error?.root?.message ?? error?.message}
                         helperText={helperText}
                     />

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -66,7 +66,7 @@ import { ArrayInputContext } from './ArrayInputContext';
  * list item (<li>). It also provides controls for adding and removing
  * a sub-record (a backlink in this example).
  *
- * @see {@link https://react-hook-form.com/api/usefieldarray}
+ * @see {@link https://www.react-hook-form.com/api/usefieldarray}
  */
 export const ArrayInput = (props: ArrayInputProps) => {
     const {
@@ -188,7 +188,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
                         touched={isDirty || isSubmitted}
                         // root property is applicable to built-in validation only,
                         // Resolvers are yet to support useFieldArray root level validation.
-                        // Reference: https://react-hook-form.com/api/usefieldarray
+                        // Reference: https://www.react-hook-form.com/api/usefieldarray
                         error={error?.root?.message ?? error?.message}
                         helperText={helperText}
                     />

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInputContext.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInputContext.ts
@@ -5,7 +5,7 @@ import { UseFieldArrayReturn } from 'react-hook-form';
  * A React context that provides access to an ArrayInput methods as provided by react-hook-form
  * Useful to create custom array input iterators.
  * @see {ArrayInput}
- * @see {@link https://react-hook-form.com/api/usefieldarray}
+ * @see {@link https://www.react-hook-form.com/api/usefieldarray}
  */
 export const ArrayInputContext = createContext<ArrayInputContextValue>(
     undefined

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInputContext.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInputContext.ts
@@ -5,7 +5,7 @@ import { UseFieldArrayReturn } from 'react-hook-form';
  * A React context that provides access to an ArrayInput methods as provided by react-hook-form
  * Useful to create custom array input iterators.
  * @see {ArrayInput}
- * @see {@link https://www.react-hook-form.com/api/usefieldarray}
+ * @see {@link https://react-hook-form.com/docs/usefieldarray}
  */
 export const ArrayInputContext = createContext<ArrayInputContextValue>(
     undefined

--- a/packages/ra-ui-materialui/src/input/ArrayInput/useArrayInput.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/useArrayInput.ts
@@ -5,7 +5,7 @@ import { ArrayInputContext, ArrayInputContextValue } from './ArrayInputContext';
  * A hook to access an array input methods as provided by react-hook-form.
  * Useful to create custom array input iterators.
  * @see {ArrayInput}
- * @see https://www.react-hook-form.com/api/usefieldarray
+ * @see https://react-hook-form.com/docs/usefieldarray
  */
 export const useArrayInput = (
     props?: Partial<ArrayInputContextValue>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/useArrayInput.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/useArrayInput.ts
@@ -5,7 +5,7 @@ import { ArrayInputContext, ArrayInputContextValue } from './ArrayInputContext';
  * A hook to access an array input methods as provided by react-hook-form.
  * Useful to create custom array input iterators.
  * @see {ArrayInput}
- * @see https://react-hook-form.com/api/usefieldarray
+ * @see https://www.react-hook-form.com/api/usefieldarray
  */
 export const useArrayInput = (
     props?: Partial<ArrayInputContextValue>

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -229,7 +229,7 @@ const StyledForm = styled('form', {
 
 /**
  * Because we are using controlled inputs with react-hook-form, we must provide a default value
- * for each input when resetting the form. (see https://react-hook-form.com/api/useform/reset).
+ * for each input when resetting the form. (see https://www.react-hook-form.com/api/useform/reset).
  * To ensure we don't provide undefined which will result to the current input value being reapplied
  * and due to the dynamic nature of the filter form, we rebuild the filter form values from its current
  * values and make sure to pass at least an empty string for each input.

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -229,7 +229,7 @@ const StyledForm = styled('form', {
 
 /**
  * Because we are using controlled inputs with react-hook-form, we must provide a default value
- * for each input when resetting the form. (see https://www.react-hook-form.com/api/useform/reset).
+ * for each input when resetting the form. (see https://react-hook-form.com/docs/useform/reset).
  * To ensure we don't provide undefined which will result to the current input value being reapplied
  * and due to the dynamic nature of the filter form, we rebuild the filter form values from its current
  * values and make sure to pass at least an empty string for each input.


### PR DESCRIPTION
Dunno if it's temporary (and intentional) or not, but the RHF doc is now under www.react-hook-form.com instead of react-hook-form.com, so this PR changes the links accordingly

EDIT

According to https://github.com/react-hook-form/documentation/issues/971, the path has to be changed to `/docs`, so this is what this PR does.