### PR TITLE
Add `onClick` prop to `<LoadingIndicator>`, allowing to trigger actions (like a refresh) on click

### DIFF
--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '@mui/material/styles';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useLoading } from 'ra-core';
 
-import { RefreshIconButton } from '../button';
+import { RefreshIconButton, RefreshIconButtonProps } from '../button';
 import { SxProps } from '@mui/system';
 
 export const LoadingIndicator = (props: LoadingIndicatorProps) => {
@@ -44,11 +44,12 @@ LoadingIndicator.propTypes = {
     width: PropTypes.string,
 };
 
-interface LoadingIndicatorProps {
+interface Props {
     className?: string;
-    onClick?: (e: MouseEvent) => void;
     sx?: SxProps;
 }
+
+type LoadingIndicatorProps = Props & Pick<RefreshIconButtonProps, 'onClick'>;
 
 const PREFIX = 'RaLoadingIndicator';
 

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
@@ -10,7 +10,7 @@ import { RefreshIconButton } from '../button';
 import { SxProps } from '@mui/system';
 
 export const LoadingIndicator = (props: LoadingIndicatorProps) => {
-    const { className, sx, ...rest } = props;
+    const { className, onClick, sx, ...rest } = props;
     const loading = useLoading();
 
     const theme = useTheme();
@@ -20,6 +20,7 @@ export const LoadingIndicator = (props: LoadingIndicatorProps) => {
                 className={`${LoadingIndicatorClasses.loadedIcon} ${
                     loading && LoadingIndicatorClasses.loadedLoading
                 }`}
+                onClick={onClick}
             />
             {loading && (
                 <CircularProgress
@@ -45,6 +46,7 @@ LoadingIndicator.propTypes = {
 
 interface LoadingIndicatorProps {
     className?: string;
+    onClick?: (e: MouseEvent) => void;
     sx?: SxProps;
 }
 


### PR DESCRIPTION
As requested in #9418

This makes it possible to invoke a callback when a user clicks the `LoadingIndicator` to trigger a refresh, primarily to address this use-case: https://github.com/marmelab/react-admin/issues/3617#issuecomment-525812935

I didn't find any existing unit tests for this part of the code, but I'm happy to add a unit test if somebody can point me to where it should go.