### PR TITLE
Fix `useGetList` optimistic cache update leads to ui freeze when too many records are returned

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -91,9 +91,9 @@ export const useGetList = <RecordType extends RaRecord = any>(
                 // optimistically populate the getOne cache
                 if (
                     value?.data &&
-                    value?.data?.length <= MAX_DATA_LENGTH_TO_CACHE
+                    value.data.length <= MAX_DATA_LENGTH_TO_CACHE
                 ) {
-                    value?.data?.forEach(record => {
+                    value.data.forEach(record => {
                         queryClient.setQueryData(
                             [
                                 resource,


### PR DESCRIPTION
**Solution**: only pre-populate the `getOne` query cache when there is a reasonable number of records returned, say 100.