### PR TITLE
style: narrowing ReactQueryDevtools button

### DIFF
--- a/examples/simple/assets/app.css
+++ b/examples/simple/assets/app.css
@@ -1,3 +1,7 @@
+/* 
+Because the style prop no longer exist in TanStack Query v5,
+we have to use this rule to customize ReactQueryDevtools button size:
+*/
 .tsqd-transitions-container>div {
   height: 30px;
   width: 30px;

--- a/examples/simple/assets/app.css
+++ b/examples/simple/assets/app.css
@@ -1,0 +1,4 @@
+.tsqd-transitions-container>div {
+  height: 30px;
+  width: 30px;
+}

--- a/examples/simple/src/Layout.tsx
+++ b/examples/simple/src/Layout.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AppBar, Layout, InspectorButton, TitlePortal } from 'react-admin';
+import '../assets/app.css';
 
 const MyAppBar = () => (
     <AppBar>


### PR DESCRIPTION
## Problem
The ReactQueryDevtools button is too big

![image](https://github.com/marmelab/react-admin/assets/7949510/3b709a3d-b14b-4f57-98d1-a7d25d0d2829)

## Solution

![2024-01-04_15-28](https://github.com/marmelab/react-admin/assets/7949510/11672786-015b-4962-8c38-f7976cc7b4d7)
