### PR TITLE
Update Filter Form to show remove button after the input

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -85,6 +85,16 @@ export const FilterButton = (props: FilterButtonProps): JSX.Element => {
     const handleShow = useCallback(
         ({ source, defaultValue }) => {
             showFilter(source, defaultValue === '' ? undefined : defaultValue);
+            // We have to fallback to imperative code because the new FilterFormInput
+            // has no way of knowing it has just been displayed (and thus that it should focus its input)
+            setTimeout(() => {
+                const inputElement = document.querySelector(
+                    `input[name='${source}']`
+                ) as HTMLInputElement;
+                if (inputElement) {
+                    inputElement.focus();
+                }
+            }, 50);
             setOpen(false);
         },
         [showFilter, setOpen]

--- a/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import { IconButton } from '@mui/material';
-import ActionHide from '@mui/icons-material/HighlightOff';
+import ActionHide from '@mui/icons-material/RemoveCircleOutline';
 import clsx from 'clsx';
 import { useResourceContext, useTranslate } from 'ra-core';
 
@@ -16,6 +16,14 @@ export const FilterFormInput = props => {
             data-source={filterElement.props.source}
             className={clsx('filter-field', className)}
         >
+            {React.cloneElement(filterElement, {
+                resource,
+                record: emptyRecord,
+                size: filterElement.props.size ?? 'small',
+                helperText: false,
+                // ignore defaultValue in Field because it was already set in Form (via mergedInitialValuesWithDefaultValues)
+                defaultValue: undefined,
+            })}
             {!filterElement.props.alwaysOn && (
                 <IconButton
                     className={clsx(
@@ -30,14 +38,7 @@ export const FilterFormInput = props => {
                     <ActionHide />
                 </IconButton>
             )}
-            {React.cloneElement(filterElement, {
-                resource,
-                record: emptyRecord,
-                size: filterElement.props.size ?? 'small',
-                helperText: false,
-                // ignore defaultValue in Field because it was already set in Form (via mergedInitialValuesWithDefaultValues)
-                defaultValue: undefined,
-            })}
+
             <div className={FilterFormInputClasses.spacer}>&nbsp;</div>
         </Root>
     );


### PR DESCRIPTION
## Problem

The Remove button on filter inputs is confusing when there are more than one input - it's hard to determine if it relates to the input on the left or on the right

And on mobile, the remove button breaks the layout

## Solution

- Move the remove button after the input, so that it comes first in the focus order, and the layout is clearer
- Change the remove icon so that it is not too close to the clear icon in resettable text inputs
- automatically focus an input after being added to save 1 click


https://github.com/marmelab/react-admin/assets/99944/bbe88607-b660-457b-8770-9fcccc468d92



| Before | After |
| -- | -- |
| ![127 0 0 1_8000_(iPhone 12 Pro) (1)](https://github.com/marmelab/react-admin/assets/99944/44dce1f3-869b-4018-9037-8b231a7a3666) | ![127 0 0 1_8000_(iPhone 12 Pro)](https://github.com/marmelab/react-admin/assets/99944/ffd3dde9-e505-45bc-bed5-668673bc5b7b) |
