### PR TITLE
Fix `<FilterLiveSearch>` uses label as placeholder by default

### DIFF
--- a/docs/FilterLiveSearch.md
+++ b/docs/FilterLiveSearch.md
@@ -50,7 +50,7 @@ export const CustomerList = () => (
 
 | Prop | Required | Type | Default | Description |
 |------|----------|------|---------|-------------|
-| `hiddenLabel` | Optional | `boolean` | `false` | If true, use the label as a placeholder |
+| `hiddenLabel` | Optional | `boolean` | `false` | If true, use the label as a placeholder. |
 | `label` | Optional | `string` | 'ra.action.search' | The label of the search input. |
 | `source` | Optional | `string` | 'q' | The field to filter on. |
 | `variant` | Optional | `string` | 'standard' | The variant of the search input. Can be one of 'standard', 'outlined', or 'filled'. |

--- a/docs/FilterLiveSearch.md
+++ b/docs/FilterLiveSearch.md
@@ -12,19 +12,24 @@ title: "The FilterLiveSearch Component"
 </video>
 
 
-The filter sidebar is not a form. Therefore, if your users need to enter complex filters, you'll have to recreate a filter form using react-hook-form (see the [Building a custom filter](./FilteringTutorial.md#building-a-custom-filter) section below for an example). However, if you only need one text input with a filter-as-you-type behavior, you'll find the `<FilterLiveSearch>` component convenient.
+The filter sidebar is not a form. Therefore, if your users need to enter complex filters, you'll have to recreate a filter form using react-hook-form (see the [Building a custom filter](./FilteringTutorial.md#building-a-custom-filter) for an example). However, if you only need one text input with a filter-as-you-type behavior, you'll find the `<FilterLiveSearch>` component convenient.
 
-It outputs a form containing a single `<SearchInput>`, which modifies the page filter on change. That's usually what users expect for a full-text filter. `<FilterLiveSearch>` only needs a `source` field.
+It outputs a form containing a single `<TextInput>`, which modifies the page filter on change. That's usually what users expect for a full-text filter.
 
-So for instance, to add a search filter on the customer full name, add the following line to the Sidebar:
+## Usage
 
-```diff
-+import { FilterLiveSearch } from 'react-admin';
+To add a full-text search filter on customers, include `<FilterLiveSearch>` in a sidebar component, then use that component in the `<List>` component's `aside` prop:
+
+{% raw %}
+```tsx
+import { List, FilterLiveSearch } from 'react-admin';
+import { Card, CardContent } from '@material-ui/core';
+import { LastVisitedFilter, HasOrderedFilter, HasNewsletterFilter, SegmentFilter } from './filters';
 
 const FilterSidebar = () => (
-    <Card>
+    <Card sx={{ order: -1, mr: 2, mt: 9, width: 200 }}>
         <CardContent>
-+           <FilterLiveSearch source="full_name" />
+            <FilterLiveSearch source="q" label="Search" />
             <LastVisitedFilter />
             <HasOrderedFilter />
             <HasNewsletterFilter />
@@ -32,4 +37,22 @@ const FilterSidebar = () => (
         </CardContent>
     </Card>
 );
+
+export const CustomerList = () => (
+    <List aside={<FilterSidebar />}>
+        ...
+    </List>
+);
 ```
+{% endraw %}
+
+## Props
+
+| Prop | Required | Type | Default | Description |
+|------|----------|------|---------|-------------|
+| `hiddenLabel` | Optional | `boolean` | `false` | If true, use the label as a placeholder |
+| `label` | Optional | `string` | 'ra.action.search' | The label of the search input. |
+| `source` | Optional | `string` | 'q' | The field to filter on. |
+| `variant` | Optional | `string` | 'standard' | The variant of the search input. Can be one of 'standard', 'outlined', or 'filled'. |
+
+Additional props are passed down to [the Material UI `<TextField>` component](https://mui.com/material-ui/api/text-field/).

--- a/examples/crm/src/companies/CompanyListFilter.tsx
+++ b/examples/crm/src/companies/CompanyListFilter.tsx
@@ -18,7 +18,7 @@ export const CompanyListFilter = () => {
     const { identity } = useGetIdentity();
     return (
         <Box width="13em" minWidth="13em" order={-1} mr={2} mt={7}>
-            <FilterLiveSearch />
+            <FilterLiveSearch hiddenLabel />
 
             <FilterList label="Size" icon={<BusinessIcon />}>
                 {sizes.map(size => (

--- a/examples/crm/src/contacts/ContactListFilter.tsx
+++ b/examples/crm/src/contacts/ContactListFilter.tsx
@@ -25,6 +25,7 @@ export const ContactListFilter = () => {
     return (
         <Box width="13em" minWidth="13em" order={-1} mr={2} mt={7}>
             <FilterLiveSearch
+                hiddenLabel
                 sx={{
                     display: 'block',
                     '& .MuiFilledInput-root': { width: '100%' },

--- a/examples/demo/src/products/Aside.tsx
+++ b/examples/demo/src/products/Aside.tsx
@@ -31,7 +31,7 @@ const Aside = () => {
             }}
         >
             <CardContent sx={{ pt: 1 }}>
-                <FilterLiveSearch />
+                <FilterLiveSearch hiddenLabel />
 
                 <SavedQueriesList />
 

--- a/examples/demo/src/visitors/VisitorListAside.tsx
+++ b/examples/demo/src/visitors/VisitorListAside.tsx
@@ -35,7 +35,7 @@ const Aside = () => (
         }}
     >
         <CardContent sx={{ pt: 1 }}>
-            <FilterLiveSearch />
+            <FilterLiveSearch hiddenLabel />
 
             <SavedQueriesList />
 

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
@@ -1,35 +1,44 @@
 import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import { Basic } from './FilterLiveSearch.stories';
+import { Basic, HiddenLabel } from './FilterLiveSearch.stories';
 
 describe('FilterLiveSearch', () => {
     it('renders an empty text input', () => {
         render(<Basic />);
         expect(
-            screen.getByPlaceholderText('ra.action.search').getAttribute('type')
+            screen.getByLabelText('ra.action.search').getAttribute('type')
         ).toBe('text');
         expect(
-            screen
-                .getByPlaceholderText('ra.action.search')
-                .getAttribute('value')
+            screen.getByLabelText('ra.action.search').getAttribute('value')
         ).toBe('');
     });
     it('filters the list when typing', () => {
         render(<Basic />);
         expect(screen.queryAllByRole('listitem')).toHaveLength(27);
-        fireEvent.change(screen.getByPlaceholderText('ra.action.search'), {
+        fireEvent.change(screen.getByLabelText('ra.action.search'), {
             target: { value: 'st' },
         });
         expect(screen.queryAllByRole('listitem')).toHaveLength(2); // Austria and Estonia
     });
     it('clears the filter when user click on the reset button', () => {
         render(<Basic />);
-        fireEvent.change(screen.getByPlaceholderText('ra.action.search'), {
+        fireEvent.change(screen.getByLabelText('ra.action.search'), {
             target: { value: 'st' },
         });
         expect(screen.queryAllByRole('listitem')).toHaveLength(2);
         fireEvent.click(screen.getByLabelText('ra.action.clear_input_value'));
         expect(screen.queryAllByRole('listitem')).toHaveLength(27);
+    });
+    describe('hiddenLabel', () => {
+        it('turns the label into a placeholder', () => {
+            render(<HiddenLabel />);
+            expect(
+                screen
+                    .getByPlaceholderText('ra.action.search')
+                    .getAttribute('type')
+            ).toBe('text');
+            expect(screen.queryByLabelText('ra.action.search')).toBeNull();
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
@@ -81,6 +81,13 @@ export const Label = () => (
     </Wrapper>
 );
 
+export const HiddenLabel = () => (
+    <Wrapper>
+        <FilterLiveSearch source="q" hiddenLabel />
+        <CountryList />
+    </Wrapper>
+);
+
 export const Variant = () => (
     <Wrapper>
         <FilterLiveSearch source="q" variant="outlined" />

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -29,8 +29,8 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
 
     const {
         source = 'q',
-        variant,
         label = translate('ra.action.search'),
+        placeholder,
         ...rest
     } = props;
 
@@ -69,13 +69,10 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
                     }}
                     onChange={handleChange}
                     size="small"
-                    {...(variant === 'outlined'
-                        ? { variant: 'outlined', label }
-                        : {
-                              placeholder: label,
-                              label: false,
-                              hiddenLabel: true,
-                          })}
+                    label={rest.hiddenLabel ? false : label}
+                    placeholder={
+                        placeholder ?? (rest.hiddenLabel ? label : undefined)
+                    }
                     {...rest}
                 />
             </form>


### PR DESCRIPTION
Closes #9175

This could be considered as a minor change, but since the doc was never up to date, and since it's easy to override, I think we can accept it as a bugfix. 