### PR TITLE
[Doc] Correct an example in useList doc, with page option

### DIFF
--- a/docs/useList.md
+++ b/docs/useList.md
@@ -195,7 +195,8 @@ const { total, data } = useList({
 });
 // total will be 3 and data will be
 // [
-//    { id: 3, name: 'Jean-Claude' },
+//    { id: 1, name: 'Arnold' },
+//    { id: 2, name: 'Sylvester' },
 // ]
 ```
 


### PR DESCRIPTION
In the example of useList, with page: 1 in option, 
```js
const { total, data } = useList({
    data: [
        { id: 1, name: 'Arnold' },
        { id: 2, name: 'Sylvester' },
        { id: 3, name: 'Jean-Claude' },
    ],
    perPage: 2,
    page: 1,
});
```

the data result will be
```js
[
    { id: 1, name: 'Arnold' },
    { id: 2, name: 'Sylvester' },
]
```
and not 
```js
[
   { id: 3, name: 'Jean-Claude' },
]
```