### PR TITLE
[JSDoc] Fix ToggleThemeButton deprecated props JSDoc

### DIFF
--- a/packages/ra-ui-materialui/src/button/ToggleThemeButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ToggleThemeButton.tsx
@@ -63,11 +63,11 @@ export const ToggleThemeButton = (props: ToggleThemeButtonProps) => {
 
 export interface ToggleThemeButtonProps {
     /**
-     * @deprecated Set the lightTheme in the <Admin> component instead.
+     * @deprecated Set the lightTheme in the `<Admin>` component instead.
      */
     lightTheme?: RaThemeOptions;
     /**
-     * @deprecated Set the darkTheme in the <Admin> component instead.
+     * @deprecated Set the darkTheme in the `<Admin>` component instead.
      */
     darkTheme?: RaThemeOptions;
 }


### PR DESCRIPTION
Currently, the JSDoc for the deprecated `lightTheme` prop appear as `Set the lightTheme in the component instead.`, which does not make much sense.

This PR fixes it to be `Set the lightTheme in the <Admin> component instead.`

Same for `darkTheme` of course.