### PR TITLE
[Doc] Improve description of rbac tab, panel, section, and step

### DIFF
--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1218,26 +1218,24 @@ const ProductCreate = () => (
 ```
 {% endraw %}
 
-### `<WizardFormStep>`
+### `<WizardForm.Step>`
 
-Replacement for the default `<WizardFormStep>` that only renders a step if the user has the right permissions.
+Replacement for the default `<WizardForm.Step>` that only renders a step if the user has the right permissions.
 Use it with `<WizardForm>` from `@react-admin/ra-enterprise` to only display the steps the user has access to in the stepper.
 
-This component is provided by the `@react-admin/ra-enterprise` package.
+Add a `name` prop to the `<WizardForm.Step>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<WizardForm.Step>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.step.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<WizardForm.Step>`.
 
-Add a `name` prop to the `<WizardFormStep>` so you can reference it in the permissions.  
-Then, to allow users to access a particular `<WizardFormStep>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.step.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<WizardFormStep>`.
+> For instance, to allow users access to the following tab `<WizardForm.Step label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.step.description' }`.
 
-> For instance, to allow users access to the following tab `<WizardFormStep label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.step.description' }`.
-
-`<WizardFormStep>` also only renders the child inputs for which the user has the 'write' permissions.
+`<WizardForm.Step>` also only renders the child inputs for which the user has the 'write' permissions.
 
 To learn more about the permissions format, please refer to the [`@react-admin/ra-rbac` documentation](https://marmelab.com/ra-enterprise/modules/ra-rbac).
 
 {% raw %}
 ```tsx
 import { Edit, TextInput } from 'react-admin';
-import { WizardForm, WizardFormStep } from '@react-admin/ra-enterprise';
+import { WizardForm } from '@react-admin/ra-enterprise';
 
 const authProvider = {
     // ...
@@ -1260,22 +1258,22 @@ const authProvider = {
 const ProductCreate = () => (
     <Create>
         <WizardForm>
-            <WizardFormStep label="Description" name="description">
+            <WizardForm.Step label="Description" name="description">
                 <TextInput source="reference" />
                 <TextInput source="width" />
                 <TextInput source="height" />
                 // not displayed
                 <TextInput source="description" />
-            </WizardFormStep>
-            <WizardFormStep label="Images" name="images">
+            </WizardForm.Step>
+            <WizardForm.Step label="Images" name="images">
                 // not displayed
                 <TextInput source="image" />
                 <TextInput source="thumbnail" />
-            </WizardFormStep>
+            </WizardForm.Step>
             // not displayed
-            <WizardFormStep label="Stock" name="stock">
+            <WizardForm.Step label="Stock" name="stock">
                 <TextInput source="stock" />
-            </WizardFormStep>
+            </WizardForm.Step>
         </WizardForm>
     </Create>
 );

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1193,7 +1193,7 @@ To learn more about the permissions format, please refer to the [`@react-admin/r
 {% raw %}
 ```tsx
 import { Edit, TextInput } from 'react-admin';
-import { WizardForm, WizardFormStep } from '@react-admin/ra-enterprise';
+import { WizardForm } from '@react-admin/ra-enterprise';
 
 const authProvider = {
     // ...

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1125,10 +1125,10 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
-        // note that the panel with the name 'description' will be displayed 
-        { action: 'write', resource: 'products.panel.description' },
-        // note that the panel with the name 'images' will be displayed 
-        { action: 'write', resource: 'products.panel.images' },
+        // note that the section with the name 'description' will be displayed 
+        { action: 'write', resource: 'products.section.description' },
+        // note that the section with the name 'images' will be displayed 
+        { action: 'write', resource: 'products.section.images' },
         // 'products.panel.stock' is missing
     ]),
 };

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1102,9 +1102,9 @@ Replacement for the default `<LongForm.Section>` that only renders a section if 
 Use it with `<LongForm>` from `@react-admin/ra-enterprise` to only display the section the user has access to in the form.
 
 Add a `name` prop to the `<LongForm.Section>` so you can reference it in the permissions.  
-Then, to allow users to access a particular `<LongForm.Section>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.panel.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<LongForm.Section>`.
+Then, to allow users to access a particular `<LongForm.Section>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.section.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<LongForm.Section>`.
 
-> For instance, to allow users access to the following tab `<LongForm.Section label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
+> For instance, to allow users access to the following tab `<LongForm.Section label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.section.description' }`.
 
 `<LongForm.Section>` also only renders the child inputs for which the user has the 'write' permissions.
 

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -632,7 +632,9 @@ const ProductShow = () => (
 
 Replacement for the `<TabbedShowLayout.Tab>` that only renders a tab if the user has the right permissions.
 
-Add a `name` prop to the Tab to define the resource on which the user needs to have the 'read' permissions for.
+Add a `name` prop to the `<Tab>` to define the resource on which the user needs to have the 'read' permissions for.
+Then, to display a particular `<Tab>` update permissions definition as follows: `{ action: 'read', resource: '${resource}.tab.${source}' }`. 
+> For instance, to allow user access `<Tab label="Description" name="description">` in product resource, add this line in permissions: `{ action: 'read', resource: 'products.tab.description' }`. 
 
 `<Tab>` also only renders the child fields for which the user has the 'read' permissions.
 

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1096,24 +1096,23 @@ const ProductEdit = () => (
 ```
 {% endraw %}
 
-### `<LongFormSection>`
+### `<LongForm.Section>`
 
-Replacement for the default `<LongFormSection>` that only renders a section if the user has the right permissions.
+Replacement for the default `<LongForm.Section>` that only renders a section if the user has the right permissions.
+Use it with `<LongForm>` from `@react-admin/ra-enterprise` to only display the section the user has access to in the form.
 
-Add a `name` prop to the `<LongFormSection>` so you can reference it in the permissions.  
-Then, to allow users to access a particular `<LongFormSection>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.panel.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<LongFormSection>`.
+Add a `name` prop to the `<LongForm.Section>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<LongForm.Section>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.panel.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<LongForm.Section>`.
 
-> For instance, to allow users access to the following tab `<LongFormSection label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
+> For instance, to allow users access to the following tab `<LongForm.Section label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
 
-`<LongFormSection>` also only renders the child inputs for which the user has the 'write' permissions.
-
-This component is provided by the `@react-admin/ra-enterprise` package.
+`<LongForm.Section>` also only renders the child inputs for which the user has the 'write' permissions.
 
 To learn more about the permissions format, please refer to the [`@react-admin/ra-rbac` documentation](https://marmelab.com/ra-enterprise/modules/ra-rbac).
 
 {% raw %}
 ```tsx
-import { LongForm, LongFormSection } from '@react-admin/ra-enterprise';
+import { LongForm } from '@react-admin/ra-enterprise';
 
 const authProvider = {
     // ...
@@ -1136,22 +1135,22 @@ const authProvider = {
 const ProductEdit = () => (
     <Edit>
         <LongForm>
-            <LongFormSection name="description" label="Description">
+            <LongForm.Section name="description" label="Description">
                 <TextInput source="reference" />
                 <TextInput source="width" />
                 <TextInput source="height" />
                 // not displayed
                 <TextInput source="description" />
-            </LongFormSection>
-            <LongFormSection name="images" label="Images">
+            </LongForm.Section>
+            <LongForm.Section name="images" label="Images">
                 // not displayed
                 <TextInput source="image" />
                 <TextInput source="thumbnail" />
-            </LongFormSection>
+            </LongForm.Section>
             // not displayed
-            <LongFormSection name="stock" label="Stock">
+            <LongForm.Section name="stock" label="Stock">
                 <TextInput source="stock" />
-            </LongFormSection>
+            </LongForm.Section>
         </LongForm>
     </Edit>
 );

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -651,7 +651,9 @@ const authProvider = {
             // 'products.description' is missing
             { action: 'read', resource: 'products.thumbnail' },
             // 'products.image' is missing
+            // note that the tab with the name 'description' will be displayed 
             { action: 'read', resource: 'products.tab.description' },
+            // note that the tab with the name 'images' will be displayed 
             { action: 'read', resource: 'products.tab.images' },
             // 'products.tab.stock' is missing
         ],
@@ -758,7 +760,9 @@ const authProvider = {
             // 'products.description' is missing
             { action: 'write', resource: 'products.thumbnail' },
             // 'products.image' is missing
+            // note that the tab with the name 'description' will be displayed 
             { action: 'write', resource: 'products.tab.description' },
+            // note that the tab with the name 'images' will be displayed 
             { action: 'write', resource: 'products.tab.images' },
             // 'products.tab.stock' is missing
         ],
@@ -813,7 +817,9 @@ const authProvider = {
             // 'products.description' is missing
             { action: 'write', resource: 'products.thumbnail' },
             // 'products.image' is missing
+            // note that the tab with the name 'description' will be displayed 
             { action: 'write', resource: 'products.tab.description' },
+            // note that the tab with the name 'images' will be displayed 
             { action: 'write', resource: 'products.tab.images' },
             // 'products.tab.stock' is missing
         ],
@@ -870,7 +876,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the panel with the name 'description' will be displayed 
         { action: 'write', resource: 'products.panel.description' },
+        // note that the panel with the name 'images' will be displayed 
         { action: 'write', resource: 'products.panel.images' },
         // 'products.panel.stock' is missing
     ]),
@@ -922,7 +930,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the panel with the name 'description' will be displayed 
         { action: 'write', resource: 'products.panel.description' },
+        // note that the panel with the name 'images' will be displayed 
         { action: 'write', resource: 'products.panel.images' },
         // 'products.panel.stock' is missing
     ]),
@@ -977,7 +987,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the section with the name 'description' will be displayed 
         { action: 'write', resource: 'products.section.description' },
+        // note that the section with the name 'images' will be displayed 
         { action: 'write', resource: 'products.section.images' },
         // 'products.section.stock' is missing
     ]),
@@ -1036,7 +1048,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the section with the name 'description' will be displayed 
         { action: 'write', resource: 'products.section.description' },
+        // note that the section with the name 'images' will be displayed 
         { action: 'write', resource: 'products.section.images' },
         // 'products.Section.stock' is missing
     ]),
@@ -1089,7 +1103,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the panel with the name 'description' will be displayed 
         { action: 'write', resource: 'products.panel.description' },
+        // note that the panel with the name 'images' will be displayed 
         { action: 'write', resource: 'products.panel.images' },
         // 'products.panel.stock' is missing
     ]),
@@ -1147,7 +1163,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the step with the name 'description' will be displayed 
         { action: 'write', resource: 'products.step.description' },
+        // note that the step with the name 'images' will be displayed 
         { action: 'write', resource: 'products.step.images' },
         // 'products.step.stock' is missing
     ]),
@@ -1205,7 +1223,9 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
+        // note that the step with the name 'description' will be displayed 
         { action: 'write', resource: 'products.step.description' },
+        // note that the step with the name 'images' will be displayed 
         { action: 'write', resource: 'products.step.images' },
         // 'products.step.stock' is missing
     ]),

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -632,7 +632,7 @@ const ProductShow = () => (
 
 Replacement for the `<TabbedShowLayout.Tab>` that only renders a tab if the user has the right permissions.
 
-Add a `name` prop to the `<Tab>` so you can reference it in the permissions.
+Add a `name` prop to the `<Tab>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<Tab>`, update the permissions definition as follows: `{ action: 'read', resource: '{RESOURCE}.tab.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<Tab>`.
 
 > For instance, to allow users access to the following tab `<Tab label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'read', resource: 'products.tab.description' }`. 
@@ -802,7 +802,10 @@ const ProductEdit = () => (
 
 Replacement for the default `<FormTab>` that only renders a tab if the user has the right permissions.
 
-Add a `name` prop to the `FormTab` to define the sub-resource that the user needs to have the right permissions for.
+Add a `name` prop to the `<FormTab>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<FormTab>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.tab.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<FormTab>`.
+
+> For instance, to allow users access to the following tab `<FormTab label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.tab.description' }`.
 
 `<FormTab>` also only renders the child inputs for which the user has the 'write' permissions.
 
@@ -914,7 +917,12 @@ const ProductEdit = () => (
 ### `<AccordionFormPanel>`
 
 Replacement for the default `<AccordionFormPanel>` that only renders a section if the user has the right permissions.
-Add a `name` prop to the `AccordionFormPanel` to define the sub-resource that the user needs to have the right permissions for.
+
+Add a `name` prop to the `<AccordionFormPanel>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<AccordionFormPanel>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.panel.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<FormTab>`.
+
+> For instance, to allow users access to the following tab `<AccordionFormPanel label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
+
 `<AccordionFormPanel>` also only renders the child inputs for which the user has the 'write' permissions.
 
 To learn more about the permissions format, please refer to the [`@react-admin/ra-rbac` documentation](https://marmelab.com/ra-enterprise/modules/ra-rbac).
@@ -969,7 +977,12 @@ const ProductEdit = () => (
 ### `<AccordionSection>`
 
 Replacement for the default `<AccordionSection>` that only renders a section if the user has the right permissions.
-Add a `name` prop to the `AccordionSection` to define the sub-resource that the user needs to have the right permissions for.
+
+Add a `name` prop to the `<AccordionSection>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<AccordionSection>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.section.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<AccordionSection>`.
+
+> For instance, to allow users access to the following tab `<AccordionSection label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.section.description' }`.
+
 `<AccordionSection>` also only renders the child inputs for which the user has the 'write' permissions.
 
 This component is provided by the `@react-admin/ra-enterprise` package.
@@ -1086,7 +1099,12 @@ const ProductEdit = () => (
 ### `<LongFormSection>`
 
 Replacement for the default `<LongFormSection>` that only renders a section if the user has the right permissions.
-Add a `name` prop to the `LongFormSection` to define the sub-resource that the user needs to have the right permissions for.
+
+Add a `name` prop to the `<LongFormSection>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<LongFormSection>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.panel.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<LongFormSection>`.
+
+> For instance, to allow users access to the following tab `<LongFormSection label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
+
 `<LongFormSection>` also only renders the child inputs for which the user has the 'write' permissions.
 
 This component is provided by the `@react-admin/ra-enterprise` package.
@@ -1207,7 +1225,11 @@ Use it with `<WizardForm>` from `@react-admin/ra-enterprise` to only display the
 
 This component is provided by the `@react-admin/ra-enterprise` package.
 
-Add a `name` prop to the WizardFormStep to define the sub-resource that the user needs to have the right permissions for.
+Add a `name` prop to the `<WizardFormStep>` so you can reference it in the permissions.  
+Then, to allow users to access a particular `<WizardFormStep>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.step.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<WizardFormStep>`.
+
+> For instance, to allow users access to the following tab `<WizardFormStep label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.step.description' }`.
+
 `<WizardFormStep>` also only renders the child inputs for which the user has the 'write' permissions.
 
 To learn more about the permissions format, please refer to the [`@react-admin/ra-rbac` documentation](https://marmelab.com/ra-enterprise/modules/ra-rbac).

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -632,9 +632,11 @@ const ProductShow = () => (
 
 Replacement for the `<TabbedShowLayout.Tab>` that only renders a tab if the user has the right permissions.
 
-Add a `name` prop to the `<Tab>` to define the resource on which the user needs to have the 'read' permissions for.
-Then, to display a particular `<Tab>` update permissions definition as follows: `{ action: 'read', resource: '${resource}.tab.${source}' }`. 
-> For instance, to allow user access `<Tab label="Description" name="description">` in product resource, add this line in permissions: `{ action: 'read', resource: 'products.tab.description' }`. 
+Add a `name` prop to the `<Tab>` so you can reference it in the permissions.
+Then, to allow users to access a particular `<Tab>`, update the permissions definition as follows: `{ action: 'read', resource: '{RESOURCE}.tab.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<Tab>`.
+
+> For instance, to allow users access to the following tab `<Tab label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'read', resource: 'products.tab.description' }`. 
+
 
 `<Tab>` also only renders the child fields for which the user has the 'read' permissions.
 

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1237,7 +1237,7 @@ To learn more about the permissions format, please refer to the [`@react-admin/r
 {% raw %}
 ```tsx
 import { Edit, TextInput } from 'react-admin';
-import { WizardForm } from '@react-admin/ra-enterprise';
+import { WizardForm, WizardFormStep } from '@react-admin/ra-enterprise';
 
 const authProvider = {
     // ...
@@ -1260,22 +1260,22 @@ const authProvider = {
 const ProductCreate = () => (
     <Create>
         <WizardForm>
-            <WizardForm.Step label="Description" name="description">
+            <WizardFormStep label="Description" name="description">
                 <TextInput source="reference" />
                 <TextInput source="width" />
                 <TextInput source="height" />
                 // not displayed
                 <TextInput source="description" />
-            </WizardForm.Step>
-            <WizardForm.Step label="Images" name="images">
+            </WizardFormStep>
+            <WizardFormStep label="Images" name="images">
                 // not displayed
                 <TextInput source="image" />
                 <TextInput source="thumbnail" />
-            </WizardForm.Step>
+            </WizardFormStep>
             // not displayed
-            <WizardForm.Step label="Stock" name="stock">
+            <WizardFormStep label="Stock" name="stock">
                 <TextInput source="stock" />
-            </WizardForm.Step>
+            </WizardFormStep>
         </WizardForm>
     </Create>
 );

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -1036,8 +1036,8 @@ const authProvider = {
         // 'products.description' is missing
         { action: 'write', resource: 'products.thumbnail' },
         // 'products.image' is missing
-        { action: 'write', resource: 'products.Section.description' },
-        { action: 'write', resource: 'products.Section.images' },
+        { action: 'write', resource: 'products.section.description' },
+        { action: 'write', resource: 'products.section.images' },
         // 'products.Section.stock' is missing
     ]),
 };

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -635,7 +635,7 @@ Replacement for the `<TabbedShowLayout.Tab>` that only renders a tab if the user
 Add a `name` prop to the `<Tab>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<Tab>`, update the permissions definition as follows: `{ action: 'read', resource: '{RESOURCE}.tab.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<Tab>`.
 
-> For instance, to allow users access to the following tab `<Tab label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'read', resource: 'products.tab.description' }`. 
+> For instance, to allow users access to the following tab `<Tab label="Description" name="description">` in `products` resource, add this line in permissions: `{ action: 'read', resource: 'products.tab.description' }`. 
 
 
 `<Tab>` also only renders the child fields for which the user has the 'read' permissions.
@@ -805,7 +805,7 @@ Replacement for the default `<FormTab>` that only renders a tab if the user has 
 Add a `name` prop to the `<FormTab>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<FormTab>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.tab.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<FormTab>`.
 
-> For instance, to allow users access to the following tab `<FormTab label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.tab.description' }`.
+> For instance, to allow users access to the following tab `<FormTab label="Description" name="description">` in `products` resource, add this line in permissions: `{ action: 'write', resource: 'products.tab.description' }`.
 
 `<FormTab>` also only renders the child inputs for which the user has the 'write' permissions.
 
@@ -921,7 +921,7 @@ Replacement for the default `<AccordionFormPanel>` that only renders a section i
 Add a `name` prop to the `<AccordionFormPanel>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<AccordionFormPanel>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.panel.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<FormTab>`.
 
-> For instance, to allow users access to the following tab `<AccordionFormPanel label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
+> For instance, to allow users access to the following tab `<AccordionFormPanel label="Description" name="description">` in `products` resource, add this line in permissions: `{ action: 'write', resource: 'products.panel.description' }`.
 
 `<AccordionFormPanel>` also only renders the child inputs for which the user has the 'write' permissions.
 
@@ -981,7 +981,7 @@ Replacement for the default `<AccordionSection>` that only renders a section if 
 Add a `name` prop to the `<AccordionSection>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<AccordionSection>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.section.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<AccordionSection>`.
 
-> For instance, to allow users access to the following tab `<AccordionSection label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.section.description' }`.
+> For instance, to allow users access to the following tab `<AccordionSection label="Description" name="description">` in `products` resource, add this line in permissions: `{ action: 'write', resource: 'products.section.description' }`.
 
 `<AccordionSection>` also only renders the child inputs for which the user has the 'write' permissions.
 
@@ -1104,7 +1104,7 @@ Use it with `<LongForm>` from `@react-admin/ra-enterprise` to only display the s
 Add a `name` prop to the `<LongForm.Section>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<LongForm.Section>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.section.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<LongForm.Section>`.
 
-> For instance, to allow users access to the following tab `<LongForm.Section label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.section.description' }`.
+> For instance, to allow users access to the following tab `<LongForm.Section label="Description" name="description">` in `products` resource, add this line in permissions: `{ action: 'write', resource: 'products.section.description' }`.
 
 `<LongForm.Section>` also only renders the child inputs for which the user has the 'write' permissions.
 
@@ -1225,7 +1225,7 @@ Use it with `<WizardForm>` from `@react-admin/ra-enterprise` to only display the
 Add a `name` prop to the `<WizardForm.Step>` so you can reference it in the permissions.  
 Then, to allow users to access a particular `<WizardForm.Step>`, update the permissions definition as follows: `{ action: 'write', resource: '{RESOURCE}.step.{NAME}' }`, where `RESOURCE` is the resource name, and `NAME` the name you provided to the `<WizardForm.Step>`.
 
-> For instance, to allow users access to the following tab `<WizardForm.Step label="Description" name="description">` in `product` resource, add this line in permissions: `{ action: 'write', resource: 'products.step.description' }`.
+> For instance, to allow users access to the following tab `<WizardForm.Step label="Description" name="description">` in `products` resource, add this line in permissions: `{ action: 'write', resource: 'products.step.description' }`.
 
 `<WizardForm.Step>` also only renders the child inputs for which the user has the 'write' permissions.
 


### PR DESCRIPTION
On first reading, I didn't see that `{ action: 'write', resource: 'products.tab.description' },` allowed to display corresponding tab with the name `description`. Same for panel, section and step.

I added some comments to make things clearer and fix a typo