### PR TITLE
fix: merge InputProps so Autocomplete still works

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -1592,9 +1592,11 @@ describe('<AutocompleteInput />', () => {
     describe('InputProps', () => {
         it('should pass InputProps to the input', async () => {
             render(<WithInputProps />);
-            await screen.findByRole('textbox');
+            const input = await screen.findByRole('textbox');
             screen.getByTestId('AttributionIcon');
             screen.getByTestId('ExpandCircleDownIcon');
+            fireEvent.click(input);
+            screen.getByText('Victor Hugo');
         });
     });
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -1221,7 +1221,7 @@ export const WithInputProps = () => {
                                 TextFieldProps={{
                                     InputProps: {
                                         startAdornment: (
-                                            <InputAdornment position="end">
+                                            <InputAdornment position="start">
                                                 <AttributionIcon />
                                             </InputAdornment>
                                         ),

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -560,42 +560,51 @@ If you provided a React element for the optionText prop, you must also provide t
                 id={id}
                 isOptionEqualToValue={isOptionEqualToValue}
                 filterSelectedOptions
-                renderInput={params => (
-                    <TextField
-                        name={field.name}
-                        label={
-                            <FieldTitle
-                                label={label}
-                                source={source}
-                                resource={resourceProp}
-                                isRequired={isRequired}
-                            />
-                        }
-                        error={
-                            !!fetchError ||
-                            ((isTouched || isSubmitted) && invalid)
-                        }
-                        helperText={
-                            renderHelperText ? (
-                                <InputHelperText
-                                    touched={
-                                        isTouched || isSubmitted || fetchError
-                                    }
-                                    error={
-                                        error?.message || fetchError?.message
-                                    }
-                                    helperText={helperText}
+                renderInput={params => {
+                    const mergedTextFieldProps = {
+                        ...params.InputProps,
+                        ...TextFieldProps.InputProps,
+                    };
+                    return (
+                        <TextField
+                            name={field.name}
+                            label={
+                                <FieldTitle
+                                    label={label}
+                                    source={source}
+                                    resource={resourceProp}
+                                    isRequired={isRequired}
                                 />
-                            ) : null
-                        }
-                        margin={margin}
-                        variant={variant}
-                        className={AutocompleteInputClasses.textField}
-                        {...params}
-                        {...TextFieldProps}
-                        size={size}
-                    />
-                )}
+                            }
+                            error={
+                                !!fetchError ||
+                                ((isTouched || isSubmitted) && invalid)
+                            }
+                            helperText={
+                                renderHelperText ? (
+                                    <InputHelperText
+                                        touched={
+                                            isTouched ||
+                                            isSubmitted ||
+                                            fetchError
+                                        }
+                                        error={
+                                            error?.message ||
+                                            fetchError?.message
+                                        }
+                                        helperText={helperText}
+                                    />
+                                ) : null
+                            }
+                            margin={margin}
+                            variant={variant}
+                            className={AutocompleteInputClasses.textField}
+                            {...params}
+                            InputProps={mergedTextFieldProps}
+                            size={size}
+                        />
+                    );
+                }}
                 multiple={multiple}
                 renderTags={(value, getTagProps) =>
                     value.map((option, index) => (


### PR DESCRIPTION
## Problem

Passing `InputProps` to the `TextFieldProps` prop of `<AutocompleteInput>` works but it leads to break the `Autocomplete` behavior we want to keep.

## Solution

Merge `InputProps` to apply them AND keep the `Autocomplete` behavior