### PR TITLE
[WIP] add use of rest parameters in combineDataProviders

### DIFF
--- a/packages/ra-core/src/dataProvider/combineDataProviders.spec.ts
+++ b/packages/ra-core/src/dataProvider/combineDataProviders.spec.ts
@@ -27,4 +27,26 @@ describe('combineDataProviders', () => {
         expect(dataProvider1.getOne).not.toHaveBeenCalled();
         expect(dataProvider2.getOne).toHaveBeenCalled();
     });
+    it('calls custom dataProvider methods with any number of parameters', async () => {
+        const dataProviderWithCustomMethod = testDataProvider({
+            customMethod: jest
+                .fn()
+                .mockResolvedValue({ data: { id: 1, foo: 'bar' } }),
+        });
+        const dataProvider = combineDataProviders(resource => {
+            switch (resource) {
+                case 'custom':
+                    return dataProviderWithCustomMethod;
+                default:
+                    throw new Error('Unknown resource');
+            }
+        });
+        dataProvider.customMethod('custom', 1, 2, 3);
+        expect(dataProviderWithCustomMethod.customMethod).toHaveBeenCalledWith(
+            'custom',
+            1,
+            2,
+            3
+        );
+    });
 });

--- a/packages/ra-core/src/dataProvider/combineDataProviders.ts
+++ b/packages/ra-core/src/dataProvider/combineDataProviders.ts
@@ -26,11 +26,12 @@ export const combineDataProviders = (
 ): DataProvider =>
     new Proxy(defaultDataProvider, {
         get: (target, name) => {
-            return (resource, params) => {
+            // Using rest parameters to support custom dataProvider methods with any number of parameters
+            return (resource, ...params) => {
                 if (typeof name === 'symbol' || name === 'then') {
                     return;
                 }
-                return dataProviderMatcher(resource)[name](resource, params);
+                return dataProviderMatcher(resource)[name](resource, ...params);
             };
         },
     });


### PR DESCRIPTION
Closes #9675
The current implementation doesn't work with dataProvider methods with more than 2 parameters.  According to documentation, the method parameter format is not strictly typed, so it is possible to add as many params as needed and then guess why combineDataProviders doesn't work
