### PR TITLE
Reduce `<TopToolbar>` min height to move content up when there is no filter

### DIFF
--- a/examples/crm/src/companies/CompanyListFilter.tsx
+++ b/examples/crm/src/companies/CompanyListFilter.tsx
@@ -17,7 +17,7 @@ import { sectors } from './sectors';
 export const CompanyListFilter = () => {
     const { identity } = useGetIdentity();
     return (
-        <Box width="13em" minWidth="13em" order={-1} mr={2} mt={7}>
+        <Box width="13em" minWidth="13em" order={-1} mr={2} mt={5}>
             <FilterLiveSearch hiddenLabel />
 
             <FilterList label="Size" icon={<BusinessIcon />}>

--- a/examples/crm/src/contacts/ContactListFilter.tsx
+++ b/examples/crm/src/contacts/ContactListFilter.tsx
@@ -23,7 +23,7 @@ export const ContactListFilter = () => {
         sort: { field: 'name', order: 'ASC' },
     });
     return (
-        <Box width="13em" minWidth="13em" order={-1} mr={2} mt={7}>
+        <Box width="13em" minWidth="13em" order={-1} mr={2} mt={5}>
             <FilterLiveSearch
                 hiddenLabel
                 sx={{

--- a/examples/demo/src/categories/CategoryList.tsx
+++ b/examples/demo/src/categories/CategoryList.tsx
@@ -36,7 +36,7 @@ const CategoryGrid = () => {
         return null;
     }
     return (
-        <Grid container spacing={2} sx={{ marginTop: '1em' }}>
+        <Grid container spacing={2} sx={{ mt: 0 }}>
             {data.map(record => (
                 <RecordContextProvider key={record.id} value={record}>
                     <Grid

--- a/examples/demo/src/products/ProductList.tsx
+++ b/examples/demo/src/products/ProductList.tsx
@@ -74,7 +74,7 @@ export const productFilters = [
 ];
 
 const ListActions = ({ isSmall }: any) => (
-    <TopToolbar sx={{ minHeight: { sm: 56 } }}>
+    <TopToolbar>
         {isSmall && <FilterButton />}
         <SortButton fields={['reference', 'sales', 'stock']} />
         <CreateButton />

--- a/examples/demo/src/segments/Segments.tsx
+++ b/examples/demo/src/segments/Segments.tsx
@@ -16,7 +16,7 @@ const Segments = () => {
     const translate = useTranslate();
 
     return (
-        <Card sx={{ mt: 8 }}>
+        <Card sx={{ mt: 2 }}>
             <Title
                 title={translate('resources.segments.name', { smart_count: 2 })}
             />

--- a/examples/demo/src/visitors/VisitorListAside.tsx
+++ b/examples/demo/src/visitors/VisitorListAside.tsx
@@ -30,7 +30,7 @@ const Aside = () => (
             order: -1,
             flex: '0 0 15em',
             mr: 2,
-            mt: 8,
+            mt: 6,
             alignSelf: 'flex-start',
         }}
     >

--- a/packages/ra-ui-materialui/src/layout/TopToolbar.tsx
+++ b/packages/ra-ui-materialui/src/layout/TopToolbar.tsx
@@ -1,9 +1,21 @@
 import * as React from 'react';
+import { useMediaQuery, Theme } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import Toolbar, { ToolbarProps } from '@mui/material/Toolbar';
 
-export const TopToolbar = (props: ToolbarProps) => <StyledToolbar {...props} />;
+export const TopToolbar = (props: ToolbarProps) => {
+    const isXSmall = useMediaQuery<Theme>(theme =>
+        theme.breakpoints.down('sm')
+    );
+    return (
+        <StyledToolbar
+            disableGutters
+            variant={isXSmall ? 'regular' : 'dense'}
+            {...props}
+        />
+    );
+};
 
 TopToolbar.propTypes = {
     children: PropTypes.node,
@@ -23,17 +35,14 @@ const StyledToolbar = styled(Toolbar, {
     gap: theme.spacing(1),
     whiteSpace: 'nowrap',
     flex: '0 1 auto',
-    minHeight: theme.spacing(8),
-    [theme.breakpoints.up('md')]: {
-        padding: theme.spacing(0.5),
-        paddingTop: theme.spacing(1),
-    },
+    padding: theme.spacing(0.5),
+    paddingBottom: theme.spacing(1),
     [theme.breakpoints.down('md')]: {
         flex: '0 1 100%',
-        padding: theme.spacing(0.5),
-        paddingBottom: theme.spacing(1),
     },
     [theme.breakpoints.down('sm')]: {
         backgroundColor: theme.palette.background.paper,
+        padding: 0,
+        paddingBottom: 0,
     },
 }));

--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -3,7 +3,7 @@ import { FC, memo } from 'react';
 import { styled } from '@mui/material/styles';
 import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { Toolbar, ToolbarProps } from '@mui/material';
+import { ToolbarProps } from '@mui/material';
 import { Exporter } from 'ra-core';
 
 import { FilterForm } from './filter';
@@ -63,18 +63,16 @@ export interface ListToolbarProps
 
 const PREFIX = 'RaListToolbar';
 
-const Root = styled(Toolbar, {
+const Root = styled('div', {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
+    display: 'flex',
     position: 'relative',
     justifyContent: 'space-between',
     alignItems: 'flex-end',
     width: '100%',
-    padding: '0 !important',
-    minHeight: theme.spacing(8),
     [theme.breakpoints.down('md')]: {
-        margin: 0,
         flexWrap: 'wrap',
     },
     [theme.breakpoints.down('sm')]: {

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -216,6 +216,9 @@ const StyledForm = styled('form', {
     [theme.breakpoints.down('sm')]: {
         width: '100%',
     },
+    [theme.breakpoints.up('sm')]: {
+        minHeight: theme.spacing(8),
+    },
     [theme.breakpoints.up('md')]: {
         flex: '0 1 100%',
     },


### PR DESCRIPTION
## Problem

In List views, if there is no filter, there is a lot of wasted space between the app bar and the list. This is especially visible when using alternative layouts. 

## Solution

Remove the min height of the `TopToolbar`(which applies to all pages) and add it to the `FilterForm`, so that the top toolbar remains tall enough when there are filters. 

As a consequence:

- list with filters see no change
- list without filters have a reduced top margin