### PR TITLE
Fix clearing a nested filter re-renders the previous value when navigating back to the list

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -285,9 +285,6 @@ const getInputValue = (
                     innerKey,
                     (filterValues || {})[key] ?? {}
                 );
-                if (nestedInputValue === '') {
-                    return acc;
-                }
                 acc[innerKey] = nestedInputValue;
                 return acc;
             },


### PR DESCRIPTION
**Problem**

Due to a regression brought by #8637 , clearing a filter with a nested value would indeed clear its value in the `filter` object, but would prevent react-hook-form from clearing the value in the form state.
Hence, this could lead to having the previous value come back when leaving the list and then navigating back. (especially visible when using an `<AutocompleteArrayInput>` as filter)

**Solution**

Partially revert the change brought by #8637 .

#8637 Seems to indicate the way to deal with nested values is

```tsx
        <TextInput
            label="Nested"
            source="nested"
            defaultValue={{ foo: 'bar' }}
            format={v => v?.foo || ''}
            parse={v => ({ foo: v })}
        />,
```

Whereas it actually should be

```tsx
        <TextInput label="Nested" source="nested.foo" defaultValue="bar" />,
```