### PR TITLE
[Doc] Explain how `<PasswordInput>` can be used to update a password

### DIFF
--- a/docs/PasswordInput.md
+++ b/docs/PasswordInput.md
@@ -58,6 +58,45 @@ Set the [`autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/
 ```
 {% endraw %}
 
+## Validating Identical Passwords
+
+If you want to validate that the user has entered the same password in two different password inputs, you must use [global validation](./Validation.md#global-validation) at the form level:
+
+```jsx
+import { Create, SimpleForm, TextInput, PasswordInput } from 'react-admin';
+
+const validate = values => {
+    const errors = {} as any;
+    if (!values.name) {
+        errors.name = 'Name is required';
+    }
+    if (!values.email) {
+        errors.email = 'Email is required';
+    }
+    if (!values.password) {
+        errors.password = 'Password is required';
+    }
+    if (values.password && values.password !== values.confirm_password) {
+        errors.confirm_password = 'The two password fields must match';
+    }
+    return errors;
+}
+
+const UserCreate = () => (
+    <Create validate={validate}>
+        <SimpleForm>
+            <TextInput source="name" isRequired />
+            <TextInput source="email" isRequired />
+            <PasswordInput source="password" isRequired />
+            <PasswordInput source="confirm_password" />
+        </SimpleForm>
+    </Create>
+);
+```
+
+You can't use the `validate` prop in the Input components, as global and field-level validation are mutually exclusive. To show that an input is required, use the `isRequired` prop instead of `validate`.
+
+
 ## Usage in Edit Views
 
 You may want to allow users to *update* a password on an existing record. The usual solution to this is to include a `new_password` input in the Edition form. The API will then check if this field is present in the payload, and update the password accordingly.

--- a/docs/PasswordInput.md
+++ b/docs/PasswordInput.md
@@ -16,7 +16,7 @@ Use it like a [`<TextInput>`](./TextInput.md):
 ```jsx
 import { Create, SimpleForm, TextInput, PasswordInput } from 'react-admin';
 
-const UserCreate = () => (
+export const UserCreate = () => (
     <Create>
         <SimpleForm>
             <TextInput source="name" />
@@ -82,7 +82,7 @@ const validate = values => {
     return errors;
 }
 
-const UserCreate = () => (
+export const UserCreate = () => (
     <Create validate={validate}>
         <SimpleForm>
             <TextInput source="name" isRequired />
@@ -99,12 +99,12 @@ You can't use the `validate` prop in the Input components, as global and field-l
 
 ## Usage in Edit Views
 
-You may want to allow users to *update* a password on an existing record. The usual solution to this is to include a `new_password` input in the Edition form. The API will then check if this field is present in the payload, and update the password accordingly.
+You may want to allow users to *update* a password on an existing record. The usual solution to this is to include a `new_password` input in the Edition form. Your API should then check if this field is present in the payload, and update the password accordingly.
 
 ```jsx
 import { Edit, SimpleForm, TextInput, PasswordInput } from 'react-admin';
 
-const UserEdit = () => (
+export const UserEdit = () => (
     <Edit>
         <SimpleForm>
             <TextInput source="name" />

--- a/docs/PasswordInput.md
+++ b/docs/PasswordInput.md
@@ -14,10 +14,20 @@ title: "The PasswordInput Component"
 Use it like a [`<TextInput>`](./TextInput.md):
 
 ```jsx
-import { PasswordInput } from 'react-admin';
+import { Create, SimpleForm, TextInput, PasswordInput } from 'react-admin';
 
-<PasswordInput source="password" />
+const UserCreate = () => (
+    <Create>
+        <SimpleForm>
+            <TextInput source="name" />
+            <TextInput source="email" />
+            <PasswordInput source="password" />
+        </SimpleForm>
+    </Create>
+);
 ```
+
+**Tip**: Your API should never send the password in any of its responses, because the API backend shouldn't store the password in clear. In particular, the response to the `dataProvider.create()` call should not contain the password passed as input.
 
 ## Props
 
@@ -47,3 +57,22 @@ Set the [`autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/
 <PasswordInput source="password" inputProps={{ autocomplete: 'current-password' }} />
 ```
 {% endraw %}
+
+## Usage in Edit Views
+
+You may want to allow users to *update* a password on an existing record. The usual solution to this is to include a `new_password` input in the Edition form. The API will then check if this field is present in the payload, and update the password accordingly.
+
+```jsx
+import { Edit, SimpleForm, TextInput, PasswordInput } from 'react-admin';
+
+const UserEdit = () => (
+    <Edit>
+        <SimpleForm>
+            <TextInput source="name" />
+            <TextInput source="email" />
+            <PasswordInput source="new_password" />
+        </SimpleForm>
+    </Edit>
+);
+```
+

--- a/docs/PasswordInput.md
+++ b/docs/PasswordInput.md
@@ -60,42 +60,28 @@ Set the [`autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/
 
 ## Validating Identical Passwords
 
-If you want to validate that the user has entered the same password in two different password inputs, you must use [global validation](./Validation.md#global-validation) at the form level:
+If you want to validate that the user has entered the same password in two different password inputs, use a [custom function validator](./Validation.md#per-input-validation-custom-function-validator):
 
 ```jsx
 import { Create, SimpleForm, TextInput, PasswordInput } from 'react-admin';
 
-const validate = values => {
-    const errors = {} as any;
-    if (!values.name) {
-        errors.name = 'Name is required';
+const equalToPassword = (value, allValues) => {
+    if (value !== allValues.password) {
+        return 'The two passwords must match';
     }
-    if (!values.email) {
-        errors.email = 'Email is required';
-    }
-    if (!values.password) {
-        errors.password = 'Password is required';
-    }
-    if (values.password && values.password !== values.confirm_password) {
-        errors.confirm_password = 'The two password fields must match';
-    }
-    return errors;
 }
 
 export const UserCreate = () => (
-    <Create validate={validate}>
+    <Create>
         <SimpleForm>
-            <TextInput source="name" isRequired />
-            <TextInput source="email" isRequired />
-            <PasswordInput source="password" isRequired />
-            <PasswordInput source="confirm_password" />
+            <TextInput source="name" />
+            <TextInput source="email" />
+            <PasswordInput source="password" />
+            <PasswordInput source="confirm_password" validate={equalToPassword} />
         </SimpleForm>
     </Create>
 );
 ```
-
-You can't use the `validate` prop in the Input components, as global and field-level validation are mutually exclusive. To show that an input is required, use the `isRequired` prop instead of `validate`.
-
 
 ## Usage in Edit Views
 


### PR DESCRIPTION
## Problem

The doc doesn't explain how to use `<PasswordInput>` in Edit view. This may lead developers to expose passwords in clear.

## Solution

Be very clear about never exposing password, even in the Edition view. 

