### PR TITLE
Add ability to use SimpleList without `primaryText`

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -38,24 +38,24 @@ The `<Datagrid>` is an **iterator** component: it gets an array of records from 
 
 ## Props
 
-Here are all the props accepted by the component:
-
-* [`body`](#body)
-* [`bulkActionButtons`](#bulkactionbuttons)
-* [`children`](#children)
-* [`empty`](#empty)
-* [`expand`](#expand)
-* [`expandSingle`](#expandsingle) 
-* [`header`](#header)
-* [`hover`](#hover)
-* [`isRowExpandable`](#isrowexpandable)
-* [`isRowSelectable`](#isrowselectable)
-* [`optimized`](#optimized-better-performance-for-large-tables)
-* [`rowStyle`](#rowstyle)
-* [`rowSx`](#rowsx)
-* [`rowClick`](#rowclick)
-* [`size`](#size)
-* [`sx`](#sx-css-api)
+| Prop | Required | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `children` | Required | Element | n/a | The list of `<Field>` components to render as columns. |
+| `body` | Optional | Element | `<Datagrid Body>` | The component used to render the body of the table. |
+| `bulkActionButtons` | Optional | Element | `<BulkDelete Button>` | The component used to render the bulk action buttons. |
+| `empty` | Optional | Element | `<Empty>` | The component used to render the empty table. |
+| `expand` | Optional | Element |  | The component used to render the expand panel for each row. |
+| `expandSingle` | Optional | Boolean | `false` | Whether to allow only one expanded row at a time. |
+| `header` | Optional | Element | `<Datagrid Header>` | The component used to render the table header. |
+| `hover` | Optional | Boolean | `true` | Whether to highlight the row under the mouse. |
+| `isRowExpandable` | Optional | Function | `() => true` | A function that returns whether a row is expandable. |
+| `isRowSelectable` | Optional | Function | `() => true` | A function that returns whether a row is selectable. |
+| `optimized` | Optional | Boolean | `false` | Whether to optimize the rendering of the table. |
+| `rowClick` | Optional | mixed | | The action to trigger when the user clicks on a row.  |
+| `rowStyle` | Optional | Function | | A function that returns the style to apply to a row. |
+| `rowSx` | Optional | Function | | A function that returns the sx prop to apply to a row. |
+| `size` | Optional | `'small'` or `'medium'` | `'small'` | The size of the table. |
+| `sx` | Optional | Object | | The sx prop passed down to the Material UI `<Table>` element. |
 
 Additional props are passed down to [the Material UI `<Table>` element](https://mui.com/material-ui/api/table/).
 
@@ -106,39 +106,6 @@ const PostList = () => (
 
 export default PostList;
 ```
-
-## `children`
-
-`<Datagrid>` accepts a list of Field components as children. It inspects each child's `source` and/or `label` props to determine the name of the column.
-
-What's a Field component? Simply a component that reads the record (via `useRecordContext`) and renders a value. React-admin includes many Field components that you can use as children of `<Datagrid>` (`<TextField>`, `<NumberField>`, `<DateField>`, `<ReferenceField>`, and many more). Check [the Fields documentation](./Fields.md) for more information. 
-
-You can even create your own field components.
-
-```jsx
-// in src/posts.js
-import * as React from 'react';
-import { useRecordContext, List, Datagrid, TextField, DateField } from 'react-admin';
-
-const FullNameField = () => {
-    const record = useRecordContext();
-    return <span>{record.firstName} {record.lastName}</span>;
-}
-
-export const UserList = () => (
-    <List>
-        <Datagrid rowclick="edit">
-            <FullNameField source="last_name" label="Name" />
-            <DateField source="dob" />
-            <TextField source="city" />
-        </Datagrid>
-    </List>
-);
-```
-
-`<Datagrid>` also inspects its children for `headerClassName` and `cellClassName` props, and gives the class names to the headers and the cells of that column. 
-
-Finally, `<Datagrid>` inspects children for props that indicate how it should be sorted (see [the Customizing The Sort Order For Columns section](#customizing-column-sort)) below.
 
 ## `bulkActionButtons`
 
@@ -377,6 +344,39 @@ const CustomResetViewsButton = () => {
 };
 ```
 
+## `children`
+
+`<Datagrid>` accepts a list of Field components as children. It inspects each child's `source` and/or `label` props to determine the name of the column.
+
+What's a Field component? Simply a component that reads the record (via `useRecordContext`) and renders a value. React-admin includes many Field components that you can use as children of `<Datagrid>` (`<TextField>`, `<NumberField>`, `<DateField>`, `<ReferenceField>`, and many more). Check [the Fields documentation](./Fields.md) for more information. 
+
+You can even create your own field components.
+
+```jsx
+// in src/posts.js
+import * as React from 'react';
+import { useRecordContext, List, Datagrid, TextField, DateField } from 'react-admin';
+
+const FullNameField = () => {
+    const record = useRecordContext();
+    return <span>{record.firstName} {record.lastName}</span>;
+}
+
+export const UserList = () => (
+    <List>
+        <Datagrid rowclick="edit">
+            <FullNameField source="last_name" label="Name" />
+            <DateField source="dob" />
+            <TextField source="city" />
+        </Datagrid>
+    </List>
+);
+```
+
+`<Datagrid>` also inspects its children for `headerClassName` and `cellClassName` props, and gives the class names to the headers and the cells of that column. 
+
+Finally, `<Datagrid>` inspects children for props that indicate how it should be sorted (see [the Customizing The Sort Order For Columns section](#customizing-column-sort)) below.
+
 ## `empty`
 
 It's possible that a Datagrid will have no records to display. If the Datagrid's parent component does not handle the empty state, the Datagrid will display a message indicating there are no results. This message is translatable and its key is `ra.navigation.no_results`.
@@ -606,7 +606,7 @@ export const PostList = () => (
 ```
 {% endraw %}
 
-## `optimized`: Better Performance For Large Tables
+## `optimized`
 
 When displaying large pages of data, you might experience some performance issues.
 This is mostly due to the fact that we iterate over the `<Datagrid>` children and clone them.
@@ -623,48 +623,6 @@ const PostList = () => (
             <TextField source="id" />
             <TextField source="title" />
             <TextField source="views" />
-        </Datagrid>
-    </List>
-);
-```
-
-## `rowStyle`
-
-You can customize the `<Datagrid>` row style (applied to the `<tr>` element) based on the record, thanks to the `rowStyle` prop, which expects a function. React-admin calls this function for each row, passing the current record and index as arguments. The function should return a style object, which react-admin uses as a `<tr style>` prop. 
-
-For instance, this allows to apply a custom background to the entire row if one value of the record - like its number of views - passes a certain threshold.
-
-```jsx
-import { List, Datagrid } from 'react-admin';
-
-const postRowStyle = (record, index) => ({
-    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
-});
-export const PostList = () => (
-    <List>
-        <Datagrid rowStyle={postRowStyle}>
-            ...
-        </Datagrid>
-    </List>
-);
-```
-
-## `rowSx`
-
-You can customize the styles of rows and cells in `<Datagrid>` (applied to the `<DatagridRow>` element) based on the record, thanks to the `rowSx` prop, which expects a function. React-admin calls this function for each row, passing the current record and index as arguments. The function should return a Material UI [`sx`](https://mui.com/system/getting-started/the-sx-prop/), which react-admin uses as a `<TableRow sx>` prop. 
-
-For instance, this allows to apply a custom background to the entire row if one value of the record - like its number of views - passes a certain threshold.
-
-```jsx
-import { List, Datagrid } from 'react-admin';
-
-const postRowSx = (record, index) => ({
-    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
-});
-export const PostList = () => (
-    <List>
-        <Datagrid rowSx={postRowSx}>
-            ...
         </Datagrid>
     </List>
 );
@@ -710,6 +668,50 @@ const getPermissions = useGetPermissions();
 const postRowClick = (id, resource, record) => 
     useGetPermissions()
     .then(permissions => permissions === 'admin' ? 'edit' : 'show');
+```
+
+## `rowStyle`
+
+*Deprecated - use [`rowSx`](#rowsx) instead.*
+
+You can customize the `<Datagrid>` row style (applied to the `<tr>` element) based on the record, thanks to the `rowStyle` prop, which expects a function. React-admin calls this function for each row, passing the current record and index as arguments. The function should return a style object, which react-admin uses as a `<tr style>` prop. 
+
+For instance, this allows to apply a custom background to the entire row if one value of the record - like its number of views - passes a certain threshold.
+
+```jsx
+import { List, Datagrid } from 'react-admin';
+
+const postRowStyle = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+export const PostList = () => (
+    <List>
+        <Datagrid rowStyle={postRowStyle}>
+            ...
+        </Datagrid>
+    </List>
+);
+```
+
+## `rowSx`
+
+You can customize the styles of rows and cells in `<Datagrid>` (applied to the `<DatagridRow>` element) based on the record, thanks to the `rowSx` prop, which expects a function. React-admin calls this function for each row, passing the current record and index as arguments. The function should return a Material UI [`sx`](https://mui.com/system/getting-started/the-sx-prop/), which react-admin uses as a `<TableRow sx>` prop. 
+
+For instance, this allows to apply a custom background to the entire row if one value of the record - like its number of views - passes a certain threshold.
+
+```jsx
+import { List, Datagrid } from 'react-admin';
+
+const postRowSx = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+export const PostList = () => (
+    <List>
+        <Datagrid rowSx={postRowSx}>
+            ...
+        </Datagrid>
+    </List>
+);
 ```
 
 ## `size`

--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -37,19 +37,40 @@ export const PostList = () => (
 
 `<SimpleList>` executes the functions passed as `primaryText`, `secondaryText`, and `tertiaryText` on render, passing the current `record` as parameter. It uses the result to render each List item.
 
-It accepts the following props:
+## Props
 
-* [`primaryText`](#primarytext) (required)
-* [`secondaryText`](#secondarytext)
-* [`tertiaryText`](#tertiarytext)
-* [`linkType`](#linktype)
-* [`leftAvatar`](#leftavatar)
-* [`leftIcon`](#lefticon)
-* [`rightAvatar`](#rightavatar)
-* [`rightIcon`](#righticon)
-* [`rowStyle`](#rowstyle)
-* [`rowSx`](#rowsx)
-* [`empty`](#empty)
+| Prop | Required | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `primaryText` | Optional | mixed | record representation | The primary text to display. |
+| `secondaryText` | Optional | mixed | | The secondary text to display. |
+| `tertiaryText` | Optional | mixed | | The tertiary text to display. |
+| `linkType` | Optional |mixed | `"edit"` | The target of each item click |
+| `leftAvatar` | Optional | function | | A function returning an `<Avatar>` component to display before the primary text. |
+| `leftIcon` | Optional | function | | A function returning an `<Icon>` component to display before the primary text. |
+| `rightAvatar` | Optional | function | | A function returning an `<Avatar>` component to display after the primary text. |
+| `rightIcon` | Optional | function | | A function returning an `<Icon>` component to display after the primary text. |
+| `rowStyle` | Optional | function | | A function returning a style object to apply to each row. |
+| `rowSx` | Optional | function | | A function returning a sx object to apply to each row. |
+| `empty` | Optional | ReactElement | | A ReactElement to display instead of the list when the data is empty. |
+
+## `empty`
+
+It's possible that a SimpleList will have no records to display. If the SimpleList's parent component does not handle the empty state, the SimpleList will display a message indicating there are no results. This message is translatable and its key is `ra.navigation.no_results`.
+
+You can customize the empty state by passing  a component to the `empty` prop:
+
+```jsx
+const CustomEmpty = () => <div>No books found</div>;
+
+const PostList = () => (
+    <List>
+        <SimpleList
+            primaryText={record => record.title}
+            empty={<CustomEmpty />}
+        />
+    </List>
+);
+```
 
 ## `leftAvatar`
 
@@ -78,22 +99,20 @@ export const PostList = () => (
 );
 ```
 
-
 `linkType` accepts the following values:
 
 * `linkType="edit"`: links to the edit page. This is the default behavior.
 * `linkType="show"`: links to the show page.
 * `linkType={false}`: does not create any link.
 
-
-
 ## `primaryText`
 
-The `primaryText`, `secondaryText` and `tertiaryText` props can accept 3 types of values:
+The `primaryText`, `secondaryText` and `tertiaryText` props can accept 4 types of values:
 
 1. a function returning a string, 
 2. a string, 
 3. a React element. 
+4. `undefined` (the default)
 
 If it's a **function**, react-admin passes the current record as parameter:
 
@@ -151,6 +170,18 @@ export const PostList = () => (
 
 `<SimpleList>` creates a `RecordContext` for each list item. This allows Field components to grab the current record using [`useRecordContext`](./useRecordContext.md).
 
+If it's **undefined**, react-admin uses the [`recordRepresentation`](./Resource.md#recordrepresentation) for the current Resource. This is the default value.
+
+```jsx
+import { List, SimpleList } from 'react-admin';
+
+export const PostList = () => (
+    <List>
+        <SimpleList />
+    </List>
+);
+```
+
 ## `rightAvatar`
 
 This prop should be a function returning an `<Avatar>` component. When present, the `<ListItem>` renders a `<ListItemAvatar>` after the `<ListItemText>`
@@ -160,6 +191,8 @@ This prop should be a function returning an `<Avatar>` component. When present, 
 This prop should be a function returning an `<Icon>` component. When present, the `<ListItem>` renders a `<ListIcon>` after the `<ListItemText>`.
 
 ## `rowStyle`
+
+*Deprecated - use [`rowSx`](#rowsx) instead.*
 
 This optional prop should be a function, which gets called for each row. It receives the current record and index as arguments, and should return a style object. The style object is applied to the `<ListItem>` styles prop.
 
@@ -203,24 +236,6 @@ See [`primaryText`](#primarytext)
 
 See [`primaryText`](#primarytext)
 
-## `empty`
-
-It's possible that a SimpleList will have no records to display. If the SimpleList's parent component does not handle the empty state, the SimpleList will display a message indicating there are no results. This message is translatable and its key is `ra.navigation.no_results`.
-
-You can customize the empty state by passing  a component to the `empty` prop:
-
-```jsx
-const CustomEmpty = () => <div>No books found</div>;
-
-const PostList = () => (
-    <List>
-        <SimpleList
-            primaryText={record => record.title}
-            empty={<CustomEmpty />}
-        />
-    </List>
-);
-```
 
 ## Using `<SimpleList>` On Small Screens
 

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -5,6 +5,7 @@ import { ListContext, ResourceContextProvider } from 'ra-core';
 import { AdminContext } from '../../AdminContext';
 import { SimpleList } from './SimpleList';
 import { TextField } from '../../field';
+import { NoPrimaryText } from './SimpleList.stories';
 
 const Wrapper = ({ children }: any) => (
     <AdminContext>
@@ -145,5 +146,10 @@ describe('<SimpleList />', () => {
             </ListContext.Provider>
         );
         expect(screen.queryByText('ra.navigation.no_results')).not.toBeNull();
+    });
+
+    it('should fall back to record representation when no primaryText is provided', async () => {
+        render(<NoPrimaryText />);
+        await screen.findByText('War and Peace');
     });
 });

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -131,6 +131,26 @@ export const FullApp = () => (
     </AdminContext>
 );
 
+export const NoPrimaryText = () => (
+    <AdminContext
+        dataProvider={dataProvider}
+        i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+    >
+        <AdminUI>
+            <Resource
+                name="books"
+                recordRepresentation="title"
+                list={() => (
+                    <List>
+                        <SimpleList />
+                    </List>
+                )}
+                edit={EditGuesser}
+            />
+        </AdminUI>
+    </AdminContext>
+);
+
 export const ErrorInFetch = () => (
     <MemoryRouter>
         <ListContextProvider

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -24,6 +24,7 @@ import {
     sanitizeListRestProps,
     useListContext,
     useResourceContext,
+    useGetRecordRepresentation,
     useCreatePath,
     useTranslate,
 } from 'ra-core';
@@ -87,6 +88,7 @@ export const SimpleList = <RecordType extends RaRecord = any>(
     } = props;
     const { data, isLoading, total } = useListContext<RecordType>(props);
     const resource = useResourceContext(props);
+    const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();
 
     if (isLoading === true) {
@@ -158,14 +160,16 @@ export const SimpleList = <RecordType extends RaRecord = any>(
                             <ListItemText
                                 primary={
                                     <div>
-                                        {typeof primaryText === 'string'
-                                            ? translate(primaryText, {
-                                                  ...record,
-                                                  _: primaryText,
-                                              })
-                                            : isElement(primaryText)
-                                            ? primaryText
-                                            : primaryText(record, record.id)}
+                                        {primaryText
+                                            ? typeof primaryText === 'string'
+                                                ? translate(primaryText, {
+                                                      ...record,
+                                                      _: primaryText,
+                                                  })
+                                                : isElement(primaryText)
+                                                ? primaryText
+                                                : primaryText(record, record.id)
+                                            : getRecordRepresentation(record)}
 
                                         {!!tertiaryText &&
                                             (isValidElement(tertiaryText) ? (
@@ -280,6 +284,9 @@ export interface SimpleListProps<RecordType extends RaRecord = any>
     secondaryText?: FunctionToElement<RecordType> | ReactElement | string;
     tertiaryText?: FunctionToElement<RecordType> | ReactElement | string;
     rowSx?: (record: RecordType, index: number) => SxProps;
+    /**
+     * @deprecated Use rowSx instead
+     */
     rowStyle?: (record: RecordType, index: number) => any;
     // can be injected when using the component without context
     resource?: string;

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -52,6 +52,7 @@ const defaultBulkActionButtons = <BulkDeleteButton />;
  *  - isRowSelectable
  *  - optimized
  *  - rowClick
+ *  - rowSx
  *  - size
  *  - sx
  *
@@ -349,6 +350,9 @@ export interface DatagridProps<RecordType extends RaRecord = any>
     optimized?: boolean;
     rowClick?: string | RowClickFunction | false;
     rowSx?: (record: RecordType, index: number) => SxProps;
+    /**
+     * @deprecated use rowStyle instead
+     */
     rowStyle?: (record: RecordType, index: number) => any;
     size?: 'medium' | 'small';
     // can be injected when using the component without context


### PR DESCRIPTION
## Problem

In most cases, the `primaryText` of a SimpleList is the resource's `resordRepresentation`. If feels repetitive to have to pass an explicit value to this prop. 

## Solution

Default to `recordRepresentation` so we can do the following:

```jsx
Const PostList = () => (
  <List>
    <SimpleList />
  </List>
)
```