### PR TITLE
Automatically convert TS examples to JS

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -113,5 +113,10 @@
             data-website-id="ef7f8242-2808-4cbf-9dff-564daa515bbd"
             src="https://analytics.marmelab.com/umami.js"
         ></script>
+
+        <script async defer src="https://unpkg.com/typescript@5.1.3/lib/typescript.js"></script>
+        <script async defer src="https://unpkg.com/prettier@2.8.8/standalone.js"></script>
+        <script async defer src="https://unpkg.com/prettier@2.8.8/parser-babel.js"></script>
+
     </body>
 </html>

--- a/docs/css/prism.css
+++ b/docs/css/prism.css
@@ -42,7 +42,7 @@ pre[class*="language-"]::selection {
 }
 pre[class*="language-"] {
   padding: 1em;
-  margin: 0.5em 0;
+  margin: 0;
   overflow: auto;
 }
 :not(pre) > code[class*="language-"],

--- a/docs/css/style-v17.css
+++ b/docs/css/style-v17.css
@@ -46,7 +46,9 @@ main > .container .markdown-section {
     top: 20px;
     padding-left: 1em;
     overflow-y: auto;
-    max-height: calc(100vh - 114px); /* 114px = 50px container top padding + 64px navbar height  */
+    max-height: calc(
+        100vh - 114px
+    ); /* 114px = 50px container top padding + 64px navbar height  */
 }
 .toc.is-position-fixed {
     position: static !important;
@@ -134,7 +136,6 @@ nav ul#nav-mobile a {
         font-size: 1.2em;
         font-weight: normal;
     }
-     
 }
 
 .sidenav.sidenav-fixed ul.collapsible-accordion a.collapsible-header {
@@ -282,18 +283,21 @@ ul.sidenav code {
     }
 }
 
-.markdown-section img, .markdown-section video {
+.markdown-section img,
+.markdown-section video {
     max-width: 100%;
 }
 
 @media only screen and (min-width: 601px) {
-    .markdown-section img, .markdown-section video {
+    .markdown-section img,
+    .markdown-section video {
         max-width: 90%;
         box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.24);
         border-radius: 2px;
         margin: 1rem;
     }
-    .markdown-section img.no-shadow, .markdown-section video.no-shadow {
+    .markdown-section img.no-shadow,
+    .markdown-section video.no-shadow {
         max-width: 90%;
         box-shadow: none;
         border-radius: 0;
@@ -606,7 +610,6 @@ body.no-sidebar .sidenav-trigger {
     background: none;
 }
 
-
 .pages-index {
     column-count: 3;
 }
@@ -620,7 +623,7 @@ body.no-sidebar .sidenav-trigger {
 
 .pages-index code {
     font-size: 0.8em;
-    background: none!important;
+    background: none !important;
 }
 
 #docsearch .DocSearch-Button {
@@ -628,9 +631,9 @@ body.no-sidebar .sidenav-trigger {
 }
 
 @media only screen and (max-width: 1500px) {
-        #docsearch .DocSearch-Button {
-            width: 200px !important;
-        }
+    #docsearch .DocSearch-Button {
+        width: 200px !important;
+    }
 }
 
 .news {
@@ -655,4 +658,20 @@ body.no-sidebar .sidenav-trigger {
     .news-mobile {
         display: none;
     }
+}
+
+.marmelab-language-switcher-tabs {
+    display: flex;
+    gap: 1rem;
+    justify-content: end;
+}
+
+.language-switcher {
+    background-color: #f5f2f0;
+    padding: 0.5rem 1rem;
+    transition: all 0.2s ease-in-out;
+}
+
+.language-switcher.active {
+    background-color: #f5f2f0;
 }

--- a/docs/css/style-v17.css
+++ b/docs/css/style-v17.css
@@ -674,4 +674,5 @@ body.no-sidebar .sidenav-trigger {
 
 .language-switcher.active {
     background-color: #f5f2f0;
+    text-decoration: none !important;
 }

--- a/docs/js/ra-doc-exec.js
+++ b/docs/js/ra-doc-exec.js
@@ -21,7 +21,13 @@ const applyPreferredLanguage = async () => {
             if (fence.classList.contains(`language-${preferredLanguage}`)) {
                 fence.style.display = 'block';
             } else {
-                fence.style.display = 'none';
+                if (
+                    (fence.classList.contains(`language-jsx`) &&
+                        fence.dataset.tsBlock) ||
+                    fence.classList.contains(`language-tsx`)
+                ) {
+                    fence.style.display = 'none';
+                }
             }
 
             if (

--- a/docs/js/ra-doc-exec.js
+++ b/docs/js/ra-doc-exec.js
@@ -87,7 +87,7 @@ const transpileToJS = async tsCode => {
     return jsCode;
 };
 
-const builtJSCodeBlocksFromTS = async () => {
+const buildJSCodeBlocksFromTS = async () => {
     const tsBlocks = document.querySelectorAll('div.language-tsx');
 
     await Promise.all(
@@ -293,7 +293,7 @@ document.addEventListener('click', event => {
     fetch(href)
         .then(res => res.text())
         .then(replaceContent)
-        .then(builtJSCodeBlocksFromTS);
+        .then(buildJSCodeBlocksFromTS);
     // change the URL
     window.history.pushState(null, null, href);
     changeSelectedMenu();
@@ -313,7 +313,7 @@ window.addEventListener('popstate', () => {
         fetch(window.location.pathname)
             .then(res => res.text())
             .then(replaceContent)
-            .then(builtJSCodeBlocksFromTS);
+            .then(buildJSCodeBlocksFromTS);
     }
     changeSelectedMenu();
 });
@@ -328,5 +328,5 @@ window.addEventListener('DOMContentLoaded', () => {
     buildPageToC();
 
     navigationFitScroll();
-    builtJSCodeBlocksFromTS();
+    buildJSCodeBlocksFromTS();
 });

--- a/docs/js/ra-doc-exec.js
+++ b/docs/js/ra-doc-exec.js
@@ -63,6 +63,7 @@ const transpileToJS = async tsCode => {
         await new Promise(resolve => setTimeout(resolve, 100));
         return transpileToJS(tsCode);
     }
+
     const transpilation = window.ts.transpileModule(
         // Ensure blank lines are preserved
         tsCode.replace(/\n\n/g, '\n/** THIS_IS_A_NEWLINE **/'),
@@ -72,6 +73,7 @@ const transpileToJS = async tsCode => {
                 target: 99,
                 noResolve: true,
                 isolatedModules: true,
+                verbatimModuleSyntax: true,
             },
             reportDiagnostics: false,
         }
@@ -82,11 +84,13 @@ const transpileToJS = async tsCode => {
         // Ensure blank lines are preserved
         transpilation.outputText.replace(
             /\/\*\* THIS_IS_A_NEWLINE \*\*\//g,
-            '\n'
+            '\n\n'
         ),
         {
             plugins: [prettierPlugins.babel],
             parser: 'babel',
+            tabWidth: 4,
+            printWidth: 120,
         }
     );
 
@@ -160,11 +164,13 @@ const buildJSCodeBlocksFromTS = async () => {
             parent.insertBefore(container, block);
             parent.removeChild(block);
 
-            jsTabTitle.addEventListener('click', () => {
+            jsTabTitle.addEventListener('click', event => {
+                event.preventDefault();
                 window.localStorage.setItem('preferred-language', 'jsx');
                 applyPreferredLanguage();
             });
-            tsTabTitle.addEventListener('click', () => {
+            tsTabTitle.addEventListener('click', event => {
+                event.preventDefault();
                 window.localStorage.setItem('preferred-language', 'tsx');
                 applyPreferredLanguage();
             });

--- a/docs/js/ra-doc-exec.js
+++ b/docs/js/ra-doc-exec.js
@@ -1,4 +1,172 @@
+/* global Prism, prettier, prettierPlugins */
 var allMenus, navLinks, versionsLinks;
+
+const applyPreferredLanguage = async () => {
+    const preferredLanguage =
+        window.localStorage.getItem('preferred-language') || 'jsx';
+
+    const languageSwitchers = document.querySelectorAll('.language-switcher');
+    const codeFences = document.querySelectorAll('div[class^=language-]');
+
+    languageSwitchers.forEach(switcher => {
+        if (switcher.dataset.language === preferredLanguage) {
+            switcher.classList.add('active');
+        } else {
+            switcher.classList.remove('active');
+        }
+    });
+
+    await Promise.all(
+        Array.from(codeFences).map(async fence => {
+            if (fence.classList.contains(`language-${preferredLanguage}`)) {
+                fence.style.display = 'block';
+            } else {
+                fence.style.display = 'none';
+            }
+
+            if (
+                // We want to transpile TS code blocks to JS only when actually requested
+                preferredLanguage === 'jsx' &&
+                // The code block is a JSX one
+                fence.classList.contains('language-jsx') &&
+                // That has been generated from a TSX block
+                fence.dataset.tsBlock &&
+                // And has not been transpiled yet
+                fence.dataset.transpiled !== 'true'
+            ) {
+                const tsBlock = document.getElementById(fence.dataset.tsBlock);
+                if (tsBlock) {
+                    const jsCode = await transpileToJS(tsBlock.innerText);
+                    fence.querySelector('code').textContent = jsCode;
+                    fence.dataset.transpiled = 'true';
+                    Prism.highlightElement(fence.querySelector('code'));
+                }
+            }
+        })
+    );
+};
+
+const transpileToJS = async tsCode => {
+    // As we load those libs asynchronously, we need to ensure they are loaded
+    // before using them
+    if (
+        window.ts === undefined ||
+        window.prettier === undefined ||
+        window.prettierPlugins === undefined
+    ) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        return transpileToJS(tsCode);
+    }
+    const transpilation = window.ts.transpileModule(
+        // Ensure blank lines are preserved
+        tsCode.replace(/\n\n/g, '\n/** THIS_IS_A_NEWLINE **/'),
+        {
+            compilerOptions: {
+                jsx: 'preserve',
+                target: 99,
+                noResolve: true,
+                isolatedModules: true,
+            },
+            reportDiagnostics: false,
+        }
+    );
+
+    // prettier is necessary because the transpiled code is not formatted
+    const jsCode = prettier.format(
+        // Ensure blank lines are preserved
+        transpilation.outputText.replace(
+            /\/\*\* THIS_IS_A_NEWLINE \*\*\//g,
+            '\n'
+        ),
+        {
+            plugins: [prettierPlugins.babel],
+            parser: 'babel',
+        }
+    );
+
+    return jsCode;
+};
+
+const builtJSCodeBlocksFromTS = async () => {
+    const tsBlocks = document.querySelectorAll('div.language-tsx');
+
+    await Promise.all(
+        Array.from(tsBlocks).map(async (block, index) => {
+            const parent = block.parentNode;
+
+            // Container for both tabs links and panels
+            const container = document.createElement('div');
+            container.className = 'marmelab-code-container';
+
+            // Container for tabs links
+            const tabs = document.createElement('div');
+            tabs.className = 'marmelab-language-switcher-tabs';
+
+            // JS tab link
+            const jsTab = document.createElement('span');
+            const jsTabTitle = document.createElement('a');
+            jsTabTitle.className = 'language-switcher';
+            jsTabTitle.dataset.language = 'jsx';
+            jsTabTitle.href = `#jsx-${index}`;
+            jsTabTitle.title = 'JavaScript';
+            jsTabTitle.innerText = 'JS';
+            jsTab.appendChild(jsTabTitle);
+
+            // JS tab panel
+            const jsTabContent = document.createElement('div');
+            jsTabContent.className = 'language-jsx highlighter-rouge';
+            jsTabContent.id = `jsx-${index}`;
+            // Allows us to find the corresponding TS block to hide it when switching to JS
+            jsTabContent.dataset.tsBlock = `tsx-${index}`;
+
+            // Containers for Prism highlighter
+            const highlight = document.createElement('div');
+            jsTabContent.appendChild(highlight);
+            const jsTabContentPre = document.createElement('pre');
+            highlight.appendChild(jsTabContentPre);
+
+            // The actual JS code element
+            const jsTabContentCode = document.createElement('code');
+            jsTabContentCode.className = 'language-jsx';
+            jsTabContentPre.appendChild(jsTabContentCode);
+            tabs.appendChild(jsTab);
+
+            // TS tab link
+            const tsTab = document.createElement('span');
+            const tsTabTitle = document.createElement('a');
+            tsTabTitle.className = 'language-switcher';
+            tsTabTitle.href = `#tsx-${index}`;
+            tsTabTitle.title = 'TypeScript';
+            tsTabTitle.innerText = 'TS';
+            tsTabTitle.dataset.language = 'tsx';
+            tsTab.appendChild(tsTabTitle);
+
+            // TS tab panel (the block we cloned is already Prism highlighted)
+            const tsTabContent = block.cloneNode(true);
+            tsTabContent.id = `tsx-${index}`;
+            tabs.appendChild(tsTab);
+
+            container.appendChild(tabs);
+            container.appendChild(jsTabContent);
+            container.appendChild(tsTabContent);
+
+            // Replace the old TS only block by the new tabs container
+            parent.insertBefore(container, block);
+            parent.removeChild(block);
+
+            jsTabTitle.addEventListener('click', () => {
+                window.localStorage.setItem('preferred-language', 'jsx');
+                applyPreferredLanguage();
+            });
+            tsTabTitle.addEventListener('click', () => {
+                window.localStorage.setItem('preferred-language', 'tsx');
+                applyPreferredLanguage();
+            });
+        })
+    );
+
+    applyPreferredLanguage();
+};
 
 // eslint-disable-next-line no-unused-vars
 function slugify(text) {
@@ -124,14 +292,15 @@ document.addEventListener('click', event => {
     // fetch the new content
     fetch(href)
         .then(res => res.text())
-        .then(replaceContent);
+        .then(replaceContent)
+        .then(builtJSCodeBlocksFromTS);
     // change the URL
     window.history.pushState(null, null, href);
     changeSelectedMenu();
 });
 
 // make back button work again
-window.addEventListener('popstate', event => {
+window.addEventListener('popstate', () => {
     if (document.location.href.indexOf('#') !== -1) {
         // popstate triggered by a click on an anchor, not back button
         return;
@@ -143,7 +312,8 @@ window.addEventListener('popstate', event => {
         // fetch the new content
         fetch(window.location.pathname)
             .then(res => res.text())
-            .then(replaceContent);
+            .then(replaceContent)
+            .then(builtJSCodeBlocksFromTS);
     }
     changeSelectedMenu();
 });
@@ -158,4 +328,5 @@ window.addEventListener('DOMContentLoaded', () => {
     buildPageToC();
 
     navigationFitScroll();
+    builtJSCodeBlocksFromTS();
 });

--- a/docs/useDataProvider.md
+++ b/docs/useDataProvider.md
@@ -62,7 +62,7 @@ export interface DataProviderWithCustomMethods extends DataProvider {
     }) => Promise<any>
 }
 
-export const dataProvider: DataProviderWithCustomMethods {
+export const dataProvider: DataProviderWithCustomMethods = {
     // ...Standard dataProvider methods
     archive: (resource, params) => {
         // Call the archive endpoint and return a promise


### PR DESCRIPTION
Done client side and only when needed.
I compared locally with the previous docs and didn't notice any difference even with CPU throttling x6 on slow 3G

## How to test

- Open AccordionForm.md
- Click on the AccordionForm.Panel section 
- Scroll down
- The first snippet is bi-lingual
<img width="1494" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/739e21be-c745-40af-bc63-755b19b16a38">
