### PR TITLE
[Typescript] Fix `<CheckForApplicationUpdate>` props type should allow `onNewVersionAvailable`

### DIFF
--- a/packages/ra-ui-materialui/src/layout/CheckForApplicationUpdate.tsx
+++ b/packages/ra-ui-materialui/src/layout/CheckForApplicationUpdate.tsx
@@ -85,7 +85,7 @@ export const CheckForApplicationUpdate = (
 };
 
 export interface CheckForApplicationUpdateProps
-    extends Omit<UseCheckForApplicationUpdateOptions, 'onNewVersionAvailable'> {
+    extends UseCheckForApplicationUpdateOptions {
     notification?: ReactElement;
 }
 

--- a/packages/ra-ui-materialui/src/layout/CheckForApplicationUpdate.tsx
+++ b/packages/ra-ui-materialui/src/layout/CheckForApplicationUpdate.tsx
@@ -85,7 +85,8 @@ export const CheckForApplicationUpdate = (
 };
 
 export interface CheckForApplicationUpdateProps
-    extends UseCheckForApplicationUpdateOptions {
+    extends Omit<UseCheckForApplicationUpdateOptions, 'onNewVersionAvailable'> {
+    onNewVersionAvailable?: UseCheckForApplicationUpdateOptions['onNewVersionAvailable'];
     notification?: ReactElement;
 }
 


### PR DESCRIPTION
Fix suggested in https://github.com/marmelab/react-admin/pull/9437#issuecomment-1808727199