### PR TITLE
match code and illustrations for SearchInput

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -17,7 +17,7 @@ We've crafted the API of react-admin's components and hooks to be as **intuitive
 
 React-admin provides the **best-in-class documentation**, demo apps, and support. Error messages are clear and actionable. Thanks to extensive TypeScript types and JSDoc, it's easy to use react-admin in any IDE. The API is stable and **breaking changes are very rare**. You can debug your app with the [query](./DataProviders.md#enabling-query-logs) and [form](https://react-hook-form.com/dev-tools) developer tools, and inspect the react-admin code right in your browser.
 
-That probably explains why more than 3,000 new apps are published every month using react-admin. 
+That probably explains why more than 3,000 new apps are published every month using react-admin.
 
 So react-admin is not just the assembly of [react-query](https://react-query.tanstack.com/), [react-hook-form](https://marmelab.com/react-admin/assets/techs/react-hook-form.jpeg), [react-router](https://reacttraining.com/react-router/), [Material UI](https://mui.com/material-ui/getting-started/) and [Emotion](https://github.com/emotion-js/emotion). It's a **framework** made to speed up and facilitate the development of single-page apps in React.
 
@@ -61,7 +61,7 @@ Which kind of API? **All kinds**. React-admin is backend agnostic. It doesn't ca
 
 React-admin ships with [more than 50 adapters](./DataProviderList.md) for popular API flavors, and gives you all the tools to build your own adapter. This works thanks to a powerful abstraction layer called the [Data Provider](./DataProviders.md).
 
-In a react-admin app, you don't write API Calls. Instead, you communicate with your API using a set of high-level functions, called "Data Provider methods". For instance, to fetch a list of posts, you call the `getList()` method, passing the resource name and the query parameters. 
+In a react-admin app, you don't write API Calls. Instead, you communicate with your API using a set of high-level functions, called "Data Provider methods". For instance, to fetch a list of posts, you call the `getList()` method, passing the resource name and the query parameters.
 
 ```jsx
 import { useState, useEffect } from 'react';
@@ -73,10 +73,10 @@ const PostList = () => {
     const [isLoading, setIsLoading] = useState(true);
     const dataProvider = useDataProvider();
     useEffect(() => {
-        dataProvider.getList('posts', { 
+        dataProvider.getList('posts', {
             pagination: { page: 1, perPage: 10 },
             sort: { field: 'published_at', order: 'DESC' },
-            filter: { status: 'published' } 
+            filter: { status: 'published' }
         })
             .then(({ data }) => setPosts(data))
             .catch(error => setError(error))
@@ -121,7 +121,7 @@ const PostList = () => {
 
 React-admin is also **backend agnostic for authentication and authorization**. Whether your API uses JWT, OAuth, a third-party provider like Auth0 or Cognito, or even Azure Active Directory, you can communicate with the authentication backend through an adapter object called [the Auth Provider](./Authentication.md).
 
-You can then use specialized hooks on your components to restrict access. For instance, to forbid anonymous access, use `useAuthenticated`: 
+You can then use specialized hooks on your components to restrict access. For instance, to forbid anonymous access, use `useAuthenticated`:
 
 ```jsx
 import { useAuthenticated } from 'react-admin';
@@ -140,7 +140,7 @@ export default MyPage;
 
 ## Relationships
 
-APIs often expose a relational model, i.e. endpoints returning foreign keys to other endpoints. **React-admin leverages relational APIs** to provide smart components that display related records and components that allow editing of related records. 
+APIs often expose a relational model, i.e. endpoints returning foreign keys to other endpoints. **React-admin leverages relational APIs** to provide smart components that display related records and components that allow editing of related records.
 
 ```
 ┌──────────────┐       ┌────────────────┐
@@ -153,7 +153,7 @@ APIs often expose a relational model, i.e. endpoints returning foreign keys to o
 └──────────────┘       └────────────────┘
 ```
 
-For instance, `<ReferenceField>` displays the name of a related record, like the name of an author for a book. 
+For instance, `<ReferenceField>` displays the name of a related record, like the name of an author for a book.
 
 ```jsx
 const BookList = () => (
@@ -170,7 +170,7 @@ const BookList = () => (
 
 ![ReferenceField](./img/reference-field-link.png)
 
-You don't need anything fancy on the API side to support that. Simple CRUD routes for both the `books` and `authors` resources are enough. `<ReferenceField>` will fetch the book authors via one single API call: 
+You don't need anything fancy on the API side to support that. Simple CRUD routes for both the `books` and `authors` resources are enough. `<ReferenceField>` will fetch the book authors via one single API call:
 
 ```
 GET https://my.api.url/authors?filter={ids:[1,2,3,4,5,6,7]}
@@ -263,7 +263,7 @@ And if the default design isn't good enough for you, you can easily customize it
 
 Modern web apps are often very visually pleasing, but they can be difficult to use due to low information density. End users need a lot of scrolling and clicking to complete moderately complex tasks.
 
-On the other hand, the default React-admin skin is designed to be dense, giving **more space to the content and less to the chrome**, which allows for faster user interaction. 
+On the other hand, the default React-admin skin is designed to be dense, giving **more space to the content and less to the chrome**, which allows for faster user interaction.
 
 [![Dense layout](./img/dense.webp)](https://marmelab.com/react-admin-demo/#/)
 
@@ -273,7 +273,7 @@ And for mobile users, react-admin renders a different layout with larger margins
 
 ## Guessers & Scaffolding
 
-When mapping a new API route to a CRUD view, adding fields one by one can be tedious. React-admin provides a set of guessers that can automatically **generate a complete CRUD UI based on an API response**. 
+When mapping a new API route to a CRUD view, adding fields one by one can be tedious. React-admin provides a set of guessers that can automatically **generate a complete CRUD UI based on an API response**.
 
 For instance, the following code will generate a complete CRUD UI for the `posts` resource:
 
@@ -341,13 +341,13 @@ In most admin and B2B apps, the most common task is to look for a record. React-
 </tr>
 </tbody></table>
 
-These features rely on powerful components with an intuitive API. For instance, you can set the Filter Button/Form Combo with the `<List filters>` prop, using the same input components as in edition forms: 
+These features rely on powerful components with an intuitive API. For instance, you can set the Filter Button/Form Combo with the `<List filters>` prop, using the same input components as in edition forms:
 
 ```jsx
-import { List, TextInput } from 'react-admin';
+import { List, TextInput, SearchInput } from 'react-admin';
 
 const postFilters = [
-    <TextInput label="Search" source="q" alwaysOn />,
+    <SearchInput source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 
@@ -365,7 +365,7 @@ Check the following chapters to learn more about each search and filtering compo
 - [`<StackedFilters>`](./StackedFilters.md)
 - [`<Search>`](./Search.md)
 
-Users often apply the same filters over and over again. Saved Queries **let users save a combination of filters** and sort parameters into a new, personal filter, that persists between sessions. 
+Users often apply the same filters over and over again. Saved Queries **let users save a combination of filters** and sort parameters into a new, personal filter, that persists between sessions.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/SavedQueriesList.webm" type="video/webm"/>
@@ -435,7 +435,7 @@ import {
     DateField,
     TextInput,
     ReferenceManyField,
-    NumberInput,    
+    NumberInput,
     DateInput,
     BooleanInput,
     EditButton
@@ -493,7 +493,7 @@ React-admin offers, out of the box, several form layouts:
 
 ### Input Components
 
-Inside forms, you can use specialize [input components](./Inputs.md), designed for many types of data: 
+Inside forms, you can use specialize [input components](./Inputs.md), designed for many types of data:
 
 | Data Type             | Example value                                                | Input Components                                                                                                                                                                                     |
 |-----------------------|--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -517,7 +517,7 @@ Inside forms, you can use specialize [input components](./Inputs.md), designed f
 | Translations          | `{ en: 'Hello', fr: 'Bonjour' }`                             | [`<TranslatableInputs>`](./TranslatableInputs.md)                                                                                                                                                    |
 | Related records       | `[{ id: 42, title: 'Hello' }, { id: 43, title: 'World' }]`   | [`<ReferenceManyInput>`](./ReferenceManyInput.md), [`<ReferenceManyToManyInput>`](./ReferenceManyToManyInput.md), [`<ReferenceOneInput>`](./ReferenceOneInput.md)                                    |
 
-### Dependent Inputs 
+### Dependent Inputs
 
 You can build dependent inputs, using the [react-hook-form's `useWatch` hook](https://react-hook-form.com/docs/usewatch). For instance, here is a `CityInput` that displays the cities of the selected country:
 
@@ -733,7 +733,7 @@ React-admin takes advantage of the Single-Page-Application architecture, impleme
 
 ## Undo
 
-When users submit a form, or delete a record, the UI reflects their change immediately. They also see a confirmation message for the change, containing an "Undo" button. If they click on it before the confirmation slides out (the default delay is 5s), react-admin reverts to the previous state and cancels the call to the data provider. 
+When users submit a form, or delete a record, the UI reflects their change immediately. They also see a confirmation message for the change, containing an "Undo" button. If they click on it before the confirmation slides out (the default delay is 5s), react-admin reverts to the previous state and cancels the call to the data provider.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/tutorial_post_edit_undo.webm" type="video/webm"/>
@@ -965,7 +965,7 @@ A UI kit like Material UI provides basic building blocks like a button, a form, 
 
 These building blocks include:
 
-- A [notification system](./useNotify.md) 
+- A [notification system](./useNotify.md)
 - A smart location framework, simplifying the management of [breadcrumbs](./Breadcrumb.md) an [hierarchical menus](./MultiLevelMenu.md)
 - [Import](https://github.com/benwinding/react-admin-import-csv) / [export](./Buttons.md#exportbutton) buttons
 - An [editable datagrid](./EditableDatagrid.md)
@@ -976,7 +976,7 @@ These building blocks include:
 - A [clone button](./Buttons.md#clonebutton)
 - Various navigation menus ([simple](./Menu.md), [hierarchical](./MultiLevelMenu.md), [horizontal](./HorizontalMenu.md), etc.)
 - Various [page](./ContainerLayout.md) and [form](https://marmelab.com/ra-enterprise/modules/ra-form-layout) layouts
-- ...and many more. 
+- ...and many more.
 
 And if you want to create your building blocks, you can use any of the [75+ hooks](./Reference.md#hooks) that carry **headless, reusable logic**. To name a few of them:
 
@@ -1148,7 +1148,7 @@ This feature leverages the following hooks:
 
 ## Preferences
 
-End-users tweak the UI to their liking, and **they expect these preferences to be saved** so that they don't need to do it again the next time they visit the app. React-admin provides a persistent `Store` for user preferences and uses it in many components. 
+End-users tweak the UI to their liking, and **they expect these preferences to be saved** so that they don't need to do it again the next time they visit the app. React-admin provides a persistent `Store` for user preferences and uses it in many components.
 
 For instance, the Saved Queries feature lets users **save a combination of filters** and sort parameters into a new, personal filter.
 
@@ -1190,7 +1190,7 @@ const SongList = () => (
 );
 ```
 
-React-admin also **persists the light/dark mode and the language choice** of end-users. 
+React-admin also **persists the light/dark mode and the language choice** of end-users.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/ToggleThemeButton.webm" type="video/webm"/>
@@ -1257,7 +1257,7 @@ Check the following components for details:
 
 The default [Material Design](https://material.io/) look and feel is nice, but a bit... Google-y. If this bothers you, or if you need to brand your app, rest assured: react-admin is fully themeable.
 
-React-admin comes with 4 built-in themes: [Default](./AppTheme.md#default), [Nano](./AppTheme.md#nano), [Radiant](./AppTheme.md#radiant), and [House](./AppTheme.md#house). The [e-commerce demo](https://marmelab.com/react-admin-demo/) contains a theme switcher, so you can test them in a real application. 
+React-admin comes with 4 built-in themes: [Default](./AppTheme.md#default), [Nano](./AppTheme.md#nano), [Radiant](./AppTheme.md#radiant), and [House](./AppTheme.md#house). The [e-commerce demo](https://marmelab.com/react-admin-demo/) contains a theme switcher, so you can test them in a real application.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/demo-themes.mp4" type="video/mp4"/>
@@ -1542,7 +1542,7 @@ Check the following sections for help on making your app responsive:
 
 ## Type-Safe
 
-React-admin is written in TypeScript. That doesn't mean you have to use TypeScript to use react-admin - **you can write react-admin apps in JavaScript**. But if you do, you get compile-time type checking for your components, hooks, data providers, auth providers, translation messages, and more. 
+React-admin is written in TypeScript. That doesn't mean you have to use TypeScript to use react-admin - **you can write react-admin apps in JavaScript**. But if you do, you get compile-time type checking for your components, hooks, data providers, auth providers, translation messages, and more.
 
 And if your IDE supports TypeScript, you get autocompletion and inline documentation for all react-admin components and hooks.
 
@@ -1556,7 +1556,7 @@ Building react-admin apps with TypeScript brings more safety and productivity to
 
 ## Sustainable
 
-Last but not least, react-admin is here to stay. That's because the development of the open-source project is **funded by the customers** of the [Enterprise Edition](https://marmelab.com/ra-enterprise/). 
+Last but not least, react-admin is here to stay. That's because the development of the open-source project is **funded by the customers** of the [Enterprise Edition](https://marmelab.com/ra-enterprise/).
 
 Maintaining a large open-source project in the long term is a challenge. But the react-admin core team, hosted by [Marmelab](https://marmelab.com), doesn't have to worry about the next funding round, or about paying back venture capital by raising prices. React-admin has zero debt, has already **passed the break-even point**, and the team will only grow as the number of customers grows.
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -344,10 +344,10 @@ In most admin and B2B apps, the most common task is to look for a record. React-
 These features rely on powerful components with an intuitive API. For instance, you can set the Filter Button/Form Combo with the `<List filters>` prop, using the same input components as in edition forms:
 
 ```jsx
-import { List, TextInput, SearchInput } from 'react-admin';
+import { List, TextInput } from 'react-admin';
 
 const postFilters = [
-    <SearchInput source="q" alwaysOn />,
+    <TextInput label="Search" source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 

--- a/docs/FilterButton.md
+++ b/docs/FilterButton.md
@@ -14,14 +14,14 @@ Part of the filter button/form combo, `<FilterButton>` renders whenever you use 
 </video>
 
 
-It's an internal component that you should only need if you build a custom List layout. 
+It's an internal component that you should only need if you build a custom List layout.
 
 ## Usage
 
 `<FilterButton>` expects an array of filter inputs as `filters` prop:
 
 ```jsx
-import { 
+import {
     CreateButton,
     Datagrid,
     FilterButton,
@@ -30,11 +30,12 @@ import {
     Pagination,
     TextField,
     TextInput,
+    SearchInput
 } from 'react-admin';
 import { Stack } from '@mui/material';
 
 const postFilters = [
-    <TextInput label="Search" source="q" alwaysOn />,
+    <SearchInput source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 
@@ -63,7 +64,7 @@ const PostList = () => (
 
 ## `disableSaveQuery`
 
-By default, the filter button lets users save a group of filters for later reuse. You can set the `disableSaveQuery` prop in the filter button to disable this feature. 
+By default, the filter button lets users save a group of filters for later reuse. You can set the `disableSaveQuery` prop in the filter button to disable this feature.
 
 ```jsx
 const ListToolbar = () => (

--- a/docs/FilterForm.md
+++ b/docs/FilterForm.md
@@ -14,14 +14,14 @@ Part of the filter button/form combo, `<FilterForm>` renders whenever you use th
 </video>
 
 
-It's an internal component that you should only need if you build a custom List layout. 
+It's an internal component that you should only need if you build a custom List layout.
 
 ## Usage
 
 `<FilterForm>` expects an array of filter inputs as `filters` prop:
 
 ```jsx
-import { 
+import {
     CreateButton,
     Datagrid,
     FilterButton,
@@ -30,11 +30,12 @@ import {
     Pagination,
     TextField,
     TextInput,
+    SearchInput
 } from 'react-admin';
 import { Stack } from '@mui/material';
 
 const postFilters = [
-    <TextInput label="Search" source="q" alwaysOn />,
+    <SearchInput source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 
@@ -60,4 +61,3 @@ const PostList = () => (
     </ListBase>
 )
 ```
-

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -5,7 +5,7 @@ title: "Filtering the List"
 
 # Filtering the List
 
-One of the most important features of the List page is the ability to filter the results. React-admin offers powerful filter components, and gets out of the way when you want to go further. 
+One of the most important features of the List page is the ability to filter the results. React-admin offers powerful filter components, and gets out of the way when you want to go further.
 
 ## Overview
 
@@ -60,13 +60,13 @@ React-admin offers 4 different ways to filter the list. Depending on the type of
 </video>
 
 
-The default appearance for filters is an inline form displayed on top of the list. Users also see a dropdown button allowing to add more inputs to that form. This functionality relies on the `<List filters>` prop: 
+The default appearance for filters is an inline form displayed on top of the list. Users also see a dropdown button allowing to add more inputs to that form. This functionality relies on the `<List filters>` prop:
 
 ```jsx
-import { TextInput } from 'react-admin';
+import { TextInput, SearchInput } from 'react-admin';
 
 const postFilters = [
-    <TextInput label="Search" source="q" alwaysOn />,
+    <SearchInput source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 
@@ -83,7 +83,7 @@ Elements passed as `filters` are regular inputs. That means you can build sophis
 
 `<List>` uses the elements passed as `filters` twice:
 
-- once to render the filter *form* 
+- once to render the filter *form*
 - once to render the filter *button* (using each element `label`, falling back to the humanized `source`)
 
 ### `<SearchInput>`
@@ -95,7 +95,7 @@ Elements passed as `filters` are regular inputs. That means you can build sophis
 </video>
 
 
-In addition to [the usual input types](./Inputs.md) (`<TextInput>`, `<SelectInput>`, `<ReferenceInput>`, etc.), you can use the `<SearchInput>` in the `filters` array. This input is designed especially for the [`Filter Form`](./FilterForm.md). It's like a `<TextInput resettable>` with a magnifier glass icon - exactly the type of input users look for when they want to do a full-text search. 
+In addition to [the usual input types](./Inputs.md) (`<TextInput>`, `<SelectInput>`, `<ReferenceInput>`, etc.), you can use the `<SearchInput>` in the `filters` array. This input is designed especially for the [`Filter Form`](./FilterForm.md). It's like a `<TextInput resettable>` with a magnifier glass icon - exactly the type of input users look for when they want to do a full-text search.
 
 ```jsx
 import { SearchInput, TextInput } from 'react-admin';
@@ -116,7 +116,7 @@ In the example given above, the `q` filter triggers a full-text search on all fi
 </video>
 
 
-Users usually dislike using their keyboard to filter a list (especially on mobile). A good way to satisfy this user requirement is to turn filters into *quick filter*. A Quick filter is a filter with a non-editable `defaultValue`. Users can only enable or disable them. 
+Users usually dislike using their keyboard to filter a list (especially on mobile). A good way to satisfy this user requirement is to turn filters into *quick filter*. A Quick filter is a filter with a non-editable `defaultValue`. Users can only enable or disable them.
 
 Here is how to implement a generic `<QuickFilter>` component:
 
@@ -139,7 +139,7 @@ const postFilters = [
 ```
 {% endraw %}
 
-**Tip**: It's currently not possible to use two quick filters for the same source. 
+**Tip**: It's currently not possible to use two quick filters for the same source.
 
 ## The `<FilterList>` Sidebar
 
@@ -283,11 +283,11 @@ Check the [`<StackedFilters>` documentation](./StackedFilters.md) for more infor
   Your browser does not support the video tag.
 </video>
 
-Although list filters allow to make precise queries using per-field criteria, users often prefer simpler interfaces like full-text search. After all, that's what they use every day on search engines, email clients, and in their file explorer. 
+Although list filters allow to make precise queries using per-field criteria, users often prefer simpler interfaces like full-text search. After all, that's what they use every day on search engines, email clients, and in their file explorer.
 
 If you want to display a full-text search allowing to look for any record in the admin using a single form input, check out [the `<Search>` component](./Search.md), an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> exclusive.
 
-`<Search>` can plug to any existing search engine (ElasticSearch, Lucene, or custom search engine), and lets you customize the search results to provide quick navigation to related items, turning the search engine into an "Omnibox": 
+`<Search>` can plug to any existing search engine (ElasticSearch, Lucene, or custom search engine), and lets you customize the search results to provide quick navigation to related items, turning the search engine into an "Omnibox":
 
 <video controls autoplay playsinline muted loop>
   <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.webm" type="video/webm" />
@@ -295,11 +295,11 @@ If you want to display a full-text search allowing to look for any record in the
   Your browser does not support the video tag.
 </video>
 
-For mode details about the global search, check the [`<Search>` documentation](./Search.md). 
+For mode details about the global search, check the [`<Search>` documentation](./Search.md).
 
 ## Filter Query Parameter
 
-React-admin uses the `filter` query parameter from the URL to determine the filters to apply to the list. 
+React-admin uses the `filter` query parameter from the URL to determine the filters to apply to the list.
 
 Here is a typical List page URL in a react-admin application:
 
@@ -325,7 +325,7 @@ When a user adds or remove a filter, react-admin changes the `filter` query para
 
 **Tip**: Once a user sets a filter, react-admin persists the filter value in the application state, so that when the user comes back to the list, they should see the filtered list. That's a design choice.
 
-**Tip**: You can change the filters programmatically by updating the query parameter, e.g. using the `<Link>` component or the `useNavigate()` hook from `react-router-dom`. 
+**Tip**: You can change the filters programmatically by updating the query parameter, e.g. using the `<Link>` component or the `useNavigate()` hook from `react-router-dom`.
 
 ## Linking To A Pre-Filtered List
 
@@ -351,7 +351,7 @@ const LinkToRelatedProducts = () => {
                 search: `filter=${JSON.stringify({ category_id: record.id })}`,
             }}
         >
-            All posts with the category {record.name} ; 
+            All posts with the category {record.name} ;
         </Button>
     ) : null;
 };
@@ -425,7 +425,7 @@ export default {
 </video>
 
 
-Saved Queries let users save a combination of filters and sort parameters into a new, personal filter. Saved queries persist between sessions, so users can find their custom queries even after closing and reopening the admin. Saved queries are available both for the Filter Button/Form combo and for the `<FilterList>` Sidebar. It's enabled by default for the Filter Button/Form combo but you have to add it yourself in the `<FilterList>` Sidebar. 
+Saved Queries let users save a combination of filters and sort parameters into a new, personal filter. Saved queries persist between sessions, so users can find their custom queries even after closing and reopening the admin. Saved queries are available both for the Filter Button/Form combo and for the `<FilterList>` Sidebar. It's enabled by default for the Filter Button/Form combo but you have to add it yourself in the `<FilterList>` Sidebar.
 
 `<SavedQueriesList>` is a complement to `<FilterList>` sections for the filter sidebar
 
@@ -469,7 +469,7 @@ const SongList = () => (
 
 If neither the Filter button/form combo nor the `<FilterList>` sidebar match your need, you can always build your own. React-admin provides shortcuts to facilitate the development of custom filters.
 
-For instance, by default, the filter button/form combo doesn't provide a submit button, and submits automatically after the user has finished interacting with the form. This provides a smooth user experience, but for some APIs, it can cause too many calls. 
+For instance, by default, the filter button/form combo doesn't provide a submit button, and submits automatically after the user has finished interacting with the form. This provides a smooth user experience, but for some APIs, it can cause too many calls.
 
 In that case, the solution is to process the filter when users click on a submit button, rather than when they type values in form inputs. React-admin doesn't provide any component for that, but it's a good opportunity to illustrate the internals of the filter functionality. We'll actually provide an alternative implementation to the Filter button/form combo.
 
@@ -511,7 +511,7 @@ const PostFilterButton = () => {
 };
 ```
 
-Normally, `showFilter()` adds one input to the `displayedFilters` list. As the filter form will be entirely hidden or shown, we use `showFilter()` with a virtual "main" input, which represents the entire form. 
+Normally, `showFilter()` adds one input to the `displayedFilters` list. As the filter form will be entirely hidden or shown, we use `showFilter()` with a virtual "main" input, which represents the entire form.
 
 ### Custom Filter Form
 

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -63,10 +63,10 @@ React-admin offers 4 different ways to filter the list. Depending on the type of
 The default appearance for filters is an inline form displayed on top of the list. Users also see a dropdown button allowing to add more inputs to that form. This functionality relies on the `<List filters>` prop:
 
 ```jsx
-import { TextInput, SearchInput } from 'react-admin';
+import { TextInput } from 'react-admin';
 
 const postFilters = [
-    <SearchInput source="q" alwaysOn />,
+    <TextInput label="Search" source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -5,7 +5,7 @@ title: "The List Component"
 
 # `<List>`
 
-The `<List>` component is the root component for list pages. It fetches a list of records from the data provider, puts it in a [`ListContext`](./useListContext.md), renders the default list page layout (title, buttons, filters, pagination), and renders its children. Usual children of `<List>`, like [`<Datagrid>`](./Datagrid.md), are responsible for displaying the list of records. 
+The `<List>` component is the root component for list pages. It fetches a list of records from the data provider, puts it in a [`ListContext`](./useListContext.md), renders the default list page layout (title, buttons, filters, pagination), and renders its children. Usual children of `<List>`, like [`<Datagrid>`](./Datagrid.md), are responsible for displaying the list of records.
 
 ![Simple posts list](./img/simple-post-list.png)
 
@@ -46,7 +46,7 @@ export default App;
 
 That's enough to display a basic post list, with functional sort and pagination.
 
-You can find more advanced examples of `<List>` usage in the [demos](./Demos.md). 
+You can find more advanced examples of `<List>` usage in the [demos](./Demos.md).
 
 ## Props
 
@@ -83,7 +83,7 @@ By default, the `<List>` view displays a toolbar on top of the list. It contains
 
 - A `<FilterButton>` to display the filter form if you set [the `filters` prop](#filters-filter-inputs)
 - A `<CreateButton>` if the resource has a creation view, or if you set [the `hasCreate` prop](#hascreate)
-- An `<ExportButton>` 
+- An `<ExportButton>`
 
 ![Actions Toolbar](./img/actions-toolbar.png)
 
@@ -98,6 +98,7 @@ import {
     List,
     SelectColumnsButton,
     TopToolbar,
+    SearchInput,
 } from 'react-admin';
 import IconEvent from '@mui/icons-material/Event';
 
@@ -111,7 +112,7 @@ const ListActions = () => (
 );
 
 const postFilters = [
-    <TextInput label="Search" source="q" alwaysOn />,
+    <SearchInput source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 
@@ -127,7 +128,7 @@ export const PostList = () => (
 Use the `useListContext` hook to customize the actions depending on the list context, and the `usePermissions` to show/hide buttons depending on permissions. For example, you can hide the `<CreateButton>` when the user doesn't have the right permission, and disable the `<ExportButton>` when the list is empty:
 
 ```jsx
-import { 
+import {
     useListContext,
     usePermissions,
     TopToolbar,
@@ -200,7 +201,7 @@ const Aside = () => {
 ```
 {% endraw %}
 
-The `aside` prop is also the preferred way to add a [Filter Sidebar](./FilteringTutorial.md#the-filterlist-sidebar) to a list view: 
+The `aside` prop is also the preferred way to add a [Filter Sidebar](./FilteringTutorial.md#the-filterlist-sidebar) to a list view:
 
 {% raw %}
 ```jsx
@@ -278,7 +279,7 @@ React-admin provides several components that can read and display a list of reco
 - [`<SimpleList>`](./SimpleList.md) displays records in a list without many details - suitable for mobile devices
 - [`<Tree>`](./TreeWithDetails.md) displays records in a tree structure
 - [`<Calendar>`](./Calendar.md) displays event records in a calendar
-- [`<SingleFieldList>`](./SingleFieldList.md) displays records inline, showing one field per record 
+- [`<SingleFieldList>`](./SingleFieldList.md) displays records inline, showing one field per record
 
 So for instance, you can use a `<SimpleList>` instead of a `<Datagrid>` on mobile devices:
 
@@ -352,7 +353,7 @@ const PostList = () => (
     </List>
 );
 
-// use a custom component as root component 
+// use a custom component as root component
 const PostList = () => (
     <List component={MyComponent}>
         ...
@@ -379,7 +380,7 @@ const PostList = () => (
 
 ## `disableAuthentication`
 
-By default, all pages using `<List>` require the user to be authenticated - any anonymous access redirects the user to the login page. 
+By default, all pages using `<List>` require the user to be authenticated - any anonymous access redirects the user to the login page.
 
 If you want to allow anonymous access to a List page, set the `disableAuthentication` prop to `true`.
 
@@ -465,7 +466,7 @@ const ProductList = () => (
 ```
 {% endraw %}
 
-The `empty` component can call the `useListContext()` hook to receive the same props as the `List` child component. 
+The `empty` component can call the `useListContext()` hook to receive the same props as the `List` child component.
 
 You can also set the `empty` props value to `false` to bypass the empty page display and render an empty list instead.
 
@@ -527,7 +528,7 @@ const SimpleBookList = () => {
 }
 ```
 
-The `<List emptyWhileLoading>` prop provides a convenient shortcut for that use case. When enabled, `<List>` won't render its child until `data` is defined. 
+The `<List emptyWhileLoading>` prop provides a convenient shortcut for that use case. When enabled, `<List>` won't render its child until `data` is defined.
 
 ```diff
 const BookList = () => (
@@ -641,7 +642,7 @@ You can add an array of filter Inputs to the List using the `filters` prop:
 
 ```jsx
 const postFilters = [
-    <TextInput label="Search" source="q" alwaysOn />,
+    <SearchInput source="q" alwaysOn />,
     <TextInput label="Title" source="title" defaultValue="Hello, World!" />,
 ];
 
@@ -656,7 +657,7 @@ export const PostList = () => (
 
 **Tip**: Filters will render as disabled inputs or menu items (depending on filter context) if passed the prop `disabled`.
 
-Filter Inputs are regular inputs. `<List>` hides them all by default, except those that have the `alwaysOn` prop. 
+Filter Inputs are regular inputs. `<List>` hides them all by default, except those that have the `alwaysOn` prop.
 
 You can also display filters as a sidebar:
 
@@ -667,7 +668,7 @@ You can also display filters as a sidebar:
 </video>
 
 
-For more details about customizing filters, see the [Filtering the List](./FilteringTutorial.md#filtering-the-list) documentation. 
+For more details about customizing filters, see the [Filtering the List](./FilteringTutorial.md#filtering-the-list) documentation.
 
 ## `filter`: Permanent Filter
 
@@ -782,7 +783,7 @@ export const PostList = () => (
 
 ## `queryOptions`
 
-`<List>` accepts a `queryOptions` prop to pass options to the react-query client. 
+`<List>` accepts a `queryOptions` prop to pass options to the react-query client.
 
 This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getList()` call.
 
@@ -856,7 +857,7 @@ export const PostList = () => (
 
 `sort` defines the *default* sort order ; the list remains sortable by clicking on column headers.
 
-For more details on list sort, see the [Sorting The List](./ListTutorial.md#sorting-the-list) section below. 
+For more details on list sort, see the [Sorting The List](./ListTutorial.md#sorting-the-list) section below.
 
 ## `storeKey`
 
@@ -960,7 +961,7 @@ Here is an example:
 {% raw %}
 ```jsx
 const PostList = () => (
-    <List 
+    <List
         sx={{
             backgroundColor: 'yellow',
             '& .RaList-content': {


### PR DESCRIPTION
## Problem
On the documentation, videos, pictures and gifs are showing `<SearchInput />` element, but in the code it's writed `<TextInput label="Search" />` as this:

![image](https://github.com/marmelab/react-admin/assets/131013150/a2621b8b-cee2-4d7d-a1e5-8419cc9b134d)

## Solution
Match code and illustrations by apllying `<SearchInput />` everywhere.