### PR TITLE
added rowsPerPage label and its translation

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -181,6 +181,12 @@ export interface TranslationMessages extends StringMap {
             remove_message: string;
             help: string;
         };
+        rowCount: {
+            per_page_5: string;
+            per_page_10: string;
+            per_page_25: string;
+            per_page_50: string;
+        };
         configurable?: {
             customize: string;
             configureMode: string;

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -185,6 +185,12 @@ const englishMessages: TranslationMessages = {
                 'Are you sure you want to remove that item from your list of saved queries?',
             help: 'Filter the list and save this query for later',
         },
+        rowCount: {
+            per_page_5: '5 per page',
+            per_page_10: '10 per page',
+            per_page_25: '25 per page',
+            per_page_50: '50 per page',
+        },
         configurable: {
             customize: 'Customize',
             configureMode: 'Configure this page',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -192,6 +192,12 @@ const frenchMessages: TranslationMessages = {
                 'Etes-vous sûr(e) de vouloir supprimer cette requête de votre liste de requêtes ?',
             help: 'Filtrez la liste et ajoutez cette requête à votre liste',
         },
+        rowCount: {
+            per_page_5: '5 par page',
+            per_page_10: '10 par page',
+            per_page_25: '25 par page',
+            per_page_50: '50 par page',
+        },
         configurable: {
             customize: 'Personnaliser',
             configureMode: 'Configurer cette page',

--- a/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
@@ -19,6 +19,14 @@ import {
 import { PaginationActions, PaginationActionsProps } from './PaginationActions';
 
 export const Pagination: FC<PaginationProps> = memo(props => {
+    const translate = useTranslate();
+    const DefaultRowsPerPageOptions = [
+        { label: translate('ra.rowCount.per_page_5'), value: 5 },
+        { label: translate('ra.rowCount.per_page_10'), value: 10 },
+        { label: translate('ra.rowCount.per_page_25'), value: 25 },
+        { label: translate('ra.rowCount.per_page_50'), value: 50 },
+    ];
+    const emptyArray = [];
     const {
         rowsPerPageOptions = DefaultRowsPerPageOptions,
         actions,
@@ -34,7 +42,6 @@ export const Pagination: FC<PaginationProps> = memo(props => {
         setPage,
         setPerPage,
     } = useListPaginationContext(props);
-    const translate = useTranslate();
     const isSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('md')
     );
@@ -152,9 +159,6 @@ Pagination.propTypes = {
     limit: PropTypes.element,
     rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
 };
-
-const DefaultRowsPerPageOptions = [5, 10, 25, 50];
-const emptyArray = [];
 
 export interface PaginationProps
     extends TablePaginationBaseProps,


### PR DESCRIPTION
For issue #8609 

As requested I have added label to rowsPerPageOptions
Referred to docs : https://mui.com/material-ui/api/table-pagination/
Screenshot: ![image](https://github.com/marmelab/react-admin/assets/99895046/5271aeac-9dbe-49e7-aba0-dd6b765be815)

Also at PR #9324 , it was asked by @djhi sir that I should add the translation feature which I did
Screenshot: ![image](https://github.com/marmelab/react-admin/assets/99895046/8c7dbd1b-c69a-4b00-a1d5-ba53ad610520)

But unfortunately I was not able to fork 'next' branch of react-admin so I was unable to create the pull request to next branch as there was a lot of conflict if I tried to merge from master branch since the next branch is behind master branch by quiet some commits...

* [ Also a newbie mistake, I tried to fork the next branch in doing so I thought I need to delete my current forked repo as a result my last PR #9324 got closed, really sorry for that ] 