### PR TITLE
docs: update Vietnamese link to replace the deprecated package

### DIFF
--- a/docs/TranslationLocales.md
+++ b/docs/TranslationLocales.md
@@ -45,7 +45,7 @@ You can find translation packages for the following languages:
 - Swedish (`sv`): [kolben/ra-language-swedish](https://github.com/kolben/ra-language-swedish)
 - Turkish (`tr`): [KamilGunduz/ra-language-turkish](https://github.com/KamilGunduz/ra-language-turkish)
 - Ukrainian (`ua`): [koresar/ra-language-ukrainian](https://github.com/koresar/ra-language-ukrainian)
-- Vietnamese (`vi`): [hieunguyendut/ra-language-vietnamese](https://github.com/hieunguyendut/ra-language-vietnamese)
+- Vietnamese (`vi`): [completejavascript/ra-language-vietnamese](https://github.com/completejavascript/ra-language-vietnamese)
 
 In addition, the previous version of react-admin, called admin-on-rest, was translated into the following languages:
 


### PR DESCRIPTION
- Add Vietnamese messages for React-Admin v4.16.6
- Support TypeScript