### PR TITLE
Sending json Content-Type header for empty body breaks some parsers 

### DIFF
--- a/packages/ra-core/src/dataProvider/fetch.spec.ts
+++ b/packages/ra-core/src/dataProvider/fetch.spec.ts
@@ -62,13 +62,20 @@ describe('flattenObject', () => {
 });
 
 describe('createHeadersFromOptions', () => {
-    it('should add a Content-Type header for POST requests', () => {
-        const options = {
+    it('should add a Content-Type header for POST requests if there is a body', () => {
+        const optionsWithBody = {
+            method: 'POST',
+            body: JSON.stringify(null),
+        };
+
+        const headers = createHeadersFromOptions(optionsWithBody);
+        expect(headers.get('Content-Type')).toStrictEqual('application/json');
+        const optionsWithoutBody = {
             method: 'POST',
         };
 
-        const headers = createHeadersFromOptions(options);
-        expect(headers.get('Content-Type')).toStrictEqual('application/json');
+        const headersWithoutBody = createHeadersFromOptions(optionsWithoutBody);
+        expect(headersWithoutBody.get('Content-Type')).toBeNull();
     });
 
     it('should not add a Content-Type header for GET requests', () => {
@@ -84,5 +91,41 @@ describe('createHeadersFromOptions', () => {
             optionsWithoutMethod
         );
         expect(headersWithoutMethod.get('Content-Type')).toBeNull();
+    });
+
+    it('should not add a Content-Type header if there is no body', () => {
+        const optionsWithDelete = {
+            method: 'DELETE',
+        };
+
+        const headersWithDelete = createHeadersFromOptions(optionsWithDelete);
+        expect(headersWithDelete.get('Content-Type')).toBeNull();
+        const optionsWithDeleteAndBody = {
+            method: 'DELETE',
+            body: JSON.stringify(null),
+        };
+
+        const headersWithDeleteAndBody = createHeadersFromOptions(
+            optionsWithDeleteAndBody
+        );
+        expect(headersWithDeleteAndBody.get('Content-Type')).toStrictEqual(
+            'application/json'
+        );
+    });
+
+    it('should not add a Content-Type header if there already is a Content-Type header', () => {
+        const optionsWithContentType = {
+            headers: new Headers({
+                'Content-Type': 'not undefined',
+            }) as Headers,
+            body: 'not undefined either',
+        };
+
+        const headersWithContentType = createHeadersFromOptions(
+            optionsWithContentType
+        );
+        expect(headersWithContentType.get('Content-Type')).toStrictEqual(
+            'not undefined'
+        );
     });
 });

--- a/packages/ra-core/src/dataProvider/fetch.ts
+++ b/packages/ra-core/src/dataProvider/fetch.ts
@@ -14,9 +14,12 @@ export const createHeadersFromOptions = (options: Options): Headers => {
             Accept: 'application/json',
         })) as Headers;
     if (
+        // An application/json Content-Type header in requests without a body breaks some parsers, like fastify
+        options &&
+        options.body &&
         !requestHeaders.has('Content-Type') &&
-        !(options && (!options.method || options.method === 'GET')) &&
-        !(options && options.body && options.body instanceof FormData)
+        !(!options.method || options.method === 'GET') &&
+        !(options.body instanceof FormData)
     ) {
         requestHeaders.set('Content-Type', 'application/json');
     }


### PR DESCRIPTION
I'm using Fastify on the backend, and it refuses `DELETE` requests sent from react-admin's `ra-data-json-server`.
It is because `fetchUtils.fetchJson` is setting the `Content-Type` header to `application/json`, even with an empty body like in the delete requests. The function that is setting the header is `createHeadersFromOptions` in `fetch.ts`.

It is not against the RFCs to do so, but it just breaks Fastify, and it makes little sense to send a Content-Type with a body that doesn't adhere to the content type: an empty body isn't valid json.

This pull request fixes the issue and adds new unit tests to ensure there is no regression.

`yarn test-unit -- ./packages/ra-core/src/dataProvider/fetch.spec.ts` passes.

I guess the alternatives are:
- sending a body if there isn't one already (with `'null'` in it)
- modifying the `ra-data-json-server` package (and other data providers which are using DELETE with no body) to specify a body.

I thought fixing the `createHeadersFromOptions` option was the cleanest