### PR TITLE
[Doc] Fix deprecated bulkActionButtons prop of List component

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -587,7 +587,7 @@ const CommentList = () => (
 
 **Tip**: The `<ExportButton>` limits the main request to the `dataProvider` to 1,000 records. If you want to increase or decrease this limit, pass a `maxResults` prop to the `<ExportButton>` in a custom `<ListActions>` component.
 
-**Tip**: React-admin also provides a `<BulkExportButton>` component that depends on the `exporter`, and that you can use in the `bulkActionButtons` prop of the `<List>` component.
+**Tip**: React-admin also provides a `<BulkExportButton>` component that depends on the `exporter`, and that you can use in the `bulkActionButtons` prop of the `<Datagrid>` component.
 
 **Tip**: For complex (or large) exports, fetching all the related records and assembling them client-side can be slow. In that case, create the CSV on the server side, and replace the `<ExportButton>` component by a custom one, fetching the CSV route.
 


### PR DESCRIPTION
The bulkActionButtons prop is deprecated on both List and ListView https://github.com/marmelab/react-admin/blob/0155a34f7d70535b21a385e5c0b18370ed071e64/packages/ra-ui-materialui/src/list/ListView.tsx#L124

Update the doc to pass the prop to Datagrid component.