### PR TITLE
Introduce SourcePrefixContext

### DIFF
--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -163,6 +163,21 @@ const CompanyField = () => (
 ```
 {% endraw %}
 
+## `<SimpleFormIterator>` no longer clone its children
+
+One consequence is that defining the `disabled` prop on the `<ArrayInput>` component does not disable its children inputs anymore. If you relied on this behavior, you now have to specify the `disabled` prop on each input:
+
+```diff
+<ArrayInput disabled={someCondition}>
+   <SimpleFormIterator>
+-      <TextInput source="lastName" />
+-      <TextInput source="firstName" />
++      <TextInput source="lastName" disabled={someCondition} />
++      <TextInput source="firstName" disabled={someCondition} />
+   </SimpleFormIterator>
+</ArrayInput>
+```
+
 ## Upgrading to v4
 
 If you are on react-admin v3, follow the [Upgrading to v4](https://marmelab.com/react-admin/doc/4.16/Upgrade.html) guide before upgrading to v5. 

--- a/packages/ra-core/src/core/SourcePrefixContext.tsx
+++ b/packages/ra-core/src/core/SourcePrefixContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+export type SourcePrefixContextValue = string;
+
+/**
+ * Context to that provides a possible prefix for the source prop of fields and inputs.
+ */
+export const SourcePrefixContext = createContext<SourcePrefixContextValue>('');
+
+export const SourcePrefixContextProvider = SourcePrefixContext.Provider;
+
+/**
+ * Hook to get the source prefix that a field or input should add to its source prop.
+ * @returns The source prefix that a field or input should add to its source prop.
+ */
+export const useSourcePrefix = (): string => {
+    const prefix = useContext(SourcePrefixContext);
+    return prefix ?? '';
+};

--- a/packages/ra-core/src/core/index.ts
+++ b/packages/ra-core/src/core/index.ts
@@ -13,3 +13,4 @@ export * from './useResourceContext';
 export * from './useResourceDefinition';
 export * from './useResourceDefinitions';
 export * from './useGetRecordRepresentation';
+export * from './SourcePrefixContext';

--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -34,31 +34,6 @@ describe('FormDataConsumerView', () => {
         });
     });
 
-    it('calls its children function with scopedFormData and getSource if it received an index prop', () => {
-        const children = jest.fn(({ getSource }) => {
-            getSource('id');
-            return null;
-        });
-        const formData = { id: 123, title: 'A title', authors: [{ id: 0 }] };
-
-        render(
-            <FormDataConsumerView
-                form="a-form"
-                source="authors[0]"
-                index={0}
-                formData={formData}
-            >
-                {children}
-            </FormDataConsumerView>
-        );
-
-        expect(children.mock.calls[0][0].formData).toEqual(formData);
-        expect(children.mock.calls[0][0].scopedFormData).toEqual({ id: 0 });
-        expect(children.mock.calls[0][0].getSource('id')).toEqual(
-            'authors[0].id'
-        );
-    });
-
     it('calls its children with updated formData on first render', async () => {
         let globalFormData;
         render(
@@ -130,10 +105,7 @@ describe('FormDataConsumerView', () => {
                                     globalScopedFormData = scopedFormData;
                                     return scopedFormData &&
                                         scopedFormData.name ? (
-                                        <TextInput
-                                            source={getSource('role')}
-                                            {...rest}
-                                        />
+                                        <TextInput source="role" {...rest} />
                                     ) : null;
                                 }}
                             </FormDataConsumer>

--- a/packages/ra-core/src/form/FormDataConsumer.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import { useFormContext, FieldValues } from 'react-hook-form';
 import get from 'lodash/get';
 import { useFormValues } from './useFormValues';
+import { useSourcePrefix } from '../core';
 
 /**
  * Get the current (edited) value of the record from the form and pass it
@@ -64,13 +65,17 @@ export const FormDataConsumerView = <
 >(
     props: Props<TFieldValues>
 ) => {
-    const { children, form, formData, source, index, ...rest } = props;
+    const { children, form, formData, source, ...rest } = props;
     let ret;
 
+    const prefix = useSourcePrefix();
+    const matches = ArraySourceRegex.exec(prefix);
+
     // If we have an index, we are in an iterator like component (such as the SimpleFormIterator)
-    if (typeof index !== 'undefined' && source) {
-        const scopedFormData = get(formData, source);
-        const getSource = (scopedSource: string) => `${source}.${scopedSource}`;
+    if (matches && prefix) {
+        const scopedFormData = get(formData, prefix);
+        // Not needed anymore. Kept to avoid breaking existing code
+        const getSource = (scopedSource: string) => scopedSource;
         ret = children({ formData, scopedFormData, getSource, ...rest });
     } else {
         ret = children({
@@ -84,6 +89,8 @@ export const FormDataConsumerView = <
 };
 
 export default FormDataConsumer;
+
+const ArraySourceRegex = new RegExp(/.+\.\d+$/);
 
 export interface FormDataConsumerRenderParams<
     TFieldValues extends FieldValues = FieldValues,

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -16,6 +16,7 @@ import { useFormGroupContext } from './useFormGroupContext';
 import { useFormGroups } from './useFormGroups';
 import { useApplyInputDefaultValues } from './useApplyInputDefaultValues';
 import { useEvent } from '../util';
+import { useSourcePrefix } from '../core';
 
 // replace null or undefined values by empty string to avoid controlled/uncontrolled input warning
 const defaultFormat = (value: any) => (value == null ? '' : value);
@@ -38,7 +39,9 @@ export const useInput = <ValueType = any>(
         validate,
         ...options
     } = props;
-    const finalName = name || source;
+    const prefix = useSourcePrefix();
+    const finalSource = prefix ? `${prefix}.${source}` : source;
+    const finalName = name || finalSource;
     const formGroupName = useFormGroupContext();
     const formGroups = useFormGroups();
     const record = useRecordContext();
@@ -48,12 +51,12 @@ export const useInput = <ValueType = any>(
             return;
         }
 
-        formGroups.registerField(source, formGroupName);
+        formGroups.registerField(finalSource, formGroupName);
 
         return () => {
-            formGroups.unregisterField(source, formGroupName);
+            formGroups.unregisterField(finalSource, formGroupName);
         };
-    }, [formGroups, formGroupName, source]);
+    }, [formGroups, formGroupName, finalSource]);
 
     const sanitizedValidate = Array.isArray(validate)
         ? composeValidators(validate)
@@ -120,7 +123,7 @@ export const useInput = <ValueType = any>(
     };
 
     return {
-        id: id || source,
+        id: id || finalSource,
         field,
         fieldState,
         formState,

--- a/packages/ra-core/src/util/FieldTitle.tsx
+++ b/packages/ra-core/src/util/FieldTitle.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ReactElement, memo } from 'react';
 
 import { useTranslateLabel } from '../i18n';
+import { useSourcePrefix } from '../core';
 
 export interface FieldTitleProps {
     isRequired?: boolean;
@@ -12,6 +13,8 @@ export interface FieldTitleProps {
 
 export const FieldTitle = (props: FieldTitleProps) => {
     const { source, label, resource, isRequired } = props;
+    const prefix = useSourcePrefix();
+    const finalSource = prefix ? `${prefix}.${source}` : source;
     const translateLabel = useTranslateLabel();
 
     if (label === true) {
@@ -33,7 +36,7 @@ export const FieldTitle = (props: FieldTitleProps) => {
             {translateLabel({
                 label,
                 resource,
-                source,
+                source: finalSource,
             })}
             {isRequired && <span aria-hidden="true">&thinsp;*</span>}
         </span>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
     RecordContextProvider,
+    ResourceContextProvider,
     minLength,
     required,
     testDataProvider,
@@ -104,22 +105,24 @@ describe('<ArrayInput />', () => {
     it('should clone each input once per value in the array', () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
-                <SimpleForm
-                    onSubmit={jest.fn}
-                    defaultValues={{
-                        arr: [
-                            { id: 123, foo: 'bar' },
-                            { id: 456, foo: 'baz' },
-                        ],
-                    }}
-                >
-                    <ArrayInput resource="bar" source="arr">
-                        <SimpleFormIterator>
-                            <NumberInput source="id" />
-                            <TextInput source="foo" />
-                        </SimpleFormIterator>
-                    </ArrayInput>
-                </SimpleForm>
+                <ResourceContextProvider value="bar">
+                    <SimpleForm
+                        onSubmit={jest.fn}
+                        defaultValues={{
+                            arr: [
+                                { id: 123, foo: 'bar' },
+                                { id: 456, foo: 'baz' },
+                            ],
+                        }}
+                    >
+                        <ArrayInput source="arr">
+                            <SimpleFormIterator>
+                                <NumberInput source="id" />
+                                <TextInput source="foo" />
+                            </SimpleFormIterator>
+                        </ArrayInput>
+                    </SimpleForm>
+                </ResourceContextProvider>
             </AdminContext>
         );
         expect(
@@ -143,29 +146,30 @@ describe('<ArrayInput />', () => {
     it('should apply validation to both itself and its inner inputs', async () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
-                <SimpleForm
-                    onSubmit={jest.fn}
-                    defaultValues={{
-                        arr: [],
-                    }}
-                >
-                    <ArrayInput
-                        resource="bar"
-                        source="arr"
-                        validate={[minLength(2, 'array_min_length')]}
+                <ResourceContextProvider value="bar">
+                    <SimpleForm
+                        onSubmit={jest.fn}
+                        defaultValues={{
+                            arr: [],
+                        }}
                     >
-                        <SimpleFormIterator>
-                            <TextInput
-                                source="id"
-                                validate={[required('id_required')]}
-                            />
-                            <TextInput
-                                source="foo"
-                                validate={[required('foo_required')]}
-                            />
-                        </SimpleFormIterator>
-                    </ArrayInput>
-                </SimpleForm>
+                        <ArrayInput
+                            source="arr"
+                            validate={[minLength(2, 'array_min_length')]}
+                        >
+                            <SimpleFormIterator>
+                                <TextInput
+                                    source="id"
+                                    validate={[required('id_required')]}
+                                />
+                                <TextInput
+                                    source="foo"
+                                    validate={[required('foo_required')]}
+                                />
+                            </SimpleFormIterator>
+                        </ArrayInput>
+                    </SimpleForm>
+                </ResourceContextProvider>
             </AdminContext>
         );
 

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -10,6 +10,7 @@ import {
     useGetValidationErrorMessage,
     useFormGroupContext,
     useFormGroups,
+    useSourcePrefix,
 } from 'ra-core';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import {
@@ -90,6 +91,8 @@ export const ArrayInput = (props: ArrayInputProps) => {
 
     const formGroupName = useFormGroupContext();
     const formGroups = useFormGroups();
+    const prefix = useSourcePrefix();
+    const finalSource = prefix ? `${prefix}.${source}` : source;
 
     const sanitizedValidate = Array.isArray(validate)
         ? composeSyncValidators(validate)
@@ -105,7 +108,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
     } = useFormContext();
 
     const fieldProps = useFieldArray({
-        name: source,
+        name: finalSource,
         rules: {
             validate: async value => {
                 if (!sanitizedValidate) return true;
@@ -125,14 +128,14 @@ export const ArrayInput = (props: ArrayInputProps) => {
 
     // We need to register the array itself as a field to enable validation at its level
     useEffect(() => {
-        register(source);
-        formGroups.registerField(source, formGroupName);
+        register(finalSource);
+        formGroups.registerField(finalSource, formGroupName);
 
         return () => {
-            unregister(source, { keepValue: true });
-            formGroups.unregisterField(source, formGroupName);
+            unregister(finalSource, { keepValue: true });
+            formGroups.unregisterField(finalSource, formGroupName);
         };
-    }, [register, unregister, source, formGroups, formGroupName]);
+    }, [register, unregister, finalSource, formGroups, formGroupName]);
 
     useApplyInputDefaultValues({
         inputProps: props,
@@ -140,7 +143,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
         fieldArrayInputControl: fieldProps,
     });
 
-    const { isDirty, error } = getFieldState(source, formState);
+    const { isDirty, error } = getFieldState(finalSource, formState);
 
     if (isPending) {
         return (
@@ -158,7 +161,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
             margin={margin}
             className={clsx(
                 'ra-input',
-                `ra-input-${source}`,
+                `ra-input-${finalSource}`,
                 ArrayInputClasses.root,
                 className
             )}
@@ -166,7 +169,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
             {...sanitizeInputRestProps(rest)}
         >
             <InputLabel
-                htmlFor={source}
+                htmlFor={finalSource}
                 className={ArrayInputClasses.label}
                 shrink
                 error={(isDirty || isSubmitted) && !!error}

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
@@ -57,33 +57,6 @@ describe('<SimpleFormIterator />', () => {
         expect((inputElements[1] as HTMLInputElement).value).toBe('bar');
     });
 
-    it('should render disabled inputs when disabled is true', () => {
-        render(
-            <Wrapper>
-                <SimpleForm
-                    record={{
-                        id: 'whatever',
-                        emails: [{ email: 'foo' }, { email: 'bar' }],
-                    }}
-                >
-                    <ArrayInput source="emails" disabled>
-                        <SimpleFormIterator>
-                            <TextInput source="email" />
-                        </SimpleFormIterator>
-                    </ArrayInput>
-                </SimpleForm>
-            </Wrapper>
-        );
-        const inputElements = screen.queryAllByLabelText(
-            'resources.undefined.fields.emails.email'
-        );
-        expect(inputElements).toHaveLength(2);
-        expect((inputElements[0] as HTMLInputElement).disabled).toBeTruthy();
-        expect((inputElements[0] as HTMLInputElement).value).toBe('foo');
-        expect((inputElements[1] as HTMLInputElement).disabled).toBeTruthy();
-        expect((inputElements[1] as HTMLInputElement).value).toBe('bar');
-    });
-
     it('should allow to override the disabled prop of each inputs', () => {
         render(
             <Wrapper>
@@ -501,17 +474,14 @@ describe('<SimpleFormIterator />', () => {
                     <ArrayInput source="emails">
                         <SimpleFormIterator>
                             <FormDataConsumer>
-                                {({ getSource }) => (
+                                {() => (
                                     <>
                                         <TextInput
-                                            source={getSource!('email')}
+                                            source="email"
                                             label="Email"
                                             defaultValue="default@marmelab.com"
                                         />
-                                        <TextInput
-                                            source={getSource!('name')}
-                                            label="Name"
-                                        />
+                                        <TextInput source="name" label="Name" />
                                     </>
                                 )}
                             </FormDataConsumer>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import {
-    Children,
     cloneElement,
     MouseEvent,
     MouseEventHandler,
-    isValidElement,
     ReactElement,
     ReactNode,
     useMemo,
 } from 'react';
 import { Typography } from '@mui/material';
 import clsx from 'clsx';
-import { RaRecord } from 'ra-core';
+import { RaRecord, SourcePrefixContextProvider } from 'ra-core';
 
 import { SimpleFormIteratorClasses } from './useSimpleFormIteratorStyles';
 import { useSimpleFormIterator } from './useSimpleFormIterator';
@@ -35,7 +33,6 @@ export const SimpleFormIteratorItem = React.forwardRef(
             record,
             removeButton,
             reOrderButtons,
-            resource,
             source,
         } = props;
 
@@ -94,24 +91,9 @@ export const SimpleFormIteratorItem = React.forwardRef(
                             inline && SimpleFormIteratorClasses.inline
                         )}
                     >
-                        {Children.map(
-                            children,
-                            (input: ReactElement, index2) => {
-                                if (!isValidElement<any>(input)) {
-                                    return null;
-                                }
-                                const { source, ...inputProps } = input.props;
-                                return cloneElement(input, {
-                                    source: source
-                                        ? `${member}.${source}`
-                                        : member,
-                                    index: source ? undefined : index2,
-                                    resource,
-                                    disabled,
-                                    ...inputProps,
-                                });
-                            }
-                        )}
+                        <SourcePrefixContextProvider value={member}>
+                            {children}
+                        </SourcePrefixContextProvider>
                     </section>
                     {!disabled && (
                         <span className={SimpleFormIteratorClasses.action}>


### PR DESCRIPTION
## Problem

We need to prefix sources in multiple cases: ArrayInput + SimpleFormIterator, and many EE components.

To do that we currently clone children.

## Solution

This is avoidable by introducing a context that useInput would use to set the source.

It’s a breaking change though for custom inputs that don’t use `useInput`.