### PR TITLE
Keep errors and other state on ArrayInput unmount

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -256,6 +256,60 @@ describe('<ArrayInput />', () => {
         });
     });
 
+    it('should not clear errors of children when unmounted', async () => {
+        let setArrayInputVisible;
+
+        const MyArrayInput = () => {
+            const [visible, setVisible] = React.useState(true);
+
+            setArrayInputVisible = setVisible;
+
+            return visible ? (
+                <ArrayInput resource="bar" source="arr">
+                    <SimpleFormIterator>
+                        <TextInput source="id" />
+                        <TextInput source="foo" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            ) : null;
+        };
+
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <SimpleForm
+                    onSubmit={jest.fn}
+                    defaultValues={{
+                        arr: [
+                            { id: 1, foo: 'bar' },
+                            { id: 2, foo: 'baz' },
+                        ],
+                    }}
+                    validate={() => ({ arr: [{ foo: 'Must be "baz"' }, {}] })}
+                >
+                    <MyArrayInput />
+                </SimpleForm>
+            </AdminContext>
+        );
+
+        // change one input to enable the SaveButton (which is disabled when the form is pristine)
+        fireEvent.change(
+            screen.getAllByLabelText('resources.bar.fields.arr.id')[0],
+            {
+                target: { value: '42' },
+            }
+        );
+        fireEvent.click(await screen.findByLabelText('ra.action.save'));
+
+        await screen.findByText('Must be "baz"');
+
+        setArrayInputVisible(false);
+        expect(screen.queryByText('Must be "baz"')).toBeNull();
+
+        // ensure errors are still there after re-mount
+        setArrayInputVisible(true);
+        await screen.findByText('Must be "baz"');
+    });
+
     it('should allow to have a helperText', () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -128,7 +128,12 @@ export const ArrayInput = (props: ArrayInputProps) => {
         formGroups.registerField(source, formGroupName);
 
         return () => {
-            unregister(source, { keepValue: true });
+            unregister(source, {
+                keepValue: true,
+                keepError: true,
+                keepDirty: true,
+                keepTouched: true,
+            });
             formGroups.unregisterField(source, formGroupName);
         };
     }, [register, unregister, source, formGroups, formGroupName]);


### PR DESCRIPTION
We have a rather large form, in which we for optimization reasons unmount parts of the form when not visible. This doesn't work to well with `<ArrayInput />` however, which clears all state (errors, touched, etc.) when it is unmounted, which both means that the general valid/invalid state of the form is no longer correct.

To reproduce:

1. Setup a react-admin project with an `<ArrayInput />` that can be unmounted and some field that can have errors as child
2. Open, enter an invalid value, try to save, field gets marked as error
3. Trigger unmounting and remounting of `<ArrayInput />`
4. The error is gone, despite the value still being invalid

Here is a reproducible example: https://stackblitz.com/edit/github-ntzyud-hb8uu4?file=src%2Fposts%2FPostEdit.tsx (note that tabbed forms have a similar issue, however that can more easily be worked around in user-space code)

This fix uses the `react-hook-form` options to keep the state of the `<ArrayInput />` when it is unmounted.

I'm not 100% sure if this might break BC (I think it would be possible to build a form that depends on the current behavior, but I don't think it would make much sense to do so), if that is the case let me now and I'll retarget this PR to the `next` branch.