### PR TITLE
[Fix] Fix CRM demo error

### DIFF
--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -87,7 +87,8 @@ const DealShowContent = () => {
                                 Start
                             </Typography>
                             <Typography variant="subtitle1">
-                                {format(new Date(record.start_at), 'PP')}
+                                {record.start_at &&
+                                    format(new Date(record.start_at), 'PP')}
                             </Typography>
                         </Box>
 


### PR DESCRIPTION
## Problem
In the CRM demo, there is an error on viewing a newly created deal.:

When you create a new deal. You didn't set se `start_at` value.
On the show page, we try to format this date.
When there is any value in the `start_at` column, we have an error.

## Solution
Format this value conditionally