### PR TITLE
fix: <BooleanInput> color property should be configurable globally through MUI defaultProps system.

### DIFF
--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -77,7 +77,6 @@ export const BooleanInput = (props: BooleanInputProps) => {
                     <Switch
                         id={id}
                         name={field.name}
-                        color="primary"
                         onChange={handleChange}
                         onFocus={onFocus}
                         checked={Boolean(field.value)}


### PR DESCRIPTION
fixes #9360

Following the template used in issue: 

#### with `defaultProps` configuration

```tsx
export const theme: ThemeOptions = {
    components: {
        MuiSwitch: {
            defaultProps: {
                color: 'warning',
            },
        },
    },
};
```

![image](https://github.com/marmelab/react-admin/assets/102964006/d7336134-ba80-4933-b101-4e03eaf23ff6)

#### without

![image](https://github.com/marmelab/react-admin/assets/102964006/8fe76580-c515-4188-b685-d88e38e1ba99)

#### when specifying `color` prop

```tsx
<p>
    Switch
    <Switch color="success" />
</p>
<p>
    BooleanField
    <BooleanInput source="id" color="success" />
</p>
```

![image](https://github.com/marmelab/react-admin/assets/102964006/c62c14fc-bd19-4340-a7cf-557e07a4388e)

