### PR TITLE
Fix `<TabbedShowLayout>` displays its fields as full width blocks

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { isValidElement, ReactElement, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
-import { Tab as MuiTab, TabProps as MuiTabProps, Stack } from '@mui/material';
+import {
+    Tab as MuiTab,
+    TabProps as MuiTabProps,
+    Stack,
+    styled,
+} from '@mui/material';
 import { ResponsiveStyleValue } from '@mui/system';
 import { useTranslate, RaRecord } from 'ra-core';
 import clsx from 'clsx';
@@ -101,7 +106,7 @@ export const Tab = ({
     };
 
     const renderContent = () => (
-        <Stack className={contentClassName} spacing={spacing} divider={divider}>
+        <Root className={contentClassName} spacing={spacing} divider={divider}>
             {React.Children.map(children, field =>
                 field && isValidElement<any>(field) ? (
                     <Labeled
@@ -110,6 +115,7 @@ export const Tab = ({
                             'ra-field',
                             field.props.source &&
                                 `ra-field-${field.props.source}`,
+                            TabClasses.row,
                             field.props.className
                         )}
                     >
@@ -117,11 +123,28 @@ export const Tab = ({
                     </Labeled>
                 ) : null
             )}
-        </Stack>
+        </Root>
     );
 
     return context === 'header' ? renderHeader() : renderContent();
 };
+
+const PREFIX = 'RaTab';
+
+export const TabClasses = {
+    row: `${PREFIX}-row`,
+};
+
+const Root = styled(Stack, {
+    name: PREFIX,
+    overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
+    flex: 1,
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+    [`& .${TabClasses.row}`]: {
+        display: 'inline',
+    },
+}));
 
 Tab.propTypes = {
     children: PropTypes.node,

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -138,9 +138,7 @@ export const TabClasses = {
 const Root = styled(Stack, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
-})(({ theme }) => ({
-    flex: 1,
-    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+})(() => ({
     [`& .${TabClasses.row}`]: {
         display: 'inline',
     },


### PR DESCRIPTION
Before:
![image](https://github.com/marmelab/react-admin/assets/1122076/938f8f77-61db-40df-8240-37d725ac3e7c)

After:
![image](https://github.com/marmelab/react-admin/assets/1122076/f9f14f54-a398-47c7-a56b-ce3a56ef89b1)

I applied the same styles as the `SimpleShowLayout`

Fixes #9405