### PR TITLE
Include full record in `<AutocompleteInput>` and `<AutocompleteArrayInput>`'s `onChange`

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -67,6 +67,7 @@ The form value for the source must be an array of the selected values, e.g.
 | `filterToQuery`            | Optional | `string` => `Object`  | `q => ({ q })`           | How to transform the searchText into a parameter for the data provider                                                                                  |
 | `inputText`                | Optional | `Function`            | `-`                      | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                 |
 | `matchSuggestion`          | Optional | `Function`            | `-`                      | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean` |
+| `onChange`                 | Optional | `Function`            | `-`                      | A function called with the new value, along with the selected records, when the input value changes |
 | `onCreate`                 | Optional | `Function`            | `-`                      | A function called with the current filter value when users choose to create a new choice.                                                               |
 | `optionText`               | Optional | `string` &#124; `Function` &#124; `Component` | `name` | Field name of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`)           |
 | `optionValue`              | Optional | `string`              | `id`                     | Field name of record containing the value to use as input value                                                                                         |
@@ -254,6 +255,85 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
     <AutocompleteArrayInput filterToQuery={filterToQuery} />
 </ReferenceArrayInput>
 ```
+
+## `onChange`
+
+Use the `onChange` prop to get notified when the input value changes.
+
+Its value must be a function, defined as follows:
+
+```ts
+type OnChange = (
+        value: any[], // the new value
+        record: RaRecord[] // the selected records
+    ) => void;
+```
+
+In the following example, the `onChange` prop is used to update the `language` field whenever the user selects a new author:
+
+{% raw %}
+```tsx
+import * as React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import {
+    ArrayInput,
+    AutocompleteArrayInput,
+    AutocompleteArrayInputProps,
+    Create,
+    ReferenceArrayInput,
+    SimpleForm,
+    SimpleFormIterator,
+    TextInput,
+} from 'react-admin';
+
+const LanguageChangingAuthorInput = () => {
+    const { setValue } = useFormContext();
+    const handleChange: AutocompleteArrayInputProps['onChange'] = (
+        value,
+        records
+    ) => {
+        // handleChange will be called with, for instance:
+        //   value: [2],
+        //   record: [{ id: 2, name: 'Victor Hugo', language: 'French' }]
+        setValue(
+            'language',
+            records?.map(record => record.language)
+        );
+    };
+    return (
+        <ReferenceArrayInput reference="authors" source="author">
+            <AutocompleteArrayInput
+                fullWidth
+                optionText="name"
+                onChange={handleChange}
+                label="Authors"
+            />
+        </ReferenceArrayInput>
+    );
+};
+
+const BookEdit = () => (
+    <Create
+        mutationOptions={{
+            onSuccess: data => {
+                console.log(data);
+            },
+        }}
+        redirect={false}
+    >
+        <SimpleForm>
+            <LanguageChangingAuthorInput />
+            <ArrayInput source="language" label="Languages">
+                <SimpleFormIterator>
+                    <TextInput source="." label="Language" />
+                </SimpleFormIterator>
+            </ArrayInput>
+        </SimpleForm>
+    </Create>
+);
+```
+{% endraw %}
 
 ## `onCreate`
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -69,6 +69,7 @@ The form value for the source must be the selected value, e.g.
 | `isLoading`                | Optional | `boolean`             | `false`                                                             | If `true`, the component will display a loading indicator.                                                                                                                                                          |
 | `inputText`                | Optional | `Function`            | `-`                                                                 | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                                                                             |
 | `matchSuggestion`          | Optional | `Function`            | `-`                                                                 | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                             |
+| `onChange`                 | Optional | `Function`            | `-`                                                                 | A function called with the new value, along with the selected record, when the input value changes |
 | `onCreate`                 | Optional | `Function`            | `-`                                                                 | A function called with the current filter value when users choose to create a new choice.                                                                                                                           |
 | `optionText`               | Optional | `string` &#124; `Function` &#124; `Component` |  `undefined` &#124; `record Representation` | Field name of record to display in the suggestion item or function using the choice object as argument                                                                                                              |
 | `optionValue`              | Optional | `string`              | `id`                                                                | Field name of record containing the value to use as input value                                                                                                                                                     |
@@ -297,6 +298,74 @@ const UserCountry = () => {
     );
 }
 ```
+
+## `onChange`
+
+Use the `onChange` prop to get notified when the input value changes.
+
+Its value must be a function, defined as follows:
+
+```ts
+type OnChange = (
+        value: any, // the new value
+        record: RaRecord // the selected record
+    ) => void;
+```
+
+In the following example, the `onChange` prop is used to update the `language` field whenever the user selects a new author:
+
+{% raw %}
+```tsx
+import * as React from 'react';
+import {
+    AutocompleteInput,
+    AutocompleteInputProps,
+    Create,
+    ReferenceInput,
+    SimpleForm,
+    TextInput,
+} from 'react-admin';
+import { useFormContext } from 'react-hook-form';
+
+const LanguageChangingAuthorInput = () => {
+    const { setValue } = useFormContext();
+    const handleChange: AutocompleteInputProps['onChange'] = (
+        value,
+        record
+    ) => {
+        // handleChange will be called with, for instance:
+        //   value: 2,
+        //   record: { id: 2, name: 'Victor Hugo', language: 'French' }
+        setValue('language', record?.language);
+    };
+    return (
+        <ReferenceInput reference="authors" source="author">
+            <AutocompleteInput
+                fullWidth
+                optionText="name"
+                onChange={handleChange}
+            />
+        </ReferenceInput>
+    );
+};
+
+const BookCreate = () => (
+    <Create
+        mutationOptions={{
+            onSuccess: data => {
+                console.log(data);
+            },
+        }}
+        redirect={false}
+    >
+        <SimpleForm>
+            <LanguageChangingAuthorInput />
+            <TextInput source="language" />
+        </SimpleForm>
+    </Create>
+);
+```
+{% endraw %}
 
 ## `onCreate`
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -11,7 +11,11 @@ import { AdminContext } from '../AdminContext';
 import { SimpleForm } from '../form';
 import { AutocompleteArrayInput } from './AutocompleteArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
-import { InsideReferenceArrayInput } from './AutocompleteArrayInput.stories';
+import {
+    InsideReferenceArrayInput,
+    InsideReferenceArrayInputOnChange,
+    OnChange,
+} from './AutocompleteArrayInput.stories';
 
 describe('<AutocompleteArrayInput />', () => {
     const defaultProps = {
@@ -357,7 +361,10 @@ describe('<AutocompleteArrayInput />', () => {
         fireEvent.blur(input);
 
         expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange).toHaveBeenCalledWith(['t']);
+        expect(onChange).toHaveBeenCalledWith(
+            ['t'],
+            [{ id: 't', name: 'Technical' }]
+        );
     });
 
     it('should reset filter when input value changed', async () => {
@@ -1026,5 +1033,73 @@ describe('<AutocompleteArrayInput />', () => {
             </AdminContext>
         );
         expect(screen.queryByRole('textbox')).not.toBeNull();
+    });
+
+    it('should include full records when calling onChange', async () => {
+        const onChange = jest.fn();
+        render(<OnChange onChange={onChange} />);
+        await screen.findByText('Editor');
+        await screen.findByText('Reviewer');
+        screen.getByRole('textbox').focus();
+        fireEvent.click(await screen.findByText('Admin'));
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(
+                ['u001', 'u003', 'admin'],
+                [
+                    {
+                        id: 'u001',
+                        name: 'Editor',
+                    },
+                    {
+                        id: 'u003',
+                        name: 'Reviewer',
+                    },
+                    {
+                        id: 'admin',
+                        name: 'Admin',
+                    },
+                ]
+            );
+        });
+    });
+
+    it('should include full records when calling onChange inside ReferenceArrayInput', async () => {
+        const onChange = jest.fn();
+        render(<InsideReferenceArrayInputOnChange onChange={onChange} />);
+        (await screen.findByRole('textbox')).focus();
+        fireEvent.click(await screen.findByText('Leo Tolstoy'));
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(
+                [1],
+                [
+                    {
+                        id: 1,
+                        name: 'Leo Tolstoy',
+                        language: 'Russian',
+                    },
+                ]
+            );
+        });
+        expect(screen.getByDisplayValue('Russian')).not.toBeNull();
+        screen.getAllByRole('textbox')[0].focus();
+        fireEvent.click(await screen.findByText('Victor Hugo'));
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(
+                [1, 2],
+                [
+                    {
+                        id: 1,
+                        name: 'Leo Tolstoy',
+                        language: 'Russian',
+                    },
+                    {
+                        id: 2,
+                        name: 'Victor Hugo',
+                        language: 'French',
+                    },
+                ]
+            );
+        });
+        expect(screen.getByDisplayValue('French')).not.toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -17,7 +17,10 @@ import { useFormContext } from 'react-hook-form';
 import { AdminContext } from '../AdminContext';
 import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
-import { AutocompleteArrayInput } from './AutocompleteArrayInput';
+import {
+    AutocompleteArrayInput,
+    AutocompleteArrayInputProps,
+} from './AutocompleteArrayInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import { TextInput } from './TextInput';
@@ -51,7 +54,7 @@ export const Basic = () => (
 
 export const OnChange = ({
     onChange = (value, records) => console.log({ value, records }),
-}) => (
+}: Pick<AutocompleteArrayInputProps, 'onChange'>) => (
     <AdminContext i18nProvider={i18nProvider}>
         <Create
             resource="posts"
@@ -472,7 +475,7 @@ const LanguageChangingAuthorInput = ({ onChange }) => {
 
 export const InsideReferenceArrayInputOnChange = ({
     onChange = (value, records) => console.log({ value, records }),
-}) => (
+}: Pick<AutocompleteArrayInputProps, 'onChange'>) => (
     <Admin
         dataProvider={dataProviderWithAuthors}
         history={createMemoryHistory({ initialEntries: ['/books/create'] })}

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -12,6 +12,7 @@ import {
     Button,
     Stack,
 } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 
 import { AdminContext } from '../AdminContext';
 import { Create, Edit } from '../detail';
@@ -19,6 +20,7 @@ import { SimpleForm } from '../form';
 import { AutocompleteArrayInput } from './AutocompleteArrayInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
+import { TextInput } from './TextInput';
 
 export default { title: 'ra-ui-materialui/input/AutocompleteArrayInput' };
 
@@ -446,35 +448,50 @@ export const InsideReferenceArrayInput = () => (
     </Admin>
 );
 
+const LanguageChangingAuthorInput = ({ onChange }) => {
+    const { setValue } = useFormContext();
+    const handleChange = (value, records) => {
+        setValue(
+            'language',
+            records?.map(record => record.language).join(', ')
+        );
+        onChange(value, records);
+    };
+    return (
+        <ReferenceArrayInput reference="authors" source="author">
+            <AutocompleteArrayInput
+                fullWidth
+                optionText="name"
+                onChange={handleChange}
+            />
+        </ReferenceArrayInput>
+    );
+};
+
 export const InsideReferenceArrayInputOnChange = ({
     onChange = (value, records) => console.log({ value, records }),
 }) => (
-    <Admin dataProvider={dataProviderWithAuthors} history={history}>
+    <Admin
+        dataProvider={dataProviderWithAuthors}
+        history={createMemoryHistory({ initialEntries: ['/books/create'] })}
+    >
         <Resource name="authors" />
         <Resource
             name="books"
-            edit={() => (
-                <Edit
-                    mutationMode="pessimistic"
+            create={() => (
+                <Create
                     mutationOptions={{
                         onSuccess: data => {
                             console.log(data);
                         },
                     }}
+                    redirect={false}
                 >
                     <SimpleForm>
-                        <ReferenceArrayInput
-                            reference="authors"
-                            source="author"
-                        >
-                            <AutocompleteArrayInput
-                                fullWidth
-                                optionText="name"
-                                onChange={onChange}
-                            />
-                        </ReferenceArrayInput>
+                        <LanguageChangingAuthorInput onChange={onChange} />
+                        <TextInput source="language" />
                     </SimpleForm>
-                </Edit>
+                </Create>
             )}
         />
     </Admin>

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -46,6 +46,31 @@ export const Basic = () => (
     </AdminContext>
 );
 
+export const OnChange = ({
+    onChange = (value, records) => console.log({ value, records }),
+}) => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <Create
+            resource="posts"
+            record={{ roles: ['u001', 'u003'] }}
+            sx={{ width: 600 }}
+        >
+            <SimpleForm>
+                <AutocompleteArrayInput
+                    source="roles"
+                    choices={[
+                        { id: 'admin', name: 'Admin' },
+                        { id: 'u001', name: 'Editor' },
+                        { id: 'u002', name: 'Moderator' },
+                        { id: 'u003', name: 'Reviewer' },
+                    ]}
+                    onChange={onChange}
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
 const choices = [
     { id: 'admin', name: 'Admin' },
     { id: 'u001', name: 'Editor' },
@@ -418,6 +443,40 @@ export const InsideReferenceArrayInput = () => (
     <Admin dataProvider={dataProviderWithAuthors} history={history}>
         <Resource name="authors" />
         <Resource name="books" edit={BookEditWithReference} />
+    </Admin>
+);
+
+export const InsideReferenceArrayInputOnChange = ({
+    onChange = (value, records) => console.log({ value, records }),
+}) => (
+    <Admin dataProvider={dataProviderWithAuthors} history={history}>
+        <Resource name="authors" />
+        <Resource
+            name="books"
+            edit={() => (
+                <Edit
+                    mutationMode="pessimistic"
+                    mutationOptions={{
+                        onSuccess: data => {
+                            console.log(data);
+                        },
+                    }}
+                >
+                    <SimpleForm>
+                        <ReferenceArrayInput
+                            reference="authors"
+                            source="author"
+                        >
+                            <AutocompleteArrayInput
+                                fullWidth
+                                optionText="name"
+                                onChange={onChange}
+                            />
+                        </ReferenceArrayInput>
+                    </SimpleForm>
+                </Edit>
+            )}
+        />
     </Admin>
 );
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -21,6 +21,7 @@ import { AutocompleteArrayInput } from './AutocompleteArrayInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import { TextInput } from './TextInput';
+import { ArrayInput, SimpleFormIterator } from './ArrayInput';
 
 export default { title: 'ra-ui-materialui/input/AutocompleteArrayInput' };
 
@@ -453,7 +454,7 @@ const LanguageChangingAuthorInput = ({ onChange }) => {
     const handleChange = (value, records) => {
         setValue(
             'language',
-            records?.map(record => record.language).join(', ')
+            records?.map(record => record.language)
         );
         onChange(value, records);
     };
@@ -463,6 +464,7 @@ const LanguageChangingAuthorInput = ({ onChange }) => {
                 fullWidth
                 optionText="name"
                 onChange={handleChange}
+                label="Authors"
             />
         </ReferenceArrayInput>
     );
@@ -489,7 +491,11 @@ export const InsideReferenceArrayInputOnChange = ({
                 >
                     <SimpleForm>
                         <LanguageChangingAuthorInput onChange={onChange} />
-                        <TextInput source="language" />
+                        <ArrayInput source="language" label="Languages">
+                            <SimpleFormIterator>
+                                <TextInput source="." label="Language" />
+                            </SimpleFormIterator>
+                        </ArrayInput>
                     </SimpleForm>
                 </Create>
             )}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -21,6 +21,8 @@ import {
     NullishValuesSupport,
     VeryLargeOptionsNumber,
     TranslateChoice,
+    OnChange,
+    InsideReferenceInputOnChange,
 } from './AutocompleteInput.stories';
 import { act } from '@testing-library/react-hooks';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
@@ -1262,6 +1264,24 @@ describe('<AutocompleteInput />', () => {
         });
     });
 
+    it('should include full record when calling onChange', async () => {
+        const onChange = jest.fn();
+        render(<OnChange onChange={onChange} />);
+        await waitFor(() => {
+            expect(
+                (screen.getByRole('textbox') as HTMLInputElement).value
+            ).toBe('Leo Tolstoy');
+        });
+        screen.getByRole('textbox').focus();
+        fireEvent.click(await screen.findByText('Victor Hugo'));
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(2, {
+                id: 2,
+                name: 'Victor Hugo',
+            });
+        });
+    });
+
     describe('Inside <ReferenceInput>', () => {
         it('should work inside a ReferenceInput field', async () => {
             render(<InsideReferenceInput />);
@@ -1402,6 +1422,21 @@ describe('<AutocompleteInput />', () => {
                 { timeout: 2000 }
             );
             expect(matchSuggestion).not.toHaveBeenCalled();
+        });
+
+        it('should include full record when calling onChange', async () => {
+            const onChange = jest.fn();
+            render(<InsideReferenceInputOnChange onChange={onChange} />);
+            (await screen.findAllByRole('textbox'))[0].focus();
+            fireEvent.click(await screen.findByText('Victor Hugo'));
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalledWith(2, {
+                    id: 2,
+                    language: 'French',
+                    name: 'Victor Hugo',
+                });
+            });
+            expect(screen.getByDisplayValue('French')).not.toBeNull();
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -153,6 +153,45 @@ export const IsLoading = () => {
     );
 };
 
+export const OnChange = ({
+    onChange = (value, record) => console.log({ value, record }),
+}) => {
+    const choices = [
+        { id: 1, name: 'Leo Tolstoy' },
+        { id: 2, name: 'Victor Hugo' },
+        { id: 3, name: 'William Shakespeare' },
+        { id: 4, name: 'Charles Baudelaire' },
+        { id: 5, name: 'Marcel Proust' },
+    ];
+    return (
+        <Admin dataProvider={dataProvider} history={history}>
+            <Resource
+                name="books"
+                edit={() => (
+                    <Edit
+                        mutationMode="pessimistic"
+                        mutationOptions={{
+                            onSuccess: data => {
+                                console.log(data);
+                            },
+                        }}
+                    >
+                        <SimpleForm>
+                            <AutocompleteInput
+                                source="author"
+                                choices={choices}
+                                validate={required()}
+                                fullWidth
+                                onChange={onChange}
+                            />
+                        </SimpleForm>
+                    </Edit>
+                )}
+            />
+        </Admin>
+    );
+};
+
 const BookEditCustomText = () => {
     const choices = [
         { id: 1, fullName: 'Leo Tolstoy' },
@@ -527,6 +566,37 @@ export const InsideReferenceInput = () => (
                     <SimpleForm>
                         <ReferenceInput reference="authors" source="author">
                             <AutocompleteInput fullWidth optionText="name" />
+                        </ReferenceInput>
+                    </SimpleForm>
+                </Edit>
+            )}
+        />
+    </Admin>
+);
+
+export const InsideReferenceInputOnChange = ({
+    onChange = (value, record) => console.log({ value, record }),
+}) => (
+    <Admin dataProvider={dataProviderWithAuthors} history={history}>
+        <Resource name="authors" />
+        <Resource
+            name="books"
+            edit={() => (
+                <Edit
+                    mutationMode="pessimistic"
+                    mutationOptions={{
+                        onSuccess: data => {
+                            console.log(data);
+                        },
+                    }}
+                >
+                    <SimpleForm>
+                        <ReferenceInput reference="authors" source="author">
+                            <AutocompleteInput
+                                fullWidth
+                                optionText="name"
+                                onChange={onChange}
+                            />
                         </ReferenceInput>
                     </SimpleForm>
                 </Edit>

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -20,11 +20,12 @@ import {
     Typography,
     Box,
 } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 import fakeRestProvider from 'ra-data-fakerest';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 
-import { Edit } from '../detail';
+import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { AutocompleteInput, AutocompleteInputProps } from './AutocompleteInput';
 import { ReferenceInput } from './ReferenceInput';
@@ -574,32 +575,47 @@ export const InsideReferenceInput = () => (
     </Admin>
 );
 
+const LanguageChangingAuthorInput = ({ onChange }) => {
+    const { setValue } = useFormContext();
+    const handleChange = (value, record) => {
+        setValue('language', record?.language);
+        onChange(value, record);
+    };
+    return (
+        <ReferenceInput reference="authors" source="author">
+            <AutocompleteInput
+                fullWidth
+                optionText="name"
+                onChange={handleChange}
+            />
+        </ReferenceInput>
+    );
+};
+
 export const InsideReferenceInputOnChange = ({
     onChange = (value, record) => console.log({ value, record }),
 }) => (
-    <Admin dataProvider={dataProviderWithAuthors} history={history}>
+    <Admin
+        dataProvider={dataProviderWithAuthors}
+        history={createMemoryHistory({ initialEntries: ['/books/create'] })}
+    >
         <Resource name="authors" />
         <Resource
             name="books"
-            edit={() => (
-                <Edit
-                    mutationMode="pessimistic"
+            create={() => (
+                <Create
                     mutationOptions={{
                         onSuccess: data => {
                             console.log(data);
                         },
                     }}
+                    redirect={false}
                 >
                     <SimpleForm>
-                        <ReferenceInput reference="authors" source="author">
-                            <AutocompleteInput
-                                fullWidth
-                                optionText="name"
-                                onChange={onChange}
-                            />
-                        </ReferenceInput>
+                        <LanguageChangingAuthorInput onChange={onChange} />
+                        <TextInput source="language" />
                     </SimpleForm>
-                </Edit>
+                </Create>
             )}
         />
     </Admin>

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -156,7 +156,7 @@ export const IsLoading = () => {
 
 export const OnChange = ({
     onChange = (value, record) => console.log({ value, record }),
-}) => {
+}: Pick<AutocompleteInputProps, 'onChange'>) => {
     const choices = [
         { id: 1, name: 'Leo Tolstoy' },
         { id: 2, name: 'Victor Hugo' },
@@ -594,7 +594,7 @@ const LanguageChangingAuthorInput = ({ onChange }) => {
 
 export const InsideReferenceInputOnChange = ({
     onChange = (value, record) => console.log({ value, record }),
-}) => (
+}: Pick<AutocompleteInputProps, 'onChange'>) => (
     <Admin
         dataProvider={dataProviderWithAuthors}
         history={createMemoryHistory({ initialEntries: ['/books/create'] })}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -34,7 +34,6 @@ import {
     warning,
     useGetRecordRepresentation,
     useEvent,
-    Identifier,
 } from 'ra-core';
 import {
     SupportCreateSuggestionOptions,

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -702,13 +702,7 @@ export interface AutocompleteInputProps<
     filterToQuery?: (searchText: string) => any;
     inputText?: (option: any) => string;
     onChange?: (
-        value: OptionType extends RaRecord
-            ? Multiple extends true
-                ? OptionType['id'][]
-                : OptionType['id']
-            : Multiple extends true
-            ? Identifier[]
-            : Identifier,
+        value: Multiple extends true ? any[] : any, // We can't know upfront what the value type will be
         record: Multiple extends true ? OptionType[] : OptionType
     ) => void;
     setFilter?: (value: string) => void;

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -34,6 +34,7 @@ import {
     warning,
     useGetRecordRepresentation,
     useEvent,
+    Identifier,
 } from 'ra-core';
 import {
     SupportCreateSuggestionOptions,
@@ -681,7 +682,7 @@ export interface AutocompleteInputProps<
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
     SupportCreate extends boolean | undefined = false
-> extends Omit<CommonInputProps, 'source'>,
+> extends Omit<CommonInputProps, 'source' | 'onChange'>,
         ChoicesProps,
         UseSuggestionsOptions,
         Omit<SupportCreateSuggestionOptions, 'handleChange' | 'optionText'>,
@@ -700,6 +701,16 @@ export interface AutocompleteInputProps<
     emptyValue?: any;
     filterToQuery?: (searchText: string) => any;
     inputText?: (option: any) => string;
+    onChange?: (
+        value: OptionType extends RaRecord
+            ? Multiple extends true
+                ? OptionType['id'][]
+                : OptionType['id']
+            : Multiple extends true
+            ? Identifier[]
+            : Identifier,
+        record: Multiple extends true ? OptionType[] : OptionType
+    ) => void;
     setFilter?: (value: string) => void;
     shouldRenderSuggestions?: any;
     // Source is optional as AutocompleteInput can be used inside a ReferenceInput that already defines the source

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -702,8 +702,10 @@ export interface AutocompleteInputProps<
     filterToQuery?: (searchText: string) => any;
     inputText?: (option: any) => string;
     onChange?: (
-        value: Multiple extends true ? any[] : any, // We can't know upfront what the value type will be
-        record: Multiple extends true ? OptionType[] : OptionType
+        // We can't know upfront what the value type will be
+        value: Multiple extends true ? any[] : any,
+        // We return an empty string when the input is cleared in single mode
+        record: Multiple extends true ? OptionType[] : OptionType | ''
     ) => void;
     setFilter?: (value: string) => void;
     shouldRenderSuggestions?: any;

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -319,15 +319,15 @@ If you provided a React element for the optionText prop, you must also provide t
     const handleChange = (newValue: any) => {
         if (multiple) {
             if (Array.isArray(newValue)) {
-                field.onChange(newValue.map(getChoiceValue));
+                field.onChange(newValue.map(getChoiceValue), newValue);
             } else {
-                field.onChange([
-                    ...(field.value ?? []),
-                    getChoiceValue(newValue),
-                ]);
+                field.onChange(
+                    [...(field.value ?? []), getChoiceValue(newValue)],
+                    newValue
+                );
             }
         } else {
-            field.onChange(getChoiceValue(newValue) ?? emptyValue);
+            field.onChange(getChoiceValue(newValue) ?? emptyValue, newValue);
         }
     };
 


### PR DESCRIPTION
## Problem

If we want to react to a change in `<AutocompleteInput>`'s value, all we can have in `onChange` is the selected value (i.e. its id in most cases).

If we want to use another field of the selected record, we first need to fetch the record by its id (for instance using `useGetOne`), which is cumbersome, especially knowing the full record is already available in the ChoicesContext.

## Solution

Add a second argument to `onChange` to pass the full record, which allows the developer to use any field of it.

## Technical details

- This was also implemented in `<AutocompleteArrayInput>`
- However I could not implement it in `<SelectInput>` nor in `<SelectArrayInput>`, because they both rely on HTML's `<select>`, which only provides the option's `value` in `event.target.value`. It may be still doable by using the ChoicesContext, but I didn't manage to do it for now.

## Screencasts

https://github.com/marmelab/react-admin/assets/14542336/d6643d53-4376-4c64-8c8e-3ae56ef83d67


