### PR TITLE
Fix i18next translation provider fails to use smart count in BulkActionsToolbar

### DIFF
--- a/packages/ra-i18n-i18next/src/stories-en.ts
+++ b/packages/ra-i18n-i18next/src/stories-en.ts
@@ -1,8 +1,7 @@
 import raMessages from 'ra-language-english';
-import { convertRaTranslationsToI18next } from './convertRaTranslationsToI18next';
 
 export default {
-    ...convertRaTranslationsToI18next(raMessages),
+    ...raMessages,
     resources: {
         posts: {
             name_one: 'Post',

--- a/packages/ra-i18n-i18next/src/stories-fr.ts
+++ b/packages/ra-i18n-i18next/src/stories-fr.ts
@@ -1,8 +1,7 @@
 import raMessages from 'ra-language-french';
-import { convertRaTranslationsToI18next } from './convertRaTranslationsToI18next';
 
 export default {
-    ...convertRaTranslationsToI18next(raMessages),
+    ...raMessages,
     resources: {
         posts: {
             name_one: 'Article',

--- a/packages/ra-i18n-i18next/src/useI18nextProvider.ts
+++ b/packages/ra-i18n-i18next/src/useI18nextProvider.ts
@@ -106,11 +106,10 @@ export const getI18nProvider = async (
 
     return {
         translate: (key: string, options: any = {}) => {
-            const { _: defaultValue, smart_count: count, ...otherOptions } =
-                options || {};
+            const { _: defaultValue, ...otherOptions } = options || {};
             return translate(key, {
                 defaultValue,
-                count,
+                count: options.smart_count,
                 ...otherOptions,
             }).toString();
         },


### PR DESCRIPTION
## Problem
The bulk actions toolbar label doesn’t replace the token with the value

## Solution
Change the variable name from `count` to `smart_count` on the i18nextProbider

## Before
![image](https://github.com/marmelab/react-admin/assets/131013150/b2a15a23-3b1b-4805-95ab-5fa9d808df75)

## After
![image](https://github.com/marmelab/react-admin/assets/131013150/dad857a1-a945-470e-89d2-6be6b8e6f683)