### PR TITLE
Fix Guessers should not log in CI by default

### DIFF
--- a/packages/ra-ui-materialui/src/detail/EditGuesser.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.spec.tsx
@@ -27,7 +27,7 @@ describe('<EditGuesser />', () => {
         render(
             <ThemeProvider theme={{}}>
                 <CoreAdminContext dataProvider={dataProvider as any}>
-                    <EditGuesser resource="comments" id={123} />
+                    <EditGuesser resource="comments" id={123} enableLog />
                 </CoreAdminContext>
             </ThemeProvider>
         );

--- a/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
@@ -15,7 +15,7 @@ import { EditView } from './EditView';
 import { editFieldTypes } from './editFieldTypes';
 
 export const EditGuesser = <RecordType extends RaRecord = RaRecord>(
-    props: EditProps<RecordType>
+    props: EditProps<RecordType> & { enableLog?: boolean }
 ) => {
     const {
         resource,
@@ -44,10 +44,16 @@ export const EditGuesser = <RecordType extends RaRecord = RaRecord>(
     );
 };
 
-const EditViewGuesser = props => {
+const EditViewGuesser = (
+    props: Omit<EditProps, 'children'> & { enableLog?: boolean }
+) => {
     const resource = useResourceContext(props);
     const { record } = useEditContext();
     const [child, setChild] = useState(null);
+    const {
+        enableLog = process.env.NODE_ENV === 'development',
+        ...rest
+    } = props;
 
     useEffect(() => {
         setChild(null);
@@ -66,7 +72,7 @@ const EditViewGuesser = props => {
             );
             setChild(inferredChild.getElement());
 
-            if (process.env.NODE_ENV === 'production') return;
+            if (!enableLog) return;
 
             const representation = inferredChild.getRepresentation();
 
@@ -97,9 +103,9 @@ ${representation}
 );`
             );
         }
-    }, [record, child, resource]);
+    }, [record, child, resource, enableLog]);
 
-    return <EditView {...props}>{child}</EditView>;
+    return <EditView {...rest}>{child}</EditView>;
 };
 
 EditViewGuesser.propTypes = EditView.propTypes;

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.spec.tsx
@@ -26,7 +26,7 @@ describe('<ShowGuesser />', () => {
         render(
             <ThemeProvider theme={{}}>
                 <CoreAdminContext dataProvider={dataProvider as any}>
-                    <ShowGuesser resource="comments" id={123} />
+                    <ShowGuesser resource="comments" id={123} enableLog />
                 </CoreAdminContext>
             </ThemeProvider>
         );

--- a/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowGuesser.tsx
@@ -18,16 +18,22 @@ export const ShowGuesser = ({
     queryOptions,
     resource,
     ...rest
-}: Omit<ShowProps, 'children'>) => (
+}: Omit<ShowProps, 'children'> & { enableLog?: boolean }) => (
     <ShowBase id={id} resource={resource} queryOptions={queryOptions}>
         <ShowViewGuesser {...rest} />
     </ShowBase>
 );
 
-const ShowViewGuesser = props => {
+const ShowViewGuesser = (
+    props: Omit<ShowProps, 'children'> & { enableLog?: boolean }
+) => {
     const resource = useResourceContext(props);
     const { record } = useShowContext();
     const [child, setChild] = useState(null);
+    const {
+        enableLog = process.env.NODE_ENV === 'development',
+        ...rest
+    } = props;
 
     useEffect(() => {
         setChild(null);
@@ -46,7 +52,7 @@ const ShowViewGuesser = props => {
             );
             setChild(inferredChild.getElement());
 
-            if (process.env.NODE_ENV === 'production') return;
+            if (!enableLog) return;
 
             const representation = inferredChild.getRepresentation();
             const components = ['Show']
@@ -76,9 +82,9 @@ ${inferredChild.getRepresentation()}
 );`
             );
         }
-    }, [record, child, resource]);
+    }, [record, child, resource, enableLog]);
 
-    return <ShowView {...props}>{child}</ShowView>;
+    return <ShowView {...rest}>{child}</ShowView>;
 };
 
 ShowViewGuesser.propTypes = ShowView.propTypes;

--- a/packages/ra-ui-materialui/src/list/ListGuesser.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.spec.tsx
@@ -29,7 +29,7 @@ describe('<ListGuesser />', () => {
         render(
             <ThemeProvider theme={{}}>
                 <CoreAdminContext dataProvider={dataProvider as any}>
-                    <ListGuesser resource="comments" />
+                    <ListGuesser resource="comments" enableLog />
                 </CoreAdminContext>
             </ThemeProvider>
         );

--- a/packages/ra-ui-materialui/src/list/ListGuesser.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.tsx
@@ -36,7 +36,7 @@ import { listFieldTypes } from './listFieldTypes';
  * );
  */
 export const ListGuesser = <RecordType extends RaRecord = any>(
-    props: Omit<ListProps, 'children'>
+    props: Omit<ListProps, 'children'> & { enableLog?: boolean }
 ) => {
     const {
         debounce,
@@ -69,11 +69,17 @@ export const ListGuesser = <RecordType extends RaRecord = any>(
     );
 };
 
-const ListViewGuesser = (props: Omit<ListViewProps, 'children'>) => {
+const ListViewGuesser = (
+    props: Omit<ListViewProps, 'children'> & { enableLog?: boolean }
+) => {
     const { data } = useListContext(props);
     const resource = useResourceContext();
     const { hasEdit, hasShow } = useResourceDefinition(props);
     const [child, setChild] = useState(null);
+    const {
+        enableLog = process.env.NODE_ENV === 'development',
+        ...rest
+    } = props;
 
     useEffect(() => {
         setChild(null);
@@ -92,7 +98,7 @@ const ListViewGuesser = (props: Omit<ListViewProps, 'children'>) => {
             );
             setChild(inferredChild.getElement());
 
-            if (process.env.NODE_ENV === 'production') return;
+            if (!enableLog) return;
 
             const representation = inferredChild.getRepresentation();
             const components = ['List']
@@ -122,9 +128,9 @@ ${inferredChild.getRepresentation()}
 );`
             );
         }
-    }, [data, child, resource, hasEdit, hasShow]);
+    }, [data, child, resource, hasEdit, hasShow, enableLog]);
 
-    return <ListView {...props}>{child}</ListView>;
+    return <ListView {...rest}>{child}</ListView>;
 };
 
 ListViewGuesser.propTypes = ListView.propTypes;


### PR DESCRIPTION
## Problem

Guessers are convenient for tests... except they log their output to the console

## Solution

- Disable guessers log outside development by default
- expose a prop to set the logging behavior