### PR TITLE
[Doc] Fix typo in `<Show queryOptions>` doc

### DIFF
--- a/docs/Show.md
+++ b/docs/Show.md
@@ -300,6 +300,7 @@ You can also use the `queryOptions` prop to override the default error side effe
 
 You can override this behavior and pass custom side effects by providing a custom `queryOptions` prop:
 
+{% raw %}
 ```jsx
 import * as React from 'react';
 import { useNotify, useRefresh, useRedirect, Show, SimpleShowLayout } from 'react-admin';
@@ -324,6 +325,7 @@ const PostShow = () => {
     );
 }
 ```
+{% endraw %}
 
 The `onError` function receives the error from the dataProvider call (`dataProvider.getOne()`), which is a JavaScript Error object (see [the dataProvider documentation for details](./DataProviderWriting.md#error-format)).
 


### PR DESCRIPTION
Fixes this issue in the [docs](https://marmelab.com/react-admin/Show.html#queryoptions):

![image](https://github.com/marmelab/react-admin/assets/14542336/f4c4e81a-6e22-407f-9141-636ceef14775)
