### PR TITLE
[Doc] Improve the Create redirect section

### DIFF
--- a/docs/Create.md
+++ b/docs/Create.md
@@ -261,6 +261,8 @@ You can customize the redirection by setting the `redirect` prop to one of the f
 - `'list'`: redirect to the List view
 - `'show'`: redirect to the Show view
 - `false`: do not redirect
+- A function `(resource, id, data) => string` to redirect to different targets depending on the record
+
 
 ```jsx
 const PostCreate = () => (


### PR DESCRIPTION
### Problem

The chapters of the Create redirect section don't list function option as it show redirect Edit section while react-admin also admit that option.

### Solution

Add that options as Edit redirect chapters
