### PR TITLE
Fix demos don't allow to visualize source maps

### DIFF
--- a/examples/crm/package.json
+++ b/examples/crm/package.json
@@ -32,13 +32,12 @@
         "@types/react-beautiful-dnd": "^13.0.0",
         "@types/react-dom": "^17.0.9",
         "@vitejs/plugin-react": "^2.2.0",
-        "source-map-explorer": "^2.0.0",
+        "rollup-plugin-visualizer": "^5.9.2",
         "typescript": "^5.1.3",
         "vite": "^3.2.0",
         "web-vitals": "^1.0.1"
     },
     "scripts": {
-        "analyze": "source-map-explorer './dist/assets/*.js'",
         "dev": "vite",
         "build": "tsc && vite build",
         "preview": "vite preview"

--- a/examples/crm/vite.config.ts
+++ b/examples/crm/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import path from 'path';
 import fs from 'fs';
 import react from '@vitejs/plugin-react';
+import visualizer from 'rollup-plugin-visualizer';
 
 const packages = fs.readdirSync(path.resolve(__dirname, '../../packages'));
 const aliases = packages.reduce((acc, dirName) => {
@@ -20,7 +21,13 @@ const aliases = packages.reduce((acc, dirName) => {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react()],
+    plugins: [
+        react(),
+        visualizer({
+            open: process.env.NODE_ENV !== 'CI',
+            filename: './dist/stats.html',
+        }),
+    ],
     define: {
         'process.env': process.env,
     },

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -38,7 +38,6 @@
         "recharts": "^2.1.15"
     },
     "scripts": {
-        "analyze": "source-map-explorer 'dist/assets/*.js'",
         "dev": "vite",
         "build": "tsc && vite build",
         "preview": "vite preview"
@@ -52,7 +51,7 @@
         "@types/react-dom": "^17.0.9",
         "@vitejs/plugin-react": "^2.2.0",
         "rewire": "^5.0.0",
-        "source-map-explorer": "^2.0.0",
+        "rollup-plugin-visualizer": "^5.9.2",
         "typescript": "^5.1.3",
         "vite": "^3.2.0"
     }

--- a/examples/demo/vite.config.ts
+++ b/examples/demo/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import path from 'path';
 import fs from 'fs';
 import react from '@vitejs/plugin-react';
+import visualizer from 'rollup-plugin-visualizer';
 
 const packages = fs.readdirSync(path.resolve(__dirname, '../../packages'));
 const aliases = packages.reduce((acc, dirName) => {
@@ -20,7 +21,13 @@ const aliases = packages.reduce((acc, dirName) => {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react()],
+    plugins: [
+        react(),
+        visualizer({
+            open: process.env.NODE_ENV !== 'CI',
+            filename: './dist/stats.html',
+        }),
+    ],
     define: {
         'process.env': process.env,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8012,15 +8012,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"btoa@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "btoa@npm:1.2.1"
-  bin:
-    btoa: bin/btoa.js
-  checksum: 557b9682e40a68ae057af1b377e28884e6ff756ba0f499fe0f8c7b725a5bfb5c0d891604ac09944dbe330c9d43fb3976fef734f9372608d0d8e78a30eda292ae
-  languageName: node
-  linkType: hard
-
 "buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
@@ -9866,7 +9857,7 @@ __metadata:
     react-router-dom: ^6.1.0
     recharts: ^2.1.15
     rewire: ^5.0.0
-    source-map-explorer: ^2.0.0
+    rollup-plugin-visualizer: ^5.9.2
     typescript: ^5.1.3
     vite: ^3.2.0
   languageName: unknown
@@ -10148,7 +10139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexer@npm:^0.1.1, duplexer@npm:^0.1.2":
+"duplexer@npm:^0.1.1":
   version: 0.1.2
   resolution: "duplexer@npm:0.1.2"
   checksum: c57bcd4bdf7e623abab2df43a7b5b23d18152154529d166c1e0da6bee341d84c432d157d7e97b32fecb1bf3a8b8857dd85ed81a915789f550637ed25b8e64fc2
@@ -10548,7 +10539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
+"escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
@@ -12383,7 +12374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -12581,15 +12572,6 @@ __metadata:
   bin:
     gunzip-maybe: bin.js
   checksum: 42798a8061759885c2084e1804e51313d14f2dc9cf6c137e222953ec802f914e592d6f9dbf6ad67f4e78eb036e86db017d9c7c93bb23e90cd5ae09326296ed77
-  languageName: node
-  linkType: hard
-
-"gzip-size@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "gzip-size@npm:6.0.0"
-  dependencies:
-    duplexer: ^0.1.2
-  checksum: 4ccb924626c82125897a997d1c84f2377846a6ef57fbee38f7c0e6b41387fba4d00422274440747b58008b5d60114bac2349c2908e9aba55188345281af40a3f
   languageName: node
   linkType: hard
 
@@ -16847,7 +16829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^7.0.3, open@npm:^7.3.1":
+"open@npm:^7.0.3":
   version: 7.4.2
   resolution: "open@npm:7.4.2"
   dependencies:
@@ -18621,7 +18603,7 @@ __metadata:
     react-error-boundary: ^3.1.4
     react-router: ^6.1.0
     react-router-dom: ^6.1.0
-    source-map-explorer: ^2.0.0
+    rollup-plugin-visualizer: ^5.9.2
     typescript: ^5.1.3
     vite: ^3.2.0
     web-vitals: ^1.0.1
@@ -19846,6 +19828,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup-plugin-visualizer@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "rollup-plugin-visualizer@npm:5.9.2"
+  dependencies:
+    open: ^8.4.0
+    picomatch: ^2.3.1
+    source-map: ^0.7.4
+    yargs: ^17.5.1
+  peerDependencies:
+    rollup: 2.x || 3.x
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  bin:
+    rollup-plugin-visualizer: dist/bin/cli.js
+  checksum: e6280bed797084e9f9ee06726e46706e32854fc7647c5c5bcec68a9be8ca8e6fbf7f8a0b2f76255e9df72e84135a7d57eb2662b6cfd68496a1ef60fa33597eaf
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^2.79.1":
   version: 2.79.1
   resolution: "rollup@npm:2.79.1"
@@ -20429,29 +20430,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-explorer@npm:^2.0.0":
-  version: 2.5.2
-  resolution: "source-map-explorer@npm:2.5.2"
-  dependencies:
-    btoa: ^1.2.1
-    chalk: ^4.1.0
-    convert-source-map: ^1.7.0
-    ejs: ^3.1.5
-    escape-html: ^1.0.3
-    glob: ^7.1.6
-    gzip-size: ^6.0.0
-    lodash: ^4.17.20
-    open: ^7.3.1
-    source-map: ^0.7.3
-    temp: ^0.9.4
-    yargs: ^16.2.0
-  bin:
-    sme: bin/cli.js
-    source-map-explorer: bin/cli.js
-  checksum: f70fcee4e569bfece11868d230db4e8d9a683b25d579f318c1384de48cb62e1132917bef975451b5c93dcad1704506bef5c1d03f05d5b3595315a852202a0a4c
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
@@ -20507,6 +20485,13 @@ __metadata:
   version: 0.7.3
   resolution: "source-map@npm:0.7.3"
   checksum: 7d2ddb51f3d2451847692a9ac7808da2b2b3bf7aef92ece33128919040a7e74d9a5edfde7a781f035c974deff876afaf83f2e30484faffffb86484e7408f5d7c
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: dc0cf3768fe23c345ea8760487f8c97ef6fca8a73c83cd7c9bf2fde8bc2c34adb9c0824d6feb14bc4f9e37fb522e18af621543f1289038a66ac7586da29aa7dc
   languageName: node
   linkType: hard
 
@@ -21112,16 +21097,6 @@ __metadata:
   dependencies:
     rimraf: ~2.6.2
   checksum: 7f071c963031bfece37e13c5da11e9bb451e4ddfc4653e23e327a2f91594102dc826ef6a693648e09a6e0eb856f507967ec759ae55635e0878091eccf411db37
-  languageName: node
-  linkType: hard
-
-"temp@npm:^0.9.4":
-  version: 0.9.4
-  resolution: "temp@npm:0.9.4"
-  dependencies:
-    mkdirp: ^0.5.1
-    rimraf: ~2.6.2
-  checksum: 7a1cd75efa65b9ca97fc0dfa752673842d23fa41d9c641a447d86ca986eb7662f0d17771e1edf8d0149e76de3c6e7005faf2ccaa3baf64811c86d1d1a951dda7
   languageName: node
   linkType: hard
 
@@ -22769,7 +22744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1, yargs@npm:^17.6.2":
+"yargs@npm:^17.3.1, yargs@npm:^17.5.1, yargs@npm:^17.6.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Problem

The `yarn analyze` command fails on the CRM and ecommerce demos, as some source maps can't be interpreted since the upgrade to Vite

## Solution

Use the rollup plugin for source map visualization, and open the dataviz on build. 

<img width="1433" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/0be5019c-c1fc-44e7-bfb5-f0b69982ae31">
