### PR TITLE
Rich Text Input - working as JSON

### DIFF
--- a/packages/ra-input-rich-text/README.md
+++ b/packages/ra-input-rich-text/README.md
@@ -28,6 +28,52 @@ export const PostEdit = (props) => (
 );
 ```
 
+## Using JSON as the data format
+Under the hood, the `<RichTextInput>` defaultly uses HTML as the data format - which when saved, is then exported as raw HTML in string. If you want to use JSON as the data format, you can pass the `useJson` prop to the `<RichTextInput>` component. This will then save the data as JSON in raw string, using the TipTap's JSON scheme. 
+
+```jsx
+import { Edit, SimpleForm, TextInput } from 'react-admin';
+import { RichTextInput } from 'ra-input-rich-text';
+
+export const PostEdit = (props) => (
+	<Edit {...props}>
+		<SimpleForm>
+			<TextInput source="title" />
+			<RichTextInput source="body" useJson />
+		</SimpleForm>
+	</Edit>
+);
+```
+
+Example of the JSON data format:
+
+```json
+{
+  "type": "doc",
+  "content": [
+	{
+	  "type": "heading",
+	  "attrs": { "textAlign": "left", "level": 1 },
+	  "content": [
+		{
+		  "type": "text",
+		  "text": "Hello world!"
+		}
+	  ]
+	}
+  ]
+}
+```
+Renders as:
+```html
+<h1 style="text-align: left;">Hello world!</h1>
+```
+
+It should be noted that react-admin's [`<RichTextField>`](https://marmelab.com/react-admin/RichTextField.html) currently does not support rendering JSON data format. **Therefore, you will need to create your own custom `<RichTextField>` component with custom renderer to render the JSON data format.**
+As a starting point, we suggest to take a look at **[troop's TipTap React Render](https://github.com/troop-dev/tiptap-react-render)**.
+
+
+
 ## Customizing the Toolbar
 
 The `<RichTextInput>` component has a `toolar` prop that accepts a `ReactNode`.

--- a/packages/ra-input-rich-text/src/RichTextInput.spec.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render, waitFor } from '@testing-library/react';
-import { Basic } from './RichTextInput.stories';
+import { Basic, UseJson } from './RichTextInput.stories';
 
 describe('<RichTextInput />', () => {
     it('should update its content when fields value changes', async () => {
@@ -16,6 +16,50 @@ describe('<RichTextInput />', () => {
 
         const newRecord = { id: 123, body: '<h1>Goodbye world!</h1>' };
         rerender(<Basic record={newRecord} />);
+
+        await waitFor(() => {
+            expect(container.querySelector('#body').innerHTML).toEqual(
+                '<h1>Goodbye world!</h1>'
+            );
+        });
+    });
+
+    it('should update its content when fields value changes changes, using JSON in the background', async () => {
+        const record = {
+            id: 123,
+            body: {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'heading',
+                        attrs: { textAlign: 'left', level: 1 },
+                        content: [{ type: 'text', text: 'Hello world!' }],
+                    },
+                ],
+            },
+        };
+        const { container, rerender } = render(<UseJson record={record} />);
+
+        await waitFor(() => {
+            expect(container.querySelector('#body').innerHTML).toEqual(
+                '<h1>Hello world!</h1>'
+            );
+        });
+
+        const newRecord = {
+            id: 123,
+            body: {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'heading',
+                        attrs: { textAlign: 'left', level: 1 },
+                        content: [{ type: 'text', text: 'Goodbye world!' }],
+                    },
+                ],
+            },
+        };
+        rerender(<UseJson record={newRecord} />);
 
         await waitFor(() => {
             expect(container.querySelector('#body').innerHTML).toEqual(

--- a/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
@@ -111,3 +111,27 @@ export const Validation = (props: Partial<SimpleFormProps>) => (
         </SimpleForm>
     </AdminContext>
 );
+
+export const UseJson = (props: Partial<SimpleFormProps>) => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <SimpleForm
+            onSubmit={() => {}}
+            defaultValues={{
+                body: {
+                    type: 'doc',
+                    content: [
+                        {
+                            type: 'heading',
+                            attrs: { textAlign: 'left', level: 1 },
+                            content: [{ type: 'text', text: 'Hello World' }],
+                        },
+                    ],
+                },
+            }}
+            {...props}
+        >
+            <RichTextInput label="Body" source="body" useJson />
+            <FormInspector />
+        </SimpleForm>
+    </AdminContext>
+);

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -84,6 +84,7 @@ export const RichTextInput = (props: RichTextInputProps) => {
         readOnly = false,
         source,
         toolbar,
+        useJson
     } = props;
 
     const resource = useResourceContext(props);
@@ -156,9 +157,15 @@ export const RichTextInput = (props: RichTextInputProps) => {
                 return;
             }
 
-            const html = editor.getHTML();
-            field.onChange(html);
-            field.onBlur();
+            if (!useJson) {
+                const html = editor.getHTML();
+                field.onChange(html);
+                field.onBlur();
+            } else {
+                const json = editor.getJSON();
+                field.onChange(json);
+                field.onBlur();
+            }
         };
 
         editor.on('update', handleEditorUpdate);
@@ -302,6 +309,7 @@ export type RichTextInputProps = CommonInputProps &
         readOnly?: boolean;
         editorOptions?: Partial<EditorOptions>;
         toolbar?: ReactNode;
+        useJson?: boolean;
     };
 
 export type RichTextInputContentProps = {


### PR DESCRIPTION
I have added a optional prop useJson to RichTextInput. It is very common for these kinds of inputs to be stored in JSON format rather than raw HTML and TipTap has full supoort for this approach - the getJSON() function. IT automatically parses the output back in to the editor and is compatible with everything i found so far.