### PR TITLE
Mutation options on bulk update buttons

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -13,11 +13,14 @@ import {
     useUnselectAll,
     useResourceContext,
     MutationMode,
+    RaRecord,
+    UpdateManyParams,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
 import { Button, ButtonProps } from './Button';
 import { BulkActionProps } from '../types';
+import { UseMutationOptions } from 'react-query';
 
 export const BulkUpdateWithConfirmButton = (
     props: BulkUpdateWithConfirmButtonProps
@@ -67,16 +70,19 @@ export const BulkUpdateWithConfirmButton = (
             );
             setOpen(false);
         },
+        mutationOptions = {},
         ...rest
     } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
 
     const [updateMany, { isLoading }] = useUpdateMany(
         resource,
-        { ids: selectedIds, data },
+        { ids: selectedIds, data, meta: mutationMeta },
         {
             onSuccess,
             onError,
             mutationMode,
+            ...otherMutationOptions,
         }
     );
 
@@ -145,8 +151,10 @@ const sanitizeRestProps = ({
     'resource' | 'selectedIds' | 'icon' | 'data'
 >) => rest;
 
-export interface BulkUpdateWithConfirmButtonProps
-    extends BulkActionProps,
+export interface BulkUpdateWithConfirmButtonProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> extends BulkActionProps,
         ButtonProps {
     confirmContent?: React.ReactNode;
     confirmTitle?: string;
@@ -155,6 +163,11 @@ export interface BulkUpdateWithConfirmButtonProps
     onSuccess?: () => void;
     onError?: (error: any) => void;
     mutationMode?: MutationMode;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        MutationOptionsError,
+        UpdateManyParams<RecordType>
+    > & { meta?: any };
 }
 
 BulkUpdateWithConfirmButton.propTypes = {

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -62,16 +62,19 @@ export const BulkUpdateWithUndoButton = (
             );
             refresh();
         },
+        mutationOptions = {},
         ...rest
     } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
 
     const [updateMany, { isLoading }] = useUpdateMany(
         resource,
-        { ids: selectedIds, data },
+        { ids: selectedIds, data, meta: mutationMeta },
         {
             onSuccess,
             onError,
             mutationMode: 'undoable',
+            ...otherMutationOptions,
         }
     );
 

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -11,7 +11,10 @@ import {
     useUnselectAll,
     useResourceContext,
     useListContext,
+    RaRecord,
+    UpdateManyParams,
 } from 'ra-core';
+import { UseMutationOptions } from 'react-query';
 
 import { Button, ButtonProps } from './Button';
 import { BulkActionProps } from '../types';
@@ -102,13 +105,20 @@ const sanitizeRestProps = ({
     ...rest
 }: Omit<BulkUpdateWithUndoButtonProps, 'resource' | 'icon' | 'data'>) => rest;
 
-export interface BulkUpdateWithUndoButtonProps
-    extends BulkActionProps,
+export interface BulkUpdateWithUndoButtonProps<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown
+> extends BulkActionProps,
         ButtonProps {
     icon?: ReactElement;
     data: any;
     onSuccess?: () => void;
     onError?: (error: any) => void;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        MutationOptionsError,
+        UpdateManyParams<RecordType>
+    > & { meta?: any };
 }
 
 BulkUpdateWithUndoButton.propTypes = {


### PR DESCRIPTION
https://github.com/marmelab/react-admin/issues/9029

1. Extended BulkUpdateWithUndoButtonProps and BulkUpdateWithConfirmButtonProps to inlude mutation options
2. Passing the props to the underlying useUpdateMany calls