### PR TITLE
[TypeScript] Fix TS errors with `<ArrayField>` and `<ChipField>` in stories

### DIFF
--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -100,7 +100,7 @@ export const ArrayField = genericMemo(ArrayFieldImpl);
 export interface ArrayFieldProps<
     RecordType extends Record<string, unknown> = Record<string, any>
 > extends FieldProps<RecordType> {
-    children: ReactNode;
+    children?: ReactNode;
     perPage?: number;
     sort?: SortPayload;
     filter?: FilterPayload;

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -54,7 +54,12 @@ export const ChipField = genericMemo(ChipFieldImpl);
 export interface ChipFieldProps<
     RecordType extends Record<string, unknown> = Record<string, any>
 > extends FieldProps<RecordType>,
-        Omit<ChipProps, 'label'> {}
+        Omit<ChipProps, 'label' | 'children'> {
+    /**
+     * @internal do not use (prop required for TS to be able to cast ChipField as FunctionComponent)
+     */
+    children?: React.ReactNode;
+}
 
 const PREFIX = 'RaChipField';
 


### PR DESCRIPTION
Fixes errors such as the following in `ArrayField.stories.tsx`:

```
Type '{ children: Element; record: { id: number; books: { id: number; title: string; author_id: number; }[]; }; source: string; }' is not assignable to type 'IntrinsicAttributes & { children?: ReactNode; }'.
  Property 'record' does not exist on type 'IntrinsicAttributes & { children?: ReactNode; }'.ts(2322)
```

Basically, if the `children` prop type is not exactly the same as what React expects (`ReactNode | undefined`), the type of the component will be `React.FunctionComponent<{}>` instead if the declared type (and hence every additional prop is not recognized)