### PR TITLE
[no-ci][Doc] fix AutoSaveToolbar is not a ReactElement

### DIFF
--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -495,7 +495,7 @@ const PersonEdit = () => (
     <Edit mutationMode="optimistic">
         <AccordionForm
             resetOptions={{ keepDirtyValues: true }}
-            toolbar={AutoSaveToolbar}
+            toolbar={<AutoSaveToolbar />}
         >
             <AccordionForm.Panel label="identity">
                 <TextInput source="first_name" />

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -785,7 +785,7 @@ const PersonEdit = () => (
     <Edit mutationMode="optimistic">
         <SimpleForm
             resetOptions={{ keepDirtyValues: true }}
-            toolbar={AutoSaveToolbar}
+            toolbar={<AutoSaveToolbar />}
         >
             <TextInput source="first_name" />
             <TextInput source="last_name" />

--- a/docs/LongForm.md
+++ b/docs/LongForm.md
@@ -445,7 +445,7 @@ const PersonEdit = () => (
     <Edit mutationMode="optimistic">
         <LongForm
             resetOptions={{ keepDirtyValues: true }}
-            toolbar={AutoSaveToolbar}
+            toolbar={<AutoSaveToolbar />}
         >
             <LongForm.Section label="identity">
                 <TextInput source="first_name" />

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -630,7 +630,7 @@ const PersonEdit = () => (
     <Edit mutationMode="optimistic">
         <SimpleForm
             resetOptions={{ keepDirtyValues: true }}
-            toolbar={AutoSaveToolbar}
+            toolbar={<AutoSaveToolbar />}
         >
             <TextInput source="first_name" />
             <TextInput source="last_name" />

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -804,7 +804,7 @@ const PostEdit = () => (
     <Edit mutationMode="optimistic">
         <TabbedForm
             resetOptions={{ keepDirtyValues: true }}
-            toolbar={AutoSaveToolbar}
+            toolbar={<AutoSaveToolbar />}
         >
             <TabbedForm.Tab label="summary">
                 <TextInput source="title" />


### PR DESCRIPTION
When I tried to use AutoSave toolbar, as described in the documentation, TS throw an error `Type '() => JSX.Element' is not assignable to type 'false | ReactElement<any, string | JSXElementConstructor<any>> | undefined'`

## Todo

- [x] Add missing tags in the documentation snippet to make AutoSave a ReactElement
