### PR TITLE
[Doc] Fix link to documentation root

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -58,7 +58,11 @@ d88   888  888    888 d88   888
     function replaceNavigationWithVersion(version) {
         var location = document.location.href.split('#')[0];
         var locationSlices = location.split('/');
-        var href = [...locationSlices.slice(0, locationSlices.length - 2), version, 'Readme.html'].join('/');
+        var href = [
+            ...locationSlices.slice(0, locationSlices.length - 2),
+            version,
+            'navigation.html',
+        ].join('/');
         // fetch the new content
         fetch(href)
             .then(res => res.text())

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -84,7 +84,7 @@ export const Error = (
                                 <ul>
                                     <li>
                                         Check the{' '}
-                                        <a href="https://marmelab.com/react-admin/Readme.html">
+                                        <a href="https://marmelab.com/react-admin/documentation.html">
                                             react-admin documentation
                                         </a>
                                     </li>

--- a/packages/react-admin/README.md
+++ b/packages/react-admin/README.md
@@ -43,7 +43,7 @@ yarn add react-admin
 
 1. Read the [Tutorial](https://marmelab.com/react-admin/Tutorial.html) for a 30 minutes introduction. 
 2. Read the source code of [the demos](https://marmelab.com/react-admin/Demos.html) for real-life examples.
-3. Read the [Documentation](https://marmelab.com/react-admin/Readme.html) for a deep dive into the react-admin components and hooks.
+3. Read the [Documentation](https://marmelab.com/react-admin/documentation.html) for a deep dive into the react-admin components and hooks.
 4. Red the [Architecture decisions](https://marmelab.com/react-admin/Architecture.html) to better understand why features are implemented that way.
 5. Check out the [API Reference](https://marmelab.com/react-admin/Reference.html) for a complete list of the public API.
 6. Get [Support](#support) for fixing your own problems


### PR DESCRIPTION
The page https://marmelab.com/react-admin/Readme.html is no longer maintained an isn't the documentation root anymore. Yet it is visited by users who find links elsewhere in the documentation. 

We can't remove this page though, as existing installations of react-admin will still point to it in the Error page. 