### PR TITLE
[Demo] Fix missing tags field in simple example fake dataset raises a warning

### DIFF
--- a/examples/simple/src/data.tsx
+++ b/examples/simple/src/data.tsx
@@ -121,6 +121,7 @@ export default {
             average_note: 3,
             commentable: true,
             published_at: new Date('2012-08-05'),
+            tags: [],
             category: 'tech',
             notifications: [12, 31, 42],
         },


### PR DESCRIPTION
Raised the following warning in the console:

```
Value of field 'tags' is not an array.
```