### PR TITLE
[Doc] Explain how to lazy load `<richTextInput>`

### DIFF
--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -200,7 +200,7 @@ export const PostEdit = () => (
 
 ## Lazy Loading
 
-The `<RichTextInput>` component depends on TipTap, which in turns depends on ProseMirror. Together, these libraries represent about 120kB of minified JavaScript. If you don't use `<RichTextInput>` on all your forms, you can lazy load it to reduce the size of your bundle.
+The `<RichTextInput>` component depends on TipTap, which in turns depends on ProseMirror. Together, these libraries represent about 120kB of minified JavaScript. If you don't use `<RichTextInput>` on all your forms, you can [lazy load](https://react.dev/reference/react/lazy#suspense-for-code-splitting) it to reduce the size of your bundle.
 
 To do so, replace the import:
 

--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -198,4 +198,24 @@ export const PostEdit = () => (
 
 `<SmartRichTextInput>` is available as part of the [ra-ai](https://marmelab.com/ra-enterprise/modules/ra-ai) enterprise package.
 
+## Lazy Loading
 
+The `<RichTextInput>` component depends on TipTap, which in turns depends on ProseMirror. Together, these libraries represent about 120kB of minified JavaScript. If you don't use `<RichTextInput>` on all your forms, you can lazy load it to reduce the size of your bundle.
+
+To do so, replace the import:
+
+```jsx
+import { RichTextInput } from 'ra-input-rich-text';
+```
+
+with a dynamic import:
+
+```jsx
+const RichTextInput = React.lazy(() =>
+    import('ra-input-rich-text').then(module => ({
+        default: module.RichTextInput,
+    }))
+);
+```
+
+Once compiled, your application will load the `<RichTextInput>` only when needed.

--- a/examples/demo/src/products/ProductCreate.tsx
+++ b/examples/demo/src/products/ProductCreate.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { Create, TabbedForm, TextInput, required } from 'react-admin';
-import { RichTextInput } from 'ra-input-rich-text';
-
 import { ProductEditDetails } from './ProductEditDetails';
+const RichTextInput = React.lazy(() =>
+    import('ra-input-rich-text').then(module => ({
+        default: module.RichTextInput,
+    }))
+);
 
 const ProductCreate = () => (
     <Create>

--- a/examples/demo/src/products/ProductEdit.tsx
+++ b/examples/demo/src/products/ProductEdit.tsx
@@ -13,13 +13,18 @@ import {
     TextInput,
     useRecordContext,
 } from 'react-admin';
-import { RichTextInput } from 'ra-input-rich-text';
 
 import { ProductEditDetails } from './ProductEditDetails';
 import CustomerReferenceField from '../visitors/CustomerReferenceField';
 import StarRatingField from '../reviews/StarRatingField';
 import Poster from './Poster';
 import { Product } from '../types';
+
+const RichTextInput = React.lazy(() =>
+    import('ra-input-rich-text').then(module => ({
+        default: module.RichTextInput,
+    }))
+);
 
 const ProductTitle = () => {
     const record = useRecordContext<Product>();


### PR DESCRIPTION
The `<RichTextInput>` component depends on TipTap, which in turns depends on ProseMirror. Together, these libraries represent about 120kB of minified JavaScript. If you don't use `<RichTextInput>` on all your forms, you can lazy load it to reduce the size of your bundle.

To do so, replace the import:

```jsx
import { RichTextInput } from 'ra-input-rich-text';
```

with a dynamic import:

```jsx
const RichTextInput = React.lazy(() =>
    import('ra-input-rich-text').then(module => ({
        default: module.RichTextInput,
    }))
);
```

Once compiled, your application will load the `<RichTextInput>` only when needed.