### PR TITLE
Additional exports for customization in ra-data-graphql-simple

### DIFF
--- a/packages/ra-data-graphql-simple/src/index.ts
+++ b/packages/ra-data-graphql-simple/src/index.ts
@@ -3,11 +3,16 @@ import buildDataProvider, { BuildQueryFactory, Options } from 'ra-data-graphql';
 import { DataProvider, Identifier } from 'ra-core';
 
 import defaultBuildQuery from './buildQuery';
+
+export const buildQuery = defaultBuildQuery;
+export { buildQueryFactory } from './buildQuery';
+export { default as buildGqlQuery } from './buildGqlQuery';
+export { default as buildVariables } from './buildVariables';
+export { default as getResponseParser } from './getResponseParser';
+
 const defaultOptions = {
     buildQuery: defaultBuildQuery,
 };
-
-export const buildQuery = defaultBuildQuery;
 
 export default (
     options: Omit<Options, 'buildQuery'> & { buildQuery?: BuildQueryFactory }


### PR DESCRIPTION
Resolves #9278, same as #9279 but targeting `next` instead of `master`

## Problem

Without writing a complete build query factory it's not possible to customize `ra-data-graphql-simple`'s default build query. If we only want to modify the response parser for example, we would need to write build GraphQL query and variables logic as well.

## Solution

Export `buildQueryFactory`, `buildGqlQuery`, `buildVariables` and `getResponseParser` from the package to allow for more granular customization.
