### PR TITLE
Allow overriding the error props in Input components

### DIFF
--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -269,6 +269,7 @@ const sanitizeRestProps = ({
     setSort,
     loaded,
     touched,
+    error,
     ...rest
 }: any) => sanitizeInputRestProps(rest);
 

--- a/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
@@ -62,13 +62,18 @@ export const DefaultValue = () => (
 
 export const HelperText = () => (
     <Wrapper>
-        <NumberInput source="views" />
-        <NumberInput source="views" helperText={false} />
-        <NumberInput
-            source="views"
-            helperText="Number of times the post was read"
-        />
-    </Wrapper>
+                <NumberInput source="views" />
+                <NumberInput source="views" helperText={false} />
+                <NumberInput
+                    source="views"
+                    helperText="Number of times the post was read"
+                />
+                <NumberInput
+                    source="views"
+                    helperText="Number of times the post was read"
+                    error={true}
+                />
+            </Wrapper>
 );
 
 export const Label = () => (

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -50,13 +50,18 @@ export const DefaultValue = () => (
 
 export const HelperText = () => (
     <Wrapper>
-        <TextInput source="title" />
-        <TextInput source="title" helperText={false} />
-        <TextInput
-            source="title"
-            helperText="Number of times the post was read"
-        />
-    </Wrapper>
+                <TextInput source="title" />
+                <TextInput source="title" helperText={false} />
+                <TextInput
+                    source="title"
+                    helperText="Number of times the post was read"
+                />
+                <TextInput
+                    source="title"
+                    helperText="Number of times the post was read"
+                    error={true}
+                />
+            </Wrapper>
 );
 
 export const Label = () => (

--- a/packages/ra-ui-materialui/src/input/sanitizeInputRestProps.ts
+++ b/packages/ra-ui-materialui/src/input/sanitizeInputRestProps.ts
@@ -6,7 +6,6 @@ export const sanitizeInputRestProps = ({
     component,
     data,
     defaultValue,
-    error,
     format,
     formatOnBlur,
     formClassName,


### PR DESCRIPTION
The basic idea is to be able to override when a helper text becomes an error. In our case we want to override the behaviour of react-admin to only consider a field as errored when the field is touched or submitted. We would _always_ like to show the error message. Unfortunately, react-hook-form does not provide a way to set the internal touched state. However, when being able to override the error prop we can customize the behaviour ourselves.

The CheckboxGroupInput.tsx is also changed here, as the initial omitting of the error prop was introduced to fix a bug in this component. That's also why I moved the omitting of the prop to the local omit within the component.