### PR TITLE
Partially revert "Fix Next.js integration"

### DIFF
--- a/docs/NextJs.md
+++ b/docs/NextJs.md
@@ -225,6 +225,7 @@ Next, replace the `app/page.tsx` file with the following code, which initializes
 
 ```jsx
 // in app/page.tsx
+"use client";
 import { Admin, Resource, ListGuesser, EditGuesser } from "react-admin";
 import jsonServerProvider from "ra-data-json-server";
 
@@ -248,7 +249,7 @@ Now, start the server with `yarn dev`, browse to `http://localhost:3000/`, and y
 React-admin renders a CRUD for users, posts and comments, guessing the data structure from the API response. 
 
 
-**Tip**: The `<Admin>` component uses the `"use client"` directive, because React-admin is designed as a Single-Page Application, rendered on the client-side. It comes with various client-side only libraries (emotion, material-ui, react-query) leveraging the React Context API, and cannot be rendered using React Server components.
+**Tip**: Why the `"use client"` directive? React-admin is designed as a Single-Page Application, rendered on the client-side. It comes with various client-side only libraries (emotion, material-ui, react-query) leveraging the React Context API, and cannot be rendered using React Server components.
 
 **Tip**: If you migrated from the Pages Router, you might have to delete the `.next` directory in your project to ensure NextJS bundles the client dependencies correctly.
 


### PR DESCRIPTION
https://github.com/marmelab/react-admin/pull/9014 is not enough to fix the Next.js integration. Let's keep the `"use client"` directive in the doc for now.