### PR TITLE
Handle error for values of invalid data types in DateField

### DIFF
--- a/packages/ra-ui-materialui/src/field/DateField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.spec.tsx
@@ -37,6 +37,13 @@ describe('<DateField />', () => {
         expect(container.firstChild).toBeNull();
     });
 
+    it('should return null when the record has an invalid type for the source', () => {
+        const { container } = render(
+            <DateField record={{ id: 123, foo: {} }} source="foo" />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
     it('should render a date', () => {
         const { queryByText } = render(
             <DateField

--- a/packages/ra-ui-materialui/src/field/DateField.tsx
+++ b/packages/ra-ui-materialui/src/field/DateField.tsx
@@ -61,7 +61,18 @@ const DateFieldImpl = <
     }
 
     const value = get(record, source);
-    if (value == null || value === '') {
+    const parsedDate = (value: any) => {
+        if (value == null || value === '') return undefined;
+
+        return value instanceof Date
+            ? value
+            : typeof value === 'string' || typeof value === 'number'
+            ? new Date(value)
+            : undefined;
+    };
+    const date = parsedDate(value);
+
+    if (typeof date === 'undefined') {
         return emptyText ? (
             <Typography
                 component="span"
@@ -73,13 +84,6 @@ const DateFieldImpl = <
             </Typography>
         ) : null;
     }
-
-    const date =
-        value instanceof Date
-            ? value
-            : typeof value === 'string' || typeof value === 'number'
-            ? new Date(value)
-            : undefined;
 
     let dateOptions = options;
     if (


### PR DESCRIPTION
This PR proposes changes to handle the scenario when the DateField value does not match the type criteria to be handled as a Date.

Current behavior causes an error when executing `date.toLocaleString();` on an undefined date value. 