### PR TITLE
[Doc] fix jekyll trying to parse jsx code on <Edit> mutationOptions

### DIFF
--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -365,6 +365,7 @@ The default `onSuccess` function is:
 
 **Tip**: When you use `mutationMode="pessimistic"`, the `onSuccess` function receives the response from the `dataProvider.update()` call, which is the created/edited record (see [the dataProvider documentation for details](./DataProviderWriting.md#response-format)). You can use that response in the success side effects: 
 
+{% raw %}
 ```jsx
 import * as React from 'react';
 import { useNotify, useRefresh, useRedirect, Edit, SimpleForm } from 'react-admin';
@@ -389,6 +390,7 @@ const PostEdit = () => {
     );
 }
 ```
+{% endraw %}
 
 **Tip**: If you want to have different success side effects based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save and redirect to the list", and another to "save and display an empty form"), you can set the `mutationOptions` prop on [the `<SaveButton>` component](./SaveButton.md), too.
 

--- a/docs/Resource.md
+++ b/docs/Resource.md
@@ -90,7 +90,7 @@ The routing will map the component as follows:
 
 * [`name`](#name)
 * [`icon`](#icon)
-* [`options`](#icon)
+* [`options`](#options)
 * [`recordRepresentation`](#recordrepresentation)
 
 ## `children`


### PR DESCRIPTION
I didn't run this locally, but my research points to me that this should fix the issue of 
`<Edit mutationOptions={{ onSuccess }} mutationMode="pessimistic">`
being displayed as 
`<Edit mutationOptions= mutationMode="pessimistic">`

![image](https://github.com/marmelab/react-admin/assets/60754055/955f2261-8a55-4209-a757-0f83ef077228)
