### PR TITLE
Fix label inference regression

### DIFF
--- a/packages/ra-core/src/i18n/useTranslateLabel.ts
+++ b/packages/ra-core/src/i18n/useTranslateLabel.ts
@@ -19,8 +19,6 @@ export const useTranslateLabel = () => {
             label?: string | false | ReactElement;
             resource?: string;
         }) => {
-            const finalSource = sourceContext?.getSource(source) ?? source;
-
             if (label === false || label === '') {
                 return null;
             }
@@ -35,7 +33,7 @@ export const useTranslateLabel = () => {
                     defaultLabel: sourceContext?.getLabel(source),
                     resource,
                     resourceFromContext,
-                    source: finalSource,
+                    source,
                 })
             );
         },

--- a/packages/ra-ui-materialui/src/input/TranslatableInputs.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputs.spec.tsx
@@ -10,6 +10,7 @@ import { SimpleForm } from '../form';
 import { TranslatableInputs } from './TranslatableInputs';
 import { TranslatableInputsTab } from './TranslatableInputsTab';
 import { TranslatableInputsTabContentClasses } from './TranslatableInputsTabContent';
+import { Basic } from './TranslatableInputs.stories';
 
 const record = {
     id: 123,
@@ -272,5 +273,12 @@ describe('<TranslatableInputs />', () => {
         expect(screen.getByLabelText('fr').classList).not.toContain(
             TranslatableInputsTabContentClasses.hidden
         );
+    });
+
+    it('should infer labels correctly', async () => {
+        render(<Basic />);
+
+        expect(await screen.findAllByLabelText('Title')).toHaveLength(2);
+        expect(await screen.findAllByLabelText('Description')).toHaveLength(2);
     });
 });


### PR DESCRIPTION
# Problem

When introducing the `SourceContext`, we also introduced a regression on the label inference (when no translations are provided). We pass the modified `source` to the inference function (eg: `title.en`) instead of the input `source` (eg: `title`).
This results in wrong label like `Title en` instead of `Title`