### PR TITLE
[RFR] Add maintained ra-language-german

### DIFF
--- a/docs/TranslationLocales.md
+++ b/docs/TranslationLocales.md
@@ -23,7 +23,7 @@ You can find translation packages for the following languages:
 - Farsi (`fa`): [hamidfzm/ra-language-farsi](https://github.com/hamidfzm/ra-language-farsi)
 - Finnish (`fi`): [aikain/ra-language-finnish](https://github.com/aikain/ra-language-finnish)
 - French (`fr`): [marmelab/ra-language-french](https://github.com/marmelab/react-admin/tree/master/packages/ra-language-french)
-- German (`de`): [greenbananaCH/ra-language-german](https://github.com/greenbananaCH/ra-language-german) (tree translation: [straurob/ra-tree-language-german](https://github.com/straurob/ra-tree-language-german))
+- German (`de`): [haleosdev/ra-language-german](https://github.com/HaleosDev/ra-language-german) (formal and informal translation packages available)
 - Greek (`el`): [panterz/ra-language-greek](https://github.com/panterz/ra-language-greek)
 - Hebrew (`he`): [ak-il/ra-language-hebrew](https://github.com/ak-il/ra-language-hebrew)
 - Hindi (`hi`): [harshit-budhraja/ra-language-hindi](https://github.com/harshit-budhraja/ra-language-hindi)


### PR DESCRIPTION
The packages previously provided are either no longer maintained or not obtainable anymore. We have created a package providing both formal ("Sie") as well as informal ("du") translation, so that the user can choose what fits best. We are committed to keep the package up-to-date.