### PR TITLE
Fix `<SelectInput>` throws error when fetching choices manually

### DIFF
--- a/packages/ra-core/src/form/choices/useChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/useChoicesContext.ts
@@ -11,6 +11,7 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
     >;
     const { data, ...list } = useList<ChoicesType>({
         data: options.choices,
+        isLoading: options.isLoading,
         // When not in a ChoicesContext, paginating does not make sense (e.g. AutocompleteInput).
         perPage: Infinity,
     });
@@ -30,8 +31,8 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
                 hasPreviousPage:
                     options.hasPreviousPage ?? list.hasPreviousPage,
                 hideFilter: options.hideFilter ?? list.hideFilter,
-                isFetching: options.isFetching ?? list.isFetching,
-                isLoading: options.isLoading ?? list.isLoading,
+                isLoading: list.isLoading, // we must take the one for useList, otherwise the loading state isn't synchronized with the data
+                isFetching: list.isFetching, // same
                 page: options.page ?? list.page,
                 perPage: options.perPage ?? list.perPage,
                 refetch: options.refetch ?? list.refetch,

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -12,6 +12,7 @@ import {
     InsideReferenceInputDefaultValue,
     Sort,
     TranslateChoice,
+    FetchChoices,
 } from './SelectInput.stories';
 
 describe('<SelectInput />', () => {
@@ -721,6 +722,14 @@ describe('<SelectInput />', () => {
             expect(onChange).toHaveBeenCalledWith('js_fatigue');
         });
     });
+
+    describe('fetching choices', () => {
+        it('should display the choices once fetched', async () => {
+            render(<FetchChoices />);
+            await screen.findByText('Leo Tolstoy');
+        });
+    });
+
     describe('inside ReferenceInput', () => {
         it('should use the recordRepresentation as optionText', async () => {
             render(<InsideReferenceInput />);

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createMemoryHistory } from 'history';
 import { Admin, AdminContext } from 'react-admin';
-import { Resource, required } from 'ra-core';
+import { Resource, required, useGetList } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 
@@ -253,6 +253,50 @@ const dataProviderWithAuthors = {
 } as any;
 
 const history = createMemoryHistory({ initialEntries: ['/books/1'] });
+
+export const FetchChoices = () => {
+    const BookAuthorsInput = () => {
+        const { data, isLoading } = useGetList('authors');
+        return (
+            <SelectInput
+                source="author"
+                choices={data}
+                optionText={record =>
+                    `${record.first_name} ${record.last_name}`
+                }
+                isLoading={isLoading}
+            />
+        );
+    };
+    return (
+        <Admin dataProvider={dataProviderWithAuthors} history={history}>
+            <Resource
+                name="authors"
+                recordRepresentation={record =>
+                    `${record.first_name} ${record.last_name}`
+                }
+            />
+            <Resource
+                name="books"
+                edit={() => (
+                    <Edit
+                        mutationMode="pessimistic"
+                        mutationOptions={{
+                            onSuccess: data => {
+                                console.log(data);
+                            },
+                        }}
+                    >
+                        <SimpleForm>
+                            <BookAuthorsInput />
+                            <FormInspector name="author" />
+                        </SimpleForm>
+                    </Edit>
+                )}
+            />
+        </Admin>
+    );
+};
 
 export const InsideReferenceInput = () => (
     <Admin dataProvider={dataProviderWithAuthors} history={history}>


### PR DESCRIPTION
## Analysis

There are 2 problems:

- `useChoicesContext` doesn't pass the `isLoading` prop to `useList`
- `useChoicesContext` returns the `isLoading` prop it receives directly

This leads to a race condition where `isLoading` is already `false` while `allChoices` isn't updated yet (due to `useEffect` in `useList`). 

## Solution

Pass the `isLoading` from prop to `useList`, and return the `isLoading` from `useList`

Closes #9138