### PR TITLE
[Demo] Remove useless defaultProps usage

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -288,7 +288,7 @@ And see [the Material UI system documentation](https://mui.com/system/the-sx-pro
 
 This prop defines the text alignment of the field when rendered inside a `<Datagrid>` cell. By default, datagrid values are left-aligned ; for numeric values, it's often better to right-align them. Set `textAlign` to `right` for that.
 
-[`<NumberField>`](./NumberField.md) already uses `textAlign="right"`. Set the default value for this prop if you create a custom numeric field. 
+[`<NumberField>`](./NumberField.md) already uses `textAlign="right"`. Set the default value for this prop if you create a custom numeric field.
 
 ```jsx
 const BasketTotal = () => {

--- a/examples/crm/src/deals/DealList.tsx
+++ b/examples/crm/src/deals/DealList.tsx
@@ -44,7 +44,7 @@ const DealList = () => {
 
 const dealFilters = [
     <SearchInput source="q" alwaysOn />,
-    <OnlyMineInput alwaysOn />,
+    <OnlyMineInput source="sales_id" alwaysOn />,
     <SelectInput source="type" choices={typeChoices} />,
 ];
 

--- a/examples/crm/src/deals/OnlyMineInput.tsx
+++ b/examples/crm/src/deals/OnlyMineInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useListFilterContext, useGetIdentity } from 'react-admin';
 import { Box, Switch, FormControlLabel } from '@mui/material';
 
-export const OnlyMineInput = (_: { alwaysOn: boolean }) => {
+export const OnlyMineInput = (_: { alwaysOn: boolean; source: string }) => {
     const {
         filterValues,
         displayedFilters,
@@ -35,5 +35,3 @@ export const OnlyMineInput = (_: { alwaysOn: boolean }) => {
         </Box>
     );
 };
-
-OnlyMineInput.defaultProps = { source: 'sales_id' };

--- a/examples/demo/src/i18n/en.ts
+++ b/examples/demo/src/i18n/en.ts
@@ -53,6 +53,7 @@ const customEnglishMessages: TranslationMessages = {
             fields: {
                 commands: 'Orders',
                 first_seen: 'First seen',
+                full_name: 'Name',
                 groups: 'Segments',
                 last_seen: 'Last seen',
                 last_seen_gte: 'Visited Since',

--- a/examples/demo/src/i18n/fr.ts
+++ b/examples/demo/src/i18n/fr.ts
@@ -58,6 +58,7 @@ const customFrenchMessages: TranslationMessages = {
                 commands: 'Commandes',
                 first_name: 'Prénom',
                 first_seen: 'Première visite',
+                full_name: 'Nom',
                 groups: 'Segments',
                 has_newsletter: 'Abonné à la newsletter',
                 has_ordered: 'A commandé',

--- a/examples/demo/src/orders/MobileGrid.tsx
+++ b/examples/demo/src/orders/MobileGrid.tsx
@@ -81,9 +81,4 @@ const MobileGrid = () => {
     );
 };
 
-MobileGrid.defaultProps = {
-    data: {},
-    ids: [],
-};
-
 export default MobileGrid;

--- a/examples/demo/src/orders/NbItemsField.tsx
+++ b/examples/demo/src/orders/NbItemsField.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
-import { FunctionField } from 'react-admin';
+import { FunctionField, FieldProps } from 'react-admin';
 import { Order } from '../types';
 
-const render = (record: Order) => record.basket.length;
-
-const NbItemsField = () => <FunctionField<Order> render={render} />;
-
-NbItemsField.defaultProps = {
-    label: 'resources.commands.fields.nb_items',
-    textAlign: 'right',
-};
+const NbItemsField = (_: FieldProps) => (
+    <FunctionField<Order> render={record => record.basket.length} />
+);
 
 export default NbItemsField;

--- a/examples/demo/src/orders/OrderList.tsx
+++ b/examples/demo/src/orders/OrderList.tsx
@@ -142,7 +142,10 @@ const TabbedDatagrid = () => {
                             >
                                 <AddressField />
                             </ReferenceField>
-                            <NbItemsField />
+                            <NbItemsField
+                                label="resources.commands.fields.nb_items"
+                                textAlign="right"
+                            />
                             <NumberField
                                 source="total_ex_taxes"
                                 options={{
@@ -190,7 +193,10 @@ const TabbedDatagrid = () => {
                             >
                                 <AddressField />
                             </ReferenceField>
-                            <NbItemsField />
+                            <NbItemsField
+                                label="resources.commands.fields.nb_items"
+                                textAlign="right"
+                            />
                             <NumberField
                                 source="total_ex_taxes"
                                 options={{
@@ -242,7 +248,10 @@ const TabbedDatagrid = () => {
                             >
                                 <AddressField />
                             </ReferenceField>
-                            <NbItemsField />
+                            <NbItemsField
+                                label="resources.commands.fields.nb_items"
+                                textAlign="right"
+                            />
                             <NumberField
                                 source="total_ex_taxes"
                                 options={{

--- a/examples/demo/src/products/ProductRefField.tsx
+++ b/examples/demo/src/products/ProductRefField.tsx
@@ -4,7 +4,7 @@ import { Link as MuiLink } from '@mui/material';
 import { useRecordContext } from 'react-admin';
 import { Product } from '../types';
 
-const ProductRefField = () => {
+const ProductRefField = (_: { source: string }) => {
     const record = useRecordContext<Product>();
     return record ? (
         <MuiLink
@@ -15,11 +15,6 @@ const ProductRefField = () => {
             {record.reference}
         </MuiLink>
     ) : null;
-};
-
-ProductRefField.defaultProps = {
-    source: 'id',
-    label: 'Reference',
 };
 
 export default ProductRefField;

--- a/examples/demo/src/products/ProductReferenceField.tsx
+++ b/examples/demo/src/products/ProductReferenceField.tsx
@@ -19,8 +19,4 @@ const ProductReferenceField = (
     </ReferenceField>
 );
 
-ProductReferenceField.defaultProps = {
-    source: 'product_id',
-};
-
 export default ProductReferenceField;

--- a/examples/demo/src/reviews/ReviewEdit.tsx
+++ b/examples/demo/src/reviews/ReviewEdit.tsx
@@ -45,7 +45,7 @@ const ReviewEdit = ({ id, onCancel }: Props) => {
                             </Labeled>
                         </Grid>
                         <Grid item xs={6}>
-                            <Labeled>
+                            <Labeled label="resources.reviews.fields.product_id">
                                 <ProductReferenceField />
                             </Labeled>
                         </Grid>

--- a/examples/demo/src/reviews/ReviewListDesktop.tsx
+++ b/examples/demo/src/reviews/ReviewListDesktop.tsx
@@ -49,7 +49,7 @@ const ReviewListDesktop = ({ selectedRow }: ReviewListDesktopProps) => (
     >
         <DateField source="date" />
         <CustomerReferenceField link={false} />
-        <ProductReferenceField link={false} />
+        <ProductReferenceField source="product_id" link={false} />
         <StarRatingField size="small" />
         <TextField source="comment" />
         <TextField source="status" />

--- a/examples/demo/src/reviews/ReviewListMobile.tsx
+++ b/examples/demo/src/reviews/ReviewListMobile.tsx
@@ -22,12 +22,4 @@ const ReviewListMobile = () => {
     );
 };
 
-ReviewListMobile.propTypes = {
-    data: PropTypes.any,
-    hasBulkActions: PropTypes.bool.isRequired,
-    ids: PropTypes.array,
-    onToggleItem: PropTypes.func,
-    selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
-};
-
 export default ReviewListMobile;

--- a/examples/demo/src/reviews/ReviewListMobile.tsx
+++ b/examples/demo/src/reviews/ReviewListMobile.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { List } from '@mui/material';
 import { RecordContextProvider, useListContext } from 'react-admin';
 

--- a/examples/demo/src/reviews/ReviewListMobile.tsx
+++ b/examples/demo/src/reviews/ReviewListMobile.tsx
@@ -30,9 +30,4 @@ ReviewListMobile.propTypes = {
     selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
 };
 
-ReviewListMobile.defaultProps = {
-    hasBulkActions: false,
-    selectedIds: [],
-};
-
 export default ReviewListMobile;

--- a/examples/demo/src/visitors/CustomerLinkField.tsx
+++ b/examples/demo/src/visitors/CustomerLinkField.tsx
@@ -16,8 +16,4 @@ const CustomerLinkField = (_: FieldProps<Customer>) => {
     );
 };
 
-CustomerLinkField.defaultProps = {
-    source: 'customer_id',
-};
-
 export default CustomerLinkField;

--- a/examples/demo/src/visitors/VisitorList.tsx
+++ b/examples/demo/src/visitors/VisitorList.tsx
@@ -51,7 +51,10 @@ const VisitorList = () => {
                         },
                     }}
                 >
-                    <CustomerLinkField />
+                    <CustomerLinkField
+                        source="last_name"
+                        label="resources.customers.fields.full_name"
+                    />
                     <DateField source="last_seen" />
                     <NumberField
                         source="nb_commands"

--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -135,11 +135,6 @@ const CommentGrid = () => {
     );
 };
 
-CommentGrid.defaultProps = {
-    data: {},
-    ids: [],
-};
-
 const CommentMobileList = () => (
     <SimpleList
         primaryText={record => record.author.name}

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -172,11 +172,6 @@ NumberInput.propTypes = {
     step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-NumberInput.defaultProps = {
-    step: 'any',
-    textAlign: 'right',
-};
-
 export interface NumberInputProps
     extends CommonInputProps,
         Omit<


### PR DESCRIPTION
React discourages the use of defaultProps and may one day remove support for it. They aren't even documented in the latest version of the React docs. 

Our demos contain custom components that don't really need defaultProps, so this PR replaces it with real props.

Some custom components with defaultProps remain in the demo (StarRatingField, ColoredNumberField, etc) because removing defaultProps for them would lead to a lot of repetition. These currently need defaultProps and there is no better alternative for now.