### PR TITLE
Fix `<Pagination>` logs a warning

### DIFF
--- a/packages/ra-ui-materialui/src/list/pagination/PaginationActions.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/PaginationActions.tsx
@@ -92,5 +92,6 @@ const Root = styled('div', {
 const sanitizeRestProps = ({
     nextIconButtonProps,
     backIconButtonProps,
+    slotProps,
     ...rest
 }: any) => rest;


### PR DESCRIPTION
Material-ui v5.15.18 introduced a new prop injected to `PaginationAction`, `slotProps`, which isn't supposed to be passed down to the `Pagination` component.

Refs https://github.com/mui/material-ui/pull/39353
Closes `<Pagination>` logs a warning #9470