### PR TITLE
Translations in Rich Text Input Toolbar Buttons

### DIFF
--- a/packages/ra-input-rich-text/src/buttons/AlignmentButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/AlignmentButtons.tsx
@@ -15,15 +15,28 @@ import FormatAlignJustify from '@mui/icons-material/FormatAlignJustify';
 import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 
-export const AlignmentButtons = (props: ToggleButtonGroupProps) => {
+export interface AlignmentButtonsProps {
+  leftLabel?: string;
+  rightLabel?: string;
+  centerLabel?: string;
+  justifyLabel?: string;
+}
+
+export const AlignmentButtons = (props: ToggleButtonGroupProps & AlignmentButtonsProps) => {
     const editor = useTiptapEditor();
     const translate = useTranslate();
     const [value, setValue] = useState<string>('left');
 
-    const leftLabel = translate('ra.tiptap.align_left', { _: 'Align left' });
-    const rightLabel = translate('ra.tiptap.align_right', { _: 'Align right' });
-    const centerLabel = translate('ra.tiptap.align_center', { _: 'Center' });
-    const justifyLabel = translate('ra.tiptap.align_justify', { _: 'Justify' });
+    const leftLabel =
+        props.leftLabel || translate("ra.tiptap.align_left", { _: "Align left" });
+    const rightLabel =
+        props.rightLabel ||
+        translate("ra.tiptap.align_right", { _: "Align right" });
+    const centerLabel =
+        props.centerLabel || translate("ra.tiptap.align_center", { _: "Center" });
+    const justifyLabel =
+        props.justifyLabel ||
+        translate("ra.tiptap.align_justify", { _: "Justify" });
 
     useEffect(() => {
         const handleUpdate = () => {

--- a/packages/ra-input-rich-text/src/buttons/ClearButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/ClearButtons.tsx
@@ -4,13 +4,20 @@ import FormatClear from '@mui/icons-material/FormatClear';
 import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 
-export const ClearButtons = (props: Omit<ToggleButtonProps, 'value'>) => {
+export interface ClearButtonsProps {
+  label?: string;
+}
+
+export const ClearButtons = (props: Omit<ToggleButtonProps, 'value'> & ClearButtonsProps) => {
     const editor = useTiptapEditor();
     const translate = useTranslate();
 
-    const label = translate('ra.tiptap.clear_format', {
-        _: 'Clear format',
-    });
+    const label =
+        props.label ||
+        translate("ra.tiptap.clear_format", {
+        _: "Clear format",
+        });
+
 
     return (
         <ToggleButton

--- a/packages/ra-input-rich-text/src/buttons/ColorButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/ColorButtons.tsx
@@ -26,7 +26,12 @@ enum ColorType {
     BACKGROUND = 'background',
 }
 
-export const ColorButtons = (props: Omit<ToggleButtonProps, 'value'>) => {
+export interface ColorButtonsProps {
+  colorLabel?: string;
+  highlightLabel?: string;
+}
+
+export const ColorButtons = (props: Omit<ToggleButtonProps, 'value'> & ColorButtonsProps) => {
     const translate = useTranslate();
     const editor = useTiptapEditor();
     const [showColorChoiceDialog, setShowColorChoiceDialog] = React.useState<
@@ -34,8 +39,11 @@ export const ColorButtons = (props: Omit<ToggleButtonProps, 'value'>) => {
     >(false);
     const [colorType, setColorType] = React.useState<ColorType>(ColorType.FONT);
 
-    const colorLabel = translate('ra.tiptap.color', { _: 'Color' });
-    const highlightLabel = translate('ra.tiptap.highlight', { _: 'Highlight' });
+  const colorLabel =
+    props.colorLabel || translate("ra.tiptap.color", { _: "Color" });
+  const highlightLabel =
+    props.highlightLabel ||
+    translate("ra.tiptap.highlight", { _: "Highlight" });
 
     const displayColorChoiceDialog = (colorType: ColorType) => {
         setShowColorChoiceDialog(true);

--- a/packages/ra-input-rich-text/src/buttons/FormatButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/FormatButtons.tsx
@@ -15,30 +15,48 @@ import Code from '@mui/icons-material/Code';
 import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 
-export const FormatButtons = (props: ToggleButtonGroupProps) => {
+export interface FormatButtonsProps {
+  boldLabel?: string;
+  italicLabel?: string;
+  underlineLabel?: string;
+  strikeLabel?: string;
+  codeLabel?: string;
+}
+
+export const FormatButtons = (props: ToggleButtonGroupProps & FormatButtonsProps) => {
     const editor = useTiptapEditor();
     const translate = useTranslate();
     const [values, setValues] = useState<string[]>([]);
 
-    const boldLabel = translate('ra.tiptap.bold', {
-        _: 'Bold',
-    });
+    const boldLabel =
+        props.boldLabel ||
+        translate("ra.tiptap.bold", {
+        _: "Bold",
+        });
 
-    const italicLabel = translate('ra.tiptap.italic', {
-        _: 'Italic',
-    });
+    const italicLabel =
+        props.italicLabel ||
+        translate("ra.tiptap.italic", {
+        _: "Italic",
+        });
 
-    const underlineLabel = translate('ra.tiptap.underline', {
-        _: 'Underline',
-    });
+    const underlineLabel =
+        props.underlineLabel ||
+        translate("ra.tiptap.underline", {
+        _: "Underline",
+        });
 
-    const strikeLabel = translate('ra.tiptap.strike', {
-        _: 'Strikethrough',
-    });
+    const strikeLabel =
+        props.strikeLabel ||
+        translate("ra.tiptap.strike", {
+        _: "Strikethrough",
+        });
 
-    const codeLabel = translate('ra.tiptap.code', {
-        _: 'Code',
-    });
+    const codeLabel =
+        props.codeLabel ||
+        translate("ra.tiptap.code", {
+        _: "Code",
+        });
 
     useEffect(() => {
         const handleUpdate = () => {

--- a/packages/ra-input-rich-text/src/buttons/ImageButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/ImageButtons.tsx
@@ -4,15 +4,22 @@ import ImageIcon from '@mui/icons-material/Image';
 import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 
-export const ImageButtons = (props: Omit<ToggleButtonProps, 'value'>) => {
+export interface ImageButtonsProps {
+    label?: string;
+    promptLabel?: string;
+}
+
+
+export const ImageButtons = (props: Omit<ToggleButtonProps, 'value'> & ImageButtonsProps) => {
     const translate = useTranslate();
     const editor = useTiptapEditor();
 
-    const label = translate('ra.tiptap.image', { _: 'Image' });
+    const label = props.label || translate("ra.tiptap.image", { _: "Image" });
 
     const addImage = React.useCallback(() => {
         const url = window.prompt(
-            translate('ra.tiptap.image_dialog', { _: 'Image URL' })
+        props.promptLabel ||
+            translate("ra.tiptap.image_dialog", { _: "Image URL" })
         );
 
         if (url) {

--- a/packages/ra-input-rich-text/src/buttons/LevelSelect.tsx
+++ b/packages/ra-input-rich-text/src/buttons/LevelSelect.tsx
@@ -85,9 +85,12 @@ export const LevelSelect = (props: LevelSelectProps) => {
         <Root>
             <List
                 component="nav"
-                aria-label={translate('ra.tiptap.select_level', {
-                    _: 'Select the level',
-                })}
+                aria-label={
+                    props.selectLevelLabel ||
+                    translate("ra.tiptap.select_level", {
+                        _: "Select the level",
+                    })
+                }
                 dense
                 disablePadding
                 className={classes.list}
@@ -96,9 +99,12 @@ export const LevelSelect = (props: LevelSelectProps) => {
                     button
                     aria-haspopup="true"
                     aria-controls="level-menu"
-                    aria-label={translate('ra.tiptap.current_level', {
-                        _: 'Current level',
-                    })}
+                    aria-label={
+                        props.currentLevelLabel ||
+                        translate("ra.tiptap.current_level", {
+                        _: "Current level",
+                        })
+                    }
                     disabled={!editor?.isEditable}
                     onClick={handleClickListItem}
                     className={clsx({
@@ -224,4 +230,6 @@ const Root = styled('div')(({ theme }) => ({
 
 export type LevelSelectProps = {
     size?: 'small' | 'medium' | 'large';
+    selectLevelLabel?: string;
+    currentLevelLabel?: string;
 };

--- a/packages/ra-input-rich-text/src/buttons/LinkButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/LinkButtons.tsx
@@ -6,13 +6,20 @@ import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 import { useEditorSelection } from './useEditorSelection';
 
-export const LinkButtons = (props: Omit<ToggleButtonProps, 'value'>) => {
+export interface LinkButtonsProps {
+  label?: string;
+}
+
+
+export const LinkButtons = (props: Omit<ToggleButtonProps, 'value'> & LinkButtonsProps) => {
     const editor = useTiptapEditor();
     const translate = useTranslate();
     const currentTextSelection = useEditorSelection();
 
-    const label = translate('ra.tiptap.link', {
-        _: 'Add a link',
+    const label =
+        props.label ||
+        translate("ra.tiptap.link", {
+        _: "Add a link",
     });
 
     const handleClick = () => {

--- a/packages/ra-input-rich-text/src/buttons/ListButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/ListButtons.tsx
@@ -13,16 +13,25 @@ import FormatListNumbered from '@mui/icons-material/FormatListNumbered';
 import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 
-export const ListButtons = (props: ToggleButtonGroupProps) => {
+export interface ListButtonsProps {
+  bulletListLabel?: string;
+  numberListLabel?: string;
+}
+
+export const ListButtons = (props: ToggleButtonGroupProps & ListButtonsProps) => {
     const editor = useTiptapEditor();
     const translate = useTranslate();
 
-    const bulletListLabel = translate('ra.tiptap.list_bulleted', {
-        _: 'Bulleted list',
-    });
-    const numberListLabel = translate('ra.tiptap.list_numbered', {
-        _: 'Numbered list',
-    });
+    const bulletListLabel =
+        props.bulletListLabel ||
+        translate("ra.tiptap.list_bulleted", {
+        _: "Bulleted list",
+        });
+    const numberListLabel =
+        props.numberListLabel ||
+        translate("ra.tiptap.list_numbered", {
+        _: "Numbered list",
+        });
 
     const [value, setValue] = useState<string>();
 

--- a/packages/ra-input-rich-text/src/buttons/QuoteButtons.tsx
+++ b/packages/ra-input-rich-text/src/buttons/QuoteButtons.tsx
@@ -5,13 +5,19 @@ import FormatQuote from '@mui/icons-material/FormatQuote';
 import { useTranslate } from 'ra-core';
 import { useTiptapEditor } from '../useTiptapEditor';
 
-export const QuoteButtons = (props: Omit<ToggleButtonProps, 'value'>) => {
+export interface QuoteButtonsProps {
+  label?: string;
+}
+
+export const QuoteButtons = (props: Omit<ToggleButtonProps, 'value'> & QuoteButtonsProps) => {
     const editor = useTiptapEditor();
     const translate = useTranslate();
     const [isActive, setIsActive] = useState(false);
 
-    const label = translate('ra.tiptap.blockquote', {
-        _: 'Blockquote',
+    const label =
+        props.label ||
+        translate("ra.tiptap.blockquote", {
+        _: "Blockquote",
     });
 
     useEffect(() => {


### PR DESCRIPTION
Most of React Admin uses the ability to specify translations, I think its nice to have the option to have the translations available in these buttons too.