### PR TITLE
Allow to pass custom provider types to addRefreshAuth functions

### DIFF
--- a/packages/ra-core/src/auth/addRefreshAuthToAuthProvider.ts
+++ b/packages/ra-core/src/auth/addRefreshAuthToAuthProvider.ts
@@ -20,10 +20,12 @@ import { AuthProvider } from '../types';
  *
  * const authProvider = addRefreshAuthToAuthProvider(authProvider, refreshAuth);
  */
-export const addRefreshAuthToAuthProvider = (
-    provider: AuthProvider,
+export const addRefreshAuthToAuthProvider = <
+    AuthProviderType extends AuthProvider = AuthProvider
+>(
+    provider: AuthProviderType,
     refreshAuth: () => Promise<void>
-): AuthProvider => {
+): AuthProviderType => {
     const proxy = new Proxy(provider, {
         get(_, name) {
             const shouldIntercept =

--- a/packages/ra-core/src/auth/addRefreshAuthToDataProvider.ts
+++ b/packages/ra-core/src/auth/addRefreshAuthToDataProvider.ts
@@ -19,10 +19,12 @@ import { DataProvider } from '../types';
  *
  * const dataProvider = addRefreshAuthToDataProvider(jsonServerProvider('http://localhost:3000'), refreshAuth);
  */
-export const addRefreshAuthToDataProvider = (
-    provider: DataProvider,
+export const addRefreshAuthToDataProvider = <
+    DataProviderType extends DataProvider = DataProvider
+>(
+    provider: DataProviderType,
     refreshAuth: () => Promise<void>
-): DataProvider => {
+): DataProviderType => {
     const proxy = new Proxy(provider, {
         get(_, name) {
             return async (...args: any[]) => {


### PR DESCRIPTION
## Problem

When you have a custom dataProvider with custom methods, passing it to the `addRefreshAuthToDataProvider` method loose its type. Same for the `addRefreshAuthToAuthProvider`.

## Solution

Declare a type parameter. You don't have to specify the type, it's inferred