### PR TITLE
[Doc] Update RBAC to mention ability to define permissions on an array of resources

### DIFF
--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -98,6 +98,7 @@ Here are a few examples of permissions:
 
 - `{ action: "*", resource: "*" }`: allow everything
 - `{ action: "read", resource: "*" }`: allow read actions on all resources
+- `{ action: "read", resource: ["companies", "people"] }`: allow read actions on a subset of resources
 - `{ action: ["read", "create", "edit", "export"], resource: "companies" }`: allow all actions except delete on companies
 - `{ action: ["write"], resource: "game.score", record: { "id": "123" } }`: allow to change the score on a particular game
 


### PR DESCRIPTION
## Problem
In ra-enterprise RBAC package documentation, we now mention the ability to define permissions on an array of resources

## Solution
Update the documentation