### PR TITLE
Remove `cloneElement` in list actions and bulk actions

### DIFF
--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -31,6 +31,7 @@ Then, add the `<CreateDialog>` component as a sibling to a `<List>` component.
 ```jsx
 import {
     List,
+    ListActions,
     Datagrid,
     SimpleForm,
     TextInput,
@@ -42,7 +43,7 @@ import { CreateDialog } from '@react-admin/ra-form-layout';
 
 const CustomerList = () => (
     <>
-        <List hasCreate>
+        <List actions={<ListActions hasCreate />}>
             <Datagrid>
                 ...
             </Datagrid>
@@ -58,7 +59,7 @@ const CustomerList = () => (
 );
 ```
 
-**Tip**: In the example above, notice the `<List hasCreate>` prop. It is necessary in order to display the "Create" button, because react-admin has no way of knowing that creation form for the "customer" resource exists.
+**Tip**: In the example above, notice the `<List actions>` prop. It is necessary in order to display the "Create" button, because react-admin has no way of knowing that creation form for the "customer" resource exists.
 
 In the related `<Resource>`, you don't need to declare a `create` component as the creation UI is part of the `list` component:
 

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -965,6 +965,7 @@ The separation between list pages and edit pages is not always relevant. Sometim
 ```tsx
 import {
     List,
+    ListActions,
     TextField,
     TextInput,
     DateField,
@@ -982,7 +983,7 @@ const professionChoices = [
 ];
 
 const ArtistList = () => (
-    <List hasCreate empty={false}>
+    <List actions={<ListActions hasCreate />} empty={false}>
         <EditableDatagrid
             mutationMode="undoable"
             createForm={<ArtistForm />}

--- a/docs/EditableDatagrid.md
+++ b/docs/EditableDatagrid.md
@@ -36,11 +36,11 @@ yarn add @react-admin/ra-editable-datagrid
 Then, replace `<Datagrid>` with `<EditableDatagrid>` in a react-admin `<List>`, `<ReferenceManyField>`, or any other component that creates a `ListContext`. In addition, pass a form component to be displayed when the user switches to edit or create mode.
 
 ```tsx
-import { List, TextField, TextInput, DateField, DateInput, SelectField, SelectInput, required } from 'react-admin';
+import { List, ListActions,TextField, TextInput, DateField, DateInput, SelectField, SelectInput, required } from 'react-admin';
 import { EditableDatagrid, RowForm } from '@react-admin/ra-editable-datagrid';
 
 export const ArtistList = () => (
-    <List hasCreate empty={false}>
+    <List actions={<ListActions hasCreate />} empty={false}>
         <EditableDatagrid
             createForm={<ArtistForm />}
             editForm={<ArtistForm />}
@@ -136,7 +136,7 @@ The component displayed as the first row when a user clicks on the Create button
 
 ```tsx
 export const ArtistList = () => (
-    <List hasCreate empty={false}>
+    <List actions={<ListActions hasCreate />} empty={false}>
         <EditableDatagrid
             editForm={<ArtistForm />}
             createForm={<ArtistForm />}
@@ -161,7 +161,7 @@ const ArtistForm = () => (
 
 **Tip**: It's a good idea to reuse the same form component for `createForm` and `editForm`, as in the example above.
 
-Since the creation form is embedded in the List view, you shouldn't set the `<Resource create>` prop. But react-admin's `<List>` only displays a Create button if the current `Resource` has a `create` page. That's why you must force the [`<List hasCreate>`](./List.md#hascreate) prop to `true`, as in the example above, to have the Create button show up with `<EditableDatagrid>`.
+Since the creation form is embedded in the List view, you shouldn't set the `<Resource create>` prop. But react-admin's `<List>` only displays a Create button if the current `Resource` has a `create` page. That's why you must force the [`<List actions>`](./List.md#actions) value, as in the example above, to have the Create button show up with `<EditableDatagrid>`.
 
 Also, when the list is empty, the `<List>` component normally doesn't render its children (it renders an `empty` component instead). To bypass this system and see the empty editable datagrid with a create button instead, you need to force the `<List empty={false}>` prop, as in the example above.
 
@@ -233,11 +233,11 @@ You can disable the delete button by setting the `noDelete` prop to `true`:
 `<RowForm>` renders a form in a table row, with one table cell per child. It is designed to be used as [`editForm`](#editform) and [`createForm`](#createform) element.
 
 ```tsx
-import { List, TextField, TextInput } from 'react-admin';
+import { List, ListActions, TextField, TextInput } from 'react-admin';
 import { EditableDatagrid, RowForm } from '@react-admin/ra-editable-datagrid';
 
 export const ArtistList = () => (
-    <List hasCreate empty={false}>
+    <List actions={<ListActions hasCreate />} empty={false}>
         <EditableDatagrid
             createForm={<ArtistForm />}
             editForm={<ArtistForm />}
@@ -299,7 +299,7 @@ For instance, the following example displays a custom message when the list is e
 ```tsx
 import React from 'react';
 import { Typography, Box } from '@mui/material';
-import { CreateButton, List } from 'react-admin';
+import { CreateButton, List, ListActions } from 'react-admin';
 import {
     EditableDatagrid,
     useEditableDatagridContext,
@@ -320,7 +320,7 @@ const MyCreateButton = () => {
 };
 
 export const BookList = () => (
-    <List hasCreate empty={false}>
+    <List actions={<ListActions hasCreate />} empty={false}>
         <EditableDatagrid empty={<MyCreateButton />}>
            {/*...*/}
         </EditableDatagrid>
@@ -512,6 +512,7 @@ import {
     SelectField,
     required,
     List,
+    ListActions,
 } from 'react-admin';
 import {
     EditableDatagrid,
@@ -541,7 +542,11 @@ const ArtistForm = ({ meta }) => (
 const ArtistListWithMeta = () => {
     const meta = { foo: 'bar' };
     return (
-        <List hasCreate sort={{ field: 'id', order: 'DESC' }} empty={false}>
+        <List
+            actions={<ListActions hasCreate />}
+            sort={{ field: 'id', order: 'DESC' }}
+            empty={false}
+        >
             <EditableDatagrid
                 createForm={<ArtistForm meta={meta} />}
                 editForm={<ArtistForm meta={meta} />}
@@ -605,7 +610,7 @@ const ArtistForm = ({ meta }) => (
 );
 
 const ArtistList = () => (
-    <List hasCreate empty={false}>
+    <List actions={<ListActions hasCreate />} empty={false}>
 -        <EditableDatagrid
 +        <EditableDatagridConfigurable
             mutationMode="undoable"

--- a/docs/InfiniteList.md
+++ b/docs/InfiniteList.md
@@ -70,7 +70,6 @@ The props are the same as [the `<List>` component](./List.md):
 | `filters`                  | Optional | `ReactElement` | -                       | The filters to display in the toolbar.                                                       |
 | `filter`                   | Optional | `object`       | -                       | The permanent filter values.                                                                 |
 | `filter DefaultValues`     | Optional | `object`       | -                       | The default filter values.                                                                   |
-| `hasCreate`                | Optional | `boolean`      | `false`                 | Set to `true` to show the create button.                                                     |
 | `pagination`               | Optional | `ReactElement` | `<Infinite Pagination>` | The pagination component to use.                                                             |
 | `perPage`                  | Optional | `number`       | `10`                    | The number of records to fetch per page.                                                     |
 | `queryOptions`             | Optional | `object`       | -                       | The options to pass to the `useQuery` hook.                                                  |

--- a/docs/List.md
+++ b/docs/List.md
@@ -67,7 +67,6 @@ You can find more advanced examples of `<List>` usage in the [demos](./Demos.md)
 | `filters`                 | Optional | `ReactElement` | -              | The filters to display in the toolbar.                                                       |
 | `filter`                  | Optional | `object`       | -              | The permanent filter values.                                                                 |
 | `filter DefaultValues`    | Optional | `object`       | -              | The default filter values.                                                                   |
-| `hasCreate`               | Optional | `boolean`      | `false`        | Set to `true` to show the create button.                                                     |
 | `pagination`              | Optional | `ReactElement` | `<Pagination>` | The pagination component to use.                                                             |
 | `perPage`                 | Optional | `number`       | `10`           | The number of records to fetch per page.                                                     |
 | `queryOptions`            | Optional | `object`       | -              | The options to pass to the `useQuery` hook.                                                  |
@@ -84,12 +83,26 @@ Additional props are passed down to the root component (a MUI `<Card>` by defaul
 By default, the `<List>` view displays a toolbar on top of the list. It contains:
 
 - A `<FilterButton>` to display the filter form if you set [the `filters` prop](#filters-filter-inputs)
-- A `<CreateButton>` if the resource has a creation view, or if you set [the `hasCreate` prop](#hascreate)
+- A `<CreateButton>` if the resource has a creation view
 - An `<ExportButton>`
 
 ![Actions Toolbar](./img/actions-toolbar.png)
 
-You can replace this toolbar  by your own using the `actions` prop. For instance, to add a [`<SelectColumnsButton>`](./SelectColumnsButton.md) to let the user choose which columns to display in the list:
+The `actions` prop allows you to replace the default toolbar by your own.
+
+For instance, you can force the toolbar to display a Create button, even if the resource has no creation view, by passing a custom `<ListActions>` component:
+
+```jsx
+import { List, ListActions } from 'react-admin';
+
+export const PostList = () => (
+    <List actions={<ListActions hasCreate />}>
+        ...
+    </List>
+);
+```
+
+You can also add custom actions, e.g. a [`<SelectColumnsButton>`](./SelectColumnsButton.md) to let the user choose which columns to display in the list:
 
 ```jsx
 import {
@@ -716,18 +729,6 @@ export const PostList = () => (
 
 ```js
 const filterSentToDataProvider = { ...filterDefaultValues, ...filterChosenByUser, ...filter };
-```
-
-## `hasCreate`
-
-The List page shows a Create button if the resource has a create view, or if the `hasCreate` prop is set to true. Using this prop lets you force the display of the create button, or hide it.
-
-```jsx
-export const PostList = () => (
-    <List hasCreate={false}>
-        ...
-    </List>
-);
 ```
 
 ## `pagination`

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -276,6 +276,22 @@ The following deprecated hooks have been removed
 
 - `usePermissionsOptimized`. Use `usePermissions` instead.
 
+## `<List hasCreate>` Is No Longer Supported
+
+To force a List view to display a Create button even though the corresponding resource doesn't have a `create` component, pass a custom actions component to the List component:
+
+```diff
+-import { List } from 'react-admin';
++import { List, ListActions } from 'react-admin';
+
+const PostList = () => (
+-   <List hasCreate>
++   <List actions={<ListActions hasCreate />}>
+        ...
+    </List>
+);
+```
+
 ## `<Datagrid rowClick>` is no longer `false` by default
 
 `<Datagrid>` will now make the rows clickable as soon as a Show or Edit view is declared on the resource (using the [resource definition](https://marmelab.com/react-admin/Resource.html)).
@@ -287,6 +303,57 @@ If you previously relied on the fact that the rows were not clickable by default
 +<Datagrid rowClick={false}>
    ...
 </Datagrid>
+```
+
+## Updates to `bulkActionButtons` Syntax
+
+The `bulkActionButtons` prop has been moved from the `<List>` component to the `<Datagrid>` component. 
+
+```diff
+const PostList = () => (
+-   <List bulkActionButtons={<BulkActionButtons />}>
++   <List>
+-      <Datagrid>
++      <Datagrid bulkActionButtons={<BulkActionButtons />}>
+           ...
+       </Datagrid>
+   </List>
+);
+```
+
+Besides, the buttons passed as `bulkActionButtons` no longer receive any prop. If you need the current filter values or the selected ids, you'll have to use the `useListContext` hook:
+
+```diff
+-const BulkResetViewsButton = ({ resource, selectedIds }) => {
++const BulkResetViewsButton = () => {
++   const { resource, selectedIds } = useListContext();
+    const notify = useNotify();
+    const unselectAll = useUnselectAll(resource);
+    const [updateMany, { isPending }] = useUpdateMany();
+
+    const handleClick = () => {
+        updateMany(
+            resource,
+            { ids: selectedIds, data: { views: 0 } },
+            {
+                onSuccess: () => {
+                    notify('Views reset');
+                    unselectAll();
+                },
+                onError: () => notify('Views not reset', { type: 'error' }),
+            }
+        );
+    }
+    return (
+        <Button
+            label="Reset views"
+            disabled={isPending}
+            onClick={() => updateMany()}
+        >
+            <VisibilityOff />
+        </Button>
+    );
+};
 ```
 
 ## Dark Theme Is Available By Default

--- a/docs/useDeleteMany.md
+++ b/docs/useDeleteMany.md
@@ -33,9 +33,10 @@ So, should you pass the parameters when calling the hook, or when executing the 
 
 ```jsx
 // set params when calling the hook
-import { useDeleteMany } from 'react-admin';
+import { useListContext, useDeleteMany } from 'react-admin';
 
-const BulkDeletePostsButton = ({ selectedIds }) => {
+const BulkDeletePostsButton = () => {
+    const { selectedIds } = useListContext();
     const [deleteMany, { isPending, error }] = useDeleteMany(
         'posts',
         { ids: selectedIds }
@@ -48,9 +49,10 @@ const BulkDeletePostsButton = ({ selectedIds }) => {
 };
 
 // set params when calling the deleteMany callback
-import { useDeleteMany } from 'react-admin';
+import { useListContext, useDeleteMany } from 'react-admin';
 
-const BulkDeletePostsButton = ({ selectedIds }) => {
+const BulkDeletePostsButton = () => {
+    const { selectedIds } = useListContext();
     const [deleteMany, { isPending, error }] = useDeleteMany();
     const handleClick = () => {
         deleteMany(

--- a/examples/simple/src/posts/PostList.tsx
+++ b/examples/simple/src/posts/PostList.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Fragment, memo } from 'react';
 import BookIcon from '@mui/icons-material/Book';
 import { Box, Chip, useMediaQuery } from '@mui/material';
 import { Theme, styled } from '@mui/material/styles';
@@ -67,7 +66,7 @@ const exporter = posts => {
     return jsonExport(data, (err, csv) => downloadCSV(csv, 'posts'));
 };
 
-const PostListMobileActions = () => (
+const postListMobileActions = (
     <TopToolbar>
         <FilterButton />
         <CreateButton />
@@ -80,7 +79,7 @@ const PostListMobile = () => (
         filters={postFilter}
         sort={{ field: 'published_at', order: 'DESC' }}
         exporter={exporter}
-        actions={<PostListMobileActions />}
+        actions={postListMobileActions}
     >
         <SimpleList
             primaryText={record => record.title}
@@ -110,23 +109,15 @@ const StyledDatagrid = styled(DatagridConfigurable)(({ theme }) => ({
     '& .publishedAt': { fontStyle: 'italic' },
 }));
 
-const PostListBulkActions = memo(
-    ({
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        children,
-        ...props
-    }: {
-        children?: React.ReactNode;
-    }) => (
-        <Fragment>
-            <ResetViewsButton {...props} />
-            <BulkDeleteButton {...props} />
-            <BulkExportButton {...props} />
-        </Fragment>
-    )
+const postListBulkActions = (
+    <>
+        <ResetViewsButton />
+        <BulkDeleteButton />
+        <BulkExportButton />
+    </>
 );
 
-const PostListActions = () => (
+const postListActions = (
     <TopToolbar>
         <SelectColumnsButton />
         <FilterButton />
@@ -158,10 +149,10 @@ const PostListDesktop = () => (
         filters={postFilter}
         sort={{ field: 'published_at', order: 'DESC' }}
         exporter={exporter}
-        actions={<PostListActions />}
+        actions={postListActions}
     >
         <StyledDatagrid
-            bulkActionButtons={<PostListBulkActions />}
+            bulkActionButtons={postListBulkActions}
             rowClick={rowClick}
             expand={PostPanel}
             omit={['average_note']}

--- a/examples/simple/src/posts/ResetViewsButton.tsx
+++ b/examples/simple/src/posts/ResetViewsButton.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import { useUpdateMany, useNotify, useUnselectAll, Button } from 'react-admin';
+import {
+    useUpdateMany,
+    useNotify,
+    useUnselectAll,
+    Button,
+    useListContext,
+} from 'react-admin';
 
-const ResetViewsButton = ({ resource, selectedIds }) => {
+const ResetViewsButton = () => {
+    const { resource, selectedIds } = useListContext();
     const notify = useNotify();
     const unselectAll = useUnselectAll(resource);
     const [updateMany, { isPending }] = useUpdateMany(

--- a/examples/simple/src/tags/TagEdit.tsx
+++ b/examples/simple/src/tags/TagEdit.tsx
@@ -12,6 +12,7 @@ import {
     ResourceContextProvider,
     EditButton,
     TranslatableInputs,
+    ListActions,
 } from 'react-admin';
 
 const TagEdit = () => {
@@ -28,8 +29,7 @@ const TagEdit = () => {
             </Edit>
             <ResourceContextProvider value="posts">
                 <List
-                    hasCreate={false}
-                    resource="posts"
+                    actions={<ListActions hasCreate={false} />}
                     filter={{ tags: [id] }}
                     title=" "
                 >

--- a/packages/ra-ui-materialui/src/button/BulkDeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteButton.tsx
@@ -13,23 +13,23 @@ import { MutationMode } from 'ra-core';
 /**
  * Deletes the selected rows.
  *
- * To be used inside the <List bulkActionButtons> prop (where it's enabled by default).
+ * To be used inside the <Datagrid bulkActionButtons> prop (where it's enabled by default).
  *
  * @example // basic usage
- * import * as React from 'react';
- * import { Fragment } from 'react';
- * import { BulkDeleteButton, BulkExportButton } from 'react-admin';
+ * import { BulkDeleteButton, BulkExportButton, List, Datagrid } from 'react-admin';
  *
  * const PostBulkActionButtons = () => (
- *     <Fragment>
+ *     <>
  *         <BulkExportButton />
  *         <BulkDeleteButton />
- *     </Fragment>
+ *     </>
  * );
  *
  * export const PostList = () => (
- *     <List bulkActionButtons={<PostBulkActionButtons />}>
- *         ...
+ *     <List>
+ *        <Datagrid bulkActionButtons={<PostBulkActionButtons />}>
+ *             ...
+ *       </Datagrid>
  *     </List>
  * );
  */

--- a/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
@@ -16,23 +16,23 @@ import { Button, ButtonProps } from './Button';
 /**
  * Export the selected rows
  *
- * To be used inside the <List bulkActionButtons> prop.
+ * To be used inside the <Datagrid bulkActionButtons> prop.
  *
  * @example // basic usage
- * import * as React from 'react';
- * import { Fragment } from 'react';
- * import { BulkDeleteButton, BulkExportButton } from 'react-admin';
+ * import { BulkDeleteButton, BulkExportButton, List, Datagrid } from 'react-admin';
  *
  * const PostBulkActionButtons = () => (
- *     <Fragment>
+ *     <>
  *         <BulkExportButton />
  *         <BulkDeleteButton />
- *     </Fragment>
+ *     </>
  * );
  *
  * export const PostList = () => (
- *     <List bulkActionButtons={<PostBulkActionButtons />}>
- *         ...
+ *     <List>
+ *        <Datagrid bulkActionButtons={<PostBulkActionButtons />}>
+ *          ...
+ *       </Datagrid>
  *     </List>
  * );
  */

--- a/packages/ra-ui-materialui/src/button/BulkUpdateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateButton.tsx
@@ -13,23 +13,23 @@ import { MutationMode } from 'ra-core';
 /**
  * Updates the selected rows.
  *
- * To be used inside the <List bulkActionButtons> prop (where it's enabled by default).
+ * To be used inside the <Datagrid bulkActionButtons> prop (where it's enabled by default).
  *
  * @example // basic usage
- * import * as React from 'react';
- * import { Fragment } from 'react';
- * import { BulkUpdateButton, BulkExportButton } from 'react-admin';
+ * import { BulkUpdateButton, BulkExportButton, List, Datagrid } from 'react-admin';
  *
  * const PostBulkActionButtons = () => (
- *     <Fragment>
+ *     <>
  *         <BulkExportButton />
  *         <BulkUpdateButton label="Reset Views" data={{ views: 0 }} />
- *     </Fragment>
+ *     </>
  * );
  *
  * export const PostList = () => (
- *     <List bulkActionButtons={<PostBulkActionButtons />}>
- *         ...
+ *     <List>
+ *        <Datagrid bulkActionButtons={<PostBulkActionButtons />}>
+ *          ...
+ *        </Datagrid>
  *     </List>
  * );
  */

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-    Children,
-    ReactNode,
-    cloneElement,
-    isValidElement,
-    useCallback,
-} from 'react';
+import { ReactNode, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import clsx from 'clsx';
@@ -30,12 +24,7 @@ export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
         className,
         ...rest
     } = props;
-    const {
-        filterValues,
-        resource,
-        selectedIds = [],
-        onUnselectItems,
-    } = useListContext(props);
+    const { selectedIds = [], onUnselectItems } = useListContext(props);
 
     const translate = useTranslate();
 
@@ -71,15 +60,7 @@ export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
                     </Typography>
                 </div>
                 <TopToolbar className={BulkActionsToolbarClasses.topToolbar}>
-                    {Children.map(children, child =>
-                        isValidElement<any>(child)
-                            ? cloneElement(child, {
-                                  filterValues,
-                                  resource,
-                                  selectedIds,
-                              })
-                            : null
-                    )}
+                    {children}
                 </TopToolbar>
             </Toolbar>
         </Root>

--- a/packages/ra-ui-materialui/src/list/Empty.tsx
+++ b/packages/ra-ui-materialui/src/list/Empty.tsx
@@ -55,6 +55,7 @@ export const Empty = (props: EmptyProps) => {
 
 export interface EmptyProps {
     resource?: string;
+    hasCreate?: boolean;
     className?: string;
 }
 

--- a/packages/ra-ui-materialui/src/list/Empty.tsx
+++ b/packages/ra-ui-materialui/src/list/Empty.tsx
@@ -55,7 +55,6 @@ export const Empty = (props: EmptyProps) => {
 
 export interface EmptyProps {
     resource?: string;
-    hasCreate?: boolean;
     className?: string;
 }
 

--- a/packages/ra-ui-materialui/src/list/InfiniteList.tsx
+++ b/packages/ra-ui-materialui/src/list/InfiniteList.tsx
@@ -129,7 +129,6 @@ InfiniteList.propTypes = {
     title: TitlePropType,
     // the props managed by react-admin
     disableSyncWithLocation: PropTypes.bool,
-    hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasList: PropTypes.bool,
     hasShow: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -10,6 +10,7 @@ import fakeRestDataProvider from 'ra-data-fakerest';
 import { Box, Card, Stack, Typography, Button } from '@mui/material';
 
 import { List } from './List';
+import { ListActions } from './ListActions';
 import { Datagrid } from './datagrid';
 import { TextField } from '../field';
 import { SearchInput, TextInput } from '../input';
@@ -209,16 +210,17 @@ export const Title = () => (
     </TestMemoryRouter>
 );
 
-const BookListWithCreate = () => (
-    <List hasCreate={true}>
-        <BookList />
-    </List>
-);
-
 export const HasCreate = () => (
     <TestMemoryRouter initialEntries={['/books']}>
         <Admin dataProvider={dataProvider}>
-            <Resource name="books" list={BookListWithCreate} />
+            <Resource
+                name="books"
+                list={() => (
+                    <List actions={<ListActions hasCreate />}>
+                        <BookList />
+                    </List>
+                )}
+            />
         </Admin>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -118,7 +118,6 @@ List.propTypes = {
     title: TitlePropType,
     // the props managed by react-admin
     disableSyncWithLocation: PropTypes.bool,
-    hasCreate: PropTypes.bool,
     resource: PropTypes.string,
 };
 

--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -17,11 +17,7 @@ export const ListToolbar: FC<ListToolbarProps> = memo(props => {
             <Root className={className}>
                 <FilterForm />
                 <span />
-                {actions &&
-                    React.cloneElement(actions, {
-                        ...rest,
-                        ...actions.props,
-                    })}
+                {actions}
             </Root>
         </FilterContext.Provider>
     ) : (

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -358,5 +358,7 @@ const Root = styled('div', {
 
     [`& .${ListClasses.actions}`]: {},
 
-    [`& .${ListClasses.noResults}`]: {},
+    [`& .${ListClasses.noResults}`]: {
+        flex: 1,
+    },
 }));

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { cloneElement, ReactElement, ReactNode, ElementType } from 'react';
+import { ReactElement, ReactNode, ElementType } from 'react';
 import PropTypes from 'prop-types';
 import { SxProps } from '@mui/system';
 import Card from '@mui/material/Card';
@@ -26,9 +26,7 @@ export const ListView = <RecordType extends RaRecord = any>(
         actions = defaultActions,
         aside,
         filters,
-        bulkActionButtons,
         emptyWhileLoading,
-        hasCreate,
         pagination = defaultPagination,
         children,
         className,
@@ -57,19 +55,9 @@ export const ListView = <RecordType extends RaRecord = any>(
                     className={ListClasses.actions}
                     filters={filters}
                     actions={actions}
-                    hasCreate={hasCreate}
                 />
             )}
-            <Content className={ListClasses.content}>
-                {bulkActionButtons &&
-                children &&
-                React.isValidElement<any>(children)
-                    ? // FIXME remove in 5.0
-                      cloneElement(children, {
-                          bulkActionButtons,
-                      })
-                    : children}
-            </Content>
+            <Content className={ListClasses.content}>{children}</Content>
             {error ? (
                 <Error error={error} resetErrorBoundary={null} />
             ) : (
@@ -79,8 +67,7 @@ export const ListView = <RecordType extends RaRecord = any>(
     );
 
     const renderEmpty = () =>
-        empty !== false &&
-        cloneElement(empty, { className: ListClasses.noResults, hasCreate });
+        empty !== false && <div className={ListClasses.noResults}>{empty}</div>;
 
     const shouldRenderEmptyPage =
         !isPending &&
@@ -112,7 +99,6 @@ ListView.propTypes = {
         PropTypes.element,
         PropTypes.arrayOf(PropTypes.element),
     ]),
-    hasCreate: PropTypes.bool,
     pagination: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     title: TitlePropType,
 };
@@ -180,11 +166,6 @@ export interface ListViewProps {
      * );
      */
     aside?: ReactElement;
-
-    /**
-     * @deprecated pass the bulkActionButtons prop to the List child (Datagrid or SimpleList) instead
-     */
-    bulkActionButtons?: ReactElement | false;
 
     /**
      * A class name to apply to the root div element
@@ -292,21 +273,6 @@ export interface ListViewProps {
      * );
      */
     filters?: ReactElement | ReactElement[];
-
-    /**
-     * Set to true to force a Create button in the toolbar, even if there is no create view declared in Resource
-     *
-     * @see https://marmelab.com/react-admin/List.html#hascreate
-     * @example
-     * import { List } from 'react-admin';
-     *
-     * export const PostList = () => (
-     *     <List hasCreate={false}>
-     *         ...
-     *     </List>
-     * );
-     */
-    hasCreate?: boolean;
 
     /**
      * The pagination component to display. defaults to <Pagination />


### PR DESCRIPTION
## Problem

Wenever we use `cloneElement`, developers find it hard to swap the component with their own as they don't know which props are injected. 

## Solution

Remove `cloneElement` and make child elements pull data from the context. 

Applied to List components. 

Note: there are still some `cloneElement` to support the deprecated `<List filters={<Filter>...</Filter>} />` syntax (instead of `<List filters={[...]} />`). The discussion is open to determine if we should remove those. 

## `<List hasCreate>` Is No Longer Supported

To force a List view to display a Create button even though the corresponding resource doesn't have a `create` component, pass a custom actions component to the List component:

```diff
-import { List } from 'react-admin';
+import { List, ListActions } from 'react-admin';

const PostList = () => (
-   <List hasCreate>
+   <List actions={<ListActions hasCreate />}>
        ...
    </List>
);
```

## Updates to `bulkActionButtons` Syntax

The `bulkActionButtons` prop has been moved from the `<List>` component to the `<Datagrid>` component. 

```diff
const PostList = () => (
-   <List bulkActionButtons={<BulkActionButtons />}>
+   <List>
-      <Datagrid>
+      <Datagrid bulkActionButtons={<BulkActionButtons />}>
           ...
       </Datagrid>
   </List>
);
```

Besides, the buttons passed as `bulkActionButtons` no longer receive any prop. If you need the current filter values or the selected ids, you'll have to use the `useListContext` hook:

```diff
-const BulkResetViewsButton = ({ resource, selectedIds }) => {
+const BulkResetViewsButton = () => {
+   const { resource, selectedIds } = useListContext();
    const notify = useNotify();
    const unselectAll = useUnselectAll(resource);
    const [updateMany, { isPending }] = useUpdateMany();

    const handleClick = () => {
        updateMany(
            resource,
            { ids: selectedIds, data: { views: 0 } },
            {
                onSuccess: () => {
                    notify('Views reset');
                    unselectAll();
                },
                onError: () => notify('Views not reset', { type: 'error' }),
            }
        );
    }
    return (
        <Button
            label="Reset views"
            disabled={isPending}
            onClick={() => updateMany()}
        >
            <VisibilityOff />
        </Button>
    );
};
```
