### PR TITLE
Fix AutoCompletInput Clear button is over BulkActionsToolbar

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -3,6 +3,7 @@ import { Admin } from 'react-admin';
 import { Resource, required, useCreate, useRecordContext } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
+import fakeRestDataProvider from 'ra-data-fakerest';
 import { createMemoryHistory } from 'history';
 import {
     Dialog,
@@ -25,6 +26,9 @@ import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import { TextInput } from './TextInput';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
+import { AdminUI } from '../AdminUI';
+import { Datagrid, List } from '../list';
+import { TextField as TextFieldByRA } from '../field';
 
 export default { title: 'ra-ui-materialui/input/AutocompleteArrayInput' };
 
@@ -588,4 +592,114 @@ export const InsideReferenceArrayInputWithCreationSupport = () => (
         <Resource name="authors" />
         <Resource name="books" edit={BookEditWithReferenceAndCreationSupport} />
     </Admin>
+);
+
+const booksDataProvider = fakeRestDataProvider({
+    books: [
+        {
+            id: 1,
+            title: 'War and Peace',
+            author: 'Leo Tolstoy',
+            year: 1869,
+        },
+        {
+            id: 2,
+            title: 'Pride and Predjudice',
+            author: 'Jane Austen',
+            year: 1813,
+        },
+        {
+            id: 3,
+            title: 'The Picture of Dorian Gray',
+            author: 'Oscar Wilde',
+            year: 1890,
+        },
+        {
+            id: 4,
+            title: 'Le Petit Prince',
+            author: 'Antoine de Saint-Exupéry',
+            year: 1943,
+        },
+        {
+            id: 5,
+            title: "Alice's Adventures in Wonderland",
+            author: 'Lewis Carroll',
+            year: 1865,
+        },
+        {
+            id: 6,
+            title: 'Madame Bovary',
+            author: 'Gustave Flaubert',
+            year: 1856,
+        },
+        {
+            id: 7,
+            title: 'The Lord of the Rings',
+            author: 'J. R. R. Tolkien',
+            year: 1954,
+        },
+        {
+            id: 8,
+            title: "Harry Potter and the Philosopher's Stone",
+            author: 'J. K. Rowling',
+            year: 1997,
+        },
+        {
+            id: 9,
+            title: 'The Alchemist',
+            author: 'Paulo Coelho',
+            year: 1988,
+        },
+        {
+            id: 10,
+            title: 'A Catcher in the Rye',
+            author: 'J. D. Salinger',
+            year: 1951,
+        },
+        {
+            id: 11,
+            title: 'Ulysses',
+            author: 'James Joyce',
+            year: 1922,
+        },
+    ],
+    authors: [],
+});
+
+const listHistory = createMemoryHistory({ initialEntries: ['/books'] });
+
+const postFilters: React.ReactElement[] = [
+    <AutocompleteArrayInput
+        label="Post"
+        source="id"
+        choices={[
+            { id: '1', name: 'post1' },
+            { id: '2', name: 'post2' },
+        ]}
+        alwaysOn
+        multiple
+    />,
+];
+export const OnAList = () => (
+    <AdminContext
+        dataProvider={booksDataProvider}
+        i18nProvider={i18nProvider}
+        history={listHistory}
+    >
+        <AdminUI>
+            <Resource
+                name="books"
+                list={
+                    <List filters={postFilters}>
+                        <Datagrid>
+                            <TextFieldByRA source="id" />
+                            <TextFieldByRA source="title" />
+                            <TextFieldByRA source="author" />
+                            <TextFieldByRA source="year" />
+                        </Datagrid>
+                    </List>
+                }
+            />
+        </AdminUI>
+    </AdminContext>
 );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -605,13 +605,6 @@ If you provided a React element for the optionText prop, you must also provide t
                                     ? inputText(option)
                                     : getChoiceText(option)
                             }
-                            sx={{
-                                '.MuiSvgIcon-root': {
-                                    // FIXME: Workaround to allow choices deletion
-                                    // Maybe related to storybook and mui using different versions of emotion
-                                    zIndex: 100,
-                                },
-                            }}
                             size="small"
                             {...getTagProps({ index })}
                         />


### PR DESCRIPTION
## Problem
When the bulk actions toolbar appears, the remove button of the chips of an AutocompleteInput filter are shown on top of the bulk actions toolbar.
![image](https://github.com/marmelab/react-admin/assets/131013150/a6f001f1-b4f5-4141-a2b7-816bb777c296)

## Solution
Fix index of this button

## Issue
#9408 