### PR TITLE
Locales button icon

### DIFF
--- a/docs/LocalesMenuButton.md
+++ b/docs/LocalesMenuButton.md
@@ -78,6 +78,22 @@ An array of objects (`{ locale, name }`) representing the key and the label of t
 
 The `locale` will be passed to `setLocale` when the user selects the language, and must be supported by the `i18nProvider`.
 
+## `icon`
+
+A React node for the icon:
+
+```jsx
+import LanguageIcon from '@mui/icons-material/Language';
+
+<LocalesMenuButton
+    languages={[
+        { locale: 'en', name: 'English' },
+        { locale: 'fr', name: 'Français' },
+    ]}
+    icon={<LanguageIcon />}
+/>
+```
+
 ## `sx`: CSS API
 
 The `<LocalesMenuButton>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property (see [the `sx` documentation](./SX.md) for syntax and examples).

--- a/packages/ra-ui-materialui/src/button/LocalesMenuButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/LocalesMenuButton.stories.tsx
@@ -6,6 +6,7 @@ import { useTranslate, Resource } from 'ra-core';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { createMemoryHistory } from 'history';
 import { Typography } from '@mui/material';
+import LanguageIcon from '@mui/icons-material/Language';
 
 import { LocalesMenuButton } from './LocalesMenuButton';
 import { AdminContext } from '../AdminContext';
@@ -50,6 +51,19 @@ export const Basic = () => (
                 { locale: 'en', name: 'English' },
                 { locale: 'fr', name: 'Français' },
             ]}
+        />
+        <Component />
+    </AdminContext>
+);
+
+export const CustomIcon = () => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <LocalesMenuButton
+            languages={[
+                { locale: 'en', name: 'English' },
+                { locale: 'fr', name: 'Français' },
+            ]}
+            icon={<LanguageIcon />}
         />
         <Component />
     </AdminContext>

--- a/packages/ra-ui-materialui/src/button/LocalesMenuButton.tsx
+++ b/packages/ra-ui-materialui/src/button/LocalesMenuButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MouseEvent, useState } from 'react';
+import { MouseEvent, ReactNode, useState } from 'react';
 import { useLocaleState, useLocales } from 'ra-core';
 import { Box, Button, Menu, MenuItem, styled } from '@mui/material';
 import LanguageIcon from '@mui/icons-material/Translate';
@@ -22,8 +22,9 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
  * );
  */
 export const LocalesMenuButton = (props: LocalesMenuButtonProps) => {
+    const { icon = DefaultIcon, languages: languagesProp } = props;
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-    const languages = useLocales({ locales: props.languages });
+    const languages = useLocales({ locales: languagesProp });
     const [locale, setLocale] = useLocaleState();
 
     const getNameForLocale = (locale: string): string => {
@@ -53,7 +54,7 @@ export const LocalesMenuButton = (props: LocalesMenuButtonProps) => {
                 aria-label=""
                 aria-haspopup="true"
                 onClick={handleLanguageClick}
-                startIcon={<LanguageIcon />}
+                startIcon={icon}
                 endIcon={<ExpandMoreIcon fontSize="small" />}
             >
                 {getNameForLocale(locale)}
@@ -79,6 +80,7 @@ export const LocalesMenuButton = (props: LocalesMenuButtonProps) => {
     );
 };
 
+const DefaultIcon = <LanguageIcon />;
 const PREFIX = 'RaLocalesMenuButton';
 
 export const LocalesMenuButtonClasses = {};
@@ -89,5 +91,6 @@ const Root = styled(Box, {
 })({});
 
 export interface LocalesMenuButtonProps {
+    icon?: ReactNode;
     languages?: { locale: string; name: string }[];
 }


### PR DESCRIPTION
If you want to customize the `<LocalesMenuButton>` icon, you have to rewrite it. This PR adds an optional `icon` prop.