### PR TITLE
Added type for `mutationMode` to `mutationOptions` prop for <BulkDeleteWithUndoButton>

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -12,6 +12,7 @@ import {
     useListContext,
     RaRecord,
     DeleteManyParams,
+    MutationMode,
 } from 'ra-core';
 
 import { Button, ButtonProps } from './Button';
@@ -109,7 +110,7 @@ export interface BulkDeleteWithUndoButtonProps<
         RecordType,
         MutationOptionsError,
         DeleteManyParams<RecordType>
-    > & { meta?: any };
+    > & { meta?: any; mutationMode?: MutationMode };
 }
 
 const PREFIX = 'RaBulkDeleteWithUndoButton';


### PR DESCRIPTION
 \<BulkDeleteWithUndoButton> prop `mutationOptions` does not have sufficient types.
 It lacks MutationMode. It is in fact hardcoded but it can be also overwritten by `otherMutationOptions`. 

https://github.com/marmelab/react-admin/blob/6afaa0a64b4fa9d9fc11c499395ce23a43efc42f/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx#L30-L32

https://github.com/marmelab/react-admin/blob/6afaa0a64b4fa9d9fc11c499395ce23a43efc42f/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx#L69-L74

The use case is utilization of existing bulk delete button without confirmation but with pessimistic mode.