### PR TITLE
Doc: Improve MarkdownInput documentation

### DIFF
--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -424,7 +424,7 @@ Here are all the props you can set on the `<AccordionSection>` component:
 | `AccordionSummary` | Optional | `Component` | -       | The component to use as the accordion summary.                |
 | `label`            | Required | `string`    | -       | The main label used as the accordion summary.                 |
 | `children`         | Required | `ReactNode` | -       | A list of `<Input>` elements                                  |
-| `fullWidth`        | Optional | `boolean`   | `false` | If true, the Accordion take sthe entire form width.           |
+| `fullWidth`        | Optional | `boolean`   | `false` | If true, the Accordion takes the entire form width.           |
 | `className`        | Optional | `string`    | -       | A class name to style the underlying `<Accordion>`            |
 | `secondary`        | Optional | `string`    | -       | The secondary label used as the accordion summary             |
 | `defaultExpanded`  | Optional | `boolean`   | `false` | Set to true to have the accordion expanded by default         |

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -132,5 +132,45 @@ You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop 
 ```
 {% endraw %}
 
+## Add Your Own Buttons
+
+You can add your own buttons to the markdown editor by using the `toolbarItems` prop. It accepts an array of [toolbar items](https://nhn.github.io/tui.editor/latest/ToastUIEditorToolbar#toolbar-items) and is set to `null` by default.
+
+{% raw %}
+```jsx
+function createLastButton() {
+    const button = document.createElement('button');
+    button.className = 'toastui-editor-toolbar-icons last';
+    button.style.backgroundImage = 'none';
+    button.style.margin = '0';
+    button.style.width = '100%';
+    button.innerHTML = `<i>Custom Button</i>`;
+    button.addEventListener('click', () => {
+        alert('Custom Button action');
+    });
+
+    return button;
+}
+
+return (
+    <SimpleForm>
+        <MarkdownInput 
+            source="description" 
+            toolbarItems={[
+                ['heading', 'bold', 'italic', 'strike'],
+                [
+                    {
+                        el: createLastButton(),
+                        tooltip: 'Custom Command',
+                        name: 'custom',
+                    },
+                ],
+            ]
+        } />
+    </SimpleForm>
+);
+```
+{% endraw %}
+
 
 Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: "The MarkdownInput Component"
+title: 'The MarkdownInput Component'
 ---
 
 # `<MarkdownInput>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit and preview Markdown data, based on [the Toast UI editor](https://nhn.github.io/tui.editor/latest/ToastUIEditor).
+This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit and preview Markdown data, based on [the Toast UI editor](https://nhn.github.io/tui.editor/latest/ToastUIEditor). To be used in Edit and Create views.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/markdown-input.webm" type="video/webm"/>
@@ -29,36 +29,59 @@ const PostEdit = () => (
 );
 ```
 
+You can customize the markdown renderer used for the preview, so that it matches the rendering you need in read mode just by applying the CSS rules you want.
+
+```JSX
+import { Edit, SimpleForm, TextInput } from "react-admin";
+import { MarkdownInput } from "@react-admin/ra-markdown";
+
+// Additional props are passed to `tui-editor`'s `<Editor>` component
+const options = {
+  previewStyle: "tab",
+  height: "300px",
+  initialEditType: "markdown",
+  useCommandShortcut: false,
+};
+
+const PostEdit = () => (
+  <Edit>
+    <SimpleForm>
+      <TextInput source="title" />
+      <MarkdownInput source="description" {...options} />
+    </SimpleForm>
+  </Edit>
+);
+```
+
 ## Props
 
 `<MarkdownInput>` accepts the following props:
 
-| Prop                 | Required | Type      | Default    | Description                                                           |
-| -------------------- | -------- | --------- | ---------- | --------------------------------------------------------------------- |
-| `source`             | Required | `string`  |            | The field name in the record                                          |
-| `fullWidth`          | Optional | `boolean` | `true`     | If `true`, the input will expand to fill the form width               |
-| `label`              | Optional | `string`  |            | The label. If not set, the label is inferred from the child component |
-| `helperText`         | Optional | `string`  |            | The helper text to display under the input                            |
-| `previewStyle`       | Optional | `string`  | `vertical` | Markdown editor's preview style. Can be `tab` or `vertical`           |
-| `height`             | Optional | `string`  | `512px`    | Markdown editor's height                                              |
-| `initialEditType`    | Optional | `string`  | `wysiwyg`  | Markdown editor's initial edit type. Can be `markdown` or `wysiwyg`   |
-| `useCommandShortcut` | Optional | `boolean` | `true`     | Whether use keyboard shortcuts to perform commands                    |
+| Prop                 | Required | Type      | Default    | Description                                                                                         |
+| -------------------- | -------- | --------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| `source`             | Required | `string`  |            | The field name in the record                                                                        |
+| `fullWidth`          | Optional | `boolean` | `true`     | If `true`, the input will expand to fill the form width                                             |
+| `height`             | Optional | `string`  | `512px`    | Markdown editor's height                                                                            |
+| `helperText`         | Optional | `string`  |            | The helper text to display under the input                                                          |
+| `initialEditType`    | Optional | `string`  | `wysiwyg`  | Markdown editor's initial edit type. Can be `markdown` or `wysiwyg`                                 |
+| `label`              | Optional | `string`  |            | The label. If not set, the label is inferred from the child component                               |
+| `previewStyle`       | Optional | `string`  | `vertical` | Markdown editor's preview style. Can be `tab` or `vertical`                                         |
+| `toolbarItems`       | Optional | `array`   |            | The toolbar items to display in the editor. See [Adding Buttons](#adding-buttons) for more details. |
+| `useCommandShortcut` | Optional | `boolean` | `true`     | Whether use keyboard shortcuts to perform commands                                                  |
 
-`<MarkdownInput>` also accepts the [common input props](https://marmelab.com/react-admin/Inputs.html#common-input-props) and the [editor props](https://nhn.github.io/tui.editor/latest/ToastUIEditorCore) from the Toast UI editor.
+`<MarkdownInput>` also accepts the [common input props](https://marmelab.com/react-admin/Inputs.html#common-input-props) and the [editor props](https://nhn.github.io/tui.editor/latest/ToastUIEditorCore) from the [Toast UI](https://ui.toast.com/) editor.
 
 ## `source`
 
 Specifies the field of the record that the input should edit. It is required.
 
 {% raw %}
-
 ```jsx
-<Form record={{ id: 123, title: 'Hello, world!', body: '<p>Lorem Ipsum</p>' }}>
+<Form record={{ id: 123, title: 'Hello, world!', body: '**Lorem Ipsum**' }}>
     <MarkdownInput source="body" />
-    {/* default value is "<p>Lorem Ipsum</p>" */}
+    {/* default value is "**Lorem Ipsum**" */}
 </Form>
 ```
-
 {% endraw %}
 
 ## `fullWidth`
@@ -66,13 +89,23 @@ Specifies the field of the record that the input should edit. It is required.
 You can make the markdown editor full width by setting the `fullWidth` prop to `true`:
 
 {% raw %}
-
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" fullwidth />
 </SimpleForm>
 ```
+{% endraw %}
 
+## `height`
+
+The editor has a size that can be customized by setting the `height` prop. It is set to `512px` by default. You can use `px` or `%` units.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" height="300px" />
+</SimpleForm>
+```
 {% endraw %}
 
 ## `helperText`
@@ -80,7 +113,6 @@ You can make the markdown editor full width by setting the `fullWidth` prop to `
 If you need to display a text below the markdown editor (usually to explain the expected data to the user), use the `helperText` prop.
 
 {% raw %}
-
 ```jsx
 <SimpleForm>
     <MarkdownInput
@@ -89,35 +121,6 @@ If you need to display a text below the markdown editor (usually to explain the 
     />
 </SimpleForm>
 ```
-
-{% endraw %}
-
-## `previewStyle`
-
-You can customize the preview style by setting the `previewStyle` prop. It accepts `tab` or `vertical` and is set to `vertical` by default.
-
-{% raw %}
-
-```jsx
-<SimpleForm>
-    <MarkdownInput source="description" previewStyle="tab" />
-</SimpleForm>
-```
-
-{% endraw %}
-
-## `height`
-
-The editor has a size that can be customized by setting the `height` prop. It is set to `512px` by default. You can use `px` or `%` units.
-
-{% raw %}
-
-```jsx
-<SimpleForm>
-    <MarkdownInput source="description" height="300px" />
-</SimpleForm>
-```
-
 {% endraw %}
 
 ## `initialEditType`
@@ -125,13 +128,36 @@ The editor has a size that can be customized by setting the `height` prop. It is
 This prop allows to set the initial edit type of the editor. It accepts `markdown` or `wysiwyg` and is set to `wysiwyg` by default.
 
 {% raw %}
-
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" initialEditType="markdown" />
 </SimpleForm>
 ```
+{% endraw %}
 
+## `label`
+
+You can customize the label by setting the `label` prop. It is inferred from the `source` prop by default.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" label="Description" />
+</SimpleForm>
+```
+{% endraw %}
+
+## `previewStyle`
+
+You can customize the preview style by setting the `previewStyle` prop. It accepts `tab` or `vertical` and is set to `vertical` by default.
+If you chose `vertical`, the content and the preview will be displayed side by side. If you chose `tab`, the content and the preview will be displayed in two separate tabs. You can switch between the two tabs by clicking on it.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" previewStyle="tab" />
+</SimpleForm>
+```
 {% endraw %}
 
 ## `useCommandShortcut`
@@ -139,23 +165,23 @@ This prop allows to set the initial edit type of the editor. It accepts `markdow
 You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop to `false`. It is set to `true` by default.
 
 {% raw %}
-
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" useCommandShortcut={false} />
 </SimpleForm>
 ```
-
 {% endraw %}
 
-## Add Your Own Buttons
+## Adding Buttons
 
-You can add your own buttons to the markdown editor by using the `toolbarItems` prop. It accepts an array of [toolbar items](https://nhn.github.io/tui.editor/latest/ToastUIEditorToolbar#toolbar-items) and is set to `null` by default.
+You can add your own buttons to the markdown editor by using the `toolbarItems` prop. It accepts an array of [toolbar items](https://nhn.github.io/tui.editor/latest/tutorial-example15-customizing-toolbar-buttons) and is set to `null` by default.
 
 {% raw %}
+```tsx
+// src/Example.tsx
+import { Edit, SimpleForm, MarkdownInput } from 'react-admin';
 
-```jsx
-function createLastButton() {
+function createLastButton(): HTMLButtonElement {
     const button = document.createElement('button');
     button.className = 'toastui-editor-toolbar-icons last';
     button.style.backgroundImage = 'none';
@@ -169,25 +195,26 @@ function createLastButton() {
     return button;
 }
 
-return (
-    <SimpleForm>
-        <MarkdownInput
-            source="description"
-            toolbarItems={[
-                ['heading', 'bold', 'italic', 'strike'],
-                [
-                    {
-                        el: createLastButton(),
-                        tooltip: 'Custom Command',
-                        name: 'custom',
-                    },
-                ],
-            ]}
-        />
-    </SimpleForm>
+const Example = () => (
+    <Edit>
+        <SimpleForm>
+           <MarkdownInput
+                source="description"
+                toolbarItems={[
+                    ['heading', 'bold', 'italic', 'strike'],
+                    [
+                        {
+                            el: createLastButton(),
+                            tooltip: 'Custom Command',
+                            name: 'custom',
+                        },
+                    ],
+                ]}
+            />
+        </SimpleForm>
+    </Edit>
 );
 ```
-
 {% endraw %}
 
 Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -71,19 +71,6 @@ const PostEdit = () => (
 
 `<MarkdownInput>` also accepts the [common input props](https://marmelab.com/react-admin/Inputs.html#common-input-props) and the [editor props](https://nhn.github.io/tui.editor/latest/ToastUIEditorCore) from the [Toast UI](https://ui.toast.com/) editor.
 
-## `source`
-
-Specifies the field of the record that the input should edit. It is required.
-
-{% raw %}
-```jsx
-<Form record={{ id: 123, title: 'Hello, world!', body: '**Lorem Ipsum**' }}>
-    <MarkdownInput source="body" />
-    {/* default value is "**Lorem Ipsum**" */}
-</Form>
-```
-{% endraw %}
-
 ## `fullWidth`
 
 You can make the markdown editor full width by setting the `fullWidth` prop to `true`:
@@ -149,6 +136,19 @@ You can customize the preview style by setting the `previewStyle` prop. It accep
 </SimpleForm>
 ```
 
+## `source`
+
+Specifies the field of the record that the input should edit. It is required.
+
+{% raw %}
+```jsx
+<Form record={{ id: 123, title: 'Hello, world!', body: '**Lorem Ipsum**' }}>
+    <MarkdownInput source="body" />
+    {/* default value is "**Lorem Ipsum**" */}
+</Form>
+```
+{% endraw %}
+
 ## `useCommandShortcut`
 
 You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop to `false`. It is set to `true` by default.
@@ -165,7 +165,7 @@ You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop 
 
 You can add your own buttons to the markdown editor by using the `toolbarItems` prop. It accepts an array of [toolbar items](https://nhn.github.io/tui.editor/latest/tutorial-example15-customizing-toolbar-buttons) and is set to `null` by default.
 
-In this example, we will add a custom button to the toolbar that will display an alert when clicked. We create an HTML button element via the `createLastButton` function and pass it to the `toolbarItems` prop.
+The following example shows a custom button in the toolbar that displays an alert when clicked. It uses the `createLastButton` function to create an HTML button element, and the `toolbarItems` prop to pass it to the toolbar.
 
 {% raw %}
 ```tsx

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -30,4 +30,107 @@ const PostEdit = () => (
 );
 ```
 
+## Props
+
+`<MarkdownInput>` accepts the following props:
+
+| Prop              | Required | Type     | Default   | Description                                                                                                             |
+| ----------------- | -------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `source`          | Required | `string`   |           | The field name in the record                                                                                            |
+| `fullWidth` | Optional | `boolean` | `true` | If `true`, the input will expand to fill the form width |
+| `label`      | Optional | `string`           |           | The label. If not set, the label is inferred from the child component |
+| `helperText`      | Optional | `string`           |           | The helper text to display under the input |
+| `previewStyle`     | Optional | `string`           |     `vertical`      | Markdown editor's preview style. Can be `tab` or `vertical` |
+| `height`     | Optional | `string`           |     `512px`      | Markdown editor's height |
+| `initialEditType`     | Optional | `string`           |     `wysiwyg`      | Markdown editor's initial edit type. Can be `markdown` or `wysiwyg` |
+| `useCommandShortcut`     | Optional | `boolean`           |     `true`      | Whether use keyboard shortcuts to perform commands|
+
+`<MarkdownInput>` also accepts the [common input props](https://marmelab.com/react-admin/Inputs.html#common-input-props) and the [editor props](https://nhn.github.io/tui.editor/latest/ToastUIEditorCore) from the Toast UI editor.
+
+## `source`
+
+Specifies the field of the record that the input should edit. It is required.
+
+{% raw %}
+```jsx
+<Form record={{ id: 123, title: 'Hello, world!', body: '<p>Lorem Ipsum</p>' }}>
+    <MarkdownInput source="body" />
+    {/* default value is "<p>Lorem Ipsum</p>" */}
+</Form>
+```
+{% endraw %}
+
+## `fullWidth`
+
+You can make the markdown editor full width by setting the `fullWidth` prop to `true`:
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" fullwidth />
+</SimpleForm>
+```
+{% endraw %}
+
+## `helperText`
+
+If you need to display a text below the markdown editor (usually to explain the expected data to the user), use the `helperText` prop.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" helperText="Enter a description of the post" />
+</SimpleForm>
+```
+{% endraw %}
+
+## `previewStyle`
+
+You can customize the preview style by setting the `previewStyle` prop. It accepts `tab` or `vertical` and is set to `vertical` by default.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" previewStyle="tab" />
+</SimpleForm>
+```
+{% endraw %}
+
+## `height`
+
+The editor has a size that can be customized by setting the `height` prop. It is set to `512px` by default. You can use `px` or `%` units.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" height="300px" />
+</SimpleForm>
+```
+{% endraw %}
+
+## `initialEditType`
+
+This prop allows to set the initial edit type of the editor. It accepts `markdown` or `wysiwyg` and is set to `wysiwyg` by default.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" initialEditType="markdown" />
+</SimpleForm>
+```
+{% endraw %}
+
+## `useCommandShortcut`
+
+You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop to `false`. It is set to `true` by default.
+
+{% raw %}
+```jsx
+<SimpleForm>
+    <MarkdownInput source="description" useCommandShortcut={false} />
+</SimpleForm>
+```
+{% endraw %}
+
+
 Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -31,7 +31,7 @@ const PostEdit = () => (
 
 You can customize the markdown renderer used for the preview, so that it matches the rendering you need in read mode just by applying the CSS rules you want.
 
-```JSX
+```jsx
 import { Edit, SimpleForm, TextInput } from "react-admin";
 import { MarkdownInput } from "@react-admin/ra-markdown";
 
@@ -88,31 +88,26 @@ Specifies the field of the record that the input should edit. It is required.
 
 You can make the markdown editor full width by setting the `fullWidth` prop to `true`:
 
-{% raw %}
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" fullwidth />
 </SimpleForm>
 ```
-{% endraw %}
 
 ## `height`
 
 The editor has a size that can be customized by setting the `height` prop. It is set to `512px` by default. You can use `px` or `%` units.
 
-{% raw %}
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" height="300px" />
 </SimpleForm>
 ```
-{% endraw %}
 
 ## `helperText`
 
 If you need to display a text below the markdown editor (usually to explain the expected data to the user), use the `helperText` prop.
 
-{% raw %}
 ```jsx
 <SimpleForm>
     <MarkdownInput
@@ -121,44 +116,38 @@ If you need to display a text below the markdown editor (usually to explain the 
     />
 </SimpleForm>
 ```
-{% endraw %}
 
 ## `initialEditType`
 
 This prop allows to set the initial edit type of the editor. It accepts `markdown` or `wysiwyg` and is set to `wysiwyg` by default.
 
-{% raw %}
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" initialEditType="markdown" />
 </SimpleForm>
 ```
-{% endraw %}
 
 ## `label`
 
 You can customize the label by setting the `label` prop. It is inferred from the `source` prop by default.
 
-{% raw %}
 ```jsx
 <SimpleForm>
-    <MarkdownInput source="description" label="Description" />
+    <MarkdownInput source="description" label="Explanation" />
 </SimpleForm>
 ```
-{% endraw %}
 
 ## `previewStyle`
 
 You can customize the preview style by setting the `previewStyle` prop. It accepts `tab` or `vertical` and is set to `vertical` by default.
-If you chose `vertical`, the content and the preview will be displayed side by side. If you chose `tab`, the content and the preview will be displayed in two separate tabs. You can switch between the two tabs by clicking on it.
+- With the `vertical` style, the content and the preview will be displayed side by side.
+- With the `tab` style, the content and the preview will be displayed in two separate tabs. Users can switch between the two tabs by clicking on the tab header.
 
-{% raw %}
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" previewStyle="tab" />
 </SimpleForm>
 ```
-{% endraw %}
 
 ## `useCommandShortcut`
 
@@ -175,6 +164,8 @@ You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop 
 ## Adding Buttons
 
 You can add your own buttons to the markdown editor by using the `toolbarItems` prop. It accepts an array of [toolbar items](https://nhn.github.io/tui.editor/latest/tutorial-example15-customizing-toolbar-buttons) and is set to `null` by default.
+
+In this example, we will add a custom button to the toolbar that will display an alert when clicked. We create an HTML button element via the `createLastButton` function and pass it to the `toolbarItems` prop.
 
 {% raw %}
 ```tsx

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -13,7 +13,6 @@ This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" s
   Your browser does not support the video tag.
 </video>
 
-
 ## Usage
 
 ```jsx
@@ -34,16 +33,16 @@ const PostEdit = () => (
 
 `<MarkdownInput>` accepts the following props:
 
-| Prop              | Required | Type     | Default   | Description                                                                                                             |
-| ----------------- | -------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `source`          | Required | `string`   |           | The field name in the record                                                                                            |
-| `fullWidth` | Optional | `boolean` | `true` | If `true`, the input will expand to fill the form width |
-| `label`      | Optional | `string`           |           | The label. If not set, the label is inferred from the child component |
-| `helperText`      | Optional | `string`           |           | The helper text to display under the input |
-| `previewStyle`     | Optional | `string`           |     `vertical`      | Markdown editor's preview style. Can be `tab` or `vertical` |
-| `height`     | Optional | `string`           |     `512px`      | Markdown editor's height |
-| `initialEditType`     | Optional | `string`           |     `wysiwyg`      | Markdown editor's initial edit type. Can be `markdown` or `wysiwyg` |
-| `useCommandShortcut`     | Optional | `boolean`           |     `true`      | Whether use keyboard shortcuts to perform commands|
+| Prop                 | Required | Type      | Default    | Description                                                           |
+| -------------------- | -------- | --------- | ---------- | --------------------------------------------------------------------- |
+| `source`             | Required | `string`  |            | The field name in the record                                          |
+| `fullWidth`          | Optional | `boolean` | `true`     | If `true`, the input will expand to fill the form width               |
+| `label`              | Optional | `string`  |            | The label. If not set, the label is inferred from the child component |
+| `helperText`         | Optional | `string`  |            | The helper text to display under the input                            |
+| `previewStyle`       | Optional | `string`  | `vertical` | Markdown editor's preview style. Can be `tab` or `vertical`           |
+| `height`             | Optional | `string`  | `512px`    | Markdown editor's height                                              |
+| `initialEditType`    | Optional | `string`  | `wysiwyg`  | Markdown editor's initial edit type. Can be `markdown` or `wysiwyg`   |
+| `useCommandShortcut` | Optional | `boolean` | `true`     | Whether use keyboard shortcuts to perform commands                    |
 
 `<MarkdownInput>` also accepts the [common input props](https://marmelab.com/react-admin/Inputs.html#common-input-props) and the [editor props](https://nhn.github.io/tui.editor/latest/ToastUIEditorCore) from the Toast UI editor.
 
@@ -52,12 +51,14 @@ const PostEdit = () => (
 Specifies the field of the record that the input should edit. It is required.
 
 {% raw %}
+
 ```jsx
 <Form record={{ id: 123, title: 'Hello, world!', body: '<p>Lorem Ipsum</p>' }}>
     <MarkdownInput source="body" />
     {/* default value is "<p>Lorem Ipsum</p>" */}
 </Form>
 ```
+
 {% endraw %}
 
 ## `fullWidth`
@@ -65,11 +66,13 @@ Specifies the field of the record that the input should edit. It is required.
 You can make the markdown editor full width by setting the `fullWidth` prop to `true`:
 
 {% raw %}
+
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" fullwidth />
 </SimpleForm>
 ```
+
 {% endraw %}
 
 ## `helperText`
@@ -77,11 +80,16 @@ You can make the markdown editor full width by setting the `fullWidth` prop to `
 If you need to display a text below the markdown editor (usually to explain the expected data to the user), use the `helperText` prop.
 
 {% raw %}
+
 ```jsx
 <SimpleForm>
-    <MarkdownInput source="description" helperText="Enter a description of the post" />
+    <MarkdownInput
+        source="description"
+        helperText="Enter a description of the post"
+    />
 </SimpleForm>
 ```
+
 {% endraw %}
 
 ## `previewStyle`
@@ -89,11 +97,13 @@ If you need to display a text below the markdown editor (usually to explain the 
 You can customize the preview style by setting the `previewStyle` prop. It accepts `tab` or `vertical` and is set to `vertical` by default.
 
 {% raw %}
+
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" previewStyle="tab" />
 </SimpleForm>
 ```
+
 {% endraw %}
 
 ## `height`
@@ -101,11 +111,13 @@ You can customize the preview style by setting the `previewStyle` prop. It accep
 The editor has a size that can be customized by setting the `height` prop. It is set to `512px` by default. You can use `px` or `%` units.
 
 {% raw %}
+
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" height="300px" />
 </SimpleForm>
 ```
+
 {% endraw %}
 
 ## `initialEditType`
@@ -113,11 +125,13 @@ The editor has a size that can be customized by setting the `height` prop. It is
 This prop allows to set the initial edit type of the editor. It accepts `markdown` or `wysiwyg` and is set to `wysiwyg` by default.
 
 {% raw %}
+
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" initialEditType="markdown" />
 </SimpleForm>
 ```
+
 {% endraw %}
 
 ## `useCommandShortcut`
@@ -125,11 +139,13 @@ This prop allows to set the initial edit type of the editor. It accepts `markdow
 You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop to `false`. It is set to `true` by default.
 
 {% raw %}
+
 ```jsx
 <SimpleForm>
     <MarkdownInput source="description" useCommandShortcut={false} />
 </SimpleForm>
 ```
+
 {% endraw %}
 
 ## Add Your Own Buttons
@@ -137,6 +153,7 @@ You can disable the keyboard shortcuts by setting the `useCommandShortcut` prop 
 You can add your own buttons to the markdown editor by using the `toolbarItems` prop. It accepts an array of [toolbar items](https://nhn.github.io/tui.editor/latest/ToastUIEditorToolbar#toolbar-items) and is set to `null` by default.
 
 {% raw %}
+
 ```jsx
 function createLastButton() {
     const button = document.createElement('button');
@@ -154,8 +171,8 @@ function createLastButton() {
 
 return (
     <SimpleForm>
-        <MarkdownInput 
-            source="description" 
+        <MarkdownInput
+            source="description"
             toolbarItems={[
                 ['heading', 'bold', 'italic', 'strike'],
                 [
@@ -165,12 +182,12 @@ return (
                         name: 'custom',
                     },
                 ],
-            ]
-        } />
+            ]}
+        />
     </SimpleForm>
 );
 ```
-{% endraw %}
 
+{% endraw %}
 
 Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.


### PR DESCRIPTION
## Problem

The documentation for MarkdownInput is short and doesn't show the power of that component. 

https://marmelab.com/react-admin/MarkdownInput.html

## Solution

Expand it