### PR TITLE
[Doc] Fix not parsed mutationOptions value in useNotify/undoable

### DIFF
--- a/docs/useNotify.md
+++ b/docs/useNotify.md
@@ -149,6 +149,7 @@ notify('This is an error', { type: 'error' });
 
 When using `useNotify` as a side effect for an `undoable` mutation, you MUST set the `undoable` option to `true`, otherwise the "undo" button will not appear, and the actual update will never occur.
 
+{% raw %}
 ```jsx
 import * as React from 'react';
 import { useNotify, Edit, SimpleForm } from 'react-admin';
@@ -169,6 +170,7 @@ const PostEdit = () => {
     );
 }
 ```
+{% endraw %}
 
 ## Custom Notification Content
 


### PR DESCRIPTION
Fixed not properly parsed jsx in the useNotify docs page for the `mutationOptions`

<img width="780" alt="image" src="https://github.com/marmelab/react-admin/assets/26602880/33645459-0f96-4d6d-b57b-1f89712d12fa">
