### PR TITLE
Ensure type consistency between `WithRecord` and `FunctionField`

### DIFF
--- a/packages/ra-core/src/controller/record/WithRecord.tsx
+++ b/packages/ra-core/src/controller/record/WithRecord.tsx
@@ -21,9 +21,7 @@ export const WithRecord = <RecordType extends Record<string, any> = any>({
     return record ? <>{render(record)}</> : null;
 };
 
-export interface WithRecordProps<
-    RecordType extends Record<string, any> = any
-> {
+export interface WithRecordProps<RecordType extends Record<string, any> = any> {
     render: (record: RecordType) => ReactNode;
     label?: string;
 }

--- a/packages/ra-core/src/controller/record/WithRecord.tsx
+++ b/packages/ra-core/src/controller/record/WithRecord.tsx
@@ -14,7 +14,7 @@ import { useRecordContext } from './useRecordContext';
  *   </Show>
  * );
  */
-export const WithRecord = <RecordType extends Record<string, unknown> = any>({
+export const WithRecord = <RecordType extends Record<string, any> = any>({
     render,
 }: WithRecordProps<RecordType>) => {
     const record = useRecordContext<RecordType>();
@@ -22,7 +22,7 @@ export const WithRecord = <RecordType extends Record<string, unknown> = any>({
 };
 
 export interface WithRecordProps<
-    RecordType extends Record<string, unknown> = any
+    RecordType extends Record<string, any> = any
 > {
     render: (record: RecordType) => ReactNode;
     label?: string;


### PR DESCRIPTION
This PR aims to align the types used in `FunctionField` and `WithRecord`. Currently, `FunctionField` utilizes `Record<string, any>`, whereas `WithRecord` employs `Record<string, unknown>`. The proposed change seeks to standardize these types.

I came across this change (https://github.com/marmelab/react-admin/pull/9092) and noticed that the `WithRecord` prop type hasn't been updated yet.

Given the discussion in this comment (https://github.com/marmelab/react-admin/pull/8963#discussion_r1213580943), maintaining type consistency between `FunctionField` and `WithRecord` seems crucial.
