### PR TITLE
Fix AutocompleteInput ignores TextFieldProps

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -600,6 +600,7 @@ If you provided a React element for the optionText prop, you must also provide t
                             variant={variant}
                             className={AutocompleteInputClasses.textField}
                             {...params}
+                            {...TextFieldProps}
                             InputProps={mergedTextFieldProps}
                             size={size}
                         />


### PR DESCRIPTION
Autocomplete accepts TextFieldProps, which allows to override the props of the inner TextField (see https://mui.com/material-ui/api/text-field/). This ability was lost in #9559