### PR TITLE
Fix `<PrevNextButton>` default style

### DIFF
--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.stories.tsx
@@ -6,12 +6,18 @@ import {
     ResourceContext,
     testDataProvider,
 } from 'ra-core';
+import englishMessages from 'ra-language-english';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import { MemoryRouter } from 'react-router';
+import { seed, address, internet, name } from 'faker/locale/en_GB';
+import { QueryClient } from 'react-query';
+
 import {
     AdminUI,
+    AdminContext,
     Edit,
     EditButton,
     ListGuesser,
-    PrevNextButtons,
     Show,
     ShowButton,
     SimpleForm,
@@ -19,20 +25,15 @@ import {
     TextField,
     TextInput,
     TopToolbar,
-} from 'react-admin';
-import englishMessages from 'ra-language-english';
-import polyglotI18nProvider from 'ra-i18n-polyglot';
-import { MemoryRouter } from 'react-router';
-import { seed, address, internet, name } from 'faker/locale/en_GB';
-import { QueryClient } from 'react-query';
-
-import { AdminContext } from '../AdminContext';
+} from '../';
+import { PrevNextButtons } from './PrevNextButtons';
 
 export default { title: 'ra-ui-materialui/button/PrevNextButtons' };
 
 const i18nProvider = polyglotI18nProvider(() => englishMessages, 'en');
 
 seed(123); // we want consistent results
+
 const data = {
     customers: Array.from(Array(900).keys()).map(id => {
         const first_name = name.firstName();
@@ -52,35 +53,30 @@ const data = {
 const dataProvider = fakeRestDataProvider(data);
 
 const MyTopToolbar = ({ children }) => (
-    <TopToolbar
-        sx={{
-            justifyContent: 'space-between',
-        }}
-    >
-        {children}
-    </TopToolbar>
+    <TopToolbar sx={{ justifyContent: 'space-between' }}>{children}</TopToolbar>
 );
 
-const defaultFields = [
-    <TextField source="id" key="id" />,
-    <TextField source="first_name" key="first_name" />,
-    <TextField source="last_name" key="last_name" />,
-    <TextField source="email" key="email" />,
-    <TextField source="city" key="city" />,
-];
-
-const defaultInputs = [
-    <TextInput source="first_name" key="first_name" />,
-    <TextInput source="last_name" key="last_name" />,
-    <TextInput source="email" key="email" />,
-    <TextInput source="city" key="city" />,
-];
-
-const DefaultSimpleForm = () => (
-    <SimpleForm warnWhenUnsavedChanges>{defaultInputs}</SimpleForm>
+const CustomerEdit = ({ actions }: any) => (
+    <Edit redirect={false} actions={actions}>
+        <SimpleForm warnWhenUnsavedChanges>
+            <TextInput source="first_name" key="first_name" />
+            <TextInput source="last_name" key="last_name" />
+            <TextInput source="email" key="email" />
+            <TextInput source="city" key="city" />
+        </SimpleForm>
+    </Edit>
 );
-const DefaultSimpleShowLayout = () => (
-    <SimpleShowLayout>{defaultFields}</SimpleShowLayout>
+
+const CustomerShow = ({ actions }: any) => (
+    <Show actions={actions}>
+        <SimpleShowLayout>
+            <TextField source="id" key="id" />
+            <TextField source="first_name" key="first_name" />
+            <TextField source="last_name" key="last_name" />
+            <TextField source="email" key="email" />
+            <TextField source="city" key="city" />
+        </SimpleShowLayout>
+    </Show>
 );
 
 export const Basic = () => (
@@ -91,28 +87,24 @@ export const Basic = () => (
                     name="customers"
                     list={<ListGuesser />}
                     edit={
-                        <Edit
-                            redirect={false}
+                        <CustomerEdit
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons />
                                     <ShowButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleForm />
-                        </Edit>
+                        />
                     }
                     show={
-                        <Show
+                        <CustomerShow
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons linkType="show" />
+                                    <EditButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleShowLayout />
-                        </Show>
+                        />
                     }
                 />
             </AdminUI>
@@ -128,20 +120,17 @@ export const WithStoreKey = () => (
                     name="customers"
                     list={<ListGuesser storeKey="withStoreKey" />}
                     edit={
-                        <Edit
-                            redirect={false}
+                        <CustomerEdit
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons storeKey="withStoreKey" />
                                     <ShowButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleForm />
-                        </Edit>
+                        />
                     }
                     show={
-                        <Show
+                        <CustomerShow
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons
@@ -151,9 +140,7 @@ export const WithStoreKey = () => (
                                     <EditButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleShowLayout />
-                        </Show>
+                        />
                     }
                 />
             </AdminUI>
@@ -174,8 +161,7 @@ export const WithFilter = () => (
                         />
                     }
                     edit={
-                        <Edit
-                            redirect={false}
+                        <CustomerEdit
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons
@@ -188,12 +174,10 @@ export const WithFilter = () => (
                                     <ShowButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleForm />
-                        </Edit>
+                        />
                     }
                     show={
-                        <Show
+                        <CustomerShow
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons
@@ -207,9 +191,7 @@ export const WithFilter = () => (
                                     <EditButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleShowLayout />
-                        </Show>
+                        />
                     }
                 />
             </AdminUI>
@@ -235,29 +217,24 @@ export const WithQueryFilter = () => (
                         />
                     }
                     edit={
-                        <Edit
-                            redirect={false}
+                        <CustomerEdit
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons />
                                     <ShowButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleForm />
-                        </Edit>
+                        />
                     }
                     show={
-                        <Show
+                        <CustomerShow
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons linkType="show" />
                                     <EditButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleShowLayout />
-                        </Show>
+                        />
                     }
                 />
             </AdminUI>
@@ -276,32 +253,27 @@ export const WithLimit = ({ customDataProvider = dataProvider }) => (
                     name="customers"
                     list={<ListGuesser />}
                     edit={
-                        <Edit
-                            redirect={false}
+                        <CustomerEdit
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons limit={500} />
                                     <ShowButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleForm />
-                        </Edit>
+                        />
                     }
                     show={
-                        <Show
+                        <CustomerShow
                             actions={
                                 <MyTopToolbar>
                                     <PrevNextButtons
                                         linkType="show"
                                         limit={500}
                                     />
-                                    <ShowButton />
+                                    <EditButton />
                                 </MyTopToolbar>
                             }
-                        >
-                            <DefaultSimpleShowLayout />
-                        </Show>
+                        />
                     }
                 />
             </AdminUI>
@@ -313,19 +285,10 @@ export const WithStyle = () => (
     <AdminContext dataProvider={dataProvider}>
         <ResourceContext.Provider value="customers">
             <RecordContextProvider value={data.customers[0]}>
-                <PrevNextButtons
-                    sx={{
-                        color: 'blue',
-                    }}
-                />
+                <PrevNextButtons sx={{ color: 'blue' }} />
                 <PrevNextButtons
                     linkType="show"
-                    sx={{
-                        '& .RaPrevNextButton-list': {
-                            marginBottom: '20px',
-                            color: 'red',
-                        },
-                    }}
+                    sx={{ marginBottom: '20px', color: 'red' }}
                 />
             </RecordContextProvider>
         </ResourceContext.Provider>

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
@@ -8,7 +8,14 @@ import {
 import { NavigateBefore, NavigateNext } from '@mui/icons-material';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Link } from 'react-router-dom';
-import { Box, IconButton, SxProps, styled } from '@mui/material';
+import {
+    Box,
+    Stack,
+    Typography,
+    IconButton,
+    SxProps,
+    styled,
+} from '@mui/material';
 import clsx from 'clsx';
 
 import { LinearProgress } from '../layout/LinearProgress';
@@ -108,7 +115,7 @@ export const PrevNextButtons = <RecordType extends RaRecord = any>(
 
     if (isLoading) {
         return (
-            <Box minHeight={theme => theme.spacing(4)}>
+            <Box minHeight={34} display="flex" alignItems="center">
                 <LinearProgress />
             </Box>
         );
@@ -124,38 +131,40 @@ export const PrevNextButtons = <RecordType extends RaRecord = any>(
         );
     }
     if (!hasPrev && !hasNext) {
-        return <Box minHeight={theme => theme.spacing(5)} />;
+        return <Box minHeight={34} />;
     }
 
     return (
-        <Root sx={sx}>
-            <ul className={clsx(PrevNextButtonClasses.list)}>
-                <li>
-                    <IconButton
-                        component={hasPrev ? Link : undefined}
-                        to={prevPath}
-                        aria-label={translate('ra.navigation.previous')}
-                        disabled={!hasPrev}
-                    >
-                        <NavigateBefore />
-                    </IconButton>
-                </li>
-                {typeof index === 'number' && (
-                    <li>
-                        {index + 1} / {total}
-                    </li>
-                )}
-                <li>
-                    <IconButton
-                        component={hasNext ? Link : undefined}
-                        to={nextPath}
-                        aria-label={translate('ra.navigation.next')}
-                        disabled={!hasNext}
-                    >
-                        <NavigateNext />
-                    </IconButton>
-                </li>
-            </ul>
+        <Root
+            sx={sx}
+            direction="row"
+            className={clsx(PrevNextButtonClasses.root)}
+        >
+            <IconButton
+                component={hasPrev ? Link : undefined}
+                to={prevPath}
+                aria-label={translate('ra.navigation.previous')}
+                disabled={!hasPrev}
+                size="small"
+            >
+                <NavigateBefore />
+            </IconButton>
+
+            {typeof index === 'number' && (
+                <Typography variant="body2">
+                    {index + 1} / {total}
+                </Typography>
+            )}
+
+            <IconButton
+                component={hasNext ? Link : undefined}
+                to={nextPath}
+                aria-label={translate('ra.navigation.next')}
+                disabled={!hasNext}
+                size="small"
+            >
+                <NavigateNext />
+            </IconButton>
         </Root>
     );
 };
@@ -168,19 +177,14 @@ export interface PrevNextButtonProps<RecordType extends RaRecord = any>
 const PREFIX = 'RaPrevNextButton';
 
 export const PrevNextButtonClasses = {
-    list: `${PREFIX}-list`,
+    root: `${PREFIX}-root`,
 };
 
-const Root = styled('nav', {
+const Root = styled(Stack, {
     name: PREFIX,
     overridesResolver: (_props, styles) => styles.root,
 })({
-    [`& .${PrevNextButtonClasses.list}`]: {
-        display: 'flex',
-        flexWrap: 'wrap',
-        alignItems: 'center',
-        padding: 0,
-        margin: 0,
-        listStyle: 'none',
-    },
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5em',
 });

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
@@ -137,6 +137,7 @@ export const PrevNextButtons = <RecordType extends RaRecord = any>(
     return (
         <Root
             sx={sx}
+            role="navigation"
             direction="row"
             className={clsx(PrevNextButtonClasses.root)}
         >


### PR DESCRIPTION
## Problems

- `<PrevNextButton>` takes the entire line by default. It should be inline instead of block
- `<PrevNextButton>` doesn't use the base Typography
- `<PrevNextButton>` adds useless markup

## Solution

Use `<Stack>` with custom styling

The change of inner class name is technically a breaking change, but I suggest to accept it because the feature is very recent and wasn't properly styled before. 

## Before
<img width="709" alt="Capture d’écran 2023-09-19 à 00 12 50" src="https://github.com/marmelab/react-admin/assets/99944/2e5f86e6-d49b-4bf0-84eb-4951c0b9d2a8">

## After
<img width="707" alt="Capture d’écran 2023-09-19 à 00 12 27 1" src="https://github.com/marmelab/react-admin/assets/99944/4de1d338-2fc7-4350-9d09-1b851e89a57e">
