### PR TITLE
Fix `<WithRecord>` `render` prop type

### DIFF
--- a/examples/demo/src/orders/NbItemsField.tsx
+++ b/examples/demo/src/orders/NbItemsField.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { FunctionField, RenderRecordFunction } from 'react-admin';
+import { FunctionField } from 'react-admin';
 import { Order } from '../types';
 
-const render: RenderRecordFunction<Order> = record => record.basket.length;
+const render = (record: Order) => record.basket.length;
 
 const NbItemsField = () => <FunctionField<Order> render={render} />;
 

--- a/packages/ra-core/src/controller/record/WithRecord.tsx
+++ b/packages/ra-core/src/controller/record/WithRecord.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import * as React from 'react';
+import { ReactNode } from 'react';
 import { useRecordContext } from './useRecordContext';
 
 /**
@@ -17,12 +18,12 @@ export const WithRecord = <RecordType extends Record<string, unknown> = any>({
     render,
 }: WithRecordProps<RecordType>) => {
     const record = useRecordContext<RecordType>();
-    return record ? render(record) : null;
+    return record ? <>{render(record)}</> : null;
 };
 
 export interface WithRecordProps<
     RecordType extends Record<string, unknown> = any
 > {
-    render: (record: RecordType) => ReactElement;
+    render: (record: RecordType) => ReactNode;
     label?: string;
 }

--- a/packages/ra-core/src/controller/record/WithRecord.tsx
+++ b/packages/ra-core/src/controller/record/WithRecord.tsx
@@ -1,4 +1,4 @@
-import { RenderRecordFunction } from '../../types';
+import { ReactElement } from 'react';
 import { useRecordContext } from './useRecordContext';
 
 /**
@@ -23,6 +23,6 @@ export const WithRecord = <RecordType extends Record<string, unknown> = any>({
 export interface WithRecordProps<
     RecordType extends Record<string, unknown> = any
 > {
-    render: RenderRecordFunction<RecordType>;
+    render: (record: RecordType) => ReactElement;
     label?: string;
 }

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -361,10 +361,6 @@ export interface ResourceProps {
     children?: ReactNode;
 }
 
-export type RenderRecordFunction<
-    RecordType extends Record<string, unknown> = any
-> = (record: RecordType, source?: string) => ReactNode;
-
 export type Exporter = (
     data: any,
     fetchRelatedRecords: (

--- a/packages/ra-ui-materialui/src/field/FunctionField.tsx
+++ b/packages/ra-ui-materialui/src/field/FunctionField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useMemo } from 'react';
-import { RenderRecordFunction, useRecordContext } from 'ra-core';
+import { useMemo, ReactNode } from 'react';
+import { useRecordContext } from 'ra-core';
 import PropTypes from 'prop-types';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 
@@ -50,5 +50,5 @@ export interface FunctionFieldProps<
     RecordType extends Record<string, unknown> = any
 > extends FieldProps<RecordType>,
         Omit<TypographyProps, 'textAlign'> {
-    render: RenderRecordFunction<RecordType>;
+    render: (record: RecordType, source?: string) => ReactNode;
 }


### PR DESCRIPTION
**Problem**

https://github.com/marmelab/react-admin/pull/8963 introduced a change to `<WithRecord>`, which allowed the `render` prop return a `ReactNode` instead of a `ReactElement`.
But since `<WithRecord>` currently returns the result of the `render` function without wrapping it in JSX first, we get the following TS error:

![image](https://github.com/marmelab/react-admin/assets/14542336/9b76cfcc-c649-45dc-ade7-b3145609e2c1)

**Solution**

Wrap the result of the `render` function in a React Fragment.
Also, I removed the the `RenderRecordFunction` type because to me `FunctionField` and `WithRecord` do not share the same `render` function signature.