### PR TITLE
Fix useUnique send request even if the field value is empty

### DIFF
--- a/packages/ra-core/src/form/useUnique.spec.tsx
+++ b/packages/ra-core/src/form/useUnique.spec.tsx
@@ -258,4 +258,20 @@ describe('useUnique', () => {
         fireEvent.click(screen.getByText('Submit'));
         expect(screen.queryByText('Must be unique')).toBeNull();
     });
+
+    it('should not show an error when the field value is empty', async () => {
+        const dataProvider = baseDataProvider();
+        render(<Create dataProvider={dataProvider} />);
+
+        const input = await screen.findByDisplayValue('John Doe');
+        fireEvent.change(input, { target: { value: '' } });
+        fireEvent.click(screen.getByText('Submit'));
+
+        await waitFor(() => {
+            expect(dataProvider.create).toHaveBeenCalled();
+        });
+
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        expect(screen.queryByText('Must be unique')).toBeNull();
+    });
 });

--- a/packages/ra-core/src/form/useUnique.ts
+++ b/packages/ra-core/src/form/useUnique.ts
@@ -87,6 +87,9 @@ export const useUnique = (options?: UseUniqueOptions) => {
             );
 
             return async (value: any, allValues: any, props: InputProps) => {
+                if (!value) {
+                    return undefined;
+                }
                 try {
                     const finalFilter = set(
                         merge({}, filter),

--- a/packages/ra-core/src/form/useUnique.ts
+++ b/packages/ra-core/src/form/useUnique.ts
@@ -7,6 +7,7 @@ import { useCallback, useRef } from 'react';
 import set from 'lodash/set';
 import { asyncDebounce } from '../util';
 import { useRecordContext } from '../controller';
+import { isEmpty } from './validate';
 
 /**
  * A hook that returns a validation function checking for a record field uniqueness
@@ -87,7 +88,7 @@ export const useUnique = (options?: UseUniqueOptions) => {
             );
 
             return async (value: any, allValues: any, props: InputProps) => {
-                if (!value) {
+                if (isEmpty(value)) {
                     return undefined;
                 }
                 try {

--- a/packages/ra-core/src/form/validate.ts
+++ b/packages/ra-core/src/form/validate.ts
@@ -4,7 +4,7 @@ import lodashMemoize from 'lodash/memoize';
 /* @link http://stackoverflow.com/questions/46155/validate-email-address-in-javascript */
 const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; // eslint-disable-line no-useless-escape
 
-const isEmpty = (value: any) =>
+export const isEmpty = (value: any) =>
     typeof value === 'undefined' ||
     value === null ||
     value === '' ||


### PR DESCRIPTION
## Problem

While using `useUnique` in an non required input, and when sending the form with empty value within this input, `useUnique` search for data with `null` value and returns results that indicates the record is not unique and indeed, cause errors on form.

This issue happens with some DBMS and DataProvider

## Solution

Do not send request to the API if value tested by useUnique is empty.

## Todo
- [x]  use `isEmpty` function to check if the tested input is empty