### PR TITLE
Fix: query permissions at startup only when a child function exist

### DIFF
--- a/packages/create-react-admin/templates/local-auth-provider/authProvider.ts
+++ b/packages/create-react-admin/templates/local-auth-provider/authProvider.ts
@@ -29,7 +29,10 @@ export const authProvider: AuthProvider = {
     checkError: () => Promise.resolve(),
     checkAuth: () =>
         localStorage.getItem('user') ? Promise.resolve() : Promise.reject(),
-    getPermissions: () => Promise.reject('Unknown method'),
+    getPermissions: () => {
+        const role = localStorage.getItem('permissions');
+        return role ? Promise.resolve(role) : Promise.reject();
+    },
     getIdentity: () => {
         const persistedUser = localStorage.getItem('user');
         const user = persistedUser ? JSON.parse(persistedUser) : null;

--- a/packages/create-react-admin/templates/local-auth-provider/authProvider.ts
+++ b/packages/create-react-admin/templates/local-auth-provider/authProvider.ts
@@ -30,8 +30,7 @@ export const authProvider: AuthProvider = {
     checkAuth: () =>
         localStorage.getItem('user') ? Promise.resolve() : Promise.reject(),
     getPermissions: () => {
-        const role = localStorage.getItem('permissions');
-        return role ? Promise.resolve(role) : Promise.reject();
+        return Promise.resolve(undefined);
     },
     getIdentity: () => {
         const persistedUser = localStorage.getItem('user');

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -35,10 +35,11 @@ const emptyParams = {};
  */
 const usePermissions = <Permissions = any, Error = any>(
     params = emptyParams,
-    queryParams: UseQueryOptions<Permissions, Error> = {
-        staleTime: 5 * 60 * 1000,
-    }
+    queryParams: UseQueryOptions<Permissions, Error>
 ) => {
+    if (!queryParams.staleTime) {
+        queryParams = { ...queryParams, staleTime: 5 * 60 * 1000 };
+    }
     const authProvider = useAuthProvider();
 
     const result = useQuery(

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -3,6 +3,9 @@ import { useQuery, UseQueryOptions } from 'react-query';
 import useAuthProvider from './useAuthProvider';
 
 const emptyParams = {};
+const defaultQueryParams: UseQueryOptions = {
+    staleTime: 5 * 60 * 1000,
+};
 /**
  * Hook for getting user permissions
  *
@@ -35,11 +38,8 @@ const emptyParams = {};
  */
 const usePermissions = <Permissions = any, Error = any>(
     params = emptyParams,
-    queryParams: UseQueryOptions<Permissions, Error>
+    queryParams: UseQueryOptions<Permissions, Error> = {}
 ) => {
-    if (!queryParams.staleTime) {
-        queryParams = { ...queryParams, staleTime: 5 * 60 * 1000 };
-    }
     const authProvider = useAuthProvider();
 
     const result = useQuery(
@@ -47,7 +47,10 @@ const usePermissions = <Permissions = any, Error = any>(
         authProvider
             ? () => authProvider.getPermissions(params)
             : async () => [],
-        queryParams
+        {
+            ...defaultQueryParams,
+            ...queryParams,
+        }
     );
 
     return useMemo(

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -3,9 +3,7 @@ import { useQuery, UseQueryOptions } from 'react-query';
 import useAuthProvider from './useAuthProvider';
 
 const emptyParams = {};
-const defaultQueryParams: UseQueryOptions = {
-    staleTime: 5 * 60 * 1000,
-};
+
 /**
  * Hook for getting user permissions
  *
@@ -38,7 +36,9 @@ const defaultQueryParams: UseQueryOptions = {
  */
 const usePermissions = <Permissions = any, Error = any>(
     params = emptyParams,
-    queryParams: UseQueryOptions<Permissions, Error> = {}
+    queryParams: UseQueryOptions<Permissions, Error> = {
+        staleTime: 5 * 60 * 1000,
+    }
 ) => {
     const authProvider = useAuthProvider();
 
@@ -47,10 +47,7 @@ const usePermissions = <Permissions = any, Error = any>(
         authProvider
             ? () => authProvider.getPermissions(params)
             : async () => [],
-        {
-            ...defaultQueryParams,
-            ...queryParams,
-        }
+        queryParams
     );
 
     return useMemo(

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -45,6 +45,7 @@ export const useConfigureAdminRouterFromChildren = (
 ): RoutesAndResources & { status: AdminRouterStatus } => {
     const { permissions, isLoading } = usePermissions(undefined, {
         enabled: !!getSingleChildFunction(children),
+        staleTime: 5 * 60 * 1000,
     });
 
     // Whenever children are updated, update our custom routes and resources

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -43,9 +43,7 @@ import { useResourceDefinitionContext } from './useResourceDefinitionContext';
 export const useConfigureAdminRouterFromChildren = (
     children: AdminChildren
 ): RoutesAndResources & { status: AdminRouterStatus } => {
-    const { permissions, isLoading } = usePermissions(undefined, {
-        enabled: !!getSingleChildFunction(children),
-    });
+    const { permissions, isLoading } = usePermissions();
 
     // Whenever children are updated, update our custom routes and resources
     const [routesAndResources, status] = useRoutesAndResourcesFromChildren(

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -45,7 +45,6 @@ export const useConfigureAdminRouterFromChildren = (
 ): RoutesAndResources & { status: AdminRouterStatus } => {
     const { permissions, isLoading } = usePermissions(undefined, {
         enabled: !!getSingleChildFunction(children),
-        staleTime: 5 * 60 * 1000,
     });
 
     // Whenever children are updated, update our custom routes and resources

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -43,7 +43,9 @@ import { useResourceDefinitionContext } from './useResourceDefinitionContext';
 export const useConfigureAdminRouterFromChildren = (
     children: AdminChildren
 ): RoutesAndResources & { status: AdminRouterStatus } => {
-    const { permissions, isLoading } = usePermissions();
+    const { permissions, isLoading } = usePermissions(undefined, {
+        enabled: !!getSingleChildFunction(children),
+    });
 
     // Whenever children are updated, update our custom routes and resources
     const [routesAndResources, status] = useRoutesAndResourcesFromChildren(


### PR DESCRIPTION
When creating a React Admin App with `create-react-admin`, and choosing to add an `authProvider`, the provider is created with this method: `getPermissions: () => Promise.reject("Unknown method"),`.
This leads to an error log in browser devtools console (e.g: `Unknown method`), even the app doesn't need permission anywhere. 

Reproduce:
- Create a React Admin App with [`create-react-admin`](https://marmelab.com/react-admin/CreateReactAdmin.html)
- Run the app, go on the app with a browser and open browser devtools
- Wait some second and see the error throws in the console

~~Fix: Call `authProvider.getPermissions` only when a [child function exist](https://marmelab.com/react-admin/Permissions.html#restricting-access-to-resources-or-views) and only when the hook `usePermissions` is used in the application.~~

Fix: change `authProvider` template in `create-react-admin` package