### PR TITLE
[Doc] Remove create-react-app chapter

### DIFF
--- a/docs/CreateReactApp.md
+++ b/docs/CreateReactApp.md
@@ -5,7 +5,9 @@ title: "Create_React-App Integration"
 
 # Create-React-App Integration
 
-[Create-React-App](https://create-react-app.dev/) is a convenient way to bootstrap single-page React applications. It provides a pre-configured build setup with no configuration.
+[Create-React-App](https://create-react-app.dev/) allows to bootstrap single-page React applications. It provides a pre-configured build setup with no configuration.
+
+**Warning**: We don't recommend using Create-React-App for new applications, as it is not maintained anymore. Prefer [create-react-admin](./CreateReactAdmin.md) (based on [Vite](./Vite.md)), [Remix](./Remix.md), or [Next.js](./Nextjs.md) instead.
 
 ## Setting Up Create React App
 

--- a/docs/CreateReactApp.md
+++ b/docs/CreateReactApp.md
@@ -7,7 +7,7 @@ title: "Create_React-App Integration"
 
 [Create-React-App](https://create-react-app.dev/) allows to bootstrap single-page React applications. It provides a pre-configured build setup with no configuration.
 
-**Warning**: We don't recommend using Create-React-App for new applications, as it is not maintained anymore. Prefer [create-react-admin](./CreateReactAdmin.md) (based on [Vite](./Vite.md)), [Remix](./Remix.md), or [Next.js](./Nextjs.md) instead.
+**Warning**: We don't recommend using Create-React-App for new applications, as it is not maintained anymore. Prefer [create-react-admin](./CreateReactAdmin.md) (based on [Vite](./Vite.md)), [Remix](./Remix.md), or [Next.js](./NextJs.md) instead.
 
 ## Setting Up Create React App
 

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -17,7 +17,7 @@ Here is an overview of the result:
 
 ## Setting Up
 
-React-admin uses React. We'll use [create-react-admin](./CreateReactAdmin.md) to bootstrap a new admin:
+React-admin uses React. We'll use [create-react-admin](./CreateReactAdmin.md) to bootstrap a new web application:
 
 ```sh
 npm init react-admin test-admin
@@ -38,7 +38,7 @@ You should be up and running with an empty React admin application on port 5173:
 
 [![Empty Admin](./img/tutorial_empty.png)](./img/tutorial_empty.png)
 
-**Tip**: Although this tutorial uses [Vite](https://vitejs.dev/) with [TypeScript](https://www.typescriptlang.org/), you can use react-admin with JavaScript if you prefer. Also, you can use [Next.js](./NextJs.md), [Remix](./Remix.md), [create-react-app](./CreateReactApp.md), or any other React framework to create your admin app. React-admin is framework-agnostic.
+**Tip**: The `create-react-admin` script creates a single-page application powered by [Vite](https://vitejs.dev/) and [TypeScript](https://www.typescriptlang.org/). You can also use react-admin with JavaScript if you prefer. Additionally, you can use [Next.js](./NextJs.md), [Remix](./Remix.md), or any other React framework to create your react-admin app. React-admin is framework-agnostic.
 
 Let's take a look at the generated code. The main entry point is `index.tsx`, which renders the `App` component in the DOM:
 

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -15,7 +15,6 @@
   <li {% if page.path == 'Vite.md' %} class="active beginner" {% else %} class="beginner" {% endif %}><a class="nav-link" href="./Vite.html">Vite</a></li>
   <li {% if page.path == 'NextJs.md' %} class="active" {% endif %}><a class="nav-link" href="./NextJs.html">Next.js</a></li>
   <li {% if page.path == 'Remix.md' %} class="active" {% endif %}><a class="nav-link" href="./Remix.html">Remix</a></li>
-  <li {% if page.path == 'CreateReactApp.md' %} class="active" {% endif %}><a class="nav-link" href="./CreateReactApp.html">Create React App</a></li>
   <li {% if page.path == 'Community.md' %} class="active beginner" {% else %} class="beginner" {% endif %}><a class="nav-link" href="./Community.html">Community</a></li>
   <li {% if page.path == 'Upgrade.md' %} class="active" {% endif %}><a class="nav-link" href="./Upgrade.html">Upgrading to v4</a></li>
 </ul>


### PR DESCRIPTION
## Problems

- [Create-React-App](https://github.com/facebook/create-react-app) is abandonware. We shouldn't encourage developers to use it.
- The doc index on the sidebar is super crowded. We need to remove useless entries.

## Solution

- Remove the entry in the navigation
- add a warning in the Create-React-App page
- Keep the page to avoid 404 for external links

![image](https://github.com/marmelab/react-admin/assets/99944/d16dd12c-dcff-4f1a-825c-ed8b8f638864)
