### PR TITLE
Add missing types for TranslationMessages

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -44,6 +44,7 @@ export interface TranslationMessages extends StringMap {
             open: string;
             toggle_theme: string;
             select_columns: string;
+            update_application: string;
         };
         boolean: {
             [key: string]: StringMap | string;
@@ -155,6 +156,7 @@ export interface TranslationMessages extends StringMap {
             canceled: string;
             logged_out: string;
             not_authorized: string;
+            application_update_available: string;
         };
         validation: {
             [key: string]: StringMap | string;


### PR DESCRIPTION
Add missing types for TranslationMessages.

https://github.com/marmelab/react-admin/pull/9059/files#diff-d55e636245f2994de4a9a74002cca1fec0a6a2e68d1805a5439a0c885f37263b