### PR TITLE
Fix: string value supplied to BooleanInput checked prop

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -79,7 +79,7 @@ export const BooleanInput = (props: BooleanInputProps) => {
                         color="primary"
                         onChange={handleChange}
                         onFocus={onFocus}
-                        checked={field.value}
+                        checked={Boolean(field.value)}
                         {...sanitizeInputRestProps(rest)}
                         {...options}
                         disabled={disabled}


### PR DESCRIPTION
Cast `field.value` passed to `checked` prop in boolean, to avoid `checked` prop to be `<empty string>` in `<BooleanInput>`
Fix #9042