### PR TITLE
Add ability to override useCreatePath (DO NOT MERGE)

### DIFF
--- a/examples/simple/src/ResourceWithReg.tsx
+++ b/examples/simple/src/ResourceWithReg.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+
+import { useEffect, ComponentType, ReactElement, isValidElement } from 'react';
+import { isValidElementType } from 'react-is';
+
+import { Route, Routes, useResolvedPath } from 'react-router-dom';
+import {
+    useResourceDefinitionContext,
+    ResourceDefinition,
+    ResourceProps,
+    useBasename,
+    ResourceContextProvider,
+    removeDoubleSlashes,
+    CreatePathParams,
+} from 'react-admin';
+
+const registerResource = ({
+    create,
+    edit,
+    icon,
+    list,
+    name,
+    options,
+    show,
+    recordRepresentation,
+    hasCreate,
+    hasEdit,
+    hasShow,
+    createPath,
+    routeType,
+}: ResourceProps) => ({
+    name,
+    options: options ?? {},
+    hasList: !!list,
+    hasCreate: !!create || !!hasCreate,
+    hasEdit: !!edit || !!hasEdit,
+    hasShow: !!show || !!hasShow,
+    icon,
+    recordRepresentation,
+    createPath,
+    routeType,
+});
+
+export const getElement = (
+    ElementOrComponent: ComponentType<any> | ReactElement
+) => {
+    if (isValidElement(ElementOrComponent)) {
+        return ElementOrComponent;
+    }
+
+    if (isValidElementType(ElementOrComponent)) {
+        return <ElementOrComponent />;
+    }
+
+    return <>{null}</>;
+};
+
+export function ResourceWithReg(props: ResourceProps) {
+    const basename = useBasename();
+
+    const registrationProps = registerResource(props);
+
+    const { create, edit, list, show } = props;
+
+    const resolved = useResolvedPath('');
+
+    const {
+        name,
+        icon,
+        options,
+        hasCreate,
+        hasEdit,
+        hasShow,
+        hasList,
+        recordRepresentation,
+        createPath,
+        routeType,
+    } = registrationProps;
+
+    const {
+        register,
+        unregister,
+        definitions,
+    } = useResourceDefinitionContext();
+
+    const def: ResourceDefinition = definitions[name];
+
+    // register resource if not defined or was registered before in a different root
+    useEffect(() => {
+        const newDef: ResourceDefinition = {
+            name,
+            hasList,
+            hasCreate,
+            hasEdit,
+            hasShow,
+            icon,
+            options,
+            recordRepresentation,
+            createPath,
+            routeType,
+        };
+
+        /** path to `list` component */
+        const newRoot = createPath
+            ? removeDoubleSlashes(createPath({ resource: name, type: 'list' }))
+            : removeDoubleSlashes(`${basename}/${name}`);
+
+        if (!def) {
+            console.log(
+                `ResourceEx: REGISTER "${routeType}" "${name}" at "${newRoot}"`
+            );
+            register(newDef);
+        } else {
+            /** path to `list` component computed using current definition */
+            const defRoot = def.createPath
+                ? removeDoubleSlashes(
+                      def.createPath({ resource: name, type: 'list' })
+                  )
+                : removeDoubleSlashes(`${basename}/${name}`);
+
+            // different paths indicate we are attempting to render an already registered resource inside a different URL;
+            // before we can render the resource, we need to unregister the current resource and then register new resource
+            if (newRoot !== defRoot || def?.routeType !== routeType) {
+                console.log(
+                    `ResourceEx: UNREGISTER "${def?.routeType}" "${name}" at "${defRoot}"`
+                );
+                unregister({ name });
+            }
+        }
+    }, [
+        def,
+        hasCreate,
+        hasEdit,
+        hasList,
+        hasShow,
+        icon,
+        name,
+        options,
+        recordRepresentation,
+        register,
+        unregister,
+        createPath,
+        routeType,
+        basename,
+        resolved.pathname,
+    ]);
+
+    if (def) {
+        if (
+            routeType === 'resourceWithParent' ||
+            routeType === 'childResource'
+        ) {
+            return (
+                <ResourceContextProvider value={name}>
+                    <Routes>
+                        {list && routeType === 'resourceWithParent' && (
+                            <Route index element={getElement(list)} />
+                        )}
+                        <Route
+                            path={`${name}/*`}
+                            element={
+                                <>
+                                    <div>Child "resource" routes:</div>
+                                    <Routes>
+                                        {create && (
+                                            <>
+                                                <Route
+                                                    path="create/*"
+                                                    element={getElement(create)}
+                                                />
+                                            </>
+                                        )}
+                                        {show && (
+                                            <Route
+                                                path=":id/show/*"
+                                                element={getElement(show)}
+                                            />
+                                        )}
+                                        {edit && (
+                                            <Route
+                                                path=":id/*"
+                                                element={getElement(edit)}
+                                            />
+                                        )}
+                                        {list && (
+                                            <Route
+                                                path="/*"
+                                                element={getElement(list)}
+                                            />
+                                        )}
+                                        {props.children}
+                                    </Routes>
+                                </>
+                            }
+                        />
+                    </Routes>
+                </ResourceContextProvider>
+            );
+        }
+
+        return (
+            <ResourceContextProvider value={name}>
+                <Routes>
+                    {create && (
+                        <Route path="create/*" element={getElement(create)} />
+                    )}
+                    {show && (
+                        <Route path=":id/show/*" element={getElement(show)} />
+                    )}
+                    {edit && <Route path=":id/*" element={getElement(edit)} />}
+                    {list && <Route path="/*" element={getElement(list)} />}
+                    {props.children}
+                </Routes>
+            </ResourceContextProvider>
+        );
+    }
+
+    return null;
+}
+
+ResourceWithReg.raName = 'Resource';
+ResourceWithReg.registerResource = registerResource;
+
+export const createResourceCbFactory = (
+    rootPath: string,
+    routeType: ResourceDefinition['routeType']
+) => {
+    return (params: CreatePathParams): string => {
+        const { resource, type, id } = params;
+
+        /** route to list component */
+        const listPath =
+            routeType === 'childResource'
+                ? `${rootPath}/${resource}`
+                : rootPath;
+
+        /** used by create, show and edit routes */
+        const nestedPath =
+            routeType === 'default' ? rootPath : `${rootPath}/${resource}`;
+
+        switch (type) {
+            case 'list':
+                return removeDoubleSlashes(`${listPath}`);
+            case 'create':
+                return removeDoubleSlashes(`${nestedPath}/create`);
+            case 'edit': {
+                if (id == null) {
+                    // maybe the id isn't defined yet
+                    // instead of throwing an error, fallback to list link
+                    return removeDoubleSlashes(`${listPath}`);
+                }
+                return removeDoubleSlashes(
+                    `${nestedPath}/${encodeURIComponent(id)}`
+                );
+            }
+            case 'show': {
+                if (id == null) {
+                    // maybe the id isn't defined yet
+                    // instead of throwing an error, fallback to list link
+                    return removeDoubleSlashes(`${listPath}`);
+                }
+                return removeDoubleSlashes(
+                    `${nestedPath}/${encodeURIComponent(id)}/show`
+                );
+            }
+            default:
+                return type;
+        }
+    };
+};

--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -152,7 +152,7 @@ const CommentMobileList = () => (
 );
 
 const CommentList = () => (
-    <ListBase perPage={6} exporter={exporter}>
+    <ListBase perPage={6} exporter={exporter} disableSyncWithLocation>
         <ListView />
     </ListBase>
 );

--- a/examples/simple/src/index.tsx
+++ b/examples/simple/src/index.tsx
@@ -14,6 +14,8 @@ import Layout from './Layout';
 import posts from './posts';
 import users from './users';
 import tags from './tags';
+import { Tab1, Tab2 } from './test';
+import { ResourceWithReg } from './ResourceWithReg';
 
 render(
     <React.StrictMode>
@@ -30,8 +32,12 @@ render(
                     element={<CustomRouteNoLayout title="Posts from /custom" />}
                 />
             </CustomRoutes>
-            <Resource name="posts" {...posts} />
-            <Resource name="comments" {...comments} />
+            <ResourceWithReg name="posts" {...posts} />
+            <CustomRoutes>
+                <Route path="/tabs/1/*" element={<Tab1 />} />
+                <Route path="/tabs/2/*" element={<Tab2 />} />
+            </CustomRoutes>
+            <ResourceWithReg name="comments" {...comments} />
             <Resource name="tags" {...tags} />
             {permissions => (
                 <>

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -32,6 +32,7 @@ import {
     useCreateSuggestionContext,
     EditActionsProps,
     usePermissions,
+    useRecordContext,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import {
     Box,
@@ -100,8 +101,15 @@ const categories = [
     { name: 'Lifestyle', id: 'lifestyle' },
 ];
 
+const Test = () => {
+    const record = useRecordContext();
+    console.log('Zzz', record);
+    return null;
+};
+
 const PostEdit = () => {
     const { permissions } = usePermissions();
+
     return (
         <Edit title={<PostTitle />} actions={<EditActions />}>
             <TabbedForm
@@ -123,6 +131,7 @@ const PostEdit = () => {
                             resettable
                         />
                     </SanitizedBox>
+                    <Test />
                     <TextInput
                         multiline
                         fullWidth

--- a/examples/simple/src/posts/PostList.tsx
+++ b/examples/simple/src/posts/PostList.tsx
@@ -157,6 +157,7 @@ const PostListDesktop = () => (
         sort={{ field: 'published_at', order: 'DESC' }}
         exporter={exporter}
         actions={<PostListActions />}
+        disableSyncWithLocation
     >
         <StyledDatagrid
             bulkActionButtons={<PostListBulkActions />}

--- a/examples/simple/src/test.tsx
+++ b/examples/simple/src/test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ResourceWithReg, createResourceCbFactory } from './ResourceWithReg';
+import posts from './posts';
+import comments from './comments';
+import { useResolvedPath } from 'react-router-dom';
+
+const t1 = 'default';
+const fn_1 = createResourceCbFactory('/tabs/1', t1);
+
+const Info = () => {
+    const path = useResolvedPath('');
+
+    return (
+        <div>
+            This is a <b>"{path.pathname}/*"</b> custom route
+        </div>
+    );
+};
+
+export const Tab1 = () => {
+    return (
+        <>
+            <Info />
+            <ResourceWithReg
+                {...posts}
+                name="posts"
+                createPath={fn_1}
+                routeType={t1}
+            />
+        </>
+    );
+};
+
+const t2 = 'resourceWithParent';
+const fn_2 = createResourceCbFactory('/tabs/2', t2);
+export const Tab2 = () => {
+    return (
+        <>
+            <Info />
+            <ResourceWithReg
+                {...posts}
+                name="posts"
+                createPath={fn_2}
+                routeType={t2}
+            />
+            <ResourceWithReg
+                {...comments}
+                name="comments"
+                createPath={fn_2}
+                routeType={t2}
+            />
+        </>
+    );
+};

--- a/examples/simple/src/test.tsx
+++ b/examples/simple/src/test.tsx
@@ -12,7 +12,7 @@ const Info = () => {
 
     return (
         <div>
-            This is a <b>"{path.pathname}/*"</b> custom route
+            This is a <b>"{path.pathname}"</b> custom route
         </div>
     );
 };

--- a/packages/ra-core/src/routing/useCreatePath.spec.tsx
+++ b/packages/ra-core/src/routing/useCreatePath.spec.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { CreatePathType, useCreatePath } from './useCreatePath';
+import { useCreatePath } from './useCreatePath';
 import { AtRoot, SubPath } from './useCreatePath.stories';
-import { Identifier } from '../types';
+import { Identifier, CreatePathType } from '../types';
 
 describe('useCreatePath', () => {
     beforeEach(() => {

--- a/packages/ra-core/src/routing/useCreatePath.ts
+++ b/packages/ra-core/src/routing/useCreatePath.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
 
-import { Identifier } from '../types';
 import { useBasename } from './useBasename';
+import { useResourceDefinitions } from '../core/useResourceDefinitions';
+import { CreatePathParams } from '../types';
 
 /**
  * Get a callback to create a link to a given page in the admin app.
@@ -39,8 +40,12 @@ import { useBasename } from './useBasename';
  */
 export const useCreatePath = () => {
     const basename = useBasename();
+    const definitions = useResourceDefinitions();
     return useCallback(
         ({ resource, id, type }: CreatePathParams): string => {
+            const createPath = definitions?.[resource]?.createPath;
+            if (createPath) return createPath({ type, resource, id });
+
             switch (type) {
                 case 'list':
                     return removeDoubleSlashes(`${basename}/${resource}`);
@@ -72,17 +77,8 @@ export const useCreatePath = () => {
                     return type;
             }
         },
-        [basename]
+        [basename, definitions]
     );
 };
-
-type AnyString = string & {};
-export type CreatePathType = 'list' | 'edit' | 'show' | 'create' | AnyString;
-
-export interface CreatePathParams {
-    type: CreatePathType;
-    resource: string;
-    id?: Identifier;
-}
 
 export const removeDoubleSlashes = (path: string) => path.replace('//', '/');

--- a/packages/ra-core/src/routing/useRedirect.ts
+++ b/packages/ra-core/src/routing/useRedirect.ts
@@ -2,9 +2,9 @@ import { useCallback } from 'react';
 import { useNavigate, To } from 'react-router-dom';
 import { parsePath } from 'history';
 
-import { Identifier, RaRecord } from '../types';
+import { Identifier, RaRecord, CreatePathType } from '../types';
 import { useBasename } from './useBasename';
-import { CreatePathType, useCreatePath } from './useCreatePath';
+import { useCreatePath } from './useCreatePath';
 
 type RedirectToFunction = (
     resource?: string,

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -289,6 +289,13 @@ export interface ResourceDefinition<OptionsType extends ResourceOptions = any> {
         | ReactElement
         | RecordToStringFunction
         | string;
+    readonly createPath?: (params: CreatePathParams) => string;
+    /**
+     * this attributes does not have to be present in ra-core; can be defined in user code;
+     * included here for now, since it make it easier to demonstrate this feature
+     * see ResourceWithReg component in simple app for usage info
+     */
+    readonly routeType?: 'default' | `childResource` | 'resourceWithParent';
 }
 
 /**
@@ -359,6 +366,23 @@ export interface ResourceProps {
     recordRepresentation?: ReactElement | RecordToStringFunction | string;
     options?: ResourceOptions;
     children?: ReactNode;
+    /** if provided, this callback is used to build routes inside useCreatePath() */
+    createPath?: (params: CreatePathParams) => string;
+    /**
+     * this attributes does not have to be present in ra-core; can be defined in user code;
+     * included here for now, since it make it easier to demonstrate this feature
+     * see ResourceWithReg component in simple app for usage info
+     */
+    routeType?: 'default' | `childResource` | 'resourceWithParent';
+}
+
+type AnyString = string & {};
+export type CreatePathType = 'list' | 'edit' | 'show' | 'create' | AnyString;
+
+export interface CreatePathParams {
+    type: CreatePathType;
+    resource: string;
+    id?: Identifier;
 }
 
 export type Exporter = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 6
+  version: 5
   cacheKey: 8c0
 
 "@ampproject/remapping@npm:^2.1.0, @ampproject/remapping@npm:^2.2.0":
@@ -103,7 +103,7 @@ __metadata:
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
-    json5: ^2.1.2
+    json5: ^2.2.2
     semver: ^6.3.0
     source-map: ^0.5.0
   checksum: 01e69670445a712fba0c6a2d20b442fac6c7bd48d3bee25f3034a5a772bdf7fe442f1164d5c0d4ad420aacf19d701326d014e9bb0daa88fdd0831d0cc832e7fd
@@ -810,20 +810,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1c273d0ec3d49d0fe80bd754ec0191016e5b3ab4fb1e162ac0c014e9d3c1517a5d973afbf8b6dc9f9c98a8605c79e5f9e8b5ee158a4313fa68d1ff7b02084b6a
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-proposal-private-property-in-object@npm:^7.16.0":
-  version: 7.21.11
-  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.11"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-create-class-features-plugin": ^7.21.0
-    "@babel/helper-plugin-utils": ^7.20.2
-    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 3c8c9ea175101b1cbb2b0e8fee20fcbdd03eb0700d3581aa826ac3573c9b002f39b1512c2af9fd1903ff921bcc864da95ad3cdeba53c9fbcfb3dc23916eacf47
   languageName: node
   linkType: hard
 
@@ -3372,28 +3358,28 @@ __metadata:
 "@nx/nx-linux-arm64-gnu@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-arm64-gnu@npm:16.3.2"
-  conditions: os=linux & cpu=arm64 & libc=glibc
+  conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
 "@nx/nx-linux-arm64-musl@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-arm64-musl@npm:16.3.2"
-  conditions: os=linux & cpu=arm64 & libc=musl
+  conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
 "@nx/nx-linux-x64-gnu@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-x64-gnu@npm:16.3.2"
-  conditions: os=linux & cpu=x64 & libc=glibc
+  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
 "@nx/nx-linux-x64-musl@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-x64-musl@npm:16.3.2"
-  conditions: os=linux & cpu=x64 & libc=musl
+  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
@@ -12020,7 +12006,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -19711,7 +19697,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>":
   version: 1.22.3
-  resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=07638b"
   dependencies:
     is-core-module: ^2.12.0
     path-parse: ^1.0.7
@@ -19724,7 +19710,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
   version: 1.22.0
-  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
   dependencies:
     is-core-module: ^2.8.1
     path-parse: ^1.0.7
@@ -19737,7 +19723,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -19750,7 +19736,7 @@ __metadata:
 
 "resolve@patch:resolve@^2.0.0-next.3#~builtin<compat/resolve>":
   version: 2.0.0-next.3
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.3#~builtin<compat/resolve>::version=2.0.0-next.3&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.3#~builtin<compat/resolve>::version=2.0.0-next.3&hash=07638b"
   dependencies:
     is-core-module: ^2.2.0
     path-parse: ^1.0.6
@@ -21645,11 +21631,11 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>, typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
   version: 5.1.3
-  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
+  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 769c5a11a9d5207ae5ce4c84b5c7a72ad92a28877a0061881ccfb326a43a1a1de79c4daff2f9d74720137744cfc9332fddbfbc4c3973c1e859b2f977f5d11b72
+  checksum: 6219383250b585b201c9ea10576164c9d5760c7a167bc761b118692c9fb8e88610f37730c0a1169d96ac19b29ed80418048763d0c1ff00ce48e051abbc213a9b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 5
+  version: 6
   cacheKey: 8c0
 
 "@ampproject/remapping@npm:^2.1.0, @ampproject/remapping@npm:^2.2.0":
@@ -103,7 +103,7 @@ __metadata:
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
-    json5: ^2.2.2
+    json5: ^2.1.2
     semver: ^6.3.0
     source-map: ^0.5.0
   checksum: 01e69670445a712fba0c6a2d20b442fac6c7bd48d3bee25f3034a5a772bdf7fe442f1164d5c0d4ad420aacf19d701326d014e9bb0daa88fdd0831d0cc832e7fd
@@ -810,6 +810,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1c273d0ec3d49d0fe80bd754ec0191016e5b3ab4fb1e162ac0c014e9d3c1517a5d973afbf8b6dc9f9c98a8605c79e5f9e8b5ee158a4313fa68d1ff7b02084b6a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-property-in-object@npm:^7.16.0":
+  version: 7.21.11
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.11"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-create-class-features-plugin": ^7.21.0
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3c8c9ea175101b1cbb2b0e8fee20fcbdd03eb0700d3581aa826ac3573c9b002f39b1512c2af9fd1903ff921bcc864da95ad3cdeba53c9fbcfb3dc23916eacf47
   languageName: node
   linkType: hard
 
@@ -3358,28 +3372,28 @@ __metadata:
 "@nx/nx-linux-arm64-gnu@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-arm64-gnu@npm:16.3.2"
-  conditions: os=linux & cpu=arm64
+  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@nx/nx-linux-arm64-musl@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-arm64-musl@npm:16.3.2"
-  conditions: os=linux & cpu=arm64
+  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@nx/nx-linux-x64-gnu@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-x64-gnu@npm:16.3.2"
-  conditions: os=linux & cpu=x64
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@nx/nx-linux-x64-musl@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/nx-linux-x64-musl@npm:16.3.2"
-  conditions: os=linux & cpu=x64
+  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -12006,7 +12020,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -19697,7 +19711,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>":
   version: 1.22.3
-  resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=c3c19d"
   dependencies:
     is-core-module: ^2.12.0
     path-parse: ^1.0.7
@@ -19710,7 +19724,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
   version: 1.22.0
-  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=c3c19d"
   dependencies:
     is-core-module: ^2.8.1
     path-parse: ^1.0.7
@@ -19723,7 +19737,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -19736,7 +19750,7 @@ __metadata:
 
 "resolve@patch:resolve@^2.0.0-next.3#~builtin<compat/resolve>":
   version: 2.0.0-next.3
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.3#~builtin<compat/resolve>::version=2.0.0-next.3&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.3#~builtin<compat/resolve>::version=2.0.0-next.3&hash=c3c19d"
   dependencies:
     is-core-module: ^2.2.0
     path-parse: ^1.0.6
@@ -21631,11 +21645,11 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>, typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
   version: 5.1.3
-  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=493e53"
+  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6219383250b585b201c9ea10576164c9d5760c7a167bc761b118692c9fb8e88610f37730c0a1169d96ac19b29ed80418048763d0c1ff00ce48e051abbc213a9b
+  checksum: 769c5a11a9d5207ae5ce4c84b5c7a72ad92a28877a0061881ccfb326a43a1a1de79c4daff2f9d74720137744cfc9332fddbfbc4c3973c1e859b2f977f5d11b72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As discussed at https://github.com/marmelab/react-admin/issues/9129, I've implemented proposed changes that allow customizing useCreatePath return values
- packages/ra-core/src/types.ts
- packages/ra-core/src/routing/useCreatePath.ts

For demo and testing purposes, I've updated a simple demo application to add a `ResourceWithReg` component; was based on `Resource` component in React-Admin with additional features:
- It can register a resource during runtime (when accessed from a custom route)
- It will update registration if a resource is already registered from a different path
- It provides different modes of route registration, including:
  - `default` - similar to react-admin; it will register `create/*`,  `:id/show/*`, `:id/*` and `/*` routes inside a route if was called from;
  - `resourceWithParent` - if will register  `<resource>/create/*`,  `<resource>/:id/show/*`, `<resource>/:id/*` and `<resource>/*`  routes inside a route if was called from, plus will register list component to  `/*`; this is useful for displaying multiple lists from the same page
  
  Examples in simple demo:
  
  # custom route /tabs/1
Will register a `posts` resource in `default` mode inside `/tabs/1` route:
- `http://localhost:8080/#/tabs/1` will show list component; notice that "create" button will redirect to proper `create` route
- `http://localhost:8080/#/tabs/1/create` will show 'create' component;

  # custom route /tabs/2
  Will register `posts` and `comments` resources inside `/tabs/2` route:
  - both lists will be visible in page root `http://localhost:8080/#/tabs/2`
  - create routes are `http://localhost:8080/#/tabs/2/posts/create` and `http://localhost:8080/#/tabs/2/comments/create`
  - list component will also be visible from `http://localhost:8080/#/tabs/2/posts` and `http://localhost:8080/#/tabs/2/comments` URLs; however, there pages will only show resources that they own
  - when a resource is updated, the page is redirected to `/tabs/2` that shows both lists
  - limitation: notice that for multi-list pages, we need to disable sync with location; otherwise both resources will be impacted
  
My ask is, can I prepare a pull request that includes changes to the following files? I will remove updates to "simple demo" application, and will also remove `routeType` property - it is not required in ra-core, and only will be used in user land (e.g. `resourceWithParent` component)

- packages/ra-core/src/types.ts
- packages/ra-core/src/routing/useCreatePath.ts