### PR TITLE
Update `<PrevNextButtons>` to fetch less aggressively

### DIFF
--- a/docs/PrevNextButtons.md
+++ b/docs/PrevNextButtons.md
@@ -362,7 +362,7 @@ export const CustomerShow = () => (
 ```
 {% endraw %}
 
-## Navigating Through Records In`<Edit>` Views After Submit
+## Navigating Through Records In `<Edit>` Views After Submit
 
 Let's says users want to edit customer records and to navigate between records in the `<Edit>` view. The default react-admin behaviors causes two problems: 
 - when they save a record the user is redirected to the `<List>` view,
@@ -390,3 +390,11 @@ export const CustomerEdit = () => (
 );
 ```
 {% endraw %}
+
+## Performance
+
+This components tries to avoid fetching the API to determine the previous and next item link. It does so by inspecting the cache of the list view. If the user has already rendered the list view for the current resource, `<PrevNextButtons>` will not need to call the `dataProvider` at all. 
+
+However, if the user has never displayed a list view, or if the current record is outside of the boundaries of the list view cache, `<PrevNextButtons>` will have to **fetch the entire list of records** for the current resource to determine the previous and next item link. This can be costly in terms of server and network performance. 
+
+If this is a problem, use [the `limit` prop](#limit) to limit the number of records fetched from the API. You can also pass a `meta` parameter to select only the `id` field in the records.

--- a/docs/PrevNextButtons.md
+++ b/docs/PrevNextButtons.md
@@ -45,6 +45,7 @@ export const CustomerEdit = () => (
 | Prop           | Required | Type             | Default                             | Description                                                                                 |
 | -------------- | -------- | ---------------- | ----------------------------------- | ------------------------------------------------------------------------------------------- |
 | `filter`       | Optional | `object`         | `{}`                                | The permanent filter values.                                                                |
+| `filter DefaultValues` | Optional | `object`  | `{}`                                | The default filter values.                                                                |
 | `limit`        | Optional | `number`         | `1000`                              | Maximum number of records to fetch.                                                         |
 | `linkType`     | Optional | `string`         | 'edit'                              | Specifies the view to redirect to when navigating.                                          |
 | `queryOptions` | Optional | `object`         | `{ staleTime: 5 * 60 * 1000 }`      | The options to pass to the useQuery hook.                                                   |
@@ -55,7 +56,7 @@ export const CustomerEdit = () => (
 
 ## `filter`
 
-Just like [Permanent `filter` in `<List>`](./List.md#filter-permanent-filter), you can specify what filter when fetching the list of records.
+Just like [Permanent `filter` in `<List>`](./List.md#filter-permanent-filter), you can specify a filter always applied when fetching the list of records.
 
 {% raw %}
 ```jsx
@@ -91,6 +92,56 @@ export const MyAdmin = () => (
                     actions={
                         <TopToolbar>
                             <PrevNextButtons filter={{ city: 'Hill Valley' }} />
+                        </TopToolbar>
+                    }
+                >
+                ...
+                </Edit>
+            }
+        />
+    </Admin>
+);
+```
+{% endraw %}
+
+## `filterDefaultValues`
+
+To use a default filter value, set the `filterDefaultValues` prop. 
+
+{% raw %}
+```jsx
+export const CustomerEdit = () => (
+    <Edit
+        actions={
+            <TopToolbar>
+                <PrevNextButtons filterDefaultValues={{ city: 'Hill Valley' }} />
+            </TopToolbar>
+        }
+    >
+    ...
+    </Edit>
+);
+```
+{% endraw %}
+
+This prop is useful to set the same default filter as the `<List>` for the same resource:
+
+{% raw %}
+```tsx
+export const MyAdmin = () => (
+    <Admin>
+        <Resource
+            name="customers"
+            list={
+                <List filterDefaultValues={{ city: 'Hill Valley' }}>
+                ...
+                </List>
+            }
+            edit={
+                <Edit
+                    actions={
+                        <TopToolbar>
+                            <PrevNextButtons filterDefaultValues={{ city: 'Hill Valley' }} />
                         </TopToolbar>
                     }
                 >

--- a/examples/demo/src/orders/OrderEdit.tsx
+++ b/examples/demo/src/orders/OrderEdit.tsx
@@ -5,6 +5,7 @@ import {
     Edit,
     Form,
     Labeled,
+    PrevNextButtons,
     ReferenceField,
     SelectInput,
     TextField,
@@ -83,6 +84,10 @@ const OrderForm = () => {
     return (
         <Form>
             <Box maxWidth="50em">
+                <PrevNextButtons
+                    filterDefaultValues={{ status: 'ordered' }}
+                    sort={{ field: 'date', order: 'DESC' }}
+                />
                 <Card>
                     <CardContent>
                         <Grid container spacing={1}>

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -131,6 +131,8 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
             filter: filterDefaultValues,
             order: initialSort.order,
             sort: initialSort.field,
+            page: 1,
+            perPage: 10,
         }
     );
 
@@ -189,7 +191,7 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
 
     let finalData = canUseCacheData ? queryData.data : data?.data || [];
 
-    if (!record) return null;
+    if (!record || isLoading) return { isLoading: true };
 
     const ids = finalData.map(record => record.id);
     const index = ids.indexOf(record.id);
@@ -242,13 +244,17 @@ export interface UsePrevNextControllerProps<RecordType extends RaRecord = any> {
     }> & { meta?: any };
 }
 
-export interface UsePrevNextControllerResult {
-    hasPrev: boolean;
-    hasNext: boolean;
-    prevPath: string | undefined;
-    nextPath: string | undefined;
-    index: number | undefined;
-    total: number | undefined;
-    error?: any;
-    isLoading: boolean;
-}
+export type UsePrevNextControllerResult =
+    | {
+          isLoading: true;
+      }
+    | {
+          hasPrev: boolean;
+          hasNext: boolean;
+          prevPath: string | undefined;
+          nextPath: string | undefined;
+          index: number | undefined;
+          total: number | undefined;
+          error?: any;
+          isLoading: false;
+      };

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -1,6 +1,6 @@
 import { UseQueryOptions, useQuery } from 'react-query';
 import { useResourceContext } from '../core';
-import { useDataProvider, useGetList } from '../dataProvider';
+import { useDataProvider } from '../dataProvider';
 import { useStore } from '../store';
 import { FilterPayload, RaRecord, SortPayload } from '../types';
 import { ListParams, SORT_ASC } from './list';

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -189,7 +189,7 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
         }
     );
 
-    let finalData = canUseCacheData ? queryData.data : data?.data || [];
+    const finalData = canUseCacheData ? queryData.data : data?.data || [];
 
     if (!record || isLoading) return { isLoading: true };
 

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -247,8 +247,16 @@ export interface UsePrevNextControllerProps<RecordType extends RaRecord = any> {
 export type UsePrevNextControllerResult =
     | {
           isLoading: true;
+          hasPrev?: boolean;
+          hasNext?: boolean;
+          prevPath?: string | undefined;
+          nextPath?: string | undefined;
+          index?: number | undefined;
+          total?: number | undefined;
+          error?: any;
       }
     | {
+          isLoading: false;
           hasPrev: boolean;
           hasNext: boolean;
           prevPath: string | undefined;
@@ -256,5 +264,4 @@ export type UsePrevNextControllerResult =
           index: number | undefined;
           total: number | undefined;
           error?: any;
-          isLoading: false;
       };

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { address, internet, name } from 'faker/locale/en_GB';
+import fakeRestDataProvider from 'ra-data-fakerest';
+
 import {
     Basic,
     ErrorState,
@@ -12,6 +15,12 @@ import {
 describe('<PrevNextButtons />', () => {
     beforeEach(() => {
         window.scrollTo = jest.fn();
+        // avoid logs due to the use of ListGuesser
+        console.log = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
     it('should render the current record position according to the clicked item in the list', async () => {
@@ -44,6 +53,16 @@ describe('<PrevNextButtons />', () => {
         expect(nextButton).toHaveProperty('disabled', true);
     });
 
+    it('should render a total based on query filter', async () => {
+        render(<WithQueryFilter />);
+        const input = await screen.findByLabelText('Search');
+        fireEvent.change(input, { target: { value: 'east' } });
+        const item = await screen.findByText('217');
+        fireEvent.click(item);
+        await screen.findByRole('navigation');
+        expect(screen.getByText('10 / 57')).toBeDefined();
+    });
+
     it('should link to the edit view by default', async () => {
         render(<Basic />);
         const row = await screen.findByText('Deja');
@@ -55,53 +74,76 @@ describe('<PrevNextButtons />', () => {
         );
     });
 
-    it('should link to the show view when linkType is show', async () => {
-        render(<Basic />);
-        const row = await screen.findByText('Deja');
-        fireEvent.click(row);
-        fireEvent.click(screen.getByLabelText('Show'));
-        const next = await screen.findByLabelText('Go to next page');
-        fireEvent.click(next);
-        expect(screen.queryByLabelText('First name')).toBeNull();
-        expect(screen.getByText('First name')).toBeDefined();
-    });
-
-    it('should render a total based on filter', async () => {
-        render(<WithFilter />);
-        const item = await screen.findByText('822');
-        fireEvent.click(item);
-        await screen.findByRole('navigation');
-        expect(screen.getByText('1 / 5')).toBeDefined();
-    });
-
-    it('should render a total based on query filter', async () => {
-        render(<WithQueryFilter />);
-        const input = await screen.findByLabelText('Search');
-        fireEvent.change(input, { target: { value: 'east' } });
-        const item = await screen.findByText('217');
-        fireEvent.click(item);
-        await screen.findByRole('navigation');
-        expect(screen.getByText('10 / 57')).toBeDefined();
-    });
-
-    it('should render a total based on limit', async () => {
-        render(<WithLimit />);
-        const item = await screen.findByText('0');
-        fireEvent.click(item);
-        await screen.findByRole('navigation');
-        expect(screen.getByText('1 / 500')).toBeDefined();
-    });
-
     it('should render an error UI in case of data provider error', async () => {
         console.error = jest.fn();
         render(<ErrorState />);
-        await screen.findByRole('progressbar');
-        expect(screen.getByText('error')).toBeDefined();
+        await screen.findByText('error');
     });
 
     it('should render a loading UI in case of slow data provider response', async () => {
         render(<LoadingState />);
         const progress = await screen.findByRole('progressbar');
         expect(progress).toBeDefined();
+    });
+
+    describe('linkType', () => {
+        it('should link to the show view when linkType is show', async () => {
+            render(<Basic />);
+            const row = await screen.findByText('Deja');
+            fireEvent.click(row);
+            fireEvent.click(screen.getByLabelText('Show'));
+            const next = await screen.findByLabelText('Go to next page');
+            fireEvent.click(next);
+            expect(screen.queryByLabelText('First name')).toBeNull();
+            expect(screen.getByText('First name')).toBeDefined();
+        });
+    });
+
+    describe('filter', () => {
+        it('should render a total based on filter', async () => {
+            render(<WithFilter />);
+            const item = await screen.findByText('822');
+            fireEvent.click(item);
+            await screen.findByRole('navigation');
+            expect(screen.getByText('1 / 5')).toBeDefined();
+        });
+    });
+
+    describe('limit', () => {
+        it('should render the total number of items, even with a limit', async () => {
+            render(<WithLimit />);
+            const item = await screen.findByText('0');
+            fireEvent.click(item);
+            await screen.findByText('1 / 900');
+        });
+        it('should limit the number of items fetched from the data provider', async () => {
+            const data = {
+                customers: Array.from(Array(900).keys()).map(id => {
+                    const first_name = name.firstName();
+                    const last_name = name.lastName();
+                    const email = internet.email(first_name, last_name);
+
+                    return {
+                        id,
+                        first_name,
+                        last_name,
+                        email,
+                        city: address.city(),
+                    };
+                }),
+            };
+            const dataProvider = fakeRestDataProvider(data);
+            const spy = jest.spyOn(dataProvider, 'getList');
+            render(<WithLimit customDataProvider={dataProvider} />);
+            const item = await screen.findByText('9');
+            fireEvent.click(item);
+            await screen.findByText('10 / 900');
+            expect(spy).toHaveBeenCalledWith('customers', {
+                pagination: { page: 1, perPage: 500 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: {},
+                meta: undefined,
+            });
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { AdminContext } from '../AdminContext';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import {
     RecordContextProvider,
@@ -26,6 +25,8 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 import { MemoryRouter } from 'react-router';
 import { seed, address, internet, name } from 'faker/locale/en_GB';
 import { QueryClient } from 'react-query';
+
+import { AdminContext } from '../AdminContext';
 
 export default { title: 'ra-ui-materialui/button/PrevNextButtons' };
 
@@ -264,9 +265,12 @@ export const WithQueryFilter = () => (
     </MemoryRouter>
 );
 
-export const WithLimit = () => (
+export const WithLimit = ({ customDataProvider = dataProvider }) => (
     <MemoryRouter>
-        <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+        <AdminContext
+            dataProvider={customDataProvider}
+            i18nProvider={i18nProvider}
+        >
             <AdminUI>
                 <Resource
                     name="customers"

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
@@ -8,8 +8,10 @@ import {
 import { NavigateBefore, NavigateNext } from '@mui/icons-material';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Link } from 'react-router-dom';
-import { IconButton, LinearProgress, SxProps, styled } from '@mui/material';
+import { Box, IconButton, SxProps, styled } from '@mui/material';
 import clsx from 'clsx';
+
+import { LinearProgress } from '../layout/LinearProgress';
 
 /**
  * A component used to render the previous and next buttons in a Show or Edit view.
@@ -105,7 +107,11 @@ export const PrevNextButtons = <RecordType extends RaRecord = any>(
     const translate = useTranslate();
 
     if (isLoading) {
-        return <LinearProgress />;
+        return (
+            <Box minHeight={theme => theme.spacing(4)}>
+                <LinearProgress />
+            </Box>
+        );
     }
     if (error) {
         return (
@@ -116,6 +122,9 @@ export const PrevNextButtons = <RecordType extends RaRecord = any>(
                 aria-errormessage={error.message}
             />
         );
+    }
+    if (!hasPrev && !hasNext) {
+        return <Box minHeight={theme => theme.spacing(5)} />;
     }
 
     return (


### PR DESCRIPTION
## Problem

`<PrevNextButtons>` has to fetch the entire list to determine the previous and next id. This may be costly in network and server time (on the client-side, iven with a list of 1000 items, the time is negligible). 

## Solution

Check if the previous and next id can't be determined from the cache first, so that users coming from a list page don't need to fetch the entire list of records

## Out of scope

When a user reaches the end of the list cache, update the list params in the store to increment or decrement the page. 

## To Do

- [x] Use `<PrevNextButtons />` in the demo
- [x] Allow to specify `filterDefaultValues`
- [x] Use the cache if possible
