### PR TITLE
[TypeScript] Fix some strict null checks errors in core

### DIFF
--- a/packages/ra-core/src/auth/useHandleAuthCallback.ts
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.ts
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useLocation } from 'react-router';
 import { useRedirect } from '../routing';
-import { AuthProvider, AuthRedirectResult } from '../types';
+import { AuthRedirectResult } from '../types';
 import useAuthProvider from './useAuthProvider';
 
 /**
@@ -12,7 +12,7 @@ import useAuthProvider from './useAuthProvider';
  * @returns An object containing { isLoading, data, error, refetch }.
  */
 export const useHandleAuthCallback = (
-    options?: UseQueryOptions<ReturnType<AuthProvider['handleCallback']>>
+    options?: UseQueryOptions<AuthRedirectResult | void | any>
 ) => {
     const authProvider = useAuthProvider();
     const redirect = useRedirect();
@@ -24,7 +24,10 @@ export const useHandleAuthCallback = (
 
     return useQuery(
         ['auth', 'handleCallback'],
-        () => authProvider.handleCallback(),
+        () =>
+            authProvider && typeof authProvider.handleCallback === 'function'
+                ? authProvider.handleCallback()
+                : Promise.resolve(),
         {
             retry: false,
             onSuccess: data => {

--- a/packages/ra-core/src/core/useResourceDefinitions.ts
+++ b/packages/ra-core/src/core/useResourceDefinitions.ts
@@ -1,4 +1,5 @@
-import { ResourceDefinitions } from './ResourceDefinitionContext';
+import type { ResourceOptions } from '../types';
+import type { ResourceDefinitions } from './ResourceDefinitionContext';
 import { useResourceDefinitionContext } from './useResourceDefinitionContext';
 
 /**
@@ -20,6 +21,6 @@ import { useResourceDefinitionContext } from './useResourceDefinitionContext';
  * // }
  */
 export const useResourceDefinitions = <
-    OptionsType = any
+    OptionsType extends ResourceOptions = any
 >(): ResourceDefinitions<OptionsType> =>
     useResourceDefinitionContext().definitions;

--- a/packages/ra-core/src/dataProvider/fetch.ts
+++ b/packages/ra-core/src/dataProvider/fetch.ts
@@ -95,7 +95,7 @@ const isValidObject = value => {
     return !isArray && !isBuffer && isObject && hasKeys;
 };
 
-export const flattenObject = (value, path = []) => {
+export const flattenObject = (value: any, path: string[] = []) => {
     if (isValidObject(value)) {
         return Object.assign(
             {},

--- a/packages/ra-core/src/form/useUnique.ts
+++ b/packages/ra-core/src/form/useUnique.ts
@@ -106,7 +106,11 @@ export const useUnique = (options?: UseUniqueOptions) => {
                         }
                     );
 
-                    if (total > 0 && !data.some(r => r.id === record?.id)) {
+                    if (
+                        typeof total !== 'undefined' &&
+                        total > 0 &&
+                        !data.some(r => r.id === record?.id)
+                    ) {
                         return {
                             message,
                             args: {


### PR DESCRIPTION
Fixes the following TS compilation errors when enabling `strickNullChecks`:

```
     3  src/auth/useGetIdentity.ts:51
     2  src/auth/useHandleAuthCallback.ts:15
     1  src/core/useResourceDefinitions.ts:24
     1  src/dataProvider/fetch.ts:103
     1  src/form/useUnique.ts:109
```

In master, this reduces the number of strict null check errors from 246 to 238.

Refs #9622