### PR TITLE
Fix inputs with `disabled={false}` throw an error (workaround)

### DIFF
--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -63,9 +63,23 @@ export const useInput = <ValueType = any>(
     // This ensures dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level defaultValues so that it works as it should in react-hook-form
     // (i.e. field level defaultValue override form level defaultValues for this field).
-    const { field: controllerField, fieldState, formState } = useController({
+    console.log('useController', {
         name: finalName,
         defaultValue: get(record, source, defaultValue),
+        rules: {
+            validate: async (value, values) => {
+                if (!sanitizedValidate) return true;
+                const error = await sanitizedValidate(value, values, props);
+
+                if (!error) return true;
+                return `@@react-admin@@${JSON.stringify(error)}`;
+            },
+        },
+        ...options,
+    });
+    const { field: controllerField, fieldState, formState } = useController({
+        name: finalName,
+        defaultValue: get(record, source, defaultValue), // here ?
         rules: {
             validate: async (value, values) => {
                 if (!sanitizedValidate) return true;
@@ -82,6 +96,9 @@ export const useInput = <ValueType = any>(
             },
         },
         ...options,
+        // Workaround for https://github.com/react-hook-form/react-hook-form/issues/10907
+        // FIXME - remove when fixed
+        disabled: options.disabled || undefined,
     });
 
     // Because our forms may receive an asynchronously loaded record for instance,

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -63,20 +63,6 @@ export const useInput = <ValueType = any>(
     // This ensures dynamically added inputs have their value set correctly (ArrayInput for example).
     // We don't do this for the form level defaultValues so that it works as it should in react-hook-form
     // (i.e. field level defaultValue override form level defaultValues for this field).
-    console.log('useController', {
-        name: finalName,
-        defaultValue: get(record, source, defaultValue),
-        rules: {
-            validate: async (value, values) => {
-                if (!sanitizedValidate) return true;
-                const error = await sanitizedValidate(value, values, props);
-
-                if (!error) return true;
-                return `@@react-admin@@${JSON.stringify(error)}`;
-            },
-        },
-        ...options,
-    });
     const { field: controllerField, fieldState, formState } = useController({
         name: finalName,
         defaultValue: get(record, source, defaultValue), // here ?

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -84,6 +84,7 @@ export const useInput = <ValueType = any>(
         ...options,
         // Workaround for https://github.com/react-hook-form/react-hook-form/issues/10907
         // FIXME - remove when fixed
+        // @ts-ignore - only exists since react-hook-form 7.46.0
         disabled: options.disabled || undefined,
     });
 

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -65,7 +65,7 @@ export const useInput = <ValueType = any>(
     // (i.e. field level defaultValue override form level defaultValues for this field).
     const { field: controllerField, fieldState, formState } = useController({
         name: finalName,
-        defaultValue: get(record, source, defaultValue), // here ?
+        defaultValue: get(record, source, defaultValue),
         rules: {
             validate: async (value, values) => {
                 if (!sanitizedValidate) return true;


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/9261

Actually this is a workaround, since the root issue has to be fixed on RHF's side (https://github.com/react-hook-form/react-hook-form/issues/10907)

Cannot be tested automatically.

To test:
- Upgrade to RHF >= 7.46.0
- Upgrade to React 18
- Set `disabled={false}` somewhere in the demo