### PR TITLE
Fix `<ReferenceInput>` throws a recoverable error in production

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -84,13 +84,10 @@ export const ReferenceInput = (props: ReferenceInputProps) => {
         filter,
     });
 
-    if (props.validate) {
+    if (props.validate && process.env.NODE_ENV !== 'production') {
         throw new Error(
             '<ReferenceInput> does not accept a validate prop. Set the validate prop on the child instead.'
         );
-    }
-    if (Children.count(children) !== 1) {
-        throw new Error('<ReferenceInput> only accepts a single child');
     }
 
     return (

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.tsx
@@ -1,4 +1,4 @@
-import React, { Children, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     ChoicesContextProvider,


### PR DESCRIPTION
## Problem

Since #9637, users see an error in production while the app isn't broken

## Solution

Only throw in development.