### PR TITLE
Add onBeforeHideFilter function to FilterFormInput

### DIFF
--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -407,6 +407,10 @@ export default {
 }
 ```
 
+For complex filters such as the one above, or for cases involving pre-filtered lists, you may want to change the way filters are hidden. For example, in the above example, you may want to remove both the `released_gte` and `released_lte` filters when a user attempts to hide one of them. Or, you may want to provide users with a warning if they attempt to hide an important filter. For these and many other applications, you may use the prop `onBeforeHideFilter`, which, when passed to an input, will be called when the hide icon is clicked, interrupting the default process. `onBeforeHideFilter` receives the click event as an argument.
+
+**Tip**: If you make use of `onBeforeHideFilter`, you are responsible for re-initiating the `hideFilter` method from `useListContext()` after your function has run. Otherwise, the filter will not be removed.
+
 ## Saved Queries: Let Users Save Filter And Sort
 
 <video controls autoplay playsinline muted loop>

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -117,7 +117,15 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
     };
 
     const handleHide = useCallback(
-        event => hideFilter(event.currentTarget.dataset.key),
+        (event, onBeforeHideFilter) => {
+            if (
+                onBeforeHideFilter &&
+                'function' === typeof onBeforeHideFilter
+            ) {
+                return onBeforeHideFilter(event);
+            }
+            hideFilter(event.currentTarget.dataset.key);
+        },
         [hideFilter]
     );
 

--- a/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
@@ -30,7 +30,9 @@ export const FilterFormInput = props => {
                         'hide-filter',
                         FilterFormInputClasses.hideButton
                     )}
-                    onClick={handleHide}
+                    onClick={ev =>
+                        handleHide(ev, filterElement.props.onBeforeHideFilter)
+                    }
                     data-key={filterElement.props.source}
                     title={translate('ra.action.remove_filter')}
                     size="small"


### PR DESCRIPTION
This PR might be a bit of an edge-case, but it would solve a few problems on my side, and perhaps that will be the case for others.

I've added a function called `onBeforeHideFilter` that, when passed to an Input used as a filter, will interrupt the typical `hideFilter` call when that filter's Close icon is clicked. This gives the opportunity for the developer to display a warning/confirmation, to make other changes to the list (perhaps hiding columns), as well as myriad other use cases. 

In my particular case, I use a pair of DateInputs as a jury-rigged Date Range filter, and I would like to hide both DateInputs when I click the Close icon next to the pair of them. But since the input's `source` is the expected argument for updating the list's filters, and since my inputs' source naming convention is `${field_source}_from` and `${field_source}_to`, I need a supplementary way of hiding filters to accomplish this.

Let me know if you want any changes here! One though I'd had is to pass the default `hideFilter(event.currentTarget.dataset.key)` function as a second argument to `onBeforeHideFilter` so that it can be easily called after the completion of the interruption, but that may be an overcomplication.