### PR TITLE
Add SelectAllButton to BulkActionsToolbar

### DIFF
--- a/packages/ra-core/src/controller/list/useRecordSelection.spec.tsx
+++ b/packages/ra-core/src/controller/list/useRecordSelection.spec.tsx
@@ -33,47 +33,102 @@ describe('useRecordSelection', () => {
         expect(selected).toEqual([123, 456]);
     });
 
-    it('should allow to select/unselect a record', () => {
-        const { result } = renderHook(() => useRecordSelection('foo'), {
-            wrapper,
+    describe('select', () => {
+        it('should allow to select a record', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [selected1, { select }] = result.current;
+            expect(selected1).toEqual([]);
+            select([123, 456]);
+            const [selected2] = result.current;
+            expect(selected2).toEqual([123, 456]);
         });
-        const [selected1, { select }] = result.current;
-        expect(selected1).toEqual([]);
-        select([123, 456]);
-        const [selected2, { unselect }] = result.current;
-        expect(selected2).toEqual([123, 456]);
-        unselect([123]);
-        const [selected3] = result.current;
-        expect(selected3).toEqual([456]);
+        it('should ignore previous selection', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [selected1, { select }] = result.current;
+            expect(selected1).toEqual([]);
+            select([123, 456]);
+            const [selected2] = result.current;
+            expect(selected2).toEqual([123, 456]);
+            select([123, 789]);
+            const [selected3] = result.current;
+            expect(selected3).toEqual([123, 789]);
+        });
     });
-
-    it('should allow to toggle a record', () => {
-        const { result } = renderHook(() => useRecordSelection('foo'), {
-            wrapper,
+    describe('unselect', () => {
+        it('should allow to unselect a record', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [, { select, unselect }] = result.current;
+            select([123, 456]);
+            unselect([123]);
+            const [selected] = result.current;
+            expect(selected).toEqual([456]);
         });
-        const [selected1, { toggle }] = result.current;
-        expect(selected1).toEqual([]);
-        toggle(123);
-        const [selected2] = result.current;
-        expect(selected2).toEqual([123]);
-        toggle(456);
-        const [selected3] = result.current;
-        expect(selected3).toEqual([123, 456]);
-        toggle(123);
-        const [selected4] = result.current;
-        expect(selected4).toEqual([456]);
+        it('should not fail if the record was not selected', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [, { select, unselect }] = result.current;
+            select([123, 456]);
+            unselect([789]);
+            const [selected] = result.current;
+            expect(selected).toEqual([123, 456]);
+        });
     });
-
-    it('should allow to clear the selection', () => {
-        const { result } = renderHook(() => useRecordSelection('foo'), {
-            wrapper,
+    describe('toggle', () => {
+        it('should allow to toggle a record selection', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [selected1, { toggle }] = result.current;
+            expect(selected1).toEqual([]);
+            toggle(123);
+            const [selected2] = result.current;
+            expect(selected2).toEqual([123]);
+            toggle(456);
+            const [selected3] = result.current;
+            expect(selected3).toEqual([123, 456]);
+            toggle(123);
+            const [selected4] = result.current;
+            expect(selected4).toEqual([456]);
         });
-        const [, { toggle, clearSelection }] = result.current;
-        toggle(123);
-        const [selected2] = result.current;
-        expect(selected2).toEqual([123]);
-        clearSelection();
-        const [selected3] = result.current;
-        expect(selected3).toEqual([]);
+        it('should allow to empty the selection', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [, { select, toggle }] = result.current;
+            select([123]);
+            toggle(123);
+            const [selected] = result.current;
+            expect(selected).toEqual([]);
+        });
+    });
+    describe('clearSelection', () => {
+        it('should allow to clear the selection', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [, { toggle, clearSelection }] = result.current;
+            toggle(123);
+            const [selected2] = result.current;
+            expect(selected2).toEqual([123]);
+            clearSelection();
+            const [selected3] = result.current;
+            expect(selected3).toEqual([]);
+        });
+        it('should not fail on empty selection', () => {
+            const { result } = renderHook(() => useRecordSelection('foo'), {
+                wrapper,
+            });
+            const [, { clearSelection }] = result.current;
+            clearSelection();
+            const [selected] = result.current;
+            expect(selected).toEqual([]);
+        });
     });
 });

--- a/packages/ra-core/src/controller/list/useRecordSelection.ts
+++ b/packages/ra-core/src/controller/list/useRecordSelection.ts
@@ -27,9 +27,10 @@ export const useRecordSelection = <RecordType extends RaRecord = any>(
 
     const selectionModifiers = useMemo(
         () => ({
-            select: (idsToAdd: RecordType['id'][]) => {
-                if (!idsToAdd) return;
-                setIds([...idsToAdd]);
+            // erase the selection and replace it with the new one
+            select: (ids: RecordType['id'][]) => {
+                if (!ids) return;
+                setIds([...ids]);
             },
             unselect(idsToRemove: RecordType['id'][]) {
                 if (!idsToRemove || idsToRemove.length === 0) return;


### PR DESCRIPTION
## Problem

When a user selects all the records of a given page, they often want to select all the records regardless of pagination. Doing so is cumbersome as it implies browsing every page and clicking on "select all". 

## Solution

Add a "select all" button allowing to expand the selection to the same query (with the same filters), but without pagination. 

https://github.com/marmelab/react-admin/assets/99944/9697a1c8-df1b-40ef-8b49-63ab601357e0

## Todo

- [x] Make it work
- [ ] Add tests
- [ ] Add stories
- [ ] Document it


