### PR TITLE
Introduce ReferenceFieldBase

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CoreAdminContext } from '../../core/CoreAdminContext';
+import { useResourceContext } from '../../core/useResourceContext';
+import { testDataProvider } from '../../dataProvider';
+import { ReferenceFieldBase } from './ReferenceFieldBase';
+import { Error, Loading, Meta } from './ReferenceFieldBase.stories';
+
+describe('<ReferenceFieldBase />', () => {
+    const defaultProps = {
+        reference: 'posts',
+        resource: 'comments',
+        source: 'post_id',
+    };
+
+    beforeAll(() => {
+        window.scrollTo = jest.fn();
+    });
+
+    it('should display an error if error is defined', async () => {
+        jest.spyOn(console, 'error')
+            .mockImplementationOnce(() => {})
+            .mockImplementationOnce(() => {});
+
+        render(<Error />);
+        await waitFor(() => {
+            expect(screen.queryByText('Error')).not.toBeNull();
+        });
+    });
+
+    it('should pass the loading state', async () => {
+        jest.spyOn(console, 'error')
+            .mockImplementationOnce(() => {})
+            .mockImplementationOnce(() => {});
+
+        render(<Loading />);
+        await waitFor(() => {
+            expect(screen.queryByText('Loading...')).not.toBeNull();
+        });
+    });
+
+    it('should pass the correct resource down to child component', async () => {
+        const MyComponent = () => {
+            const resource = useResourceContext();
+            return <div>{resource}</div>;
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: () =>
+                Promise.resolve({ data: [{ id: 1 }, { id: 2 }], total: 2 }),
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <ReferenceFieldBase {...defaultProps}>
+                    <MyComponent />
+                </ReferenceFieldBase>
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(screen.queryByText('posts')).not.toBeNull();
+        });
+    });
+
+    it('should accept meta in queryOptions', async () => {
+        const getMany = jest
+            .fn()
+            .mockImplementationOnce(() =>
+                Promise.resolve({ data: [], total: 25 })
+            );
+        const dataProvider = testDataProvider({
+            getMany,
+            getOne: () =>
+                Promise.resolve({
+                    data: {
+                        id: 1,
+                        title: 'War and Peace',
+                        author: 1,
+                        summary:
+                            "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                        year: 1869,
+                    },
+                }),
+        });
+        render(<Meta dataProvider={dataProvider} />);
+        await screen.findByText('War and Peace');
+        await waitFor(() => {
+            expect(getMany).toHaveBeenCalledWith('authors', {
+                ids: [1],
+                meta: { test: true },
+                signal: expect.any(AbortSignal),
+            });
+        });
+    });
+});

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
@@ -264,13 +264,9 @@ export const QueryOptions = () => (
 );
 
 const BookShowMeta = () => {
-    const [enabled, setEnabled] = React.useState(false);
     return (
         <ShowBase>
             <>
-                <button onClick={() => setEnabled(!enabled)}>
-                    Enable the query
-                </button>
                 <TextField source="title" />
                 <ReferenceFieldBase
                     reference="authors"
@@ -281,7 +277,6 @@ const BookShowMeta = () => {
                         <TextField source="last_name" />
                     </MyReferenceField>
                 </ReferenceFieldBase>
-                <button type="submit">Save</button>
             </>
         </ShowBase>
     );

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import fakeRestDataProvider from 'ra-data-fakerest';
 import { CoreAdmin } from '../../core/CoreAdmin';
 import { Resource } from '../../core/Resource';
 import { ShowBase } from '../../controller/show/ShowBase';
@@ -6,7 +8,7 @@ import { TestMemoryRouter } from '../../routing';
 import { ReferenceFieldBase } from './ReferenceFieldBase';
 import { useFieldValue } from '../../util/useFieldValue';
 import { useReferenceFieldContext } from './ReferenceFieldContext';
-import { QueryClient } from '@tanstack/react-query';
+import { DataProvider } from '../../types';
 
 export default {
     title: 'ra-core/fields/ReferenceFieldBase',
@@ -172,11 +174,193 @@ export const Loading = ({ dataProvider = dataProviderWithAuthorsLoading }) => (
     </TestMemoryRouter>
 );
 
+const BookShowQueryOptions = () => {
+    const [enabled, setEnabled] = React.useState(false);
+    return (
+        <ShowBase>
+            <>
+                <button onClick={() => setEnabled(!enabled)}>
+                    Enable the query
+                </button>
+                <TextField source="title" />
+                <ReferenceFieldBase
+                    reference="authors"
+                    source="author"
+                    queryOptions={{ enabled }}
+                >
+                    <MyReferenceField>
+                        <TextField source="last_name" />
+                    </MyReferenceField>
+                </ReferenceFieldBase>
+                <button type="submit">Save</button>
+            </>
+        </ShowBase>
+    );
+};
+
+export const QueryOptions = () => (
+    <TestMemoryRouter initialEntries={['/books/1/show']}>
+        <CoreAdmin
+            dataProvider={fakeRestDataProvider(
+                {
+                    books: [
+                        {
+                            id: 1,
+                            title: 'War and Peace',
+                            author: 1,
+                            summary:
+                                "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                            year: 1869,
+                        },
+                    ],
+                    authors: [
+                        {
+                            id: 1,
+                            first_name: 'Leo',
+                            last_name: 'Tolstoy',
+                            language: 'Russian',
+                        },
+                        {
+                            id: 2,
+                            first_name: 'Victor',
+                            last_name: 'Hugo',
+                            language: 'French',
+                        },
+                        {
+                            id: 3,
+                            first_name: 'William',
+                            last_name: 'Shakespeare',
+                            language: 'English',
+                        },
+                        {
+                            id: 4,
+                            first_name: 'Charles',
+                            last_name: 'Baudelaire',
+                            language: 'French',
+                        },
+                        {
+                            id: 5,
+                            first_name: 'Marcel',
+                            last_name: 'Proust',
+                            language: 'French',
+                        },
+                    ],
+                },
+                process.env.NODE_ENV === 'development'
+            )}
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: {
+                            retry: false,
+                        },
+                    },
+                })
+            }
+        >
+            <Resource name="books" show={BookShowQueryOptions} />
+        </CoreAdmin>
+    </TestMemoryRouter>
+);
+
+const BookShowMeta = () => {
+    const [enabled, setEnabled] = React.useState(false);
+    return (
+        <ShowBase>
+            <>
+                <button onClick={() => setEnabled(!enabled)}>
+                    Enable the query
+                </button>
+                <TextField source="title" />
+                <ReferenceFieldBase
+                    reference="authors"
+                    source="author"
+                    queryOptions={{ meta: { test: true } }}
+                >
+                    <MyReferenceField>
+                        <TextField source="last_name" />
+                    </MyReferenceField>
+                </ReferenceFieldBase>
+                <button type="submit">Save</button>
+            </>
+        </ShowBase>
+    );
+};
+
+export const Meta = ({
+    dataProvider = fakeRestDataProvider(
+        {
+            books: [
+                {
+                    id: 1,
+                    title: 'War and Peace',
+                    author: 1,
+                    summary:
+                        "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                    year: 1869,
+                },
+            ],
+            authors: [
+                {
+                    id: 1,
+                    first_name: 'Leo',
+                    last_name: 'Tolstoy',
+                    language: 'Russian',
+                },
+                {
+                    id: 2,
+                    first_name: 'Victor',
+                    last_name: 'Hugo',
+                    language: 'French',
+                },
+                {
+                    id: 3,
+                    first_name: 'William',
+                    last_name: 'Shakespeare',
+                    language: 'English',
+                },
+                {
+                    id: 4,
+                    first_name: 'Charles',
+                    last_name: 'Baudelaire',
+                    language: 'French',
+                },
+                {
+                    id: 5,
+                    first_name: 'Marcel',
+                    last_name: 'Proust',
+                    language: 'French',
+                },
+            ],
+        },
+        process.env.NODE_ENV === 'development'
+    ),
+}: {
+    dataProvider: DataProvider;
+}) => (
+    <TestMemoryRouter initialEntries={['/books/1/show']}>
+        <CoreAdmin
+            dataProvider={dataProvider}
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: {
+                            retry: false,
+                        },
+                    },
+                })
+            }
+        >
+            <Resource name="books" show={BookShowMeta} />
+        </CoreAdmin>
+    </TestMemoryRouter>
+);
+
 const MyReferenceField = (props: { children: React.ReactNode }) => {
     const context = useReferenceFieldContext();
 
     if (context.isLoading) {
-        return <p>...Loading</p>;
+        return <p>Loading...</p>;
     }
 
     if (context.error) {

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import { CoreAdmin } from '../../core/CoreAdmin';
+import { Resource } from '../../core/Resource';
+import { ShowBase } from '../../controller/show/ShowBase';
+import { TestMemoryRouter } from '../../routing';
+import { ReferenceFieldBase } from './ReferenceFieldBase';
+import { useFieldValue } from '../../util/useFieldValue';
+import { useReferenceFieldContext } from './ReferenceFieldContext';
+import { QueryClient } from '@tanstack/react-query';
+
+export default {
+    title: 'ra-core/fields/ReferenceFieldBase',
+    excludeStories: ['dataProviderWithAuthors'],
+};
+
+const authors = [
+    { id: 1, first_name: 'Leo', last_name: 'Tolstoy', language: 'Russian' },
+    { id: 2, first_name: 'Victor', last_name: 'Hugo', language: 'French' },
+    {
+        id: 3,
+        first_name: 'William',
+        last_name: 'Shakespeare',
+        language: 'English',
+    },
+    {
+        id: 4,
+        first_name: 'Charles',
+        last_name: 'Baudelaire',
+        language: 'French',
+    },
+    { id: 5, first_name: 'Marcel', last_name: 'Proust', language: 'French' },
+];
+
+export const dataProviderWithAuthors = {
+    getOne: () =>
+        Promise.resolve({
+            data: {
+                id: 1,
+                title: 'War and Peace',
+                author: 1,
+                summary:
+                    "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                year: 1869,
+            },
+        }),
+    getMany: (_resource, params) =>
+        Promise.resolve({
+            data: authors.filter(author => params.ids.includes(author.id)),
+        }),
+} as any;
+
+export const Basic = ({ dataProvider = dataProviderWithAuthors }) => (
+    <TestMemoryRouter initialEntries={['/books/1/show']}>
+        <CoreAdmin
+            dataProvider={dataProvider}
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: {
+                            retry: false,
+                        },
+                    },
+                })
+            }
+        >
+            <Resource name="authors" />
+            <Resource
+                name="books"
+                show={
+                    <ShowBase>
+                        <ReferenceFieldBase source="author" reference="authors">
+                            <MyReferenceField>
+                                <TextField source="first_name" />
+                            </MyReferenceField>
+                        </ReferenceFieldBase>
+                    </ShowBase>
+                }
+            />
+        </CoreAdmin>
+    </TestMemoryRouter>
+);
+
+const dataProviderWithAuthorsError = {
+    getOne: () =>
+        Promise.resolve({
+            data: {
+                id: 1,
+                title: 'War and Peace',
+                author: 1,
+                summary:
+                    "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                year: 1869,
+            },
+        }),
+    getMany: _resource => Promise.reject('Error'),
+} as any;
+
+export const Error = ({ dataProvider = dataProviderWithAuthorsError }) => (
+    <TestMemoryRouter initialEntries={['/books/1/show']}>
+        <CoreAdmin
+            dataProvider={dataProvider}
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: {
+                            retry: false,
+                        },
+                    },
+                })
+            }
+        >
+            <Resource name="authors" />
+            <Resource
+                name="books"
+                show={
+                    <ShowBase>
+                        <ReferenceFieldBase source="author" reference="authors">
+                            <MyReferenceField>
+                                <TextField source="first_name" />
+                            </MyReferenceField>
+                        </ReferenceFieldBase>
+                    </ShowBase>
+                }
+            />
+        </CoreAdmin>
+    </TestMemoryRouter>
+);
+
+const dataProviderWithAuthorsLoading = {
+    getOne: () =>
+        Promise.resolve({
+            data: {
+                id: 1,
+                title: 'War and Peace',
+                author: 1,
+                summary:
+                    "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                year: 1869,
+            },
+        }),
+    getMany: _resource => new Promise(() => {}),
+} as any;
+
+export const Loading = ({ dataProvider = dataProviderWithAuthorsLoading }) => (
+    <TestMemoryRouter initialEntries={['/books/1/show']}>
+        <CoreAdmin
+            dataProvider={dataProvider}
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: {
+                            retry: false,
+                        },
+                    },
+                })
+            }
+        >
+            <Resource name="authors" />
+            <Resource
+                name="books"
+                show={
+                    <ShowBase>
+                        <ReferenceFieldBase source="author" reference="authors">
+                            <MyReferenceField>
+                                <TextField source="first_name" />
+                            </MyReferenceField>
+                        </ReferenceFieldBase>
+                    </ShowBase>
+                }
+            />
+        </CoreAdmin>
+    </TestMemoryRouter>
+);
+
+const MyReferenceField = (props: { children: React.ReactNode }) => {
+    const context = useReferenceFieldContext();
+
+    if (context.isLoading) {
+        return <p>...Loading</p>;
+    }
+
+    if (context.error) {
+        return <p style={{ color: 'red' }}>{context.error}</p>;
+    }
+    return props.children;
+};
+
+const TextField = ({ source }: { source: string }) => {
+    const value = useFieldValue({ source });
+    return <p>{value}</p>;
+};

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { ReactNode } from 'react';
+import { UseQueryOptions } from '@tanstack/react-query';
+import { ReferenceFieldContextProvider } from './ReferenceFieldContext';
+import { RaRecord } from '../../types';
+import { useReferenceFieldController } from './useReferenceFieldController';
+import { ResourceContextProvider } from '../../core';
+import { RecordContextProvider } from '../record';
+
+/**
+ * Fetch reference record, and render its representation, or delegate rendering to child component.
+ *
+ * The reference prop should be the name of one of the <Resource> components
+ * added as <Admin> child.
+ *
+ * @example // using recordRepresentation
+ * <ReferenceFieldBase label="User" source="userId" reference="users" />
+ *
+ * @example // using a Field component to represent the record
+ * <ReferenceFieldBase label="User" source="userId" reference="users">
+ *     <TextField source="name" />
+ * </ReferenceFieldBase>
+ *
+ * @example // By default, includes a link to the <Edit> page of the related record
+ * // (`/users/:userId` in the previous example).
+ * // Set the `link` prop to "show" to link to the <Show> page instead.
+ * <ReferenceFieldBase label="User" source="userId" reference="users" link="show" />
+ *
+ * @example // You can also prevent `<ReferenceFieldBase>` from adding link to children
+ * // by setting `link` to false.
+ * <ReferenceFieldBase label="User" source="userId" reference="users" link={false} />
+ *
+ * @example // Alternatively, you can also pass a custom function to `link`.
+ * // It must take reference and record as arguments and return a string
+ * <ReferenceFieldBase label="User" source="userId" reference="users" link={(record, reference) => "/path/to/${reference}/${record}"} />
+ *
+ * @default
+ * In previous versions of React-Admin, the prop `linkType` was used. It is now deprecated and replaced with `link`. However
+ * backward-compatibility is still kept
+ */
+export const ReferenceFieldBase = <
+    RecordType extends Record<string, any> = Record<string, any>,
+    ReferenceRecordType extends RaRecord = RaRecord
+>(
+    props: ReferenceFieldBaseProps<ReferenceRecordType>
+) => {
+    const { children } = props;
+
+    const controllerProps = useReferenceFieldController<
+        RecordType,
+        ReferenceRecordType
+    >(props);
+
+    console.log({ controllerProps });
+    return (
+        <ResourceContextProvider value={props.reference}>
+            <ReferenceFieldContextProvider value={controllerProps}>
+                <RecordContextProvider value={controllerProps.referenceRecord}>
+                    {children}
+                </RecordContextProvider>
+            </ReferenceFieldContextProvider>
+        </ResourceContextProvider>
+    );
+};
+
+export interface ReferenceFieldBaseProps<
+    ReferenceRecordType extends RaRecord = RaRecord
+> {
+    children?: ReactNode;
+    className?: string;
+    error?: ReactNode;
+    label?: string;
+    queryOptions?: UseQueryOptions<ReferenceRecordType[], Error> & {
+        meta?: any;
+    };
+    reference: string;
+    source: string;
+}

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
@@ -39,17 +39,15 @@ import { RecordContextProvider } from '../record';
  * backward-compatibility is still kept
  */
 export const ReferenceFieldBase = <
-    RecordType extends Record<string, any> = Record<string, any>,
     ReferenceRecordType extends RaRecord = RaRecord
 >(
     props: ReferenceFieldBaseProps<ReferenceRecordType>
 ) => {
     const { children } = props;
 
-    const controllerProps = useReferenceFieldController<
-        RecordType,
-        ReferenceRecordType
-    >(props);
+    const controllerProps = useReferenceFieldController<ReferenceRecordType>(
+        props
+    );
 
     return (
         <ResourceContextProvider value={props.reference}>

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
@@ -51,7 +51,6 @@ export const ReferenceFieldBase = <
         ReferenceRecordType
     >(props);
 
-    console.log({ controllerProps });
     return (
         <ResourceContextProvider value={props.reference}>
             <ReferenceFieldContextProvider value={controllerProps}>
@@ -69,7 +68,6 @@ export interface ReferenceFieldBaseProps<
     children?: ReactNode;
     className?: string;
     error?: ReactNode;
-    label?: string;
     queryOptions?: UseQueryOptions<ReferenceRecordType[], Error> & {
         meta?: any;
     };

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
@@ -68,9 +68,11 @@ export interface ReferenceFieldBaseProps<
     children?: ReactNode;
     className?: string;
     error?: ReactNode;
-    queryOptions?: UseQueryOptions<ReferenceRecordType[], Error> & {
-        meta?: any;
-    };
+    queryOptions?: Partial<
+        UseQueryOptions<ReferenceRecordType[], Error> & {
+            meta?: any;
+        }
+    >;
     reference: string;
     source: string;
 }

--- a/packages/ra-core/src/controller/field/ReferenceFieldContext.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { UseReferenceFieldControllerResult } from './useReferenceFieldController';
+
+export const ReferenceFieldContext = createContext<
+    UseReferenceFieldControllerResult
+>(null);
+
+export const ReferenceFieldContextProvider = ReferenceFieldContext.Provider;
+
+export const useReferenceFieldContext = () => {
+    const context = useContext(ReferenceFieldContext);
+    if (!context) {
+        throw new Error(
+            'useReferenceFieldContext must be used inside a ReferenceFieldContextProvider'
+        );
+    }
+    return context;
+};

--- a/packages/ra-core/src/controller/field/index.ts
+++ b/packages/ra-core/src/controller/field/index.ts
@@ -1,3 +1,6 @@
+export * from './ReferenceFieldBase';
+export * from './ReferenceFieldContext';
 export * from './useReferenceArrayFieldController';
+export * from './useReferenceFieldController';
 export * from './useReferenceManyFieldController';
 export * from './useReferenceOneFieldController';

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -19,7 +19,10 @@ export const useReferenceFieldController = <
     const referenceRecordQuery = useReference<ReferenceRecordType>({
         reference,
         id,
-        options: { ...queryOptions, enabled: id != null },
+        options: {
+            ...queryOptions,
+            enabled: queryOptions?.enabled ?? id != null,
+        },
     });
 
     const createPath = useCreatePath();
@@ -57,9 +60,11 @@ export interface UseReferenceFieldControllerOptions<
     ReferenceRecordType extends RaRecord = RaRecord
 > {
     source: string;
-    queryOptions?: UseQueryOptions<ReferenceRecordType[], Error> & {
-        meta?: any;
-    };
+    queryOptions?: Partial<
+        UseQueryOptions<ReferenceRecordType[], Error> & {
+            meta?: any;
+        }
+    >;
     reference: string;
     link?: LinkToType<ReferenceRecordType>;
 }

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -14,6 +14,11 @@ export const useReferenceFieldController = <
     options: UseReferenceFieldControllerOptions<ReferenceRecordType>
 ): UseReferenceFieldControllerResult<ReferenceRecordType> => {
     const { source, link = 'edit', reference, queryOptions } = options;
+    if (!reference) {
+        throw new Error(
+            'useReferenceFieldController: missing reference prop. You must provide a reference, e.g. reference="posts".'
+        );
+    }
     const record = useRecordContext<RecordType>(options);
     const id = get(record, source);
     const referenceRecordQuery = useReference<ReferenceRecordType>({
@@ -21,7 +26,7 @@ export const useReferenceFieldController = <
         id,
         options: {
             ...queryOptions,
-            enabled: queryOptions?.enabled ?? id != null,
+            enabled: queryOptions?.enabled && id != null,
         },
     });
 

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -1,26 +1,23 @@
 import { useMemo } from 'react';
 import { UseQueryOptions } from '@tanstack/react-query';
-import get from 'lodash/get';
 import { RaRecord } from '../../types';
-import { useRecordContext } from '../record';
 import { LinkToType, useCreatePath } from '../../routing';
 import { UseReferenceResult, useReference } from '../useReference';
 import { useResourceDefinition } from '../../core';
+import { useFieldValue } from '../../util';
 
 export const useReferenceFieldController = <
-    RecordType extends Record<string, any> = Record<string, any>,
     ReferenceRecordType extends RaRecord = RaRecord
 >(
     options: UseReferenceFieldControllerOptions<ReferenceRecordType>
 ): UseReferenceFieldControllerResult<ReferenceRecordType> => {
-    const { source, link = 'edit', reference, queryOptions } = options;
+    const { link = 'edit', reference, queryOptions } = options;
     if (!reference) {
         throw new Error(
             'useReferenceFieldController: missing reference prop. You must provide a reference, e.g. reference="posts".'
         );
     }
-    const record = useRecordContext<RecordType>(options);
-    const id = get(record, source);
+    const id = useFieldValue(options);
     const referenceRecordQuery = useReference<ReferenceRecordType>({
         reference,
         id,

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -26,7 +26,7 @@ export const useReferenceFieldController = <
         id,
         options: {
             ...queryOptions,
-            enabled: queryOptions?.enabled && id != null,
+            enabled: queryOptions?.enabled === true && id != null,
         },
     });
 

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -26,7 +26,10 @@ export const useReferenceFieldController = <
         id,
         options: {
             ...queryOptions,
-            enabled: queryOptions?.enabled === true && id != null,
+            enabled:
+                (queryOptions?.enabled == null ||
+                    queryOptions?.enabled === true) &&
+                id != null,
         },
     });
 

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { UseQueryOptions } from '@tanstack/react-query';
+import get from 'lodash/get';
+import { RaRecord } from '../../types';
+import { useRecordContext } from '../record';
+import { LinkToType, useCreatePath } from '../../routing';
+import { UseReferenceResult, useReference } from '../useReference';
+import { useResourceDefinition } from '../../core';
+
+export const useReferenceFieldController = <
+    RecordType extends Record<string, any> = Record<string, any>,
+    ReferenceRecordType extends RaRecord = RaRecord
+>(
+    options: UseReferenceFieldControllerOptions<ReferenceRecordType>
+): UseReferenceFieldControllerResult<ReferenceRecordType> => {
+    const { source, link = 'edit', reference, queryOptions } = options;
+    const record = useRecordContext<RecordType>(options);
+    const id = get(record, source);
+    const referenceRecordQuery = useReference<ReferenceRecordType>({
+        reference,
+        id,
+        options: { ...queryOptions, enabled: id != null },
+    });
+
+    const createPath = useCreatePath();
+    const resourceDefinition = useResourceDefinition({ resource: reference });
+
+    const result = useMemo(
+        () =>
+            ({
+                ...referenceRecordQuery,
+                link:
+                    referenceRecordQuery.referenceRecord != null
+                        ? link === false ||
+                          (link === 'edit' && !resourceDefinition.hasEdit) ||
+                          (link === 'show' && !resourceDefinition.hasShow)
+                            ? false
+                            : createPath({
+                                  resource: reference,
+                                  id: referenceRecordQuery.referenceRecord.id,
+                                  type:
+                                      typeof link === 'function'
+                                          ? link(
+                                                referenceRecordQuery.referenceRecord,
+                                                reference
+                                            )
+                                          : link,
+                              })
+                        : undefined,
+            } as const),
+        [createPath, link, reference, referenceRecordQuery, resourceDefinition]
+    );
+    return result;
+};
+
+export interface UseReferenceFieldControllerOptions<
+    ReferenceRecordType extends RaRecord = RaRecord
+> {
+    source: string;
+    queryOptions?: UseQueryOptions<ReferenceRecordType[], Error> & {
+        meta?: any;
+    };
+    reference: string;
+    link?: LinkToType<ReferenceRecordType>;
+}
+
+export interface UseReferenceFieldControllerResult<
+    ReferenceRecordType extends RaRecord = RaRecord
+> extends UseReferenceResult<ReferenceRecordType> {
+    link?: string | false;
+}

--- a/packages/ra-core/src/core/ResourceContextProvider.tsx
+++ b/packages/ra-core/src/core/ResourceContextProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { ResourceContext, ResourceContextValue } from './ResourceContext';
 
 /**
@@ -25,7 +25,7 @@ export const ResourceContextProvider = ({
     children,
     value,
 }: {
-    children: ReactElement;
+    children: ReactNode;
     value?: ResourceContextValue;
 }) =>
     value ? (

--- a/packages/ra-core/src/util/useFieldValue.ts
+++ b/packages/ra-core/src/util/useFieldValue.ts
@@ -26,7 +26,6 @@ export const useFieldValue = <
     const sourceContext = useSourceContext();
     const record = useRecordContext<RecordType>(params);
 
-    console.log({ record });
     return get(
         record,
         sourceContext?.getSource(source) ?? source,

--- a/packages/ra-core/src/util/useFieldValue.ts
+++ b/packages/ra-core/src/util/useFieldValue.ts
@@ -26,6 +26,7 @@ export const useFieldValue = <
     const sourceContext = useSourceContext();
     const record = useRecordContext<RecordType>(params);
 
+    console.log({ record });
     return get(
         record,
         sourceContext?.getSource(source) ?? source,

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -14,8 +14,8 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { ReferenceField } from './ReferenceField';
 import {
     Children,
-    EmptyWithTranslate,
-    MissingReference,
+    MissingReferenceIdEmptyTextTranslation,
+    MissingReferenceEmptyText,
     SXLink,
     SXNoLink,
 } from './ReferenceField.stories';
@@ -299,7 +299,7 @@ describe('<ReferenceField />', () => {
     });
 
     it('should display the emptyText if there is no reference', async () => {
-        render(<MissingReference />);
+        render(<MissingReferenceEmptyText />);
         await screen.findByText('no detail');
     });
 
@@ -622,7 +622,7 @@ describe('<ReferenceField />', () => {
     });
 
     it('should translate emptyText', () => {
-        render(<EmptyWithTranslate />);
+        render(<MissingReferenceIdEmptyTextTranslation />);
 
         expect(screen.findByText('Not found')).not.toBeNull();
     });

--- a/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
@@ -110,7 +110,15 @@ export const Loading = () => (
     </Wrapper>
 );
 
-export const Empty = () => (
+export const NoReferenceId = () => (
+    <Wrapper record={{ id: 1, title: 'War and Peace' }}>
+        <ReferenceField source="detail_id" reference="book_details">
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
+);
+
+export const EmptyText = () => (
     <Wrapper record={{ id: 1, title: 'War and Peace' }}>
         <ReferenceField
             source="detail_id"

--- a/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
@@ -110,7 +110,7 @@ export const Loading = () => (
     </Wrapper>
 );
 
-export const NoReferenceId = () => (
+export const MissingReferenceId = () => (
     <Wrapper record={{ id: 1, title: 'War and Peace' }}>
         <ReferenceField source="detail_id" reference="book_details">
             <TextField source="ISBN" />
@@ -118,7 +118,7 @@ export const NoReferenceId = () => (
     </Wrapper>
 );
 
-export const EmptyText = () => (
+export const MissingReferenceIdEmptyText = () => (
     <Wrapper record={{ id: 1, title: 'War and Peace' }}>
         <ReferenceField
             source="detail_id"
@@ -130,7 +130,7 @@ export const EmptyText = () => (
     </Wrapper>
 );
 
-export const EmptyWithTranslate = () => (
+export const MissingReferenceIdEmptyTextTranslation = () => (
     <Wrapper record={{ id: 1, title: 'War and Peace' }}>
         <I18nContextProvider value={i18nProvider}>
             <ReferenceField
@@ -152,6 +152,14 @@ const missingReferenceDataProvider = {
 } as any;
 
 export const MissingReference = () => (
+    <Wrapper dataProvider={missingReferenceDataProvider}>
+        <ReferenceField source="detail_id" reference="book_details">
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
+);
+
+export const MissingReferenceEmptyText = () => (
     <Wrapper dataProvider={missingReferenceDataProvider}>
         <ReferenceField
             source="detail_id"

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -12,6 +12,7 @@ import {
     RaRecord,
     ReferenceFieldBase,
     useReferenceFieldContext,
+    useFieldValue,
 } from 'ra-core';
 import { UseQueryOptions } from '@tanstack/react-query';
 
@@ -57,11 +58,22 @@ export const ReferenceField = <
 >(
     props: ReferenceFieldProps<RecordType, ReferenceRecordType>
 ) => {
-    const { link, ...rest } = props;
+    const { emptyText } = props;
+    const translate = useTranslate();
+    const id = useFieldValue(props);
+
+    if (id == null) {
+        return emptyText ? (
+            <Typography component="span" variant="body2">
+                {emptyText && translate(emptyText, { _: emptyText })}
+            </Typography>
+        ) : null;
+    }
+
     return (
-        <ReferenceFieldBase {...props}>
+        <ReferenceFieldBase<ReferenceRecordType> {...props}>
             <PureReferenceFieldView<RecordType, ReferenceRecordType>
-                {...rest}
+                {...props}
             />
         </ReferenceFieldBase>
     );

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -145,7 +145,9 @@ export const ReferenceFieldView = <
     }
     if (!referenceRecord) {
         return emptyText ? (
-            <>{emptyText && translate(emptyText, { _: emptyText })}</>
+            <Typography component="span" variant="body2">
+                {emptyText && translate(emptyText, { _: emptyText })}
+            </Typography>
         ) : null;
     }
 

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -94,9 +94,11 @@ export interface ReferenceFieldProps<
 > extends Omit<FieldProps<RecordType>, 'source'>,
         Required<Pick<FieldProps<RecordType>, 'source'>> {
     children?: ReactNode;
-    queryOptions?: UseQueryOptions<ReferenceRecordType[], Error> & {
-        meta?: any;
-    };
+    queryOptions?: Partial<
+        UseQueryOptions<ReferenceRecordType[], Error> & {
+            meta?: any;
+        }
+    >;
     reference: string;
     translateChoice?: Function | boolean;
     link?: LinkToType<ReferenceRecordType>;


### PR DESCRIPTION
## Problem

While working on the alternative UI libraries demos, we had to re-implement all the reference fields and inputs logic.

## Solution

Add core headless versions for these components
This PR introduces only the `ReferenceFieldBase`.

## Tasks

- [x] Implementation
- [x] Tests