### PR TITLE
Update `<SingleFieldList>` to make it more powerful

### DIFF
--- a/docs/SingleFieldList.md
+++ b/docs/SingleFieldList.md
@@ -13,7 +13,9 @@ Use `<SingleFieldList>` when you want to display only one property for each reco
 
 ## Usage
 
-`<SingleFieldList>` grabs the current `ListContext`, and renders a Material UI `<Stack>` with one `<ChipField>` for each record in the list, using the `recordRepresentation`. It is especially useful as child of `<ReferenceManyField>` and `<ReferenceArrayField>` components. 
+`<SingleFieldList>` grabs the current `ListContext`, and renders a Material UI `<Stack>` with one `<ChipField>` for each record in the list, using the `recordRepresentation`. It is especially useful as child of `<ReferenceManyField>` and `<ReferenceArrayField>` components.
+
+Here is an example of a Post show page showing the list of tags for the current post:
 
 ```jsx
 import {
@@ -36,7 +38,7 @@ const PostShow = () => (
 );
 ```
 
-You can customize how each record is displayed by passing a Field component as child. For example, here is how to use `<SingleFieldList>` to display a list of tags for each post in a Datagrid:
+You can also use  `<SingleFieldList>` in a list view, e.g. to display the tags for each post in a `<Datagrid>`:
 
 ```jsx
 import { 
@@ -68,6 +70,14 @@ const PostList = () => (
 ```
 
 ![SingleFieldList in Datagrid](./img/singlefieldlist-datagrid.png)
+
+You can customize how each record is displayed by passing a Field component as child. For example, you can change the field name used by the `<ChipField>`:
+
+```jsx
+<SingleFieldList>
+    <ChipField source="tag" clickable />
+</SingleFieldList>
+```
 
 ## Props
 

--- a/docs/SingleFieldList.md
+++ b/docs/SingleFieldList.md
@@ -13,15 +13,30 @@ Use `<SingleFieldList>` when you want to display only one property for each reco
 
 ## Usage
 
-Use `<SingleFieldList>` wherever there is a `ListContext`. It is especially useful as child of `<ReferenceManyField>` and `<ReferenceArrayField>` components. `<SingleFieldList>` expects a single `<Field>` as child.
+`<SingleFieldList>` grabs the current `ListContext`, and renders a Material UI `<Stack>` with one `<ChipField>` for each record in the list, using the `recordRepresentation`. It is especially useful as child of `<ReferenceManyField>` and `<ReferenceArrayField>` components. 
 
 ```jsx
-<SingleFieldList>
-    <ChipField source="name" />
-</SingleFieldList>
+import {
+    Show,
+    SimpleShowLayout,
+    TextField,
+    ReferenceArrayField,
+    SingleFieldList
+} from 'react-admin';
+
+const PostShow = () => (
+    <Show>
+        <SimpleShowLayout>
+            <TextField source="title" />
+            <ReferenceArrayField label="Tags" reference="tags" source="tags">
+                <SingleFieldList />
+            </ReferenceArrayField>
+        </SimpleShowLayout>
+    </Show>
+);
 ```
 
-The following example shows how to use `<SingleFieldList>` to display a list of tags for each post in a Datagrid:
+You can customize how each record is displayed by passing a Field component as child. For example, here is how to use `<SingleFieldList>` to display a list of tags for each post in a Datagrid:
 
 ```jsx
 import { 
@@ -45,9 +60,7 @@ const PostList = () => (
             <BooleanField source="commentable" />
             <NumberField source="views" />
             <ReferenceArrayField label="Tags" reference="tags" source="tags">
-                <SingleFieldList>
-                    <ChipField source="name" />
-                </SingleFieldList>
+                <SingleFieldList />
             </ReferenceArrayField>
         </Datagrid>
     </List>
@@ -60,10 +73,34 @@ const PostList = () => (
 
 `<SingleFieldList>` accepts the following props:
 
-| Prop        | Required | Type                      | Default | Description                                   |
-| ----------- | -------- | ------------------------- | ------- | --------------------------------------------- |
-| `linkType`  | Optional | `'edit' | 'show' | false` | `edit`  | The target of the link on each item           |
-| `sx`        | Optional | `object`                  |         | The sx props of the Material UI Box component |
+| Prop        | Required | Type                      | Default | Description                                     |
+| ----------- | -------- | ------------------------- | ------- | ----------------------------------------------- |
+| `children`  | Optional | `ReactNode`               |         | React element to render for each record         |
+| `empty`     | Optional | `ReactNode`               |         | React element to display when the list is empty |
+| `linkType`  | Optional | `'edit' | 'show' | false` | `edit`  | The target of the link on each item             |
+| `sx`        | Optional | `object`                  |         | The sx props of the Material UI Box component   |
+
+Additional props are passed down to the underlying [Material UI `<Stack>` component](https://mui.com/material-ui/react-stack/).
+
+## `children`
+
+By default, `<SingleFieldList>` renders a `<ChipField>` for each record. You can customize the rendering by passing a Field component as child. 
+
+For example, if you want to customize the field name used by the `<ChipField>`:
+
+```jsx
+<SingleFieldList>
+    <ChipField source="tag" clickable />
+</SingleFieldList>
+```
+
+## `empty`
+
+When the list is empty, `<SingleFieldList>` displays nothing. You can customize this behavior by passing a React element as the `empty` prop. For example, to display a message:
+
+```jsx
+<SingleFieldList empty={<p>Nothing to display</p>} />
+```
 
 ## `linkType`
 
@@ -76,9 +113,7 @@ The `<SingleFieldList>` items link to the edition page by default. You can set t
     reference="tags"
     source="tags"
 >
-    <SingleFieldList linkType="show">
-        <ChipField source="name" />
-    </SingleFieldList>
+    <SingleFieldList linkType="show" />
 </ReferenceArrayField>
 ```
 

--- a/examples/crm/src/contacts/ContactList.tsx
+++ b/examples/crm/src/contacts/ContactList.tsx
@@ -88,7 +88,8 @@ const ContactListContent = () => {
                                             <TextField source="name" />
                                         </ReferenceField>{' '}
                                         {contact.nb_notes &&
-                                            `- ${contact.nb_notes} notes `}
+                                            `- ${contact.nb_notes} notes`}
+                                        &nbsp;&nbsp;
                                         <TagsList />
                                     </>
                                 }

--- a/examples/crm/src/contacts/TagsList.tsx
+++ b/examples/crm/src/contacts/TagsList.tsx
@@ -26,7 +26,7 @@ export const TagsList = () => (
         source="tags"
         reference="tags"
     >
-        <SingleFieldList linkType={false} component="span">
+        <SingleFieldList linkType={false}>
             <ColoredChipField source="name" variant="outlined" size="small" />
         </SingleFieldList>
     </ReferenceArrayField>

--- a/examples/simple/src/posts/PostList.tsx
+++ b/examples/simple/src/posts/PostList.tsx
@@ -192,8 +192,8 @@ const PostListDesktop = () => (
                 cellClassName="hiddenOnSmallScreens"
                 headerClassName="hiddenOnSmallScreens"
             >
-                <SingleFieldList sx={{ my: -2 }}>
-                    <ChipField source="name.en" size="small" />
+                <SingleFieldList>
+                    <ChipField clickable source="name.en" size="small" />
                 </SingleFieldList>
             </ReferenceArrayField>
             <NumberField source="average_note" />

--- a/examples/simple/src/posts/PostShow.tsx
+++ b/examples/simple/src/posts/PostShow.tsx
@@ -75,6 +75,7 @@ const PostShow = () => {
                                 <ChipField
                                     source={`name.${locale}`}
                                     size="small"
+                                    clickable
                                 />
                             </SingleFieldList>
                         </ReferenceArrayField>

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -71,5 +71,5 @@ const StyledChip = styled(Chip, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })({
-    [`&.${ChipFieldClasses.chip}`]: { margin: 4, cursor: 'inherit' },
+    [`&.${ChipFieldClasses.chip}`]: { cursor: 'inherit' },
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.stories.tsx
@@ -1,14 +1,70 @@
 import * as React from 'react';
 import fakeRestProvider from 'ra-data-fakerest';
+import { CardContent } from '@mui/material';
+import { ResourceDefinitionContextProvider } from 'ra-core';
 
 import { AdminContext } from '../AdminContext';
 import { Datagrid } from '../list';
 import { ReferenceArrayField } from './ReferenceArrayField';
 import { TextField } from './TextField';
-import { Show } from '../detail';
-import { CardContent } from '@mui/material';
+import { Show, SimpleShowLayout } from '../detail';
+
+export default { title: 'ra-ui-materialui/fields/ReferenceArrayField' };
 
 const fakeData = {
+    bands: [{ id: 1, name: 'The Beatles', members: [1, 2, 3, 4] }],
+    artists: [
+        { id: 1, name: 'John Lennon' },
+        { id: 2, name: 'Paul McCartney' },
+        { id: 3, name: 'Ringo Star' },
+        { id: 4, name: 'George Harrison' },
+        { id: 5, name: 'Mick Jagger' },
+    ],
+};
+const dataProvider = fakeRestProvider(fakeData, false);
+
+const resouceDefs = {
+    artists: {
+        name: 'artists',
+        hasList: true,
+        hasEdit: true,
+        hasShow: true,
+        hasCreate: true,
+        recordRepresentation: 'name',
+    },
+};
+export const Basic = () => (
+    <AdminContext dataProvider={dataProvider}>
+        <ResourceDefinitionContextProvider definitions={resouceDefs}>
+            <Show resource="bands" id={1} sx={{ width: 600 }}>
+                <SimpleShowLayout>
+                    <TextField source="name" />
+                    <ReferenceArrayField source="members" reference="artists" />
+                </SimpleShowLayout>
+            </Show>
+        </ResourceDefinitionContextProvider>
+    </AdminContext>
+);
+
+export const Children = () => (
+    <AdminContext dataProvider={dataProvider}>
+        <ResourceDefinitionContextProvider definitions={resouceDefs}>
+            <Show resource="bands" id={1} sx={{ width: 600 }}>
+                <SimpleShowLayout>
+                    <TextField source="name" />
+                    <ReferenceArrayField source="members" reference="artists">
+                        <Datagrid bulkActionButtons={false}>
+                            <TextField source="id" />
+                            <TextField source="name" />
+                        </Datagrid>
+                    </ReferenceArrayField>
+                </SimpleShowLayout>
+            </Show>
+        </ResourceDefinitionContextProvider>
+    </AdminContext>
+);
+
+const fakeDataWidthDifferentIdTypes = {
     bands: [{ id: 1, name: 'band_1', members: [1, '2', '3'] }],
     artists: [
         { id: 1, name: 'artist_1' },
@@ -17,32 +73,30 @@ const fakeData = {
         { id: 4, name: 'artist_4' },
     ],
 };
+const dataProviderWithDifferentIdTypes = fakeRestProvider(
+    fakeDataWidthDifferentIdTypes,
+    false
+);
 
-export default { title: 'ra-ui-materialui/fields/ReferenceArrayField' };
-
-const dataProvider = fakeRestProvider(fakeData, false);
-
-export const DifferentIdTypes = () => {
-    return (
-        <AdminContext dataProvider={dataProvider}>
-            <CardContent>
-                <Show resource="bands" id={1} sx={{ width: 600 }}>
-                    <TextField source="name" fullWidth />
-                    <ReferenceArrayField
-                        fullWidth
-                        source="members"
-                        reference="artists"
-                    >
-                        <Datagrid bulkActionButtons={false}>
-                            <TextField source="id" />
-                            <TextField source="name" />
-                        </Datagrid>
-                    </ReferenceArrayField>
-                </Show>
-            </CardContent>
-        </AdminContext>
-    );
-};
+export const DifferentIdTypes = () => (
+    <AdminContext dataProvider={dataProviderWithDifferentIdTypes}>
+        <CardContent>
+            <Show resource="bands" id={1} sx={{ width: 600 }}>
+                <TextField source="name" fullWidth />
+                <ReferenceArrayField
+                    fullWidth
+                    source="members"
+                    reference="artists"
+                >
+                    <Datagrid bulkActionButtons={false}>
+                        <TextField source="id" />
+                        <TextField source="name" />
+                    </Datagrid>
+                </ReferenceArrayField>
+            </Show>
+        </CardContent>
+    </AdminContext>
+);
 
 const dataProviderWithLog = {
     ...dataProvider,

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -10,17 +10,15 @@ import {
     FilterPayload,
     ResourceContextProvider,
     useRecordContext,
-    useResourceDefinition,
     RaRecord,
 } from 'ra-core';
 import { styled } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
+import { UseQueryOptions } from 'react-query';
 
 import { fieldPropTypes, FieldProps } from './types';
 import { LinearProgress } from '../layout';
 import { SingleFieldList } from '../list/SingleFieldList';
-import { ChipField } from './ChipField';
-import { UseQueryOptions } from 'react-query';
 
 /**
  * A container component that fetches records from another resource specified
@@ -152,26 +150,8 @@ export interface ReferenceArrayFieldViewProps
         Omit<ListControllerProps, 'queryOptions'> {}
 
 export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props => {
-    const { children, pagination, reference, className, sx } = props;
+    const { children, pagination, className, sx } = props;
     const { isLoading, total } = useListContext(props);
-
-    const { recordRepresentation } = useResourceDefinition({
-        resource: reference,
-    });
-    let child = children ? (
-        children
-    ) : (
-        <SingleFieldList>
-            <ChipField
-                source={
-                    typeof recordRepresentation === 'string'
-                        ? recordRepresentation
-                        : 'id'
-                }
-                size="small"
-            />
-        </SingleFieldList>
-    );
 
     return (
         <Root className={className} sx={sx}>
@@ -181,7 +161,7 @@ export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props =
                 />
             ) : (
                 <span>
-                    {child}
+                    {children || <SingleFieldList />}
                     {pagination && total !== undefined ? pagination : null}
                 </span>
             )}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -103,11 +103,6 @@ export const SimpleList = <RecordType extends RaRecord = any>(
         );
     }
 
-    /**
-     * Once loaded, the data for the list may be empty. Instead of
-     * displaying the table header with zero data rows,
-     * the SimpleList the empty component.
-     */
     if (data == null || data.length === 0 || total === 0) {
         if (empty) {
             return empty;

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.spec.tsx
@@ -5,6 +5,7 @@ import { ListContext, ResourceContextProvider } from 'ra-core';
 import { AdminContext } from '../AdminContext';
 import { SingleFieldList } from './SingleFieldList';
 import { ChipField } from '../field';
+import { Empty } from './SingleFieldList.stories';
 
 describe('<SingleFieldList />', () => {
     it('should render a link to the Edit page of the related record by default', () => {
@@ -149,28 +150,43 @@ describe('<SingleFieldList />', () => {
         });
     });
 
-    it('should render no link when the linkType is false', () => {
-        render(
-            <AdminContext>
-                <ListContext.Provider
-                    value={{
-                        data: [
-                            { id: 1, title: 'foo' },
-                            { id: 2, title: 'bar' },
-                        ],
-                        resource: 'bar',
-                    }}
-                >
-                    <SingleFieldList linkType={false}>
-                        <ChipField source="title" />
-                    </SingleFieldList>
-                </ListContext.Provider>
-            </AdminContext>
-        );
+    describe('linkType', () => {
+        it('should render no link when the linkType is false', () => {
+            render(
+                <AdminContext>
+                    <ListContext.Provider
+                        value={{
+                            data: [
+                                { id: 1, title: 'foo' },
+                                { id: 2, title: 'bar' },
+                            ],
+                            resource: 'bar',
+                        }}
+                    >
+                        <SingleFieldList linkType={false}>
+                            <ChipField source="title" />
+                        </SingleFieldList>
+                    </ListContext.Provider>
+                </AdminContext>
+            );
 
-        const linkElements = screen.queryAllByRole('link');
-        expect(linkElements).toHaveLength(0);
-        expect(screen.queryByText('foo')).not.toBeNull();
-        expect(screen.queryByText('bar')).not.toBeNull();
+            const linkElements = screen.queryAllByRole('link');
+            expect(linkElements).toHaveLength(0);
+            expect(screen.queryByText('foo')).not.toBeNull();
+            expect(screen.queryByText('bar')).not.toBeNull();
+        });
+    });
+
+    describe('empty', () => {
+        it('should use the empty element when there is no data', () => {
+            render(<Empty />);
+            expect(screen.queryByText('No genres')).not.toBeNull();
+        });
+        it('should not render the empty element while loading', () => {
+            render(
+                <Empty listContext={{ isLoading: true, data: [] } as any} />
+            );
+            expect(screen.queryByText('No genres')).toBeNull();
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.stories.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import {
+    ListContextProvider,
+    ResourceContextProvider,
+    ResourceDefinitionContextProvider,
+    useList,
+} from 'ra-core';
+import { MemoryRouter } from 'react-router-dom';
+import { Typography, Divider as MuiDivider } from '@mui/material';
+
+import { SingleFieldList } from './SingleFieldList';
+import { ChipField } from '../field/ChipField';
+import { TextField } from '../field/TextField';
+
+const bookGenres = [
+    { id: 0, name: 'Fiction' },
+    { id: 1, name: 'Science-fiction' },
+    { id: 2, name: 'Horror' },
+    { id: 3, name: 'Biography' },
+    { id: 4, name: 'Historical' },
+    { id: 5, name: 'Crime' },
+    { id: 6, name: 'Romance' },
+    { id: 7, name: 'Humor' },
+];
+
+export default {
+    title: 'ra-ui-materialui/list/SingleFieldList',
+};
+
+const Wrapper = ({
+    children,
+    data = [bookGenres[2], bookGenres[4], bookGenres[1]],
+}) => {
+    const listContextValue = useList({
+        data,
+    });
+    return (
+        <MemoryRouter>
+            <ResourceDefinitionContextProvider
+                definitions={{
+                    books: {
+                        name: 'books',
+                        hasList: true,
+                        hasEdit: true,
+                        hasShow: true,
+                        hasCreate: true,
+                        recordRepresentation: 'name',
+                    },
+                }}
+            >
+                <ResourceContextProvider value="books">
+                    <ListContextProvider value={listContextValue}>
+                        {children}
+                    </ListContextProvider>
+                </ResourceContextProvider>
+            </ResourceDefinitionContextProvider>
+        </MemoryRouter>
+    );
+};
+const Title = ({ children }) => (
+    <Typography ml={1} mt={2} mb={1}>
+        {children}
+    </Typography>
+);
+
+export const Basic = () => (
+    <Wrapper>
+        <SingleFieldList />
+    </Wrapper>
+);
+
+export const Children = () => (
+    <Wrapper>
+        <Title>Text Field</Title>
+        <SingleFieldList>
+            <TextField
+                source="name"
+                sx={{
+                    m: 1,
+                    p: 0.5,
+                    border: '1px solid grey',
+                    borderRadius: 2,
+                }}
+            />
+        </SingleFieldList>
+        <Title>Chip Field</Title>
+        <SingleFieldList>
+            <ChipField source="name" />
+        </SingleFieldList>
+        <Title>Chip Field small</Title>
+        <SingleFieldList>
+            <ChipField source="name" size="small" />
+        </SingleFieldList>
+    </Wrapper>
+);
+
+export const LinkType = () => (
+    <Wrapper>
+        <Title>Default (Edit link)</Title>
+        <SingleFieldList />
+        <Title>Show link</Title>
+        <SingleFieldList linkType="show" />
+        <Title>No link</Title>
+        <SingleFieldList linkType={false} />
+    </Wrapper>
+);
+
+export const NoData = () => (
+    <Wrapper data={[]}>
+        <SingleFieldList />
+    </Wrapper>
+);
+
+export const Empty = ({ listContext = { data: [] } }) => (
+    <ListContextProvider value={listContext as any}>
+        <SingleFieldList empty={<div>No genres</div>} />
+    </ListContextProvider>
+);
+
+export const Loading = () => (
+    <ListContextProvider value={{ isLoading: true } as any}>
+        <SingleFieldList />
+    </ListContextProvider>
+);
+
+export const Direction = () => (
+    <Wrapper>
+        <Title>Default (row)</Title>
+        <SingleFieldList />
+        <Title>Column</Title>
+        <SingleFieldList direction="column" />
+    </Wrapper>
+);
+
+export const Gap = () => (
+    <Wrapper>
+        <Title>No gap</Title>
+        <SingleFieldList gap={0} />
+        <Title>Default (1)</Title>
+        <SingleFieldList />
+        <Title>Custom gap</Title>
+        <SingleFieldList gap={2} />
+    </Wrapper>
+);
+
+export const Divider = () => (
+    <Wrapper>
+        <SingleFieldList
+            divider={<MuiDivider orientation="vertical" flexItem />}
+        />
+    </Wrapper>
+);
+
+export const SX = () => (
+    <Wrapper>
+        <SingleFieldList sx={{ border: '1px solid grey' }} />
+    </Wrapper>
+);
+
+export const Controlled = () => (
+    <Wrapper>
+        <SingleFieldList
+            data={[bookGenres[3], bookGenres[6], bookGenres[7], bookGenres[2]]}
+            resource="book_genres"
+        />
+    </Wrapper>
+);

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.stories.tsx
@@ -151,6 +151,12 @@ export const Divider = () => (
     </Wrapper>
 );
 
+export const Component = () => (
+    <Wrapper>
+        <SingleFieldList component="span" />
+    </Wrapper>
+);
+
 export const SX = () => (
     <Wrapper>
         <SingleFieldList sx={{ border: '1px solid grey' }} />

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -54,7 +54,6 @@ export const SingleFieldList = (props: SingleFieldListProps) => {
         children,
         empty,
         linkType = 'edit',
-        component: Component = Root,
         gap = 1,
         direction = 'row',
         ...rest
@@ -76,7 +75,7 @@ export const SingleFieldList = (props: SingleFieldListProps) => {
     }
 
     return (
-        <Component
+        <Root
             gap={gap}
             direction={direction}
             className={className}
@@ -119,7 +118,7 @@ export const SingleFieldList = (props: SingleFieldListProps) => {
                     </RecordContextProvider>
                 );
             })}
-        </Component>
+        </Root>
     );
 };
 

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -18,29 +18,31 @@ import { Link } from '../Link';
 /**
  * Iterator component to be used to display a list of entities, using a single field
  *
- * @example Display all the books by the current author
- * <ReferenceManyField reference="books" target="author_id">
+ * @example Display all the orders by the current customer as a list of chips
+ * <ReferenceManyField reference="orders" target="customer_id">
+ *     <SingleFieldList />
+ * </ReferenceManyField>
+
+* @example Choose the field to be used as text label
+ * <ReferenceManyField reference="orders" target="customer_id">
  *     <SingleFieldList>
- *         <ChipField source="title" />
+ *         <ChipField source="reference" />
  *     </SingleFieldList>
  * </ReferenceManyField>
  *
- * By default, it includes a link to the <Edit> page of the related record
- * (`/books/:id` in the previous example).
- *
- * Set the linkType prop to "show" to link to the <Show> page instead.
- *
- * @example
+ * @example Customize the link type
+ * // By default, it includes a link to the <Edit> page of the related record
+ * // (`/orders/:id` in the previous example).
+ * // Set the linkType prop to "show" to link to the <Show> page instead.
  * <ReferenceManyField reference="books" target="author_id">
  *     <SingleFieldList linkType="show">
  *         <ChipField source="title" />
  *     </SingleFieldList>
  * </ReferenceManyField>
  *
- * You can also prevent `<SingleFieldList>` from adding link to children by setting
- * `linkType` to false.
- *
- * @example
+ * @example Disable the link
+ * // You can also prevent `<SingleFieldList>` from adding link to children by
+ * // setting `linkType` to false.
  * <ReferenceManyField reference="books" target="author_id">
  *     <SingleFieldList linkType={false}>
  *         <ChipField source="title" />

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Chip, Stack, StackProps, styled } from '@mui/material';
-import { cloneElement, Children, ComponentType } from 'react';
 import PropTypes from 'prop-types';
 import {
     sanitizeListRestProps,
@@ -123,7 +122,7 @@ export const SingleFieldList = (props: SingleFieldListProps) => {
 };
 
 SingleFieldList.propTypes = {
-    children: PropTypes.element,
+    children: PropTypes.node,
     classes: PropTypes.object,
     className: PropTypes.string,
     component: ComponentPropType,
@@ -148,10 +147,9 @@ SingleFieldList.propTypes = {
 export interface SingleFieldListProps<RecordType extends RaRecord = any>
     extends StackProps {
     className?: string;
-    component?: string | ComponentType<any>;
     empty?: React.ReactElement;
     linkType?: string | false;
-    children?: React.ReactElement;
+    children?: React.ReactNode;
     // can be injected when using the component without context
     data?: RecordType[];
     total?: number;


### PR DESCRIPTION
## Problems

`<SingleFieldList>` has many issues:

- It still clones its children (we don't do this since 3.x)
- It forces users to pass children, while most of the time it's a `<ChipField>`
- It renders kind of a `Stack`, except it's not a `Stack`
- It doesn't support the `empty` prop

## Solution

- `<SingleFieldList>` now renders a real `<Stack>`, and supports all its props
- `<SingleFieldList>` used without children renders a `<ChipField>` with the `recordRepresentation`
- `<SingleFieldList>` supports an `empty` prop

```jsx
const PostList = () => (
    <List>
        <Datagrid>
            <TextField source="id" />
            <TextField source="title" />
            <DateField source="published_at" />
            <BooleanField source="commentable" />
            <NumberField source="views" />
            <ReferenceArrayField label="Tags" reference="tags" source="tags">
                <SingleFieldList />
            </ReferenceArrayField>
        </Datagrid>
    </List>
)
```

Closes #7634

## Minor BC Break

If you used `<SingleFieldList>` with a `<ChipField>` child and enabled the links, the chips background will no longer change on hover. To reenable this visual effect, add the `clickable` prop to the `<ChipField>`:

```diff
const PostList = () => (
    <List>
        <Datagrid>
            <TextField source="id" />
            <TextField source="title" />
            <DateField source="published_at" />
            <BooleanField source="commentable" />
            <NumberField source="views" />
            <ReferenceArrayField label="Tags" reference="tags" source="tags">
                <SingleFieldList>
-                  <ChipField source="name" />
+                  <ChipField source="name" clickable />
               </SingleFieldList>
            </ReferenceArrayField>
        </Datagrid>
    </List>
)
```

Alternately, if the `<ChipField source>` is the same as the resource's `recordRepresentation`, you can omit the child altogether. 

```diff
const PostList = () => (
    <List>
        <Datagrid>
            <TextField source="id" />
            <TextField source="title" />
            <DateField source="published_at" />
            <BooleanField source="commentable" />
            <NumberField source="views" />
            <ReferenceArrayField label="Tags" reference="tags" source="tags">
-               <SingleFieldList>
-                  <ChipField source="name" />
-              </SingleFieldList>
+              <SingleFieldList />
            </ReferenceArrayField>
        </Datagrid>
    </List>
)
```