### PR TITLE
[Doc] Fix Layout doc links to wrong anchor

### DIFF
--- a/docs/Layout.md
+++ b/docs/Layout.md
@@ -366,7 +366,7 @@ This property accepts the following subclasses:
 
 To override the style of `<Layout>` using the [application-wide style overrides](./AppTheme.md#theming-individual-components), use the `RaLayout` key.
 
-**Tip**: If you need to override global styles (like the default font size or family), you should [write a custom theme](./AppTheme.md) rather than override the `<Layout sx>` prop. And if you need to tweak the default layout to add a right column or move the menu to the top, you're probably better off [writing your own layout component](./AppTheme.md#writing-a-custom-theme). 
+**Tip**: If you need to override global styles (like the default font size or family), you should [write a custom theme](./AppTheme.md#writing-a-custom-theme) rather than override the `<Layout sx>` prop. And if you need to tweak the default layout to add a right column or move the menu to the top, you're probably better off [writing your own layout component](./Layout.md#writing-a-layout-from-scratch). 
 
 ## Adding A Custom Context
 

--- a/docs/Layout.md
+++ b/docs/Layout.md
@@ -366,7 +366,7 @@ This property accepts the following subclasses:
 
 To override the style of `<Layout>` using the [application-wide style overrides](./AppTheme.md#theming-individual-components), use the `RaLayout` key.
 
-**Tip**: If you need to override global styles (like the default font size or family), you should [write a custom theme](./AppTheme.md) rather than override the `<Layout sx>` prop. And if you need to tweak the default layout to add a right column or move the menu to the top, you're probably better off [writing your own layout component](./Layout.md#writing-a-layout-from-scratch). 
+**Tip**: If you need to override global styles (like the default font size or family), you should [write a custom theme](./AppTheme.md) rather than override the `<Layout sx>` prop. And if you need to tweak the default layout to add a right column or move the menu to the top, you're probably better off [writing your own layout component](./AppTheme.md#writing-a-custom-theme). 
 
 ## Adding A Custom Context
 


### PR DESCRIPTION
## Problem

When mentioning custom themes, the Layout doc points to the AppTheme page. The custom theme is a section in this page: https://marmelab.com/react-admin/AppTheme.html#writing-a-custom-theme 

## Solution

Update the link to include the anchor. 