### PR TITLE
Add setParams callback to ListContext

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -6,7 +6,7 @@ import { useSafeSetState, removeEmpty } from '../../util';
 import { useGetManyReference } from '../../dataProvider';
 import { useNotify } from '../../notification';
 import { Identifier, RaRecord, SortPayload } from '../../types';
-import { ListControllerResult } from '../list';
+import { ListControllerResult, ListParams } from '../list';
 import usePaginationState from '../usePaginationState';
 import { useRecordSelection } from '../list/useRecordSelection';
 import useSortState from '../useSortState';
@@ -144,6 +144,30 @@ export const useReferenceManyFieldController = <
         }
     });
 
+    const setParams = useCallback(
+        (params: Partial<ListParams>) => {
+            if (params.filter) {
+                setFilters(params.filter, params.displayedFilters);
+            }
+            if (params.sort && !params.order) {
+                throw new Error('sort must be used with order');
+            }
+            if (params.order && !params.sort) {
+                throw new Error('order must be used with sort');
+            }
+            if (params.sort || params.order) {
+                setSort({ field: params.sort, order: params.order });
+            }
+            if (params.perPage) {
+                setPerPage(params.perPage);
+            }
+            if (params.page) {
+                setPage(params.page);
+            }
+        },
+        [setFilters, setPerPage, setSort, setPage]
+    );
+
     const {
         data,
         total,
@@ -213,6 +237,7 @@ export const useReferenceManyFieldController = <
             ? page * perPage < total
             : undefined,
         hasPreviousPage: pageInfo ? pageInfo.hasPreviousPage : page > 1,
+        setParams,
         setSort,
         showFilter,
         total,

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
@@ -161,6 +161,7 @@ export const useReferenceArrayInputController = <
         setPerPage: paramsModifiers.setPerPage,
         setSort: paramsModifiers.setSort,
         showFilter: paramsModifiers.showFilter,
+        setParams: paramsModifiers.setParams,
         source,
         total: total,
         hasNextPage: pageInfo

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -184,6 +184,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         setPerPage: paramsModifiers.setPerPage,
         setSort: paramsModifiers.setSort,
         showFilter: paramsModifiers.showFilter,
+        setParams: paramsModifiers.setParams,
         source,
         total: finalTotal,
         hasNextPage: pageInfo

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -12,6 +12,8 @@ import {
     SET_SORT,
     SHOW_FILTER,
     SORT_ASC,
+    SET_PARAMS,
+    ListParams,
 } from '../list';
 
 /**
@@ -176,6 +178,17 @@ export const useReferenceParams = ({
             },
         });
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const setParamsCallback = useCallback(
+        (params: Partial<ListParams>) => {
+            changeParams({
+                type: SET_PARAMS,
+                payload: params,
+            });
+        },
+        [changeParams]
+    );
+
     return [
         {
             displayedFilters: displayedFilterValues,
@@ -191,6 +204,7 @@ export const useReferenceParams = ({
             setFilters,
             hideFilter,
             showFilter,
+            setParams: setParamsCallback,
         },
     ];
 };
@@ -313,6 +327,7 @@ interface Modifiers {
     setFilters: (filters: any, displayedFilters: any) => void;
     hideFilter: (filterName: string) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
+    setParams: (params: Partial<ListParams>) => void;
 }
 
 const emptyObject = {};

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -23,6 +23,7 @@ import { ListControllerResult } from './useListController';
  * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
+ * @prop {Function} setParams a callback to update some list params (page, perPage, sort, order, filter), e.g. setParams({ sort: 'name', order: 'ASC', page: 5, perPage: 20 })
  * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
  * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
  * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
@@ -74,10 +75,11 @@ export const ListContext = createContext<ListControllerResult>({
     resource: null,
     selectedIds: undefined,
     setFilters: null,
+    showFilter: null,
     setPage: null,
     setPerPage: null,
     setSort: null,
-    showFilter: null,
+    setParams: null,
     total: null,
 });
 

--- a/packages/ra-core/src/controller/list/queryReducer.ts
+++ b/packages/ra-core/src/controller/list/queryReducer.ts
@@ -16,6 +16,8 @@ export const SET_FILTER = 'SET_FILTER';
 export const SHOW_FILTER = 'SHOW_FILTER';
 export const HIDE_FILTER = 'HIDE_FILTER';
 
+export const SET_PARAMS = 'SET_PARAMS';
+
 const oppositeOrder = direction =>
     direction === SORT_DESC ? SORT_ASC : SORT_DESC;
 
@@ -49,6 +51,10 @@ type ActionTypes =
     | {
           type: typeof HIDE_FILTER;
           payload: string;
+      }
+    | {
+          type: typeof SET_PARAMS;
+          payload: Partial<ListParams>;
       };
 
 /**
@@ -138,6 +144,23 @@ export const queryReducer: Reducer<ListParams, ActionTypes> = (
                       )
                     : previousState.displayedFilters,
             };
+        }
+
+        case SET_PARAMS: {
+            const newParams = { ...action.payload };
+            // reset pagination if sort changes
+            if ((newParams.sort || newParams.order) && !newParams.page) {
+                newParams.page = 1;
+            }
+            // reset pagination if filter changes
+            if (newParams.filter && !newParams.page) {
+                newParams.page = 1;
+            }
+            // remove empty filters
+            if (newParams.filter) {
+                newParams.filter = removeEmpty(newParams.filter);
+            }
+            return { ...previousState, ...newParams };
         }
 
         default:

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -193,6 +193,7 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
         setPerPage: queryModifiers.setPerPage,
         setSort: queryModifiers.setSort,
         showFilter: queryModifiers.showFilter,
+        setParams: queryModifiers.setParams,
         total: total,
         hasNextPage,
         hasPreviousPage,

--- a/packages/ra-core/src/controller/list/useList.spec.tsx
+++ b/packages/ra-core/src/controller/list/useList.spec.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import expect from 'expect';
 
 import { useList, UseListOptions, UseListValue } from './useList';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ListContextProvider } from './ListContextProvider';
 import { useListContext } from './useListContext';
 
@@ -124,6 +124,78 @@ describe('<useList />', () => {
                     total: 7,
                 })
             );
+        });
+    });
+
+    describe('setParams', () => {
+        it('should apply all params to the list', async () => {
+            const callback = jest.fn();
+            const data = [
+                { id: 1, title: 'hello' },
+                { id: 2, title: 'world' },
+            ];
+
+            const ChangeParamsButton = () => {
+                const { setParams } = useListContext();
+                return (
+                    <button
+                        onClick={() =>
+                            setParams({
+                                sort: 'title',
+                                order: 'ASC',
+                                filter: { title: 'hello' },
+                                perPage: 5,
+                            })
+                        }
+                    >
+                        Change Params
+                    </button>
+                );
+            };
+
+            render(
+                <UseList
+                    data={data}
+                    sort={{ field: 'title', order: 'DESC' }}
+                    perPage={10}
+                    callback={callback}
+                >
+                    <ChangeParamsButton />
+                </UseList>
+            );
+
+            await waitFor(() => {
+                expect(callback).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        sort: { field: 'title', order: 'DESC' },
+                        isFetching: false,
+                        isLoading: false,
+                        data: [
+                            { id: 2, title: 'world' },
+                            { id: 1, title: 'hello' },
+                        ],
+                        error: undefined,
+                        total: 2,
+                    })
+                );
+            });
+
+            fireEvent.click(screen.getByText('Change Params'));
+
+            await waitFor(() => {
+                expect(callback).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        sort: { field: 'title', order: 'ASC' },
+                        perPage: 5,
+                        filterValues: { title: 'hello' },
+                        isFetching: false,
+                        isLoading: false,
+                        data: [{ id: 1, title: 'hello' }],
+                        error: undefined,
+                        total: 1,
+                    })
+                );
+            });
         });
     });
 

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -9,6 +9,7 @@ import useSortState from '../useSortState';
 import { useRecordSelection } from './useRecordSelection';
 import { ListControllerResult } from './useListController';
 import { flattenObject } from '../../dataProvider/fetch';
+import { ListParams } from './useListParams';
 
 const refetch = () => {
     throw new Error(
@@ -161,6 +162,33 @@ export const useList = <RecordType extends RaRecord = any>(
         }
     });
 
+    const setParams = useCallback(
+        (params: Partial<ListParams>) => {
+            if (params.filter) {
+                setFilters(params.filter, undefined);
+            }
+            if (params.displayedFilters) {
+                setDisplayedFilters(params.displayedFilters);
+            }
+            if (params.sort && !params.order) {
+                throw new Error('sort must be used with order');
+            }
+            if (params.order && !params.sort) {
+                throw new Error('order must be used with sort');
+            }
+            if (params.sort || params.order) {
+                setSort({ field: params.sort, order: params.order });
+            }
+            if (params.perPage) {
+                setPerPage(params.perPage);
+            }
+            if (params.page) {
+                setPage(params.page);
+            }
+        },
+        [setFilters, setPerPage, setSort, setPage, setDisplayedFilters]
+    );
+
     // We do all the data processing (filtering, sorting, paginating) client-side
     useEffect(
         () => {
@@ -283,6 +311,7 @@ export const useList = <RecordType extends RaRecord = any>(
         setPerPage,
         setSort,
         showFilter,
+        setParams,
         total: finalItems?.total,
     };
 };

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -428,6 +428,91 @@ describe('useListController', () => {
         });
     });
 
+    describe('setParams', () => {
+        it('should apply the list parameters', async () => {
+            const callback = jest.fn();
+            const getList = jest
+                .fn()
+                .mockImplementation(() =>
+                    Promise.resolve({ data: [], total: 0 })
+                );
+            const dataProvider = testDataProvider({ getList });
+            const history = createMemoryHistory({
+                initialEntries: [`/posts`],
+            });
+            const ChangeParamsButton = ({ setParams }) => (
+                <button
+                    onClick={() =>
+                        setParams({
+                            sort: 'title',
+                            order: 'ASC',
+                            filter: { title: 'hello' },
+                            perPage: 5,
+                        })
+                    }
+                >
+                    Change Params
+                </button>
+            );
+
+            const store = memoryStore();
+
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    history={history}
+                    store={store}
+                >
+                    <ListController
+                        resource="posts"
+                        sort={{ field: 'title', order: 'DESC' }}
+                        perPage={10}
+                    >
+                        {listParams => {
+                            callback(listParams);
+                            return (
+                                <ChangeParamsButton
+                                    setParams={listParams.setParams}
+                                />
+                            );
+                        }}
+                    </ListController>
+                </CoreAdminContext>
+            );
+
+            await waitFor(() => {
+                expect(callback).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        sort: { field: 'title', order: 'DESC' },
+                        perPage: 10,
+                        isFetching: false,
+                        isLoading: false,
+                        data: [],
+                        error: null,
+                        total: 0,
+                    })
+                );
+            });
+
+            fireEvent.click(screen.getByText('Change Params'));
+
+            await waitFor(() => {
+                expect(callback).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        sort: { field: 'title', order: 'ASC' },
+                        perPage: 5,
+                        filterValues: { title: 'hello' },
+                        isFetching: false,
+                        isLoading: false,
+                        data: [],
+                        error: null,
+                        total: 0,
+                    })
+                );
+            });
+        });
+    });
+
     describe('getListControllerProps', () => {
         it('should only pick the props injected by the ListController', () => {
             expect(

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -13,7 +13,7 @@ import { defaultExporter } from '../../export';
 import { FilterPayload, SortPayload, RaRecord, Exporter } from '../../types';
 import { useResourceContext, useGetResourceLabel } from '../../core';
 import { useRecordSelection } from './useRecordSelection';
-import { useListParams } from './useListParams';
+import { ListParams, useListParams } from './useListParams';
 
 /**
  * Prepare data for the List view
@@ -173,6 +173,7 @@ export const useListController = <RecordType extends RaRecord = any>(
         setPerPage: queryModifiers.setPerPage,
         setSort: queryModifiers.setSort,
         showFilter: queryModifiers.showFilter,
+        setParams: queryModifiers.setParams,
         total: total,
         hasNextPage: pageInfo
             ? pageInfo.hasNextPage
@@ -424,6 +425,7 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     setPerPage: (page: number) => void;
     setSort: (sort: SortPayload) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
+    setParams: (params: Partial<ListParams>) => void;
     total: number;
     hasNextPage: boolean;
     hasPreviousPage: boolean;

--- a/packages/ra-core/src/form/choices/ChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/ChoicesContext.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
 import { UseGetListHookValue } from '../../dataProvider/useGetList';
 import { FilterPayload, RaRecord, SortPayload } from '../../types';
+import { ListParams } from '../../controller';
 
 /**
  * Context to store choices and functions to retrieve them.
@@ -38,6 +39,7 @@ export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     setPerPage: (page: number) => void;
     setSort: (sort: SortPayload) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
+    setParams: (params: Partial<ListParams>) => void;
     sort: SortPayload;
     source: string;
     total: number;

--- a/packages/ra-core/src/form/choices/useChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/useChoicesContext.ts
@@ -45,6 +45,7 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
                 setPerPage: options.setPerPage ?? list.setPerPage,
                 setSort: options.setSort ?? list.setSort,
                 showFilter: options.showFilter ?? list.showFilter,
+                setParams: options.setParams ?? list.setParams,
                 sort: options.sort ?? list.sort,
                 source: options.source,
                 total: options.total ?? list.total,


### PR DESCRIPTION
## Problem

In a `<List>`, it's not possible to set both the sort and filter simultaneously. 

## Solution

Introduce a new calback in ListContext, `setParams`, which lets users set all the params they want in one shot. 

Closes #4189
Supersedes #9340

## Todo

- [x] Basic implementation for List
- [x] Unit tests for List
- [x] Basic implementation for InfiniteList
- [ ] Unit tests for InfiniteList
- [x] Basic implementation for useList
- [x] Unit tests for useList
- [x] Basic implementation for ReferenceManyField
- [ ] Unit tests for ReferenceManyField
- [x] Basic implementation for ReferenceInput
- [ ] Unit tests for ReferenceInput
- [x] Basic implementation for ReferenceArrayInput
- [ ] Unit tests for ReferenceArrayInput
- [ ] Add stories
- [ ] Add documentation

