### PR TITLE
[Doc] Fix HowTos order and syntax in various chapters

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -756,107 +756,6 @@ const PostList = () => (
 
 **Tip**: The `Datagrid` component `classes` can also be customized for all instances of the component with its global css name `"RaDatagrid"` as [describe here](https://marmelab.com/blog/2019/12/18/react-admin-3-1.html#theme-overrides)
 
-## Styling Specific Columns
-
-If you want to style a particular column, you can take advantage of the generated class names per column. For instance, for a column formed for a `<TextField source="title" />` both the column header and the cells will have the class `column-title`.
-
-Using the `sx` prop, the column customization is just one line:
-
-{% raw %}
-```jsx
-import { List, Datagrid, TextField } from 'react-admin';
-
-const PostList = () => (
-    <List>
-        <Datagrid
-            sx={{
-                '& .column-title': { backgroundColor: '#fee' },
-            }}
-        >
-            <TextField source="id" />
-            <TextField source="title" /> {/* will have different background */}
-            <TextField source="author" />
-            <TextField source="year" />
-        </Datagrid>
-    </List>
-);
-```
-{% endraw %}
-
-You can even style the header cells differently by passing a more specific CSS selector (e.g. `& tr.column-title`).
-
-A common practice is to hide certain columns on smaller screens. You can use the same technique:
-
-{% raw %}
-```jsx
-import { List, Datagrid, TextField } from 'react-admin';
-
-const PostList = () => (
-    <List>
-        <Datagrid
-            sx={{
-                '& .column-title': {
-                    sm: { display: 'none' },
-                    md: { display: 'table-cell' },
-                },
-            }}
-        >
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" />
-        </Datagrid>
-    </List>
-);
-```
-{% endraw %}
-
-## Showing / Hiding Columns
-
-The [`<SelectColumnsButton>`](./SelectColumnsButton.md) component lets users hide, show, and reorder datagrid columns. 
-
-<video controls autoplay playsinline muted loop>
-  <source src="./img/SelectColumnsButton.webm" type="video/webm"/>
-  <source src="./img/SelectColumnsButton.mp4" type="video/mp4"/>
-  Your browser does not support the video tag.
-</video>
-
-
-```jsx
-import {
-    DatagridConfigurable,
-    List,
-    SelectColumnsButton,
-    FilterButton,
-    CreateButton,
-    ExportButton,
-    TextField,
-    TopToolbar,
-} from "react-admin";
-
-const PostListActions = () => (
-    <TopToolbar>
-        <SelectColumnsButton />
-        <FilterButton />
-        <CreateButton />
-        <ExportButton />
-    </TopToolbar>
-);
-
-const PostList = () => (
-    <List actions={<PostListActions />}>
-        <DatagridConfigurable>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" />
-        </DatagridConfigurable>
-    </List>
-);
-```
-
-`<SelectColumnsButton>` must be used in conjunction with `<DatagridConfigurable>`, the configurable version of `<Datagrid>`, described in the next section.
-
 ## Configurable
 
 You can let end users customize the fields displayed in the `<Datagrid>` by using the `<DatagridConfigurable>` component instead.
@@ -1013,92 +912,6 @@ const ArtistForm = () => (
 
 Check [the `ra-editable-datagrid` documentation](https://marmelab.com/ra-enterprise/modules/ra-editable-datagrid) for more details.
 
-
-## Customizing Column Sort
-
-<video controls autoplay playsinline muted loop>
-  <source src="./img/sort-column-header.webm" type="video/webm"/>
-  <source src="./img/sort-column-header.mp4" type="video/mp4"/>
-  Your browser does not support the video tag.
-</video>
-
-
-The column headers are buttons allowing users to change the list sort field and order. This feature requires no configuration and works out fo the box. The next sections explain how you can disable or modify the field used for sorting on a particular column.
-
-### Disabling Sorting
-
-It is possible to disable sorting for a specific `<Field>` by passing a `sortable` property set to `false`:
-
-{% raw %}
-```jsx
-// in src/posts.js
-import { List, Datagrid, TextField } from 'react-admin';
-
-export const PostList = () => (
-    <List>
-        <Datagrid>
-            <TextField source="id" sortable={false} />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
-    </List>
-);
-```
-{% endraw %}
-
-### Specifying A Sort Field
-
-By default, a column is sorted by the `source` property. To define another attribute to sort by, set it via the `<Field sortBy>` property:
-
-{% raw %}
-```jsx
-// in src/posts.js
-import { List, Datagrid, FunctionField, ReferenceField, TextField } from 'react-admin';
-
-export const PostList = () => (
-    <List>
-        <Datagrid>
-            <ReferenceField label="Post" source="id" reference="posts" sortBy="title">
-                <TextField source="title" />
-            </ReferenceField>
-            <FunctionField
-                label="Author"
-                sortBy="last_name"
-                render={record => `${record.author.first_name} ${record.author.last_name}`}
-            />
-            <TextField source="body" />
-        </Datagrid>
-    </List>
-);
-```
-{% endraw %}
-
-### Specifying The Sort Order
-
-By default, when the user clicks on a column header, the list becomes sorted in the ascending order. You change this behavior by setting the `sortByOrder` prop to `"DESC"` in a `<Datagrid>` `<Field>`:
-
-```jsx
-// in src/posts.js
-import { List, Datagrid, FunctionField, ReferenceField, TextField } from 'react-admin';
-
-export const PostList = () => (
-    <List>
-        <Datagrid>
-            <ReferenceField label="Post" source="id" reference="posts" sortByOrder="DESC">
-                <TextField source="title" />
-            </ReferenceField>
-            <FunctionField
-                label="Author"
-                sortBy="last_name"
-                sortByOrder="DESC"
-                render={record => `${record.author.first_name} ${record.author.last_name}`}
-            />
-            <TextField source="body" />
-        </Datagrid>
-    </List>
-);
-```
-
 ## Fields And Permissions
 
 You might want to display some fields only to users with specific permissions. Use the `usePermissions` hook to get the user permissions and hide Fields accordingly:
@@ -1202,9 +1015,110 @@ const MyCustomList = () => {
 };
 ```
 
-## How to disable checkboxes
+## Styling Specific Columns
 
-You can disable bulk actions altogether by passing `false` to the `bulkActionButtons` prop. In this case, the checkboxes column doesn’t show up anymore.
+If you want to style a particular column, you can take advantage of the generated class names per column. For instance, for a column formed for a `<TextField source="title" />` both the column header and the cells will have the class `column-title`.
+
+Using the `sx` prop, the column customization is just one line:
+
+{% raw %}
+```jsx
+import { List, Datagrid, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <Datagrid
+            sx={{
+                '& .column-title': { backgroundColor: '#fee' },
+            }}
+        >
+            <TextField source="id" />
+            <TextField source="title" /> {/* will have different background */}
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+    </List>
+);
+```
+{% endraw %}
+
+You can even style the header cells differently by passing a more specific CSS selector (e.g. `& tr.column-title`).
+
+A common practice is to hide certain columns on smaller screens. You can use the same technique:
+
+{% raw %}
+```jsx
+import { List, Datagrid, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <Datagrid
+            sx={{
+                '& .column-title': {
+                    sm: { display: 'none' },
+                    md: { display: 'table-cell' },
+                },
+            }}
+        >
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+    </List>
+);
+```
+{% endraw %}
+
+## Showing / Hiding Columns
+
+The [`<SelectColumnsButton>`](./SelectColumnsButton.md) component lets users hide, show, and reorder datagrid columns. 
+
+<video controls autoplay playsinline muted loop>
+  <source src="./img/SelectColumnsButton.webm" type="video/webm"/>
+  <source src="./img/SelectColumnsButton.mp4" type="video/mp4"/>
+  Your browser does not support the video tag.
+</video>
+
+
+```jsx
+import {
+    DatagridConfigurable,
+    List,
+    SelectColumnsButton,
+    FilterButton,
+    CreateButton,
+    ExportButton,
+    TextField,
+    TopToolbar,
+} from "react-admin";
+
+const PostListActions = () => (
+    <TopToolbar>
+        <SelectColumnsButton />
+        <FilterButton />
+        <CreateButton />
+        <ExportButton />
+    </TopToolbar>
+);
+
+const PostList = () => (
+    <List actions={<PostListActions />}>
+        <DatagridConfigurable>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </DatagridConfigurable>
+    </List>
+);
+```
+
+`<SelectColumnsButton>` must be used in conjunction with `<DatagridConfigurable>`, the configurable version of `<Datagrid>`, described in the next section.
+
+## Hiding Checkboxes
+
+You can hide the checkbox column by passing `false` to the [`bulkActionButtons`](#bulkactionbuttons) prop:
 
 ```tsx
 import { Datagrid, List } from 'react-admin';
@@ -1218,18 +1132,86 @@ export const PostList = () => (
 );
 ```
 
-## Disable column sorting
+## Customizing Column Sort
 
-In a `<Datagrid>`, users can change the sort field and order by clicking on the column headers. You may want to disable this behavior for a given field (e.g. for reference or computed fields). In that case, pass a `false` value to the `sortable` prop on the field.
+<video controls autoplay playsinline muted loop>
+  <source src="./img/sort-column-header.webm" type="video/webm"/>
+  <source src="./img/sort-column-header.mp4" type="video/mp4"/>
+  Your browser does not support the video tag.
+</video>
 
+
+The column headers are buttons allowing users to change the list sort field and order. This feature requires no configuration and works out fo the box. The next sections explain how you can disable or modify the field used for sorting on a particular column.
+
+### Disabling Sorting
+
+It is possible to disable sorting for a specific `<Field>` by passing a `sortable` property set to `false`:
+
+{% raw %}
 ```jsx
-const PostList = () => (
+// in src/posts.js
+import { List, Datagrid, TextField } from 'react-admin';
+
+export const PostList = () => (
     <List>
         <Datagrid>
+            <TextField source="id" sortable={false} />
             <TextField source="title" />
-            <ReferenceField source="author_id" sortable={false}>
-                <TextField source="name" />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+```
+{% endraw %}
+
+### Specifying A Sort Field
+
+By default, a column is sorted by the `source` property. To define another attribute to sort by, set it via the `<Field sortBy>` property:
+
+{% raw %}
+```jsx
+// in src/posts.js
+import { List, Datagrid, FunctionField, ReferenceField, TextField } from 'react-admin';
+
+export const PostList = () => (
+    <List>
+        <Datagrid>
+            <ReferenceField label="Post" source="id" reference="posts" sortBy="title">
+                <TextField source="title" />
             </ReferenceField>
+            <FunctionField
+                label="Author"
+                sortBy="last_name"
+                render={record => `${record.author.first_name} ${record.author.last_name}`}
+            />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+```
+{% endraw %}
+
+### Specifying The Sort Order
+
+By default, when the user clicks on a column header, the list becomes sorted in the ascending order. You change this behavior by setting the `sortByOrder` prop to `"DESC"` in a `<Datagrid>` `<Field>`:
+
+```jsx
+// in src/posts.js
+import { List, Datagrid, FunctionField, ReferenceField, TextField } from 'react-admin';
+
+export const PostList = () => (
+    <List>
+        <Datagrid>
+            <ReferenceField label="Post" source="id" reference="posts" sortByOrder="DESC">
+                <TextField source="title" />
+            </ReferenceField>
+            <FunctionField
+                label="Author"
+                sortBy="last_name"
+                sortByOrder="DESC"
+                render={record => `${record.author.first_name} ${record.author.last_name}`}
+            />
+            <TextField source="body" />
         </Datagrid>
     </List>
 );

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -368,16 +368,14 @@ const BookEdit = () => (
 );
 ```
 
-## Hiding A Field Label
+## Hiding The Field Label
 
-You can opt out of the label decoration by passing `false` to the `label` prop.
+React-admin Field layout components like [`<Datagrid>`](./Datagrid.md) and [`<SimpleShowLayout>`](./SimpleShowLayout.md) inspect their children and use their `source` prop to set the table headers or the field labels. To opt out of this behavior, pass `false` to the `label` prop.
 
 ```jsx
-// No label will be added
+// No label will be added in SimpleShowLayout
 <TextField source="author.name" label={false} />
 ```
-
-**Note**: This prop has no effect when rendering a field outside a `<Datagrid>`, a `<SimpleShowLayout>`, a `<TabbedShowLayout>`, a `<SimpleForm>`, or a `<TabbedForm>`.
 
 ## Conditional Formatting
 

--- a/docs/FilterList.md
+++ b/docs/FilterList.md
@@ -50,7 +50,7 @@ export const PostFilterSidebar = () => (
 ```
 {% endraw %}
 
-Add this component to the list view using [the `<List aside>` prop](./):
+Add this component to the list view using [the `<List aside>` prop](./List.md#aside):
 
 ```jsx
 import { PostFilterSidebar } from './PostFilterSidebar';

--- a/docs/FilterList.md
+++ b/docs/FilterList.md
@@ -50,7 +50,7 @@ export const PostFilterSidebar = () => (
 ```
 {% endraw %}
 
-Add this component to the list view using [the `<List aside>` prop](./List.md#aside-side-component):
+Add this component to the list view using [the `<List aside>` prop](./):
 
 ```jsx
 import { PostFilterSidebar } from './PostFilterSidebar';

--- a/docs/List.md
+++ b/docs/List.md
@@ -52,7 +52,7 @@ You can find more advanced examples of `<List>` usage in the [demos](./Demos.md)
 
 | Prop                      | Required | Type           | Default        | Description                                                                                  |
 |---------------------------|----------|----------------|----------------|----------------------------------------------------------------------------------------------|
-| `children`                | Required | `ReactNode`    | -              | The component to use to render the list of records.                                          |
+| `children`                | Required | `ReactNode`    | -              | The components rendering the list of records.                                          |
 | `actions`                 | Optional | `ReactElement` | -              | The actions to display in the toolbar.                                                       |
 | `aside`                   | Optional | `ReactElement` | -              | The component to display on the side of the list.                                            |
 | `component`               | Optional | `Component`    | `Card`         | The component to render as the root element.                                                 |
@@ -60,18 +60,18 @@ You can find more advanced examples of `<List>` usage in the [demos](./Demos.md)
 | `disable Authentication`  | Optional | `boolean`      | `false`        | Set to `true` to disable the authentication check.                                           |
 | `disable SyncWithLocation`| Optional | `boolean`      | `false`        | Set to `true` to disable the synchronization of the list parameters with the URL.            |
 | `empty`                   | Optional | `ReactElement` | -              | The component to display when the list is empty.                                             |
-| `emptyWhileLoading`       | Optional | `boolean`      | `false`        | Set to `true` to return `null` while the list is loading.                                    |
+| `empty WhileLoading`      | Optional | `boolean`      | `false`        | Set to `true` to return `null` while the list is loading.                                    |
 | `exporter`                | Optional | `function`     | -              | The function to call to export the list.                                                     |
 | `filters`                 | Optional | `ReactElement` | -              | The filters to display in the toolbar.                                                       |
 | `filter`                  | Optional | `object`       | -              | The permanent filter values.                                                                 |
-| `filterDefaultValues`     | Optional | `object`       | -              | The default filter values.                                                                   |
+| `filter DefaultValues`    | Optional | `object`       | -              | The default filter values.                                                                   |
 | `hasCreate`               | Optional | `boolean`      | `false`        | Set to `true` to show the create button.                                                     |
 | `pagination`              | Optional | `ReactElement` | `<Pagination>` | The pagination component to use.                                                             |
 | `perPage`                 | Optional | `number`       | `10`           | The number of records to fetch per page.                                                     |
 | `queryOptions`            | Optional | `object`       | -              | The options to pass to the `useQuery` hook.                                                  |
 | `resource`                | Optional | `string`       | -              | The resource name, e.g. `posts`.                                                             |
 | `sort`                    | Optional | `object`       | -              | The initial sort parameters.                                                                 |
-| `storeKey`                | Optional | `string` | `false` | -              | The key to use to store the current filter & sort. Pass `false` to disable                                         |
+| `storeKey`                | Optional | `string | false` | -            | The key to use to store the current filter & sort. Pass `false` to disable                                         |
 | `title`                   | Optional | `string`       | -              | The title to display in the App Bar.                                                         |
 | `sx`                      | Optional | `object`       | -              | The CSS styles to apply to the component.                                                    |
 
@@ -143,7 +143,7 @@ const ListActions = () => {
 }
 ```
 
-## `aside`: Side Component
+## `aside`
 
 You may want to display additional information on the side of the list. Use the `aside` prop for that, passing the component of your choice:
 
@@ -232,7 +232,7 @@ export const PostList = () => (
 
 **Tip**: the `<Card sx>` prop in the `PostFilterSidebar` component above is here to put the sidebar on the left side of the screen, instead of the default right side.
 
-## `children`: List Layout
+## `children`
 
 `<List>` itself doesn't render the list of records. It delegates this task to its children components. These children components grab the `data` from the `ListContext` and render them on screen.
 
@@ -397,7 +397,7 @@ const Dashboard = () => (
 
 Please note that the selection state is not synced in the URL but in a global store using the resource as key. Thus, all lists in the page using the same resource will share the same selection state. This is a design choice because if row selection is not tied to a resource, then when a user deletes a record it may remain selected without any ability to unselect it. If you want the selection state to be local, you will have to implement your own `useListController` hook and pass a custom key to the `useRecordSelection` hook. You will then need to implement your own `DeleteButton` and `BulkDeleteButton` to manually unselect rows when deleting records.
 
-## `empty`: Empty Page Component
+## `empty`
 
 When there is no result, and there is no active filter, and the resource has a create page, react-admin displays a special page inviting the user to create the first record.
 
@@ -694,7 +694,7 @@ export const PostList = () => (
 );
 ```
 
-## `pagination`: Pagination Component
+## `pagination`
 
 The `pagination` prop allows to replace the default pagination controls by your own.
 
@@ -713,7 +713,7 @@ export const PostList = () => (
 
 See [Paginating the List](./ListTutorial.md#building-a-custom-pagination) for details.
 
-## `perPage`: Pagination Size 
+## `perPage`
 
 By default, the list paginates results by groups of 10. You can override this setting by specifying the `perPage` prop:
 
@@ -801,7 +801,7 @@ export const UsersList = () => (
 );
 ```
 
-## `sort`: Default Sort Field & Order
+## `sort`
 
 Pass an object literal as the `sort` prop to determine the default `field` and `order` used for sorting:
 
@@ -821,13 +821,11 @@ For more details on list sort, see the [Sorting The List](./ListTutorial.md#sort
 
 ## `storeKey`
 
-To display multiple lists of the same resource and keep distinct store states for each of them (filters, sorting and pagination), specify unique keys with the `storeKey` property.
+By default, react-admin stores the list parameters (sort, pagination, filters) in localStorage so that  users can come back to the list and find it in the same state as when they left it. React-admin uses the current resource as the identifier to store the list parameters (under the key `${resource}.listParams`).
 
-In case no `storeKey` is provided, the states will be stored with the following key: `${resource}.listParams`.
+If you want to display multiple lists of the same resource and keep distinct store states for each of them (filters, sorting and pagination), you must give each list a unique `storeKey` property. You can also disable the persistence of list parameters in the store by setting the `storeKey` prop to `false`.
 
-**Note:** Please note that selection state will remain linked to a resource-based key as described [here](./List.md#disablesyncwithlocation).
-
-In the example below, both lists `NewerBooks` and `OlderBooks` use the same resource ('books'), but their controller states are stored separately (under the store keys `'newerBooks'` and `'olderBooks'` respectively). This allows to use both components in the same app, each having its own state (filters, sorting and pagination).
+In the example below, both lists `NewerBooks` and `OlderBooks` use the same resource ('books'), but their list parameters are stored separately (under the store keys `'newerBooks'` and `'olderBooks'` respectively). This allows to use both components in the same app, each having its own state (filters, sorting and pagination).
 
 {% raw %}
 ```jsx
@@ -887,7 +885,7 @@ const Admin = () => {
 
 **Tip:** The `storeKey` is actually passed to the underlying `useListController` hook, which you can use directly for more complex scenarios. See the [`useListController` doc](./useListController.md#storekey) for more info.
 
-You can disable this feature by setting the `storeKey` prop to `false`. When disabled, parameters will not be persisted in the store.
+**Note:** *Selection state* will remain linked to a resource-based key regardless of the `storeKey`. This is a design choice because if row selection is not tied to a resource, then when a user deletes a record it may remain selected without any ability to unselect it. If you want the selection state to be local, you will have to implement your own `useListController` hook and pass a custom key to the `useRecordSelection` hook. You will then need to implement your own `DeleteButton` and `BulkDeleteButton` to manually unselect rows when deleting records.
 
 ## `title`
 
@@ -934,22 +932,6 @@ const PostList = () => (
 {% endraw %}
 
 **Tip**: The `List` component `classes` can also be customized for all instances of the component with its global css name `RaList` as [describe here](https://marmelab.com/blog/2019/12/18/react-admin-3-1.html#theme-overrides)
-
-## Adding `meta` To The DataProvider Call
-
-Use [the `queryOptions` prop](#queryoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getList()` call.
-
-{% raw %}
-```jsx
-import { List } from 'react-admin';
-
-const PostList = () => (
-    <List queryOptions={{ meta: { foo: 'bar' } }}>
-        ...
-    </List>
-);
-```
-{% endraw %}
 
 ## Infinite Scroll Pagination
 
@@ -1008,9 +990,27 @@ const PostList = () => (
 
 The list will automatically update when a new record is created, or an existing record is updated or deleted.
 
-## How to render an empty list
+## Adding `meta` To The DataProvider Call
 
-You can set the `empty` props value to `false` to bypass the empty page display and render an empty list instead.
+Use [the `queryOptions` prop](#queryoptions) to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getList()` call.
+
+{% raw %}
+```jsx
+import { List } from 'react-admin';
+
+const PostList = () => (
+    <List queryOptions={{ meta: { foo: 'bar' } }}>
+        ...
+    </List>
+);
+```
+{% endraw %}
+
+## Rendering An Empty List
+
+When there is no data, react-admin displays a special page inviting the user to create the first record. This page can be customized using [the `empty` prop](#empty-empty-page-component).
+
+You can set the `empty` props value to `false` to render an empty list instead.
 
 ```tsx
 import { List } from 'react-admin';
@@ -1022,23 +1022,11 @@ const ProductList = () => (
 )
 ```
 
-## How to remove the `<ExportButton>`
+## Disabling Parameters Persistence
 
-You can remove the `<ExportButton>` by passing `false` to the `exporter` prop.
+By default, react-admin stores the list parameters (sort, pagination, filters) in localStorage so that  users can come back to the list and find it in the same state as when they left it. This also synchronizes the list parameters across tabs.
 
-```tsx
-import { List } from 'react-admin';
-
-const ProductList = () => (
-    <List exporter={false}>
-        ...
-    </List>
-)
-```
-
-## How to disable storing the list parameters in the Store
-
-You can disable the `storeKey` feature by setting the `storeKey` prop to `false`. When disabled, the list parameters will not be persisted in [the Store](./Store.md).
+You can disable this feature by setting [the `storeKey` prop](#storekey) to `false`:
 
 ```tsx
 import { List } from 'react-admin';

--- a/docs/ListBase.md
+++ b/docs/ListBase.md
@@ -58,11 +58,11 @@ The `<ListBase>` component accepts the same props as [`useListController`](./use
 * [`exporter`](./List.md#exporter)
 * [`filter`](./List.md#filter-permanent-filter)
 * [`filterDefaultValues`](./List.md#filterdefaultvalues)
-* [`perPage`](./List.md#perpage-pagination-size)
+* [`perPage`](./List.md#perpage)
 * [`queryOptions`](./List.md#queryoptions)
 * [`resource`](./List.md#resource)
-* [`sort`](./List.md#sort-default-sort-field--order)
+* [`sort`](./List.md#sort)
 
 These are a subset of the props accepted by `<List>` - only the props that change data fetching, and not the props related to the user interface.
 
-In addition, `<ListBase>` renders its children components inside a `ListContext`. Check [the `<List children>` documentation](./List.md#children-list-layout) for usage examples.
+In addition, `<ListBase>` renders its children components inside a `ListContext`. Check [the `<List children>` documentation](./List.md#children) for usage examples.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -65,7 +65,7 @@ title: "Index"
 * [`<EditDialog>`](./EditDialog)<img class="icon" src="./img/premium.svg" />
 * [`<EditInDialogButton>`](./EditInDialogButton.md)<img class="icon" src="./img/premium.svg" />
 * [`<EmailField>`](./EmailField.md)
-* [`<Empty>`](./List.md#empty-empty-page-component)
+* [`<Empty>`](./List.md#empty)
 
 **- F -**
 * [`<FileField>`](./FileField.md)
@@ -121,7 +121,7 @@ title: "Index"
 * [`<NumberInput>`](./NumberInput.md)
 
 **- P -**
-* [`<Pagination>`](./List.md#pagination-pagination-component)
+* [`<Pagination>`](./List.md#pagination)
 * [`<PasswordInput>`](./PasswordInput.md)
 * [`<PreferencesSetter>`](https://marmelab.com/ra-enterprise/modules/ra-preferences#preferencessetter-setting-preferences-declaratively)<img class="icon" src="./img/premium.svg" />
 

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -190,6 +190,53 @@ The `<ReferenceField>` component accepts the usual `className` prop. You can als
 
 To override the style of all instances of `<ReferenceField>` using the [Material UI style overrides](https://mui.com/material-ui/customization/theme-components/#theme-style-overrides), use the `RaReferenceField` key.
 
+## Performance
+
+When used in a `<Datagrid>`, `<ReferenceField>` fetches the referenced record only once for the entire table. 
+
+![ReferenceField](./img/reference-field.png)
+
+For instance, with this code:
+
+```jsx
+import { List, Datagrid, ReferenceField, TextField, EditButton } from 'react-admin';
+
+export const PostList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="id" />
+            <ReferenceField label="User" source="user_id" reference="users" />
+            <TextField source="title" />
+            <EditButton />
+        </Datagrid>
+    </List>
+);
+```
+
+React-admin accumulates and deduplicates the ids of the referenced records to make *one* `dataProvider.getMany()` call for the entire list, instead of n `dataProvider.getOne()` calls. So for instance, if the API returns the following list of posts:
+
+```js
+[
+    {
+        id: 123,
+        title: 'Totally agree',
+        user_id: 789,
+    },
+    {
+        id: 124,
+        title: 'You are right my friend',
+        user_id: 789
+    },
+    {
+        id: 125,
+        title: 'Not sure about this one',
+        user_id: 735
+    }
+]
+```
+
+Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField>`, fetches the API for the related users in one call (`dataProvider.getMany('users', { ids: [789,735] }`), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.
+
 ## Rendering More Than One Field
 
 You often need to render more than one field of the reference table (e.g. if the `users` table has a `first_name` and a `last_name` field).
@@ -255,54 +302,7 @@ export const PostShow = () => (
 );
 ```
 
-## Performance
-
-When used in a `<Datagrid>`, `<ReferenceField>` fetches the referenced record only once for the entire table. 
-
-![ReferenceField](./img/reference-field.png)
-
-For instance, with this code:
-
-```jsx
-import { List, Datagrid, ReferenceField, TextField, EditButton } from 'react-admin';
-
-export const PostList = () => (
-    <List>
-        <Datagrid>
-            <TextField source="id" />
-            <ReferenceField label="User" source="user_id" reference="users" />
-            <TextField source="title" />
-            <EditButton />
-        </Datagrid>
-    </List>
-);
-```
-
-React-admin accumulates and deduplicates the ids of the referenced records to make *one* `dataProvider.getMany()` call for the entire list, instead of n `dataProvider.getOne()` calls. So for instance, if the API returns the following list of posts:
-
-```js
-[
-    {
-        id: 123,
-        title: 'Totally agree',
-        user_id: 789,
-    },
-    {
-        id: 124,
-        title: 'You are right my friend',
-        user_id: 789
-    },
-    {
-        id: 125,
-        title: 'Not sure about this one',
-        user_id: 735
-    }
-]
-```
-
-Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField>`, fetches the API for the related users in one call (`dataProvider.getMany('users', { ids: [789,735] }`), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.
-
-## Removing the link
+## Removing The Link
 
 You can prevent `<ReferenceField>` from adding a link to its children by setting `link` to `false`.
 

--- a/docs/ReferenceOneField.md
+++ b/docs/ReferenceOneField.md
@@ -224,7 +224,7 @@ const BookShow = () => (
 ```
 {% endraw %}
 
-## Removing the link
+## Removing The Link
 
 By default, `<ReferenceOneField>` links to the edition page of the related record. You can disable this behavior by setting the `link` prop to `false`.
 

--- a/docs/SimpleShowLayout.md
+++ b/docs/SimpleShowLayout.md
@@ -7,6 +7,8 @@ title: "SimpleShowLayout"
 
 The `<SimpleShowLayout>` pulls the `record` from the `RecordContext`. It renders the record fields in a single-column layout (via Material UI's `<Stack>` component). `<SimpleShowLayout>` delegates the actual rendering of fields to its children. It wraps each field inside [a `<Labeled>` component](./Labeled.md) to add a label.
 
+![Simple Show Layout](./img/post-show.png)
+
 ## Usage
 
 Use `<SimpleShowLayout>` as descendant of a `<Show>` component (or any component creating a `<RecordContext>`), and set the fields to be displayed as children:
@@ -34,7 +36,7 @@ const PostShow = () => (
 
 Additional props are passed to the root component (`<div>`).
 
-## Fields
+## `children`
 
 `<SimpleShowLayout>` renders each child inside a `<Labeled>` component. The above snippet roughly translates to:
 
@@ -121,7 +123,7 @@ const PostShow = () => (
 );
 ```
 
-## Spacing
+## `spacing`
 
 `<SimpleShowLayout>` renders a Material UI `<Stack>`. You can customize the spacing of each row by passing a `spacing` prop:
 
@@ -137,7 +139,7 @@ const PostShow = () => (
 
 The default spacing is `1`.
 
-## Divider
+## `divider`
 
 `<Stack>` accepts an optional `divider` prop - a component rendered between each row. `<SimpleShowLayout>` also accepts this props, and passes it to the `<Stack>` component.
 
@@ -153,9 +155,36 @@ const PostShow = () => (
 );
 ```
 
-## More Than One Column
+## `sx`: CSS API
 
-`<SimpleShowLayout>` arranges fields with labels in a single column. If you need more than one column, nothing prevents you from using this layout several times:
+The `<SimpleShowLayout>` component accepts the usual `className` prop but you can override many class names injected to the inner components by React-admin thanks to the `sx` property (as most Material UI components, see their [documentation about it](https://mui.com/material-ui/customization/how-to-customize/#overriding-nested-component-styles)). This property accepts the following subclasses:
+
+| Rule name                     | Description                                             |
+|-------------------------------|---------------------------------------------------------|
+| `& .RaSimpleShowLayout-stack` | Applied to the `<Stack>` element                        |
+| `& .RaSimpleShowLayout-row`   | Applied to each child of the stack (i.e. to each field) |
+
+To override the style of all instances of `<SimpleShowLayout>` using the [Material UI style overrides](https://mui.com/material-ui/customization/theme-components/#theme-style-overrides), use the `RaSimpleShowLayout` key.
+
+## Controlled Mode
+
+By default, `<SimpleShowLayout>` reads the record from the `ResourceContext`. But by passing a `record` prop, you can render the component outside a `ResourceContext`.
+
+{% raw %}
+```jsx
+const StaticPostShow = () => (
+    <SimpleShowLayout record={{ id: 123, title: 'Hello world' }}>
+        <TextField source="title" />
+    </SimpleShowLayout>
+);
+```
+{% endraw %}
+
+When passed a `record`, `<SimpleShowLayout>` creates a `RecordContext` with the given record.
+
+## Rendering More Than One Column
+
+`<SimpleShowLayout>` arranges fields with labels in a single column. If you need more than one column, you can use this component several times, for instance in a grid:
 
 ```jsx
 const BookShow = () => (
@@ -179,36 +208,9 @@ const BookShow = () => (
 );
 ```
 
-## Controlled Mode
+## Hiding The Field Labels
 
-By default, `<SimpleShowLayout>` reads the record from the `ResourceContext`. But by passing a `record` prop, you can render the component outside a `ResourceContext`.
-
-{% raw %}
-```jsx
-const StaticPostShow = () => (
-    <SimpleShowLayout record={{ id: 123, title: 'Hello world' }}>
-        <TextField source="title" />
-    </SimpleShowLayout>
-);
-```
-{% endraw %}
-
-When passed a `record`, `<SimpleShowLayout>` creates a `RecordContext` with the given record.
-
-## `sx`: CSS API
-
-The `<SimpleShowLayout>` component accepts the usual `className` prop but you can override many class names injected to the inner components by React-admin thanks to the `sx` property (as most Material UI components, see their [documentation about it](https://mui.com/material-ui/customization/how-to-customize/#overriding-nested-component-styles)). This property accepts the following subclasses:
-
-| Rule name                     | Description                                             |
-|-------------------------------|---------------------------------------------------------|
-| `& .RaSimpleShowLayout-stack` | Applied to the `<Stack>` element                        |
-| `& .RaSimpleShowLayout-row`   | Applied to each child of the stack (i.e. to each field) |
-
-To override the style of all instances of `<SimpleShowLayout>` using the [Material UI style overrides](https://mui.com/material-ui/customization/theme-components/#theme-style-overrides), use the `RaSimpleShowLayout` key.
-
-## Hiding the labels
-
-You can disable the `<Labeled>` decoration added by `<SimpleShowLayout>` by passing setting `label={false}` on a field:
+You can disable the `<Labeled>` decoration added by `<SimpleShowLayout>` by setting `label={false}` on a field:
 
 ```jsx
 const PostShow = () => (
@@ -216,15 +218,6 @@ const PostShow = () => (
         <SimpleShowLayout>
             <TextField label={false} source="title" />
         </SimpleShowLayout>
-    </Show>
-);
-
-// translates to
-const PostShow = () => (
-    <Show>
-        <Stack>
-            <TextField source="title" />
-        </Stack>
     </Show>
 );
 ```

--- a/docs/useListContext.md
+++ b/docs/useListContext.md
@@ -158,9 +158,9 @@ export const PostList = () => (
 
 You can find many usage examples of `useListContext` in the documentation, including:
 
-- [Adding a Side Component with `<List actions>`](./List.md#aside-side-component)
+- [Adding a Side Component with `<List actions>`](./List.md#aside)
 - [Building a Custom Actions Bar via `<List actions>`](./List.md#actions)
-- [Building a Custom Empty Page via `<List empty>`](./List.md#empty-empty-page-component)
+- [Building a Custom Empty Page via `<List empty>`](./List.md#empty)
 - [Building a Custom Filter](./FilteringTutorial.md#building-a-custom-filter)
 - [Building a Custom Sort Control](./ListTutorial.md#building-a-custom-sort-control)
 - [Building a Custom Pagination Control](./ListTutorial.md#building-a-custom-pagination)

--- a/docs/useListController.md
+++ b/docs/useListController.md
@@ -39,10 +39,10 @@ const MyList = () => {
 * [`exporter`](./List.md#exporter): exporter function
 * [`filter`](./List.md#filter-permanent-filter): permanent filter, forced over the user filter
 * [`filterDefaultValues`](./List.md#filterdefaultvalues): default values for the filter form
-* [`perPage`](./List.md#perpage-pagination-size): number of results per page
+* [`perPage`](./List.md#perpage): number of results per page
 * [`queryOptions`](./List.md#queryoptions): react-query options for the useQuery call
 * [`resource`](./List.md#resource): resource name, e.g. 'posts' ; defaults to the current resource context
-* [`sort`](./List.md#sort-default-sort-field--order), current sort value, e.g. `{ field: 'published_at', order: 'DESC' }`
+* [`sort`](./List.md#sort), current sort value, e.g. `{ field: 'published_at', order: 'DESC' }`
 * [`storeKey`](#storekey): key used to differentiate the list from another sharing the same resource, in store managed states
 
 Here are their default values:


### PR DESCRIPTION
In doc chapters, I'm trying to keep the same order of sections:

0. screenshot
1. usage
2. list of props
3. one section for each prop
4. additional features
5. "How To" sections, starting with a verb in gerund

I modified chapters edited in #9086 to reflect that.