### PR TITLE
Fix `<SortButton>` should use the provided `resource` prop to build its label

### DIFF
--- a/packages/ra-ui-materialui/src/button/SortButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SortButton.tsx
@@ -53,8 +53,14 @@ const SortButton = (props: SortButtonProps) => {
         icon = defaultIcon,
         sx,
         className,
+        resource: resourceProp,
     } = props;
-    const { resource, sort, setSort } = useListSortContext();
+    const {
+        resource: resourceFromContext,
+        sort,
+        setSort,
+    } = useListSortContext();
+    const resource = resourceProp || resourceFromContext;
     const translate = useTranslate();
     const translateLabel = useTranslateLabel();
     const isXSmall = useMediaQuery((theme: Theme) =>


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/9692