### PR TITLE
[TypeScript] Fix useRecordContext may return undefined

### DIFF
--- a/packages/ra-core/src/controller/record/useRecordContext.ts
+++ b/packages/ra-core/src/controller/record/useRecordContext.ts
@@ -37,7 +37,7 @@ export const useRecordContext = <
 ): RecordType | undefined => {
     // Can't find a way to specify the RecordType when CreateContext is declared
     // @ts-ignore
-    const context = useContext<RecordType>(RecordContext);
+    const context = useContext<RecordType | undefined>(RecordContext);
 
     return (props && props.record) || context;
 };


### PR DESCRIPTION
Follow https://github.com/marmelab/react-admin/pull/7498

Because of the type in useContext, the return type of useRecordContext will never be undefined.

But the doc in https://marmelab.com/react-admin/useRecordContext.html#typescript
mention that useRecordContext can be undefined.