### PR TITLE
Remove list's setFilters default debounce

### DIFF
--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -543,14 +543,14 @@ const PostFilterForm = () => {
 
     const onSubmit = (values) => {
         if (Object.keys(values).length > 0) {
-            setFilters(values, undefined, false);
+            setFilters(values, undefined);
         } else {
             hideFilter("main");
         }
     };
 
     const resetFilter = () => {
-        setFilters({}, [], false);
+        setFilters({}, []);
     };
 
     return (
@@ -626,23 +626,3 @@ export const PostList = () => (
 **Tip**: No need to pass any `filters` to the list anymore, as the `<PostFilterForm>` component will display them.
 
 You can use a similar approach to offer alternative User Experiences for data filtering, e.g. to display the filters as a line in the datagrid headers.
-
-## Using `setFilters` With Other List Context Methods
-
-The `setFilters` method takes three arguments:
-
-- `filters`: an object containing the new filter values
-- `displayedFilters`: an object containing the new displayed filters
-- `debounced`: set to false to disable the debounce (true by default)
-
-So `setFilters` is debounced by default, to avoid making too many requests to the server when using search-as-you-type inputs.
-
-When you use `setFilters` and other list context methods (like `setSort`) in a single function, you must disable the debounce. Otherwise, the `setFilters` call would override the other changes.
-
-```jsx
-const changeListParams = () => {
-    setSort({ field: 'name', order: 'ASC' });
-    // The 3rd parameter disables the debounce     ⤵
-    setFilters({ is_published: true }, undefined, false);
-};
-```

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -543,7 +543,7 @@ const PostFilterForm = () => {
 
     const onSubmit = (values) => {
         if (Object.keys(values).length > 0) {
-            setFilters(values, undefined);
+            setFilters(values);
         } else {
             hideFilter("main");
         }

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -436,6 +436,30 @@ const PostEdit = () => (
 );
 ```
 
+## `setFilters` Is No Longer Debounced By Default
+
+If you're using the `useListContext` hook to filter a list, you might have used the `setFilters` function to update the filters. In react-admin v5, the `setFilters` function is no longer debounced by default. If you want to debounce the filters, you'll have to pass `true` as the third argument:
+
+```diff
+import { useListContext } from 'react-admin';
+
+const MyFilter = () => {
+    const { filterValues, setFilters } = useListContext();
+    const handleChange = (event) => {
+-       setFilters({ ...filterValues, [event.target.name]: event.target.value });
++       setFilters({ ...filterValues, [event.target.name]: event.target.value }, undefined, true);
+    };
+
+    return (
+        <form>
+            <input name="country" value={filterValues.country} onChange={handleChange} />
+            <input name="city" value={filterValues.city} onChange={handleChange} />
+            <input name="zipcode" value={filterValues.zipcode} onChange={handleChange} />
+        </form>
+    );
+};
+```
+
 ## Upgrading to v4
 
 If you are on react-admin v3, follow the [Upgrading to v4](https://marmelab.com/react-admin/doc/4.16/Upgrade.html) guide before upgrading to v5.

--- a/docs/useListContext.md
+++ b/docs/useListContext.md
@@ -121,7 +121,7 @@ The `setFilters` method is used to update the filters. It takes three arguments:
 
 - `filters`: an object containing the new filter values
 - `displayedFilters`: an object containing the new displayed filters
-- `debounced`: set to false to disable the debounce (true by default)
+- `debounced`: set to true to debounce the call to setFilters (false by default)
 
 You can use it to update the filters in a custom filter component:
 
@@ -142,8 +142,7 @@ const CustomFilter = () => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        // The 3rd parameter disables the debounce ⤵
-        setFilters(filterFormValues, undefined, false);
+        setFilters(filterFormValues, undefined);
     };
 
     return (
@@ -154,18 +153,6 @@ const CustomFilter = () => {
             <input type="submit">Filter</input>
         </form>
     );
-};
-```
-
-Beware that `setFilters` is debounced by default, to avoid making too many requests to the server when using search-as-you-type inputs. In the example above, this is not necessary. That's why you should set the third argument to `setFilters` is set to `false` to disable the debounce.
-
-Disabling the debounce with the third parameter is also necessary when you use `setFilters` and other list context methods (like `setSort`) in a single function. Otherwise, the `setFilters` call would override the other changes.
-
-```jsx
-const changeListParams = () => {
-    setSort({ field: 'name', order: 'ASC' });
-    // The 3rd parameter disables the debounce     ⤵
-    setFilters({ is_published: true }, undefined, false);
 };
 ```
 

--- a/docs/useListContext.md
+++ b/docs/useListContext.md
@@ -142,7 +142,7 @@ const CustomFilter = () => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        setFilters(filterFormValues, undefined);
+        setFilters(filterFormValues);
     };
 
     return (

--- a/docs/useListController.md
+++ b/docs/useListController.md
@@ -282,7 +282,7 @@ const OfficeList = () => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        setFilters(filterFormValues, undefined);
+        setFilters(filterFormValues);
     };
 
     if (isLoading) return <div>Loading...</div>;

--- a/docs/useListController.md
+++ b/docs/useListController.md
@@ -261,7 +261,7 @@ The `setFilters` method is used to update the filters. It takes three arguments:
 
 - `filters`: an object containing the new filter values
 - `displayedFilters`: an object containing the new displayed filters
-- `debounced`: set to false to disable the debounce (true by default)
+- `debounced`: set to true to debounce the call to setFilters (false by default)
 
 You can use it to update the list filters:
 
@@ -282,8 +282,7 @@ const OfficeList = () => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        // The 3rd parameter disables the debounce ⤵
-        setFilters(filterFormValues, undefined, false);
+        setFilters(filterFormValues, undefined);
     };
 
     if (isLoading) return <div>Loading...</div>;
@@ -303,17 +302,5 @@ const OfficeList = () => {
             </ul>
         </>
     );
-};
-```
-
-Beware that `setFilters` is debounced by default, to avoid making too many requests to the server when using search-as-you-type inputs. In the example above, this is not necessary. That's why you should set the third argument to `setFilters` is set to `false` to disable the debounce.
-
-Disabling the debounce with the third parameter is also necessary when you use `setFilters` and other list controller methods (like `setSort`) in a single function. Otherwise, the `setFilters` call would override the other changes.
-
-```jsx
-const changeListParams = () => {
-    setSort({ field: 'name', order: 'ASC' });
-    // The 3rd parameter disables the debounce     ⤵
-    setFilters({ is_published: true }, undefined, false);
 };
 ```

--- a/examples/demo/src/orders/NbItemsField.tsx
+++ b/examples/demo/src/orders/NbItemsField.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-import { FunctionField, FieldProps } from 'react-admin';
-import { Order } from '../types';
-
-const NbItemsField = (_: FieldProps) => (
-    <FunctionField<Order> render={record => record.basket.length} />
-);
-
-export default NbItemsField;

--- a/examples/demo/src/orders/OrderList.tsx
+++ b/examples/demo/src/orders/OrderList.tsx
@@ -23,7 +23,6 @@ import {
 } from 'react-admin';
 import { useMediaQuery, Divider, Tabs, Tab, Theme } from '@mui/material';
 
-import NbItemsField from './NbItemsField';
 import CustomerReferenceField from '../visitors/CustomerReferenceField';
 import AddressField from '../visitors/AddressField';
 import MobileGrid from './MobileGrid';
@@ -141,9 +140,9 @@ const TabbedDatagrid = () => {
                             >
                                 <AddressField />
                             </ReferenceField>
-                            <NbItemsField
+                            <NumberField
+                                source="basket.length"
                                 label="resources.commands.fields.nb_items"
-                                textAlign="right"
                             />
                             <NumberField
                                 source="total_ex_taxes"
@@ -192,9 +191,9 @@ const TabbedDatagrid = () => {
                             >
                                 <AddressField />
                             </ReferenceField>
-                            <NbItemsField
+                            <NumberField
+                                source="basket.length"
                                 label="resources.commands.fields.nb_items"
-                                textAlign="right"
                             />
                             <NumberField
                                 source="total_ex_taxes"
@@ -247,9 +246,9 @@ const TabbedDatagrid = () => {
                             >
                                 <AddressField />
                             </ReferenceField>
-                            <NbItemsField
+                            <NumberField
+                                source="basket.length"
                                 label="resources.commands.fields.nb_items"
-                                textAlign="right"
                             />
                             <NumberField
                                 source="total_ex_taxes"

--- a/examples/demo/src/orders/OrderList.tsx
+++ b/examples/demo/src/orders/OrderList.tsx
@@ -85,8 +85,7 @@ const TabbedDatagrid = () => {
             setFilters &&
                 setFilters(
                     { ...filterValues, status: value },
-                    displayedFilters,
-                    false // no debounce, we want the filter to fire immediately
+                    displayedFilters
                 );
         },
         [displayedFilters, filterValues, setFilters]

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
@@ -284,7 +284,7 @@ describe('useReferenceManyFieldController', () => {
                 type="text"
                 value={filterValues.q || ''}
                 onChange={event => {
-                    setFilters({ q: event.target.value });
+                    setFilters({ q: event.target.value }, undefined, true);
                 }}
             />
         );

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -143,7 +143,7 @@ export const useReferenceManyFieldController = <
     );
 
     const setFilters = useCallback(
-        (filters, displayedFilters, debounce = true) => {
+        (filters, displayedFilters, debounce = false) => {
             if (debounce) {
                 debouncedSetFilters(filters, displayedFilters);
             } else {

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -128,7 +128,7 @@ export const useReferenceParams = ({
     const displayedFilterValues = query.displayedFilters || emptyObject;
 
     const debouncedSetFilters = useRef(
-        lodashDebounce((filter, displayedFilters) => {
+        lodashDebounce((filter, displayedFilters = undefined) => {
             changeParams({
                 type: SET_FILTER,
                 payload: {
@@ -146,7 +146,7 @@ export const useReferenceParams = ({
     }, []);
 
     const setFilters = useCallback(
-        (filter, displayedFilters, debounce = false) => {
+        (filter, displayedFilters = undefined, debounce = false) => {
             debounce
                 ? debouncedSetFilters.current(filter, displayedFilters)
                 : changeParams({
@@ -310,7 +310,11 @@ interface Modifiers {
     setPage: (page: number) => void;
     setPerPage: (pageSize: number) => void;
     setSort: (sort: SortPayload) => void;
-    setFilters: (filters: any, displayedFilters: any) => void;
+    setFilters: (
+        filters: any,
+        displayedFilters?: any,
+        debounce?: boolean
+    ) => void;
     hideFilter: (filterName: string) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
 }

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -146,7 +146,7 @@ export const useReferenceParams = ({
     }, []);
 
     const setFilters = useCallback(
-        (filter, displayedFilters, debounce = true) => {
+        (filter, displayedFilters, debounce = false) => {
             debounce
                 ? debouncedSetFilters.current(filter, displayedFilters)
                 : changeParams({

--- a/packages/ra-core/src/controller/list/InfiniteListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/InfiniteListBase.stories.tsx
@@ -75,7 +75,7 @@ const BookListView = () => {
         });
     };
     const toggleFilter = () => {
-        setFilters(filterValues.q ? {} : { q: 'The ' }, null);
+        setFilters(filterValues.q ? {} : { q: 'The ' });
     };
 
     return (

--- a/packages/ra-core/src/controller/list/ListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.stories.tsx
@@ -87,7 +87,7 @@ const BookListView = () => {
             // the last parameter is debounce false
             // without it, the filter change overrides any other list param change
             // see https://github.com/marmelab/react-admin/issues/4189
-            setFilters(value.filterValues, null, false);
+            setFilters(value.filterValues, undefined, false);
         }
         if (value.page !== page) {
             setPage(value.page);

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -144,7 +144,7 @@ export const useList = <RecordType extends RaRecord = any>(
         [setDisplayedFilters, setFilterValues]
     );
     const setFilters = useCallback(
-        (filters, displayedFilters) => {
+        (filters, displayedFilters = undefined) => {
             setFilterValues(removeEmpty(filters));
             if (displayedFilters) {
                 setDisplayedFilters(displayedFilters);

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -417,7 +417,7 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     selectedIds: RecordType['id'][];
     setFilters: (
         filters: any,
-        displayedFilters: any,
+        displayedFilters?: any,
         debounce?: boolean
     ) => void;
     setPage: (page: number) => void;

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -224,7 +224,7 @@ export const useListParams = ({
     }, debounce);
 
     const setFilters = useCallback(
-        (filter, displayedFilters, debounce = false) =>
+        (filter, displayedFilters = undefined, debounce = false) =>
             debounce
                 ? debouncedSetFilters(filter, displayedFilters)
                 : changeParams({
@@ -409,7 +409,11 @@ interface Modifiers {
     setPage: (page: number) => void;
     setPerPage: (pageSize: number) => void;
     setSort: (sort: SortPayload) => void;
-    setFilters: (filters: any, displayedFilters: any) => void;
+    setFilters: (
+        filters: any,
+        displayedFilters?: any,
+        debounce?: boolean
+    ) => void;
     hideFilter: (filterName: string) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
 }

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -224,7 +224,7 @@ export const useListParams = ({
     }, debounce);
 
     const setFilters = useCallback(
-        (filter, displayedFilters, debounce = true) =>
+        (filter, displayedFilters, debounce = false) =>
             debounce
                 ? debouncedSetFilters(filter, displayedFilters)
                 : changeParams({

--- a/packages/ra-core/src/form/choices/ChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/ChoicesContext.ts
@@ -31,7 +31,7 @@ export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     selectedChoices: RecordType[];
     setFilters: (
         filters: any,
-        displayedFilters: any,
+        displayedFilters?: any,
         debounce?: boolean
     ) => void;
     setPage: (page: number) => void;

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -345,7 +345,7 @@ If you provided a React element for the optionText prop, you must also provide t
                 return;
             }
 
-            setFilters(filterToQuery(filter), undefined, true);
+            setFilters(filterToQuery(filter), undefined);
         }, debounceDelay),
         [debounceDelay, setFilters, setFilter]
     );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -345,7 +345,7 @@ If you provided a React element for the optionText prop, you must also provide t
                 return;
             }
 
-            setFilters(filterToQuery(filter), undefined);
+            setFilters(filterToQuery(filter));
         }, debounceDelay),
         [debounceDelay, setFilters, setFilter]
     );

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
@@ -25,6 +25,14 @@ describe('<FilterButton />', () => {
         filterValues: {},
     };
 
+    beforeAll(() => {
+        window.scrollTo = jest.fn();
+    });
+
+    afterAll(() => {
+        jest.clearAllMocks();
+    });
+
     describe('filter selection menu', () => {
         it('should display only hidden filters', () => {
             const hiddenFilter = (

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -212,7 +212,7 @@ export const FilterButton = (props: FilterButtonProps): JSX.Element => {
                 {hasFilterValues && (
                     <MenuItem
                         onClick={() => {
-                            setFilters({}, {}, false);
+                            setFilters({}, {});
                             setOpen(false);
                         }}
                     >

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -111,7 +111,8 @@ describe('<FilterForm />', () => {
         await waitFor(() => {
             expect(setFilters).toHaveBeenCalledWith(
                 { title: 'foo' },
-                { title: true }
+                { title: true },
+                true
             );
         });
     });

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -31,6 +31,14 @@ describe('<FilterForm />', () => {
         displayedFilters: {},
     };
 
+    beforeAll(() => {
+        window.scrollTo = jest.fn();
+    });
+
+    afterAll(() => {
+        jest.clearAllMocks();
+    });
+
     it('should display correctly passed filters', () => {
         const setFilters = jest.fn();
         const filters = [

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -75,9 +75,9 @@ export const FilterForm = (props: FilterFormProps) => {
                 if (get(values, name) === '') {
                     const newValues = cloneDeep(values);
                     unset(newValues, name);
-                    setFilters(newValues, displayedFilters);
+                    setFilters(newValues, displayedFilters, true);
                 } else {
-                    setFilters(values, displayedFilters);
+                    setFilters(values, displayedFilters, true);
                 }
             }
         });

--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -163,8 +163,7 @@ export const FilterListItem = memo((props: FilterListItemProps) => {
     // We can't wrap this function with useEvent as it is called in the render phase
     const isSelected = getIsSelected(value, filterValues);
 
-    const handleClick = () =>
-        setFilters(toggleFilter(value, filterValues), null);
+    const handleClick = () => setFilters(toggleFilter(value, filterValues));
 
     return (
         <StyledListItem

--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -164,7 +164,7 @@ export const FilterListItem = memo((props: FilterListItemProps) => {
     const isSelected = getIsSelected(value, filterValues);
 
     const handleClick = () =>
-        setFilters(toggleFilter(value, filterValues), null, false);
+        setFilters(toggleFilter(value, filterValues), null);
 
     return (
         <StyledListItem

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -36,10 +36,14 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
 
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         if (event.target) {
-            setFilters({ ...filterValues, [source]: event.target.value }, null);
+            setFilters(
+                { ...filterValues, [source]: event.target.value },
+                null,
+                true
+            );
         } else {
             const { [source]: _, ...filters } = filterValues;
-            setFilters(filters, null, false);
+            setFilters(filters, null);
         }
     };
 

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -43,7 +43,7 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
             );
         } else {
             const { [source]: _, ...filters } = filterValues;
-            setFilters(filters, null);
+            setFilters(filters);
         }
     };
 


### PR DESCRIPTION
## Problem

The `setFilters` callback returned by `useListController` is debounced by default. This creates numerous WTF issues (e.g. #4189). This default makes sense for the Filter form/button combo, but not for the other filters.

Besides, the `setFilters` returned by other controllers (`useList`, etc) isn’t debounced by default.

## Solution

Make the `setFilters` default to `debounce=false`. Force the debounce in `FilterForm`.

Also, revert #9639 as these explanations are no longer necessary