### PR TITLE
Fix `<MenuItemLink>` type by omitting `placeholder` prop

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -140,19 +140,16 @@ export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
     );
 });
 
-export type MenuItemLinkProps = Omit<
-    LinkProps &
-        MenuItemProps<'li'> & {
-            leftIcon?: ReactElement;
-            primaryText?: ReactNode;
-            /**
-             * @deprecated
-             */
-            sidebarIsOpen?: boolean;
-            tooltipProps?: TooltipProps;
-        },
-    'placeholder'
->;
+export type MenuItemLinkProps = LinkProps &
+    Omit<MenuItemProps<'li'>, 'placeholder'> & {
+        leftIcon?: ReactElement;
+        primaryText?: ReactNode;
+        /**
+         * @deprecated
+         */
+        sidebarIsOpen?: boolean;
+        tooltipProps?: TooltipProps;
+    };
 
 MenuItemLink.propTypes = {
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -140,16 +140,19 @@ export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
     );
 });
 
-export type MenuItemLinkProps = LinkProps &
-    MenuItemProps<'li'> & {
-        leftIcon?: ReactElement;
-        primaryText?: ReactNode;
-        /**
-         * @deprecated
-         */
-        sidebarIsOpen?: boolean;
-        tooltipProps?: TooltipProps;
-    };
+export type MenuItemLinkProps = Omit<
+    LinkProps &
+        MenuItemProps<'li'> & {
+            leftIcon?: ReactElement;
+            primaryText?: ReactNode;
+            /**
+             * @deprecated
+             */
+            sidebarIsOpen?: boolean;
+            tooltipProps?: TooltipProps;
+        },
+    'placeholder'
+>;
 
 MenuItemLink.propTypes = {
     className: PropTypes.string,


### PR DESCRIPTION
With this merge request https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67170 introduced into @types/react 18.2.43, `placeholder` prop is no longer in `HTMLAttributes`.

Somehow since 18.2.43 the `<MenuItemLink>` requires us to pass the `placeholder` prop to the `<a>` tag below, where there are no such prop defined in [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)

Closes #9507