### PR TITLE
Add lookupSource to ReferenceInput

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -58,6 +58,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         queryOptions = {},
         reference,
         source,
+        lookupSource = source
     } = props;
     const { meta, ...otherQueryOptions } = queryOptions;
 
@@ -72,6 +73,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
 
     // selection logic
     const currentValue = useWatch({ name: source });
+    const lookupCurrentValue = useWatch({ name: lookupSource });
 
     const isGetMatchingEnabled = enableGetChoices
         ? enableGetChoices(params.filterValues)
@@ -112,7 +114,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         isLoading: referenceLoading,
         isFetching: referenceFetching,
     } = useReference<RecordType>({
-        id: currentValue,
+        id: lookupCurrentValue,
         reference,
         // @ts-ignore the types of the queryOptions for the getMAny and getList are not compatible
         options: {
@@ -210,5 +212,6 @@ export interface UseReferenceInputControllerParams<
     resource?: string;
     sort?: SortPayload;
     source: string;
+    lookupSource?: string;
     enableGetChoices?: (filters: any) => boolean;
 }


### PR DESCRIPTION
This is a proposal from #9516. @fzaninotto

Let me know if this looks reasonable, and then I'll take a look at tests/docs.

The basic idea of lookupSource (or maybe idSource?) is to use a different source for the ID used in the getMany call.
ReferenceInput will continue to use source when actually updating the value, but will use lookupSource to fetch the record for repr.
lookupSource defaults to source, so should be fully backwards-compatible.

--------------

This will allow using a resource structure that can support composite keys, PKs not named 'id' etc.

Taking the example from that conversation:
```
Book = {
  id: str
  data: {
    ...
    authorId: int  // FK in DB
  }
  fk_authorId: str
}
```

We would then use `<ReferenceInput source="data.authorId" lookupSource="fk_authorId" {...}>`.
This would then lookup the current record using the normalised fk_authorId, but when the selection is changed in the input it is the data.authorId attribute that would be updated (from the int value).