### PR TITLE
Fix bad url upon `<FilterLiveSearch>` submission

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import { Basic, HiddenLabel } from './FilterLiveSearch.stories';
 
@@ -33,10 +33,12 @@ describe('FilterLiveSearch', () => {
     it("input search shouldn't change url on submit", () => {
         render(<Basic />);
         const input = screen.getByRole('textbox', { name: 'ra.action.search' });
-        fireEvent.change(input, { target: { value: '23' } });
-        fireEvent.click(input);
+        fireEvent.change(input, { target: { value: 'test' } });
         fireEvent.submit(input);
-        expect(window.location.href).toBe('http://localhost/');
+        waitFor(() => {
+            expect(window.location.href).toContain('?filter={"q"%3A"test"}');
+            expect(window.location.href).not.toContain('/?q=test#/');
+        });
     });
     describe('hiddenLabel', () => {
         it('turns the label into a placeholder', () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
@@ -30,6 +30,14 @@ describe('FilterLiveSearch', () => {
         fireEvent.click(screen.getByLabelText('ra.action.clear_input_value'));
         expect(screen.queryAllByRole('listitem')).toHaveLength(27);
     });
+    it("input search shouldn't change url on submit", () => {
+        render(<Basic />);
+        const input = screen.getByRole('textbox', { name: 'ra.action.search' });
+        fireEvent.change(input, { target: { value: '23' } });
+        fireEvent.click(input);
+        fireEvent.submit(input);
+        expect(window.location.href).toBe('http://localhost/');
+    });
     describe('hiddenLabel', () => {
         it('turns the label into a placeholder', () => {
             render(<HiddenLabel />);

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { Basic, HiddenLabel } from './FilterLiveSearch.stories';
 
@@ -29,16 +29,6 @@ describe('FilterLiveSearch', () => {
         expect(screen.queryAllByRole('listitem')).toHaveLength(2);
         fireEvent.click(screen.getByLabelText('ra.action.clear_input_value'));
         expect(screen.queryAllByRole('listitem')).toHaveLength(27);
-    });
-    it("input search shouldn't change url on submit", () => {
-        render(<Basic />);
-        const input = screen.getByRole('textbox', { name: 'ra.action.search' });
-        fireEvent.change(input, { target: { value: 'test' } });
-        fireEvent.submit(input);
-        waitFor(() => {
-            expect(window.location.href).toContain('?filter={"q"%3A"test"}');
-            expect(window.location.href).not.toContain('/?q=test#/');
-        });
     });
     describe('hiddenLabel', () => {
         it('turns the label into a placeholder', () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -1,9 +1,9 @@
-import SearchIcon from '@mui/icons-material/Search';
-import { InputAdornment } from '@mui/material';
-import { SxProps } from '@mui/system';
-import { useListFilterContext, useTranslate } from 'ra-core';
 import * as React from 'react';
 import { ChangeEvent, memo, useMemo } from 'react';
+import { InputAdornment } from '@mui/material';
+import { SxProps } from '@mui/system';
+import SearchIcon from '@mui/icons-material/Search';
+import { useTranslate, useListFilterContext } from 'ra-core';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { TextInput, TextInputProps } from '../../input';

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
-import { ChangeEvent, memo, useMemo } from 'react';
+import SearchIcon from '@mui/icons-material/Search';
 import { InputAdornment } from '@mui/material';
 import { SxProps } from '@mui/system';
-import SearchIcon from '@mui/icons-material/Search';
-import { useTranslate, useListFilterContext } from 'ra-core';
+import { useListFilterContext, useTranslate } from 'ra-core';
+import * as React from 'react';
+import { ChangeEvent, memo, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { TextInput, TextInputProps } from '../../input';
@@ -52,7 +52,10 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
 
     const form = useForm({ defaultValues: initialValues });
 
-    const onSubmit = () => undefined;
+    const onSubmit = e => {
+        e.preventDefault();
+    };
+
     return (
         <FormProvider {...form}>
             <form onSubmit={onSubmit}>


### PR DESCRIPTION
## Problem
FilterLiveSearch input with "Enter" keyboard event change url from `myUrl/#/myTab?filter={"q"%3A"test"}` to `myUrl/?q=test#/myTab?filter={"q"%3A"test"}`

# Solution
Catch the natural form submit actions (with e.preventDefault)

Fix #9387 