### PR TITLE
Revert "Fix TabbedForm and TabbedShowLayout tab navigation: limit react-router version to 6.18.0 as a workaround"

### DIFF
--- a/examples/crm/package.json
+++ b/examples/crm/package.json
@@ -18,8 +18,8 @@
         "react-admin": "^4.12.0",
         "react-dom": "^17.0.0",
         "react-error-boundary": "^3.1.4",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0"
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^5.11.4",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -33,8 +33,8 @@
         "react-admin": "^4.12.0",
         "react-app-polyfill": "^2.0.0",
         "react-dom": "^17.0.0",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0",
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0",
         "recharts": "^2.1.15"
     },
     "scripts": {

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -27,8 +27,8 @@
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.43.9",
         "react-query": "^3.32.1",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0"
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0"
     },
     "devDependencies": {
         "@babel/preset-react": "^7.12.10",

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -40,8 +40,8 @@
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.43.9",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0",
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0",
         "react-test-renderer": "^16.9.0 || ^17.0.0",
         "recharts": "^2.1.15",
         "rimraf": "^3.0.2",
@@ -54,8 +54,8 @@
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-hook-form": "^7.43.9",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0"
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0"
     },
     "dependencies": {
         "clsx": "^1.1.1",

--- a/packages/ra-no-code/package.json
+++ b/packages/ra-no-code/package.json
@@ -30,8 +30,8 @@
         "cross-env": "^5.2.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0",
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0",
         "rimraf": "^3.0.2",
         "typescript": "^5.1.3"
     },

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -42,8 +42,8 @@
         "react-dom": "^17.0.0",
         "react-hook-form": "^7.43.9",
         "react-is": "^17.0.0",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0",
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0",
         "react-test-renderer": "~16.8.6",
         "rimraf": "^3.0.2",
         "typescript": "^5.1.3"
@@ -56,8 +56,8 @@
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-hook-form": "*",
         "react-is": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0"
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0"
     },
     "dependencies": {
         "autosuggest-highlight": "^3.1.1",

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -46,8 +46,8 @@
         "ra-language-english": "^4.16.1",
         "ra-ui-materialui": "^4.16.1",
         "react-hook-form": "^7.43.9",
-        "react-router": "6.1.0 - 6.18.0",
-        "react-router-dom": "6.1.0 - 6.18.0"
+        "react-router": "^6.1.0",
+        "react-router-dom": "^6.1.0"
     },
     "gitHead": "b227592132da6ae5f01438fa8269e04596cdfdd8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9968,8 +9968,8 @@ __metadata:
     react-admin: ^4.12.0
     react-app-polyfill: ^2.0.0
     react-dom: ^17.0.0
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     recharts: ^2.1.15
     rewire: ^5.0.0
     rollup-plugin-visualizer: ^5.9.2
@@ -18114,8 +18114,8 @@ __metadata:
     react-hook-form: ^7.43.9
     react-is: ^17.0.2
     react-query: ^3.32.1
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     react-test-renderer: ^16.9.0 || ^17.0.0
     recharts: ^2.1.15
     rimraf: ^3.0.2
@@ -18127,8 +18127,8 @@ __metadata:
     react: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-hook-form: ^7.43.9
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
   languageName: unknown
   linkType: soft
 
@@ -18348,8 +18348,8 @@ __metadata:
     react-dom: ^17.0.0
     react-dropzone: ^12.0.4
     react-query: ^3.32.1
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     rimraf: ^3.0.2
     typescript: ^5.1.3
   peerDependencies:
@@ -18391,8 +18391,8 @@ __metadata:
     react-hook-form: ^7.43.9
     react-is: ^17.0.0
     react-query: ^3.32.1
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     react-test-renderer: ~16.8.6
     react-transition-group: ^4.4.1
     rimraf: ^3.0.2
@@ -18405,8 +18405,8 @@ __metadata:
     react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-hook-form: "*"
     react-is: ^16.9.0 || ^17.0.0 || ^18.0.0
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
   languageName: unknown
   linkType: soft
 
@@ -18501,8 +18501,8 @@ __metadata:
     react-admin: ^4.12.0
     react-dom: ^17.0.0
     react-error-boundary: ^3.1.4
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     rollup-plugin-visualizer: ^5.9.2
     typescript: ^5.1.3
     vite: ^3.2.0
@@ -18577,8 +18577,8 @@ __metadata:
     ra-language-english: ^4.16.1
     ra-ui-materialui: ^4.16.1
     react-hook-form: ^7.43.9
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     rimraf: ^3.0.2
     typescript: ^5.1.3
   peerDependencies:
@@ -18922,7 +18922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.1.0 - 6.18.0":
+"react-router-dom@npm:^6.1.0":
   version: 6.2.1
   resolution: "react-router-dom@npm:6.2.1"
   dependencies:
@@ -18935,7 +18935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.1.0 - 6.18.0, react-router@npm:6.2.1":
+"react-router@npm:6.2.1, react-router@npm:^6.1.0":
   version: 6.2.1
   resolution: "react-router@npm:6.2.1"
   dependencies:
@@ -20146,8 +20146,8 @@ __metadata:
     react-dom: ^17.0.0
     react-hook-form: ^7.43.9
     react-query: ^3.32.1
-    react-router: 6.1.0 - 6.18.0
-    react-router-dom: 6.1.0 - 6.18.0
+    react-router: ^6.1.0
+    react-router-dom: ^6.1.0
     typescript: ^5.1.3
     vite: ^3.2.0
   languageName: unknown


### PR DESCRIPTION
Reverts marmelab/react-admin#9480

The react-router team has published a fix on their side in 6.20.1, so the version constraint on `react-router-dom` is no longer necessary.

https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v6201