### PR TITLE
Fix `useGetManyReference` default `onSuccess` throws when the query is disabled

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -105,9 +105,9 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
                 }));
         },
         {
-            onSuccess: ({ data }) => {
+            onSuccess: value => {
                 // optimistically populate the getOne cache
-                data.forEach(record => {
+                value?.data?.forEach(record => {
                     queryClient.setQueryData(
                         [resource, 'getOne', { id: String(record.id), meta }],
                         oldRecord => oldRecord ?? record


### PR DESCRIPTION
Applies same fix as https://github.com/marmelab/react-admin/pull/8941 to `useGetManyReference`.

Pointed out by https://github.com/marmelab/react-admin/issues/8940#issuecomment-1641805782