### PR TITLE
[Doc] Improve reference to Material UI

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1042,32 +1042,32 @@
             class="grid grid-cols-2 gap-6 text-[18px] font-light leading-[20px] md:grid-cols-6"
           >
             <li class="flex flex-col items-center justify-end gap-4">
-              <img src="./img/react.png" alt="React" class="h-16" />
+              <img src="./img/react.png" alt="" class="h-16" />
               <span class="text-center">React</span>
             </li>
             <li class="flex flex-col items-center justify-end gap-4">
-              <img src="./img/material-ui.png" alt="MUI" />
-              <span class="text-center">MUI</span>
+              <img src="./img/material-ui.png" alt="" />
+              <span class="text-center">Material UI</span>
             </li>
             <li class="flex flex-col items-center justify-end gap-4">
               <img
                 src="./img/react-router.png"
-                alt="React Router"
+                alt=""
                 class="mb-2"
               />
               <span class="text-center">React Router</span>
             </li>
             <li class="flex flex-col items-center justify-end gap-4">
-              <img src="./img/react-query.png" alt="React-query" />
+              <img src="./img/react-query.png" alt="" />
               <span class="text-center">React-query</span>
             </li>
             <li class="flex flex-col items-center justify-end gap-4">
-              <img src="./img/react-hook-form.png" alt="React-hook-form" />
+              <img src="./img/react-hook-form.png" alt="" />
               <span class="text-center">React-hook-form</span>
             </li>
             <li class="flex flex-col items-center justify-end gap-4">
-              <img src="./img/typescript.png" alt="Typescript" />
-              <span class="text-center">Typescript</span>
+              <img src="./img/typescript.png" alt="" />
+              <span class="text-center">TypeScript</span>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Move https://github.com/marmelab/react-admin-landing-pages/pull/1 to the right place. Same as #9087.