### PR TITLE
Fix package exports

### DIFF
--- a/examples/data-generator/package.json
+++ b/examples/data-generator/package.json
@@ -17,6 +17,7 @@
         },
         "./package.json": "./package.json"
     },
+    "sideEffects": false,
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",
         "build-cjs": "rimraf ./dist/cjs && tsc --outDir dist/cjs",

--- a/examples/data-generator/package.json
+++ b/examples/data-generator/package.json
@@ -7,6 +7,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",
         "build-cjs": "rimraf ./dist/cjs && tsc --outDir dist/cjs",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -10,6 +10,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "authors": [
         "François Zaninotto",

--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "files": [
         "LICENSE",

--- a/packages/ra-data-graphql-simple/package.json
+++ b/packages/ra-data-graphql-simple/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "repository": {
         "type": "git",

--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "repository": {
         "type": "git",

--- a/packages/ra-data-json-server/package.json
+++ b/packages/ra-data-json-server/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "files": [
         "*.md",

--- a/packages/ra-data-localforage/package.json
+++ b/packages/ra-data-localforage/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "files": [
         "LICENSE",

--- a/packages/ra-data-localstorage/package.json
+++ b/packages/ra-data-localstorage/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "files": [
         "LICENSE",

--- a/packages/ra-data-simple-rest/package.json
+++ b/packages/ra-data-simple-rest/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "files": [
         "*.md",

--- a/packages/ra-i18n-polyglot/package.json
+++ b/packages/ra-i18n-polyglot/package.json
@@ -5,6 +5,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "files": [
         "*.md",

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -15,6 +15,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",

--- a/packages/ra-language-english/package.json
+++ b/packages/ra-language-english/package.json
@@ -14,6 +14,17 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "sideEffects": false,
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",
         "build-cjs": "rimraf ./dist/cjs && tsc --outDir dist/cjs",

--- a/packages/ra-language-french/package.json
+++ b/packages/ra-language-french/package.json
@@ -14,6 +14,17 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "sideEffects": false,
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",
         "build-cjs": "rimraf ./dist/cjs && tsc --outDir dist/cjs",

--- a/packages/ra-no-code/package.json
+++ b/packages/ra-no-code/package.json
@@ -10,6 +10,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "authors": [
         "Gildas Garcia"

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -10,6 +10,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "authors": [
         "François Zaninotto",

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -11,6 +11,16 @@
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/cjs/index.d.ts",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "require": "./dist/cjs/index.js",
+            "default": "./dist/cjs/index.js",
+            "types": "./dist/cjs/index.d.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false,
     "authors": [
         "François Zaninotto"


### PR DESCRIPTION
## Problem

When using react-admin in some applications that render it on the server using node (such as Remix), our packages triggers errors.

## Solution

Add an `exports` field to our `package.json` files to ensure they can imported in all scenarios