### PR TITLE
fix autocomplete sets previous value using onInputChange

### DIFF
--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -652,7 +652,7 @@ const CompanyInput = () => {
             choices={choicesWithCurrentCompany}
             optionText="name"
             disabled={isLoading}
-            onInputChange={e => setFilter({ q: e.target.value })}
+            onInputChange={(_, newInputValue) => setFilter({ q: newInputValue })}
         />
     );
 }

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -995,7 +995,7 @@ describe('<AutocompleteInput />', () => {
             </AdminContext>
         );
         const input = screen.getByLabelText('resources.users.fields.role');
-        fireEvent.change(input, { target: { value: 'a' } });
+        userEvent.type(input, 'a');
         await waitFor(() => {
             expect(screen.queryAllByRole('option').length).toEqual(2);
         });
@@ -1022,7 +1022,7 @@ describe('<AutocompleteInput />', () => {
             </AdminContext>
         );
         const input = screen.getByLabelText('resources.users.fields.role');
-        fireEvent.change(input, { target: { value: 'ab' } });
+        userEvent.type(input, 'ab');
         await waitFor(() =>
             expect(screen.queryAllByRole('option').length).toEqual(2)
         );
@@ -1376,8 +1376,7 @@ describe('<AutocompleteInput />', () => {
                 'Author'
             )) as HTMLInputElement;
             expect(input.value).toBe('Leo Tolstoy');
-            fireEvent.mouseDown(input);
-            fireEvent.change(input, { target: { value: 'Leo Tolstoy test' } });
+            userEvent.type(input, 'Leo Tolstoy test');
             // Make sure that 'Leo Tolstoy' did not reappear
             let testFailed = false;
             try {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -1240,3 +1240,28 @@ export const WithInputProps = () => {
         </Admin>
     );
 };
+
+export const WithInputOnChange = () => {
+    const [searchText, setSearchText] = React.useState('');
+
+    return (
+        <AdminContext dataProvider={dataProviderWithAuthors}>
+            <div>Search text: {searchText}</div>
+            <SimpleForm onSubmit={() => {}} defaultValues={{ role: 2 }}>
+                <AutocompleteInput
+                    fullWidth
+                    source="role"
+                    resource="users"
+                    choices={[
+                        { id: 1, name: 'ab' },
+                        { id: 2, name: 'abc' },
+                        { id: 3, name: '123' },
+                    ]}
+                    onInputChange={(_, value) => {
+                        setSearchText(value);
+                    }}
+                />
+            </SimpleForm>
+        </AdminContext>
+    );
+};


### PR DESCRIPTION
## Problem

When providing `onInputChange` to an AutocompleteInput, a `useEffect` is run and resets the Textbox's value to the previous value. 

As a result, users can not manually type a value when `onInputChange` provided.

## Solution

It turns out the `useEffect` is not necessary if React-Admin's custom `onInputChange` properly sets the [Textbox's state](https://mui.com/material-ui/react-autocomplete/#controlled-states) whenever it is called.