### PR TITLE
Display actions first in the List view on mobile

### DIFF
--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -73,11 +73,13 @@ const Root = styled(Toolbar, {
     width: '100%',
     padding: '0 !important',
     minHeight: theme.spacing(8),
-    [theme.breakpoints.down('sm')]: {
-        backgroundColor: theme.palette.background.paper,
-    },
     [theme.breakpoints.down('md')]: {
         margin: 0,
         flexWrap: 'wrap',
+    },
+    [theme.breakpoints.down('sm')]: {
+        backgroundColor: theme.palette.background.paper,
+        flexWrap: 'inherit',
+        flexDirection: 'column-reverse',
     },
 }));


### PR DESCRIPTION
## Problem

The usability of list views on mobile is poor, because the action buttons appear below the filters. In particular, the filters are separated from the content by the actions.

## Solution

Invert the order between filter form  and actions on mobile

| before | after |
| -------|------|
| ![localhost_8000_(iPhone 12 Pro) (2)](https://github.com/marmelab/react-admin/assets/99944/72188664-9b3b-4200-979f-e657b753b81c) | ![localhost_8000_(iPhone 12 Pro) (1)](https://github.com/marmelab/react-admin/assets/99944/1d0930fe-51ee-4fcb-bba3-1b0bfe589867) |
