### PR TITLE
Fix RichTextInput does not update when its editorOptions prop changes

### DIFF
--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -56,7 +56,6 @@
         "ra-data-fakerest": "^4.14.4",
         "ra-ui-materialui": "^4.14.4",
         "react": "^17.0.0",
-        "react-admin": "^4.14.1",
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.43.9",
         "rimraf": "^3.0.2",

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -56,6 +56,7 @@
         "ra-data-fakerest": "^4.14.4",
         "ra-ui-materialui": "^4.14.4",
         "react": "^17.0.0",
+        "react-admin": "^4.14.1",
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.43.9",
         "rimraf": "^3.0.2",

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -49,6 +49,8 @@
         "@mui/icons-material": "^5.0.1",
         "@mui/material": "^5.0.2",
         "@testing-library/react": "^11.2.3",
+        "@tiptap/extension-mention": "^2.0.3",
+        "@tiptap/suggestion": "^2.0.3",
         "data-generator-retail": "^4.14.4",
         "ra-core": "^4.14.4",
         "ra-data-fakerest": "^4.14.4",
@@ -57,6 +59,7 @@
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.43.9",
         "rimraf": "^3.0.2",
+        "tippy.js": "^6.3.7",
         "typescript": "^5.1.3"
     },
     "gitHead": "b227592132da6ae5f01438fa8269e04596cdfdd8"

--- a/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
     I18nProvider,
-    Resource,
     required,
     useGetManyReference,
     useRecordContext,
@@ -14,10 +13,9 @@ import {
     SimpleFormProps,
     TopToolbar,
 } from 'ra-ui-materialui';
-import { Admin } from 'react-admin';
 import { useWatch } from 'react-hook-form';
 import fakeRestDataProvider from 'ra-data-fakerest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Mention from '@tiptap/extension-mention';
 
 import {
@@ -186,20 +184,6 @@ const dataProvider = fakeRestDataProvider({
     ],
 });
 
-const PostEdit = () => (
-    <Edit
-        actions={
-            <TopToolbar>
-                <PrevNextButtons />
-            </TopToolbar>
-        }
-    >
-        <SimpleForm>
-            <MyRichTextInput source="body" />
-        </SimpleForm>
-    </Edit>
-);
-
 const MyRichTextInput = (props: RichTextInputProps) => {
     const record = useRecordContext();
     const tags = useGetManyReference('tags', {
@@ -227,9 +211,27 @@ const MyRichTextInput = (props: RichTextInputProps) => {
 
 export const CustomOptions = () => (
     <MemoryRouter initialEntries={['/posts/1']}>
-        <Admin dataProvider={dataProvider}>
-            <Resource name="posts" edit={PostEdit} />
-        </Admin>
+        <AdminContext dataProvider={dataProvider}>
+            <Routes>
+                <Route
+                    path="/posts/:id"
+                    element={
+                        <Edit
+                            resource="posts"
+                            actions={
+                                <TopToolbar>
+                                    <PrevNextButtons />
+                                </TopToolbar>
+                            }
+                        >
+                            <SimpleForm>
+                                <MyRichTextInput source="body" />
+                            </SimpleForm>
+                        </Edit>
+                    }
+                />
+            </Routes>
+        </AdminContext>
     </MemoryRouter>
 );
 

--- a/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
@@ -375,7 +375,7 @@ const suggestions = tags => {
                 },
 
                 onKeyDown(props) {
-                    if (props.event.key === 'Escape') {
+                    if (popup && popup[0] && props.event.key === 'Escape') {
                         popup[0].hide();
 
                         return true;
@@ -396,15 +396,14 @@ const suggestions = tags => {
                         if (component) {
                             component.destroy();
                         }
+                        // Remove references to the old popup and component upon destruction/exit.
+                        // (This should prevent redundant calls to `popup.destroy()`, which Tippy
+                        // warns in the console is a sign of a memory leak, as the `suggestion`
+                        // plugin seems to call `onExit` both when a suggestion menu is closed after
+                        // a user chooses an option, *and* when the editor itself is destroyed.)
+                        popup = undefined;
+                        component = undefined;
                     });
-
-                    // Remove references to the old popup and component upon destruction/exit.
-                    // (This should prevent redundant calls to `popup.destroy()`, which Tippy
-                    // warns in the console is a sign of a memory leak, as the `suggestion`
-                    // plugin seems to call `onExit` both when a suggestion menu is closed after
-                    // a user chooses an option, *and* when the editor itself is destroyed.)
-                    popup = undefined;
-                    component = undefined;
                 },
             };
         },

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -97,18 +97,21 @@ export const RichTextInput = (props: RichTextInputProps) => {
         formState: { isSubmitted },
     } = useInput({ ...props, source, defaultValue });
 
-    const editor = useEditor({
-        ...editorOptions,
-        editable: !disabled && !readOnly,
-        content: field.value,
-        editorProps: {
-            ...editorOptions?.editorProps,
-            attributes: {
-                ...editorOptions?.editorProps?.attributes,
-                id,
+    const editor = useEditor(
+        {
+            ...editorOptions,
+            editable: !disabled && !readOnly,
+            content: field.value,
+            editorProps: {
+                ...editorOptions?.editorProps,
+                attributes: {
+                    ...editorOptions?.editorProps?.attributes,
+                    id,
+                },
             },
         },
-    });
+        [disabled, editorOptions, readOnly, id]
+    );
 
     const { error, invalid, isTouched } = fieldState;
 
@@ -123,28 +126,6 @@ export const RichTextInput = (props: RichTextInputProps) => {
 
         editor.commands.setTextSelection({ from, to });
     }, [editor, field.value]);
-
-    useEffect(() => {
-        if (!editor) return;
-
-        editor.setOptions({
-            editable: !disabled && !readOnly,
-            editorProps: {
-                ...editorOptions?.editorProps,
-                attributes: {
-                    ...editorOptions?.editorProps?.attributes,
-                    id,
-                },
-            },
-        });
-    }, [
-        disabled,
-        editor,
-        readOnly,
-        id,
-        editorOptions?.editorProps,
-        editorOptions?.editorProps?.attributes,
-    ]);
 
     useEffect(() => {
         if (!editor) {

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -123,7 +123,6 @@ export const RichTextInput = (props: RichTextInputProps) => {
         editor.commands.setContent(field.value, false, {
             preserveWhitespace: true,
         });
-
         editor.commands.setTextSelection({ from, to });
     }, [editor, field.value]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18421,6 +18421,7 @@ __metadata:
     ra-data-fakerest: ^4.14.4
     ra-ui-materialui: ^4.14.4
     react: ^17.0.0
+    react-admin: ^4.14.1
     react-dom: ^17.0.0
     react-hook-form: ^7.43.9
     rimraf: ^3.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -5310,6 +5310,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tiptap/extension-mention@npm:^2.0.3":
+  version: 2.1.10
+  resolution: "@tiptap/extension-mention@npm:2.1.10"
+  peerDependencies:
+    "@tiptap/core": ^2.0.0
+    "@tiptap/pm": ^2.0.0
+    "@tiptap/suggestion": ^2.0.0
+  checksum: 4299f11fb32214b7956aa588435360baaf282b70f9e5091bb3072c241d84873bc9b05c95a1e3b31901ea10e906eb3d34d2fd4199b9399b9f6e0d0240f66b4ffe
+  languageName: node
+  linkType: hard
+
 "@tiptap/extension-ordered-list@npm:^2.0.3":
   version: 2.0.3
   resolution: "@tiptap/extension-ordered-list@npm:2.0.3"
@@ -5450,6 +5461,16 @@ __metadata:
     "@tiptap/extension-strike": ^2.0.3
     "@tiptap/extension-text": ^2.0.3
   checksum: 0f5ff67341390ad05151d86ca0a19eeea79cf80da17a2bd3df2aa2ad1ea3cf8692f097a6527a896631dab9f8ac574738efe0d0376cf7721a02699d1689b5dc33
+  languageName: node
+  linkType: hard
+
+"@tiptap/suggestion@npm:^2.0.3":
+  version: 2.1.10
+  resolution: "@tiptap/suggestion@npm:2.1.10"
+  peerDependencies:
+    "@tiptap/core": ^2.0.0
+    "@tiptap/pm": ^2.0.0
+  checksum: 0fec5b46a09ad481d5a6839913dba3b26eea8e9aba9efd1b02a4cc0e4b3dd1645d8d2e7b5f4c6c12772def5fa4628e0c3890c2500c4efa991cbcbab9f990a2aa
   languageName: node
   linkType: hard
 
@@ -18385,6 +18406,7 @@ __metadata:
     "@tiptap/extension-highlight": ^2.0.3
     "@tiptap/extension-image": ^2.0.3
     "@tiptap/extension-link": ^2.0.3
+    "@tiptap/extension-mention": ^2.0.3
     "@tiptap/extension-placeholder": ^2.0.3
     "@tiptap/extension-text-align": ^2.0.3
     "@tiptap/extension-text-style": ^2.0.3
@@ -18392,6 +18414,7 @@ __metadata:
     "@tiptap/pm": ^2.0.3
     "@tiptap/react": ^2.0.3
     "@tiptap/starter-kit": ^2.0.3
+    "@tiptap/suggestion": ^2.0.3
     clsx: ^1.1.1
     data-generator-retail: ^4.14.4
     ra-core: ^4.14.4
@@ -18401,6 +18424,7 @@ __metadata:
     react-dom: ^17.0.0
     react-hook-form: ^7.43.9
     rimraf: ^3.0.2
+    tippy.js: ^6.3.7
     typescript: ^5.1.3
   peerDependencies:
     "@mui/icons-material": ^5.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -18421,7 +18421,6 @@ __metadata:
     ra-data-fakerest: ^4.14.4
     ra-ui-materialui: ^4.14.4
     react: ^17.0.0
-    react-admin: ^4.14.1
     react-dom: ^17.0.0
     react-hook-form: ^7.43.9
     rimraf: ^3.0.2


### PR DESCRIPTION
When adding tiptap extensions that relies on the current record, you have to update the `editorOptions`. However the changes aren't reflected.

This PR solves this by passing the `editorOptions` as `useEditor` dependencies