### PR TITLE
Doc: display a comment inviting to switch to TS if transpiled code is empty

### DIFF
--- a/docs/js/ra-doc-exec.js
+++ b/docs/js/ra-doc-exec.js
@@ -43,7 +43,10 @@ const applyPreferredLanguage = async () => {
                 const tsBlock = document.getElementById(fence.dataset.tsBlock);
                 if (tsBlock) {
                     const jsCode = await transpileToJS(tsBlock.innerText);
-                    fence.querySelector('code').textContent = jsCode;
+                    fence.querySelector('code').textContent =
+                        jsCode === ''
+                            ? '// TypeScript-only snippet, please select the TS language ↗️'
+                            : jsCode;
                     fence.dataset.transpiled = 'true';
                     Prism.highlightElement(fence.querySelector('code'));
                 }


### PR DESCRIPTION
## Problem
The TS to JS transpilation in the doc pages works well… except when a snippet contains only types. In this case, the transpiled JS is empty.

## Solution
When the transpiled JS is empty, replace the content with the following comment:
```
// TypeScript-only snippet, please select the TS language ↗️
```