### PR TITLE
Add i18n InputHelpterText section to Inputs/useInputs docs

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -766,20 +766,33 @@ Instead of HTML `input` elements, you can use a Material UI component like `Text
 ```tsx
 // in LatLongInput.js
 import TextField from '@mui/material/TextField';
+import { InputHelperText } from 'react-admin';
 import { useController } from 'react-hook-form';
 
-const BoundedTextField = ({ name, label }: { name: string; label: string }) => {
+const BoundedTextField = ({ name, label, helperText }: { name: string; label: string, helperText?: string | ReactElement | boolean }) => {
     const {
         field,
         fieldState: { isTouched, invalid, error },
         formState: { isSubmitted }
     } = useController({ name, defaultValue: '' });
+
+    const renderHelperText =
+        helperText !== false || ((isTouched || isSubmitted) && invalid);
+
     return (
         <TextField
             {...field}
             label={label}
             error={(isTouched || isSubmitted) && invalid}
-            helperText={(isTouched || isSubmitted) && invalid ? error?.message : ''}
+            helperText={
+                renderHelperText ? (
+                    <InputHelperText
+                        touched={isTouched || isSubmitted}
+                        error={error?.message}
+                        helperText={helperText}
+                    />
+                ) : null
+            }
         />
     );
 };
@@ -793,6 +806,8 @@ const LatLngInput = () => (
 ```
 
 **Tip**: Material UI's `<TextField>` component already includes a label, so you don't need to use `<Labeled>` in this case.
+
+**Tip** Notice that our custom input makes use of the react-admin component `<InputHelperText>`. This component returns a properly formatted `helperText` passed through `useTranslate`, which is important for correctly displaying form errors.
 
 **Tip**: Notice that we have added `defaultValue: ''` as one of the `useController` params. This is a good practice to avoid getting console warnings about controlled/uncontrolled components, that may arise if the value of `record.lat` or `record.lng` is `undefined` or `null`.
 
@@ -827,17 +842,17 @@ So internally, react-admin components use another hook, which wraps react-hook-f
 ```tsx
 // in LatLongInput.js
 import { TextField, TextFieldProps } from "@mui/material";
-import { useInput, required, InputProps } from "react-admin";
+import { useInput, required, InputHelperText, InputProps } from "react-admin";
 
 interface BoundedTextFieldProps
     extends Omit<
         TextFieldProps,
-        "label" | "helperText" | "onChange" | "onBlur" | "type" | "defaultValue"
+        "label" | "onChange" | "onBlur" | "type" | "defaultValue"
     >,
     InputProps {}
 
 const BoundedTextField = (props: BoundedTextFieldProps) => {
-    const { onChange, onBlur, label, ...rest } = props;
+    const { onChange, onBlur, label, helperText, ...rest } = props;
     const {
         field,
         fieldState: { isTouched, invalid, error },
@@ -851,12 +866,23 @@ const BoundedTextField = (props: BoundedTextFieldProps) => {
         ...rest,
     });
 
+    const renderHelperText =
+        helperText !== false || ((isTouched || isSubmitted) && invalid);
+
     return (
         <TextField
             {...field}
             label={label}
             error={(isTouched || isSubmitted) && invalid}
-            helperText={(isTouched || isSubmitted) && invalid ? error?.message : ""}
+            helperText={
+                renderHelperText ? (
+                    <InputHelperText
+                        touched={isTouched || isSubmitted}
+                        error={error?.message}
+                        helperText={helperText}
+                    />
+                ) : null
+            }
             required={isRequired}
             {...rest}
         />

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -766,33 +766,21 @@ Instead of HTML `input` elements, you can use a Material UI component like `Text
 ```tsx
 // in LatLongInput.js
 import TextField from '@mui/material/TextField';
-import { InputHelperText } from 'react-admin';
 import { useController } from 'react-hook-form';
 
-const BoundedTextField = ({ name, label, helperText }: { name: string; label: string, helperText?: string | ReactElement | boolean }) => {
+const BoundedTextField = ({ name, label }: { name: string; label: string }) => {
     const {
         field,
         fieldState: { isTouched, invalid, error },
         formState: { isSubmitted }
     } = useController({ name, defaultValue: '' });
 
-    const renderHelperText =
-        helperText !== false || ((isTouched || isSubmitted) && invalid);
-
     return (
         <TextField
             {...field}
             label={label}
             error={(isTouched || isSubmitted) && invalid}
-            helperText={
-                renderHelperText ? (
-                    <InputHelperText
-                        touched={isTouched || isSubmitted}
-                        error={error?.message}
-                        helperText={helperText}
-                    />
-                ) : null
-            }
+            helperText={(isTouched || isSubmitted) && invalid ? error?.message : ''}
         />
     );
 };
@@ -806,8 +794,6 @@ const LatLngInput = () => (
 ```
 
 **Tip**: Material UI's `<TextField>` component already includes a label, so you don't need to use `<Labeled>` in this case.
-
-**Tip** Notice that our custom input makes use of the react-admin component `<InputHelperText>`. This component returns a properly formatted `helperText` passed through `useTranslate`, which is important for correctly displaying form errors.
 
 **Tip**: Notice that we have added `defaultValue: ''` as one of the `useController` params. This is a good practice to avoid getting console warnings about controlled/uncontrolled components, that may arise if the value of `record.lat` or `record.lng` is `undefined` or `null`.
 
@@ -842,7 +828,7 @@ So internally, react-admin components use another hook, which wraps react-hook-f
 ```tsx
 // in LatLongInput.js
 import { TextField, TextFieldProps } from "@mui/material";
-import { useInput, required, InputHelperText, InputProps } from "react-admin";
+import { useInput, required, InputProps } from "react-admin";
 
 interface BoundedTextFieldProps
     extends Omit<
@@ -852,7 +838,7 @@ interface BoundedTextFieldProps
     InputProps {}
 
 const BoundedTextField = (props: BoundedTextFieldProps) => {
-    const { onChange, onBlur, label, helperText, ...rest } = props;
+    const { onChange, onBlur, label, ...rest } = props;
     const {
         field,
         fieldState: { isTouched, invalid, error },
@@ -866,23 +852,12 @@ const BoundedTextField = (props: BoundedTextFieldProps) => {
         ...rest,
     });
 
-    const renderHelperText =
-        helperText !== false || ((isTouched || isSubmitted) && invalid);
-
     return (
         <TextField
             {...field}
             label={label}
             error={(isTouched || isSubmitted) && invalid}
-            helperText={
-                renderHelperText ? (
-                    <InputHelperText
-                        touched={isTouched || isSubmitted}
-                        error={error?.message}
-                        helperText={helperText}
-                    />
-                ) : null
-            }
+            helperText={(isTouched || isSubmitted) && invalid ? error?.message : ""}
             required={isRequired}
             {...rest}
         />

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -961,6 +961,51 @@ const { isDirty } = useFormState(); // ✅
 const formState = useFormState(); // ❌ should deconstruct the formState      
 ```
 
+## i18n
+
+In order to properly format the input's `helperText` and error messages from `useInput()`, custom inputs should make use of the react-admin component `<InputHelperText>`, which ensures that the text below the input returns consistently whether it's a string or a React component, and whether it's a simple message or an error. Importantly, react-admin messages from `useInput()` are passed through `useTranslate()` inside `<InputHelperText>`, which makes this component important for localization.
+
+```jsx
+import TextField from '@mui/material/TextField';
+import { useInput, InputHelperText } from 'react-admin';
+
+const BoundedTextField = (props: BoundedTextFieldProps) => {
+    const { onChange, onBlur, label, helperText, ...rest } = props;
+    const {
+        field,
+        fieldState: { isTouched, invalid, error },
+        formState: { isSubmitted },
+        isRequired,
+    } = useInput({
+        onChange,
+        onBlur,
+        ...rest,
+    });
+
+    const renderHelperText =
+        helperText !== false || ((isTouched || isSubmitted) && invalid);
+
+    return (
+        <TextField
+            {...field}
+            label={label}
+            error={(isTouched || isSubmitted) && invalid}
+            helperText={
+                renderHelperText ? (
+                    <InputHelperText
+                        touched={isTouched || isSubmitted}
+                        error={error?.message}
+                        helperText={helperText}
+                    />
+                ) : null
+            }
+            required={isRequired}
+            {...rest}
+        />
+    );
+};
+```
+
 ## Third-Party Components
 
 You can find components for react-admin in third-party repositories.

--- a/docs/useInput.md
+++ b/docs/useInput.md
@@ -59,10 +59,10 @@ Additional props are passed to [react-hook-form's `useController` hook](https://
 ```jsx
 // in LatLongInput.js
 import TextField from '@mui/material/TextField';
-import { useInput, required } from 'react-admin';
+import { useInput, required, InputHelperText } from 'react-admin';
 
 const BoundedTextField = (props) => {
-    const { onChange, onBlur, ...rest } = props;
+    const { onChange, onBlur, label, helperText, ...rest } = props;
     const {
         field,
         fieldState: { isTouched, invalid, error },
@@ -73,15 +73,26 @@ const BoundedTextField = (props) => {
         // useInput will call the provided onChange and onBlur in addition to the default needed by react-hook-form.
         onChange,
         onBlur,
-        ...props,
+        ...rest,
     });
+
+    const renderHelperText =
+        helperText !== false || ((isTouched || isSubmitted) && invalid);
 
     return (
         <TextField
             {...field}
-            label={props.label}
+            label={label}
             error={(isTouched || isSubmitted) && invalid}
-            helperText={(isTouched || isSubmitted) && invalid ? error : ''}
+            helperText={
+                renderHelperText ? (
+                    <InputHelperText
+                        touched={isTouched || isSubmitted}
+                        error={error?.message}
+                        helperText={helperText}
+                    />
+                ) : null
+            }
             required={isRequired}
             {...rest}
         />

--- a/docs/useInput.md
+++ b/docs/useInput.md
@@ -148,9 +148,20 @@ const PersonEdit = () => (
 
 **Tip**: Remember to use react-admin's `<InputHelperText>` component in custom inputs to properly translate and render messages and errors coming from `useInput()`.
 
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
+## Important note about formState
+
+[react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 
 ```js
 const { isDirty } = useFormState(); // ✅
 const formState = useFormState(); // ❌ should deconstruct the formState      
+```
+
+This pattern should be followed when writing a custom input with `useInput()`.
+
+```jsx
+const { formState: { isSubmitted }} = useInput(props); // ✅
+
+const { formState } = useInput(props);
+const submitted = formState.isSubmitted; // ❌
 ```

--- a/docs/useInput.md
+++ b/docs/useInput.md
@@ -110,14 +110,6 @@ const LatLngInput = props => {
     );
 };
 ```
-
-**Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
-
-```js
-const { isDirty } = useFormState(); // ✅
-const formState = useFormState(); // ❌ should deconstruct the formState      
-```
-
 ## Usage with Material UI `<Select>`
 
 ```jsx
@@ -164,6 +156,8 @@ const PersonEdit = () => (
     </Edit>
 );
 ```
+
+**Tip**: Remember to use react-admin's `<InputHelperText>` component in custom inputs to properly translate and render messages and errors coming from `useInput()`.
 
 **Reminder:** [react-hook-form's `formState` is wrapped with a Proxy](https://react-hook-form.com/docs/useformstate/#rules) to improve render performance and skip extra computation if specific state is not subscribed. So, make sure you deconstruct or read the `formState` before render in order to enable the subscription.
 

--- a/docs/useInput.md
+++ b/docs/useInput.md
@@ -59,10 +59,10 @@ Additional props are passed to [react-hook-form's `useController` hook](https://
 ```jsx
 // in LatLongInput.js
 import TextField from '@mui/material/TextField';
-import { useInput, required, InputHelperText } from 'react-admin';
+import { useInput, required } from 'react-admin';
 
 const BoundedTextField = (props) => {
-    const { onChange, onBlur, label, helperText, ...rest } = props;
+    const { onChange, onBlur, label, ...rest } = props;
     const {
         field,
         fieldState: { isTouched, invalid, error },
@@ -76,23 +76,12 @@ const BoundedTextField = (props) => {
         ...rest,
     });
 
-    const renderHelperText =
-        helperText !== false || ((isTouched || isSubmitted) && invalid);
-
     return (
         <TextField
             {...field}
             label={label}
             error={(isTouched || isSubmitted) && invalid}
-            helperText={
-                renderHelperText ? (
-                    <InputHelperText
-                        touched={isTouched || isSubmitted}
-                        error={error?.message}
-                        helperText={helperText}
-                    />
-                ) : null
-            }
+            helperText={(isTouched || isSubmitted) && invalid ? error : ''}
             required={isRequired}
             {...rest}
         />


### PR DESCRIPTION
This PR adds an i18n section to the Inputs.md doc instructing users on the use of the `InputHelperText` component.

A **tip** referencing the use of said component has also been added to useInput.md.

I also removed a redundant `formState` reminder from useInput.md

Thanks!