### PR TITLE
[TypeScript] Forbid `<ReferenceInput validate>`

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -125,5 +125,9 @@ export interface ReferenceInputProps
         UseReferenceInputControllerParams {
     children?: ReactElement;
     label?: string;
+    /**
+     * Call validate on the child component instead
+     */
+    validate?: never;
     [key: string]: any;
 }


### PR DESCRIPTION
## Problem

Since #9637, using `<ReferenceInput validate>` fails at runtime. this is unexpected

## Solution

Fail at build time instead.

This may break existing apps, so I'm pulling against `next`.