### PR TITLE
[Doc] Update `<ReferenceManyToManyInput>` doc

### DIFF
--- a/docs/ReferenceManyToManyInput.md
+++ b/docs/ReferenceManyToManyInput.md
@@ -96,6 +96,7 @@ const BandEdit = () => (
 );
 ```
 
+**Limitation**: `<ReferenceManyToManyInput>` cannot be used to filter a list.
 
 ## Props
 


### PR DESCRIPTION
Explain in documentation that `<ReferenceManyToManyInput>` cannot be used as a Filter.