### PR TITLE
Fix FilterLiveSearch reset button does not reset the value

### DIFF
--- a/docs/useList.md
+++ b/docs/useList.md
@@ -103,7 +103,19 @@ const { data, total } = useList({
 // data will be [{ id: 1, name: 'Arnold' }] and total will be 1
 ```
 
-The filtering capabilities are very limited. For instance, there is no "greater than" or "less than" operator. You can only filter on the equality of a field.
+The filtering capabilities are very limited. A filter on a field is a simple string comparison. There is no "greater than" or "less than" operator. You can do a full-text filter by using the `q` filter.
+
+```jsx
+const { data, total } = useList({
+    data: [
+        { id: 1, name: 'Arnold' },
+        { id: 2, name: 'Sylvester' },
+        { id: 3, name: 'Jean-Claude' },
+    ],
+    filter: { q: 'arno' },
+});
+// data will be [{ id: 1, name: 'Arnold' }] and total will be 1
+```
 
 ## `filterCallback`
 

--- a/packages/ra-core/src/controller/list/useList.spec.tsx
+++ b/packages/ra-core/src/controller/list/useList.spec.tsx
@@ -21,70 +21,6 @@ const UseList = ({
 };
 
 describe('<useList />', () => {
-    it('should filter string data based on the filter props', () => {
-        const callback = jest.fn();
-        const data = [
-            { id: 1, title: 'hello' },
-            { id: 2, title: 'world' },
-        ];
-
-        render(
-            <UseList
-                data={data}
-                filter={{ title: 'world' }}
-                sort={{ field: 'id', order: 'ASC' }}
-                callback={callback}
-            />
-        );
-
-        expect(callback).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sort: { field: 'id', order: 'ASC' },
-                isFetching: false,
-                isLoading: false,
-                data: [{ id: 2, title: 'world' }],
-                error: undefined,
-                total: 1,
-            })
-        );
-    });
-
-    it('should filter array data based on the filter props', async () => {
-        const callback = jest.fn();
-        const data = [
-            { id: 1, items: ['one', 'two'] },
-            { id: 2, items: ['three'] },
-            { id: 3, items: 'four' },
-            { id: 4, items: ['five'] },
-        ];
-
-        render(
-            <UseList
-                data={data}
-                filter={{ items: ['two', 'four', 'five'] }}
-                sort={{ field: 'id', order: 'ASC' }}
-                callback={callback}
-            />
-        );
-
-        await waitFor(() => {
-            expect(callback).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    sort: { field: 'id', order: 'ASC' },
-                    isFetching: false,
-                    isLoading: false,
-                    data: [
-                        { id: 1, items: ['one', 'two'] },
-                        { id: 3, items: 'four' },
-                        { id: 4, items: ['five'] },
-                    ],
-                    error: undefined,
-                    total: 3,
-                })
-            );
-        });
-    });
-
     it('should apply sorting correctly', async () => {
         const callback = jest.fn();
         const data = [
@@ -229,66 +165,154 @@ describe('<useList />', () => {
         );
     });
 
-    it('should filter array data based on the custom filter', async () => {
-        const callback = jest.fn();
-        const data = [
-            { id: 1, items: ['one', 'two'] },
-            { id: 2, items: ['three'] },
-            { id: 3, items: 'four' },
-            { id: 4, items: ['five'] },
-        ];
+    describe('filter', () => {
+        it('should filter string data based on the filter props', () => {
+            const callback = jest.fn();
+            const data = [
+                { id: 1, title: 'hello' },
+                { id: 2, title: 'world' },
+            ];
 
-        render(
-            <UseList
-                data={data}
-                sort={{ field: 'id', order: 'ASC' }}
-                filterCallback={record => record.id > 2}
-                callback={callback}
-            />
-        );
+            render(
+                <UseList
+                    data={data}
+                    filter={{ title: 'world' }}
+                    sort={{ field: 'id', order: 'ASC' }}
+                    callback={callback}
+                />
+            );
 
-        await waitFor(() => {
             expect(callback).toHaveBeenCalledWith(
                 expect.objectContaining({
                     sort: { field: 'id', order: 'ASC' },
                     isFetching: false,
                     isLoading: false,
-                    data: [
-                        { id: 3, items: 'four' },
-                        { id: 4, items: ['five'] },
-                    ],
+                    data: [{ id: 2, title: 'world' }],
                     error: undefined,
-                    total: 2,
+                    total: 1,
                 })
             );
         });
-    });
 
-    it('should filter data based on a custom filter with nested objects', () => {
-        const callback = jest.fn();
-        const data = [
-            { id: 1, title: { name: 'hello' } },
-            { id: 2, title: { name: 'world' } },
-        ];
+        it('should filter array data based on the filter props', async () => {
+            const callback = jest.fn();
+            const data = [
+                { id: 1, items: ['one', 'two'] },
+                { id: 2, items: ['three'] },
+                { id: 3, items: 'four' },
+                { id: 4, items: ['five'] },
+            ];
 
-        render(
-            <UseList
-                data={data}
-                filter={{ title: { name: 'world' } }}
-                sort={{ field: 'id', order: 'ASC' }}
-                callback={callback}
-            />
-        );
+            render(
+                <UseList
+                    data={data}
+                    filter={{ items: ['two', 'four', 'five'] }}
+                    sort={{ field: 'id', order: 'ASC' }}
+                    callback={callback}
+                />
+            );
 
-        expect(callback).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sort: { field: 'id', order: 'ASC' },
-                isFetching: false,
-                isLoading: false,
-                data: [{ id: 2, title: { name: 'world' } }],
-                error: undefined,
-                total: 1,
-            })
-        );
+            await waitFor(() => {
+                expect(callback).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        sort: { field: 'id', order: 'ASC' },
+                        isFetching: false,
+                        isLoading: false,
+                        data: [
+                            { id: 1, items: ['one', 'two'] },
+                            { id: 3, items: 'four' },
+                            { id: 4, items: ['five'] },
+                        ],
+                        error: undefined,
+                        total: 3,
+                    })
+                );
+            });
+        });
+
+        it('should filter array data based on the custom filter', async () => {
+            const callback = jest.fn();
+            const data = [
+                { id: 1, items: ['one', 'two'] },
+                { id: 2, items: ['three'] },
+                { id: 3, items: 'four' },
+                { id: 4, items: ['five'] },
+            ];
+
+            render(
+                <UseList
+                    data={data}
+                    sort={{ field: 'id', order: 'ASC' }}
+                    filterCallback={record => record.id > 2}
+                    callback={callback}
+                />
+            );
+
+            await waitFor(() => {
+                expect(callback).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        sort: { field: 'id', order: 'ASC' },
+                        isFetching: false,
+                        isLoading: false,
+                        data: [
+                            { id: 3, items: 'four' },
+                            { id: 4, items: ['five'] },
+                        ],
+                        error: undefined,
+                        total: 2,
+                    })
+                );
+            });
+        });
+
+        it('should filter data based on a custom filter with nested objects', () => {
+            const callback = jest.fn();
+            const data = [
+                { id: 1, title: { name: 'hello' } },
+                { id: 2, title: { name: 'world' } },
+            ];
+
+            render(
+                <UseList
+                    data={data}
+                    filter={{ title: { name: 'world' } }}
+                    sort={{ field: 'id', order: 'ASC' }}
+                    callback={callback}
+                />
+            );
+
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sort: { field: 'id', order: 'ASC' },
+                    isFetching: false,
+                    isLoading: false,
+                    data: [{ id: 2, title: { name: 'world' } }],
+                    error: undefined,
+                    total: 1,
+                })
+            );
+        });
+
+        it('should apply the q filter as a full-text filter', () => {
+            const callback = jest.fn();
+            const data = [
+                { id: 1, title: 'Abc', author: 'Def' }, // matches 'ab'
+                { id: 2, title: 'Ghi', author: 'Jkl' }, // does not match 'ab'
+                { id: 3, title: 'Mno', author: 'Abc' }, // matches 'ab'
+            ];
+
+            render(
+                <UseList data={data} filter={{ q: 'ab' }} callback={callback} />
+            );
+
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: [
+                        { id: 1, title: 'Abc', author: 'Def' },
+                        { id: 3, title: 'Mno', author: 'Abc' },
+                    ],
+                })
+            );
+        });
     });
 });

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -178,6 +178,16 @@ export const useList = <RecordType extends RaRecord = any>(
                                         : recordValue.includes(filterValue)
                                     : Array.isArray(filterValue)
                                     ? filterValue.includes(recordValue)
+                                    : filterName === 'q' // special full-text filter
+                                    ? Object.keys(record).some(
+                                          key =>
+                                              typeof record[key] === 'string' &&
+                                              record[key]
+                                                  .toLowerCase()
+                                                  .includes(
+                                                      (filterValue as string).toLowerCase()
+                                                  )
+                                      )
                                     : filterValue == recordValue; // eslint-disable-line eqeqeq
                                 return result;
                             }

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { Basic } from './FilterLiveSearch.stories';
+
+describe('FilterLiveSearch', () => {
+    it('renders an empty text input', () => {
+        render(<Basic />);
+        expect(
+            screen.getByPlaceholderText('ra.action.search').getAttribute('type')
+        ).toBe('text');
+        expect(
+            screen
+                .getByPlaceholderText('ra.action.search')
+                .getAttribute('value')
+        ).toBe('');
+    });
+    it('filters the list when typing', () => {
+        render(<Basic />);
+        expect(screen.queryAllByRole('listitem')).toHaveLength(27);
+        fireEvent.change(screen.getByPlaceholderText('ra.action.search'), {
+            target: { value: 'st' },
+        });
+        expect(screen.queryAllByRole('listitem')).toHaveLength(2); // Austria and Estonia
+    });
+    it('clears the filter when user click on the reset button', () => {
+        render(<Basic />);
+        fireEvent.change(screen.getByPlaceholderText('ra.action.search'), {
+            target: { value: 'st' },
+        });
+        expect(screen.queryAllByRole('listitem')).toHaveLength(2);
+        fireEvent.click(screen.getByLabelText('ra.action.clear_input_value'));
+        expect(screen.queryAllByRole('listitem')).toHaveLength(27);
+    });
+});

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { useList, ListContextProvider, useListContext } from 'ra-core';
+import {
+    Box,
+    List,
+    ListItem,
+    ListItemText,
+    ThemeProvider,
+    createTheme,
+} from '@mui/material';
+
+import { FilterLiveSearch } from './FilterLiveSearch';
+import { defaultTheme } from '../../defaultTheme';
+
+export default {
+    title: 'ra-ui-materialui/list/filter/FilterLiveSearch',
+};
+
+const countries = [
+    { id: 1, name: 'Austria' },
+    { id: 2, name: 'Belgium' },
+    { id: 3, name: 'Bulgaria' },
+    { id: 4, name: 'Croatia' },
+    { id: 5, name: 'Republic of Cyprus' },
+    { id: 6, name: 'Czech Republic' },
+    { id: 7, name: 'Denmark' },
+    { id: 8, name: 'Estonia' },
+    { id: 9, name: 'Finland' },
+    { id: 10, name: 'France' },
+    { id: 11, name: 'Germany' },
+    { id: 12, name: 'Greece' },
+    { id: 13, name: 'Hungary' },
+    { id: 14, name: 'Ireland' },
+    { id: 15, name: 'Italy' },
+    { id: 16, name: 'Latvia' },
+    { id: 17, name: 'Lithuania' },
+    { id: 18, name: 'Luxembourg' },
+    { id: 19, name: 'Malta' },
+    { id: 20, name: 'Netherlands' },
+    { id: 21, name: 'Poland' },
+    { id: 22, name: 'Portugal' },
+    { id: 23, name: 'Romania' },
+    { id: 24, name: 'Slovakia' },
+    { id: 25, name: 'Slovenia' },
+    { id: 26, name: 'Spain' },
+    { id: 27, name: 'Sweden' },
+];
+
+const Wrapper = ({ children }) => (
+    <ThemeProvider theme={createTheme(defaultTheme)}>
+        <ListContextProvider value={useList({ data: countries })}>
+            <Box m={2}>{children}</Box>
+        </ListContextProvider>
+    </ThemeProvider>
+);
+
+const CountryList = () => {
+    const { data } = useListContext();
+    return (
+        <List>
+            {data.map(record => (
+                <ListItem key={record.id} disablePadding>
+                    <ListItemText>{record.name}</ListItemText>
+                </ListItem>
+            ))}
+        </List>
+    );
+};
+
+export const Basic = () => (
+    <Wrapper>
+        <FilterLiveSearch source="q" />
+        <CountryList />
+    </Wrapper>
+);
+
+export const Label = () => (
+    <Wrapper>
+        <FilterLiveSearch source="q" label="search" />
+        <CountryList />
+    </Wrapper>
+);
+
+export const Variant = () => (
+    <Wrapper>
+        <FilterLiveSearch source="q" variant="outlined" />
+        <CountryList />
+    </Wrapper>
+);
+
+export const FullWidth = () => (
+    <Wrapper>
+        <FilterLiveSearch source="q" fullWidth />
+        <CountryList />
+    </Wrapper>
+);
+
+export const Sx = () => (
+    <Wrapper>
+        <FilterLiveSearch source="q" sx={{ width: 300 }} />
+        <CountryList />
+    </Wrapper>
+);

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -3,7 +3,8 @@ import { ChangeEvent, memo, useMemo } from 'react';
 import { InputAdornment } from '@mui/material';
 import { SxProps } from '@mui/system';
 import SearchIcon from '@mui/icons-material/Search';
-import { Form, useTranslate, useListFilterContext } from 'ra-core';
+import { useTranslate, useListFilterContext } from 'ra-core';
+import { FormProvider, useForm } from 'react-hook-form';
 
 import { TextInput, TextInputProps } from '../../input';
 
@@ -38,7 +39,7 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
             setFilters({ ...filterValues, [source]: event.target.value }, null);
         } else {
             const { [source]: _, ...filters } = filterValues;
-            setFilters(filters, null);
+            setFilters(filters, null, false);
         }
     };
 
@@ -49,32 +50,36 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
         [filterValues, source]
     );
 
+    const form = useForm({ defaultValues: initialValues });
+
     const onSubmit = () => undefined;
     return (
-        <Form defaultValues={initialValues} onSubmit={onSubmit}>
-            <TextInput
-                resettable
-                helperText={false}
-                source={source}
-                InputProps={{
-                    endAdornment: (
-                        <InputAdornment position="end">
-                            <SearchIcon color="disabled" />
-                        </InputAdornment>
-                    ),
-                }}
-                onChange={handleChange}
-                size="small"
-                {...(variant === 'outlined'
-                    ? { variant: 'outlined', label }
-                    : {
-                          placeholder: label,
-                          label: false,
-                          hiddenLabel: true,
-                      })}
-                {...rest}
-            />
-        </Form>
+        <FormProvider {...form}>
+            <form onSubmit={onSubmit}>
+                <TextInput
+                    resettable
+                    helperText={false}
+                    source={source}
+                    InputProps={{
+                        endAdornment: (
+                            <InputAdornment position="end">
+                                <SearchIcon color="disabled" />
+                            </InputAdornment>
+                        ),
+                    }}
+                    onChange={handleChange}
+                    size="small"
+                    {...(variant === 'outlined'
+                        ? { variant: 'outlined', label }
+                        : {
+                              placeholder: label,
+                              label: false,
+                              hiddenLabel: true,
+                          })}
+                    {...rest}
+                />
+            </form>
+        </FormProvider>
     );
 });
 


### PR DESCRIPTION
Closes #9106

FilterLiveSearch used react-admin's `<Form>`, which did too many things and caused the bug. Switching to a simple form powered by `useForm` fixes the issue. 

I had to augment `useList` to make a real-life filterable list and unit test `<FilterLiveSearch>` .