### PR TITLE
Added queryOptions to ReferenceManyField (#9669)

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -26,6 +26,7 @@ export interface UseReferenceManyFieldControllerParams<
     sort?: SortPayload;
     source?: string;
     target: string;
+    queryOptions?: { meta?: any };
 }
 
 const defaultFilter = {};
@@ -72,8 +73,10 @@ export const useReferenceManyFieldController = <
         page: initialPage,
         perPage: initialPerPage,
         sort: initialSort = { field: 'id', order: 'DESC' },
+        queryOptions = {},
     } = props;
     const notify = useNotify();
+    const { meta } = queryOptions;
     const resource = useResourceContext(props);
 
     // pagination logic
@@ -178,6 +181,7 @@ export const useReferenceManyFieldController = <
             pagination: { page, perPage },
             sort,
             filter: filterValues,
+            meta,
         },
         {
             enabled: get(record, source) != null,

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -77,8 +77,9 @@ export const ReferenceManyField = <
         sort = defaultSort,
         source = 'id',
         target,
+        queryOptions,
     } = props;
-    const record = useRecordContext(props);
+    const record = useRecordContext<RecordType>(props);
 
     const controllerProps = useReferenceManyFieldController<
         RecordType,
@@ -94,6 +95,7 @@ export const ReferenceManyField = <
         sort,
         source,
         target,
+        queryOptions,
     });
 
     return (
@@ -118,6 +120,7 @@ export interface ReferenceManyFieldProps<
     reference: string;
     sort?: SortPayload;
     target: string;
+    queryOptions?: { meta?: any };
 }
 
 ReferenceManyField.propTypes = {


### PR DESCRIPTION
Closes #9669 

- Added `queryOptions` to `ReferenceManyField.tsx` and `useReferenceManyFieldController.ts`
- Added `<RecordType>` to  `const record = useRecordContext(props)` in `ReferenceManyField.tsx`