### PR TITLE
fix NumberInput setFocus (react-hook-form)

### DIFF
--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -121,10 +121,12 @@ export const NumberInput = ({
     const renderHelperText =
         helperText !== false || ((isTouched || isSubmitted) && invalid);
 
+    const { ref: fieldRef, ...fieldRest } = field;
+
     return (
         <TextField
             id={id}
-            {...field}
+            {...fieldRest}
             // use the locally controlled state instead of the react-hook-form field state
             value={value}
             onChange={handleChange}
@@ -155,6 +157,7 @@ export const NumberInput = ({
             margin={margin}
             inputProps={inputProps}
             {...sanitizeInputRestProps(rest)}
+            inputRef={fieldRef}
         />
     );
 };


### PR DESCRIPTION
React-hook-form setFocus doesn't work with NumberInput because the ref didn't go through the right props.