### PR TITLE
Fix: NanoTheme center icons in SolarMenu

### DIFF
--- a/packages/ra-ui-materialui/src/theme/nanoTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/nanoTheme.ts
@@ -304,6 +304,22 @@ const componentsOverrides = (theme: Theme) => ({
             },
         },
     },
+    RaSolarPrimarySidebar: {
+        styleOverrides: {
+            root: {
+                '& .RaSolarMenu-topToolbar': {
+                    '& .RaSolarMenuItem-icon': {
+                        justifyContent: 'center',
+                    },
+                },
+                '& .RaSolarMenu-bottomToolbar': {
+                    '& .RaSolarMenuItem-icon, & .RaSolarMenuItem-root': {
+                        justifyContent: 'center',
+                    },
+                },
+            },
+        },
+    },
 });
 
 const alert = {


### PR DESCRIPTION
## Problem
In NanoTheme, icons are not centered in  `<SolarMenu>` component
![image](https://github.com/marmelab/react-admin/assets/7949510/f6fa1885-929b-4828-92c4-9882c5cc5cb5)


## Solution
This PR attempts to fix that
![image](https://github.com/marmelab/react-admin/assets/7949510/2662e7f5-bb7c-4a4f-a2e1-fcfecfd88fa0)
