### PR TITLE
Revert "fix: SelectArrayInput does not use recordRepresentation"

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -11,7 +11,6 @@ import {
     DifferentIdTypes,
     TranslateChoice,
     InsideArrayInput,
-    WithRecordRepresentation,
 } from './SelectArrayInput.stories';
 
 describe('<SelectArrayInput />', () => {
@@ -659,21 +658,5 @@ describe('<SelectArrayInput />', () => {
         await screen.findByText('Foo');
         fireEvent.click(screen.getByLabelText('Add'));
         expect(await screen.findAllByText('Foo')).toHaveLength(2);
-    });
-
-    describe('record representation', () => {
-        it('should use record representation if defined', async () => {
-            render(<WithRecordRepresentation />);
-            await screen.findByText('resources.tags.fields.tag_ids');
-            expect(screen.queryByText('1 - Architecture')).not.toBeNull();
-            expect(screen.queryByText('3 - Painting')).not.toBeNull();
-        });
-
-        it('should use option text instead of record representation if defined', async () => {
-            render(<WithRecordRepresentation setOptionText />);
-            await screen.findByText('resources.tags.fields.tag_ids');
-            expect(screen.queryByText('Architecture')).not.toBeNull();
-            expect(screen.queryByText('Painting')).not.toBeNull();
-        });
     });
 });

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -18,11 +18,7 @@ import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import { TextInput } from './TextInput';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
-import {
-    DataProvider,
-    FormDataConsumer,
-    ResourceDefinitionContextProvider,
-} from 'ra-core';
+import { FormDataConsumer } from 'ra-core';
 import { useWatch } from 'react-hook-form';
 
 export default { title: 'ra-ui-materialui/input/SelectArrayInput' };
@@ -355,56 +351,3 @@ export const TranslateChoice = () => {
         </AdminContext>
     );
 };
-
-export const WithRecordRepresentation = ({ setOptionText = false }) => {
-    const tags = [
-        { id: 0, name: '3D' },
-        { id: 1, name: 'Architecture' },
-        { id: 2, name: 'Design' },
-        { id: 3, name: 'Painting' },
-        { id: 4, name: 'Photography' },
-    ];
-    const resouceDefs = {
-        tags: {
-            name: 'tags',
-            recordRepresentation: record => `${record.id} - ${record.name}`,
-        },
-    };
-    return (
-        <AdminContext
-            dataProvider={
-                ({
-                    getList: () =>
-                        Promise.resolve({
-                            data: tags,
-                            total: tags.length,
-                        }),
-                    getMany: (_, params) => {
-                        return Promise.resolve({
-                            data: params.ids.map(id =>
-                                tags.find(tag => tag.id === id)
-                            ),
-                        });
-                    },
-                } as unknown) as DataProvider
-            }
-        >
-            <ResourceDefinitionContextProvider definitions={resouceDefs}>
-                <SimpleForm
-                    defaultValues={{ tag_ids: [1, 3] }}
-                    onSubmit={() => {}}
-                >
-                    <ReferenceArrayInput reference="tags" source="tag_ids">
-                        <SelectArrayInput
-                            optionText={setOptionText ? 'name' : undefined}
-                        />
-                    </ReferenceArrayInput>
-                </SimpleForm>
-            </ResourceDefinitionContextProvider>
-        </AdminContext>
-    );
-};
-
-export const WithRecordRepresentationAndOptionText = () => (
-    <WithRecordRepresentation setOptionText />
-);

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -20,7 +20,6 @@ import {
     useChoicesContext,
     useChoices,
     RaRecord,
-    useGetRecordRepresentation,
 } from 'ra-core';
 import { InputHelperText } from './InputHelperText';
 import { FormControlProps } from '@mui/material/FormControl';
@@ -106,7 +105,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         onChange,
         onCreate,
         options = defaultOptions,
-        optionText,
+        optionText = 'name',
         optionValue = 'id',
         parse,
         resource: resourceProp,
@@ -135,11 +134,8 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         source: sourceProp,
     });
 
-    const getRecordRepresentation = useGetRecordRepresentation(resource);
     const { getChoiceText, getChoiceValue, getDisableValue } = useChoices({
-        optionText:
-            optionText ??
-            (isFromReference ? getRecordRepresentation : undefined),
+        optionText,
         optionValue,
         disableValue,
         translateChoice: translateChoice ?? !isFromReference,


### PR DESCRIPTION
Reverts marmelab/react-admin#9532 since it introduced a regression:
When `SelectArrayInput` is used inside a reference input, and targets a resource that does not have a record representation: we used to use the `'name'` field, whereas now the record representation will be `#${record.id}` which is less informative.