### PR TITLE
[Doc] Improve Example REST Implementation when calling create with partial data

### DIFF
--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -642,7 +642,7 @@ export default {
             method: 'POST',
             body: JSON.stringify(params.data),
         })
-        return { data: { ...params.data, id: json.id } };
+        return { data: json };
     },
 
     update: async (resource, params) => {


### PR DESCRIPTION
The previous example implementation could cause issues if you call `create` with only partial data (say, only the mandatory fields), and expect the API to return the full record (including optional fields).
This could cause the react-query cache to be filled with incomplete data, wich could cause errors when opening the record's Show view after creation.