### PR TITLE
Make input width consistent by default

### DIFF
--- a/docs/AppTheme.md
+++ b/docs/AppTheme.md
@@ -514,6 +514,12 @@ const defaultThemeInvariants = {
                 margin: 'dense' as const,
                 size: 'small' as const,
             },
+            variants: [
+                {
+                    props: {},
+                    style: () => ({ minWidth: 210 }),
+                },
+            ],
         },
     },
 };

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -323,6 +323,20 @@ Each individual input supports an `sx` prop to pass custom styles to the underly
 ```
 {% endraw %}
 
+Most inputs have a minimum width defined by the theme. If you want to set the width of a given input to a value smaller than the theme's minimum width, use the `sx` prop to unset the `minWidth` CSS property.
+
+{% raw %}
+```tsx
+<TextInput
+    source="title"
+    sx={{
+        width: 100,
+        minWidth: 'unset',
+    }}
+/>
+```
+{% endraw %}
+
 Refer to the documentation of each input component to see what inner classes you can override.
 
 ## `validate`

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -343,7 +343,25 @@ const CompanyField = () => (
 
 ## Inputs Have A Minimum Width
 
-Inputs have a consistent minimum width in each theme, so forms show better alignment and are easier to read. This may break your layout if you relied on the previous input widths. If you used any of the default themes and you want to remove the minimum input width, you must set a custom theme in your admin as follows:
+Inputs have a consistent minimum width in each theme, so forms show better alignment and are easier to read. This may break your layout if you relied on the previous input widths. 
+
+If you constrained some inputs to a small width using the `width` sx prop, you will need to unset the `minWidth` sx prop as well:
+
+```diff
+import { TextInput } from 'react-admin';
+
+const MyComponent = () => (
+    <TextInput
+        source="title"
+        sx={{
+            width: 100,
++           minWidth: unset,
+        }}
+    />
+);
+```
+
+If you used any of the default themes and you want to remove the minimum input width, you must set a custom theme in your admin as follows:
 
 ```diff
 -import { Admin } from 'react-admin';

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -341,6 +341,45 @@ const CompanyField = () => (
 ```
 {% endraw %}
 
+## Inputs Have A Minimum Width
+
+Inputs have a consistent minimum width in each theme, so forms show better alignment and are easier to read. This may break your layout if you relied on the previous input widths. If you used any of the default themes and you want to remove the minimum input width, you must set a custom theme in your admin as follows:
+
+```diff
+-import { Admin } from 'react-admin';
++import { Admin, defaultTheme } from 'react-admin';
++import { deepmerge } from '@mui/utils';
+import { dataProvider } from './dataProvider';
+
++const theme = deepmerge(defaultTheme, { components: { MuiFormControl: { variants: [] } } })
+
+const MyApp = () => (
+-   <Admin dataProvider={dataProvider}>
++   <Admin dataProvider={dataProvider} theme={theme}>
+        ...
+    </Admin>
+);
+```
+
+If you used a custom theme, you must set the minimum input width because individual input components no longer define their width:
+
+```diff
+const myTheme = {
+    // ...
+    components: {
+        // ...
++       MuiFormControl: {
++           variants: [
++               {
++                   props: {},
++                   style: () => ({ minWidth: 210 }),
++               },
++           ],
++       },
+    },
+};
+``` 
+
 ## `useTheme` no longer accepts a theme object as an optional argument
 
 The useTheme hook no longer accepts a `RaTheme` object as an argument to return a `RaTheme` object; instead, it now only takes an optional default value for the theme **preference** (`ThemeType`, like `"light"` and `"dark"`), and returns the current theme **preference** (`ThemeType`, like `"light"` and `"dark"`) and a setter for the **preference**.

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -34,8 +34,6 @@ import {
     usePermissions,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import {
-    Box,
-    BoxProps,
     Button,
     Dialog,
     DialogActions,
@@ -89,12 +87,6 @@ const EditActions = ({ hasShow }: EditActionsProps) => (
     </TopToolbar>
 );
 
-const SanitizedBox = ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    fullWidth,
-    ...props
-}: BoxProps & { fullWidth?: boolean }) => <Box {...props} />;
-
 const categories = [
     { name: 'Tech', id: 'tech' },
     { name: 'Lifestyle', id: 'lifestyle' },
@@ -109,23 +101,17 @@ const PostEdit = () => {
                 warnWhenUnsavedChanges
             >
                 <TabbedForm.Tab label="post.form.summary">
-                    <SanitizedBox
-                        display="flex"
-                        flexDirection="column"
-                        width="100%"
-                        justifyContent="space-between"
+                    <TextInput
+                        InputProps={{ disabled: true }}
+                        source="id"
                         fullWidth
-                    >
-                        <TextInput
-                            InputProps={{ disabled: true }}
-                            source="id"
-                        />
-                        <TextInput
-                            source="title"
-                            validate={required()}
-                            resettable
-                        />
-                    </SanitizedBox>
+                    />
+                    <TextInput
+                        source="title"
+                        validate={required()}
+                        resettable
+                        fullWidth
+                    />
                     <TextInput
                         multiline
                         fullWidth

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -116,7 +116,7 @@ export const AutocompleteInput = <
     OptionType extends RaRecord = RaRecord,
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
-    SupportCreate extends boolean | undefined = false
+    SupportCreate extends boolean | undefined = false,
 >(
     props: AutocompleteInputProps<
         OptionType,
@@ -650,9 +650,11 @@ If you provided a React element for the optionText prop, you must also provide t
                 onBlur={finalOnBlur}
                 onInputChange={handleInputChange}
                 renderOption={(props, record: RaRecord) => {
-                    (props as {
-                        key: string;
-                    }).key = getChoiceValue(record);
+                    (
+                        props as {
+                            key: string;
+                        }
+                    ).key = getChoiceValue(record);
 
                     const optionLabel = getOptionLabel(record, true);
 
@@ -677,10 +679,8 @@ export const AutocompleteInputClasses = {
 const StyledAutocomplete = styled(Autocomplete, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
-})(({ theme }) => ({
-    [`& .${AutocompleteInputClasses.textField}`]: {
-        minWidth: theme.spacing(20),
-    },
+})(() => ({
+    [`& .${AutocompleteInputClasses.textField}`]: {},
 }));
 
 // @ts-ignore
@@ -688,7 +688,7 @@ export interface AutocompleteInputProps<
     OptionType extends any = RaRecord,
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
-    SupportCreate extends boolean | undefined = false
+    SupportCreate extends boolean | undefined = false,
 > extends Omit<CommonInputProps, 'source' | 'onChange'>,
         ChoicesProps,
         UseSuggestionsOptions,
@@ -728,7 +728,7 @@ const useSelectedChoice = <
     OptionType extends any = RaRecord,
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
-    SupportCreate extends boolean | undefined = false
+    SupportCreate extends boolean | undefined = false,
 >(
     value: any,
     {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -116,7 +116,7 @@ export const AutocompleteInput = <
     OptionType extends RaRecord = RaRecord,
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
-    SupportCreate extends boolean | undefined = false,
+    SupportCreate extends boolean | undefined = false
 >(
     props: AutocompleteInputProps<
         OptionType,
@@ -650,11 +650,9 @@ If you provided a React element for the optionText prop, you must also provide t
                 onBlur={finalOnBlur}
                 onInputChange={handleInputChange}
                 renderOption={(props, record: RaRecord) => {
-                    (
-                        props as {
-                            key: string;
-                        }
-                    ).key = getChoiceValue(record);
+                    (props as {
+                        key: string;
+                    }).key = getChoiceValue(record);
 
                     const optionLabel = getOptionLabel(record, true);
 
@@ -688,7 +686,7 @@ export interface AutocompleteInputProps<
     OptionType extends any = RaRecord,
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
-    SupportCreate extends boolean | undefined = false,
+    SupportCreate extends boolean | undefined = false
 > extends Omit<CommonInputProps, 'source' | 'onChange'>,
         ChoicesProps,
         UseSuggestionsOptions,
@@ -728,7 +726,7 @@ const useSelectedChoice = <
     OptionType extends any = RaRecord,
     Multiple extends boolean | undefined = false,
     DisableClearable extends boolean | undefined = false,
-    SupportCreate extends boolean | undefined = false,
+    SupportCreate extends boolean | undefined = false
 >(
     value: any,
     {

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -71,7 +71,6 @@ export const DateInput = ({
             {...field}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             type="date"
-            size="small"
             variant={variant}
             margin={margin}
             error={(isTouched || isSubmitted) && invalid}

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -59,7 +59,6 @@ export const DateTimeInput = ({
             {...field}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             type="datetime-local"
-            size="small"
             variant={variant}
             margin={margin}
             error={(isTouched || isSubmitted) && invalid}
@@ -99,7 +98,10 @@ DateTimeInput.propTypes = {
 export type DateTimeInputProps = CommonInputProps &
     Omit<TextFieldProps, 'helperText' | 'label'>;
 
-const leftPad = (nb = 2) => value => ('0'.repeat(nb) + value).slice(-nb);
+const leftPad =
+    (nb = 2) =>
+    value =>
+        ('0'.repeat(nb) + value).slice(-nb);
 const leftPad4 = leftPad(4);
 const leftPad2 = leftPad(2);
 

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -98,10 +98,7 @@ DateTimeInput.propTypes = {
 export type DateTimeInputProps = CommonInputProps &
     Omit<TextFieldProps, 'helperText' | 'label'>;
 
-const leftPad =
-    (nb = 2) =>
-    value =>
-        ('0'.repeat(nb) + value).slice(-nb);
+const leftPad = (nb = 2) => value => ('0'.repeat(nb) + value).slice(-nb);
 const leftPad4 = leftPad(4);
 const leftPad2 = leftPad(2);
 

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -53,7 +53,6 @@ export const NullableBooleanInput = (props: NullableBooleanInputProps) => {
     return (
         <StyledTextField
             id={id}
-            size="small"
             {...field}
             className={clsx(
                 'ra-input',

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -97,8 +97,8 @@ export const NumberInput = ({
                     ? parse(target.valueAsNumber)
                     : target.valueAsNumber
                 : parse
-                ? parse(target.value)
-                : convertStringToNumber(target.value);
+                  ? parse(target.value)
+                  : convertStringToNumber(target.value);
         field.onChange(newValue);
     };
 
@@ -134,7 +134,6 @@ export const NumberInput = ({
             onBlur={handleBlur}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             type="number"
-            size="small"
             variant={variant}
             error={(isTouched || isSubmitted) && invalid}
             helperText={

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -97,8 +97,8 @@ export const NumberInput = ({
                     ? parse(target.valueAsNumber)
                     : target.valueAsNumber
                 : parse
-                  ? parse(target.value)
-                  : convertStringToNumber(target.value);
+                ? parse(target.value)
+                : convertStringToNumber(target.value);
         field.onChange(newValue);
     };
 

--- a/packages/ra-ui-materialui/src/input/PasswordInput.tsx
+++ b/packages/ra-ui-materialui/src/input/PasswordInput.tsx
@@ -19,7 +19,6 @@ export const PasswordInput = (props: PasswordInputProps) => {
     return (
         <TextInput
             type={visible ? 'text' : 'password'}
-            size="small"
             InputProps={{
                 endAdornment: (
                     <InputAdornment position="end">
@@ -30,7 +29,8 @@ export const PasswordInput = (props: PasswordInputProps) => {
                                     : 'ra.input.password.toggle_hidden'
                             )}
                             onClick={handleClick}
-                            size="large"
+                            size="small"
+                            edge="end"
                         >
                             {visible ? <Visibility /> : <VisibilityOff />}
                         </IconButton>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -110,7 +110,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
         optionValue = 'id',
         parse,
         resource: resourceProp,
-        size = 'small',
+        size,
         source: sourceProp,
         translateChoice,
         validate,
@@ -257,8 +257,8 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
     const finalValue = Array.isArray(field.value ?? [])
         ? field.value
         : field.value
-        ? [field.value]
-        : [];
+          ? [field.value]
+          : [];
 
     const outlinedInputProps =
         variant === 'outlined'
@@ -453,7 +453,6 @@ const StyledFormControl = styled(FormControl, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
-    minWidth: theme.spacing(20),
     [theme.breakpoints.down('sm')]: {
         width: '100%',
     },

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -257,8 +257,8 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
     const finalValue = Array.isArray(field.value ?? [])
         ? field.value
         : field.value
-          ? [field.value]
-          : [];
+        ? [field.value]
+        : [];
 
     const outlinedInputProps =
         variant === 'outlined'

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -210,9 +210,10 @@ export const SelectInput = (props: SelectInputProps) => {
             : emptyText;
     }, [emptyText, translate]);
 
-    const renderMenuItemOption = useCallback(choice => getChoiceText(choice), [
-        getChoiceText,
-    ]);
+    const renderMenuItemOption = useCallback(
+        choice => getChoiceText(choice),
+        [getChoiceText]
+    );
 
     const handleChange = useCallback(
         async (eventOrChoice: ChangeEvent<HTMLInputElement> | RaRecord) => {
@@ -417,9 +418,8 @@ const PREFIX = 'RaSelectInput';
 const StyledResettableTextField = styled(ResettableTextField, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
-})(({ theme }) => ({
+})(() => ({
     ...ResettableTextFieldStyles,
-    minWidth: theme.spacing(20),
     '& .MuiFilledInput-root': { paddingRight: 0 },
 }));
 

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -210,10 +210,9 @@ export const SelectInput = (props: SelectInputProps) => {
             : emptyText;
     }, [emptyText, translate]);
 
-    const renderMenuItemOption = useCallback(
-        choice => getChoiceText(choice),
-        [getChoiceText]
-    );
+    const renderMenuItemOption = useCallback(choice => getChoiceText(choice), [
+        getChoiceText,
+    ]);
 
     const handleChange = useCallback(
         async (eventOrChoice: ChangeEvent<HTMLInputElement> | RaRecord) => {

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -158,8 +158,13 @@ export const ExtraProps = () => (
 );
 
 const FormStateInspector = () => {
-    const { touchedFields, isDirty, dirtyFields, isValid, errors } =
-        useFormState();
+    const {
+        touchedFields,
+        isDirty,
+        dirtyFields,
+        isValid,
+        errors,
+    } = useFormState();
     return (
         <div>
             form state:&nbsp;

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -12,7 +12,7 @@ import { FormInspector } from './common';
 
 export default { title: 'ra-ui-materialui/input/TextInput' };
 
-export const Wrapper = ({ children }) => (
+const Wrapper = ({ children }) => (
     <AdminContext defaultTheme="light">
         <Create
             resource="posts"
@@ -158,13 +158,8 @@ export const ExtraProps = () => (
 );
 
 const FormStateInspector = () => {
-    const {
-        touchedFields,
-        isDirty,
-        dirtyFields,
-        isValid,
-        errors,
-    } = useFormState();
+    const { touchedFields, isDirty, dirtyFields, isValid, errors } =
+        useFormState();
     return (
         <div>
             form state:&nbsp;

--- a/packages/ra-ui-materialui/src/input/TimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TimeInput.tsx
@@ -84,7 +84,6 @@ export const TimeInput = ({
             {...field}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             type="time"
-            size="small"
             variant={variant}
             margin={margin}
             error={(isTouched || isSubmitted) && invalid}
@@ -120,7 +119,10 @@ TimeInput.propTypes = {
 export type TimeInputProps = CommonInputProps &
     Omit<TextFieldProps, 'helperText' | 'label'>;
 
-const leftPad = (nb = 2) => value => ('0'.repeat(nb) + value).slice(-nb);
+const leftPad =
+    (nb = 2) =>
+    value =>
+        ('0'.repeat(nb) + value).slice(-nb);
 const leftPad2 = leftPad(2);
 
 /**

--- a/packages/ra-ui-materialui/src/input/TimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TimeInput.tsx
@@ -119,10 +119,7 @@ TimeInput.propTypes = {
 export type TimeInputProps = CommonInputProps &
     Omit<TextFieldProps, 'helperText' | 'label'>;
 
-const leftPad =
-    (nb = 2) =>
-    value =>
-        ('0'.repeat(nb) + value).slice(-nb);
+const leftPad = (nb = 2) => value => ('0'.repeat(nb) + value).slice(-nb);
 const leftPad2 = leftPad(2);
 
 /**

--- a/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
@@ -130,7 +130,9 @@ const Root = styled('div', {
     flexGrow: 1,
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(0.5),
-
+    [theme.breakpoints.down('sm')]: {
+        width: '100%',
+    },
     [`&.${TranslatableInputsClasses.fullWidth}`]: {
         width: '100%',
     },

--- a/packages/ra-ui-materialui/src/input/inputs.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/inputs.stories.tsx
@@ -1,10 +1,24 @@
 import * as React from 'react';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
+import { StoreContextProvider, memoryStore, useStore } from 'ra-core';
+import { deepmerge } from '@mui/utils';
 
 import { AdminContext } from '../AdminContext';
 import { Create } from '../detail';
 import { SimpleForm } from '../form';
+import { ImageField } from '../field';
+import {
+    defaultLightTheme,
+    defaultDarkTheme,
+    nanoDarkTheme,
+    nanoLightTheme,
+    radiantDarkTheme,
+    radiantLightTheme,
+    houseDarkTheme,
+    houseLightTheme,
+    useTheme,
+} from '../theme';
 import {
     AutocompleteInput,
     CheckboxGroupInput,
@@ -26,98 +40,199 @@ import {
     ArrayInput,
     SimpleFormIterator,
 } from './';
-import { ImageField } from '../field';
 
 export default {
     title: 'ra-ui-materialui/input',
 };
 
+const themes = [
+    { name: 'default', light: defaultLightTheme, dark: defaultDarkTheme },
+    { name: 'nano', light: nanoLightTheme, dark: nanoDarkTheme },
+    { name: 'radiant', light: radiantLightTheme, dark: radiantDarkTheme },
+    { name: 'house', light: houseLightTheme, dark: houseDarkTheme },
+    {
+        name: 'noTheme',
+        light: {},
+        dark: { palette: { mode: 'dark' as const } },
+    },
+    {
+        name: 'compat',
+        light: deepmerge(defaultLightTheme, {
+            components: { MuiFormControl: { variants: [] } },
+        }),
+        dark: deepmerge(defaultDarkTheme, {
+            components: { MuiFormControl: { variants: [] } },
+        }),
+    },
+];
+
+const ThemeSwapper = () => {
+    const [themeName, setThemeName] = useStore('themeName', 'default');
+    const [mode, setMode] = useTheme('light');
+
+    const themeButtons = themes.map(theme => (
+        <>
+            <button
+                key={theme.name}
+                onClick={() => {
+                    setThemeName(theme.name);
+                    setMode('light');
+                }}
+                style={{
+                    fontWeight:
+                        theme.name === themeName && mode === 'light'
+                            ? 'bold'
+                            : 'normal',
+                    marginRight: 10,
+                }}
+            >
+                {theme.name} light
+            </button>
+            <button
+                key={`${theme.name}Dark`}
+                onClick={() => {
+                    setThemeName(theme.name);
+                    setMode('dark');
+                }}
+                style={{
+                    fontWeight:
+                        theme.name === themeName && mode === 'dark'
+                            ? 'bold'
+                            : 'normal',
+                    marginRight: 10,
+                }}
+            >
+                {theme.name} dark
+            </button>
+        </>
+    ));
+
+    return <div>Theme: {themeButtons}</div>;
+};
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
+const store = memoryStore();
+
+const AllInputsBase = () => {
+    const [themeName] = useStore('themeName', 'default');
+    const lightTheme = themes.find(theme => theme.name === themeName)?.light;
+    const darkTheme = themes.find(theme => theme.name === themeName)?.dark;
+    return (
+        <AdminContext
+            i18nProvider={i18nProvider}
+            lightTheme={lightTheme}
+            darkTheme={darkTheme}
+            defaultTheme="light"
+            store={store}
+        >
+            <ThemeSwapper />
+            <Create
+                resource="posts"
+                record={{ id: 1, title: 'Lorem Ipsum', updated_at: new Date() }}
+            >
+                <SimpleForm>
+                    <TextInput source="title" helperText="TextInput" />
+                    <NumberInput
+                        source="average_note"
+                        helperText="NumberInput"
+                    />
+                    <DateInput source="published_at" helperText="DateInput" />
+                    <TimeInput
+                        source="published_at_time"
+                        helperText="TimeInput"
+                    />
+                    <DateTimeInput
+                        source="updated_at"
+                        helperText="DateTimeInput"
+                    />
+                    <AutocompleteInput
+                        source="author_id"
+                        choices={[
+                            { id: 1, name: 'John Doe' },
+                            { id: 2, name: 'Jane Doe' },
+                        ]}
+                        helperText="AutocompleteInput"
+                    />
+                    <AutocompleteArrayInput
+                        source="secondary_authors_id"
+                        helperText="AutocompleteArrayInput"
+                        choices={[
+                            { id: 1, name: 'John Doe' },
+                            { id: 2, name: 'Jane Doe' },
+                        ]}
+                    />
+                    <SelectInput
+                        source="status"
+                        choices={[
+                            { id: 'draft', name: 'Draft' },
+                            { id: 'published', name: 'Published' },
+                        ]}
+                        helperText="SelectInput"
+                    />
+                    <SelectArrayInput
+                        source="tags"
+                        choices={[
+                            { id: 1, name: 'Tech' },
+                            { id: 2, name: 'Lifestyle' },
+                        ]}
+                        helperText="SelectArrayInput"
+                    />
+                    <RadioButtonGroupInput
+                        source="workflow"
+                        helperText="RadioButtonGroupInput"
+                        choices={[
+                            { id: 1, name: 'Simple' },
+                            { id: 2, name: 'Manager' },
+                            { id: 3, name: 'All' },
+                        ]}
+                    />
+                    <CheckboxGroupInput
+                        source="roles"
+                        choices={[
+                            { id: 'admin', name: 'Admin' },
+                            { id: 'u001', name: 'Editor' },
+                            { id: 'u002', name: 'Moderator' },
+                            { id: 'u003', name: 'Reviewer' },
+                        ]}
+                        helperText="CheckboxGroupInput"
+                    />
+                    <NullableBooleanInput
+                        source="exclusive"
+                        helperText="NullableBooleanInput"
+                    />
+                    <BooleanInput
+                        source="commentable"
+                        helperText="BooleanInput"
+                    />
+                    <ArrayInput source="backlinks" helperText="ArrayInput">
+                        <SimpleFormIterator>
+                            <TextInput source="url" />
+                            <TextInput source="title" />
+                        </SimpleFormIterator>
+                    </ArrayInput>
+                    <TranslatableInputs
+                        locales={['en', 'fr']}
+                        defaultLocale="en"
+                    >
+                        <TextInput source="description" />
+                        <TextInput source="body" />
+                    </TranslatableInputs>
+                    <PasswordInput
+                        source="password"
+                        helperText="PasswordInput"
+                    />
+                    <SearchInput source="q" helperText="SearchInput" />
+                    <ImageInput source="pictures" helperText="ImageInput">
+                        <ImageField source="src" title="title" />
+                    </ImageInput>
+                </SimpleForm>
+            </Create>
+        </AdminContext>
+    );
+};
 
 export const AllInputs = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="posts"
-            record={{ id: 1, title: 'Lorem Ipsum', updated_at: new Date() }}
-        >
-            <SimpleForm>
-                <TextInput source="title" helperText="TextInput" />
-                <NumberInput source="average_note" helperText="NumberInput" />
-                <DateInput source="published_at" helperText="DateInput" />
-                <TimeInput source="published_at_time" helperText="TimeInput" />
-                <DateTimeInput source="updated_at" helperText="DateTimeInput" />
-                <AutocompleteInput
-                    source="author_id"
-                    choices={[
-                        { id: 1, name: 'John Doe' },
-                        { id: 2, name: 'Jane Doe' },
-                    ]}
-                    helperText="AutocompleteInput"
-                />
-                <AutocompleteArrayInput
-                    source="secondary_authors_id"
-                    helperText="AutocompleteArrayInput"
-                    choices={[
-                        { id: 1, name: 'John Doe' },
-                        { id: 2, name: 'Jane Doe' },
-                    ]}
-                />
-                <SelectInput
-                    source="status"
-                    choices={[
-                        { id: 'draft', name: 'Draft' },
-                        { id: 'published', name: 'Published' },
-                    ]}
-                    helperText="SelectInput"
-                />
-                <SelectArrayInput
-                    source="tags"
-                    choices={[
-                        { id: 1, name: 'Tech' },
-                        { id: 2, name: 'Lifestyle' },
-                    ]}
-                    helperText="SelectArrayInput"
-                />
-                <RadioButtonGroupInput
-                    source="workflow"
-                    helperText="RadioButtonGroupInput"
-                    choices={[
-                        { id: 1, name: 'Simple' },
-                        { id: 2, name: 'Manager' },
-                        { id: 3, name: 'All' },
-                    ]}
-                />
-                <CheckboxGroupInput
-                    source="roles"
-                    choices={[
-                        { id: 'admin', name: 'Admin' },
-                        { id: 'u001', name: 'Editor' },
-                        { id: 'u002', name: 'Moderator' },
-                        { id: 'u003', name: 'Reviewer' },
-                    ]}
-                    helperText="CheckboxGroupInput"
-                />
-                <NullableBooleanInput
-                    source="exclusive"
-                    helperText="NullableBooleanInput"
-                />
-                <BooleanInput source="commentable" helperText="BooleanInput" />
-                <ArrayInput source="backlinks" helperText="ArrayInput">
-                    <SimpleFormIterator>
-                        <TextInput source="url" />
-                        <TextInput source="title" />
-                    </SimpleFormIterator>
-                </ArrayInput>
-                <TranslatableInputs locales={['en', 'fr']} defaultLocale="en">
-                    <TextInput source="description" />
-                    <TextInput source="body" />
-                </TranslatableInputs>
-                <PasswordInput source="password" helperText="PasswordInput" />
-                <SearchInput source="q" helperText="SearchInput" />
-                <ImageInput source="pictures" helperText="ImageInput">
-                    <ImageField source="src" title="title" />
-                </ImageInput>
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <StoreContextProvider value={store}>
+        <AllInputsBase />
+    </StoreContextProvider>
 );

--- a/packages/ra-ui-materialui/src/theme/defaultTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/defaultTheme.ts
@@ -43,6 +43,12 @@ const defaultThemeInvariants = {
                 margin: 'dense' as const,
                 size: 'small' as const,
             },
+            variants: [
+                {
+                    props: {},
+                    style: () => ({ minWidth: 210 }),
+                },
+            ],
         },
     },
 };

--- a/packages/ra-ui-materialui/src/theme/houseTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/houseTheme.ts
@@ -30,6 +30,12 @@ const componentsOverrides = (theme: Theme) => ({
         defaultProps: {
             margin: 'dense' as const,
         },
+        variants: [
+            {
+                props: {},
+                style: () => ({ minWidth: 220 }),
+            },
+        ],
     },
     MuiOutlinedInput: {
         styleOverrides: {

--- a/packages/ra-ui-materialui/src/theme/nanoTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/nanoTheme.ts
@@ -70,6 +70,12 @@ const componentsOverrides = (theme: Theme) => ({
             margin: 'dense' as const,
             size: 'small' as const,
         },
+        variants: [
+            {
+                props: {},
+                style: () => ({ minWidth: 160 }),
+            },
+        ],
     },
     MuiFormHelperText: {
         defaultProps: {

--- a/packages/ra-ui-materialui/src/theme/radiantTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/radiantTheme.ts
@@ -38,6 +38,12 @@ const componentsOverrides = (theme: Theme) => {
                 margin: 'dense' as const,
                 size: 'small' as const,
             },
+            variants: [
+                {
+                    props: {},
+                    style: () => ({ minWidth: 220 }),
+                },
+            ],
         },
         MuiPaper: {
             styleOverrides: {


### PR DESCRIPTION
## Problem

MUI doesn't defaine a consistent input width, and neither do we. As a consequence, forms mixing various input types don't show a proper alignment by default.

See [this story](https://react-admin-storybook.vercel.app/?path=/story/ra-ui-materialui-input--all-inputs) for an illustration. Refs #8796.

## Solution

Define a minimum input width in each themes.

| Before | After | 
| ----- | ----- |
|  <img width="302" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/ba7273d6-8d08-473a-af42-61308562cbb0">  | <img width="295" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/7c4481fd-3c8a-444b-8c4a-75398610a67c"> |

The story has been updated to let the user test all existing themes, as well as an empty theme (default MUI) and a compat theme (to get the same input widths as in react-admin v4)