### PR TITLE
[Doc] Fixed Typo in useInfiniteGetList.md

### DIFF
--- a/docs/useInfiniteGetList.md
+++ b/docs/useInfiniteGetList.md
@@ -49,7 +49,7 @@ If your data provider doesn't return the `total` number of records (see [Partial
 For instance, to render the latest news:
 
 ```jsx
-import { useInfinteGetList } from 'react-admin';
+import { useInfiniteGetList } from 'react-admin';
 
 const LatestNews = () => {
     const { 


### PR DESCRIPTION
useInfiniteGetList was missing a letter in one of the import blocks