### PR TITLE
Fix click on `<Datagrid>` Select All button bubbles up to parent Datagrid

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -245,6 +245,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                         ref={ref}
                         className={DatagridClasses.table}
                         size={size}
+                        onClick={e => e.stopPropagation()}
                         {...sanitizeRestProps(rest)}
                     >
                         {createOrCloneElement(

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -245,7 +245,6 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                         ref={ref}
                         className={DatagridClasses.table}
                         size={size}
-                        onClick={e => e.stopPropagation()}
                         {...sanitizeRestProps(rest)}
                     >
                         {createOrCloneElement(

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -124,6 +124,7 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
                                 )
                             }
                             onChange={handleSelectAll}
+                            onClick={e => e.stopPropagation()}
                         />
                     </TableCell>
                 )}


### PR DESCRIPTION
This adds stopPropagation() to the entire DataGrid, to avoid propagation when clicking anywhere in the grid.

Currently, clicking the select all checkbox or an empty space  on the header still triggers the click on the parent element (e.g. nest 2 DataGrids and the select all button will trigger the rowClick of the parent DataGrid).

If this approach seems too much, then we could move this line to the checkbox in DataGridHeader.