### PR TITLE
Rich Text Input - working as JSON

### DIFF
--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -84,6 +84,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
         readOnly = false,
         source,
         toolbar,
+        useJson
     } = props;
 
     const resource = useResourceContext(props);
@@ -156,9 +157,15 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const html = editor.getHTML();
-            field.onChange(html);
-            field.onBlur();
+            if (!useJson) {
+                const html = editor.getHTML();
+                field.onChange(html);
+                field.onBlur();
+            } else {
+                const json = editor.getJSON();
+                field.onChange(json);
+                field.onBlur();
+            }
         };
 
         editor.on('update', handleEditorUpdate);
@@ -302,6 +309,7 @@ export type RichTextInputProps = CommonInputProps &
         readOnly?: boolean;
         editorOptions?: Partial<EditorOptions>;
         toolbar?: ReactNode;
+        useJson?: boolean;
     };
 
 export type RichTextInputContentProps = {


### PR DESCRIPTION
I have added a optional prop useJson to RichTextInput. It is very common for these kinds of inputs to be stored in JSON format rather than raw HTML and TipTap has full supoort for this approach - the getJSON() function. IT automatically parses the output back in to the editor and is compatible with everything i found so far. 