### PR TITLE
Fix `useUpdateMany` doesn't properly update cache in pessimistic mode

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -146,7 +146,7 @@ export default PostList;
 
 ## `bulkActionButtons`
 
-Bulk action buttons appear when users select one or several rows, and affect all the selected records. This is useful for actions like mass deletion or mass edition.
+Bulk action buttons appear when users select one or several rows. Clicking on a bulk action button affects all the selected records. This is useful for actions like mass deletion or mass edition.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/bulk-actions-toolbar.mp4" type="video/mp4"/>
@@ -159,6 +159,20 @@ Users can select a range of rows by pressing the shift key while clicking on a r
   <source src="./img/datagrid-select-range.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
+
+You disable this feature by setting the `bulkActionButtons` prop to `false`:
+
+```tsx
+import { Datagrid, List } from 'react-admin';
+
+export const PostList = () => (
+    <List>
+        <Datagrid bulkActionButtons={false}>
+            ...
+        </Datagrid>
+    </List>
+);
+```
 
 By default, all Datagrids have a single bulk action button, the bulk delete button. You can add other bulk action buttons by passing a custom element as the `bulkActionButtons` prop of the `<Datagrid>` component:
 

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -254,11 +254,13 @@ const CustomResetViewsButton = () => {
         { ids: selectedIds, data: { views: 0 } },
         {
             onSuccess: () => {
-                refresh();
                 notify('Posts updated');
                 unselectAll();
             },
-            onError: () => notify('Error: posts not updated', { type: 'error' }),
+            onError: () => {
+                notify('Error: posts not updated', { type: 'error' });
+                refresh();
+            },
         }
     );
 
@@ -302,11 +304,13 @@ const CustomResetViewsButton = () => {
         { ids: selectedIds, data: { views: 0 } },
         {
             onSuccess: () => {
-                refresh();
                 notify('Posts updated');
                 unselectAll();
             },
-            onError: error => notify('Error: posts not updated', { type: 'error' }),
+            onError: error => {
+                notify('Error: posts not updated', { type: 'error' });
+                refresh();
+            },
         }
     );
     const handleClick = () => setOpen(true);

--- a/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
@@ -133,9 +133,53 @@ describe('useUpdateMany', () => {
             } as any;
             let localUpdateMany;
             const Dummy = () => {
-                const [updateMany] = useUpdateMany('foo', {
+                const [updateMany] = useUpdateMany();
+                localUpdateMany = updateMany;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdateMany('foo', { ids: [1, 2], data: { bar: 'baz' } });
+            await waitFor(() => {
+                expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
                     ids: [1, 2],
                     data: { bar: 'baz' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [
+                        { id: 1, bar: 'baz' },
+                        { id: 2, bar: 'baz' },
+                    ],
+                    total: 2,
+                });
+            });
+        });
+        it('updates getList query cache when dataProvider promise resolves in optimistic mode', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                ],
+                total: 2,
+            });
+            const dataProvider = {
+                updateMany: jest.fn(() =>
+                    Promise.resolve({ data: [1, 2] } as any)
+                ),
+            } as any;
+            let localUpdateMany;
+            const Dummy = () => {
+                const [updateMany] = useUpdateMany(undefined, undefined, {
+                    mutationMode: 'optimistic',
                 });
                 localUpdateMany = updateMany;
                 return <span />;
@@ -165,6 +209,107 @@ describe('useUpdateMany', () => {
                 });
             });
         });
+        it('updates getList query cache when dataProvider promise resolves and using no call-time params', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                ],
+                total: 2,
+            });
+            const dataProvider = {
+                updateMany: jest.fn(() =>
+                    Promise.resolve({ data: [1, 2] } as any)
+                ),
+            } as any;
+            let localUpdateMany;
+            const Dummy = () => {
+                const [updateMany] = useUpdateMany('foo', {
+                    ids: [1, 2],
+                    data: { bar: 'baz' },
+                });
+                localUpdateMany = updateMany;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdateMany();
+            await waitFor(() => {
+                expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+                    ids: [1, 2],
+                    data: { bar: 'baz' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [
+                        { id: 1, bar: 'baz' },
+                        { id: 2, bar: 'baz' },
+                    ],
+                    total: 2,
+                });
+            });
+        });
+        it('updates getList query cache when dataProvider promise resolves in optimistic mode with no call-time params', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getList'], {
+                data: [
+                    { id: 1, bar: 'bar' },
+                    { id: 2, bar: 'bar' },
+                ],
+                total: 2,
+            });
+            const dataProvider = {
+                updateMany: jest.fn(() =>
+                    Promise.resolve({ data: [1, 2] } as any)
+                ),
+            } as any;
+            let localUpdateMany;
+            const Dummy = () => {
+                const [updateMany] = useUpdateMany(
+                    'foo',
+                    {
+                        ids: [1, 2],
+                        data: { bar: 'baz' },
+                    },
+                    { mutationMode: 'optimistic' }
+                );
+                localUpdateMany = updateMany;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdateMany();
+            await waitFor(() => {
+                expect(dataProvider.updateMany).toHaveBeenCalledWith('foo', {
+                    ids: [1, 2],
+                    data: { bar: 'baz' },
+                });
+            });
+            await waitFor(() => {
+                expect(queryClient.getQueryData(['foo', 'getList'])).toEqual({
+                    data: [
+                        { id: 1, bar: 'baz' },
+                        { id: 2, bar: 'baz' },
+                    ],
+                    total: 2,
+                });
+            });
+        });
+
         it('updates getList query cache with pageInfo when dataProvider promise resolves', async () => {
             const queryClient = new QueryClient();
             queryClient.setQueryData(['foo', 'getList'], {

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -236,7 +236,7 @@ export const useUpdateMany = <
                 // call-time error callback is executed by react-query
             },
             onSuccess: (
-                data: Array<RecordType['id']>,
+                dataFromResponse: Array<RecordType['id']>,
                 variables: Partial<UseUpdateManyMutateParams<RecordType>> = {},
                 context: unknown
             ) => {
@@ -257,7 +257,7 @@ export const useUpdateMany = <
 
                     if (reactMutationOptions.onSuccess) {
                         reactMutationOptions.onSuccess(
-                            data,
+                            dataFromResponse,
                             variables,
                             context
                         );

--- a/packages/ra-ui-materialui/src/button/BulkUpdateButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateButton.stories.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
+import { Resource } from 'ra-core';
+import fakeRestDataProvider from 'ra-data-fakerest';
+import { MemoryRouter } from 'react-router';
+
+import { BulkUpdateButton } from './BulkUpdateButton';
+import { AdminContext } from '../AdminContext';
+import { AdminUI } from '../AdminUI';
+import { List, Datagrid } from '../list';
+import { TextField, NumberField } from '../field';
+
+export default { title: 'ra-ui-materialui/button/BulkUpdateButton' };
+
+const i18nProvider = polyglotI18nProvider(
+    () => englishMessages,
+    'en' // Default locale
+);
+
+const dataProvider = fakeRestDataProvider({
+    books: [
+        {
+            id: 1,
+            title: 'War and Peace',
+            author: 'Leo Tolstoy',
+            reads: 23,
+        },
+        {
+            id: 2,
+            title: 'Pride and Predjudice',
+            author: 'Jane Austen',
+            reads: 854,
+        },
+        {
+            id: 3,
+            title: 'The Picture of Dorian Gray',
+            author: 'Oscar Wilde',
+            reads: 126,
+        },
+        {
+            id: 4,
+            title: 'Le Petit Prince',
+            author: 'Antoine de Saint-Exupéry',
+            reads: 86,
+        },
+        {
+            id: 5,
+            title: "Alice's Adventures in Wonderland",
+            author: 'Lewis Carroll',
+            reads: 125,
+        },
+        {
+            id: 6,
+            title: 'Madame Bovary',
+            author: 'Gustave Flaubert',
+            reads: 452,
+        },
+        {
+            id: 7,
+            title: 'The Lord of the Rings',
+            author: 'J. R. R. Tolkien',
+            reads: 267,
+        },
+        {
+            id: 8,
+            title: "Harry Potter and the Philosopher's Stone",
+            author: 'J. K. Rowling',
+            reads: 1294,
+        },
+        {
+            id: 9,
+            title: 'The Alchemist',
+            author: 'Paulo Coelho',
+            reads: 23,
+        },
+        {
+            id: 10,
+            title: 'A Catcher in the Rye',
+            author: 'J. D. Salinger',
+            reads: 209,
+        },
+        {
+            id: 11,
+            title: 'Ulysses',
+            author: 'James Joyce',
+            reads: 12,
+        },
+    ],
+    authors: [],
+});
+
+const Wrapper = ({ bulkActionButtons }) => (
+    <MemoryRouter initialEntries={['/books']}>
+        <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+            <AdminUI>
+                <Resource
+                    name="books"
+                    list={() => (
+                        <List>
+                            <Datagrid bulkActionButtons={bulkActionButtons}>
+                                <TextField source="id" />
+                                <TextField source="title" />
+                                <TextField source="author" />
+                                <NumberField source="reads" />
+                            </Datagrid>
+                        </List>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
+    </MemoryRouter>
+);
+
+export const Basic = () => (
+    <Wrapper bulkActionButtons={<BulkUpdateButton data={{ reads: 0 }} />} />
+);
+
+export const Data = () => (
+    <Wrapper
+        bulkActionButtons={
+            <BulkUpdateButton
+                data={{
+                    reads: 666,
+                    title: 'Devil in the White City',
+                    author: 'Erik Larson',
+                }}
+            />
+        }
+    />
+);
+
+export const Label = () => (
+    <Wrapper
+        bulkActionButtons={
+            <BulkUpdateButton data={{ reads: 0 }} label="Reset reads" />
+        }
+    />
+);
+
+export const MutationMode = () => (
+    <Wrapper
+        bulkActionButtons={
+            <>
+                <BulkUpdateButton
+                    label="Update Undoable"
+                    data={{ reads: 0 }}
+                    mutationMode="undoable"
+                />
+                <BulkUpdateButton
+                    label="Update Optimistic"
+                    data={{ reads: 0 }}
+                    mutationMode="optimistic"
+                />
+                <BulkUpdateButton
+                    label="Update Pessimistic"
+                    data={{ reads: 0 }}
+                    mutationMode="pessimistic"
+                />
+            </>
+        }
+    />
+);

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -8,7 +8,6 @@ import {
     useListContext,
     useTranslate,
     useUpdateMany,
-    useRefresh,
     useNotify,
     useUnselectAll,
     useResourceContext,
@@ -26,7 +25,6 @@ export const BulkUpdateWithConfirmButton = (
     props: BulkUpdateWithConfirmButtonProps
 ) => {
     const notify = useNotify();
-    const refresh = useRefresh();
     const translate = useTranslate();
     const resource = useResourceContext(props);
     const unselectAll = useUnselectAll(resource);

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -42,7 +42,6 @@ export const BulkUpdateWithConfirmButton = (
         mutationMode = 'pessimistic',
         onClick,
         onSuccess = () => {
-            refresh();
             notify('ra.notification.updated', {
                 type: 'info',
                 messageArgs: { smart_count: selectedIds.length },

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -41,7 +41,6 @@ export const BulkUpdateWithUndoButton = (
                 undoable: true,
             });
             unselectAll();
-            refresh();
         },
         onError = (error: Error | string) => {
             notify(


### PR DESCRIPTION
## Problem

When writing a bulk action button based on `useUpdateMany` with the default mutation mode (pessimistic), the list data doesn't get refreshed after the mutation ends. 

You can reproduce it in the following Stackblitz: https://stackblitz.com/edit/github-4g364g?file=src%2Fposts%2FResetViewsButton.tsx

1. Select a few posts in the list
2. Click on "reset views"
3. When the notification confirms the mutation success, the views of the selected rows don't reset. 

## Solution

There is a bug in `useUpdateMany`because we use the variable name `data` at several places.