### PR TITLE
Fix SelectInput translates choices even inside a ReferenceInput

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -5,7 +5,6 @@ import {
     FormDataConsumer,
     required,
     testDataProvider,
-    TestTranslationProvider,
     useRecordContext,
 } from 'ra-core';
 import { AdminContext } from '../AdminContext';
@@ -21,6 +20,7 @@ import {
     Nullable,
     NullishValuesSupport,
     VeryLargeOptionsNumber,
+    TranslateChoice,
 } from './AutocompleteInput.stories';
 import { act } from '@testing-library/react-hooks';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
@@ -601,62 +601,38 @@ describe('<AutocompleteInput />', () => {
         });
     });
 
-    it('should translate the value by default', async () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <TestTranslationProvider translate={x => `**${x}**`}>
-                    <SimpleForm
-                        onSubmit={jest.fn()}
-                        defaultValues={{ role: 2 }}
-                    >
-                        <AutocompleteInput
-                            {...defaultProps}
-                            choices={[
-                                { id: 2, name: 'foo' },
-                                { id: 3, name: 'bar' },
-                            ]}
-                        />
-                    </SimpleForm>
-                </TestTranslationProvider>
-            </AdminContext>
-        );
-        expect(screen.queryByDisplayValue('**foo**')).not.toBeNull();
-        fireEvent.focus(
-            screen.getByLabelText('**resources.users.fields.role**')
-        );
-        await waitFor(() => {
-            expect(screen.queryByText('**bar**')).not.toBeNull();
+    describe('translateChoice', () => {
+        it('should translate the choices by default', async () => {
+            render(<TranslateChoice />);
+            const inputElement = (await screen.findByLabelText(
+                'translateChoice default'
+            )) as HTMLInputElement;
+            expect(inputElement.value).toBe('Female');
         });
-    });
-
-    it('should not translate the value if translateChoice is false', async () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <TestTranslationProvider translate={x => `**${x}**`}>
-                    <SimpleForm
-                        onSubmit={jest.fn()}
-                        defaultValues={{ role: 2 }}
-                    >
-                        <AutocompleteInput
-                            {...defaultProps}
-                            translateChoice={false}
-                            choices={[
-                                { id: 2, name: 'foo' },
-                                { id: 3, name: 'bar' },
-                            ]}
-                        />
-                    </SimpleForm>
-                </TestTranslationProvider>
-            </AdminContext>
-        );
-        expect(screen.queryByDisplayValue('foo')).not.toBeNull();
-        expect(screen.queryByDisplayValue('**foo**')).toBeNull();
-        fireEvent.focus(
-            screen.getByLabelText('**resources.users.fields.role**')
-        );
-        await waitFor(() => {
-            expect(screen.queryByText('bar')).not.toBeNull();
-            expect(screen.queryByText('**bar**')).toBeNull();
+        it('should not translate the choices when translateChoice is false', async () => {
+            render(<TranslateChoice />);
+            const inputElement = (await screen.findByLabelText(
+                'translateChoice false'
+            )) as HTMLInputElement;
+            expect(inputElement.value).toBe('option.female');
+        });
+        it('should not translate the choices when inside ReferenceInput by default', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const inputElement = screen.getByLabelText(
+                    'inside ReferenceInput'
+                ) as HTMLInputElement;
+                expect(inputElement.value).toBe('option.female');
+            });
+        });
+        it('should translate the choices when inside ReferenceInput when translateChoice is true', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const inputElement = screen.getByLabelText(
+                    'inside ReferenceInput forced'
+                ) as HTMLInputElement;
+                expect(inputElement.value).toBe('Female');
+            });
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -21,6 +21,8 @@ import {
     Box,
 } from '@mui/material';
 import fakeRestProvider from 'ra-data-fakerest';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
 
 import { Edit } from '../detail';
 import { SimpleForm } from '../form';
@@ -1023,3 +1025,86 @@ export const DifferentShapeInGetMany = () => (
         />
     </Admin>
 );
+
+export const TranslateChoice = () => {
+    const i18nProvider = polyglotI18nProvider(() => ({
+        ...englishMessages,
+        'option.male': 'Male',
+        'option.female': 'Female',
+    }));
+    return (
+        <AdminContext
+            i18nProvider={i18nProvider}
+            dataProvider={
+                {
+                    getOne: () =>
+                        Promise.resolve({ data: { id: 1, gender: 'F' } }),
+                    getList: () =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'M', name: 'option.male' },
+                                { id: 'F', name: 'option.female' },
+                            ],
+                            total: 2,
+                        }),
+                    getMany: (_resource, { ids }) =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'M', name: 'option.male' },
+                                { id: 'F', name: 'option.female' },
+                            ].filter(({ id }) => ids.includes(id)),
+                        }),
+                } as any
+            }
+        >
+            <Edit resource="posts" id="1">
+                <SimpleForm>
+                    <AutocompleteInput
+                        label="translateChoice default"
+                        source="gender"
+                        id="gender1"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                    />
+                    <AutocompleteInput
+                        label="translateChoice true"
+                        source="gender"
+                        id="gender2"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                        translateChoice
+                    />
+                    <AutocompleteInput
+                        label="translateChoice false"
+                        source="gender"
+                        id="gender3"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                        translateChoice={false}
+                    />
+                    <ReferenceInput reference="genders" source="gender">
+                        <AutocompleteInput
+                            optionText="name"
+                            label="inside ReferenceInput"
+                            id="gender4"
+                        />
+                    </ReferenceInput>
+                    <ReferenceInput reference="genders" source="gender">
+                        <AutocompleteInput
+                            optionText="name"
+                            label="inside ReferenceInput forced"
+                            id="gender5"
+                            translateChoice
+                        />
+                    </ReferenceInput>
+                </SimpleForm>
+            </Edit>
+        </AdminContext>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -311,7 +311,7 @@ If you provided a React element for the optionText prop, you must also provide t
         optionValue,
         selectedItem: selectedChoice,
         suggestionLimit,
-        translateChoice,
+        translateChoice: translateChoice ?? !isFromReference,
     });
 
     const [filterValue, setFilterValue] = useState('');

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
@@ -6,7 +6,7 @@ import { FavoriteBorder, Favorite } from '@mui/icons-material';
 import { required, testDataProvider, useRecordContext } from 'ra-core';
 
 import { AdminContext } from '../AdminContext';
-import { Create } from '../detail';
+import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { CheckboxGroupInput } from './CheckboxGroupInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
@@ -214,3 +214,81 @@ export const HelperText = () => (
         </Create>
     </AdminContext>
 );
+
+export const TranslateChoice = () => {
+    const i18nProvider = polyglotI18nProvider(() => ({
+        ...englishMessages,
+        'option.tech': 'Tech',
+        'option.business': 'Business',
+    }));
+    return (
+        <AdminContext
+            i18nProvider={i18nProvider}
+            dataProvider={
+                {
+                    getOne: () =>
+                        Promise.resolve({ data: { id: 1, tags: ['tech'] } }),
+                    getList: () =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'tech', name: 'option.tech' },
+                                { id: 'business', name: 'option.business' },
+                            ],
+                            total: 2,
+                        }),
+                    getMany: (_resource, { ids }) =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'tech', name: 'option.tech' },
+                                { id: 'business', name: 'option.business' },
+                            ].filter(({ id }) => ids.includes(id)),
+                        }),
+                } as any
+            }
+        >
+            <Edit resource="posts" id="1">
+                <SimpleForm>
+                    <CheckboxGroupInput
+                        label="translateChoice default"
+                        source="tags"
+                        choices={[
+                            { id: 'tech', name: 'option.tech' },
+                            { id: 'business', name: 'option.business' },
+                        ]}
+                    />
+                    <CheckboxGroupInput
+                        label="translateChoice true"
+                        source="tags"
+                        choices={[
+                            { id: 'tech', name: 'option.tech' },
+                            { id: 'business', name: 'option.business' },
+                        ]}
+                        translateChoice
+                    />
+                    <CheckboxGroupInput
+                        label="translateChoice false"
+                        source="tags"
+                        choices={[
+                            { id: 'tech', name: 'option.tech' },
+                            { id: 'business', name: 'option.business' },
+                        ]}
+                        translateChoice={false}
+                    />
+                    <ReferenceArrayInput reference="tags" source="tags">
+                        <CheckboxGroupInput
+                            optionText="name"
+                            label="inside ReferenceArrayInput"
+                        />
+                    </ReferenceArrayInput>
+                    <ReferenceArrayInput reference="tags" source="tags">
+                        <CheckboxGroupInput
+                            optionText="name"
+                            label="inside ReferenceArrayInput forced"
+                            translateChoice
+                        />
+                    </ReferenceArrayInput>
+                </SimpleForm>
+            </Edit>
+        </AdminContext>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -105,7 +105,7 @@ export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = pr
         resource: resourceProp,
         row = true,
         source: sourceProp,
-        translateChoice = true,
+        translateChoice,
         validate,
         ...rest
     } = props;
@@ -116,6 +116,7 @@ export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = pr
         error: fetchError,
         resource,
         source,
+        isFromReference,
     } = useChoicesContext({
         choices: choicesProp,
         isFetching: isFetchingProp,
@@ -233,7 +234,7 @@ export const CheckboxGroupInput: FunctionComponent<CheckboxGroupInputProps> = pr
                         options={options}
                         optionText={optionText}
                         optionValue={optionValue}
-                        translateChoice={translateChoice}
+                        translateChoice={translateChoice ?? !isFromReference}
                         value={value}
                         labelPlacement={labelPlacement}
                         {...sanitizeRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.spec.tsx
@@ -10,7 +10,10 @@ import {
 import { AdminContext } from '../AdminContext';
 import { SimpleForm } from '../form';
 import { RadioButtonGroupInput } from './RadioButtonGroupInput';
-import { InsideReferenceArrayInput } from './RadioButtonGroupInput.stories';
+import {
+    InsideReferenceArrayInput,
+    TranslateChoice,
+} from './RadioButtonGroupInput.stories';
 
 describe('<RadioButtonGroupInput />', () => {
     const defaultProps = {
@@ -261,23 +264,39 @@ describe('<RadioButtonGroupInput />', () => {
         expect(screen.queryByText('Mastercard')).not.toBeNull();
     });
 
-    it('should translate the choices by default', () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <TestTranslationProvider translate={x => `**${x}**`}>
-                    <SimpleForm
-                        defaultValues={{ type: 'mc' }}
-                        onSubmit={jest.fn()}
-                    >
-                        <RadioButtonGroupInput
-                            {...defaultProps}
-                            choices={[{ id: 'mc', name: 'Mastercard' }]}
-                        />
-                    </SimpleForm>
-                </TestTranslationProvider>
-            </AdminContext>
-        );
-        expect(screen.queryByText('**Mastercard**')).not.toBeNull();
+    describe('translateChoice', () => {
+        it('should translate the choices by default', async () => {
+            render(<TranslateChoice />);
+            const label = await screen.findByText('translateChoice default');
+            const options =
+                label.parentNode?.parentNode?.childNodes[1].childNodes;
+            expect(options![1].textContent).toBe('Female');
+        });
+        it('should not translate the choices when translateChoice is false', async () => {
+            render(<TranslateChoice />);
+            const label = await screen.findByText('translateChoice false');
+            const options =
+                label.parentNode?.parentNode?.childNodes[1].childNodes;
+            expect(options![1].textContent).toBe('option.female');
+        });
+        it('should not translate the choices when inside ReferenceInput by default', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const label = screen.getByText('inside ReferenceInput');
+                const options =
+                    label.parentNode?.parentNode?.childNodes[1].childNodes;
+                expect(options![1].textContent).toBe('option.female');
+            });
+        });
+        it('should translate the choices when inside ReferenceInput when translateChoice is true', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const label = screen.getByText('inside ReferenceInput forced');
+                const options =
+                    label.parentNode?.parentNode?.childNodes[1].childNodes;
+                expect(options![1].textContent).toBe('Female');
+            });
+        });
     });
 
     it('should not translate the choices if translateChoice is false', () => {

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.stories.tsx
@@ -3,10 +3,11 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 
 import { AdminContext } from '../AdminContext';
-import { Create } from '../detail';
+import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { RadioButtonGroupInput } from './RadioButtonGroupInput';
 import { FormInspector } from './common';
+import { ReferenceInput } from './ReferenceInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { testDataProvider } from 'ra-core';
 
@@ -73,7 +74,7 @@ const dataProvider = testDataProvider({
             data: choices.filter(choice => params.ids.includes(choice.id)),
             total: choices.length,
         }),
-});
+} as any);
 
 export const InsideReferenceArrayInput = () => (
     <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
@@ -144,3 +145,86 @@ const Wrapper = ({ children }) => (
         </Create>
     </AdminContext>
 );
+
+export const TranslateChoice = () => {
+    const i18nProvider = polyglotI18nProvider(() => ({
+        ...englishMessages,
+        'option.male': 'Male',
+        'option.female': 'Female',
+    }));
+    return (
+        <AdminContext
+            i18nProvider={i18nProvider}
+            dataProvider={
+                {
+                    getOne: () =>
+                        Promise.resolve({ data: { id: 1, gender: 'F' } }),
+                    getList: () =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'M', name: 'option.male' },
+                                { id: 'F', name: 'option.female' },
+                            ],
+                            total: 2,
+                        }),
+                    getMany: (_resource, { ids }) =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'M', name: 'option.male' },
+                                { id: 'F', name: 'option.female' },
+                            ].filter(({ id }) => ids.includes(id)),
+                        }),
+                } as any
+            }
+        >
+            <Edit resource="posts" id="1">
+                <SimpleForm>
+                    <RadioButtonGroupInput
+                        label="translateChoice default"
+                        source="gender"
+                        id="gender1"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                    />
+                    <RadioButtonGroupInput
+                        label="translateChoice true"
+                        source="gender"
+                        id="gender2"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                        translateChoice
+                    />
+                    <RadioButtonGroupInput
+                        label="translateChoice false"
+                        source="gender"
+                        id="gender3"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                        translateChoice={false}
+                    />
+                    <ReferenceInput reference="genders" source="gender">
+                        <RadioButtonGroupInput
+                            optionText="name"
+                            label="inside ReferenceInput"
+                            id="gender4"
+                        />
+                    </ReferenceInput>
+                    <ReferenceInput reference="genders" source="gender">
+                        <RadioButtonGroupInput
+                            optionText="name"
+                            label="inside ReferenceInput forced"
+                            id="gender5"
+                            translateChoice
+                        />
+                    </ReferenceInput>
+                </SimpleForm>
+            </Edit>
+        </AdminContext>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -99,7 +99,7 @@ export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
         resource: resourceProp,
         row = true,
         source: sourceProp,
-        translateChoice = true,
+        translateChoice,
         validate,
         ...rest
     } = props;
@@ -110,6 +110,7 @@ export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
         error: fetchError,
         resource,
         source,
+        isFromReference,
     } = useChoicesContext({
         choices: choicesProp,
         isFetching: isFetchingProp,
@@ -198,7 +199,7 @@ export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
                         optionText={optionText}
                         optionValue={optionValue}
                         source={id}
-                        translateChoice={translateChoice}
+                        translateChoice={translateChoice ?? !isFromReference}
                     />
                 ))}
             </RadioGroup>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -1,17 +1,13 @@
 import * as React from 'react';
 import expect from 'expect';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import {
-    testDataProvider,
-    TestTranslationProvider,
-    useRecordContext,
-} from 'ra-core';
+import { testDataProvider, useRecordContext } from 'ra-core';
 
 import { AdminContext } from '../AdminContext';
 import { SimpleForm } from '../form';
 import { SelectArrayInput } from './SelectArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
-import { DifferentIdTypes } from './SelectArrayInput.stories';
+import { DifferentIdTypes, TranslateChoice } from './SelectArrayInput.stories';
 
 describe('<SelectArrayInput />', () => {
     const defaultProps = {
@@ -220,21 +216,39 @@ describe('<SelectArrayInput />', () => {
         expect(option2.getAttribute('aria-disabled')).toEqual('true');
     });
 
-    it('should translate the choices', () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <TestTranslationProvider translate={x => `**${x}**`}>
-                    <SimpleForm onSubmit={jest.fn()}>
-                        <SelectArrayInput {...defaultProps} />
-                    </SimpleForm>
-                </TestTranslationProvider>
-            </AdminContext>
-        );
-        fireEvent.mouseDown(
-            screen.getByLabelText('**resources.posts.fields.categories**')
-        );
-        expect(screen.queryByText('**Programming**')).not.toBeNull();
-        expect(screen.queryByText('**Lifestyle**')).not.toBeNull();
+    describe('translateChoice', () => {
+        it('should translate the choices by default', async () => {
+            render(<TranslateChoice />);
+            const selectedElement = await screen.findByLabelText(
+                'translateChoice default'
+            );
+            expect(selectedElement.textContent).toBe('Tech');
+        });
+        it('should not translate the choices when translateChoice is false', async () => {
+            render(<TranslateChoice />);
+            const selectedElement = await screen.findByLabelText(
+                'translateChoice false'
+            );
+            expect(selectedElement.textContent).toBe('option.tech');
+        });
+        it('should not translate the choices when inside ReferenceInput by default', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const selectedElement = screen.getByLabelText(
+                    'inside ReferenceArrayInput'
+                );
+                expect(selectedElement.textContent).toBe('option.tech');
+            });
+        });
+        it('should translate the choices when inside ReferenceInput when translateChoice is true', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const selectedElement = screen.getByLabelText(
+                    'inside ReferenceArrayInput forced'
+                );
+                expect(selectedElement.textContent).toBe('Tech');
+            });
+        });
     });
 
     it('should display helperText if prop is specified', () => {

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -14,6 +14,7 @@ import { AdminContext } from '../AdminContext';
 import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { SelectArrayInput } from './SelectArrayInput';
+import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import { TextInput } from './TextInput';
 
@@ -191,6 +192,89 @@ export const DifferentSizes = () => {
                         size="medium"
                         variant="outlined"
                     />
+                </SimpleForm>
+            </Edit>
+        </AdminContext>
+    );
+};
+
+export const TranslateChoice = () => {
+    const i18nProvider = polyglotI18nProvider(() => ({
+        ...englishMessages,
+        'option.tech': 'Tech',
+        'option.business': 'Business',
+    }));
+    return (
+        <AdminContext
+            i18nProvider={i18nProvider}
+            dataProvider={
+                {
+                    getOne: () =>
+                        Promise.resolve({ data: { id: 1, tags: ['tech'] } }),
+                    getList: () =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'tech', name: 'option.tech' },
+                                { id: 'business', name: 'option.business' },
+                            ],
+                            total: 2,
+                        }),
+                    getMany: (_resource, { ids }) =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'tech', name: 'option.tech' },
+                                { id: 'business', name: 'option.business' },
+                            ].filter(({ id }) => ids.includes(id)),
+                        }),
+                } as any
+            }
+        >
+            <Edit resource="posts" id="1">
+                <SimpleForm>
+                    <SelectArrayInput
+                        label="translateChoice default"
+                        source="tags"
+                        id="tags1"
+                        choices={[
+                            { id: 'tech', name: 'option.tech' },
+                            { id: 'business', name: 'option.business' },
+                        ]}
+                    />
+                    <SelectArrayInput
+                        label="translateChoice true"
+                        source="tags"
+                        id="tags2"
+                        choices={[
+                            { id: 'tech', name: 'option.tech' },
+                            { id: 'business', name: 'option.business' },
+                        ]}
+                        translateChoice
+                    />
+                    <SelectArrayInput
+                        label="translateChoice false"
+                        source="tags"
+                        id="tags3"
+                        choices={[
+                            { id: 'tech', name: 'option.tech' },
+                            { id: 'business', name: 'option.business' },
+                        ]}
+                        translateChoice={false}
+                    />
+                    <ReferenceArrayInput reference="tags" source="tags">
+                        <SelectArrayInput
+                            optionText="name"
+                            label="inside ReferenceArrayInput"
+                            id="tags4"
+                        />
+                    </ReferenceArrayInput>
+                    <ReferenceArrayInput reference="tags" source="tags">
+                        <SelectArrayInput
+                            optionText="name"
+                            label="inside ReferenceArrayInput forced"
+                            id="tags5"
+                            translateChoice
+                        />
+                    </ReferenceArrayInput>
                 </SimpleForm>
             </Edit>
         </AdminContext>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -111,7 +111,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         resource: resourceProp,
         size = 'small',
         source: sourceProp,
-        translateChoice = true,
+        translateChoice,
         validate,
         variant,
         ...rest
@@ -125,6 +125,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         error: fetchError,
         source,
         resource,
+        isFromReference,
     } = useChoicesContext({
         choices: choicesProp,
         isLoading: isLoadingProp,
@@ -137,7 +138,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         optionText,
         optionValue,
         disableValue,
-        translateChoice,
+        translateChoice: translateChoice ?? !isFromReference,
     });
 
     const {
@@ -145,6 +146,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         isRequired,
         fieldState: { error, invalid, isTouched },
         formState: { isSubmitted },
+        id,
     } = useInput({
         format,
         onBlur,
@@ -288,7 +290,11 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                 variant={variant}
                 {...sanitizeRestProps(rest)}
             >
-                <InputLabel ref={inputLabel} id={`${label}-outlined-label`}>
+                <InputLabel
+                    ref={inputLabel}
+                    id={`${id}-outlined-label`}
+                    htmlFor={id}
+                >
                     <FieldTitle
                         label={label}
                         source={source}
@@ -297,8 +303,9 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                     />
                 </InputLabel>
                 <Select
+                    id={id}
                     autoWidth
-                    labelId={`${label}-outlined-label`}
+                    labelId={`${id}-outlined-label`}
                     label={
                         <FieldTitle
                             label={label}

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import {
-    required,
-    testDataProvider,
-    TestTranslationProvider,
-    useRecordContext,
-} from 'ra-core';
+import { required, testDataProvider, useRecordContext } from 'ra-core';
 
 import { AdminContext } from '../AdminContext';
 import { SimpleForm } from '../form';
@@ -16,6 +11,7 @@ import {
     InsideReferenceInput,
     InsideReferenceInputDefaultValue,
     Sort,
+    TranslateChoice,
 } from './SelectInput.stories';
 
 describe('<SelectInput />', () => {
@@ -334,53 +330,37 @@ describe('<SelectInput />', () => {
     });
 
     describe('translateChoice', () => {
-        it('should translate the choices by default', () => {
-            render(
-                <AdminContext dataProvider={testDataProvider()}>
-                    <TestTranslationProvider translate={x => `**${x}**`}>
-                        <SimpleForm onSubmit={jest.fn()}>
-                            <SelectInput {...defaultProps} />
-                        </SimpleForm>
-                    </TestTranslationProvider>
-                </AdminContext>
+        it('should translate the choices by default', async () => {
+            render(<TranslateChoice />);
+            const selectedElement = await screen.findByLabelText(
+                'translateChoice default'
             );
-            fireEvent.mouseDown(
-                screen.getByLabelText('**resources.posts.fields.language**')
-            );
-
-            expect(screen.queryAllByRole('option').length).toEqual(3);
-            expect(
-                screen.getByText('**Angular**').getAttribute('data-value')
-            ).toEqual('ang');
-            expect(
-                screen.getByText('**React**').getAttribute('data-value')
-            ).toEqual('rea');
+            expect(selectedElement.textContent).toBe('Female');
         });
-
-        it('should not translate the choices if translateChoice is false', () => {
-            render(
-                <AdminContext dataProvider={testDataProvider()}>
-                    <TestTranslationProvider translate={x => `**${x}**`}>
-                        <SimpleForm onSubmit={jest.fn()}>
-                            <SelectInput
-                                {...defaultProps}
-                                translateChoice={false}
-                            />
-                        </SimpleForm>
-                    </TestTranslationProvider>
-                </AdminContext>
+        it('should not translate the choices when translateChoice is false', async () => {
+            render(<TranslateChoice />);
+            const selectedElement = await screen.findByLabelText(
+                'translateChoice false'
             );
-            fireEvent.mouseDown(
-                screen.getByLabelText('**resources.posts.fields.language**')
-            );
-
-            expect(screen.queryAllByRole('option').length).toEqual(3);
-            expect(
-                screen.getByText('Angular').getAttribute('data-value')
-            ).toEqual('ang');
-            expect(
-                screen.getByText('React').getAttribute('data-value')
-            ).toEqual('rea');
+            expect(selectedElement.textContent).toBe('option.female');
+        });
+        it('should not translate the choices when inside ReferenceInput by default', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const selectedElement = screen.getByLabelText(
+                    'inside ReferenceInput'
+                );
+                expect(selectedElement.textContent).toBe('option.female');
+            });
+        });
+        it('should translate the choices when inside ReferenceInput when translateChoice is true', async () => {
+            render(<TranslateChoice />);
+            await waitFor(() => {
+                const selectedElement = screen.getByLabelText(
+                    'inside ReferenceInput forced'
+                );
+                expect(selectedElement.textContent).toBe('Female');
+            });
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -10,7 +10,7 @@ import { SimpleForm } from '../form';
 import { SelectInput } from './SelectInput';
 import { TextInput } from './TextInput';
 import { ReferenceInput } from './ReferenceInput';
-import { SaveButton } from '../button//SaveButton';
+import { SaveButton } from '../button/SaveButton';
 import { Toolbar } from '../form/Toolbar';
 import { FormInspector } from './common';
 
@@ -368,3 +368,86 @@ export const InsideReferenceInputWithError = () => (
         />
     </Admin>
 );
+
+export const TranslateChoice = () => {
+    const i18nProvider = polyglotI18nProvider(() => ({
+        ...englishMessages,
+        'option.male': 'Male',
+        'option.female': 'Female',
+    }));
+    return (
+        <AdminContext
+            i18nProvider={i18nProvider}
+            dataProvider={
+                {
+                    getOne: () =>
+                        Promise.resolve({ data: { id: 1, gender: 'F' } }),
+                    getList: () =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'M', name: 'option.male' },
+                                { id: 'F', name: 'option.female' },
+                            ],
+                            total: 2,
+                        }),
+                    getMany: (_resource, { ids }) =>
+                        Promise.resolve({
+                            data: [
+                                { id: 'M', name: 'option.male' },
+                                { id: 'F', name: 'option.female' },
+                            ].filter(({ id }) => ids.includes(id)),
+                        }),
+                } as any
+            }
+        >
+            <Edit resource="posts" id="1">
+                <SimpleForm>
+                    <SelectInput
+                        label="translateChoice default"
+                        source="gender"
+                        id="gender1"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                    />
+                    <SelectInput
+                        label="translateChoice true"
+                        source="gender"
+                        id="gender2"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                        translateChoice
+                    />
+                    <SelectInput
+                        label="translateChoice false"
+                        source="gender"
+                        id="gender3"
+                        choices={[
+                            { id: 'M', name: 'option.male' },
+                            { id: 'F', name: 'option.female' },
+                        ]}
+                        translateChoice={false}
+                    />
+                    <ReferenceInput reference="genders" source="gender">
+                        <SelectInput
+                            optionText="name"
+                            label="inside ReferenceInput"
+                            id="gender4"
+                        />
+                    </ReferenceInput>
+                    <ReferenceInput reference="genders" source="gender">
+                        <SelectInput
+                            optionText="name"
+                            label="inside ReferenceInput forced"
+                            id="gender5"
+                            translateChoice
+                        />
+                    </ReferenceInput>
+                </SimpleForm>
+            </Edit>
+        </AdminContext>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -130,7 +130,7 @@ export const SelectInput = (props: SelectInputProps) => {
         parse,
         resource: resourceProp,
         source: sourceProp,
-        translateChoice = true,
+        translateChoice,
         validate,
         ...rest
     } = props;
@@ -179,7 +179,7 @@ export const SelectInput = (props: SelectInputProps) => {
             (isFromReference ? getRecordRepresentation : undefined),
         optionValue,
         disableValue,
-        translateChoice,
+        translateChoice: translateChoice ?? !isFromReference,
     });
     const {
         field,


### PR DESCRIPTION
Closes #9134

The problem occurs in all select inputs:

- `SelectInput`
- `SelectArrayInput` 
- `AutocompleteInput`
- `AutocompleteArrayInput`
- `RadioButtonGroupInput`
- `CheckboxGroupInput`

## To do

- [x] Fix the bug in all components
- [x] Add a story to check the `translateChoice` behavior in all components
- [x] Add unit tests

The doc doesn't need to be updated, as it already states that the choices aren't translated when inside `ReferenceInput`.