### PR TITLE
feat(datagrid): add support to select non selectable rows using bulk actions

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -42,6 +42,7 @@ Here are all the props accepted by the component:
 
 * [`body`](#body)
 * [`bulkActionButtons`](#bulkactionbuttons)
+* [`bulkIgnoreNonSelectableRows`](#bulkignorenonselectablerows)
 * [`children`](#children)
 * [`empty`](#empty)
 * [`expand`](#expand)
@@ -370,6 +371,24 @@ const CustomResetViewsButton = () => {
         </Button>
     );
 };
+```
+
+## `bulkIgnoreNonSelectableRows`
+By default, when the checkbox to select all rows at the bulk actions toolbar is pressed, only the selectable rows are chosen. However, if you need to select all rows, even those that are unselectable, you can do this by using the `bulkIgnoreNonSelectableRows` prop.
+
+For instance, if you need to enforce a rule that allows selecting either all rows or none of them:
+
+```jsx
+const PostList = () => (
+    <List>
+        <Datagrid
+          isRowSelectable={() => false}
+          bulkIgnoreNonSelectableRows
+        >
+            ...
+        </Datagrid>
+    </List>
+);
 ```
 
 ## `empty`

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
@@ -239,6 +239,25 @@ describe('<Datagrid />', () => {
             expect(contextValue.onSelect).toHaveBeenCalledWith([1, 3]);
         });
 
+        it('should ignore unselectable rows when clicking on select all button using bulkIgnoreNonSelectableRows prop', () => {
+            const Test = ({ selectedIds = [] }) => (
+                <Wrapper listContext={{ ...contextValue, selectedIds }}>
+                    <Datagrid
+                        isRowSelectable={() => false}
+                        bulkIgnoreNonSelectableRows
+                    >
+                        <TitleField />
+                    </Datagrid>
+                </Wrapper>
+            );
+            render(<Test />);
+            const checkboxes = screen.queryAllByRole('checkbox');
+            expect(checkboxes.length).toBe(5);
+            fireEvent.click(checkboxes[0], { checked: true });
+
+            expect(contextValue.onSelect).toHaveBeenCalledWith([1, 2, 3, 4]);
+        });
+
         it('should not use as last selected the item that was unselected', () => {
             const Test = ({ selectedIds = [] }) => (
                 <Wrapper listContext={{ ...contextValue, selectedIds }}>

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -124,6 +124,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
         empty = DefaultEmpty,
         expand,
         bulkActionButtons = defaultBulkActionButtons,
+        bulkIgnoreNonSelectableRows = false,
         hover,
         isRowSelectable,
         isRowExpandable,
@@ -254,6 +255,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                                 data,
                                 hasExpand: !!expand,
                                 hasBulkActions,
+                                bulkIgnoreNonSelectableRows,
                                 isRowSelectable,
                                 onSelect,
                                 resource,
@@ -269,6 +271,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                                 rowClick,
                                 data,
                                 hasBulkActions,
+                                bulkIgnoreNonSelectableRows,
                                 hover,
                                 onToggleItem: handleToggleItem,
                                 resource,
@@ -295,6 +298,7 @@ Datagrid.propTypes = {
     body: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
     // @ts-ignore-line
     bulkActionButtons: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+    bulkIgnoreNonSelectableRows: PropTypes.bool,
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
     sort: PropTypes.exact({
@@ -332,6 +336,7 @@ export interface DatagridProps<RecordType extends RaRecord = any>
     body?: ReactElement | ComponentType;
     className?: string;
     bulkActionButtons?: ReactElement | false;
+    bulkIgnoreNonSelectableRows?: boolean;
     expand?:
         | ReactElement
         | FC<{

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -16,6 +16,7 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
             data,
             expand,
             hasBulkActions,
+            bulkIgnoreNonSelectableRows,
             hover,
             onToggleItem,
             resource,
@@ -50,7 +51,11 @@ const DatagridBody: FC<DatagridBodyProps> = React.forwardRef(
                         record,
                         resource,
                         rowClick,
-                        selectable: !isRowSelectable || isRowSelectable(record),
+                        selectable:
+                            !isRowSelectable ||
+                            isRowSelectable(record) ||
+                            (bulkIgnoreNonSelectableRows &&
+                                selectedIds?.includes(record.id)),
                         selected: selectedIds?.includes(record.id),
                         style: rowStyle ? rowStyle(record, rowIndex) : null,
                     },
@@ -69,6 +74,7 @@ DatagridBody.propTypes = {
     // @ts-ignore
     expand: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
     hasBulkActions: PropTypes.bool.isRequired,
+    bulkIgnoreNonSelectableRows: PropTypes.bool,
     hover: PropTypes.bool,
     onToggleItem: PropTypes.func,
     resource: PropTypes.string,
@@ -88,6 +94,7 @@ DatagridBody.propTypes = {
 DatagridBody.defaultProps = {
     data: [],
     hasBulkActions: false,
+    bulkIgnoreNonSelectableRows: false,
     row: <DatagridRow />,
 };
 
@@ -102,6 +109,7 @@ export interface DatagridBodyProps extends Omit<TableBodyProps, 'classes'> {
               resource: string;
           }>;
     hasBulkActions?: boolean;
+    bulkIgnoreNonSelectableRows?: boolean;
     hover?: boolean;
     onToggleItem?: (
         id: Identifier,

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -28,6 +28,7 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
         className,
         hasExpand = false,
         hasBulkActions = false,
+        bulkIgnoreNonSelectableRows = false,
         isRowSelectable,
     } = props;
     const resource = useResourceContext(props);
@@ -65,7 +66,8 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
                                   record => !selectedIds.includes(record.id)
                               )
                               .filter(record =>
-                                  isRowSelectable
+                                  isRowSelectable &&
+                                  !bulkIgnoreNonSelectableRows
                                       ? isRowSelectable(record)
                                       : true
                               )
@@ -73,11 +75,17 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
                       )
                     : []
             ),
-        [data, onSelect, isRowSelectable, selectedIds]
+        [
+            data,
+            onSelect,
+            isRowSelectable,
+            selectedIds,
+            bulkIgnoreNonSelectableRows,
+        ]
     );
 
     const selectableIds = Array.isArray(data)
-        ? isRowSelectable
+        ? isRowSelectable && !bulkIgnoreNonSelectableRows
             ? data
                   .filter(record => isRowSelectable(record))
                   .map(record => record.id)
@@ -162,6 +170,7 @@ DatagridHeader.propTypes = {
     data: PropTypes.arrayOf(PropTypes.any),
     hasExpand: PropTypes.bool,
     hasBulkActions: PropTypes.bool,
+    bulkIgnoreNonSelectableRows: PropTypes.bool,
     isRowSelectable: PropTypes.func,
     isRowExpandable: PropTypes.func,
     onSelect: PropTypes.func,
@@ -176,6 +185,7 @@ export interface DatagridHeaderProps<RecordType extends RaRecord = any> {
     className?: string;
     hasExpand?: boolean;
     hasBulkActions?: boolean;
+    bulkIgnoreNonSelectableRows?: boolean;
     isRowSelectable?: (record: RecordType) => boolean;
     isRowExpandable?: (record: RecordType) => boolean;
     size?: 'medium' | 'small';


### PR DESCRIPTION
- [x] Implementation
- [x] Documentation
- [x] Tests

## Context
We have received a request to implement row selection in the Datagrid is allowed only in ascending order. Users can select rows starting from the first one and proceed sequentially to the last one. Specifically, users are permitted to select only the first row initially. Once the user selects the first row, the subsequent rows become eligible for selection, following the same sequential pattern.
Only the first row is allowed to select. When it is selected by the user, then the next row is allowed to select and so on.
When the select all button in a bulk toolbar is pressed by the user, it is expected all rows on the list are selected.
The `isRowSelectable` prop of the `Datagrid` was used to satisfy that requirement.

![image](https://github.com/marmelab/react-admin/assets/37714181/c1b291a2-a144-4fc9-b10a-144b6dc4481d)


## Problem
When the select all button in a bulk toolbar is pressed, only the selectable rows are selected. In this case, only the first row. Then, the second row is allowed to be selectable and the select all button in the bulk toolbar is still not marked.

- CodeSandbox: https://codesandbox.io/p/sandbox/github/felipejh/ra-datagrid-bulk-example/tree/main

![demo](https://github.com/marmelab/react-admin/assets/37714181/1970b03b-dde9-49ca-b49f-564f3d11e973)

## Solution
Add a support to the `Datagrid` component to allow select non selectable rows using the select all bulk toolbar.
By adding an optional prop called `bulkIgnoreNonSelectableRows` to the Datagrid, we can allow users to disable the filtering of non-selectable rows.
I am unsure if that prop name is the best. Your input and ideas are welcome.

While I understand that this is a very specific use case, and the aim is to maintain the react-admin codebase small and manageable, I strongly believe that implementing this feature would be highly beneficial. It's worth noting that this feature will be optional, providing flexibility to users who may not need it while enhancing the experience for those who do.

This would be the result:
![ignoreUnselectable](https://github.com/marmelab/react-admin/assets/37714181/a9eda2ad-6a63-4c85-a555-36c609120c33)