### PR TITLE
Make useGetRecordRepresentation smarter

### DIFF
--- a/docs/RecordRepresentation.md
+++ b/docs/RecordRepresentation.md
@@ -13,6 +13,8 @@ You can also use its hook version: [`useGetRecordRepresentation`](./useGetRecord
 
 `<RecordRepresentation>` doesn't require any argument. It reads the current record from the parent [`RecordContext`](./useRecordContext.md) and the current resource from the parent `ResourceContext`.
 
+The component uses the [`useRecordRepresentation`](./useRecordRepresentation.md) hook and the same [rules](./useRecordRepresentation.md#preferences) are therefore applied.
+
 ```tsx
 // in src/posts/PostBreadcrumbs.tsx
 import * as React from 'react';

--- a/docs/useGetRecordRepresentation.md
+++ b/docs/useGetRecordRepresentation.md
@@ -9,6 +9,13 @@ Get a function that returns the record representation, leveraging the [`<Record 
 
 You can also use the component version: [`<RecordRepresentation>`](./RecordRepresentation.md).
 
+If you don't specify anything, the `useGetRecordRepresentation` function will choose the column to return according to this preference order:
+1. `name`
+2. `title`
+3. `label`
+4. `reference`
+5. `id`
+
 ## Usage
 
 ```tsx

--- a/docs/useGetRecordRepresentation.md
+++ b/docs/useGetRecordRepresentation.md
@@ -9,13 +9,6 @@ Get a function that returns the record representation, leveraging the [`<Record 
 
 You can also use the component version: [`<RecordRepresentation>`](./RecordRepresentation.md).
 
-when `<Resource recordRepresentation>` is not defined, the `useGetRecordRepresentation` function will choose the column to return according to this preference order:
-1. `name`
-2. `title`
-3. `label`
-4. `reference`
-5. `id`
-
 ## Usage
 
 ```tsx
@@ -59,6 +52,17 @@ const PostEdit = () => (
     </EditBase>
 )
 ```
+
+## Preferences
+
+When [`<Resource recordRepresentation>`](./Resource.md#recordrepresentation) is not defined, the `useGetRecordRepresentation` function will choose the column to return according to this preference order:
+1. `name`
+2. `title`
+3. `label`
+4. `reference`
+5. `id`
+
+
 
 ## Options
 

--- a/docs/useGetRecordRepresentation.md
+++ b/docs/useGetRecordRepresentation.md
@@ -9,7 +9,7 @@ Get a function that returns the record representation, leveraging the [`<Record 
 
 You can also use the component version: [`<RecordRepresentation>`](./RecordRepresentation.md).
 
-If you don't specify anything, the `useGetRecordRepresentation` function will choose the column to return according to this preference order:
+when `<Resource recordRepresentation>` is not defined, the `useGetRecordRepresentation` function will choose the column to return according to this preference order:
 1. `name`
 2. `title`
 3. `label`

--- a/docs/useGetRecordRepresentation.md
+++ b/docs/useGetRecordRepresentation.md
@@ -53,9 +53,9 @@ const PostEdit = () => (
 )
 ```
 
-## Preferences
+## Default Representation
 
-When [`<Resource recordRepresentation>`](./Resource.md#recordrepresentation) is not defined, the `useGetRecordRepresentation` function will choose the column to return according to this preference order:
+When [`<Resource recordRepresentation>`](./Resource.md#recordrepresentation) is not defined, `useGetRecordRepresentation` will return the first non-empty field from this list:  
 1. `name`
 2. `title`
 3. `label`

--- a/packages/ra-core/src/controller/record/RecordRepresentation.spec.tsx
+++ b/packages/ra-core/src/controller/record/RecordRepresentation.spec.tsx
@@ -10,7 +10,7 @@ import {
 describe('RecordRepresentation', () => {
     it('should render the record id when not provided on its parent <Resource>', async () => {
         render(<NoRecordRepresentation />);
-        await screen.findByText('#1');
+        await screen.findByText("The Hitchhiker's Guide to the Galaxy");
     });
     it('should render the record representation when provided as a field name on its parent <Resource>', async () => {
         render(<StringRecordRepresentation />);

--- a/packages/ra-core/src/controller/record/RecordRepresentation.spec.tsx
+++ b/packages/ra-core/src/controller/record/RecordRepresentation.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from './RecordRepresentation.stories';
 
 describe('RecordRepresentation', () => {
-    it('should render the record id when not provided on its parent <Resource>', async () => {
+    it('should render the record title when not provided on its parent <Resource>', async () => {
         render(<NoRecordRepresentation />);
         await screen.findByText("The Hitchhiker's Guide to the Galaxy");
     });

--- a/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
@@ -124,7 +124,7 @@ describe('useRecordRepresentation', () => {
         );
         screen.getByText('Lorem');
     });
-    it('should return the record label at second', () => {
+    it('should return the record label at third', () => {
         render(
             <UseRecordRepresentation
                 resource="users"
@@ -138,7 +138,7 @@ describe('useRecordRepresentation', () => {
         );
         screen.getByText('lorem-ipsum');
     });
-    it('should return the record reference at third', () => {
+    it('should return the record reference at fourth', () => {
         render(
             <UseRecordRepresentation
                 resource="users"

--- a/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
@@ -145,7 +145,7 @@ describe('useRecordRepresentation', () => {
                 record={{ reference: '456', id: '123', author: 'John Doe' }}
             />
         );
-        screen.getByText('#456');
+        screen.getByText('456');
     });
     it('should return the record id by default', () => {
         render(

--- a/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
@@ -124,7 +124,7 @@ describe('useRecordRepresentation', () => {
         );
         screen.getByText('Lorem');
     });
-    it('should return the record title at second', () => {
+    it('should return the record label at second', () => {
         render(
             <UseRecordRepresentation
                 resource="users"
@@ -138,7 +138,7 @@ describe('useRecordRepresentation', () => {
         );
         screen.getByText('lorem-ipsum');
     });
-    it('should return the record title at second', () => {
+    it('should return the record reference at third', () => {
         render(
             <UseRecordRepresentation
                 resource="users"
@@ -147,7 +147,7 @@ describe('useRecordRepresentation', () => {
         );
         screen.getByText('#456');
     });
-    it('should return the record title at second', () => {
+    it('should return the record id by default', () => {
         render(
             <UseRecordRepresentation
                 resource="users"

--- a/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.spec.tsx
@@ -93,4 +93,67 @@ describe('useRecordRepresentation', () => {
         );
         screen.getByText('Hello');
     });
+    it('should return the record name at first', () => {
+        render(
+            <UseRecordRepresentation
+                resource="users"
+                record={{
+                    name: 'Ipsum',
+                    title: 'Lorem',
+                    label: 'lorem-ipsum',
+                    reference: '456',
+                    id: '123',
+                    author: 'John Doe',
+                }}
+            />
+        );
+        screen.getByText('Ipsum');
+    });
+    it('should return the record title at second', () => {
+        render(
+            <UseRecordRepresentation
+                resource="users"
+                record={{
+                    title: 'Lorem',
+                    label: 'lorem-ipsum',
+                    reference: '456',
+                    id: '123',
+                    author: 'John Doe',
+                }}
+            />
+        );
+        screen.getByText('Lorem');
+    });
+    it('should return the record title at second', () => {
+        render(
+            <UseRecordRepresentation
+                resource="users"
+                record={{
+                    label: 'lorem-ipsum',
+                    reference: '456',
+                    id: '123',
+                    author: 'John Doe',
+                }}
+            />
+        );
+        screen.getByText('lorem-ipsum');
+    });
+    it('should return the record title at second', () => {
+        render(
+            <UseRecordRepresentation
+                resource="users"
+                record={{ reference: '456', id: '123', author: 'John Doe' }}
+            />
+        );
+        screen.getByText('#456');
+    });
+    it('should return the record title at second', () => {
+        render(
+            <UseRecordRepresentation
+                resource="users"
+                record={{ id: '123', author: 'John Doe' }}
+            />
+        );
+        screen.getByText('#123');
+    });
 });

--- a/packages/ra-core/src/core/useGetRecordRepresentation.ts
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.ts
@@ -31,6 +31,18 @@ export const useGetRecordRepresentation = (
             if (React.isValidElement(recordRepresentation)) {
                 return recordRepresentation;
             }
+            if ('name' in record) {
+                return record.name;
+            }
+            if ('title' in record) {
+                return record.title;
+            }
+            if ('label' in record) {
+                return record.label;
+            }
+            if ('reference' in record) {
+                return `#${record.reference}`;
+            }
             return `#${record.id}`;
         },
         [recordRepresentation]

--- a/packages/ra-core/src/core/useGetRecordRepresentation.ts
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.ts
@@ -31,16 +31,16 @@ export const useGetRecordRepresentation = (
             if (React.isValidElement(recordRepresentation)) {
                 return recordRepresentation;
             }
-            if (record?.name != null && record?.name !== '') {  
+            if (record?.name != null && record?.name !== '') {
                 return record.name;
             }
-            if (record?.title != null && record?.title !== '') {  
+            if (record?.title != null && record?.title !== '') {
                 return record.title;
             }
-            if (record?.label != null && record?.label !== '') {  
+            if (record?.label != null && record?.label !== '') {
                 return record.label;
             }
-            if (record?.reference != null && record?.reference !== '') {  
+            if (record?.reference != null && record?.reference !== '') {
                 return record.reference;
             }
             return `#${record.id}`;

--- a/packages/ra-core/src/core/useGetRecordRepresentation.ts
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.ts
@@ -31,17 +31,17 @@ export const useGetRecordRepresentation = (
             if (React.isValidElement(recordRepresentation)) {
                 return recordRepresentation;
             }
-            if ('name' in record) {
+            if (record?.name != null && record?.name !== '') {  
                 return record.name;
             }
-            if ('title' in record) {
+            if (record?.title != null && record?.title !== '') {  
                 return record.title;
             }
-            if ('label' in record) {
+            if (record?.label != null && record?.label !== '') {  
                 return record.label;
             }
-            if ('reference' in record) {
-                return `#${record.reference}`;
+            if (record?.reference != null && record?.reference !== '') {  
+                return record.reference;
             }
             return `#${record.id}`;
         },

--- a/packages/ra-i18n-i18next/src/index.spec.tsx
+++ b/packages/ra-i18n-i18next/src/index.spec.tsx
@@ -19,7 +19,7 @@ describe('i18next i18nProvider', () => {
         await screen.findByText('1-1 of 1');
         fireEvent.click(await screen.findByText('Lorem Ipsum'));
         // Check singularization
-        await screen.findByText('Post #1');
+        await screen.findByText('Post Lorem Ipsum');
     });
 
     test('should work with multiple languages', async () => {
@@ -47,7 +47,7 @@ describe('i18next i18nProvider', () => {
         await screen.findByText('1-1 of 1');
         fireEvent.click(await screen.findByText('Lorem Ipsum'));
         // Check singularization
-        await screen.findByText('Blog post #1');
+        await screen.findByText('Blog post Lorem Ipsum');
     });
 
     test('should work with custom interpolation options', async () => {
@@ -61,6 +61,6 @@ describe('i18next i18nProvider', () => {
         await screen.findByText('1-1 of 1');
         fireEvent.click(await screen.findByText('Lorem Ipsum'));
         // Check singularization
-        await screen.findByText('Post #1');
+        await screen.findByText('Post Lorem Ipsum');
     });
 });

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -811,7 +811,7 @@ describe('<Edit />', () => {
     });
 
     describe('defaultTitle', () => {
-        it('should use the record id by default', async () => {
+        it('should use the record title by default', async () => {
             const dataProvider = {
                 getOne: () =>
                     Promise.resolve({ data: { id: 123, title: 'lorem' } }),

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -831,7 +831,7 @@ describe('<Edit />', () => {
                     </Edit>
                 </AdminContext>
             );
-            await screen.findByText('Foo #123');
+            await screen.findByText('Foo lorem');
         });
         it('should use the recordRepresentation when defined', async () => {
             const dataProvider = {

--- a/packages/ra-ui-materialui/src/detail/Show.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.tsx
@@ -115,7 +115,7 @@ describe('<Show />', () => {
         await screen.findByText('Edit');
     });
 
-    it('should display a default title based on resource and id', async () => {
+    it('should display by default the title of the resource', async () => {
         render(<Basic />);
         await screen.findByText('Book War and Peace');
     });

--- a/packages/ra-ui-materialui/src/detail/Show.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.tsx
@@ -117,7 +117,7 @@ describe('<Show />', () => {
 
     it('should display a default title based on resource and id', async () => {
         render(<Basic />);
-        await screen.findByText('Book #1');
+        await screen.findByText('Book War and Peace');
     });
 
     it('should allow to override the root component', () => {
@@ -150,7 +150,7 @@ describe('<Show />', () => {
                     </Show>
                 </AdminContext>
             );
-            await screen.findByText('Foo #123');
+            await screen.findByText('Foo lorem');
         });
         it('should use the recordRepresentation when defined', async () => {
             const dataProvider = {

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -332,7 +332,7 @@ describe('<ReferenceField />', () => {
         );
         await new Promise(resolve => setTimeout(resolve, 10));
         expect(screen.queryByRole('progressbar')).toBeNull();
-        expect(screen.getByText('#123')).not.toBeNull();
+        expect(screen.getByText('foo')).not.toBeNull();
         expect(screen.queryAllByRole('link')).toHaveLength(1);
         expect(screen.queryByRole('link')?.getAttribute('href')).toBe(
             '#/posts/123'

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
@@ -251,39 +251,39 @@ describe('<ReferenceArrayInput />', () => {
 
     it('should support different types of ids', async () => {
         render(<DifferentIdTypes />);
-        await screen.findByText('#1', {
+        await screen.findByText('artist_1', {
             selector: 'div.MuiChip-root .MuiChip-label',
         });
         expect(
-            screen.queryByText('#2', {
+            screen.queryByText('artist_2', {
                 selector: 'div.MuiChip-root .MuiChip-label',
             })
         ).not.toBeNull();
         expect(
-            screen.queryByText('#3', { selector: 'div.MuiChip-root' })
+            screen.queryByText('artist_3', { selector: 'div.MuiChip-root' })
         ).toBeNull();
     });
 
     it('should unselect a value when types of ids are different', async () => {
         render(<DifferentIdTypes />);
 
-        const chip1 = await screen.findByText('#1', {
+        const chip1 = await screen.findByText('artist_1', {
             selector: '.MuiChip-label',
         });
-        const chip2 = await screen.findByText('#2', {
+        const chip2 = await screen.findByText('artist_2', {
             selector: '.MuiChip-label',
         });
 
         if (chip2.nextSibling) fireEvent.click(chip2.nextSibling);
         expect(
-            screen.queryByText('#2', {
+            screen.queryByText('artist_2', {
                 selector: '.MuiChip-label',
             })
         ).toBeNull();
 
         if (chip1.nextSibling) fireEvent.click(chip1.nextSibling);
         expect(
-            screen.queryByText('#1', {
+            screen.queryByText('artist_1', {
                 selector: '.MuiChip-label',
             })
         ).toBeNull();


### PR DESCRIPTION
## Problem
useGetRecordRepresentation could be smarter when there is no record representation on the resource.

## Solution
It could contain a list of fields that can be used as record representation by default, such as:

1. name
2. title
3. label
4. reference
5. id