### PR TITLE
Allow disabling store persistence of the list parameters

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -71,7 +71,7 @@ You can find more advanced examples of `<List>` usage in the [demos](./Demos.md)
 | `queryOptions`            | Optional | `object`       | -              | The options to pass to the `useQuery` hook.                                                  |
 | `resource`                | Optional | `string`       | -              | The resource name, e.g. `posts`.                                                             |
 | `sort`                    | Optional | `object`       | -              | The initial sort parameters.                                                                 |
-| `storeKey`                | Optional | `string`       | -              | The key to use to store the current filter & sort.                                           |
+| `storeKey`                | Optional | `string` | `false` | -              | The key to use to store the current filter & sort. Pass `false` to disable                                         |
 | `title`                   | Optional | `string`       | -              | The title to display in the App Bar.                                                         |
 | `sx`                      | Optional | `object`       | -              | The CSS styles to apply to the component.                                                    |
 
@@ -848,6 +848,8 @@ const Admin = () => {
 {% endraw %}
 
 **Tip:** The `storeKey` is actually passed to the underlying `useListController` hook, which you can use directly for more complex scenarios. See the [`useListController` doc](./useListController.md#storekey) for more info.
+
+You can disable this feature by setting the `storeKey` prop to `false`. When disabled, parameters will not be persisted in the store.
 
 ## `title`
 

--- a/docs/useListController.md
+++ b/docs/useListController.md
@@ -136,6 +136,9 @@ const FlopPosts = (
 ```
 {% endraw %}
 
+You can disable this feature by setting the `storeKey` prop to `false`. When disabled, parameters will not be persisted in the store.
+
+
 ## Return Value
 
 The return value of `useListController` has the following shape:

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -218,7 +218,7 @@ export interface InfiniteListControllerProps<
     >;
     resource?: string;
     sort?: SortPayload;
-    storeKey?: string;
+    storeKey?: string | false;
 }
 
 export interface InfiniteListControllerResult<RecordType extends RaRecord = any>

--- a/packages/ra-core/src/controller/list/useListController.storeKey.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.storeKey.spec.tsx
@@ -7,10 +7,13 @@ import {
     act,
 } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { ListsUsingSameResource } from './useListController.storeKey.stories';
+import {
+    ListsUsingSameResource,
+    ListsWithoutStore,
+} from './useListController.storeKey.stories';
 
 describe('useListController', () => {
-    describe('customStoreKey', () => {
+    describe('storeKey', () => {
         it('should keep distinct two lists of the same resource given different keys', async () => {
             render(
                 <ListsUsingSameResource
@@ -39,6 +42,68 @@ describe('useListController', () => {
             act(() => {
                 fireEvent.click(screen.getByLabelText('flop'));
             });
+            expect(
+                screen.getByLabelText('perPage').getAttribute('data-value')
+            ).toEqual('3');
+        });
+
+        it('should not use the store when storeKey is false', async () => {
+            render(
+                <ListsWithoutStore
+                    history={createMemoryHistory({
+                        initialEntries: ['/store'],
+                    })}
+                />
+            );
+
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText('perPage').getAttribute('data-value')
+                ).toEqual('3');
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByLabelText('incrementPerPage'));
+                fireEvent.click(screen.getByLabelText('incrementPerPage'));
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText('perPage').getAttribute('data-value')
+                ).toEqual('5');
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByLabelText('nostore'));
+            });
+            expect(
+                screen.getByLabelText('perPage').getAttribute('data-value')
+            ).toEqual('3');
+
+            act(() => {
+                fireEvent.click(screen.getByLabelText('incrementPerPage'));
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText('perPage').getAttribute('data-value')
+                ).toEqual('4');
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByLabelText('store'));
+            });
+            // Shouldn't have changed the store list
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText('perPage').getAttribute('data-value')
+                ).toEqual('5');
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByLabelText('nostore'));
+            });
+            // Should have reset its parameters to their default
             expect(
                 screen.getByLabelText('perPage').getAttribute('data-value')
             ).toEqual('3');

--- a/packages/ra-core/src/controller/list/useListController.storeKey.stories.tsx
+++ b/packages/ra-core/src/controller/list/useListController.storeKey.stories.tsx
@@ -49,7 +49,7 @@ const OrderedPostList = ({
     storeKey,
     sort,
 }: {
-    storeKey: string;
+    storeKey: string | false;
     sort?: SortPayload;
 }) => {
     const params = useListController({
@@ -117,6 +117,12 @@ const TopPosts = (
 const FlopPosts = (
     <OrderedPostList storeKey="flop" sort={{ field: 'votes', order: 'ASC' }} />
 );
+const StorePosts = (
+    <OrderedPostList storeKey="store" sort={{ field: 'votes', order: 'ASC' }} />
+);
+const NoStorePosts = (
+    <OrderedPostList storeKey={false} sort={{ field: 'votes', order: 'ASC' }} />
+);
 
 export const ListsUsingSameResource = (argsOrProps, context) => {
     const history = context?.history || argsOrProps.history;
@@ -132,6 +138,42 @@ export const ListsUsingSameResource = (argsOrProps, context) => {
                 </CustomRoutes>
                 <CustomRoutes>
                     <Route path="/flop" element={FlopPosts} />
+                </CustomRoutes>
+                <Resource name="posts" />
+            </CoreAdminUI>
+        </CoreAdminContext>
+    );
+};
+
+const NoStoreLayout = (props: CoreLayoutProps) => {
+    return (
+        <div style={styles.mainContainer}>
+            <Link aria-label="store" to={`/store`}>
+                Go to Store List
+            </Link>{' '}
+            <Link aria-label="nostore" to={`/nostore`}>
+                Go to No Store List
+            </Link>
+            <br />
+            <br />
+            {props.children}
+        </div>
+    );
+};
+export const ListsWithoutStore = (argsOrProps, context) => {
+    const history = context?.history || argsOrProps.history;
+    return (
+        <CoreAdminContext
+            history={history}
+            store={localStorageStore()}
+            dataProvider={dataProvider}
+        >
+            <CoreAdminUI layout={NoStoreLayout}>
+                <CustomRoutes>
+                    <Route path="/store" element={StorePosts} />
+                </CustomRoutes>
+                <CustomRoutes>
+                    <Route path="/nostore" element={NoStorePosts} />
                 </CustomRoutes>
                 <Resource name="posts" />
             </CoreAdminUI>

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -199,7 +199,7 @@ export interface ListControllerProps<RecordType extends RaRecord = any> {
     }> & { meta?: any };
     resource?: string;
     sort?: SortPayload;
-    storeKey?: string;
+    storeKey?: string | false;
 }
 
 const defaultSort = {

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -88,8 +88,8 @@ export const useListParams = ({
     const location = useLocation();
     const navigate = useNavigate();
     const [localParams, setLocalParams] = useState(defaultParams);
-    // As we can't conditionally call a hook, ff the storeKey is false,
-    // we'll ignore the params variable later on and won't call  setParams either.
+    // As we can't conditionally call a hook, if the storeKey is false,
+    // we'll ignore the params variable later on and won't call setParams either.
     const [params, setParams] = useStore(
         storeKey || `${resource}.listParams`,
         defaultParams

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -88,6 +88,8 @@ export const useListParams = ({
     const location = useLocation();
     const navigate = useNavigate();
     const [localParams, setLocalParams] = useState(defaultParams);
+    // As we can't conditionally call a hook, ff the storeKey is false,
+    // we'll ignore the params variable later on and won't call  setParams either.
     const [params, setParams] = useStore(
         storeKey || `${resource}.listParams`,
         defaultParams

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -88,15 +88,23 @@ export const useListParams = ({
     const location = useLocation();
     const navigate = useNavigate();
     const [localParams, setLocalParams] = useState(defaultParams);
-    const [params, setParams] = useStore(storeKey, defaultParams);
+    const [params, setParams] = useStore(
+        storeKey || `${resource}.listParams`,
+        defaultParams
+    );
     const tempParams = useRef<ListParams>();
     const isMounted = useIsMounted();
+    const disableSyncWithStore = storeKey === false;
 
     const requestSignature = [
         location.search,
         resource,
         storeKey,
-        JSON.stringify(disableSyncWithLocation ? localParams : params),
+        JSON.stringify(
+            disableSyncWithLocation || disableSyncWithStore
+                ? localParams
+                : params
+        ),
         JSON.stringify(filterDefaultValues),
         JSON.stringify(sort),
         perPage,
@@ -111,7 +119,10 @@ export const useListParams = ({
         () =>
             getQuery({
                 queryFromLocation,
-                params: disableSyncWithLocation ? localParams : params,
+                params:
+                    disableSyncWithLocation || disableSyncWithStore
+                        ? localParams
+                        : params,
                 filterDefaultValues,
                 sort,
                 perPage,
@@ -124,7 +135,10 @@ export const useListParams = ({
     // store as well so that we don't lose them after a redirection back
     // to the list
     useEffect(() => {
-        if (Object.keys(queryFromLocation).length > 0) {
+        if (
+            Object.keys(queryFromLocation).length > 0 &&
+            !disableSyncWithStore
+        ) {
             setParams(query);
         }
     }, [location.search]); // eslint-disable-line
@@ -377,7 +391,7 @@ export interface ListParamsOptions {
     perPage?: number;
     resource: string;
     sort?: SortPayload;
-    storeKey?: string;
+    storeKey?: string | false;
 }
 
 interface Parameters extends ListParams {

--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -390,6 +390,76 @@ export const StoreKey = () => {
     );
 };
 
+const BooksWithStoreEnabled = () => (
+    <List
+        resource="books"
+        storeKey="booksStore"
+        sort={{ field: 'year', order: 'DESC' }}
+    >
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+    </List>
+);
+
+const BooksWithStoreDisabled = () => (
+    <List
+        resource="books"
+        storeKey={false}
+        sort={{ field: 'year', order: 'ASC' }}
+    >
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+    </List>
+);
+
+const DisabledStoreDashboard = () => (
+    <>
+        <Box>
+            <Button
+                component={Link}
+                sx={{ margin: 2 }}
+                to="/store"
+                variant="contained"
+            >
+                See books with store enabled
+            </Button>
+            <Button
+                component={Link}
+                sx={{ margin: 2 }}
+                to="/nostore"
+                variant="contained"
+            >
+                See books with store disabled
+            </Button>
+        </Box>
+    </>
+);
+
+export const StoreDisabled = () => {
+    history.push('/');
+    return (
+        <Admin
+            dataProvider={dataProvider}
+            history={history}
+            dashboard={DisabledStoreDashboard}
+        >
+            <CustomRoutes>
+                <Route path="/store" element={<BooksWithStoreEnabled />} />
+                <Route path="/nostore" element={<BooksWithStoreDisabled />} />
+            </CustomRoutes>
+            <Resource name="books" />
+        </Admin>
+    );
+};
+
 export const ErrorInFetch = () => (
     <Admin
         dataProvider={


### PR DESCRIPTION
## Problem

For one-off lists (e.g. in dashboards), `<ListBase>` does the fetching and puts the data in a  `<ListContext>`, so it’s fine.

But as it uses the store by default, a list for a given resource will be affected by the actions of the user in other lists of the same resource.

It’s possible to specify a different `storeKey` to avoid that, but it’s silly to have to define a store key when what I want is to disable the use of the store altogether.

It’s also possible to use `disableSyncWithLocation`, but the name of that prop isn’t clearly related to the store.

## Solution

Allow to set `storeKey` to `false` to disable the store altogether