### PR TITLE
fix: AutocompleteInput TextFieldProps are not applied

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -23,6 +23,7 @@ import {
     TranslateChoice,
     OnChange,
     InsideReferenceInputOnChange,
+    WithInputProps,
 } from './AutocompleteInput.stories';
 import { act } from '@testing-library/react-hooks';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
@@ -1586,5 +1587,13 @@ describe('<AutocompleteInput />', () => {
         ) as HTMLInputElement;
         fireEvent.change(input, { target: { value: 'newValue' } });
         await waitFor(() => expect(onInputChange).toHaveBeenCalled());
+    });
+
+    describe('InputProps', () => {
+        it('should pass InputProps to the input', async () => {
+            render(<WithInputProps />);
+            screen.getByTestId('AttributionIcon');
+            screen.getByTestId('ExpandCircleDownIcon');
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -1592,6 +1592,7 @@ describe('<AutocompleteInput />', () => {
     describe('InputProps', () => {
         it('should pass InputProps to the input', async () => {
             render(<WithInputProps />);
+            await screen.findByRole('textbox');
             screen.getByTestId('AttributionIcon');
             screen.getByTestId('ExpandCircleDownIcon');
         });

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -19,6 +19,7 @@ import {
     TextField,
     Typography,
     Box,
+    InputAdornment,
 } from '@mui/material';
 import { useFormContext } from 'react-hook-form';
 import fakeRestProvider from 'ra-data-fakerest';
@@ -31,6 +32,8 @@ import { AutocompleteInput, AutocompleteInputProps } from './AutocompleteInput';
 import { ReferenceInput } from './ReferenceInput';
 import { TextInput } from './TextInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
+import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown';
+import AttributionIcon from '@mui/icons-material/Attribution';
 
 export default { title: 'ra-ui-materialui/input/AutocompleteInput' };
 
@@ -1192,5 +1195,48 @@ export const TranslateChoice = () => {
                 </SimpleForm>
             </Edit>
         </AdminContext>
+    );
+};
+
+export const WithInputProps = () => {
+    const choices = [
+        { id: 1, name: 'Leo Tolstoy' },
+        { id: 2, name: 'Victor Hugo' },
+        { id: 3, name: 'William Shakespeare' },
+        { id: 4, name: 'Charles Baudelaire' },
+        { id: 5, name: 'Marcel Proust' },
+    ];
+
+    return (
+        <Admin dataProvider={dataProvider} history={history}>
+            <Resource
+                name="books"
+                edit={() => (
+                    <Edit>
+                        <SimpleForm>
+                            <AutocompleteInput
+                                source="author"
+                                fullWidth
+                                choices={choices}
+                                TextFieldProps={{
+                                    InputProps: {
+                                        startAdornment: (
+                                            <InputAdornment position="end">
+                                                <AttributionIcon />
+                                            </InputAdornment>
+                                        ),
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <ExpandCircleDownIcon />
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                        </SimpleForm>
+                    </Edit>
+                )}
+            />
+        </Admin>
     );
 };

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -591,8 +591,8 @@ If you provided a React element for the optionText prop, you must also provide t
                         margin={margin}
                         variant={variant}
                         className={AutocompleteInputClasses.textField}
-                        {...TextFieldProps}
                         {...params}
+                        {...TextFieldProps}
                         size={size}
                     />
                 )}


### PR DESCRIPTION
## Problem
Some props such as `startAdornment`, `disabled` etc are not applied to the renderer input of the `<AutocompleInput>` component, because `TextFieldProps` are not applied.

## Solution 
Re-order props to avoid `TextFieldProps` to be overloaded 