### PR TITLE
Fix DatagridConfigurable editor allows to drag fields outside its list

### DIFF
--- a/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
@@ -70,7 +70,6 @@ export const FieldToggle = props => {
             }
         }
 
-        console.log({ dropItem });
         if (dropItem && list === dropItem.closest('ul')) {
             onMove(selectedItem.dataset.index, dropIndex.current);
         } else {

--- a/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
@@ -27,18 +27,22 @@ export const FieldToggle = props => {
         // imperative DOM manipulations using the native Drag API
         const selectedItem = event.target;
         selectedItem.classList.add('drag-active');
-        const list = selectedItem.parentNode;
+        const list = selectedItem.closest('ul');
         let dropItem =
             document.elementFromPoint(x.current, y.current) === null
                 ? selectedItem
-                : document.elementFromPoint(x.current, y.current);
+                : document.elementFromPoint(x.current, y.current).closest('li');
+
+        if (!dropItem) {
+            return;
+        }
         if (dropItem.classList.contains('dragIcon')) {
             dropItem = dropItem.parentNode;
         }
         if (dropItem === selectedItem) {
             return;
         }
-        if (list === dropItem.parentNode) {
+        if (list === dropItem.parentNode.closest('ul')) {
             dropIndex.current = dropItem.dataset.index;
             if (dropItem === selectedItem.nextSibling) {
                 dropItem = dropItem.nextSibling;
@@ -49,7 +53,15 @@ export const FieldToggle = props => {
 
     const handleDragEnd = event => {
         const selectedItem = event.target;
-        onMove(selectedItem.dataset.index, dropIndex.current);
+        const list = selectedItem.closest('ul');
+        let dropItem =
+            document.elementFromPoint(x.current, y.current) === null
+                ? selectedItem
+                : document.elementFromPoint(x.current, y.current).closest('li');
+
+        if (dropItem && list === dropItem.closest('ul')) {
+            onMove(selectedItem.dataset.index, dropIndex.current);
+        }
         selectedItem.classList.remove('drag-active');
         document.removeEventListener('dragover', handleDocumentDragOver);
     };
@@ -97,9 +109,10 @@ export const FieldToggle = props => {
     );
 };
 
-const Root = styled('div')(({ theme }) => ({
+const Root = styled('li')(({ theme }) => ({
     display: 'flex',
     justifyContent: 'space-between',
+    paddingLeft: 0,
     '& svg': {
         cursor: 'move',
     },

--- a/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
@@ -52,15 +52,30 @@ export const FieldToggle = props => {
     };
 
     const handleDragEnd = event => {
-        const selectedItem = event.target;
+        const selectedItem = event.target as HTMLElement;
         const list = selectedItem.closest('ul');
         let dropItem =
             document.elementFromPoint(x.current, y.current) === null
                 ? selectedItem
                 : document.elementFromPoint(x.current, y.current).closest('li');
 
+        if (!dropItem) {
+            if (
+                y.current >
+                selectedItem.closest('ul').getBoundingClientRect().bottom
+            ) {
+                dropItem = list.lastChild as HTMLElement;
+            } else {
+                dropItem = list.firstChild as HTMLElement;
+            }
+        }
+
+        console.log({ dropItem });
         if (dropItem && list === dropItem.closest('ul')) {
             onMove(selectedItem.dataset.index, dropIndex.current);
+        } else {
+            event.preventDefault();
+            event.stopPropagation();
         }
         selectedItem.classList.remove('drag-active');
         document.removeEventListener('dragover', handleDocumentDragOver);

--- a/packages/ra-ui-materialui/src/preferences/FieldsSelector.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldsSelector.tsx
@@ -100,7 +100,13 @@ export const FieldsSelector = ({
                     />
                 ))}
             </Box>
-            <Box display="flex" justifyContent="space-between" mx={-0.5} mt={1}>
+            <Box
+                onDrop={e => e.preventDefault()}
+                display="flex"
+                justifyContent="space-between"
+                mx={-0.5}
+                mt={1}
+            >
                 <Button size="small" onClick={handleHideAll}>
                     {translate('ra.inspector.hideAll', {
                         _: 'Hide All',

--- a/packages/ra-ui-materialui/src/preferences/FieldsSelector.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldsSelector.tsx
@@ -87,17 +87,19 @@ export const FieldsSelector = ({
 
     return (
         <Box pt={0.5}>
-            {availableFields.map(field => (
-                <FieldToggle
-                    key={field.index}
-                    source={field.source}
-                    label={field.label}
-                    index={field.index}
-                    selected={fields.includes(field.index)}
-                    onToggle={handleToggle}
-                    onMove={handleMove}
-                />
-            ))}
+            <Box component="ul" sx={{ paddingInlineStart: 0, m: 0 }}>
+                {availableFields.map(field => (
+                    <FieldToggle
+                        key={field.index}
+                        source={field.source}
+                        label={field.label}
+                        index={field.index}
+                        selected={fields.includes(field.index)}
+                        onToggle={handleToggle}
+                        onMove={handleMove}
+                    />
+                ))}
+            </Box>
             <Box display="flex" justifyContent="space-between" mx={-0.5} mt={1}>
                 <Button size="small" onClick={handleHideAll}>
                     {translate('ra.inspector.hideAll', {


### PR DESCRIPTION
# Problem

When configuring the `DatagridConfigurable` using its editor, one can drag and drop a field outside the list of fields (for instance below the button)

![image](https://github.com/marmelab/react-admin/assets/1122076/803887c8-be83-4f61-951f-1256597008ef)

# Solution

Wrap the items list in a `ul` element and double check users drop the column inside it