### PR TITLE
Follow up fix of `<MenuItemLink>` `placeholder` prop type

### DIFF
--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -140,16 +140,18 @@ export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
     );
 });
 
-export type MenuItemLinkProps = LinkProps &
-    Omit<MenuItemProps<'li'>, 'placeholder'> & {
-        leftIcon?: ReactElement;
-        primaryText?: ReactNode;
-        /**
-         * @deprecated
-         */
-        sidebarIsOpen?: boolean;
-        tooltipProps?: TooltipProps;
-    };
+export type MenuItemLinkProps = Omit<
+    LinkProps & MenuItemProps<'li'>,
+    'placeholder'
+> & {
+    leftIcon?: ReactElement;
+    primaryText?: ReactNode;
+    /**
+     * @deprecated
+     */
+    sidebarIsOpen?: boolean;
+    tooltipProps?: TooltipProps;
+};
 
 MenuItemLink.propTypes = {
     className: PropTypes.string,


### PR DESCRIPTION
Hi @fzaninotto,

After applying your review from https://github.com/marmelab/react-admin/pull/9555 , I built and tested it locally with `yarn link` to my own project. Omitting from just `MenuItemProps` won't fix the problem. 

It seems we have to omit the `placeholder` from the union of `LinkProps` and `MenuItemProps`. Both of them seems has some issue require a non-existent `placeholder`.