### PR TITLE
GraphQL Simple Data Provider Sparse Field Support

### DIFF
--- a/packages/ra-data-graphql-simple/README.md
+++ b/packages/ra-data-graphql-simple/README.md
@@ -209,6 +209,37 @@ Pass the introspection options to the `buildApolloProvider` function:
 buildApolloProvider({ introspection: introspectionOptions });
 ```
 
+## Sparse Field Support for Queries and Mutations
+
+By default, for every API call this data provider returns all top level fields in your GraphQL schema as well as association objects containing the association's ID. If you would like to implement sparse field support for your requests, you can request the specific fields you want in a request by passing them to the dataProvider via the available [meta param](https://marmelab.com/react-admin/Actions.html#meta-parameter). For example,
+
+```js
+dataProvider.getOne(
+    'posts',
+    { 
+        id, 
+        meta: { 
+            sparseFields: [
+                'id', 
+                'title', 
+                { 
+                    comments: [
+                        'description', 
+                        { 
+                            author : [
+                                'name', 
+                                'email'
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+);
+```
+This can increase efficiency, optimize client performance, improve security and reduce over-fetching. Also, it allows for the request of nested association fields beyond just their ID. It is available for all dataprovider actions.
+
 ## `DELETE_MANY` and `UPDATE_MANY` Optimizations
 
 Your GraphQL backend may not allow multiple deletions or updates in a single query. This provider simply makes multiple requests to handle those. This is obviously not ideal but can be alleviated by supplying your own `ApolloClient` which could use the [apollo-link-batch-http](https://www.apollographql.com/docs/link/links/batch-http.html) link if your GraphQL backend support query batching.

--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.test.ts
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.test.ts
@@ -130,10 +130,133 @@ describe('buildApolloArgs', () => {
     });
 });
 
+function buildGQLParamsWithSparseFieldsFactory() {
+    const introspectionResults = {
+        resources: [
+            {
+                type: {
+                    name: 'resourceType',
+                    fields: [
+                        {
+                            name: 'id',
+                            type: { kind: TypeKind.SCALAR, name: 'ID' },
+                        },
+                        {
+                            name: 'name',
+                            type: { kind: TypeKind.SCALAR, name: 'String' },
+                        },
+                        {
+                            name: 'foo',
+                            type: { kind: TypeKind.SCALAR, name: 'String' },
+                        },
+                    ],
+                },
+            },
+        ],
+        types: [
+            {
+                name: 'linkedType',
+                fields: [
+                    {
+                        name: 'id',
+                        type: { kind: TypeKind.SCALAR, name: 'ID' },
+                    },
+                    {
+                        name: 'title',
+                        type: { kind: TypeKind.SCALAR, name: 'String' },
+                    },
+                    {
+                        name: 'nestedLink',
+                        type: {
+                            kind: TypeKind.OBJECT,
+                            name: 'nestedLinkedType',
+                        },
+                    },
+                ],
+            },
+            {
+                name: 'nestedLinkedType',
+                fields: [
+                    {
+                        name: 'id',
+                        type: { kind: TypeKind.SCALAR, name: 'ID' },
+                    },
+                    {
+                        name: 'bar',
+                        type: { kind: TypeKind.SCALAR, name: 'String' },
+                    },
+                ],
+            },
+        ],
+    };
+
+    const resource = {
+        type: {
+            fields: [
+                { type: { kind: TypeKind.SCALAR, name: 'ID' }, name: 'id' },
+                {
+                    type: { kind: TypeKind.SCALAR, name: 'String' },
+                    name: 'address',
+                },
+                {
+                    type: { kind: TypeKind.SCALAR, name: '_internalField' },
+                    name: 'foo1',
+                },
+                {
+                    type: { kind: TypeKind.OBJECT, name: 'linkedType' },
+                    name: 'linked',
+                },
+                {
+                    type: { kind: TypeKind.OBJECT, name: 'resourceType' },
+                    name: 'resource',
+                },
+            ],
+        },
+    };
+
+    const queryType = {
+        name: 'allCommand',
+        args: [
+            {
+                name: 'foo',
+                type: {
+                    kind: TypeKind.NON_NULL,
+                    ofType: { kind: TypeKind.SCALAR, name: 'Int' },
+                },
+            },
+        ],
+    };
+
+    const params = {
+        foo: 'foo_value',
+        meta: {
+            sparseFields: [
+                'address',
+                { linked: ['title'] },
+                { resource: ['foo', 'name'] },
+            ],
+        },
+    };
+
+    return { introspectionResults, queryType, params, resource };
+}
+
 describe('buildFields', () => {
     it('returns an object with the fields to retrieve', () => {
         const introspectionResults = {
-            resources: [{ type: { name: 'resourceType' } }],
+            resources: [
+                {
+                    type: {
+                        name: 'resourceType',
+                        fields: [
+                            {
+                                name: 'id',
+                                type: { kind: TypeKind.SCALAR, name: 'ID' },
+                            },
+                        ],
+                    },
+                },
+            ],
             types: [
                 {
                     name: 'linkedType',
@@ -175,10 +298,63 @@ describe('buildFields', () => {
     });
 });
 
+describe('buildFields with nested sparse fields', () => {
+    const params = {
+        foo: 'foo_value',
+        meta: {
+            sparseFields: [
+                'address',
+                { linked: ['title', { nestedLink: ['bar'] }] },
+                { resource: ['foo', 'name'] },
+            ],
+        },
+    };
+
+    it('returns an object with the fields to retrieve', () => {
+        const {
+            introspectionResults,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildFields(introspectionResults)(
+                    resource.type.fields,
+                    params.meta.sparseFields
+                )
+            )
+        ).toEqual([
+            'address',
+            `linked {
+  title
+  nestedLink {
+    bar
+  }
+}`,
+            `resource {
+  name
+  foo
+}`,
+        ]);
+    });
+});
+
 describe('buildFieldsWithCircularDependency', () => {
     it('returns an object with the fields to retrieve', () => {
         const introspectionResults = {
-            resources: [{ type: { name: 'resourceType' } }],
+            resources: [
+                {
+                    type: {
+                        name: 'resourceType',
+                        fields: [
+                            {
+                                name: 'id',
+                                type: { kind: TypeKind.SCALAR, name: 'ID' },
+                            },
+                        ],
+                    },
+                },
+            ],
             types: [
                 {
                     name: 'linkedType',
@@ -227,7 +403,19 @@ describe('buildFieldsWithCircularDependency', () => {
 describe('buildFieldsWithSameType', () => {
     it('returns an object with the fields to retrieve', () => {
         const introspectionResults = {
-            resources: [{ type: { name: 'resourceType' } }],
+            resources: [
+                {
+                    type: {
+                        name: 'resourceType',
+                        fields: [
+                            {
+                                name: 'id',
+                                type: { kind: TypeKind.SCALAR, name: 'ID' },
+                            },
+                        ],
+                    },
+                },
+            ],
             types: [
                 {
                     name: 'linkedType',
@@ -278,7 +466,19 @@ describe('buildFieldsWithSameType', () => {
 
 describe('buildGqlQuery', () => {
     const introspectionResults = {
-        resources: [{ type: { name: 'resourceType' } }],
+        resources: [
+            {
+                type: {
+                    name: 'resourceType',
+                    fields: [
+                        {
+                            name: 'id',
+                            type: { kind: TypeKind.SCALAR, name: 'ID' },
+                        },
+                    ],
+                },
+            },
+        ],
         types: [
             {
                 name: 'linkedType',
@@ -510,6 +710,249 @@ describe('buildGqlQuery', () => {
     }
     resource {
       id
+    }
+  }
+}
+`
+        );
+    });
+});
+
+describe('buildGqlQuery with sparse fields', () => {
+    it('returns the correct query for GET_LIST', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    GET_LIST,
+                    queryType,
+                    params
+                )
+            )
+        ).toEqual(
+            `query allCommand($foo: Int!) {
+  items: allCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
+    }
+  }
+  total: _allCommandMeta(foo: $foo) {
+    count
+  }
+}
+`
+        );
+    });
+    it('returns the correct query for GET_MANY', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    GET_MANY,
+                    queryType,
+                    params
+                )
+            )
+        ).toEqual(
+            `query allCommand($foo: Int!) {
+  items: allCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
+    }
+  }
+  total: _allCommandMeta(foo: $foo) {
+    count
+  }
+}
+`
+        );
+    });
+    it('returns the correct query for GET_MANY_REFERENCE', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    GET_MANY_REFERENCE,
+                    queryType,
+                    params
+                )
+            )
+        ).toEqual(
+            `query allCommand($foo: Int!) {
+  items: allCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
+    }
+  }
+  total: _allCommandMeta(foo: $foo) {
+    count
+  }
+}
+`
+        );
+    });
+    it('returns the correct query for GET_ONE', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    GET_ONE,
+                    { ...queryType, name: 'getCommand' },
+                    params
+                )
+            )
+        ).toEqual(
+            `query getCommand($foo: Int!) {
+  data: getCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
+    }
+  }
+}
+`
+        );
+    });
+    it('returns the correct query for UPDATE', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    UPDATE,
+                    { ...queryType, name: 'updateCommand' },
+                    params
+                )
+            )
+        ).toEqual(
+            `mutation updateCommand($foo: Int!) {
+  data: updateCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
+    }
+  }
+}
+`
+        );
+    });
+    it('returns the correct query for CREATE', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    CREATE,
+                    { ...queryType, name: 'createCommand' },
+                    params
+                )
+            )
+        ).toEqual(
+            `mutation createCommand($foo: Int!) {
+  data: createCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
+    }
+  }
+}
+`
+        );
+    });
+    it('returns the correct query for DELETE', () => {
+        const {
+            introspectionResults,
+            params,
+            queryType,
+            resource,
+        } = buildGQLParamsWithSparseFieldsFactory();
+
+        expect(
+            print(
+                buildGqlQuery(introspectionResults)(
+                    resource,
+                    DELETE,
+                    { ...queryType, name: 'deleteCommand' },
+                    params
+                )
+            )
+        ).toEqual(
+            `mutation deleteCommand($foo: Int!) {
+  data: deleteCommand(foo: $foo) {
+    address
+    linked {
+      title
+    }
+    resource {
+      name
+      foo
     }
   }
 }

--- a/packages/ra-data-graphql-simple/src/buildGqlQuery.ts
+++ b/packages/ra-data-graphql-simple/src/buildGqlQuery.ts
@@ -21,17 +21,61 @@ import getFinalType from './getFinalType';
 import isList from './isList';
 import isRequired from './isRequired';
 
+type SparseFields = (string | { [k: string]: SparseFields })[];
+
+function processSparseFields(
+    resourceFields: readonly IntrospectionField[],
+    sparseFields: SparseFields
+) {
+    if (!sparseFields || sparseFields.length == 0)
+        return { fields: resourceFields, linkedSparseFields: [] }; // default (which is all available resource fields) if sparse fields not specified
+
+    const resourceFNames = resourceFields.map(f => f.name);
+
+    const expandedSparseFields = sparseFields.map(sP => {
+        if (typeof sP == 'string') return { fields: [sP] };
+
+        const [linkedType, linkedSparseFields] = Object.entries(sP)[0];
+
+        return { linkedType, fields: linkedSparseFields as string[] };
+    });
+
+    const permittedSparseFields = expandedSparseFields.filter(sF =>
+        resourceFNames.includes(sF.linkedType || sF.fields[0])
+    ); // ensure the requested fields are available
+
+    const sparseFNames = permittedSparseFields.map(
+        sF => sF.linkedType || sF.fields[0]
+    );
+
+    const fields = resourceFields.filter(rF => sparseFNames.includes(rF.name));
+    const linkedSparseFields = permittedSparseFields.filter(
+        sF => !!sF.linkedType
+    ); // sparse fields to be used for linked resources / types
+
+    return { fields, linkedSparseFields };
+}
+
 export default (introspectionResults: IntrospectionResult) => (
     resource: IntrospectedResource,
     raFetchMethod: string,
     queryType: IntrospectionField,
     variables: any
 ) => {
-    const { sortField, sortOrder, ...metaVariables } = variables;
+    let { sortField, sortOrder, ...metaVariables } = variables;
+
     const apolloArgs = buildApolloArgs(queryType, variables);
     const args = buildArgs(queryType, variables);
+
+    const sparseFields = metaVariables.meta?.sparseFields;
+    if (sparseFields) delete metaVariables.meta.sparseFields;
+
     const metaArgs = buildArgs(queryType, metaVariables);
-    const fields = buildFields(introspectionResults)(resource.type.fields);
+
+    const fields = buildFields(introspectionResults)(
+        resource.type.fields,
+        sparseFields
+    );
 
     if (
         raFetchMethod === GET_LIST ||
@@ -105,8 +149,13 @@ export default (introspectionResults: IntrospectionResult) => (
 export const buildFields = (
     introspectionResults: IntrospectionResult,
     paths = []
-) => fields =>
-    fields.reduce((acc, field) => {
+) => (fields: readonly IntrospectionField[], sparseFields?: SparseFields) => {
+    const { fields: requestedFields, linkedSparseFields } = processSparseFields(
+        fields,
+        sparseFields
+    );
+
+    return requestedFields.reduce((acc, field) => {
         const type = getFinalType(field.type);
 
         if (type.name.startsWith('_')) {
@@ -122,6 +171,15 @@ export const buildFields = (
         );
 
         if (linkedResource) {
+            const linkedResourceSparseFields = linkedSparseFields.find(
+                lSP => lSP.linkedType == field.name
+            )?.fields || ['id']; // default to id if no sparse fields specified for linked resource
+
+            const linkedResourceFields = buildFields(introspectionResults)(
+                linkedResource.type.fields,
+                linkedResourceSparseFields
+            );
+
             return [
                 ...acc,
                 gqlTypes.field(
@@ -129,7 +187,7 @@ export const buildFields = (
                     null,
                     null,
                     null,
-                    gqlTypes.selectionSet([gqlTypes.field(gqlTypes.name('id'))])
+                    gqlTypes.selectionSet(linkedResourceFields)
                 ),
             ];
         }
@@ -141,6 +199,7 @@ export const buildFields = (
         if (linkedType && !paths.includes(linkedType.name)) {
             const possibleTypes =
                 (linkedType as IntrospectionUnionType).possibleTypes || [];
+
             return [
                 ...acc,
                 gqlTypes.field(
@@ -153,7 +212,12 @@ export const buildFields = (
                         ...buildFields(introspectionResults, [
                             ...paths,
                             linkedType.name,
-                        ])((linkedType as IntrospectionObjectType).fields),
+                        ])(
+                            (linkedType as IntrospectionObjectType).fields,
+                            linkedSparseFields.find(
+                                lSP => lSP.linkedType == field.name
+                            )?.fields
+                        ),
                     ])
                 ),
             ];
@@ -163,6 +227,7 @@ export const buildFields = (
         // ending with endless circular dependencies
         return acc;
     }, []);
+};
 
 export const buildFragments = (introspectionResults: IntrospectionResult) => (
     possibleTypes: readonly IntrospectionNamedTypeRef<IntrospectionObjectType>[]

--- a/packages/ra-data-graphql-simple/src/buildVariables.test.ts
+++ b/packages/ra-data-graphql-simple/src/buildVariables.test.ts
@@ -173,3 +173,181 @@ describe('buildVariables', () => {
         });
     });
 });
+
+describe('buildVariables with meta param', () => {
+    const introspectionResult = {
+        types: [
+            {
+                name: 'PostFilter',
+                inputFields: [{ name: 'tags_some' }],
+            },
+        ],
+    };
+    describe('GET_LIST', () => {
+        it('returns correct variables', () => {
+            const params = {
+                filter: {
+                    ids: ['foo1', 'foo2'],
+                    tags: { id: ['tag1', 'tag2'] },
+                    'author.id': 'author1',
+                    views: 100,
+                },
+                pagination: { page: 10, perPage: 10 },
+                sort: { field: 'sortField', order: 'DESC' },
+                meta: { sparseFields: [] },
+            };
+
+            expect(
+                buildVariables(introspectionResult)(
+                    { type: { name: 'Post', fields: [] } },
+                    GET_LIST,
+                    params,
+                    {}
+                )
+            ).toEqual({
+                filter: {
+                    ids: ['foo1', 'foo2'],
+                    tags_some: { id_in: ['tag1', 'tag2'] },
+                    author: { id: 'author1' },
+                    views: 100,
+                },
+                page: 9,
+                perPage: 10,
+                sortField: 'sortField',
+                sortOrder: 'DESC',
+                meta: { sparseFields: [] },
+            });
+        });
+    });
+
+    describe('CREATE', () => {
+        it('returns correct variables', () => {
+            const params = {
+                data: {
+                    author: { id: 'author1' },
+                    tags: [{ id: 'tag1' }, { id: 'tag2' }],
+                    title: 'Foo',
+                    meta: { sparseFields: [] },
+                },
+            };
+            const queryType = {
+                args: [{ name: 'tagsIds' }, { name: 'authorId' }],
+            };
+
+            expect(
+                buildVariables(introspectionResult)(
+                    { type: { name: 'Post' } },
+                    CREATE,
+                    params,
+                    queryType
+                )
+            ).toEqual({
+                authorId: 'author1',
+                tagsIds: ['tag1', 'tag2'],
+                title: 'Foo',
+                meta: { sparseFields: [] },
+            });
+        });
+    });
+
+    describe('UPDATE', () => {
+        it('returns correct variables', () => {
+            const params = {
+                id: 'post1',
+                data: {
+                    author: { id: 'author1' },
+                    tags: [{ id: 'tag1' }, { id: 'tag2' }],
+                    title: 'Foo',
+                    meta: { sparseFields: [] },
+                },
+            };
+            const queryType = {
+                args: [{ name: 'tagsIds' }, { name: 'authorId' }],
+            };
+
+            expect(
+                buildVariables(introspectionResult)(
+                    { type: { name: 'Post' } },
+                    UPDATE,
+                    params,
+                    queryType
+                )
+            ).toEqual({
+                id: 'post1',
+                authorId: 'author1',
+                tagsIds: ['tag1', 'tag2'],
+                title: 'Foo',
+                meta: { sparseFields: [] },
+            });
+        });
+    });
+
+    describe('GET_MANY', () => {
+        it('returns correct variables', () => {
+            const params = {
+                ids: ['tag1', 'tag2'],
+                meta: { sparseFields: [] },
+            };
+
+            expect(
+                buildVariables(introspectionResult)(
+                    { type: { name: 'Post' } },
+                    GET_MANY,
+                    params,
+                    {}
+                )
+            ).toEqual({
+                filter: { ids: ['tag1', 'tag2'] },
+                meta: { sparseFields: [] },
+            });
+        });
+    });
+
+    describe('GET_MANY_REFERENCE', () => {
+        it('returns correct variables', () => {
+            const params = {
+                target: 'author_id',
+                id: 'author1',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'name', order: 'ASC' },
+                meta: { sparseFields: [] },
+            };
+
+            expect(
+                buildVariables(introspectionResult)(
+                    { type: { name: 'Post' } },
+                    GET_MANY_REFERENCE,
+                    params,
+                    {}
+                )
+            ).toEqual({
+                filter: { author_id: 'author1' },
+                page: 0,
+                perPage: 10,
+                sortField: 'name',
+                sortOrder: 'ASC',
+                meta: { sparseFields: [] },
+            });
+        });
+    });
+
+    describe('DELETE', () => {
+        it('returns correct variables', () => {
+            const params = {
+                id: 'post1',
+                meta: { sparseFields: [] },
+            };
+            expect(
+                buildVariables(introspectionResult)(
+                    { type: { name: 'Post', inputFields: [] } },
+                    DELETE,
+                    params,
+                    {}
+                )
+            ).toEqual({
+                id: 'post1',
+                meta: { sparseFields: [] },
+            });
+        });
+    });
+});

--- a/packages/ra-data-graphql-simple/src/buildVariables.ts
+++ b/packages/ra-data-graphql-simple/src/buildVariables.ts
@@ -43,6 +43,7 @@ export default (introspectionResults: IntrospectionResult) => (
         case GET_MANY:
             return {
                 filter: { ids: preparedParams.ids },
+                ...(preparedParams.meta ? { meta: preparedParams.meta } : {}),
             };
         case GET_MANY_REFERENCE: {
             let variables = buildGetListVariables(introspectionResults)(
@@ -62,6 +63,7 @@ export default (introspectionResults: IntrospectionResult) => (
         case DELETE:
             return {
                 id: preparedParams.id,
+                ...(preparedParams.meta ? { meta: preparedParams.meta } : {}),
             };
         case CREATE:
         case UPDATE: {
@@ -188,6 +190,7 @@ const buildGetListVariables = (introspectionResults: IntrospectionResult) => (
         perPage: number;
         sortField: string;
         sortOrder: string;
+        meta?: object;
     }> = { filter: {} };
     if (params.filter) {
         variables.filter = Object.keys(params.filter).reduce((acc, key) => {
@@ -284,6 +287,8 @@ const buildGetListVariables = (introspectionResults: IntrospectionResult) => (
         variables.sortField = params.sort.field;
         variables.sortOrder = params.sort.order;
     }
+
+    if (params.meta) variables = { ...variables, meta: params.meta };
 
     return variables;
 };


### PR DESCRIPTION
### Sparse Field Support for Queries and Mutations

By default, most data provider requests return 

1. All of the resource's top level fields as defined in the GraphQL schema
2. Association objects containing only the association's ID. 

This feature enables sparse field support for all data provider requests. Sparse fields are passed through via the existing [meta param](https://marmelab.com/react-admin/Actions.html#meta-parameter). This can increase efficiency, optimize client performance, improve security and reduce over-fetching. Also, it allows for the request of nested association fields beyond just their ID. It is available for all dataprovider actions.

An example `getOne` request would look like:

```js
dataProvider.getOne(
    'posts',
    { 
        id, 
        meta: { 
            sparseFields: [
                'id', 
                'title', 
                { 
                    comments: [
                        'description', 
                        { 
                            author : [
                                'name', 
                                'email'
                            ]
                        }
                    ]
                }
            ]
        }
    },
);
```