### PR TITLE
Add greenframe widget on landing page

### DIFF
--- a/greenframe-confirm-file.txt
+++ b/greenframe-confirm-file.txt
@@ -1,0 +1,1 @@
+b88a38d6-e12f-4d5e-b7ff-cd231099d80bhttps://marmelab.com/react-admin33fd2eaacaf0de336dc97bc7d01afbb570c85b7c60f3d4ec19e2f354478d18e5966c74f436a20e715fd71286c234715a7226

--- a/index.html
+++ b/index.html
@@ -21,11 +21,22 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://marmelab.com/react-admin" />
     <meta property="og:image" content="./img/ra-oe.svg" />
+    <script
+      id="greenframe_embedable_score_page_script"
+      src="https://app.greenframe.io/embedable_score_page.js"
+      size="big"
+    ></script>
     <script type="module" crossorigin src="./assets/index-b58e82f5.js"></script>
     <link rel="stylesheet" href="./assets/index-c356113f.css">
   </head>
 
   <body>
+    <div
+      style="position: fixed; bottom: 20px; right: 20px"
+      id="greenframe_embedable_score_page"
+    >
+      coucou
+    </div>
     <nav class="bg-[#00023b] text-white">
       <div
         class="mx-auto max-w-screen-xl px-4 py-2 md:px-8 md:py-5 lg:px-16 lg:py-8"

--- a/index.html
+++ b/index.html
@@ -34,9 +34,7 @@
     <div
       style="position: fixed; bottom: 20px; right: 20px"
       id="greenframe_embedable_score_page"
-    >
-      coucou
-    </div>
+    ></div>
     <nav class="bg-[#00023b] text-white">
       <div
         class="mx-auto max-w-screen-xl px-4 py-2 md:px-8 md:py-5 lg:px-16 lg:py-8"

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -21,9 +21,18 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://marmelab.com/react-admin" />
     <meta property="og:image" content="./img/ra-oe.svg" />
+    <script
+      id="greenframe_embedable_score_page_script"
+      src="https://app.greenframe.io/embedable_score_page.js"
+      size="big"
+    ></script>
   </head>
 
   <body>
+    <div
+      style="position: fixed; bottom: 20px; right: 20px"
+      id="greenframe_embedable_score_page"
+    ></div>
     <nav class="bg-[#00023b] text-white">
       <div
         class="mx-auto max-w-screen-xl px-4 py-2 md:px-8 md:py-5 lg:px-16 lg:py-8"

--- a/landing-page/public/greenframe-confirm-file.txt
+++ b/landing-page/public/greenframe-confirm-file.txt
@@ -1,0 +1,1 @@
+b88a38d6-e12f-4d5e-b7ff-cd231099d80bhttps://marmelab.com/react-admin33fd2eaacaf0de336dc97bc7d01afbb570c85b7c60f3d4ec19e2f354478d18e5966c74f436a20e715fd71286c234715a7226


### PR DESCRIPTION
Added on bottom right corner
No real preview available before activation, sorry
But would look like that :
![image](https://github.com/marmelab/react-admin/assets/39904906/af8556fc-5b40-4258-b1bf-ad806d5b8b9a)
