### PR TITLE
Add `<Menu.Item>title</Menu.item>` syntax

### DIFF
--- a/docs/Menu.md
+++ b/docs/Menu.md
@@ -24,7 +24,7 @@ export const MyMenu = () => (
         <Menu.ResourceItem name="posts" />
         <Menu.ResourceItem name="comments" />
         <Menu.ResourceItem name="users" />
-        <Menu.Item to="/custom-route" primaryText="Miscellaneous" leftIcon={<LabelIcon />}/>
+        <Menu.Item to="/custom-route" leftIcon={<LabelIcon />}>Miscellaneous</Menu.Item>
     </Menu>
 );
 ```
@@ -117,7 +117,7 @@ export const MyMenu = () => (
         <Menu.ResourceItem name="posts" />
         <Menu.ResourceItem name="comments" />
         <Menu.ResourceItem name="users" />
-        <Menu.Item to="/custom-route" primaryText="Miscellaneous" leftIcon={<LabelIcon />}/>
+        <Menu.Item to="/custom-route" leftIcon={<LabelIcon />}>Miscellaneous</Menu.Item>
     </Menu>
 );
 ```
@@ -166,12 +166,12 @@ import LabelIcon from '@mui/icons-material/Label';
 export const MyMenu = () => (
     <Menu>
         ...
-        <Menu.Item to="/custom-route" primaryText="Miscellaneous" leftIcon={<LabelIcon />}/>
+        <Menu.Item to="/custom-route" leftIcon={<LabelIcon />}>Miscellaneous</Menu.Item>
     </Menu>
 );
 ```
 
-The `primaryText` prop accepts a string or a React node. You can use it e.g. to display a badge on top of the menu item:
+The `children` prop accepts a string or a React node. You can use it e.g. to display a badge on top of the menu item:
 
 ```jsx
 import Badge from '@mui/material/Badge';
@@ -179,11 +179,11 @@ import Badge from '@mui/material/Badge';
 export const MyMenu = () => (
     <Menu>
         ...
-        <Menu.Item to="/custom-route" primaryText={
+        <Menu.Item to="/custom-route">
             <Badge badgeContent={4} color="primary">
                 Notifications
             </Badge>
-        } />
+        </Menu.Item>
     </Menu>
 );
 ```
@@ -309,7 +309,7 @@ the following code:
 translates to:
 
 ```jsx
-<Menu.Item to="/posts" primaryText="Posts" leftIcon={<BookIcon />}/>
+<Menu.Item to="/posts" leftIcon={<BookIcon />}>Posts</Menu.Item>
 ```
 
 ## Creating Menu Items For Resources
@@ -340,7 +340,7 @@ import LabelIcon from '@mui/icons-material/Label';
 export const MyMenu = () => (
     <Menu>
         <Menu.ResourceItems />
-        <Menu.Item to="/custom-route" primaryText="Miscellaneous" leftIcon={<LabelIcon />} />
+        <Menu.Item to="/custom-route" leftIcon={<LabelIcon />}>Miscellaneous</Menu.Item>
     </Menu>
 );
 ```
@@ -358,9 +358,10 @@ For instance, to include a menu to a list of published posts:
         pathname: '/posts',
         search: `filter=${JSON.stringify({ is_published: true })}`,
     }}
-    primaryText="Posts"
     leftIcon={<BookIcon />}
-/>
+>
+    Posts
+</Menu.Item>
 ```
 {% endraw %}
 
@@ -373,9 +374,10 @@ Just use an empty `filter` query parameter to force empty filters:
 ```jsx
 <Menu.Item
     to="/posts?filter=%7B%7D" // %7B%7D is JSON.stringify({})
-    primaryText="Posts"
     leftIcon={<BookIcon />}
-/>
+>
+    Posts
+</Menu.Item>
 ```
 
 ## Nested Menu Items

--- a/packages/ra-ui-materialui/src/layout/Menu.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.stories.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
-
-import { Resource, testDataProvider } from 'ra-core';
+import { Resource, CustomRoutes, testDataProvider } from 'ra-core';
 import { defaultTheme, Admin } from 'react-admin';
-import { Typography, ThemeOptions } from '@mui/material';
+import { Typography, Skeleton, ThemeOptions } from '@mui/material';
+import {
+    Dashboard,
+    PieChartOutlined,
+    PeopleOutlined,
+    Inventory,
+} from '@mui/icons-material';
+import { MemoryRouter, Route } from 'react-router-dom';
+
 import { Layout, Menu, Title } from '.';
 
 export default { title: 'ra-ui-materialui/layout/Menu' };
@@ -59,3 +66,51 @@ export const Dense = () => {
         </Admin>
     );
 };
+
+export const Custom = () => {
+    const CustomMenu = () => (
+        <Menu>
+            <Menu.Item to="/" leftIcon={<Dashboard />}>
+                Dashboard
+            </Menu.Item>
+            <Menu.Item to="/sales" leftIcon={<PieChartOutlined />}>
+                Sales
+            </Menu.Item>
+            <Menu.Item to="/customers" leftIcon={<PeopleOutlined />}>
+                Customers
+            </Menu.Item>
+            <Menu.Item to="/products" leftIcon={<Inventory />}>
+                Catalog
+            </Menu.Item>
+        </Menu>
+    );
+    const CustomLayout = props => <Layout {...props} menu={CustomMenu} />;
+
+    return (
+        <MemoryRouter initialEntries={['/']}>
+            <Admin dataProvider={testDataProvider()} layout={CustomLayout}>
+                <CustomRoutes>
+                    <Route path="/" element={<Page title="Dashboard" />} />
+                    <Route path="/sales" element={<Page title="Sales" />} />
+                    <Route
+                        path="/customers"
+                        element={<Page title="Customers" />}
+                    />
+                    <Route
+                        path="/products"
+                        element={<Page title="Catalog" />}
+                    />
+                </CustomRoutes>
+            </Admin>
+        </MemoryRouter>
+    );
+};
+
+const Page = ({ title }) => (
+    <>
+        <Typography variant="h5" mt={2}>
+            {title}
+        </Typography>
+        <Skeleton height={300} />
+    </>
+);

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -73,6 +73,7 @@ export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
         onClick,
         sidebarIsOpen,
         tooltipProps,
+        children,
         ...rest
     } = props;
 
@@ -113,9 +114,12 @@ export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
                         {leftIcon}
                     </ListItemIcon>
                 )}
-                {typeof primaryText === 'string'
+                {!children && typeof primaryText === 'string'
                     ? translate(primaryText, { _: primaryText })
                     : primaryText}
+                {!primaryText && typeof children === 'string'
+                    ? translate(children, { _: primaryText })
+                    : children}
             </StyledMenuItem>
         );
     };


### PR DESCRIPTION
## Problem

The `<Menu.Item primaryText>` syntax isn't intuitive, especially for someone who already knows material-ui, where the menu label is expressed via `children`.

## Solution

Support menu label is expressed via `children` *in addition to* `primaryText` for backwards compatibility. 

```jsx
const CustomMenu = () => (
    <Menu>
        <Menu.Item to="/" leftIcon={<Dashboard />}>
            Dashboard
        </Menu.Item>
        <Menu.Item to="/sales" leftIcon={<PieChartOutlined />}>
            Sales
        </Menu.Item>
        <Menu.Item to="/customers" leftIcon={<PeopleOutlined />}>
            Customers
        </Menu.Item>
        <Menu.Item to="/products" leftIcon={<Inventory />}>
            Catalog
        </Menu.Item>
    </Menu>
);
```