### PR TITLE
Use elem.key from filter elements

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -59,8 +59,8 @@ describe('<FilterForm />', () => {
     it('should retain key values in the form inputs', () => {
         // As key is not rendered, we just test that the React warning doesn't occur.
         const origWarn = console.warn;
-        console.warn = (message) => {
-            throw new Error(message)
+        console.warn = message => {
+            throw new Error(message);
         };
 
         const setFilters = jest.fn();

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -78,7 +78,7 @@ describe('<FilterForm />', () => {
             </AdminContext>
         );
         expect(screen.queryAllByLabelText('Title')).toHaveLength(1);
-        expect(screen.queryAllByLabelText('Name')).toHaveLength(1);
+        expect(screen.queryAllByLabelText('Title2')).toHaveLength(1);
     });
 
     it('should change the filter when the user updates an input', async () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -58,8 +58,8 @@ describe('<FilterForm />', () => {
 
     it('should retain key values in the form inputs', () => {
         // As key is not rendered, we just test that the React warning doesn't occur.
-        const origWarn = console.warn;
-        console.warn = message => {
+        const origError = console.error;
+        console.error = message => {
             throw new Error(message);
         };
 
@@ -85,7 +85,7 @@ describe('<FilterForm />', () => {
                 </AdminContext>
             );
         }).not.toThrow();
-        console.warn = origWarn;
+        console.error = origError;
     });
 
     it('should change the filter when the user updates an input', async () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -56,6 +56,31 @@ describe('<FilterForm />', () => {
         expect(screen.queryAllByLabelText('Name')).toHaveLength(1);
     });
 
+    it('should retain key values in the form inputs', () => {
+        const setFilters = jest.fn();
+        const filters = [
+            <TextInput source="title" label="Title" key="custom-key" />,
+            <TextInput source="title" label="Title2" key="another-key" />,
+        ];
+        const displayedFilters = {
+            title: true,
+            title2: true,
+        };
+
+        render(
+            <AdminContext>
+                <FilterForm
+                    {...defaultProps}
+                    setFilters={setFilters}
+                    filters={filters}
+                    displayedFilters={displayedFilters}
+                />
+            </AdminContext>
+        );
+        expect(screen.queryAllByLabelText('Title')).toHaveLength(1);
+        expect(screen.queryAllByLabelText('Name')).toHaveLength(1);
+    });
+
     it('should change the filter when the user updates an input', async () => {
         const filters = [<TextInput source="title" label="Title" />];
         const displayedFilters = {

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -57,6 +57,12 @@ describe('<FilterForm />', () => {
     });
 
     it('should retain key values in the form inputs', () => {
+        // As key is not rendered, we just test that the React warning doesn't occur.
+        const origWarn = console.warn;
+        console.warn = (message) => {
+            throw new Error(message)
+        };
+
         const setFilters = jest.fn();
         const filters = [
             <TextInput source="title" label="Title" key="custom-key" />,
@@ -67,18 +73,19 @@ describe('<FilterForm />', () => {
             title2: true,
         };
 
-        render(
-            <AdminContext>
-                <FilterForm
-                    {...defaultProps}
-                    setFilters={setFilters}
-                    filters={filters}
-                    displayedFilters={displayedFilters}
-                />
-            </AdminContext>
-        );
-        expect(screen.queryAllByLabelText('Title')).toHaveLength(1);
-        expect(screen.queryAllByLabelText('Title2')).toHaveLength(1);
+        expect(() => {
+            render(
+                <AdminContext>
+                    <FilterForm
+                        {...defaultProps}
+                        setFilters={setFilters}
+                        filters={filters}
+                        displayedFilters={displayedFilters}
+                    />
+                </AdminContext>
+            );
+        }).not.toThrow();
+        console.warn = origWarn;
     });
 
     it('should change the filter when the user updates an input', async () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -142,7 +142,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
             >
                 {getShownFilters().map((filterElement: JSX.Element) => (
                     <FilterFormInput
-                        key={filterElement.props.source}
+                        key={filterElement.key || filterElement.props.source}
                         filterElement={filterElement}
                         handleHide={handleHide}
                         resource={resource}

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -142,7 +142,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
             >
                 {getShownFilters().map((filterElement: JSX.Element) => (
                     <FilterFormInput
-                        key={filterElement.key || filterElement.props.source}
+                        key={filterElement.props.source}  // filterElement.key || 
                         filterElement={filterElement}
                         handleHide={handleHide}
                         resource={resource}

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -142,7 +142,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
             >
                 {getShownFilters().map((filterElement: JSX.Element) => (
                     <FilterFormInput
-                        key={filterElement.props.source}  // filterElement.key || 
+                        key={filterElement.key || filterElement.props.source}
                         filterElement={filterElement}
                         handleHide={handleHide}
                         resource={resource}


### PR DESCRIPTION
Tangentially related to #9587, if 2 inputs are used in filters with the same source then they end up with duplicate keys even when those components already provide their own unique keys.