### PR TITLE
Fix field label translation concatenates previous prefix

### DIFF
--- a/packages/ra-core/src/form/Form.tsx
+++ b/packages/ra-core/src/form/Form.tsx
@@ -50,7 +50,10 @@ export const Form = (props: FormProps) => {
 
     return (
         <OptionalRecordContextProvider value={record}>
-            <LabelPrefixContextProvider prefix={`resources.${resource}.fields`}>
+            <LabelPrefixContextProvider
+                prefix={`resources.${resource}.fields`}
+                concatenate={false}
+            >
                 <FormProvider {...form}>
                     <FormGroupsProvider>
                         <form

--- a/packages/ra-core/src/util/LabelPrefixContextProvider.spec.tsx
+++ b/packages/ra-core/src/util/LabelPrefixContextProvider.spec.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LabelPrefixContextProvider } from './LabelPrefixContextProvider';
+import { LabelPrefixContext } from './LabelPrefixContext';
+
+describe('LabelPrefixContextProvider', () => {
+    it('should return the prefix', () => {
+        const Label = () => {
+            return <>{React.useContext(LabelPrefixContext)}</>;
+        };
+        render(
+            <LabelPrefixContextProvider prefix="resource.posts.fields.title">
+                <Label />
+            </LabelPrefixContextProvider>
+        );
+        screen.getByText('resource.posts.fields.title');
+    });
+    it('should return the last prefix in the nested tree, even in nested contexts', () => {
+        const Label = () => {
+            return <>{React.useContext(LabelPrefixContext)}</>;
+        };
+        render(
+            <LabelPrefixContextProvider prefix="resource.posts.fields.title">
+                <LabelPrefixContextProvider prefix="resource.comments.fields.body">
+                    <Label />
+                </LabelPrefixContextProvider>
+            </LabelPrefixContextProvider>
+        );
+        screen.getByText('resource.comments.fields.body');
+    });
+});

--- a/packages/ra-core/src/util/LabelPrefixContextProvider.spec.tsx
+++ b/packages/ra-core/src/util/LabelPrefixContextProvider.spec.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { LabelPrefixContextProvider } from './LabelPrefixContextProvider';
-import { LabelPrefixContext } from './LabelPrefixContext';
+import { useLabelPrefix } from './useLabelPrefix';
 
 describe('LabelPrefixContextProvider', () => {
     it('should return the prefix', () => {
         const Label = () => {
-            return <>{React.useContext(LabelPrefixContext)}</>;
+            return <>{useLabelPrefix()}</>;
         };
         render(
             <LabelPrefixContextProvider prefix="resource.posts.fields.title">
@@ -17,7 +17,7 @@ describe('LabelPrefixContextProvider', () => {
     });
     it('should return the last prefix in the nested tree, even in nested contexts', () => {
         const Label = () => {
-            return <>{React.useContext(LabelPrefixContext)}</>;
+            return <>{useLabelPrefix()}</>;
         };
         render(
             <LabelPrefixContextProvider prefix="resource.posts.fields.title">

--- a/packages/ra-core/src/util/LabelPrefixContextProvider.spec.tsx
+++ b/packages/ra-core/src/util/LabelPrefixContextProvider.spec.tsx
@@ -15,13 +15,16 @@ describe('LabelPrefixContextProvider', () => {
         );
         screen.getByText('resource.posts.fields.title');
     });
-    it('should return the last prefix in the nested tree, even in nested contexts', () => {
+    it('should not concatenate previous prefix', () => {
         const Label = () => {
             return <>{useLabelPrefix()}</>;
         };
         render(
             <LabelPrefixContextProvider prefix="resource.posts.fields.title">
-                <LabelPrefixContextProvider prefix="resource.comments.fields.body">
+                <LabelPrefixContextProvider
+                    prefix="resource.comments.fields.body"
+                    concatenate={false}
+                >
                     <Label />
                 </LabelPrefixContextProvider>
             </LabelPrefixContextProvider>

--- a/packages/ra-core/src/util/LabelPrefixContextProvider.tsx
+++ b/packages/ra-core/src/util/LabelPrefixContextProvider.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
 import { LabelPrefixContext } from './LabelPrefixContext';
+import { useLabelPrefix } from './useLabelPrefix';
 
-export const LabelPrefixContextProvider = ({ prefix, children }) => {
+export const LabelPrefixContextProvider = ({
+    prefix,
+    concatenate = true,
+    children,
+}) => {
+    const oldPrefix = useLabelPrefix();
+    const newPrefix =
+        oldPrefix && concatenate ? `${oldPrefix}.${prefix}` : prefix;
     return (
-        <LabelPrefixContext.Provider value={prefix}>
+        <LabelPrefixContext.Provider value={newPrefix}>
             {children}
         </LabelPrefixContext.Provider>
     );

--- a/packages/ra-core/src/util/LabelPrefixContextProvider.tsx
+++ b/packages/ra-core/src/util/LabelPrefixContextProvider.tsx
@@ -1,17 +1,9 @@
 import * as React from 'react';
 import { LabelPrefixContext } from './LabelPrefixContext';
-import { useLabelPrefix } from './useLabelPrefix';
 
-export const LabelPrefixContextProvider = ({
-    prefix,
-    concatenate = true,
-    children,
-}) => {
-    const oldPrefix = useLabelPrefix();
-    const newPrefix =
-        oldPrefix && concatenate ? `${oldPrefix}.${prefix}` : prefix;
+export const LabelPrefixContextProvider = ({ prefix, children }) => {
     return (
-        <LabelPrefixContext.Provider value={newPrefix}>
+        <LabelPrefixContext.Provider value={prefix}>
             {children}
         </LabelPrefixContext.Provider>
     );

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
@@ -14,6 +14,7 @@ import { SimpleForm } from '../../form';
 import { ArrayInput } from './ArrayInput';
 import { TextInput } from '../TextInput';
 import { SimpleFormIterator } from './SimpleFormIterator';
+import { Basic } from './SimpleFormIterator.stories';
 
 describe('<SimpleFormIterator />', () => {
     // bypass confirm leave form with unsaved changes
@@ -977,5 +978,24 @@ describe('<SimpleFormIterator />', () => {
                 expect.anything()
             );
         });
+    });
+
+    it('should have the correct translation keys', async () => {
+        render(<Basic />);
+        const authorsTranslationKey = screen.queryByLabelText(
+            'resources.books.fields.authors'
+        );
+
+        expect(authorsTranslationKey).toBeDefined();
+
+        const authorsNameTranslationKey = await screen.findAllByLabelText(
+            'resources.books.fields.authors.name'
+        );
+        expect(authorsNameTranslationKey).toHaveLength(2);
+
+        const authorsRoleTranslationKey = await screen.findAllByLabelText(
+            'resources.books.fields.authors.role'
+        );
+        expect(authorsRoleTranslationKey).toHaveLength(2);
     });
 });

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -134,7 +134,10 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
     );
 
     return (
-        <LabelPrefixContextProvider prefix={`resources.${resource}.fields`}>
+        <LabelPrefixContextProvider
+            prefix={`resources.${resource}.fields`}
+            concatenate={false}
+        >
             <StyledForm
                 className={className}
                 {...sanitizeRestProps(rest)}


### PR DESCRIPTION
## Problem
`<LabelPrefixContextProvider>` concatenates previous prefix if it is inside a `LabelPrefixContext`.

It's lead to return translation key such as `resources.posts.fields.title.resources.comments.fields.body` but it make more sense to simply return `resources.comments.fields.body` even `LabelPrefixContext` is nested inside another.

`<LabelPrefixContextProvider>` was introduce used in this #7710 but keeping previous prefix seems to be useful. 

## Solution
Do not keep previous prefix