### PR TITLE
Propagate the abort signal to allow for automatic query cancellation

### DIFF
--- a/cypress/e2e/edit.cy.js
+++ b/cypress/e2e/edit.cy.js
@@ -306,6 +306,7 @@ describe('Edit Page', () => {
     it('should refresh the list when the update fails', () => {
         ListPagePosts.navigate();
         ListPagePosts.nextPage(); // Ensure the record is visible in the table
+        cy.contains('Sed quo et et fugiat modi'); // wait for data
 
         EditPostPage.navigate();
         EditPostPage.setInputValue('input', 'title', 'f00bar');

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -417,6 +417,7 @@ It brings several benefits to [manual data fetching](#getting-the-dataprovider-i
 2. It reduces the boilerplate code since you don't need to use `useState`, `useEffect` or `useCallback`.
 3. It supports a vast array of options
 4. It displays stale data while fetching up-to-date data, leading to a snappier UI
+5. It cancels the queries automatically when they become out-of-date or inactive
 
 See [Why You Need React Query](https://tkdodo.eu/blog/why-you-want-react-query) for more details.
 
@@ -438,7 +439,7 @@ const UserProfile = ({ userId }) => {
     const dataProvider = useDataProvider();
     const { data, isPending, error } = useQuery({
         queryKey: ['users', 'getOne', { id: userId }], 
-        queryFn: () => dataProvider.getOne('users', { id: userId })
+        queryFn: ({ signal }) => dataProvider.getOne('users', { id: userId, signal })
     });
 
     if (isPending) return <Loading />;
@@ -453,6 +454,8 @@ const UserProfile = ({ userId }) => {
     )
 };
 ```
+
+**Tip:** You may have noticed that we forward the `signal` parameter from the `queryFn` call to the dataProvider function call -- in this case `getOne`. This is needed to support automatic [Query Cancellation](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation). You can learn more about this parameter in the section dedicated to [the `signal` parameter](./DataProviderWriting.md#the-signal-parameter).
 
 To illustrate the usage of `useMutation`, here is an implementation of an "Approve" button for a comment:
 

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -436,43 +436,6 @@ const PostEdit = () => (
 );
 ```
 
-## DataProvider query functions are provided with a new `signal` parameter
-
-DataProvider query functions (`getOne`, `getList`, `getMany` and `getManyReference`) are now provided with an additional `signal` parameter. This parameter is an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to abort the request when the query is canceled (e.g. when it becomes out-of-date or inactive).
-
-The following dataProviders, provided by react-admin, have already been updated to support this new parameter:
-
-- `ra-data-json-server`
-- `ra-data-simple-rest`
-- `ra-data-graphql`
-
-This feature is optional, so you can still use any other dataProvider, even though it doesn't yet support the `signal` parameter.
-
-If you wish to update your own dataProvider to support this new parameter, you can take inspiration from how we updated the `ra-data-simple-rest` dataProvider:
-
-```diff
-// In packages/ra-data-simple-rest/src/index.ts
-import { fetchUtils, DataProvider } from 'react-admin';
-
-export default (
-    apiUrl: string,
-    httpClient = fetchUtils.fetchJson,
-    countHeader: string = 'Content-Range'
-): DataProvider => ({
-    getOne: (resource, params) =>
--       httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
-+       httpClient(`${apiUrl}/${resource}/${params.id}`, {
-+           signal: params?.signal,
-+       }).then(({ json }) => ({
-            data: json,
-        })),
-
-    /* ... other dataProvider methods ... */
-});
-```
-
-You can find more example implementations in the [Query Cancellation guide](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation).
-
 ## Upgrading to v4
 
 If you are on react-admin v3, follow the [Upgrading to v4](https://marmelab.com/react-admin/doc/4.16/Upgrade.html) guide before upgrading to v5.

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -269,7 +269,6 @@ const App = () => (
     </Admin>
 );
 ```
-```
 
 ## Removed deprecated hooks
 
@@ -436,6 +435,43 @@ const PostEdit = () => (
     </Edit>
 );
 ```
+
+## DataProvider query functions are provided with a new `signal` parameter
+
+DataProvider query functions (`getOne`, `getList`, `getMany` and `getManyReference`) are now provided with an additional `signal` parameter. This parameter is an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to abort the request when the query is canceled (e.g. when it becomes out-of-date or inactive).
+
+The following dataProviders, provided by react-admin, have already been updated to support this new parameter:
+
+- `ra-data-json-server`
+- `ra-data-simple-rest`
+- `ra-data-graphql`
+
+This feature is optional, so you can still use any other dataProvider, even though it doesn't yet support the `signal` parameter.
+
+If you wish to update your own dataProvider to support this new parameter, you can take inspiration from how we updated the `ra-data-simple-rest` dataProvider:
+
+```diff
+// In packages/ra-data-simple-rest/src/index.ts
+import { fetchUtils, DataProvider } from 'react-admin';
+
+export default (
+    apiUrl: string,
+    httpClient = fetchUtils.fetchJson,
+    countHeader: string = 'Content-Range'
+): DataProvider => ({
+    getOne: (resource, params) =>
+-       httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
++       httpClient(`${apiUrl}/${resource}/${params.id}`, {
++           signal: params?.signal,
++       }).then(({ json }) => ({
+            data: json,
+        })),
+
+    /* ... other dataProvider methods ... */
+});
+```
+
+You can find more example implementations in the [Query Cancellation guide](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation).
 
 ## Upgrading to v4
 

--- a/packages/ra-core/src/auth/Authenticated.spec.tsx
+++ b/packages/ra-core/src/auth/Authenticated.spec.tsx
@@ -85,7 +85,9 @@ describe('<Authenticated>', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({});
+            expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({
+                signal: expect.anything(),
+            });
             expect(authProvider.logout.mock.calls[0][0]).toEqual({});
             expect(reset).toHaveBeenCalledTimes(1);
             expect(notificationsSpy).toEqual([

--- a/packages/ra-core/src/auth/useAuthState.spec.tsx
+++ b/packages/ra-core/src/auth/useAuthState.spec.tsx
@@ -52,7 +52,7 @@ describe('useAuthState', () => {
         const abort = jest.fn();
         const authProvider = {
             checkAuth: jest.fn(
-                (_params, { signal }) =>
+                ({ signal }) =>
                     new Promise(() => {
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);

--- a/packages/ra-core/src/auth/useAuthState.spec.tsx
+++ b/packages/ra-core/src/auth/useAuthState.spec.tsx
@@ -4,6 +4,7 @@ import { waitFor, render, screen } from '@testing-library/react';
 import { CoreAdminContext } from '../core/CoreAdminContext';
 
 import useAuthState from './useAuthState';
+import { QueryClient } from '@tanstack/react-query';
 
 const UseAuth = (authParams: any) => {
     const state = useAuthState(authParams);
@@ -45,5 +46,37 @@ describe('useAuthState', () => {
             expect(screen.queryByText('LOADING')).toBeNull();
         });
         screen.getByText('AUTHENTICATED: false');
+    });
+
+    it('should abort the request if the query is canceled', async () => {
+        const abort = jest.fn();
+        const authProvider = {
+            checkAuth: jest.fn(
+                (_params, { signal }) =>
+                    new Promise(() => {
+                        signal.addEventListener('abort', () => {
+                            abort(signal.reason);
+                        });
+                    })
+            ) as any,
+        } as any;
+        const queryClient = new QueryClient();
+        render(
+            <CoreAdminContext
+                authProvider={authProvider}
+                queryClient={queryClient}
+            >
+                <UseAuth />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(authProvider.checkAuth).toHaveBeenCalled();
+        });
+        queryClient.cancelQueries({
+            queryKey: ['auth', 'checkAuth'],
+        });
+        await waitFor(() => {
+            expect(abort).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -68,7 +68,7 @@ const useAuthState = <ErrorType = Error>(
                 return true;
             }
             return authProvider
-                .checkAuth(params, { signal })
+                .checkAuth({ ...params, signal })
                 .then(() => true)
                 .catch(error => {
                     // This is necessary because react-query requires the error to be defined

--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -62,13 +62,13 @@ const useAuthState = <ErrorType = Error>(
 
     const result = useQuery<boolean, any>({
         queryKey: ['auth', 'checkAuth', params],
-        queryFn: () => {
+        queryFn: ({ signal }) => {
             // The authProvider is optional in react-admin
             if (!authProvider) {
                 return true;
             }
             return authProvider
-                .checkAuth(params)
+                .checkAuth(params, { signal })
                 .then(() => true)
                 .catch(error => {
                     // This is necessary because react-query requires the error to be defined

--- a/packages/ra-core/src/auth/useAuthenticated.spec.tsx
+++ b/packages/ra-core/src/auth/useAuthenticated.spec.tsx
@@ -41,7 +41,9 @@ describe('useAuthenticated', () => {
             </CoreAdminContext>
         );
         expect(authProvider.checkAuth).toBeCalledTimes(1);
-        expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({});
+        expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({
+            signal: expect.anything(),
+        });
         expect(reset).toHaveBeenCalledTimes(0);
     });
 
@@ -66,7 +68,10 @@ describe('useAuthenticated', () => {
         const { rerender } = render(<FooWrapper />);
         rerender(<FooWrapper foo="bar" />);
         expect(authProvider.checkAuth).toBeCalledTimes(2);
-        expect(authProvider.checkAuth.mock.calls[1][0]).toEqual({ foo: 'bar' });
+        expect(authProvider.checkAuth.mock.calls[1][0]).toEqual({
+            foo: 'bar',
+            signal: expect.anything(),
+        });
         expect(reset).toHaveBeenCalledTimes(0);
     });
 
@@ -145,7 +150,9 @@ describe('useAuthenticated', () => {
         await waitFor(() => {
             expect(authProvider.checkAuth).toHaveBeenCalledTimes(1);
         });
-        expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({});
+        expect(authProvider.checkAuth.mock.calls[0][0]).toEqual({
+            signal: expect.anything(),
+        });
         await waitFor(
             () => {
                 expect(authProvider.logout).toHaveBeenCalledTimes(1);

--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -54,11 +54,11 @@ export const useGetIdentity = <ErrorType extends Error = Error>(
 
     const result = useQuery({
         queryKey: ['auth', 'getIdentity'],
-        queryFn: async () => {
+        queryFn: async ({ signal }) => {
             if (!authProvider) return Promise.resolve(defaultIdentity);
             if (typeof authProvider.getIdentity !== 'function') return null;
 
-            const identity = await authProvider.getIdentity();
+            const identity = await authProvider.getIdentity({ signal });
             return identity ?? null;
         },
         ...queryOptions,

--- a/packages/ra-core/src/auth/useHandleAuthCallback.ts
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.ts
@@ -27,8 +27,10 @@ export const useHandleAuthCallback = (
 
     const queryResult = useQuery({
         queryKey: ['auth', 'handleCallback'],
-        queryFn: () =>
-            authProvider.handleCallback().then(result => result ?? null),
+        queryFn: ({ signal }) =>
+            authProvider
+                .handleCallback({ signal })
+                .then(result => result ?? null),
         retry: false,
         ...queryOptions,
     });

--- a/packages/ra-core/src/auth/usePermissions.spec.tsx
+++ b/packages/ra-core/src/auth/usePermissions.spec.tsx
@@ -105,7 +105,7 @@ describe('usePermissions', () => {
         const abort = jest.fn();
         const authProvider = {
             getPermissions: jest.fn(
-                (_params, { signal }) =>
+                ({ signal }) =>
                     new Promise(() => {
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -53,9 +53,11 @@ const usePermissions = <PermissionsType = any, ErrorType = Error>(
 
     const result = useQuery<PermissionsType, ErrorType>({
         queryKey: ['auth', 'getPermissions', params],
-        queryFn: async () => {
+        queryFn: async ({ signal }) => {
             if (!authProvider) return Promise.resolve([]);
-            const permissions = await authProvider.getPermissions(params);
+            const permissions = await authProvider.getPermissions(params, {
+                signal,
+            });
             return permissions ?? null;
         },
         ...queryOptions,

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -55,7 +55,8 @@ const usePermissions = <PermissionsType = any, ErrorType = Error>(
         queryKey: ['auth', 'getPermissions', params],
         queryFn: async ({ signal }) => {
             if (!authProvider) return Promise.resolve([]);
-            const permissions = await authProvider.getPermissions(params, {
+            const permissions = await authProvider.getPermissions({
+                ...params,
                 signal,
             });
             return permissions ?? null;

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -78,11 +78,10 @@ describe('useEditController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith(
-                'posts',
-                { id: 'test?' },
-                expect.anything()
-            );
+            expect(getOne).toHaveBeenCalledWith('posts', {
+                id: 'test?',
+                signal: expect.anything(),
+            });
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -117,11 +116,10 @@ describe('useEditController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith(
-                'posts',
-                { id: 0 },
-                expect.anything()
-            );
+            expect(getOne).toHaveBeenCalledWith('posts', {
+                id: 0,
+                signal: expect.anything(),
+            });
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -200,14 +198,11 @@ describe('useEditController', () => {
                 </CoreAdminContext>
             );
             await waitFor(() => {
-                expect(getOne).toHaveBeenCalledWith(
-                    'posts',
-                    {
-                        id: 12,
-                        meta: { foo: 'bar' },
-                    },
-                    expect.anything()
-                );
+                expect(getOne).toHaveBeenCalledWith('posts', {
+                    id: 12,
+                    meta: { foo: 'bar' },
+                    signal: expect.anything(),
+                });
             });
         });
     });

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -78,7 +78,11 @@ describe('useEditController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith('posts', { id: 'test?' });
+            expect(getOne).toHaveBeenCalledWith(
+                'posts',
+                { id: 'test?' },
+                expect.anything()
+            );
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -113,7 +117,11 @@ describe('useEditController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith('posts', { id: 0 });
+            expect(getOne).toHaveBeenCalledWith(
+                'posts',
+                { id: 0 },
+                expect.anything()
+            );
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -192,10 +200,14 @@ describe('useEditController', () => {
                 </CoreAdminContext>
             );
             await waitFor(() => {
-                expect(getOne).toHaveBeenCalledWith('posts', {
-                    id: 12,
-                    meta: { foo: 'bar' },
-                });
+                expect(getOne).toHaveBeenCalledWith(
+                    'posts',
+                    {
+                        id: 12,
+                        meta: { foo: 'bar' },
+                    },
+                    expect.anything()
+                );
             });
         });
     });

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
@@ -110,8 +110,8 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
                     filter: {},
-                },
-                expect.anything()
+                    signal: expect.anything(),
+                }
             );
         });
     });
@@ -231,8 +231,8 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
                     filter: {},
-                },
-                expect.anything()
+                    signal: expect.anything(),
+                }
             );
         });
     });
@@ -271,8 +271,8 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                },
-                expect.anything()
+                    signal: expect.anything(),
+                }
             );
         });
     });

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
@@ -110,7 +110,8 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
                     filter: {},
-                }
+                },
+                expect.anything()
             );
         });
     });
@@ -230,7 +231,8 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
                     filter: {},
-                }
+                },
+                expect.anything()
             );
         });
     });
@@ -269,7 +271,8 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                }
+                },
+                expect.anything()
             );
         });
     });

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
@@ -99,13 +99,17 @@ describe('useReferenceOneFieldController', () => {
         );
 
         await waitFor(() => {
-            expect(dataProvider.getManyReference).toHaveBeenCalledWith('bios', {
-                target: 'author_id',
-                id: 123,
-                pagination: { page: 1, perPage: 1 },
-                sort: { field: 'name', order: 'DESC' },
-                filter: { gender: 'female' },
-            });
+            expect(dataProvider.getManyReference).toHaveBeenCalledWith(
+                'bios',
+                {
+                    target: 'author_id',
+                    id: 123,
+                    pagination: { page: 1, perPage: 1 },
+                    sort: { field: 'name', order: 'DESC' },
+                    filter: { gender: 'female' },
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -175,7 +179,8 @@ describe('useReferenceOneFieldController', () => {
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                }
+                },
+                expect.anything()
             );
         });
     });
@@ -217,7 +222,8 @@ describe('useReferenceOneFieldController', () => {
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                }
+                },
+                expect.anything()
             );
         });
     });

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
@@ -99,17 +99,14 @@ describe('useReferenceOneFieldController', () => {
         );
 
         await waitFor(() => {
-            expect(dataProvider.getManyReference).toHaveBeenCalledWith(
-                'bios',
-                {
-                    target: 'author_id',
-                    id: 123,
-                    pagination: { page: 1, perPage: 1 },
-                    sort: { field: 'name', order: 'DESC' },
-                    filter: { gender: 'female' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getManyReference).toHaveBeenCalledWith('bios', {
+                target: 'author_id',
+                id: 123,
+                pagination: { page: 1, perPage: 1 },
+                sort: { field: 'name', order: 'DESC' },
+                filter: { gender: 'female' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -179,8 +176,8 @@ describe('useReferenceOneFieldController', () => {
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                },
-                expect.anything()
+                    signal: expect.anything(),
+                }
             );
         });
     });
@@ -222,8 +219,8 @@ describe('useReferenceOneFieldController', () => {
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                },
-                expect.anything()
+                    signal: expect.anything(),
+                }
             );
         });
     });

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
@@ -187,18 +187,22 @@ describe('useReferenceArrayInputController', () => {
                 </Form>
             </CoreAdminContext>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-            pagination: {
-                page: 1,
-                perPage: 25,
+        expect(dataProvider.getList).toHaveBeenCalledWith(
+            'tags',
+            {
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: undefined,
             },
-            sort: {
-                field: 'id',
-                order: 'DESC',
-            },
-            filter: {},
-            meta: undefined,
-        });
+            expect.anything()
+        );
     });
 
     it('should call getList with meta when provided', async () => {
@@ -221,18 +225,22 @@ describe('useReferenceArrayInputController', () => {
                 </Form>
             </CoreAdminContext>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-            pagination: {
-                page: 1,
-                perPage: 25,
+        expect(dataProvider.getList).toHaveBeenCalledWith(
+            'tags',
+            {
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: { value: 'a' },
             },
-            sort: {
-                field: 'id',
-                order: 'DESC',
-            },
-            filter: {},
-            meta: { value: 'a' },
-        });
+            expect.anything()
+        );
     });
 
     it('should allow to customize getList arguments with perPage, sort, and filter props', () => {
@@ -257,18 +265,22 @@ describe('useReferenceArrayInputController', () => {
                 </Form>
             </CoreAdminContext>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-            pagination: {
-                page: 2,
-                perPage: 5,
+        expect(dataProvider.getList).toHaveBeenCalledWith(
+            'tags',
+            {
+                pagination: {
+                    page: 2,
+                    perPage: 5,
+                },
+                sort: {
+                    field: 'foo',
+                    order: 'ASC',
+                },
+                filter: { permanentFilter: 'foo' },
+                meta: undefined,
             },
-            sort: {
-                field: 'foo',
-                order: 'ASC',
-            },
-            filter: { permanentFilter: 'foo' },
-            meta: undefined,
-        });
+            expect.anything()
+        );
     });
 
     it('should call getList when setFilters is called', async () => {
@@ -295,17 +307,21 @@ describe('useReferenceArrayInputController', () => {
 
         fireEvent.click(screen.getByLabelText('Filter'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-                pagination: {
-                    page: 1,
-                    perPage: 25,
+            expect(dataProvider.getList).toHaveBeenCalledWith(
+                'tags',
+                {
+                    pagination: {
+                        page: 1,
+                        perPage: 25,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'DESC',
+                    },
+                    filter: { q: 'bar' },
                 },
-                sort: {
-                    field: 'id',
-                    order: 'DESC',
-                },
-                filter: { q: 'bar' },
-            });
+                expect.anything()
+            );
         });
     });
 
@@ -329,9 +345,13 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
-                ids: [5, 6],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'tags',
+                {
+                    ids: [5, 6],
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -358,10 +378,14 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
-                ids: [5, 6],
-                meta: { value: 'a' },
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'tags',
+                {
+                    ids: [5, 6],
+                    meta: { value: 'a' },
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -509,9 +533,13 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
-                ids: [5],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'tags',
+                {
+                    ids: [5],
+                },
+                expect.anything()
+            );
         });
         rerender(
             <CoreAdminContext dataProvider={dataProvider}>
@@ -523,9 +551,13 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
-                ids: [5, 6],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'tags',
+                {
+                    ids: [5, 6],
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -578,50 +610,62 @@ describe('useReferenceArrayInputController', () => {
 
         fireEvent.click(screen.getByLabelText('setPage'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-                pagination: {
-                    page: 2,
-                    perPage: 25,
+            expect(dataProvider.getList).toHaveBeenCalledWith(
+                'tags',
+                {
+                    pagination: {
+                        page: 2,
+                        perPage: 25,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'DESC',
+                    },
+                    filter: {},
+                    meta: undefined,
                 },
-                sort: {
-                    field: 'id',
-                    order: 'DESC',
-                },
-                filter: {},
-                meta: undefined,
-            });
+                expect.anything()
+            );
         });
 
         fireEvent.click(screen.getByLabelText('setPerPage'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-                pagination: {
-                    page: 1,
-                    perPage: 50,
+            expect(dataProvider.getList).toHaveBeenCalledWith(
+                'tags',
+                {
+                    pagination: {
+                        page: 1,
+                        perPage: 50,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'DESC',
+                    },
+                    filter: {},
+                    meta: undefined,
                 },
-                sort: {
-                    field: 'id',
-                    order: 'DESC',
-                },
-                filter: {},
-                meta: undefined,
-            });
+                expect.anything()
+            );
         });
 
         fireEvent.click(screen.getByLabelText('setSort'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-                pagination: {
-                    page: 1,
-                    perPage: 50,
+            expect(dataProvider.getList).toHaveBeenCalledWith(
+                'tags',
+                {
+                    pagination: {
+                        page: 1,
+                        perPage: 50,
+                    },
+                    sort: {
+                        field: 'name',
+                        order: 'ASC',
+                    },
+                    filter: {},
+                    meta: undefined,
                 },
-                sort: {
-                    field: 'name',
-                    order: 'ASC',
-                },
-                filter: {},
-                meta: undefined,
-            });
+                expect.anything()
+            );
         });
     });
 
@@ -680,17 +724,21 @@ describe('useReferenceArrayInputController', () => {
             await waitFor(() => {
                 expect(dataProvider.getList).toHaveBeenCalledTimes(1);
             });
-            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
-                pagination: {
-                    page: 1,
-                    perPage: 25,
+            expect(dataProvider.getList).toHaveBeenCalledWith(
+                'tags',
+                {
+                    pagination: {
+                        page: 1,
+                        perPage: 25,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'DESC',
+                    },
+                    filter: { q: 'hello world' },
                 },
-                sort: {
-                    field: 'id',
-                    order: 'DESC',
-                },
-                filter: { q: 'hello world' },
-            });
+                expect.anything()
+            );
             expect(enableGetChoices).toHaveBeenCalledWith({ q: 'hello world' });
         });
 
@@ -719,9 +767,13 @@ describe('useReferenceArrayInputController', () => {
                 </CoreAdminContext>
             );
             await waitFor(() => {
-                expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
-                    ids: [5, 6],
-                });
+                expect(dataProvider.getMany).toHaveBeenCalledWith(
+                    'tags',
+                    {
+                        ids: [5, 6],
+                    },
+                    expect.anything()
+                );
             });
         });
 

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
@@ -187,22 +187,19 @@ describe('useReferenceArrayInputController', () => {
                 </Form>
             </CoreAdminContext>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith(
-            'tags',
-            {
-                pagination: {
-                    page: 1,
-                    perPage: 25,
-                },
-                sort: {
-                    field: 'id',
-                    order: 'DESC',
-                },
-                filter: {},
-                meta: undefined,
+        expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+            pagination: {
+                page: 1,
+                perPage: 25,
             },
-            expect.anything()
-        );
+            sort: {
+                field: 'id',
+                order: 'DESC',
+            },
+            filter: {},
+            meta: undefined,
+            signal: expect.anything(),
+        });
     });
 
     it('should call getList with meta when provided', async () => {
@@ -225,22 +222,19 @@ describe('useReferenceArrayInputController', () => {
                 </Form>
             </CoreAdminContext>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith(
-            'tags',
-            {
-                pagination: {
-                    page: 1,
-                    perPage: 25,
-                },
-                sort: {
-                    field: 'id',
-                    order: 'DESC',
-                },
-                filter: {},
-                meta: { value: 'a' },
+        expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+            pagination: {
+                page: 1,
+                perPage: 25,
             },
-            expect.anything()
-        );
+            sort: {
+                field: 'id',
+                order: 'DESC',
+            },
+            filter: {},
+            meta: { value: 'a' },
+            signal: expect.anything(),
+        });
     });
 
     it('should allow to customize getList arguments with perPage, sort, and filter props', () => {
@@ -265,22 +259,19 @@ describe('useReferenceArrayInputController', () => {
                 </Form>
             </CoreAdminContext>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith(
-            'tags',
-            {
-                pagination: {
-                    page: 2,
-                    perPage: 5,
-                },
-                sort: {
-                    field: 'foo',
-                    order: 'ASC',
-                },
-                filter: { permanentFilter: 'foo' },
-                meta: undefined,
+        expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+            pagination: {
+                page: 2,
+                perPage: 5,
             },
-            expect.anything()
-        );
+            sort: {
+                field: 'foo',
+                order: 'ASC',
+            },
+            filter: { permanentFilter: 'foo' },
+            meta: undefined,
+            signal: expect.anything(),
+        });
     });
 
     it('should call getList when setFilters is called', async () => {
@@ -307,21 +298,18 @@ describe('useReferenceArrayInputController', () => {
 
         fireEvent.click(screen.getByLabelText('Filter'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith(
-                'tags',
-                {
-                    pagination: {
-                        page: 1,
-                        perPage: 25,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'DESC',
-                    },
-                    filter: { q: 'bar' },
+            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+                pagination: {
+                    page: 1,
+                    perPage: 25,
                 },
-                expect.anything()
-            );
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: { q: 'bar' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -345,13 +333,10 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'tags',
-                {
-                    ids: [5, 6],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
+                ids: [5, 6],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -378,14 +363,11 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'tags',
-                {
-                    ids: [5, 6],
-                    meta: { value: 'a' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
+                ids: [5, 6],
+                meta: { value: 'a' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -533,13 +515,10 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'tags',
-                {
-                    ids: [5],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
+                ids: [5],
+                signal: expect.anything(),
+            });
         });
         rerender(
             <CoreAdminContext dataProvider={dataProvider}>
@@ -551,13 +530,10 @@ describe('useReferenceArrayInputController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'tags',
-                {
-                    ids: [5, 6],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
+                ids: [5, 6],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -610,62 +586,53 @@ describe('useReferenceArrayInputController', () => {
 
         fireEvent.click(screen.getByLabelText('setPage'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith(
-                'tags',
-                {
-                    pagination: {
-                        page: 2,
-                        perPage: 25,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'DESC',
-                    },
-                    filter: {},
-                    meta: undefined,
+            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+                pagination: {
+                    page: 2,
+                    perPage: 25,
                 },
-                expect.anything()
-            );
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: undefined,
+                signal: expect.anything(),
+            });
         });
 
         fireEvent.click(screen.getByLabelText('setPerPage'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith(
-                'tags',
-                {
-                    pagination: {
-                        page: 1,
-                        perPage: 50,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'DESC',
-                    },
-                    filter: {},
-                    meta: undefined,
+            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+                pagination: {
+                    page: 1,
+                    perPage: 50,
                 },
-                expect.anything()
-            );
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: undefined,
+                signal: expect.anything(),
+            });
         });
 
         fireEvent.click(screen.getByLabelText('setSort'));
         await waitFor(() => {
-            expect(dataProvider.getList).toHaveBeenCalledWith(
-                'tags',
-                {
-                    pagination: {
-                        page: 1,
-                        perPage: 50,
-                    },
-                    sort: {
-                        field: 'name',
-                        order: 'ASC',
-                    },
-                    filter: {},
-                    meta: undefined,
+            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+                pagination: {
+                    page: 1,
+                    perPage: 50,
                 },
-                expect.anything()
-            );
+                sort: {
+                    field: 'name',
+                    order: 'ASC',
+                },
+                filter: {},
+                meta: undefined,
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -724,21 +691,18 @@ describe('useReferenceArrayInputController', () => {
             await waitFor(() => {
                 expect(dataProvider.getList).toHaveBeenCalledTimes(1);
             });
-            expect(dataProvider.getList).toHaveBeenCalledWith(
-                'tags',
-                {
-                    pagination: {
-                        page: 1,
-                        perPage: 25,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'DESC',
-                    },
-                    filter: { q: 'hello world' },
+            expect(dataProvider.getList).toHaveBeenCalledWith('tags', {
+                pagination: {
+                    page: 1,
+                    perPage: 25,
                 },
-                expect.anything()
-            );
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: { q: 'hello world' },
+                signal: expect.anything(),
+            });
             expect(enableGetChoices).toHaveBeenCalledWith({ q: 'hello world' });
         });
 
@@ -767,13 +731,10 @@ describe('useReferenceArrayInputController', () => {
                 </CoreAdminContext>
             );
             await waitFor(() => {
-                expect(dataProvider.getMany).toHaveBeenCalledWith(
-                    'tags',
-                    {
-                        ids: [5, 6],
-                    },
-                    expect.anything()
-                );
+                expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
+                    ids: [5, 6],
+                    signal: expect.anything(),
+                });
             });
         });
 

--- a/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
@@ -62,22 +62,19 @@ describe('useReferenceInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
         });
-        expect(dataProvider.getList).toBeCalledWith(
-            'posts',
-            {
-                filter: {},
-                meta: undefined,
-                pagination: {
-                    page: 1,
-                    perPage: 25,
-                },
-                sort: {
-                    field: 'id',
-                    order: 'ASC',
-                },
+        expect(dataProvider.getList).toBeCalledWith('posts', {
+            filter: {},
+            meta: undefined,
+            pagination: {
+                page: 1,
+                perPage: 25,
             },
-            expect.anything()
-        );
+            sort: {
+                field: 'id',
+                order: 'ASC',
+            },
+            signal: expect.anything(),
+        });
     });
 
     it('should allow getList pagination and sorting customization', async () => {
@@ -99,22 +96,19 @@ describe('useReferenceInputController', () => {
 
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
-            expect(dataProvider.getList).toBeCalledWith(
-                'posts',
-                {
-                    filter: {},
-                    meta: undefined,
-                    pagination: {
-                        page: 5,
-                        perPage: 10,
-                    },
-                    sort: {
-                        field: 'title',
-                        order: 'ASC',
-                    },
+            expect(dataProvider.getList).toBeCalledWith('posts', {
+                filter: {},
+                meta: undefined,
+                pagination: {
+                    page: 5,
+                    perPage: 10,
                 },
-                expect.anything()
-            );
+                sort: {
+                    field: 'title',
+                    order: 'ASC',
+                },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -133,11 +127,10 @@ describe('useReferenceInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
             expect(dataProvider.getMany).toBeCalledTimes(1);
-            expect(dataProvider.getMany).toBeCalledWith(
-                'posts',
-                { ids: [1] },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toBeCalledWith('posts', {
+                ids: [1],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -243,43 +236,37 @@ describe('useReferenceInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
         });
-        expect(dataProvider.getList).toHaveBeenCalledWith(
-            'posts',
-            {
-                filter: {},
-                meta: undefined,
-                pagination: {
-                    page: 1,
-                    perPage: 25,
-                },
-                sort: {
-                    field: 'title',
-                    order: 'ASC',
-                },
+        expect(dataProvider.getList).toHaveBeenCalledWith('posts', {
+            filter: {},
+            meta: undefined,
+            pagination: {
+                page: 1,
+                perPage: 25,
             },
-            expect.anything()
-        );
+            sort: {
+                field: 'title',
+                order: 'ASC',
+            },
+            signal: expect.anything(),
+        });
 
         fireEvent.click(screen.getByLabelText('Change sort'));
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(2);
         });
-        expect(dataProvider.getList).toHaveBeenCalledWith(
-            'posts',
-            {
-                filter: {},
-                meta: undefined,
-                pagination: {
-                    page: 1,
-                    perPage: 25,
-                },
-                sort: {
-                    field: 'body',
-                    order: 'DESC',
-                },
+        expect(dataProvider.getList).toHaveBeenCalledWith('posts', {
+            filter: {},
+            meta: undefined,
+            pagination: {
+                page: 1,
+                perPage: 25,
             },
-            expect.anything()
-        );
+            sort: {
+                field: 'body',
+                order: 'DESC',
+            },
+            signal: expect.anything(),
+        });
     });
 
     describe('enableGetChoices', () => {

--- a/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
@@ -62,18 +62,22 @@ describe('useReferenceInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
         });
-        expect(dataProvider.getList).toBeCalledWith('posts', {
-            filter: {},
-            meta: undefined,
-            pagination: {
-                page: 1,
-                perPage: 25,
+        expect(dataProvider.getList).toBeCalledWith(
+            'posts',
+            {
+                filter: {},
+                meta: undefined,
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'ASC',
+                },
             },
-            sort: {
-                field: 'id',
-                order: 'ASC',
-            },
-        });
+            expect.anything()
+        );
     });
 
     it('should allow getList pagination and sorting customization', async () => {
@@ -95,18 +99,22 @@ describe('useReferenceInputController', () => {
 
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
-            expect(dataProvider.getList).toBeCalledWith('posts', {
-                filter: {},
-                meta: undefined,
-                pagination: {
-                    page: 5,
-                    perPage: 10,
+            expect(dataProvider.getList).toBeCalledWith(
+                'posts',
+                {
+                    filter: {},
+                    meta: undefined,
+                    pagination: {
+                        page: 5,
+                        perPage: 10,
+                    },
+                    sort: {
+                        field: 'title',
+                        order: 'ASC',
+                    },
                 },
-                sort: {
-                    field: 'title',
-                    order: 'ASC',
-                },
-            });
+                expect.anything()
+            );
         });
     });
 
@@ -125,7 +133,11 @@ describe('useReferenceInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
             expect(dataProvider.getMany).toBeCalledTimes(1);
-            expect(dataProvider.getMany).toBeCalledWith('posts', { ids: [1] });
+            expect(dataProvider.getMany).toBeCalledWith(
+                'posts',
+                { ids: [1] },
+                expect.anything()
+            );
         });
     });
 
@@ -231,35 +243,43 @@ describe('useReferenceInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
         });
-        expect(dataProvider.getList).toHaveBeenCalledWith('posts', {
-            filter: {},
-            meta: undefined,
-            pagination: {
-                page: 1,
-                perPage: 25,
+        expect(dataProvider.getList).toHaveBeenCalledWith(
+            'posts',
+            {
+                filter: {},
+                meta: undefined,
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'title',
+                    order: 'ASC',
+                },
             },
-            sort: {
-                field: 'title',
-                order: 'ASC',
-            },
-        });
+            expect.anything()
+        );
 
         fireEvent.click(screen.getByLabelText('Change sort'));
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(2);
         });
-        expect(dataProvider.getList).toHaveBeenCalledWith('posts', {
-            filter: {},
-            meta: undefined,
-            pagination: {
-                page: 1,
-                perPage: 25,
+        expect(dataProvider.getList).toHaveBeenCalledWith(
+            'posts',
+            {
+                filter: {},
+                meta: undefined,
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'body',
+                    order: 'DESC',
+                },
             },
-            sort: {
-                field: 'body',
-                order: 'DESC',
-            },
-        });
+            expect.anything()
+        );
     });
 
     describe('enableGetChoices', () => {

--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -91,6 +91,7 @@ describe('useInfiniteListController', () => {
                     pagination: { page: 1, perPage: 10 },
                     sort: { field: 'id', order: 'ASC' },
                     meta: { foo: 'bar' },
+                    signal: expect.anything(),
                 });
             });
         });

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -69,12 +69,16 @@ describe('useListController', () => {
                 </CoreAdminContext>
             );
             await waitFor(() => {
-                expect(getList).toHaveBeenCalledWith('posts', {
-                    filter: {},
-                    pagination: { page: 1, perPage: 10 },
-                    sort: { field: 'id', order: 'ASC' },
-                    meta: { foo: 'bar' },
-                });
+                expect(getList).toHaveBeenCalledWith(
+                    'posts',
+                    {
+                        filter: {},
+                        pagination: { page: 1, perPage: 10 },
+                        sort: { field: 'id', order: 'ASC' },
+                        meta: { foo: 'bar' },
+                    },
+                    expect.anything()
+                );
             });
         });
 
@@ -229,7 +233,8 @@ describe('useListController', () => {
             expect(getList).toHaveBeenCalledTimes(1);
             expect(getList).toHaveBeenCalledWith(
                 'posts',
-                expect.objectContaining({ filter: { foo: 1 } })
+                expect.objectContaining({ filter: { foo: 1 } }),
+                expect.anything()
             );
 
             // Check that the permanent filter is not included in the displayedFilters and filterValues (passed to Filter form and button)
@@ -251,7 +256,8 @@ describe('useListController', () => {
             expect(getList).toHaveBeenCalledTimes(2);
             expect(getList).toHaveBeenCalledWith(
                 'posts',
-                expect.objectContaining({ filter: { foo: 2 } })
+                expect.objectContaining({ filter: { foo: 2 } }),
+                expect.anything()
             );
             expect(children).toHaveBeenCalledTimes(2);
         });

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -69,16 +69,13 @@ describe('useListController', () => {
                 </CoreAdminContext>
             );
             await waitFor(() => {
-                expect(getList).toHaveBeenCalledWith(
-                    'posts',
-                    {
-                        filter: {},
-                        pagination: { page: 1, perPage: 10 },
-                        sort: { field: 'id', order: 'ASC' },
-                        meta: { foo: 'bar' },
-                    },
-                    expect.anything()
-                );
+                expect(getList).toHaveBeenCalledWith('posts', {
+                    filter: {},
+                    pagination: { page: 1, perPage: 10 },
+                    sort: { field: 'id', order: 'ASC' },
+                    meta: { foo: 'bar' },
+                    signal: expect.anything(),
+                });
             });
         });
 
@@ -233,8 +230,7 @@ describe('useListController', () => {
             expect(getList).toHaveBeenCalledTimes(1);
             expect(getList).toHaveBeenCalledWith(
                 'posts',
-                expect.objectContaining({ filter: { foo: 1 } }),
-                expect.anything()
+                expect.objectContaining({ filter: { foo: 1 } })
             );
 
             // Check that the permanent filter is not included in the displayedFilters and filterValues (passed to Filter form and button)
@@ -256,8 +252,7 @@ describe('useListController', () => {
             expect(getList).toHaveBeenCalledTimes(2);
             expect(getList).toHaveBeenCalledWith(
                 'posts',
-                expect.objectContaining({ filter: { foo: 2 } }),
-                expect.anything()
+                expect.objectContaining({ filter: { foo: 2 } })
             );
             expect(children).toHaveBeenCalledTimes(2);
         });

--- a/packages/ra-core/src/controller/show/useShowController.spec.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.spec.tsx
@@ -64,11 +64,10 @@ describe('useShowController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith(
-                'posts',
-                { id: 'test?' },
-                expect.anything()
-            );
+            expect(getOne).toHaveBeenCalledWith('posts', {
+                id: 'test?',
+                signal: expect.anything(),
+            });
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -104,11 +103,10 @@ describe('useShowController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith(
-                'posts',
-                { id: 0 },
-                expect.anything()
-            );
+            expect(getOne).toHaveBeenCalledWith('posts', {
+                id: 0,
+                signal: expect.anything(),
+            });
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -182,14 +180,11 @@ describe('useShowController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith(
-                'posts',
-                {
-                    id: '1',
-                    meta: { foo: 'bar' },
-                },
-                expect.anything()
-            );
+            expect(getOne).toHaveBeenCalledWith('posts', {
+                id: '1',
+                meta: { foo: 'bar' },
+                signal: expect.anything(),
+            });
         });
     });
 });

--- a/packages/ra-core/src/controller/show/useShowController.spec.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.spec.tsx
@@ -64,7 +64,11 @@ describe('useShowController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith('posts', { id: 'test?' });
+            expect(getOne).toHaveBeenCalledWith(
+                'posts',
+                { id: 'test?' },
+                expect.anything()
+            );
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -100,7 +104,11 @@ describe('useShowController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith('posts', { id: 0 });
+            expect(getOne).toHaveBeenCalledWith(
+                'posts',
+                { id: 0 },
+                expect.anything()
+            );
         });
         await waitFor(() => {
             expect(screen.queryAllByText('hello')).toHaveLength(1);
@@ -174,10 +182,14 @@ describe('useShowController', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getOne).toHaveBeenCalledWith('posts', {
-                id: '1',
-                meta: { foo: 'bar' },
-            });
+            expect(getOne).toHaveBeenCalledWith(
+                'posts',
+                {
+                    id: '1',
+                    meta: { foo: 'bar' },
+                },
+                expect.anything()
+            );
         });
     });
 });

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -187,7 +187,7 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
     const { data, error, isFetching, isLoading, isPending } = useQuery({
         queryKey: [resource, 'getList', params],
         queryFn: ({ signal }) =>
-            dataProvider.getList(resource, params, { signal }),
+            dataProvider.getList(resource, { ...params, signal }),
         enabled: !canUseCacheData,
         ...otherQueryOptions,
     });

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -186,7 +186,8 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
     // without displaying the list first
     const { data, error, isFetching, isLoading, isPending } = useQuery({
         queryKey: [resource, 'getList', params],
-        queryFn: () => dataProvider.getList(resource, params),
+        queryFn: ({ signal }) =>
+            dataProvider.getList(resource, params, { signal }),
         enabled: !canUseCacheData,
         ...otherQueryOptions,
     });

--- a/packages/ra-core/src/controller/useReference.spec.tsx
+++ b/packages/ra-core/src/controller/useReference.spec.tsx
@@ -36,9 +36,13 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
-                ids: ['1'],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'posts',
+                {
+                    ids: ['1'],
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -193,9 +197,13 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
-                ids: [1, 2, 3],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'posts',
+                {
+                    ids: [1, 2, 3],
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -209,12 +217,20 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(2);
-            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
-                ids: [1, 2],
-            });
-            expect(dataProvider.getMany).toHaveBeenCalledWith('comments', {
-                ids: [3],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'posts',
+                {
+                    ids: [1, 2],
+                },
+                expect.anything()
+            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'comments',
+                {
+                    ids: [3],
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -228,9 +244,13 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
-                ids: [1, 2],
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'posts',
+                {
+                    ids: [1, 2],
+                },
+                expect.anything()
+            );
         });
     });
 });

--- a/packages/ra-core/src/controller/useReference.spec.tsx
+++ b/packages/ra-core/src/controller/useReference.spec.tsx
@@ -36,13 +36,10 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: ['1'],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: ['1'],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -197,13 +194,10 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2, 3],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2, 3],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -217,20 +211,14 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(2);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2],
-                },
-                expect.anything()
-            );
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'comments',
-                {
-                    ids: [3],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2],
+                signal: expect.anything(),
+            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith('comments', {
+                ids: [3],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -244,13 +232,10 @@ describe('useReference', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2],
+                signal: expect.anything(),
+            });
         });
     });
 });

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -111,7 +111,11 @@ export const useDataProvider = <
                                 return response;
                             })
                             .catch(error => {
-                                if (process.env.NODE_ENV !== 'production') {
+                                if (
+                                    process.env.NODE_ENV !== 'production' &&
+                                    // do not log AbortErrors
+                                    !isAbortError(error)
+                                ) {
                                     console.error(error);
                                 }
                                 return logoutIfAccessDenied(error).then(
@@ -143,3 +147,7 @@ export const useDataProvider = <
 
     return dataProviderProxy;
 };
+
+const isAbortError = error =>
+    error instanceof DOMException &&
+    (error as DOMException).name === 'AbortError';

--- a/packages/ra-core/src/dataProvider/useGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.spec.tsx
@@ -52,15 +52,12 @@ describe('useGetList', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getList).toBeCalledTimes(1);
-            expect(dataProvider.getList).toBeCalledWith(
-                'posts',
-                {
-                    filter: {},
-                    pagination: { page: 1, perPage: 20 },
-                    sort: { field: 'id', order: 'DESC' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getList).toBeCalledWith('posts', {
+                filter: {},
+                pagination: { page: 1, perPage: 20 },
+                sort: { field: 'id', order: 'DESC' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -130,16 +127,13 @@ describe('useGetList', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(dataProvider.getList).toBeCalledWith(
-                'posts',
-                {
-                    filter: {},
-                    pagination: { page: 1, perPage: 20 },
-                    sort: { field: 'id', order: 'DESC' },
-                    meta: { hello: 'world' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getList).toBeCalledWith('posts', {
+                filter: {},
+                pagination: { page: 1, perPage: 20 },
+                sort: { field: 'id', order: 'DESC' },
+                meta: { hello: 'world' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -417,7 +411,7 @@ describe('useGetList', () => {
         const abort = jest.fn();
         const dataProvider = testDataProvider({
             getList: jest.fn(
-                (_resource, _params, { signal }) =>
+                (_resource, { signal }) =>
                     new Promise(() => {
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -85,16 +85,13 @@ export const useGetList = <RecordType extends RaRecord = any>(
         queryKey: [resource, 'getList', { pagination, sort, filter, meta }],
         queryFn: ({ signal }) =>
             dataProvider
-                .getList<RecordType>(
-                    resource,
-                    {
-                        pagination,
-                        sort,
-                        filter,
-                        meta,
-                    },
-                    { signal }
-                )
+                .getList<RecordType>(resource, {
+                    pagination,
+                    sort,
+                    filter,
+                    meta,
+                    signal,
+                })
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -83,14 +83,18 @@ export const useGetList = <RecordType extends RaRecord = any>(
         GetListResult<RecordType>
     >({
         queryKey: [resource, 'getList', { pagination, sort, filter, meta }],
-        queryFn: () =>
+        queryFn: ({ signal }) =>
             dataProvider
-                .getList<RecordType>(resource, {
-                    pagination,
-                    sort,
-                    filter,
-                    meta,
-                })
+                .getList<RecordType>(
+                    resource,
+                    {
+                        pagination,
+                        sort,
+                        filter,
+                        meta,
+                    },
+                    { signal }
+                )
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
@@ -69,13 +69,10 @@ describe('useGetMany', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -171,14 +168,11 @@ describe('useGetMany', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1],
-                    meta: { hello: 'world' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1],
+                meta: { hello: 'world' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -376,7 +370,7 @@ describe('useGetMany', () => {
         const abort = jest.fn();
         const dataProvider = testDataProvider({
             getMany: jest.fn(
-                (_resource, _params, { signal }) =>
+                (_resource, { signal }) =>
                     new Promise(() => {
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -79,13 +79,13 @@ export const useGetMany = <RecordType extends RaRecord = any>(
                 meta,
             },
         ],
-        queryFn: () => {
+        queryFn: ({ signal }) => {
             if (!ids || ids.length === 0) {
                 // no need to call the dataProvider
                 return Promise.resolve([]);
             }
             return dataProvider
-                .getMany<RecordType>(resource, { ids, meta })
+                .getMany<RecordType>(resource, { ids, meta }, { signal })
                 .then(({ data }) => data);
         },
         placeholderData: () => {

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -85,7 +85,7 @@ export const useGetMany = <RecordType extends RaRecord = any>(
                 return Promise.resolve([]);
             }
             return dataProvider
-                .getMany<RecordType>(resource, { ids, meta }, { signal })
+                .getMany<RecordType>(resource, { ids, meta, signal })
                 .then(({ data }) => data);
         },
         placeholderData: () => {

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
@@ -375,12 +375,83 @@ describe('useGetManyAggregate', () => {
         );
     });
 
-    it('should abort the request if the query is canceled', async () => {
+    it.each([
+        // case when we have only one query
+        { queries: [{ ids: ['1'] }], expectedQueryKeyParams: { ids: ['1'] } },
+        // case when we have multiple queries on the same id (deduplication)
+        {
+            queries: [{ ids: ['1'] }, { ids: ['1'] }],
+            expectedQueryKeyParams: { ids: ['1'] },
+        },
+        // case when we have multiple queries on different ids (aggregation)
+        {
+            queries: [{ ids: ['1'] }, { ids: ['2'] }],
+            expectedQueryKeyParams: { ids: ['1', '2'] },
+        },
+        // case when we have multiple queries on different ids, including a call with all ids
+        // (no manual aggregation needed)
+        {
+            queries: [{ ids: ['1'] }, { ids: ['2'] }, { ids: ['1', '2'] }],
+            expectedQueryKeyParams: { ids: ['1', '2'] },
+        },
+    ])(
+        'should abort the request if the query is canceled',
+        async ({ queries, expectedQueryKeyParams }) => {
+            const abort = jest.fn();
+            const dataProvider = testDataProvider({
+                getMany: jest.fn(
+                    (_resource, { signal }) =>
+                        new Promise(() => {
+                            signal.addEventListener('abort', () => {
+                                abort(signal.reason);
+                            });
+                        })
+                ) as any,
+            });
+            const queryClient = new QueryClient();
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    {queries.map((query, index) => (
+                        <UseGetManyAggregate
+                            key={index}
+                            resource="posts"
+                            {...query}
+                        />
+                    ))}
+                </CoreAdminContext>
+            );
+            await waitFor(() => {
+                expect(dataProvider.getMany).toHaveBeenCalled();
+            });
+            expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'posts',
+                expect.objectContaining(expectedQueryKeyParams)
+            );
+            queryClient.cancelQueries({
+                queryKey: ['posts', 'getMany', expectedQueryKeyParams],
+            });
+            await waitFor(() => {
+                expect(abort).toHaveBeenCalled();
+            });
+        }
+    );
+
+    it('should only call a query that is not yet aborted and then abort it successfully', async () => {
         const abort = jest.fn();
+        const reject = jest.fn();
         const dataProvider = testDataProvider({
             getMany: jest.fn(
                 (_resource, { signal }) =>
                     new Promise(() => {
+                        if (signal.aborted) {
+                            reject(
+                                'Test failure: called a query which already received an abort signal'
+                            );
+                        }
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);
                         });
@@ -388,17 +459,35 @@ describe('useGetManyAggregate', () => {
             ) as any,
         });
         const queryClient = new QueryClient();
-        render(
+        const { rerender } = render(
             <CoreAdminContext
                 dataProvider={dataProvider}
                 queryClient={queryClient}
             >
-                <UseGetManyAggregate resource="posts" ids={[1]} />
+                <UseGetManyAggregate resource="posts" ids={['1']} />
+            </CoreAdminContext>
+        );
+        queryClient.cancelQueries({
+            queryKey: ['posts', 'getMany', { ids: ['1'] }],
+        });
+        rerender(
+            <CoreAdminContext
+                dataProvider={dataProvider}
+                queryClient={queryClient}
+            >
+                <UseGetManyAggregate resource="posts" ids={['1']} />
+                <UseGetManyAggregate resource="posts" ids={['1']} />
             </CoreAdminContext>
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalled();
         });
+        expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
+        expect(dataProvider.getMany).toHaveBeenCalledWith(
+            'posts',
+            expect.objectContaining({ ids: ['1'] })
+        );
+        expect(reject).not.toHaveBeenCalled();
         queryClient.cancelQueries({
             queryKey: ['posts', 'getMany', { ids: ['1'] }],
         });

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
@@ -37,13 +37,10 @@ describe('useGetManyAggregate', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -266,13 +263,10 @@ describe('useGetManyAggregate', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2, 3, 4, 5, 6],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2, 3, 4, 5, 6],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -286,20 +280,14 @@ describe('useGetManyAggregate', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(2);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2, 3, 4],
-                },
-                expect.anything()
-            );
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'comments',
-                {
-                    ids: [5, 6],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2, 3, 4],
+                signal: expect.anything(),
+            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith('comments', {
+                ids: [5, 6],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -313,13 +301,10 @@ describe('useGetManyAggregate', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2, 3, 4],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2, 3, 4],
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -357,13 +342,10 @@ describe('useGetManyAggregate', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [1, 2, 3],
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [1, 2, 3],
+                signal: expect.anything(),
+            });
         });
 
         await waitFor(() => {
@@ -397,7 +379,7 @@ describe('useGetManyAggregate', () => {
         const abort = jest.fn();
         const dataProvider = testDataProvider({
             getMany: jest.fn(
-                (_resource, _params, { signal }) =>
+                (_resource, { signal }) =>
                     new Promise(() => {
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -289,7 +289,7 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
             } = callThatHasAllAggregatedIds;
 
             dataProvider
-                .getMany<any>(resource, { ids, meta }, { signal })
+                .getMany<any>(resource, { ids, meta, signal })
                 .then(({ data }) => data)
                 .then(
                     data => {
@@ -330,14 +330,11 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
                 ],
                 queryFn: ({ signal }) =>
                     dataProvider
-                        .getMany<any>(
-                            resource,
-                            {
-                                ids: aggregatedIds,
-                                meta: uniqueMeta,
-                            },
-                            { signal }
-                        )
+                        .getMany<any>(resource, {
+                            ids: aggregatedIds,
+                            meta: uniqueMeta,
+                            signal,
+                        })
                         .then(({ data }) => data),
             })
             .then(data => {

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -227,7 +227,6 @@ interface GetManyCallArgs {
 const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
     const dataProvider = calls[0].dataProvider;
     const queryClient = calls[0].queryClient;
-    const signal = calls[0].signal;
 
     /**
      * Aggregate calls by resource
@@ -286,6 +285,7 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
                 resource,
                 ids,
                 meta,
+                signal,
             } = callThatHasAllAggregatedIds;
 
             dataProvider

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -274,7 +274,9 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
         }
 
         const callThatHasAllAggregatedIds = callsForResource.find(
-            ({ ids }) => JSON.stringify(ids) === JSON.stringify(aggregatedIds)
+            ({ ids, signal }) =>
+                JSON.stringify(ids) === JSON.stringify(aggregatedIds) &&
+                !signal.aborted
         );
         if (callThatHasAllAggregatedIds) {
             // There is only one call (no aggregation), or one of the calls has the same ids as the sum of all calls.

--- a/packages/ra-core/src/dataProvider/useGetManyReference.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.spec.tsx
@@ -1,0 +1,420 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { Identifier, PaginationPayload, SortPayload } from '../types';
+import { testDataProvider } from './testDataProvider';
+import { useGetManyReference } from './useGetManyReference';
+
+const UseGetManyReference = ({
+    resource = 'posts',
+    target = 'comments',
+    id = 1,
+    pagination = { page: 1, perPage: 10 },
+    sort = { field: 'id', order: 'DESC' } as const,
+    filter = {},
+    options = {},
+    meta = undefined,
+    callback = null,
+}: {
+    resource?: string;
+    target?: string;
+    id?: Identifier;
+    pagination?: PaginationPayload;
+    sort?: SortPayload;
+    filter?: any;
+    options?: any;
+    meta?: any;
+    callback?: any;
+}) => {
+    const hookValue = useGetManyReference(
+        resource,
+        { target, id, pagination, sort, filter, meta },
+        options
+    );
+    if (callback) callback(hookValue);
+    return <div>hello</div>;
+};
+
+describe('useGetManyReference', () => {
+    it('should call dataProvider.getManyReference() on mount', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({
+                    data: [{ id: 1, title: 'foo' }],
+                    total: 1,
+                })
+            ),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledTimes(1);
+            expect(dataProvider.getManyReference).toBeCalledWith('posts', {
+                target: 'comments',
+                id: 1,
+                filter: {},
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'DESC' },
+                signal: expect.anything(),
+            });
+        });
+    });
+
+    it('should not call the dataProvider on update', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'foo' }], total: 1 })
+            ),
+        });
+        const { rerender } = render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledTimes(1);
+        });
+        rerender(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledTimes(1);
+        });
+    });
+
+    it('should call the dataProvider on update when the resource changes', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'foo' }], total: 1 })
+            ),
+        });
+        const { rerender } = render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledTimes(1);
+        });
+        rerender(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference resource="comments" />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledTimes(2);
+        });
+    });
+
+    it('should accept a meta parameter', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'foo' }], total: 1 })
+            ),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference meta={{ hello: 'world' }} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toBeCalledWith('posts', {
+                target: 'comments',
+                id: 1,
+                filter: {},
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'DESC' },
+                meta: { hello: 'world' },
+                signal: expect.anything(),
+            });
+        });
+    });
+
+    it('should return initial data based on Query Cache', async () => {
+        const callback = jest.fn();
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(
+            [
+                'posts',
+                'getManyReference',
+                {
+                    target: 'comments',
+                    id: 1,
+                    pagination: { page: 1, perPage: 10 },
+                    sort: { field: 'id', order: 'DESC' },
+                    filter: {},
+                },
+            ],
+            {
+                data: [{ id: 1, title: 'cached' }],
+                total: 1,
+            }
+        );
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
+            ),
+        });
+        render(
+            <CoreAdminContext
+                queryClient={queryClient}
+                dataProvider={dataProvider}
+            >
+                <UseGetManyReference callback={callback} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'cached' }] })
+            );
+        });
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+    });
+
+    it('should return isFetching false once the dataProvider returns', async () => {
+        const callback = jest.fn();
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({
+                    data: [
+                        { id: 1, title: 'foo' },
+                        { id: 2, title: 'bar' },
+                    ],
+                    total: 2,
+                })
+            ),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference callback={callback} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ isFetching: true })
+            );
+        });
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ isFetching: false })
+            );
+        });
+    });
+
+    it('should set the error state when the dataProvider fails', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const callback = jest.fn();
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.reject(new Error('failed'))
+            ),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference
+                    options={{ retry: false }}
+                    callback={callback}
+                />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ error: null })
+            );
+        });
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ error: new Error('failed') })
+            );
+        });
+    });
+
+    it('should execute success side effects on success', async () => {
+        const onSuccess1 = jest.fn();
+        const onSuccess2 = jest.fn();
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest
+                .fn()
+                .mockReturnValueOnce(
+                    Promise.resolve({
+                        data: [
+                            { id: 1, title: 'foo' },
+                            { id: 2, title: 'bar' },
+                        ],
+                        total: 2,
+                    })
+                )
+                .mockReturnValueOnce(
+                    Promise.resolve({
+                        data: [
+                            { id: 3, foo: 1 },
+                            { id: 4, foo: 2 },
+                        ],
+                        total: 2,
+                    })
+                ),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference options={{ onSuccess: onSuccess1 }} />
+                <UseGetManyReference
+                    resource="comments"
+                    options={{ onSuccess: onSuccess2 }}
+                />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(onSuccess1).toBeCalledTimes(1);
+            expect(onSuccess1.mock.calls.pop()[0]).toEqual({
+                data: [
+                    { id: 1, title: 'foo' },
+                    { id: 2, title: 'bar' },
+                ],
+                total: 2,
+            });
+            expect(onSuccess2).toBeCalledTimes(1);
+            expect(onSuccess2.mock.calls.pop()[0]).toEqual({
+                data: [
+                    { id: 3, foo: 1 },
+                    { id: 4, foo: 2 },
+                ],
+                total: 2,
+            });
+        });
+    });
+
+    it('should execute error side effects on failure', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const onError = jest.fn();
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.reject(new Error('failed'))
+            ),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <UseGetManyReference options={{ onError, retry: false }} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(onError).toBeCalledTimes(1);
+            expect(onError.mock.calls.pop()[0]).toEqual(new Error('failed'));
+        });
+    });
+
+    it('should pre-populate getOne Query Cache', async () => {
+        const callback = jest.fn();
+        const queryClient = new QueryClient();
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
+            ),
+        });
+        render(
+            <CoreAdminContext
+                queryClient={queryClient}
+                dataProvider={dataProvider}
+            >
+                <UseGetManyReference callback={callback} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+        expect(
+            queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
+        ).toEqual({ id: 1, title: 'live' });
+    });
+
+    it('should still pre-populate getOne Query Cache with custom onSuccess', async () => {
+        const callback = jest.fn();
+        const onSuccess = jest.fn();
+        const queryClient = new QueryClient();
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getManyReference: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'live' }], total: 1 })
+            ),
+        });
+        render(
+            <CoreAdminContext
+                queryClient={queryClient}
+                dataProvider={dataProvider}
+            >
+                <UseGetManyReference
+                    callback={callback}
+                    options={{ onSuccess }}
+                />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(callback).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalledWith(
+                expect.objectContaining({ data: [{ id: 1, title: 'live' }] })
+            );
+        });
+        expect(
+            queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
+        ).toEqual({ id: 1, title: 'live' });
+    });
+
+    it('should abort the request if the query is canceled', async () => {
+        const abort = jest.fn();
+        const dataProvider = testDataProvider({
+            getManyReference: jest.fn(
+                (_resource, { signal }) =>
+                    new Promise(() => {
+                        signal.addEventListener('abort', () => {
+                            abort(signal.reason);
+                        });
+                    })
+            ) as any,
+        });
+        const queryClient = new QueryClient();
+        render(
+            <CoreAdminContext
+                dataProvider={dataProvider}
+                queryClient={queryClient}
+            >
+                <UseGetManyReference />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getManyReference).toHaveBeenCalled();
+        });
+        queryClient.cancelQueries({
+            queryKey: ['posts', 'getManyReference'],
+        });
+        await waitFor(() => {
+            expect(abort).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -101,18 +101,15 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
                 return Promise.reject(new Error('target and id are required'));
             }
             return dataProvider
-                .getManyReference<RecordType>(
-                    resource,
-                    {
-                        target,
-                        id,
-                        pagination,
-                        sort,
-                        filter,
-                        meta,
-                    },
-                    { signal }
-                )
+                .getManyReference<RecordType>(resource, {
+                    target,
+                    id,
+                    pagination,
+                    sort,
+                    filter,
+                    meta,
+                    signal,
+                })
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -95,20 +95,24 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
             'getManyReference',
             { target, id, pagination, sort, filter, meta },
         ],
-        queryFn: () => {
+        queryFn: ({ signal }) => {
             if (!target || id == null) {
                 // check at runtime to support partial parameters with the enabled option
                 return Promise.reject(new Error('target and id are required'));
             }
             return dataProvider
-                .getManyReference<RecordType>(resource, {
-                    target,
-                    id,
-                    pagination,
-                    sort,
-                    filter,
-                    meta,
-                })
+                .getManyReference<RecordType>(
+                    resource,
+                    {
+                        target,
+                        id,
+                        pagination,
+                        sort,
+                        filter,
+                        meta,
+                    },
+                    { signal }
+                )
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
@@ -44,13 +44,10 @@ describe('useGetOne', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getOne).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getOne).toHaveBeenCalledWith(
-                'posts',
-                {
-                    id: 1,
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getOne).toHaveBeenCalledWith('posts', {
+                id: 1,
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -142,14 +139,11 @@ describe('useGetOne', () => {
         );
         await waitFor(() => {
             expect(dataProvider.getOne).toHaveBeenCalledTimes(1);
-            expect(dataProvider.getOne).toHaveBeenCalledWith(
-                'posts',
-                {
-                    id: 1,
-                    meta: { hello: 'world' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getOne).toHaveBeenCalledWith('posts', {
+                id: 1,
+                meta: { hello: 'world' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -224,7 +218,7 @@ describe('useGetOne', () => {
         const abort = jest.fn();
         const dataProvider = testDataProvider({
             getOne: jest.fn(
-                (_resource, _params, { signal }) =>
+                (_resource, { signal }) =>
                     new Promise(() => {
                         signal.addEventListener('abort', () => {
                             abort(signal.reason);

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -68,9 +68,9 @@ export const useGetOne = <RecordType extends RaRecord = any>(
         // Sometimes the id comes as a number (e.g. when read from a Record in useGetList response).
         // As the react-query cache is type-sensitive, we always stringify the identifier to get a match
         queryKey: [resource, 'getOne', { id: String(id), meta }],
-        queryFn: () =>
+        queryFn: ({ signal }) =>
             dataProvider
-                .getOne<RecordType>(resource, { id, meta })
+                .getOne<RecordType>(resource, { id, meta }, { signal })
                 .then(({ data }) => data),
         ...queryOptions,
     });

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -70,7 +70,7 @@ export const useGetOne = <RecordType extends RaRecord = any>(
         queryKey: [resource, 'getOne', { id: String(id), meta }],
         queryFn: ({ signal }) =>
             dataProvider
-                .getOne<RecordType>(resource, { id, meta }, { signal })
+                .getOne<RecordType>(resource, { id, meta, signal })
                 .then(({ data }) => data),
         ...queryOptions,
     });

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.spec.tsx
@@ -52,6 +52,7 @@ describe('useInfiniteGetList', () => {
                 filter: {},
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
+                signal: expect.anything(),
             });
         });
     });
@@ -119,6 +120,7 @@ describe('useInfiniteGetList', () => {
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { hello: 'world' },
+                signal: expect.anything(),
             });
         });
     });
@@ -377,6 +379,38 @@ describe('useInfiniteGetList', () => {
         expect(
             queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
         ).toEqual({ id: 1, title: 'changed!' });
+    });
+
+    it('should abort the request if the query is canceled', async () => {
+        const abort = jest.fn();
+        const dataProvider = testDataProvider({
+            getList: jest.fn(
+                (_resource, { signal }) =>
+                    new Promise(() => {
+                        signal.addEventListener('abort', () => {
+                            abort(signal.reason);
+                        });
+                    })
+            ) as any,
+        });
+        const queryClient = new QueryClient();
+        render(
+            <CoreAdminContext
+                dataProvider={dataProvider}
+                queryClient={queryClient}
+            >
+                <UseInfiniteGetList />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getList).toHaveBeenCalled();
+        });
+        queryClient.cancelQueries({
+            queryKey: ['posts', 'getInfiniteList'],
+        });
+        await waitFor(() => {
+            expect(abort).toHaveBeenCalled();
+        });
     });
 
     describe('fetchNextPage', () => {

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
@@ -101,7 +101,7 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
             'getInfiniteList',
             { pagination, sort, filter, meta },
         ],
-        queryFn: ({ pageParam = pagination.page }) =>
+        queryFn: ({ pageParam = pagination.page, signal }) =>
             dataProvider
                 .getList<RecordType>(resource, {
                     pagination: {
@@ -111,6 +111,7 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
                     sort,
                     filter,
                     meta,
+                    signal,
                 })
                 .then(({ data, pageInfo, total }) => ({
                     data,

--- a/packages/ra-core/src/form/useUnique.spec.tsx
+++ b/packages/ra-core/src/form/useUnique.spec.tsx
@@ -35,23 +35,19 @@ describe('useUnique', () => {
         fireEvent.click(screen.getByText('Submit'));
         await waitFor(
             () => {
-                expect(dataProvider.getList).toHaveBeenCalledWith(
-                    'users',
-                    {
-                        filter: {
-                            name: 'John Doe',
-                        },
-                        pagination: {
-                            page: 1,
-                            perPage: 1,
-                        },
-                        sort: {
-                            field: 'id',
-                            order: 'ASC',
-                        },
+                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
+                    filter: {
+                        name: 'John Doe',
                     },
-                    expect.anything()
-                );
+                    pagination: {
+                        page: 1,
+                        perPage: 1,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                });
             },
             { timeout: 5000 }
         );
@@ -102,23 +98,19 @@ describe('useUnique', () => {
 
         await waitFor(
             () =>
-                expect(dataProvider.getList).toHaveBeenCalledWith(
-                    'users',
-                    {
-                        filter: {
-                            name: 'Jane Doe',
-                        },
-                        pagination: {
-                            page: 1,
-                            perPage: 1,
-                        },
-                        sort: {
-                            field: 'id',
-                            order: 'ASC',
-                        },
+                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
+                    filter: {
+                        name: 'Jane Doe',
                     },
-                    expect.anything()
-                ),
+                    pagination: {
+                        page: 1,
+                        perPage: 1,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                }),
             { timeout: 5000 }
         );
         await screen.findByText('Must be unique');
@@ -217,24 +209,20 @@ describe('useUnique', () => {
 
         await waitFor(
             () => {
-                expect(dataProvider.getList).toHaveBeenCalledWith(
-                    'users',
-                    {
-                        filter: {
-                            name: 'John Doe',
-                            organization_id: 1,
-                        },
-                        pagination: {
-                            page: 1,
-                            perPage: 1,
-                        },
-                        sort: {
-                            field: 'id',
-                            order: 'ASC',
-                        },
+                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
+                    filter: {
+                        name: 'John Doe',
+                        organization_id: 1,
                     },
-                    expect.anything()
-                );
+                    pagination: {
+                        page: 1,
+                        perPage: 1,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                });
             },
             { timeout: 5000 }
         );
@@ -251,25 +239,21 @@ describe('useUnique', () => {
 
         await waitFor(
             () => {
-                expect(dataProvider.getList).toHaveBeenCalledWith(
-                    'users',
-                    {
-                        filter: {
-                            identity: {
-                                name: 'John Doe',
-                            },
-                        },
-                        pagination: {
-                            page: 1,
-                            perPage: 1,
-                        },
-                        sort: {
-                            field: 'id',
-                            order: 'ASC',
+                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
+                    filter: {
+                        identity: {
+                            name: 'John Doe',
                         },
                     },
-                    expect.anything()
-                );
+                    pagination: {
+                        page: 1,
+                        perPage: 1,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                });
             },
             { timeout: 5000 }
         );

--- a/packages/ra-core/src/form/useUnique.spec.tsx
+++ b/packages/ra-core/src/form/useUnique.spec.tsx
@@ -35,19 +35,23 @@ describe('useUnique', () => {
         fireEvent.click(screen.getByText('Submit'));
         await waitFor(
             () => {
-                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
-                    filter: {
-                        name: 'John Doe',
+                expect(dataProvider.getList).toHaveBeenCalledWith(
+                    'users',
+                    {
+                        filter: {
+                            name: 'John Doe',
+                        },
+                        pagination: {
+                            page: 1,
+                            perPage: 1,
+                        },
+                        sort: {
+                            field: 'id',
+                            order: 'ASC',
+                        },
                     },
-                    pagination: {
-                        page: 1,
-                        perPage: 1,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'ASC',
-                    },
-                });
+                    expect.anything()
+                );
             },
             { timeout: 5000 }
         );
@@ -81,9 +85,13 @@ describe('useUnique', () => {
         render(<Edit dataProvider={dataProvider} id={1} />);
 
         await waitFor(() =>
-            expect(dataProvider.getOne).toHaveBeenCalledWith('users', {
-                id: 1,
-            })
+            expect(dataProvider.getOne).toHaveBeenCalledWith(
+                'users',
+                {
+                    id: 1,
+                },
+                expect.anything()
+            )
         );
         await new Promise(resolve => setTimeout(resolve, 500));
         fireEvent.change(await screen.findByDisplayValue('John Doe'), {
@@ -94,19 +102,23 @@ describe('useUnique', () => {
 
         await waitFor(
             () =>
-                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
-                    filter: {
-                        name: 'Jane Doe',
+                expect(dataProvider.getList).toHaveBeenCalledWith(
+                    'users',
+                    {
+                        filter: {
+                            name: 'Jane Doe',
+                        },
+                        pagination: {
+                            page: 1,
+                            perPage: 1,
+                        },
+                        sort: {
+                            field: 'id',
+                            order: 'ASC',
+                        },
                     },
-                    pagination: {
-                        page: 1,
-                        perPage: 1,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'ASC',
-                    },
-                }),
+                    expect.anything()
+                ),
             { timeout: 5000 }
         );
         await screen.findByText('Must be unique');
@@ -205,20 +217,24 @@ describe('useUnique', () => {
 
         await waitFor(
             () => {
-                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
-                    filter: {
-                        name: 'John Doe',
-                        organization_id: 1,
+                expect(dataProvider.getList).toHaveBeenCalledWith(
+                    'users',
+                    {
+                        filter: {
+                            name: 'John Doe',
+                            organization_id: 1,
+                        },
+                        pagination: {
+                            page: 1,
+                            perPage: 1,
+                        },
+                        sort: {
+                            field: 'id',
+                            order: 'ASC',
+                        },
                     },
-                    pagination: {
-                        page: 1,
-                        perPage: 1,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'ASC',
-                    },
-                });
+                    expect.anything()
+                );
             },
             { timeout: 5000 }
         );
@@ -235,21 +251,25 @@ describe('useUnique', () => {
 
         await waitFor(
             () => {
-                expect(dataProvider.getList).toHaveBeenCalledWith('users', {
-                    filter: {
-                        identity: {
-                            name: 'John Doe',
+                expect(dataProvider.getList).toHaveBeenCalledWith(
+                    'users',
+                    {
+                        filter: {
+                            identity: {
+                                name: 'John Doe',
+                            },
+                        },
+                        pagination: {
+                            page: 1,
+                            perPage: 1,
+                        },
+                        sort: {
+                            field: 'id',
+                            order: 'ASC',
                         },
                     },
-                    pagination: {
-                        page: 1,
-                        perPage: 1,
-                    },
-                    sort: {
-                        field: 'id',
-                        order: 'ASC',
-                    },
-                });
+                    expect.anything()
+                );
             },
             { timeout: 5000 }
         );

--- a/packages/ra-core/src/form/useUnique.spec.tsx
+++ b/packages/ra-core/src/form/useUnique.spec.tsx
@@ -81,13 +81,10 @@ describe('useUnique', () => {
         render(<Edit dataProvider={dataProvider} id={1} />);
 
         await waitFor(() =>
-            expect(dataProvider.getOne).toHaveBeenCalledWith(
-                'users',
-                {
-                    id: 1,
-                },
-                expect.anything()
-            )
+            expect(dataProvider.getOne).toHaveBeenCalledWith('users', {
+                id: 1,
+                signal: expect.anything(),
+            })
         );
         await new Promise(resolve => setTimeout(resolve, 500));
         fireEvent.change(await screen.findByDisplayValue('John Doe'), {

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -62,15 +62,12 @@ export type AuthProvider = {
         params: any
     ) => Promise<{ redirectTo?: string | boolean } | void | any>;
     logout: (params: any) => Promise<void | false | string>;
-    checkAuth: (params: any, contex?: QueryFunctionContext) => Promise<void>;
+    checkAuth: (params: any & QueryFunctionContext) => Promise<void>;
     checkError: (error: any) => Promise<void>;
-    getIdentity?: (contex?: QueryFunctionContext) => Promise<UserIdentity>;
-    getPermissions: (
-        params: any,
-        contex?: QueryFunctionContext
-    ) => Promise<any>;
+    getIdentity?: (params?: QueryFunctionContext) => Promise<UserIdentity>;
+    getPermissions: (params: any & QueryFunctionContext) => Promise<any>;
     handleCallback?: (
-        contex?: QueryFunctionContext
+        params?: QueryFunctionContext
     ) => Promise<AuthRedirectResult | void | any>;
     [key: string]: any;
 };
@@ -92,26 +89,22 @@ export type LegacyAuthProvider = (
 export type DataProvider<ResourceType extends string = string> = {
     getList: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetListParams,
-        contex?: QueryFunctionContext
+        params: GetListParams & QueryFunctionContext
     ) => Promise<GetListResult<RecordType>>;
 
     getOne: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetOneParams<RecordType>,
-        contex?: QueryFunctionContext
+        params: GetOneParams<RecordType> & QueryFunctionContext
     ) => Promise<GetOneResult<RecordType>>;
 
     getMany: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetManyParams,
-        contex?: QueryFunctionContext
+        params: GetManyParams & QueryFunctionContext
     ) => Promise<GetManyResult<RecordType>>;
 
     getManyReference: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetManyReferenceParams,
-        contex?: QueryFunctionContext
+        params: GetManyReferenceParams & QueryFunctionContext
     ) => Promise<GetManyReferenceResult<RecordType>>;
 
     update: <RecordType extends RaRecord = any>(

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -62,11 +62,16 @@ export type AuthProvider = {
         params: any
     ) => Promise<{ redirectTo?: string | boolean } | void | any>;
     logout: (params: any) => Promise<void | false | string>;
-    checkAuth: (params: any) => Promise<void>;
+    checkAuth: (params: any, contex?: QueryFunctionContext) => Promise<void>;
     checkError: (error: any) => Promise<void>;
-    getIdentity?: () => Promise<UserIdentity>;
-    getPermissions: (params: any) => Promise<any>;
-    handleCallback?: () => Promise<AuthRedirectResult | void | any>;
+    getIdentity?: (contex?: QueryFunctionContext) => Promise<UserIdentity>;
+    getPermissions: (
+        params: any,
+        contex?: QueryFunctionContext
+    ) => Promise<any>;
+    handleCallback?: (
+        contex?: QueryFunctionContext
+    ) => Promise<AuthRedirectResult | void | any>;
     [key: string]: any;
 };
 
@@ -87,22 +92,26 @@ export type LegacyAuthProvider = (
 export type DataProvider<ResourceType extends string = string> = {
     getList: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetListParams
+        params: GetListParams,
+        contex?: QueryFunctionContext
     ) => Promise<GetListResult<RecordType>>;
 
     getOne: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetOneParams<RecordType>
+        params: GetOneParams<RecordType>,
+        contex?: QueryFunctionContext
     ) => Promise<GetOneResult<RecordType>>;
 
     getMany: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetManyParams
+        params: GetManyParams,
+        contex?: QueryFunctionContext
     ) => Promise<GetManyResult<RecordType>>;
 
     getManyReference: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetManyReferenceParams
+        params: GetManyReferenceParams,
+        contex?: QueryFunctionContext
     ) => Promise<GetManyReferenceResult<RecordType>>;
 
     update: <RecordType extends RaRecord = any>(
@@ -135,6 +144,10 @@ export type DataProvider<ResourceType extends string = string> = {
 
     [key: string]: any;
 };
+
+export interface QueryFunctionContext {
+    signal?: AbortSignal;
+}
 
 export interface GetListParams {
     pagination: PaginationPayload;

--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -185,6 +185,11 @@ const buildGraphQLProvider = async (
                 ...query,
                 fetchPolicy: 'network-only',
                 ...getOptions(otherOptions.query, raFetchMethod, resource),
+                context: {
+                    fetchOptions: {
+                        signal: params?.signal,
+                    },
+                },
             };
 
             return (

--- a/packages/ra-data-json-server/src/index.ts
+++ b/packages/ra-data-json-server/src/index.ts
@@ -46,24 +46,28 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-        return httpClient(url).then(({ headers, json }) => {
-            if (!headers.has('x-total-count')) {
-                throw new Error(
-                    'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
-                );
+        return httpClient(url, { signal: params?.signal }).then(
+            ({ headers, json }) => {
+                if (!headers.has('x-total-count')) {
+                    throw new Error(
+                        'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
+                    );
+                }
+                return {
+                    data: json,
+                    total: parseInt(
+                        headers.get('x-total-count').split('/').pop(),
+                        10
+                    ),
+                };
             }
-            return {
-                data: json,
-                total: parseInt(
-                    headers.get('x-total-count').split('/').pop(),
-                    10
-                ),
-            };
-        });
+        );
     },
 
     getOne: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
+        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+            signal: params?.signal,
+        }).then(({ json }) => ({
             data: json,
         })),
 
@@ -72,7 +76,9 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
             id: params.ids,
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        return httpClient(url).then(({ json }) => ({ data: json }));
+        return httpClient(url, { signal: params?.signal }).then(({ json }) => ({
+            data: json,
+        }));
     },
 
     getManyReference: (resource, params) => {
@@ -88,20 +94,22 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-        return httpClient(url).then(({ headers, json }) => {
-            if (!headers.has('x-total-count')) {
-                throw new Error(
-                    'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
-                );
+        return httpClient(url, { signal: params?.signal }).then(
+            ({ headers, json }) => {
+                if (!headers.has('x-total-count')) {
+                    throw new Error(
+                        'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
+                    );
+                }
+                return {
+                    data: json,
+                    total: parseInt(
+                        headers.get('x-total-count').split('/').pop(),
+                        10
+                    ),
+                };
             }
-            return {
-                data: json,
-                total: parseInt(
-                    headers.get('x-total-count').split('/').pop(),
-                    10
-                ),
-            };
-        });
+        );
     },
 
     update: (resource, params) =>

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -58,8 +58,9 @@ export default (
                       headers: new Headers({
                           Range: `${resource}=${rangeStart}-${rangeEnd}`,
                       }),
+                      signal: params?.signal,
                   }
-                : {};
+                : { signal: params?.signal };
 
         return httpClient(url, options).then(({ headers, json }) => {
             if (!headers.has(countHeader)) {
@@ -81,7 +82,9 @@ export default (
     },
 
     getOne: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
+        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+            signal: params?.signal,
+        }).then(({ json }) => ({
             data: json,
         })),
 
@@ -90,7 +93,9 @@ export default (
             filter: JSON.stringify({ id: params.ids }),
         };
         const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        return httpClient(url).then(({ json }) => ({ data: json }));
+        return httpClient(url, { signal: params?.signal }).then(({ json }) => ({
+            data: json,
+        }));
     },
 
     getManyReference: (resource, params) => {
@@ -116,8 +121,9 @@ export default (
                       headers: new Headers({
                           Range: `${resource}=${rangeStart}-${rangeEnd}`,
                       }),
+                      signal: params?.signal,
                   }
-                : {};
+                : { signal: params?.signal };
 
         return httpClient(url, options).then(({ headers, json }) => {
             if (!headers.has(countHeader)) {

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
@@ -140,16 +140,13 @@ describe('<PrevNextButtons />', () => {
             const item = await screen.findByText('9');
             fireEvent.click(item);
             await screen.findByText('10 / 900');
-            expect(spy).toHaveBeenCalledWith(
-                'customers',
-                {
-                    pagination: { page: 1, perPage: 500 },
-                    sort: { field: 'id', order: 'ASC' },
-                    filter: {},
-                    meta: undefined,
-                },
-                expect.anything()
-            );
+            expect(spy).toHaveBeenCalledWith('customers', {
+                pagination: { page: 1, perPage: 500 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: {},
+                meta: undefined,
+                signal: expect.anything(),
+            });
         });
     });
 });

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
@@ -140,12 +140,16 @@ describe('<PrevNextButtons />', () => {
             const item = await screen.findByText('9');
             fireEvent.click(item);
             await screen.findByText('10 / 900');
-            expect(spy).toHaveBeenCalledWith('customers', {
-                pagination: { page: 1, perPage: 500 },
-                sort: { field: 'id', order: 'ASC' },
-                filter: {},
-                meta: undefined,
-            });
+            expect(spy).toHaveBeenCalledWith(
+                'customers',
+                {
+                    pagination: { page: 1, perPage: 500 },
+                    sort: { field: 'id', order: 'ASC' },
+                    filter: {},
+                    meta: undefined,
+                },
+                expect.anything()
+            );
         });
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -649,14 +649,11 @@ describe('<ReferenceField />', () => {
             </ThemeProvider>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [123],
-                    meta: { foo: 'bar' },
-                },
-                expect.anything()
-            );
+            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
+                ids: [123],
+                meta: { foo: 'bar' },
+                signal: expect.anything(),
+            });
         });
     });
     describe('sx', () => {

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -649,10 +649,14 @@ describe('<ReferenceField />', () => {
             </ThemeProvider>
         );
         await waitFor(() => {
-            expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
-                ids: [123],
-                meta: { foo: 'bar' },
-            });
+            expect(dataProvider.getMany).toHaveBeenCalledWith(
+                'posts',
+                {
+                    ids: [123],
+                    meta: { foo: 'bar' },
+                },
+                expect.anything()
+            );
         });
     });
     describe('sx', () => {

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
@@ -36,13 +36,17 @@ describe('<ReferenceManyCount />', () => {
                 />
             </Wrapper>
         );
-        expect(dataProvider.getManyReference).toHaveBeenCalledWith('comments', {
-            target: 'post_id',
-            id: 1,
-            filter: {},
-            pagination: { page: 1, perPage: 1 },
-            sort: { field: 'custom_id', order: 'ASC' },
-            meta: undefined,
-        });
+        expect(dataProvider.getManyReference).toHaveBeenCalledWith(
+            'comments',
+            {
+                target: 'post_id',
+                id: 1,
+                filter: {},
+                pagination: { page: 1, perPage: 1 },
+                sort: { field: 'custom_id', order: 'ASC' },
+                meta: undefined,
+            },
+            expect.anything()
+        );
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
@@ -36,17 +36,14 @@ describe('<ReferenceManyCount />', () => {
                 />
             </Wrapper>
         );
-        expect(dataProvider.getManyReference).toHaveBeenCalledWith(
-            'comments',
-            {
-                target: 'post_id',
-                id: 1,
-                filter: {},
-                pagination: { page: 1, perPage: 1 },
-                sort: { field: 'custom_id', order: 'ASC' },
-                meta: undefined,
-            },
-            expect.anything()
-        );
+        expect(dataProvider.getManyReference).toHaveBeenCalledWith('comments', {
+            target: 'post_id',
+            id: 1,
+            filter: {},
+            pagination: { page: 1, perPage: 1 },
+            sort: { field: 'custom_id', order: 'ASC' },
+            meta: undefined,
+            signal: expect.anything(),
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
@@ -43,7 +43,8 @@ describe('ReferenceOneField', () => {
                     pagination: { page: 1, perPage: 1 },
                     filter: {},
                     meta: { foo: 'bar' },
-                }
+                },
+                expect.anything()
             );
         });
     });

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
@@ -43,8 +43,8 @@ describe('ReferenceOneField', () => {
                     pagination: { page: 1, perPage: 1 },
                     filter: {},
                     meta: { foo: 'bar' },
-                },
-                expect.anything()
+                    signal: expect.anything(),
+                }
             );
         });
     });

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
@@ -240,12 +240,16 @@ describe('<ReferenceArrayInput />', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getList).toHaveBeenCalledWith('tags', {
-                filter: {},
-                pagination: { page: 1, perPage: 25 },
-                sort: { field: 'id', order: 'DESC' },
-                meta: { foo: 'bar' },
-            });
+            expect(getList).toHaveBeenCalledWith(
+                'tags',
+                {
+                    filter: {},
+                    pagination: { page: 1, perPage: 25 },
+                    sort: { field: 'id', order: 'DESC' },
+                    meta: { foo: 'bar' },
+                },
+                expect.anything()
+            );
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
@@ -240,16 +240,13 @@ describe('<ReferenceArrayInput />', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getList).toHaveBeenCalledWith(
-                'tags',
-                {
-                    filter: {},
-                    pagination: { page: 1, perPage: 25 },
-                    sort: { field: 'id', order: 'DESC' },
-                    meta: { foo: 'bar' },
-                },
-                expect.anything()
-            );
+            expect(getList).toHaveBeenCalledWith('tags', {
+                filter: {},
+                pagination: { page: 1, perPage: 25 },
+                sort: { field: 'id', order: 'DESC' },
+                meta: { foo: 'bar' },
+                signal: expect.anything(),
+            });
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
@@ -128,12 +128,16 @@ describe('<ReferenceInput />', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getList).toHaveBeenCalledWith('posts', {
-                filter: {},
-                pagination: { page: 1, perPage: 25 },
-                sort: { field: 'id', order: 'DESC' },
-                meta: { foo: 'bar' },
-            });
+            expect(getList).toHaveBeenCalledWith(
+                'posts',
+                {
+                    filter: {},
+                    pagination: { page: 1, perPage: 25 },
+                    sort: { field: 'id', order: 'DESC' },
+                    meta: { foo: 'bar' },
+                },
+                expect.anything()
+            );
         });
     });
 
@@ -153,10 +157,14 @@ describe('<ReferenceInput />', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getMany).toHaveBeenCalledWith('posts', {
-                ids: [23],
-                meta: { foo: 'bar' },
-            });
+            expect(getMany).toHaveBeenCalledWith(
+                'posts',
+                {
+                    ids: [23],
+                    meta: { foo: 'bar' },
+                },
+                expect.anything()
+            );
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
@@ -128,16 +128,13 @@ describe('<ReferenceInput />', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getList).toHaveBeenCalledWith(
-                'posts',
-                {
-                    filter: {},
-                    pagination: { page: 1, perPage: 25 },
-                    sort: { field: 'id', order: 'DESC' },
-                    meta: { foo: 'bar' },
-                },
-                expect.anything()
-            );
+            expect(getList).toHaveBeenCalledWith('posts', {
+                filter: {},
+                pagination: { page: 1, perPage: 25 },
+                sort: { field: 'id', order: 'DESC' },
+                meta: { foo: 'bar' },
+                signal: expect.anything(),
+            });
         });
     });
 
@@ -157,14 +154,11 @@ describe('<ReferenceInput />', () => {
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(getMany).toHaveBeenCalledWith(
-                'posts',
-                {
-                    ids: [23],
-                    meta: { foo: 'bar' },
-                },
-                expect.anything()
-            );
+            expect(getMany).toHaveBeenCalledWith('posts', {
+                ids: [23],
+                meta: { foo: 'bar' },
+                signal: expect.anything(),
+            });
         });
     });
 

--- a/packages/ra-ui-materialui/src/list/Count.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/Count.spec.tsx
@@ -30,15 +30,12 @@ describe('<Count />', () => {
                 </ResourceContextProvider>
             </Wrapper>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith(
-            'posts',
-            {
-                filter: {},
-                pagination: { page: 1, perPage: 1 },
-                sort: { field: 'custom_id', order: 'ASC' },
-                meta: undefined,
-            },
-            expect.anything()
-        );
+        expect(dataProvider.getList).toHaveBeenCalledWith('posts', {
+            filter: {},
+            pagination: { page: 1, perPage: 1 },
+            sort: { field: 'custom_id', order: 'ASC' },
+            meta: undefined,
+            signal: expect.anything(),
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/list/Count.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/Count.spec.tsx
@@ -30,11 +30,15 @@ describe('<Count />', () => {
                 </ResourceContextProvider>
             </Wrapper>
         );
-        expect(dataProvider.getList).toHaveBeenCalledWith('posts', {
-            filter: {},
-            pagination: { page: 1, perPage: 1 },
-            sort: { field: 'custom_id', order: 'ASC' },
-            meta: undefined,
-        });
+        expect(dataProvider.getList).toHaveBeenCalledWith(
+            'posts',
+            {
+                filter: {},
+                pagination: { page: 1, perPage: 1 },
+                sort: { field: 'custom_id', order: 'ASC' },
+                meta: undefined,
+            },
+            expect.anything()
+        );
     });
 });


### PR DESCRIPTION
[TanStack Query](https://tanstack.com/query/v3/docs/react/guides/query-cancellation) provides each query function with an [AbortSignal instance](https://developer.mozilla.org/docs/Web/API/AbortSignal). When a query becomes out-of-date or inactive, this signal will become aborted.

This PR takes advantage of this, by propagating the abort signal to the dataProvider and authProvider, to allow for automatically aborting the request when the query is canceled.

## Todo

- [x] Add the abort `signal` to the parameters of all dataProvider and authProvider methods
- [x] Update the tests
- [x] Update our data providers (simple rest, graphql simple, ...) to support this feature
- [x] Update the “writing a data provider” doc to mention it
- [x] Complete the upgrade guide

## How to test

You can see query cancellation in action in
- the **tutorial** example for `ra-data-json-server`
- the **e-commerce** demo in GraphQL mode for `ra-data-graphql` (<- you will need to comment out the `fetchMock` part in `examples/demo/src/fakeServer/graphql.ts` and run a 'real' graphql server, e.g. with `json-graphql-server`)

You can use the browser's DevTools to
- disable network cache
- throttle the requests, e.g. by selecting 'Slow 3G'

With that in place, you can for instance click multiple times on the header of a Datagrid to toggle sorting in ASC or DESC order, and see in the Network tab that all requests except the last one are canceled.

![2024-01-26_11-27](https://github.com/marmelab/react-admin/assets/14542336/ebea59de-6482-4031-8018-e66243b7ea47)

## How to update your DataProvider to benefit from this feature

DataProvider query functions (`getOne`, `getList`, `getMany` and `getManyReference`) are now provided with an additional `signal` parameter. This parameter is an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to abort the request when the query is canceled (e.g. when it becomes out-of-date or inactive).

The following dataProviders, provided by react-admin, have already been updated to support this new parameter:

- `ra-data-json-server`
- `ra-data-simple-rest`
- `ra-data-graphql`

This feature is optional, so you can still use any other dataProvider, even if it doesn't yet support the `signal` parameter.

If you wish to update your own dataProvider to support this new parameter, you can take inspiration from how we updated the `ra-data-simple-rest` dataProvider:

```diff
// In packages/ra-data-simple-rest/src/index.ts
import { fetchUtils, DataProvider } from 'react-admin';

export default (
    apiUrl: string,
    httpClient = fetchUtils.fetchJson,
    countHeader: string = 'Content-Range'
): DataProvider => ({
    getOne: (resource, params) =>
-       httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
+       httpClient(`${apiUrl}/${resource}/${params.id}`, {
+           signal: params?.signal,
+       }).then(({ json }) => ({
            data: json,
        })),

    /* ... other dataProvider methods ... */
});
```

You can find more example implementations in the [Query Cancellation guide](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation).
