### PR TITLE
Fix Datagrid Header Sort Tooltip

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
@@ -272,7 +272,9 @@ describe('<Datagrid />', () => {
     it('should display a message when there is no result', () => {
         render(
             <Wrapper listContext={{ ...contextValue, data: [], total: 0 }}>
-                <Datagrid />
+                <Datagrid>
+                    <TitleField />
+                </Datagrid>
             </Wrapper>
         );
         expect(screen.queryByText('ra.navigation.no_results')).not.toBeNull();

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -10,6 +10,7 @@ import {
     useTranslate,
     SortPayload,
     useResourceContext,
+    useTranslateLabel,
 } from 'ra-core';
 
 export const DatagridHeaderCell = (
@@ -19,6 +20,16 @@ export const DatagridHeaderCell = (
     const resource = useResourceContext(props);
 
     const translate = useTranslate();
+    const translateLabel = useTranslateLabel();
+    const sortLabel = translate('ra.sort.sort_by', {
+        field: translateLabel({
+            label: field.props.label,
+            resource,
+            source: field.props.source,
+        }),
+        order: translate(`ra.sort.${sort.order === 'ASC' ? 'DESC' : 'ASC'}`),
+        _: translate('ra.action.sort'),
+    });
 
     return (
         <StyledTableCell
@@ -31,7 +42,7 @@ export const DatagridHeaderCell = (
             field.props.sortable !== false &&
             (field.props.sortBy || field.props.source) ? (
                 <Tooltip
-                    title={translate('ra.action.sort')}
+                    title={sortLabel}
                     placement={
                         field.props.textAlign === 'right'
                             ? 'bottom-end'


### PR DESCRIPTION
## Problem

In a `<Datagrid>`, the header of sortable columns has a tooltip that is the same for all columns: "Sort". It's not explicit enough, and it's even confusing for screen readers.

<img width="884" alt="Screenshot 2023-12-22 at 09 51 13" src="https://github.com/marmelab/react-admin/assets/88175581/0e418614-fd3b-4239-945f-6c2f2aa0a47f">

## Solution

Reuse the title logic from `<SortButton>`, which already solves this problem.

<img width="1297" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/08bb20ff-c135-4b66-b39a-808f87803550">


Closes #9541