### PR TITLE
[TypeScript] Make types more strict in ra-core, part II

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -1128,7 +1128,7 @@ const MyCustomList = () => {
 };
 ```
 
-This list has no filtering, sorting, or row selection - it's static. If you want to allow users to interact with this list, you should pass more props to the `<Datagrid>` component, but the logic isn't trivial. Fortunately, react-admin provides [the `useList` hook](./useList.md) to build callbacks to manipulate local data. You just have to put the result in a `ListContext` to have an interactive `<Datagrid>`:
+This list has no filtering, sorting, or row selection - it's static. If you want to allow users to interact with the `<Datagrid>`, use [the `useList` hook](./useList.md) to build callbacks to manipulate local data. You will have to put the result in a `<ListContextProvider>` parent component:
 
 ```tsx
 import {

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -827,6 +827,18 @@ const MyCustomList = () => {
 
 Besides, these hooks will now throw an error when called outside of a page context. This means that you can't use them in a custom component that is not a child of a `<List>`, `<ListBase>`, `<Edit>`, `<EditBase>`, `<Show>`, `<ShowBase>`, `<Create>`, or `<CreateBase>` component.
 
+## TypeScript: `EditProps` and `CreateProps` now expect a `children` prop
+
+`EditProps` and `CreateProps` now expect a `children` prop, just like `ListProps` and `ShowProps`. If you were using these types in your custom components, you'll have to update them:
+
+```diff
+-const ReviewEdit = ({ id }: EditProps) => (
++const ReviewEdit = ({ id }: Omit<EditProps, 'children'>) => (
+   <Edit id={id}>
+        <SimpleForm>
+            ...
+```
+
 ## List Components Can No Longer Be Used In Standalone
 
 An undocumented feature allowed some components designed for list pages to be used outside of a list page, by relying on their props instead of the `ListContext`. This feature was removed in v5.

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -270,6 +270,26 @@ const App = () => (
 );
 ```
 
+## Custom Edit or Show Actions No Longer Receive Any Props
+
+React-admin used to inject the `record` and `resource` props to custom edit or show actions. These props are no longer injected in v5. If you need them, you'll have to use the `useRecordContext` and `useResourceContext` hooks instead. But if you use the standard react-admin buttons like `<ShowButton>`, which already uses these hooks, you don't need inject anything.
+
+```diff
+-const MyEditActions = ({ data }) => (
++const MyEditActions = () => (
+    <TopToolbar>
+-       <ShowButton record={data} />
++       <ShowButton />
+    </TopToolbar>
+);
+
+const PostEdit = () => (
+    <Edit actions={<MyEditActions />} {...props}>
+        ...
+    </Edit>
+);
+```
+
 ## Removed deprecated hooks
 
 The following deprecated hooks have been removed

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -751,6 +751,108 @@ describe('my test suite', () => {
 });
 ```
 
+## TypeScript: Page Contexts Are Now Types Instead of Interfaces
+
+The return type of page controllers is now a type. If you were using an interface extending one of:
+
+- `ListControllerResult`,
+- `InfiniteListControllerResult`,
+- `EditControllerResult`,
+- `ShowControllerResult`, or
+- `CreateControllerResult`,
+
+you'll have to change it to a type:
+
+```diff
+import { ListControllerResult } from 'react-admin';
+
+-interface MyListControllerResult extends ListControllerResult {
++type MyListControllerResult = ListControllerResult & {
+    customProp: string;
+};
+```
+
+## TypeScript: Stronger Types For Page Contexts
+
+The return type of page context hooks is now smarter. This concerns the following hooks:
+
+- `useListContext`,
+- `useEditContext`,
+- `useShowContext`, and
+- `useCreateContext`
+
+Depending on the fetch status of the data, the type of the `data`, `error`, and `isPending` properties will be more precise:
+
+- Loading: `{ data: undefined, error: undefined, isPending: true }`
+- Success: `{ data: <Data>, error: undefined, isPending: false }`
+- Error: `{ data: undefined, error: <Error>, isPending: false }`
+- Error After Refetch: `{ data: <Data>, error: <Error>, isPending: false }`
+
+This means that TypeScript may complain if you use the `data` property without checking if it's defined first. You'll have to update your code to handle the different states:
+
+```diff
+const MyCustomList = () => {
+    const { data, error, isPending } = useListContext();
+    if (isPending) return <Loading />;
++   if (error) return <Error />;
+    return (
+        <ul>
+            {data.map(record => (
+                <li key={record.id}>{record.name}</li>
+            ))}
+        </ul>
+    );
+};
+```
+
+Besides, these hooks will now throw an error when called outside of a page context. This means that you can't use them in a custom component that is not a child of a `<List>`, `<ListBase>`, `<Edit>`, `<EditBase>`, `<Show>`, `<ShowBase>`, `<Create>`, or `<CreateBase>` component.
+
+## List Components Can No Longer Be Used In Standalone
+
+An undocumented feature allowed some components designed for list pages to be used outside of a list page, by relying on their props instead of the `ListContext`. This feature was removed in v5.
+
+This concerns the following components:
+
+- `<BulkActionsToolbar>`
+- `<BulkDeleteWithConfirmButton>`
+- `<BulkDeleteWithUndoButton>`
+- `<BulkExportButton>`
+- `<BulkUpdateWithConfirmButton>`
+- `<BulkUpdateWithUndoButton>`
+- `<EditActions>`
+- `<ExportButton>`
+- `<FilterButton>`
+- `<FilterForm>`
+- `<ListActions>`
+- `<Pagination>`
+- `<UpdateWithConfirmButton>`
+- `<UpdateWithUndoButton>`
+
+To continue using these components, you'll have to wrap them in a `<ListContextProvider>` component:
+
+```diff
+const MyPagination = ({
+    page,
+    perPage,
+    total,
+    setPage,
+    setPerPage,
+}) => {
+    return (
+-       <Pagination page={page} perPage={perPage} total={total} setPage={setPage} setPerPage={setPerPage} />
++       <ListContextProvider value={{ page, perPage, total, setPage, setPerPage }}>
++           <Pagination />
++       </ListContextProvider>
+    );
+};
+```
+
+The following components are not affected and can still be used in standalone mode:
+
+- `<Datagrid>`
+- `<SimpleList>`
+- `<SingleFieldList>`
+
 ## Upgrading to v4
 
 If you are on react-admin v3, follow the [Upgrading to v4](https://marmelab.com/react-admin/doc/4.16/Upgrade.html) guide before upgrading to v5.

--- a/examples/crm/src/companies/CompanyShow.tsx
+++ b/examples/crm/src/companies/CompanyShow.tsx
@@ -146,8 +146,8 @@ const TabPanel = (props: TabPanelProps) => {
 };
 
 const ContactsIterator = () => {
-    const { data: contacts, isPending } = useListContext<Contact>();
-    if (isPending) return null;
+    const { data: contacts, error, isPending } = useListContext<Contact>();
+    if (isPending || error) return null;
 
     const now = Date.now();
     return (
@@ -214,8 +214,8 @@ const CreateRelatedContactButton = () => {
 };
 
 const DealsIterator = () => {
-    const { data: deals, isPending } = useListContext<Deal>();
-    if (isPending) return null;
+    const { data: deals, error, isPending } = useListContext<Deal>();
+    if (isPending || error) return null;
 
     const now = Date.now();
     return (

--- a/examples/crm/src/companies/GridList.tsx
+++ b/examples/crm/src/companies/GridList.tsx
@@ -26,9 +26,9 @@ const LoadingGridList = () => (
 );
 
 const LoadedGridList = () => {
-    const { data, isPending } = useListContext<Company>();
+    const { data, error, isPending } = useListContext<Company>();
 
-    if (isPending) return null;
+    if (isPending || error) return null;
 
     return (
         <Box display="flex" flexWrap="wrap" width="100%" gap={1}>

--- a/examples/crm/src/contacts/ContactAside.tsx
+++ b/examples/crm/src/contacts/ContactAside.tsx
@@ -111,8 +111,8 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
 };
 
 const TasksIterator = () => {
-    const { data, isLoading } = useListContext();
-    if (isLoading || data.length === 0) return null;
+    const { data, error, isPending } = useListContext();
+    if (isPending || error || data.length === 0) return null;
     return (
         <Box>
             <Typography variant="subtitle2">Tasks</Typography>

--- a/examples/crm/src/contacts/ContactList.tsx
+++ b/examples/crm/src/contacts/ContactList.tsx
@@ -38,12 +38,16 @@ import { Contact } from '../types';
 const ContactListContent = () => {
     const {
         data: contacts,
+        error,
         isPending,
         onToggleItem,
         selectedIds,
     } = useListContext<Contact>();
     if (isPending) {
         return <SimpleListLoading hasLeftAvatarOrIcon hasSecondaryText />;
+    }
+    if (error) {
+        return null;
     }
     const now = Date.now();
 

--- a/examples/crm/src/deals/ContactList.tsx
+++ b/examples/crm/src/deals/ContactList.tsx
@@ -4,9 +4,9 @@ import { Box, Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 
 export const ContactList = () => {
-    const { data, isPending } = useListContext();
+    const { data, error, isPending } = useListContext();
 
-    if (isPending) return <div style={{ height: '2em' }} />;
+    if (isPending || error) return <div style={{ height: '2em' }} />;
     return (
         <Box
             component="ul"

--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -34,6 +34,10 @@ export const DealCreate = ({ open }: { open: boolean }) => {
     const queryClient = useQueryClient();
 
     const onSuccess = async (deal: Deal) => {
+        if (!allDeals) {
+            redirect('/deals');
+            return;
+        }
         // increase the index of all deals in the same stage as the new deal
         // first, get the list of deals in the same stage
         const deals = allDeals.filter(

--- a/examples/crm/src/notes/NotesIterator.tsx
+++ b/examples/crm/src/notes/NotesIterator.tsx
@@ -12,8 +12,8 @@ export const NotesIterator = ({
     showStatus?: boolean;
     reference: 'contacts' | 'deals';
 }) => {
-    const { data, isPending } = useListContext();
-    if (isPending) return null;
+    const { data, error, isPending } = useListContext();
+    if (isPending || error) return null;
     return (
         <>
             <NewNote showStatus={showStatus} reference={reference} />

--- a/examples/demo/src/categories/CategoryList.tsx
+++ b/examples/demo/src/categories/CategoryList.tsx
@@ -31,8 +31,11 @@ const CategoryList = () => (
 );
 
 const CategoryGrid = () => {
-    const { data, isPending } = useListContext<Category>();
+    const { data, error, isPending } = useListContext<Category>();
     if (isPending) {
+        return null;
+    }
+    if (error) {
         return null;
     }
     return (

--- a/examples/demo/src/orders/MobileGrid.tsx
+++ b/examples/demo/src/orders/MobileGrid.tsx
@@ -16,9 +16,9 @@ import CustomerReferenceField from '../visitors/CustomerReferenceField';
 import { Order } from '../types';
 
 const MobileGrid = () => {
-    const { data, isPending } = useListContext<Order>();
+    const { data, error, isPending } = useListContext<Order>();
     const translate = useTranslate();
-    if (isPending || data.length === 0) {
+    if (isPending || (data && data.length === 0) || error) {
         return null;
     }
     return (

--- a/examples/demo/src/orders/MobileGrid.tsx
+++ b/examples/demo/src/orders/MobileGrid.tsx
@@ -18,7 +18,7 @@ import { Order } from '../types';
 const MobileGrid = () => {
     const { data, error, isPending } = useListContext<Order>();
     const translate = useTranslate();
-    if (isPending || (data && data.length === 0) || error) {
+    if (isPending || error || data.length === 0) {
         return null;
     }
     return (

--- a/examples/demo/src/reviews/ReviewEdit.tsx
+++ b/examples/demo/src/reviews/ReviewEdit.tsx
@@ -5,7 +5,6 @@ import {
     TextInput,
     SimpleForm,
     DateField,
-    EditProps,
     Labeled,
 } from 'react-admin';
 import { Box, Grid, Stack, IconButton, Typography } from '@mui/material';
@@ -17,11 +16,12 @@ import StarRatingField from './StarRatingField';
 import ReviewEditToolbar from './ReviewEditToolbar';
 import { Review } from '../types';
 
-interface Props extends EditProps<Review> {
+interface ReviewEditProps {
+    id: Review['id'];
     onCancel: () => void;
 }
 
-const ReviewEdit = ({ id, onCancel }: Props) => {
+const ReviewEdit = ({ id, onCancel }: ReviewEditProps) => {
     const translate = useTranslate();
     return (
         <EditBase id={id}>

--- a/examples/demo/src/reviews/ReviewListMobile.tsx
+++ b/examples/demo/src/reviews/ReviewListMobile.tsx
@@ -6,8 +6,8 @@ import { ReviewItem } from './ReviewItem';
 import { Review } from './../types';
 
 const ReviewListMobile = () => {
-    const { data, isPending, total } = useListContext<Review>();
-    if (isPending || Number(total) === 0) {
+    const { data, error, isPending, total } = useListContext<Review>();
+    if (isPending || error || Number(total) === 0) {
         return null;
     }
     return (

--- a/examples/demo/src/visitors/MobileGrid.tsx
+++ b/examples/demo/src/visitors/MobileGrid.tsx
@@ -17,9 +17,9 @@ import { Customer } from '../types';
 
 const MobileGrid = () => {
     const translate = useTranslate();
-    const { data, isPending } = useListContext<Customer>();
+    const { data, error, isPending } = useListContext<Customer>();
 
-    if (isPending || data.length === 0) {
+    if (isPending || error || (data && data.length === 0)) {
         return null;
     }
 

--- a/examples/demo/src/visitors/MobileGrid.tsx
+++ b/examples/demo/src/visitors/MobileGrid.tsx
@@ -19,7 +19,7 @@ const MobileGrid = () => {
     const translate = useTranslate();
     const { data, error, isPending } = useListContext<Customer>();
 
-    if (isPending || error || (data && data.length === 0)) {
+    if (isPending || error || data.length === 0) {
         return null;
     }
 

--- a/examples/simple/src/customRouteLayout.tsx
+++ b/examples/simple/src/customRouteLayout.tsx
@@ -30,6 +30,8 @@ const CustomRouteLayout = ({ title = 'Posts' }) => {
                 isPending={isPending}
                 total={total}
                 rowClick="edit"
+                bulkActionButtons={false}
+                resource="posts"
             >
                 <TextField source="id" sortable={false} />
                 <TextField source="title" sortable={false} />

--- a/packages/ra-core/src/controller/create/CreateContext.tsx
+++ b/packages/ra-core/src/controller/create/CreateContext.tsx
@@ -19,13 +19,6 @@ import { CreateControllerResult } from './useCreateController';
  *     );
  * };
  */
-export const CreateContext = createContext<CreateControllerResult>({
-    isFetching: false,
-    isLoading: false,
-    isPending: false,
-    redirect: false,
-    resource: '',
-    saving: false,
-});
+export const CreateContext = createContext<CreateControllerResult | null>(null);
 
 CreateContext.displayName = 'CreateContext';

--- a/packages/ra-core/src/controller/create/CreateContext.tsx
+++ b/packages/ra-core/src/controller/create/CreateContext.tsx
@@ -20,17 +20,12 @@ import { CreateControllerResult } from './useCreateController';
  * };
  */
 export const CreateContext = createContext<CreateControllerResult>({
-    record: null,
-    defaultTitle: null,
-    isFetching: null,
-    isLoading: null,
-    isPending: null,
-    redirect: null,
-    resource: null,
-    save: null,
-    saving: null,
-    registerMutationMiddleware: null,
-    unregisterMutationMiddleware: null,
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+    redirect: false,
+    resource: '',
+    saving: false,
 });
 
 CreateContext.displayName = 'CreateContext';

--- a/packages/ra-core/src/controller/create/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/create/useCreateContext.tsx
@@ -24,7 +24,7 @@ import { CreateControllerResult } from './useCreateController';
  */
 export const useCreateContext = <RecordType extends RaRecord = RaRecord>(
     props?: any
-): Partial<CreateControllerResult<RecordType>> => {
+): CreateControllerResult<RecordType> => {
     const context = useContext(CreateContext);
     // Props take precedence over the context
     return useMemo(

--- a/packages/ra-core/src/controller/create/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/create/useCreateContext.tsx
@@ -23,19 +23,17 @@ import { CreateControllerResult } from './useCreateController';
  *
  */
 export const useCreateContext = <RecordType extends RaRecord = RaRecord>(
-    props?: Partial<CreateControllerResult<RecordType>>
-): CreateControllerResult<RecordType> => {
-    const context = useContext<CreateControllerResult<RecordType>>(
-        // Can't find a way to specify the RecordType when CreateContext is declared
-        // @ts-ignore
-        CreateContext
-    );
+    props?: any
+): Partial<CreateControllerResult<RecordType>> => {
+    const context = useContext(CreateContext);
     // Props take precedence over the context
     return useMemo(
         () =>
             defaults(
                 {},
-                props != null ? extractCreateContextProps(props) : {},
+                props != null
+                    ? extractCreateContextProps<RecordType>(props)
+                    : {},
                 context
             ),
         [context, props]
@@ -49,7 +47,7 @@ export const useCreateContext = <RecordType extends RaRecord = RaRecord>(
  *
  * @returns {CreateControllerResult} create controller props
  */
-const extractCreateContextProps = ({
+const extractCreateContextProps = <RecordType extends RaRecord = any>({
     record,
     defaultTitle,
     isFetching,
@@ -59,7 +57,7 @@ const extractCreateContextProps = ({
     resource,
     save,
     saving,
-}: any) => ({
+}: Partial<CreateControllerResult<RecordType>>) => ({
     record,
     defaultTitle,
     isFetching,

--- a/packages/ra-core/src/controller/create/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/create/useCreateContext.tsx
@@ -1,5 +1,4 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import { RaRecord } from '../../types';
 import { CreateContext } from './CreateContext';
@@ -8,63 +7,20 @@ import { CreateControllerResult } from './useCreateController';
 /**
  * Hook to read the create controller props from the CreateContext.
  *
- * Mostly used within a <CreateContext.Provider> (e.g. as a descendent of <Create>).
- *
- * But you can also use it without a <CreateContext.Provider>. In this case, it is up to you
- * to pass all the necessary props.
- *
- * The given props will take precedence over context values.
- *
- * @typedef {Object} CreateControllerProps
+ * Used within a <CreateContextProvider> (e.g. as a descendent of <Create>).
  *
  * @returns {CreateControllerResult} create controller props
  *
  * @see useCreateController for how it is filled
- *
  */
-export const useCreateContext = <RecordType extends RaRecord = RaRecord>(
-    props?: any
-): CreateControllerResult<RecordType> => {
+export const useCreateContext = <
+    RecordType extends RaRecord = RaRecord
+>(): CreateControllerResult<RecordType> => {
     const context = useContext(CreateContext);
-    // Props take precedence over the context
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null
-                    ? extractCreateContextProps<RecordType>(props)
-                    : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useCreateContext must be used inside a CreateContextProvider'
+        );
+    }
+    return context;
 };
-
-/**
- * Extract only the create controller props
- *
- * @param {Object} props props passed to the useCreateContext hook
- *
- * @returns {CreateControllerResult} create controller props
- */
-const extractCreateContextProps = <RecordType extends RaRecord = any>({
-    record,
-    defaultTitle,
-    isFetching,
-    isLoading,
-    isPending,
-    redirect,
-    resource,
-    save,
-    saving,
-}: Partial<CreateControllerResult<RecordType>>) => ({
-    record,
-    defaultTitle,
-    isFetching,
-    isLoading,
-    isPending,
-    redirect,
-    resource,
-    save,
-    saving,
-});

--- a/packages/ra-core/src/controller/edit/EditContext.tsx
+++ b/packages/ra-core/src/controller/edit/EditContext.tsx
@@ -20,19 +20,13 @@ import { EditControllerResult } from './useEditController';
  * };
  */
 export const EditContext = createContext<EditControllerResult>({
-    record: null,
-    defaultTitle: null,
-    isFetching: null,
-    isLoading: null,
-    isPending: null,
-    mutationMode: null,
-    redirect: null,
-    refetch: null,
-    resource: null,
-    save: null,
-    saving: null,
-    registerMutationMiddleware: null,
-    unregisterMutationMiddleware: null,
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+    redirect: false,
+    refetch: () => Promise.reject('not implemented'),
+    resource: '',
+    saving: false,
 });
 
 EditContext.displayName = 'EditContext';

--- a/packages/ra-core/src/controller/edit/EditContext.tsx
+++ b/packages/ra-core/src/controller/edit/EditContext.tsx
@@ -20,9 +20,11 @@ import { EditControllerResult } from './useEditController';
  * };
  */
 export const EditContext = createContext<EditControllerResult>({
+    record: null,
     isFetching: false,
     isLoading: false,
     isPending: false,
+    error: null,
     redirect: false,
     refetch: () => Promise.reject('not implemented'),
     resource: '',

--- a/packages/ra-core/src/controller/edit/EditContext.tsx
+++ b/packages/ra-core/src/controller/edit/EditContext.tsx
@@ -19,16 +19,6 @@ import { EditControllerResult } from './useEditController';
  *     );
  * };
  */
-export const EditContext = createContext<EditControllerResult>({
-    record: null,
-    isFetching: false,
-    isLoading: false,
-    isPending: false,
-    error: null,
-    redirect: false,
-    refetch: () => Promise.reject('not implemented'),
-    resource: '',
-    saving: false,
-});
+export const EditContext = createContext<EditControllerResult | null>(null);
 
 EditContext.displayName = 'EditContext';

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -24,10 +24,8 @@ import { EditControllerResult } from './useEditController';
  */
 export const useEditContext = <RecordType extends RaRecord = any>(
     props?: any
-): Partial<EditControllerResult<RecordType>> => {
-    // Can't find a way to specify the RecordType when EditContext is declared
+): EditControllerResult<RecordType> => {
     const context = useContext(EditContext);
-
     // Props take precedence over the context
     return useMemo(
         () =>

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -6,69 +6,22 @@ import { EditContext } from './EditContext';
 import { EditControllerResult } from './useEditController';
 
 /**
- * Hook to read the edit controller props from the CreateContext.
+ * Hook to read the edit controller props from the EditContext.
  *
- * Mostly used within a <EditContext.Provider> (e.g. as a descendent of <Edit>).
- *
- * But you can also use it without a <EditContext.Provider>. In this case, it is up to you
- * to pass all the necessary props.
- *
- * The given props will take precedence over context values.
- *
- * @typedef {Object} EditControllerProps
+ * Used within a <EditContextProvider> (e.g. as a descendent of <Edit>).
  *
  * @returns {EditControllerResult} edit controller props
  *
  * @see useEditController for how it is filled
- *
  */
-export const useEditContext = <RecordType extends RaRecord = any>(
-    props?: any
-): EditControllerResult<RecordType> => {
+export const useEditContext = <
+    RecordType extends RaRecord = any
+>(): EditControllerResult<RecordType> => {
     const context = useContext(EditContext);
-    // Props take precedence over the context
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null ? extractEditContextProps<RecordType>(props) : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useEditContext must be used inside an EditContextProvider'
+        );
+    }
+    return context;
 };
-
-/**
- * Extract only the edit controller props
- *
- * @param {Object} props props passed to the useEditContext hook
- *
- * @returns {EditControllerResult} edit controller props
- */
-const extractEditContextProps = <RecordType extends RaRecord = any>({
-    data,
-    record,
-    defaultTitle,
-    isFetching,
-    isLoading,
-    isPending,
-    mutationMode,
-    redirect,
-    resource,
-    save,
-    saving,
-}: Partial<EditControllerResult<RecordType>> & Record<string, any>) => ({
-    // Necessary for actions (EditActions) which expect a data prop containing the record
-    // @deprecated - to be removed in 4.0d
-    data: record || data,
-    record: record || data,
-    defaultTitle,
-    isFetching,
-    isLoading,
-    isPending,
-    mutationMode,
-    redirect,
-    resource,
-    save,
-    saving,
-});

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -23,18 +23,17 @@ import { EditControllerResult } from './useEditController';
  *
  */
 export const useEditContext = <RecordType extends RaRecord = any>(
-    props?: Partial<EditControllerResult<RecordType>>
-): EditControllerResult<RecordType> => {
+    props?: any
+): Partial<EditControllerResult<RecordType>> => {
     // Can't find a way to specify the RecordType when EditContext is declared
-    // @ts-ignore
-    const context = useContext<EditControllerResult<RecordType>>(EditContext);
+    const context = useContext(EditContext);
 
     // Props take precedence over the context
     return useMemo(
         () =>
             defaults(
                 {},
-                props != null ? extractEditContextProps(props) : {},
+                props != null ? extractEditContextProps<RecordType>(props) : {},
                 context
             ),
         [context, props]
@@ -48,7 +47,7 @@ export const useEditContext = <RecordType extends RaRecord = any>(
  *
  * @returns {EditControllerResult} edit controller props
  */
-const extractEditContextProps = ({
+const extractEditContextProps = <RecordType extends RaRecord = any>({
     data,
     record,
     defaultTitle,
@@ -60,7 +59,7 @@ const extractEditContextProps = ({
     resource,
     save,
     saving,
-}: any) => ({
+}: Partial<EditControllerResult<RecordType>> & Record<string, any>) => ({
     // Necessary for actions (EditActions) which expect a data prop containing the record
     // @deprecated - to be removed in 4.0d
     data: record || data,

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -1,5 +1,4 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import { RaRecord } from '../../types';
 import { EditContext } from './EditContext';

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -240,7 +240,6 @@ export const useEditController = <
         ]
     );
 
-    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'."
     return {
         defaultTitle,
         error,
@@ -256,7 +255,7 @@ export const useEditController = <
         save,
         saving,
         unregisterMutationMiddleware,
-    };
+    } as EditControllerResult<RecordType>;
 };
 
 const DefaultRedirect = 'list';

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -240,6 +240,7 @@ export const useEditController = <
         ]
     );
 
+    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'."
     return {
         defaultTitle,
         error,
@@ -258,6 +259,8 @@ export const useEditController = <
     };
 };
 
+const DefaultRedirect = 'list';
+
 export interface EditControllerProps<
     RecordType extends RaRecord = any,
     ErrorType = Error
@@ -273,20 +276,47 @@ export interface EditControllerProps<
     [key: string]: any;
 }
 
-export interface EditControllerResult<RecordType extends RaRecord = any>
+export interface EditControllerBaseResult<RecordType extends RaRecord = any>
     extends SaveContextValue<RecordType> {
-    // Necessary for actions (EditActions) which expect a data prop containing the record
-    // @deprecated - to be removed in 4.0d
-    data?: RecordType;
-    error?: any;
     defaultTitle?: string;
     isFetching: boolean;
     isLoading: boolean;
-    isPending: boolean;
-    record?: RecordType;
     refetch: UseGetOneHookValue<RecordType>['refetch'];
     redirect: RedirectionSideEffect;
     resource: string;
 }
 
-const DefaultRedirect = 'list';
+interface EditControllerLoadingResult<RecordType extends RaRecord = any>
+    extends EditControllerBaseResult<RecordType> {
+    record: undefined;
+    error: null;
+    isPending: true;
+}
+interface EditControllerLoadingErrorResult<
+    RecordType extends RaRecord = any,
+    TError = Error
+> extends EditControllerBaseResult<RecordType> {
+    record: undefined;
+    error: TError;
+    isPending: false;
+}
+interface EditControllerRefetchErrorResult<
+    RecordType extends RaRecord = any,
+    TError = Error
+> extends EditControllerBaseResult<RecordType> {
+    record: RecordType;
+    error: TError;
+    isPending: false;
+}
+interface EditControllerSuccessResult<RecordType extends RaRecord = any>
+    extends EditControllerBaseResult<RecordType> {
+    record: RecordType;
+    error: null;
+    isPending: false;
+}
+
+export type EditControllerResult<RecordType extends RaRecord = any> =
+    | EditControllerLoadingResult<RecordType>
+    | EditControllerLoadingErrorResult<RecordType>
+    | EditControllerRefetchErrorResult<RecordType>
+    | EditControllerSuccessResult<RecordType>;

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -285,13 +285,13 @@ export interface EditControllerBaseResult<RecordType extends RaRecord = any>
     resource: string;
 }
 
-interface EditControllerLoadingResult<RecordType extends RaRecord = any>
+export interface EditControllerLoadingResult<RecordType extends RaRecord = any>
     extends EditControllerBaseResult<RecordType> {
     record: undefined;
     error: null;
     isPending: true;
 }
-interface EditControllerLoadingErrorResult<
+export interface EditControllerLoadingErrorResult<
     RecordType extends RaRecord = any,
     TError = Error
 > extends EditControllerBaseResult<RecordType> {
@@ -299,7 +299,7 @@ interface EditControllerLoadingErrorResult<
     error: TError;
     isPending: false;
 }
-interface EditControllerRefetchErrorResult<
+export interface EditControllerRefetchErrorResult<
     RecordType extends RaRecord = any,
     TError = Error
 > extends EditControllerBaseResult<RecordType> {
@@ -307,7 +307,7 @@ interface EditControllerRefetchErrorResult<
     error: TError;
     isPending: false;
 }
-interface EditControllerSuccessResult<RecordType extends RaRecord = any>
+export interface EditControllerSuccessResult<RecordType extends RaRecord = any>
     extends EditControllerBaseResult<RecordType> {
     record: RecordType;
     error: null;

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -203,6 +203,7 @@ export const useReferenceManyFieldController = <
         }
     );
 
+    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort,
         data,

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -203,7 +203,6 @@ export const useReferenceManyFieldController = <
         }
     );
 
-    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort,
         data,
@@ -235,5 +234,5 @@ export const useReferenceManyFieldController = <
         setSort,
         showFilter,
         total,
-    };
+    } as ListControllerResult<ReferenceRecordType>;
 };

--- a/packages/ra-core/src/controller/list/InfinitePaginationContext.ts
+++ b/packages/ra-core/src/controller/list/InfinitePaginationContext.ts
@@ -26,12 +26,12 @@ import { InfiniteListControllerResult } from './useInfiniteListController';
 export const InfinitePaginationContext = createContext<
     InfinitePaginationContextValue
 >({
-    hasNextPage: null,
-    fetchNextPage: null,
-    isFetchingNextPage: null,
-    hasPreviousPage: null,
-    fetchPreviousPage: null,
-    isFetchingPreviousPage: null,
+    hasNextPage: false,
+    fetchNextPage: () => Promise.reject('not implemented'),
+    isFetchingNextPage: false,
+    hasPreviousPage: false,
+    fetchPreviousPage: () => Promise.reject('not implemented'),
+    isFetchingPreviousPage: false,
 });
 
 InfinitePaginationContext.displayName = 'InfinitePaginationContext';

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -55,6 +55,9 @@ import { SORT_ASC } from './queryReducer';
  * };
  */
 export const ListContext = createContext<ListControllerResult>({
+    data: [],
+    total: 0,
+    error: null,
     sort: {
         field: 'id',
         order: SORT_ASC,
@@ -98,7 +101,6 @@ export const ListContext = createContext<ListControllerResult>({
     showFilter: () => {
         throw new Error('not implemented');
     },
-    total: undefined,
 });
 
 ListContext.displayName = 'ListContext';

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -1,5 +1,7 @@
 import { createContext } from 'react';
 import { ListControllerResult } from './useListController';
+import { th } from 'date-fns/locale';
+import { SORT_ASC } from './queryReducer';
 
 /**
  * Context to store the result of the useListController() hook.
@@ -53,32 +55,50 @@ import { ListControllerResult } from './useListController';
  * };
  */
 export const ListContext = createContext<ListControllerResult>({
-    sort: null,
-    data: null,
-    defaultTitle: null,
+    sort: {
+        field: 'id',
+        order: SORT_ASC,
+    },
     displayedFilters: null,
-    exporter: null,
     filterValues: null,
-    hasNextPage: null,
-    hasPreviousPage: null,
-    hideFilter: null,
-    isFetching: null,
-    isLoading: null,
-    isPending: null,
-    onSelect: null,
-    onToggleItem: null,
-    onUnselectItems: null,
-    page: null,
-    perPage: null,
-    refetch: null,
-    resource: null,
-    selectedIds: undefined,
-    setFilters: null,
-    setPage: null,
-    setPerPage: null,
-    setSort: null,
-    showFilter: null,
-    total: null,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    hideFilter: () => {
+        throw new Error('not implemented');
+    },
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+    onSelect: () => {
+        throw new Error('not implemented');
+    },
+    onToggleItem: () => {
+        throw new Error('not implemented');
+    },
+    onUnselectItems: () => {
+        throw new Error('not implemented');
+    },
+    page: 1,
+    perPage: 25,
+    refetch: () => Promise.reject('not implemented'),
+    resource: '',
+    selectedIds: [],
+    setFilters: () => {
+        throw new Error('not implemented');
+    },
+    setPage: () => {
+        throw new Error('not implemented');
+    },
+    setPerPage: () => {
+        throw new Error('not implemented');
+    },
+    setSort: () => {
+        throw new Error('not implemented');
+    },
+    showFilter: () => {
+        throw new Error('not implemented');
+    },
+    total: undefined,
 });
 
 ListContext.displayName = 'ListContext';

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -1,7 +1,5 @@
 import { createContext } from 'react';
 import { ListControllerResult } from './useListController';
-import { th } from 'date-fns/locale';
-import { SORT_ASC } from './queryReducer';
 
 /**
  * Context to store the result of the useListController() hook.
@@ -54,53 +52,6 @@ import { SORT_ASC } from './queryReducer';
  *     );
  * };
  */
-export const ListContext = createContext<ListControllerResult>({
-    data: [],
-    total: 0,
-    error: null,
-    sort: {
-        field: 'id',
-        order: SORT_ASC,
-    },
-    displayedFilters: null,
-    filterValues: null,
-    hasNextPage: false,
-    hasPreviousPage: false,
-    hideFilter: () => {
-        throw new Error('not implemented');
-    },
-    isFetching: false,
-    isLoading: false,
-    isPending: false,
-    onSelect: () => {
-        throw new Error('not implemented');
-    },
-    onToggleItem: () => {
-        throw new Error('not implemented');
-    },
-    onUnselectItems: () => {
-        throw new Error('not implemented');
-    },
-    page: 1,
-    perPage: 25,
-    refetch: () => Promise.reject('not implemented'),
-    resource: '',
-    selectedIds: [],
-    setFilters: () => {
-        throw new Error('not implemented');
-    },
-    setPage: () => {
-        throw new Error('not implemented');
-    },
-    setPerPage: () => {
-        throw new Error('not implemented');
-    },
-    setSort: () => {
-        throw new Error('not implemented');
-    },
-    showFilter: () => {
-        throw new Error('not implemented');
-    },
-});
+export const ListContext = createContext<ListControllerResult | null>(null);
 
 ListContext.displayName = 'ListContext';

--- a/packages/ra-core/src/controller/list/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/list/ListFilterContext.tsx
@@ -40,10 +40,16 @@ import { ListControllerResult } from './useListController';
 export const ListFilterContext = createContext<ListFilterContextValue>({
     displayedFilters: null,
     filterValues: null,
-    hideFilter: null,
-    setFilters: null,
-    showFilter: null,
-    resource: null,
+    hideFilter: () => {
+        throw new Error('not implemented');
+    },
+    setFilters: () => {
+        throw new Error('not implemented');
+    },
+    showFilter: () => {
+        throw new Error('not implemented');
+    },
+    resource: '',
 });
 
 export type ListFilterContextValue = Pick<

--- a/packages/ra-core/src/controller/list/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/list/ListFilterContext.tsx
@@ -37,20 +37,9 @@ import { ListControllerResult } from './useListController';
  *     );
  * };
  */
-export const ListFilterContext = createContext<ListFilterContextValue>({
-    displayedFilters: null,
-    filterValues: null,
-    hideFilter: () => {
-        throw new Error('not implemented');
-    },
-    setFilters: () => {
-        throw new Error('not implemented');
-    },
-    showFilter: () => {
-        throw new Error('not implemented');
-    },
-    resource: '',
-});
+export const ListFilterContext = createContext<
+    ListFilterContextValue | undefined
+>(undefined);
 
 export type ListFilterContextValue = Pick<
     ListControllerResult,

--- a/packages/ra-core/src/controller/list/ListPaginationContext.tsx
+++ b/packages/ra-core/src/controller/list/ListPaginationContext.tsx
@@ -42,16 +42,19 @@ import { ListControllerResult } from './useListController';
  * };
  */
 export const ListPaginationContext = createContext<ListPaginationContextValue>({
-    isLoading: null,
-    isPending: null,
-    page: null,
-    perPage: null,
-    setPage: null,
-    setPerPage: null,
-    hasPreviousPage: null,
-    hasNextPage: null,
-    total: undefined,
-    resource: null,
+    isLoading: false,
+    isPending: false,
+    page: 1,
+    perPage: 25,
+    setPage: () => {
+        throw new Error('not implemented');
+    },
+    setPerPage: () => {
+        throw new Error('not implemented');
+    },
+    hasPreviousPage: false,
+    hasNextPage: false,
+    resource: '',
 });
 
 ListPaginationContext.displayName = 'ListPaginationContext';

--- a/packages/ra-core/src/controller/list/ListPaginationContext.tsx
+++ b/packages/ra-core/src/controller/list/ListPaginationContext.tsx
@@ -44,6 +44,7 @@ import { ListControllerResult } from './useListController';
 export const ListPaginationContext = createContext<ListPaginationContextValue>({
     isLoading: false,
     isPending: false,
+    total: 0,
     page: 1,
     perPage: 25,
     setPage: () => {

--- a/packages/ra-core/src/controller/list/ListPaginationContext.tsx
+++ b/packages/ra-core/src/controller/list/ListPaginationContext.tsx
@@ -41,22 +41,9 @@ import { ListControllerResult } from './useListController';
  *     );
  * };
  */
-export const ListPaginationContext = createContext<ListPaginationContextValue>({
-    isLoading: false,
-    isPending: false,
-    total: 0,
-    page: 1,
-    perPage: 25,
-    setPage: () => {
-        throw new Error('not implemented');
-    },
-    setPerPage: () => {
-        throw new Error('not implemented');
-    },
-    hasPreviousPage: false,
-    hasNextPage: false,
-    resource: '',
-});
+export const ListPaginationContext = createContext<
+    ListPaginationContextValue | undefined
+>(undefined);
 
 ListPaginationContext.displayName = 'ListPaginationContext';
 

--- a/packages/ra-core/src/controller/list/ListSortContext.tsx
+++ b/packages/ra-core/src/controller/list/ListSortContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useMemo } from 'react';
 import pick from 'lodash/pick';
 import { ListControllerResult } from './useListController';
-import { SORT_ASC } from './queryReducer';
 
 /**
  * Context to store the sort part of the useListController() result.
@@ -35,16 +34,9 @@ import { SORT_ASC } from './queryReducer';
  *     );
  * };
  */
-export const ListSortContext = createContext<ListSortContextValue>({
-    sort: {
-        field: 'id',
-        order: SORT_ASC,
-    },
-    setSort: () => {
-        throw new Error('not implemented');
-    },
-    resource: '',
-});
+export const ListSortContext = createContext<ListSortContextValue | undefined>(
+    undefined
+);
 
 export type ListSortContextValue = Pick<
     ListControllerResult,

--- a/packages/ra-core/src/controller/list/ListSortContext.tsx
+++ b/packages/ra-core/src/controller/list/ListSortContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useMemo } from 'react';
 import pick from 'lodash/pick';
 import { ListControllerResult } from './useListController';
+import { SORT_ASC } from './queryReducer';
 
 /**
  * Context to store the sort part of the useListController() result.
@@ -35,9 +36,14 @@ import { ListControllerResult } from './useListController';
  * };
  */
 export const ListSortContext = createContext<ListSortContextValue>({
-    sort: null,
-    setSort: null,
-    resource: null,
+    sort: {
+        field: 'id',
+        order: SORT_ASC,
+    },
+    setSort: () => {
+        throw new Error('not implemented');
+    },
+    resource: '',
 });
 
 export type ListSortContextValue = Pick<

--- a/packages/ra-core/src/controller/list/WithListContext.tsx
+++ b/packages/ra-core/src/controller/list/WithListContext.tsx
@@ -26,7 +26,7 @@ export const WithListContext = <RecordType extends RaRecord>({
 
 export interface WithListContextProps<RecordType extends RaRecord> {
     render: (
-        context: ListControllerResult<RecordType>
+        context: Partial<ListControllerResult<RecordType>>
     ) => ReactElement | false | null;
     label?: string;
 }

--- a/packages/ra-core/src/controller/list/WithListContext.tsx
+++ b/packages/ra-core/src/controller/list/WithListContext.tsx
@@ -26,7 +26,7 @@ export const WithListContext = <RecordType extends RaRecord>({
 
 export interface WithListContextProps<RecordType extends RaRecord> {
     render: (
-        context: Partial<ListControllerResult<RecordType>>
+        context: ListControllerResult<RecordType>
     ) => ReactElement | false | null;
     label?: string;
 }

--- a/packages/ra-core/src/controller/list/index.ts
+++ b/packages/ra-core/src/controller/list/index.ts
@@ -13,6 +13,7 @@ export * from './useInfiniteListController';
 export * from './useInfinitePaginationContext';
 export * from './useList';
 export * from './useListContext';
+export * from './useListContextWithProps';
 export * from './useListController';
 export * from './useListFilterContext';
 export * from './useListPaginationContext';

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -167,7 +167,6 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
         [data]
     );
 
-    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort: currentSort,
         data: unwrappedData,
@@ -201,7 +200,7 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
         isFetchingNextPage,
         fetchPreviousPage,
         isFetchingPreviousPage,
-    };
+    } as InfiniteListControllerResult<RecordType>;
 };
 
 export interface InfiniteListControllerProps<

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -167,6 +167,7 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
         [data]
     );
 
+    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort: currentSort,
         data: unwrappedData,
@@ -222,8 +223,9 @@ export interface InfiniteListControllerProps<
     storeKey?: string | false;
 }
 
-export interface InfiniteListControllerResult<RecordType extends RaRecord = any>
-    extends ListControllerResult<RecordType> {
+export type InfiniteListControllerResult<
+    RecordType extends RaRecord = any
+> = ListControllerResult<RecordType> & {
     fetchNextPage: InfiniteQueryObserverBaseResult<
         InfiniteData<GetInfiniteListResult<RecordType>>
     >['fetchNextPage'];
@@ -236,4 +238,4 @@ export interface InfiniteListControllerResult<RecordType extends RaRecord = any>
     isFetchingPreviousPage: InfiniteQueryObserverBaseResult<
         InfiniteData<GetInfiniteListResult<RecordType>>
     >['isFetchingPreviousPage'];
-}
+};

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -256,7 +256,6 @@ export const useList = <RecordType extends RaRecord = any>(
         }
     }, [isPending, pendingState, setPendingState]);
 
-    // @ts-ignore FIXME cannot find another way to fox this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort,
         data: finalItems?.data,
@@ -287,7 +286,7 @@ export const useList = <RecordType extends RaRecord = any>(
         setSort,
         showFilter,
         total: finalItems?.total,
-    };
+    } as UseListValue<RecordType>;
 };
 
 export interface UseListOptions<RecordType extends RaRecord = any> {

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -256,6 +256,7 @@ export const useList = <RecordType extends RaRecord = any>(
         }
     }, [isPending, pendingState, setPendingState]);
 
+    // @ts-ignore FIXME cannot find another way to fox this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort,
         data: finalItems?.data,

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -105,7 +105,9 @@ export const useList = <RecordType extends RaRecord = any>(
     );
 
     // selection logic
-    const [selectedIds, selectionModifiers] = useRecordSelection(resource);
+    const [selectedIds, selectionModifiers] = useRecordSelection(
+        resource || '' // FIXME use false as default value when https://github.com/marmelab/react-admin/pull/9742 is merged
+    );
 
     // filter logic
     const filterRef = useRef(filter);
@@ -275,7 +277,7 @@ export const useList = <RecordType extends RaRecord = any>(
         onUnselectItems: selectionModifiers.clearSelection,
         page,
         perPage,
-        resource: undefined,
+        resource: '',
         refetch,
         selectedIds,
         setFilters,

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -105,7 +105,13 @@ export const useList = <RecordType extends RaRecord = any>(
     );
 
     // selection logic
-    const [selectedIds, selectionModifiers] = useRecordSelection({ resource });
+    const [selectedIds, selectionModifiers] = useRecordSelection(
+        resource
+            ? {
+                  resource,
+              }
+            : { disableSyncWithStore: true }
+    );
 
     // filter logic
     const filterRef = useRef(filter);

--- a/packages/ra-core/src/controller/list/useListContext.ts
+++ b/packages/ra-core/src/controller/list/useListContext.ts
@@ -92,7 +92,7 @@ import { RaRecord } from '../../types';
  */
 export const useListContext = <RecordType extends RaRecord = any>(
     props?: any
-): Partial<ListControllerResult<RecordType>> => {
+): ListControllerResult<RecordType> => {
     const context = useContext(ListContext);
     // Props take precedence over the context
     return useMemo(

--- a/packages/ra-core/src/controller/list/useListContext.ts
+++ b/packages/ra-core/src/controller/list/useListContext.ts
@@ -1,5 +1,4 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import { ListContext } from './ListContext';
 import { ListControllerResult } from './useListController';
@@ -8,36 +7,7 @@ import { RaRecord } from '../../types';
 /**
  * Hook to read the list controller props from the ListContext.
  *
- * Mostly used within a <ListContext.Provider> (e.g. as a descendent of <List>
- * or <ListBase>).
- *
- * But you can also use it without a <ListContext.Provider>. In this case, it is up to you
- * to pass all the necessary props (see the list below).
- *
- * The given props will take precedence over context values.
- *
- * @typedef {Object} ListControllerProps
- * @prop {Object}   data an array of the list records, e.g. [{ id: 123, title: 'hello world' }, { ... }]
- * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
- * @prop {boolean}  isFetching boolean that is true on mount, and false once the data was fetched
- * @prop {boolean}  isLoading boolean that is false until the data is available
- * @prop {integer}  page the current page. Starts at 1
- * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
- * @prop {integer}  perPage the number of results per page. Defaults to 25
- * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
- * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
- * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field : 'name', order: 'ASC' })
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
- * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
- * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
- * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
- * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
- * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
- * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
- * @prop {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
- * @prop {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * Used within a <ListContextProvider> (e.g. as a descendent of <List>).
  *
  * @returns {ListControllerResult} list controller props
  *
@@ -90,79 +60,14 @@ import { RaRecord } from '../../types';
  *     );
  * }
  */
-export const useListContext = <RecordType extends RaRecord = any>(
-    props?: any
-): ListControllerResult<RecordType> => {
+export const useListContext = <
+    RecordType extends RaRecord = any
+>(): ListControllerResult<RecordType> => {
     const context = useContext(ListContext);
-    // Props take precedence over the context
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null ? extractListContextProps<RecordType>(props) : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useListContext must be used inside a ListContextProvider'
+        );
+    }
+    return context;
 };
-
-/**
- * Extract only the list controller props
- *
- * @param {Object} props Props passed to the useListContext hook
- *
- * @returns {ListControllerResult} List controller props
- */
-const extractListContextProps = <RecordType extends RaRecord = any>({
-    sort,
-    data,
-    defaultTitle,
-    displayedFilters,
-    exporter,
-    filterValues,
-    hasCreate,
-    hideFilter,
-    isFetching,
-    isLoading,
-    isPending,
-    onSelect,
-    onToggleItem,
-    onUnselectItems,
-    page,
-    perPage,
-    refetch,
-    resource,
-    selectedIds,
-    setFilters,
-    setPage,
-    setPerPage,
-    setSort,
-    showFilter,
-    total,
-}: Partial<ListControllerResult<RecordType>> & Record<string, any>) => ({
-    sort,
-    data,
-    defaultTitle,
-    displayedFilters,
-    exporter,
-    filterValues,
-    hasCreate,
-    hideFilter,
-    isFetching,
-    isLoading,
-    isPending,
-    onSelect,
-    onToggleItem,
-    onUnselectItems,
-    page,
-    perPage,
-    refetch,
-    resource,
-    selectedIds,
-    setFilters,
-    setPage,
-    setPerPage,
-    setSort,
-    showFilter,
-    total,
-});

--- a/packages/ra-core/src/controller/list/useListContext.ts
+++ b/packages/ra-core/src/controller/list/useListContext.ts
@@ -92,15 +92,14 @@ import { RaRecord } from '../../types';
  */
 export const useListContext = <RecordType extends RaRecord = any>(
     props?: any
-): ListControllerResult<RecordType> => {
+): Partial<ListControllerResult<RecordType>> => {
     const context = useContext(ListContext);
     // Props take precedence over the context
-    // @ts-ignore
     return useMemo(
         () =>
             defaults(
                 {},
-                props != null ? extractListContextProps(props) : {},
+                props != null ? extractListContextProps<RecordType>(props) : {},
                 context
             ),
         [context, props]
@@ -114,7 +113,7 @@ export const useListContext = <RecordType extends RaRecord = any>(
  *
  * @returns {ListControllerResult} List controller props
  */
-const extractListContextProps = ({
+const extractListContextProps = <RecordType extends RaRecord = any>({
     sort,
     data,
     defaultTitle,
@@ -140,7 +139,7 @@ const extractListContextProps = ({
     setSort,
     showFilter,
     total,
-}) => ({
+}: Partial<ListControllerResult<RecordType>> & Record<string, any>) => ({
     sort,
     data,
     defaultTitle,

--- a/packages/ra-core/src/controller/list/useListContextWithProps.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListContextWithProps.spec.tsx
@@ -3,17 +3,14 @@ import expect from 'expect';
 import { render } from '@testing-library/react';
 
 import { ListContext } from './ListContext';
-import { useListContext } from './useListContext';
+import { useListContextWithProps } from './useListContextWithProps';
 
-describe('useListContext', () => {
-    const NaiveList = () => {
-        const { isPending, error, data } = useListContext();
-        if (isPending || error) {
-            return null;
-        }
+describe('useListContextWithProps', () => {
+    const NaiveList = props => {
+        const { data } = useListContextWithProps(props);
         return (
             <ul>
-                {data.map(record => (
+                {data?.map(record => (
                     <li key={record.id}>{record.title}</li>
                 ))}
             </ul>
@@ -35,10 +32,11 @@ describe('useListContext', () => {
         expect(getByText('hello')).not.toBeNull();
     });
 
-    it('should throw when called outside of a ListContextProvider', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
-        expect(() => render(<NaiveList />)).toThrow(
-            'useListContext must be used inside a ListContextProvider'
+    it('should return injected props if the context was not set', () => {
+        jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+        const { getByText } = render(
+            <NaiveList resource="foo" data={[{ id: 1, title: 'hello' }]} />
         );
+        expect(getByText('hello')).not.toBeNull();
     });
 });

--- a/packages/ra-core/src/controller/list/useListContextWithProps.ts
+++ b/packages/ra-core/src/controller/list/useListContextWithProps.ts
@@ -1,0 +1,123 @@
+import { useContext, useMemo } from 'react';
+import defaults from 'lodash/defaults';
+
+import { ListContext } from './ListContext';
+import { ListControllerResult } from './useListController';
+import { RaRecord } from '../../types';
+
+/**
+ * Hook to read the list controller props from the ListContext.
+ *
+ * Mostly used within a <ListContext.Provider> (e.g. as a descendent of <List>
+ * or <ListBase>).
+ *
+ * But you can also use it without a <ListContext.Provider>. In this case, it is up to you
+ * to pass all the necessary props (see the list below).
+ *
+ * The given props will take precedence over context values.
+ *
+ * @typedef {Object} ListControllerProps
+ * @prop {Object}   data an array of the list records, e.g. [{ id: 123, title: 'hello world' }, { ... }]
+ * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
+ * @prop {boolean}  isFetching boolean that is true on mount, and false once the data was fetched
+ * @prop {boolean}  isLoading boolean that is false until the data is available
+ * @prop {integer}  page the current page. Starts at 1
+ * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
+ * @prop {integer}  perPage the number of results per page. Defaults to 25
+ * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
+ * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field : 'name', order: 'ASC' })
+ * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
+ * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
+ * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
+ * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
+ * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
+ * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
+ * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
+ * @prop {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
+ * @prop {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
+ * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ *
+ * @param {ListControllerProps} props Props passed to the useListContext hook
+ *
+ * @returns {ListControllerResult} list controller props
+ *
+ * @see useListController for how it is filled
+ */
+export const useListContextWithProps = <RecordType extends RaRecord = any>(
+    props?: any
+): Partial<ListControllerResult<RecordType>> => {
+    const context = useContext(ListContext);
+    // Props take precedence over the context
+    return useMemo(
+        () =>
+            defaults(
+                {},
+                props != null ? extractListContextProps<RecordType>(props) : {},
+                context
+            ),
+        [context, props]
+    );
+};
+
+/**
+ * Extract only the list controller props
+ *
+ * @param {Object} props Props passed to the useListContext hook
+ *
+ * @returns {ListControllerResult} List controller props
+ */
+const extractListContextProps = <RecordType extends RaRecord = any>({
+    sort,
+    data,
+    defaultTitle,
+    displayedFilters,
+    exporter,
+    filterValues,
+    hasCreate,
+    hideFilter,
+    isFetching,
+    isLoading,
+    isPending,
+    onSelect,
+    onToggleItem,
+    onUnselectItems,
+    page,
+    perPage,
+    refetch,
+    resource,
+    selectedIds,
+    setFilters,
+    setPage,
+    setPerPage,
+    setSort,
+    showFilter,
+    total,
+}: Partial<ListControllerResult<RecordType>> & Record<string, any>) => ({
+    sort,
+    data,
+    defaultTitle,
+    displayedFilters,
+    exporter,
+    filterValues,
+    hasCreate,
+    hideFilter,
+    isFetching,
+    isLoading,
+    isPending,
+    onSelect,
+    onToggleItem,
+    onUnselectItems,
+    page,
+    perPage,
+    refetch,
+    resource,
+    selectedIds,
+    setFilters,
+    setPage,
+    setPerPage,
+    setSort,
+    showFilter,
+    total,
+});

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -147,7 +147,7 @@ export const useListController = <RecordType extends RaRecord = any>(
         name: getResourceLabel(resource, 2),
     });
 
-    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
+    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'."
     return {
         sort: currentSort,
         data,

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -444,7 +444,7 @@ export const sanitizeListRestProps = props =>
         .filter(propName => !injectedProps.includes(propName))
         .reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
 
-interface ListControllerBaseResult<RecordType extends RaRecord = any> {
+export interface ListControllerBaseResult<RecordType extends RaRecord = any> {
     sort: SortPayload;
     defaultTitle?: string;
     displayedFilters: any;
@@ -475,14 +475,14 @@ interface ListControllerBaseResult<RecordType extends RaRecord = any> {
     isLoading?: boolean;
 }
 
-interface ListControllerLoadingResult<RecordType extends RaRecord = any>
+export interface ListControllerLoadingResult<RecordType extends RaRecord = any>
     extends ListControllerBaseResult<RecordType> {
     data: undefined;
     total: undefined;
     error: null;
     isPending: true;
 }
-interface ListControllerLoadingErrorResult<
+export interface ListControllerLoadingErrorResult<
     RecordType extends RaRecord = any,
     TError = Error
 > extends ListControllerBaseResult<RecordType> {
@@ -491,7 +491,7 @@ interface ListControllerLoadingErrorResult<
     error: TError;
     isPending: false;
 }
-interface ListControllerRefetchErrorResult<
+export interface ListControllerRefetchErrorResult<
     RecordType extends RaRecord = any,
     TError = Error
 > extends ListControllerBaseResult<RecordType> {
@@ -500,7 +500,7 @@ interface ListControllerRefetchErrorResult<
     error: TError;
     isPending: false;
 }
-interface ListControllerSuccessResult<RecordType extends RaRecord = any>
+export interface ListControllerSuccessResult<RecordType extends RaRecord = any>
     extends ListControllerBaseResult<RecordType> {
     data: RecordType[];
     total: number;

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -53,12 +53,12 @@ export const useListController = <RecordType extends RaRecord = any>(
 
     if (!resource) {
         throw new Error(
-            `<List> was called outside of a ResourceContext and without a resource prop. You must set the resource prop.`
+            `useListController requires a non-empty resource prop or context`
         );
     }
     if (filter && isValidElement(filter)) {
         throw new Error(
-            '<List> received a React element as `filter` props. If you intended to set the list filter elements, use the `filters` (with an s) prop instead. The `filter` prop is internal and should not be set by the developer.'
+            'useListController received a React element as `filter` props. If you intended to set the list filter elements, use the `filters` (with an s) prop instead. The `filter` prop is internal and should not be set by the developer.'
         );
     }
 
@@ -396,7 +396,7 @@ const defaultSort = {
 
 export interface ListControllerResult<RecordType extends RaRecord = any> {
     sort: SortPayload;
-    data: RecordType[];
+    data?: RecordType[];
     defaultTitle?: string;
     displayedFilters: any;
     error?: any;
@@ -424,9 +424,9 @@ export interface ListControllerResult<RecordType extends RaRecord = any> {
     setPerPage: (page: number) => void;
     setSort: (sort: SortPayload) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
-    total: number;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
+    total?: number;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
 }
 
 export const injectedProps = [

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -147,6 +147,7 @@ export const useListController = <RecordType extends RaRecord = any>(
         name: getResourceLabel(resource, 2),
     });
 
+    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'.""
     return {
         sort: currentSort,
         data,
@@ -394,41 +395,6 @@ const defaultSort = {
     order: SORT_ASC,
 } as const;
 
-export interface ListControllerResult<RecordType extends RaRecord = any> {
-    sort: SortPayload;
-    data?: RecordType[];
-    defaultTitle?: string;
-    displayedFilters: any;
-    error?: any;
-    exporter?: Exporter | false;
-    filter?: FilterPayload;
-    filterValues: any;
-    hideFilter: (filterName: string) => void;
-    isFetching: boolean;
-    isLoading: boolean;
-    isPending: boolean;
-    onSelect: (ids: RecordType['id'][]) => void;
-    onToggleItem: (id: RecordType['id']) => void;
-    onUnselectItems: () => void;
-    page: number;
-    perPage: number;
-    refetch: (() => void) | UseGetListHookValue<RecordType>['refetch'];
-    resource: string;
-    selectedIds: RecordType['id'][];
-    setFilters: (
-        filters: any,
-        displayedFilters?: any,
-        debounce?: boolean
-    ) => void;
-    setPage: (page: number) => void;
-    setPerPage: (page: number) => void;
-    setSort: (sort: SortPayload) => void;
-    showFilter: (filterName: string, defaultValue: any) => void;
-    total?: number;
-    hasNextPage?: boolean;
-    hasPreviousPage?: boolean;
-}
-
 export const injectedProps = [
     'sort',
     'data',
@@ -478,3 +444,73 @@ export const sanitizeListRestProps = props =>
     Object.keys(props)
         .filter(propName => !injectedProps.includes(propName))
         .reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
+
+interface ListControllerBaseResult<RecordType extends RaRecord = any> {
+    sort: SortPayload;
+    defaultTitle?: string;
+    displayedFilters: any;
+    exporter?: Exporter | false;
+    filter?: FilterPayload;
+    filterValues: any;
+    hideFilter: (filterName: string) => void;
+    onSelect: (ids: RecordType['id'][]) => void;
+    onToggleItem: (id: RecordType['id']) => void;
+    onUnselectItems: () => void;
+    page: number;
+    perPage: number;
+    refetch: (() => void) | UseGetListHookValue<RecordType>['refetch'];
+    resource: string;
+    selectedIds: RecordType['id'][];
+    setFilters: (
+        filters: any,
+        displayedFilters?: any,
+        debounce?: boolean
+    ) => void;
+    setPage: (page: number) => void;
+    setPerPage: (page: number) => void;
+    setSort: (sort: SortPayload) => void;
+    showFilter: (filterName: string, defaultValue: any) => void;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+    isFetching?: boolean;
+    isLoading?: boolean;
+}
+
+interface ListControllerLoadingResult<RecordType extends RaRecord = any>
+    extends ListControllerBaseResult<RecordType> {
+    data: undefined;
+    total: undefined;
+    error: null;
+    isPending: true;
+}
+interface ListControllerLoadingErrorResult<
+    RecordType extends RaRecord = any,
+    TError = Error
+> extends ListControllerBaseResult<RecordType> {
+    data: undefined;
+    total: undefined;
+    error: TError;
+    isPending: false;
+}
+interface ListControllerRefetchErrorResult<
+    RecordType extends RaRecord = any,
+    TError = Error
+> extends ListControllerBaseResult<RecordType> {
+    data: RecordType[];
+    total: number;
+    error: TError;
+    isPending: false;
+}
+interface ListControllerSuccessResult<RecordType extends RaRecord = any>
+    extends ListControllerBaseResult<RecordType> {
+    data: RecordType[];
+    total: number;
+    error: null;
+    isPending: false;
+}
+
+export type ListControllerResult<RecordType extends RaRecord = any> =
+    | ListControllerLoadingResult<RecordType>
+    | ListControllerLoadingErrorResult<RecordType>
+    | ListControllerRefetchErrorResult<RecordType>
+    | ListControllerSuccessResult<RecordType>;

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -147,7 +147,6 @@ export const useListController = <RecordType extends RaRecord = any>(
         name: getResourceLabel(resource, 2),
     });
 
-    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'."
     return {
         sort: currentSort,
         data,
@@ -181,7 +180,7 @@ export const useListController = <RecordType extends RaRecord = any>(
             ? query.page * query.perPage < total
             : undefined,
         hasPreviousPage: pageInfo ? pageInfo.hasPreviousPage : query.page > 1,
-    };
+    } as ListControllerResult<RecordType>;
 };
 
 export interface ListControllerProps<RecordType extends RaRecord = any> {

--- a/packages/ra-core/src/controller/list/useListFilterContext.ts
+++ b/packages/ra-core/src/controller/list/useListFilterContext.ts
@@ -1,12 +1,12 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
+import defaults from 'lodash/defaults';
 
 import { ListFilterContext, ListFilterContextValue } from './ListFilterContext';
 
 /**
- * Hook to read the list controller props from the ListContext.
+ * Hook to read the list props from the ListFilterContext.
  *
- * Must be used within a <ListContextProvider> (e.g. as a descendent of <List>
- * or <ListBase>).
+ * Must be used within a <ListFilterContextProvider>.
  *
  * @typedef {Object} ListFilterContextValue
  * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
@@ -22,23 +22,29 @@ import { ListFilterContext, ListFilterContextValue } from './ListFilterContext';
  */
 export const useListFilterContext = (props?: any): ListFilterContextValue => {
     const context = useContext(ListFilterContext);
-    if (!context.hideFilter) {
-        /**
-         * The element isn't inside a <ListFilterContext.Provider>
-         *
-         * This may only happen when using Datagrid / SimpleList / SingleFieldList components
-         * outside of a List / ReferenceManyField / ReferenceArrayField -
-         * which isn't documented but tolerated.
-         * To avoid breakage in that case, fallback to props
-         *
-         * @deprecated - to be removed in 4.0
-         */
-        if (process.env.NODE_ENV !== 'production') {
-            console.log(
-                "List components must be used inside a <ListContextProvider>. Relying on props rather than context to get List data and callbacks is deprecated and won't be supported in the next major version of react-admin."
-            );
-        }
-        return props;
-    }
-    return context;
+    return useMemo(
+        () =>
+            defaults(
+                {},
+                props != null ? extractListPaginationContextProps(props) : {},
+                context
+            ),
+        [context, props]
+    );
 };
+
+const extractListPaginationContextProps = ({
+    displayedFilters,
+    filterValues,
+    hideFilter,
+    setFilters,
+    showFilter,
+    resource,
+}) => ({
+    displayedFilters,
+    filterValues,
+    hideFilter,
+    setFilters,
+    showFilter,
+    resource,
+});

--- a/packages/ra-core/src/controller/list/useListFilterContext.ts
+++ b/packages/ra-core/src/controller/list/useListFilterContext.ts
@@ -1,5 +1,4 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import { ListFilterContext, ListFilterContextValue } from './ListFilterContext';
 
@@ -8,43 +7,16 @@ import { ListFilterContext, ListFilterContextValue } from './ListFilterContext';
  *
  * Must be used within a <ListFilterContextProvider>.
  *
- * @typedef {Object} ListFilterContextValue
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
- * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
- * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
- * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
- *
  * @returns {ListFilterContextValue} list controller props
  *
  * @see useListController for how it is filled
  */
-export const useListFilterContext = (props?: any): ListFilterContextValue => {
+export const useListFilterContext = (): ListFilterContextValue => {
     const context = useContext(ListFilterContext);
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null ? extractListPaginationContextProps(props) : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useListFilterContext must be used inside a ListFilterContextProvider'
+        );
+    }
+    return context;
 };
-
-const extractListPaginationContextProps = ({
-    displayedFilters,
-    filterValues,
-    hideFilter,
-    setFilters,
-    showFilter,
-    resource,
-}) => ({
-    displayedFilters,
-    filterValues,
-    hideFilter,
-    setFilters,
-    showFilter,
-    resource,
-});

--- a/packages/ra-core/src/controller/list/useListPaginationContext.ts
+++ b/packages/ra-core/src/controller/list/useListPaginationContext.ts
@@ -1,5 +1,4 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import {
     ListPaginationContext,
@@ -7,68 +6,21 @@ import {
 } from './ListPaginationContext';
 
 /**
- * Hook to read the list controller props from the ListContext.
+ * Hook to read the list pagination controller props from the ListPaginationContext.
  *
- * Must be used within a <ListContextProvider> (e.g. as a descendent of <List>
+ * Must be used within a <ListPaginationContext> (e.g. as a descendent of <List>
  * or <ListBase>).
- *
- * @typedef {Object} ListPaginationContextValue
- * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
- * @prop {integer}  page the current page. Starts at 1
- * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
- * @prop {integer}  perPage the number of results per page. Defaults to 25
- * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
- * @prop {Boolean}  hasPreviousPage true if the current page is not the first one
- * @prop {Boolean}  hasNextPage true if the current page is not the last one
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListPaginationContextValue} list controller props
  *
  * @see useListController for how it is filled
  */
-export const useListPaginationContext = (
-    props?: any
-): ListPaginationContextValue => {
+export const useListPaginationContext = (): ListPaginationContextValue => {
     const context = useContext(ListPaginationContext);
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null ? extractListPaginationContextProps(props) : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useListPaginationContext must be used inside a ListPaginationContextProvider'
+        );
+    }
+    return context;
 };
-
-/**
- * Extract only the list controller props
- *
- * @param {Object} props Props passed to the useListContext hook
- *
- * @returns {ListControllerResult} List controller props
- */
-const extractListPaginationContextProps = ({
-    isLoading,
-    isPending,
-    page,
-    perPage,
-    setPage,
-    setPerPage,
-    hasPreviousPage,
-    hasNextPage,
-    total,
-    resource,
-}) => ({
-    isLoading,
-    isPending,
-    page,
-    perPage,
-    setPage,
-    setPerPage,
-    hasPreviousPage,
-    hasNextPage,
-    total,
-    resource,
-});
-export default useListPaginationContext;

--- a/packages/ra-core/src/controller/list/useListSortContext.ts
+++ b/packages/ra-core/src/controller/list/useListSortContext.ts
@@ -1,38 +1,23 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import { ListSortContext, ListSortContextValue } from './ListSortContext';
 
 /**
- * Hook to read the list controller props from the ListContext.
+ * Hook to read the list sort controller props from the ListSortContext.
  *
- * Must be used within a <ListContextProvider> (e.g. as a descendent of <List>
+ * Must be used within a <ListSortContextProvider> (e.g. as a descendent of <List>
  * or <ListBase>).
- *
- * @typedef {Object} ListSortContextValue
- * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
- * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListSortContextValue} list controller props
  *
  * @see useListController for how it is filled
  */
-export const useListSortContext = (props?: any): ListSortContextValue => {
+export const useListSortContext = (): ListSortContextValue => {
     const context = useContext(ListSortContext);
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null ? extractListPaginationContextProps(props) : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useListSortContext must be used inside a ListSortContextProvider'
+        );
+    }
+    return context;
 };
-
-const extractListPaginationContextProps = ({ sort, setSort, resource }) => ({
-    sort,
-    setSort,
-    resource,
-});

--- a/packages/ra-core/src/controller/list/useListSortContext.ts
+++ b/packages/ra-core/src/controller/list/useListSortContext.ts
@@ -1,4 +1,5 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
+import defaults from 'lodash/defaults';
 
 import { ListSortContext, ListSortContextValue } from './ListSortContext';
 
@@ -19,23 +20,19 @@ import { ListSortContext, ListSortContextValue } from './ListSortContext';
  */
 export const useListSortContext = (props?: any): ListSortContextValue => {
     const context = useContext(ListSortContext);
-    if (!context.setSort) {
-        /**
-         * The element isn't inside a <ListSortContext.Provider>
-         *
-         * This may only happen when using Datagrid / SimpleList / SingleFieldList components
-         * outside of a List / ReferenceManyField / ReferenceArrayField -
-         * which isn't documented but tolerated.
-         * To avoid breakage in that case, fallback to props
-         *
-         * @deprecated - to be removed in 4.0
-         */
-        if (process.env.NODE_ENV !== 'production') {
-            console.log(
-                "List components must be used inside a <ListContextProvider>. Relying on props rather than context to get List data and callbacks is deprecated and won't be supported in the next major version of react-admin."
-            );
-        }
-        return props;
-    }
-    return context;
+    return useMemo(
+        () =>
+            defaults(
+                {},
+                props != null ? extractListPaginationContextProps(props) : {},
+                context
+            ),
+        [context, props]
+    );
 };
+
+const extractListPaginationContextProps = ({ sort, setSort, resource }) => ({
+    sort,
+    setSort,
+    resource,
+});

--- a/packages/ra-core/src/controller/record/RecordContext.tsx
+++ b/packages/ra-core/src/controller/record/RecordContext.tsx
@@ -8,9 +8,9 @@ import { RaRecord } from '../../types';
  * @see RecordContextProvider
  * @see useRecordContext
  */
-export const RecordContext = createContext<RaRecord | Omit<RaRecord, 'id'>>(
-    undefined
-);
+export const RecordContext = createContext<
+    RaRecord | Omit<RaRecord, 'id'> | undefined
+>(undefined);
 
 RecordContext.displayName = 'RecordContext';
 

--- a/packages/ra-core/src/controller/saveContext/SaveContext.ts
+++ b/packages/ra-core/src/controller/saveContext/SaveContext.ts
@@ -33,4 +33,4 @@ export type SaveHandlerCallbacks = {
     transform?: TransformData;
     meta?: any;
 };
-export const SaveContext = createContext<SaveContextValue>(undefined);
+export const SaveContext = createContext<SaveContextValue>({});

--- a/packages/ra-core/src/controller/show/ShowContext.tsx
+++ b/packages/ra-core/src/controller/show/ShowContext.tsx
@@ -20,6 +20,8 @@ import { ShowControllerResult } from './useShowController';
  * };
  */
 export const ShowContext = createContext<ShowControllerResult>({
+    record: null,
+    error: null,
     isFetching: false,
     isLoading: false,
     isPending: false,

--- a/packages/ra-core/src/controller/show/ShowContext.tsx
+++ b/packages/ra-core/src/controller/show/ShowContext.tsx
@@ -20,13 +20,11 @@ import { ShowControllerResult } from './useShowController';
  * };
  */
 export const ShowContext = createContext<ShowControllerResult>({
-    record: null,
-    defaultTitle: null,
-    isFetching: null,
-    isLoading: null,
-    isPending: null,
-    refetch: null,
-    resource: null,
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+    refetch: () => Promise.reject('not implemented'),
+    resource: '',
 });
 
 ShowContext.displayName = 'ShowContext';

--- a/packages/ra-core/src/controller/show/ShowContext.tsx
+++ b/packages/ra-core/src/controller/show/ShowContext.tsx
@@ -19,14 +19,6 @@ import { ShowControllerResult } from './useShowController';
  *     );
  * };
  */
-export const ShowContext = createContext<ShowControllerResult>({
-    record: null,
-    error: null,
-    isFetching: false,
-    isLoading: false,
-    isPending: false,
-    refetch: () => Promise.reject('not implemented'),
-    resource: '',
-});
+export const ShowContext = createContext<ShowControllerResult | null>(null);
 
 ShowContext.displayName = 'ShowContext';

--- a/packages/ra-core/src/controller/show/useShowContext.tsx
+++ b/packages/ra-core/src/controller/show/useShowContext.tsx
@@ -23,18 +23,17 @@ import { ShowControllerResult } from './useShowController';
  *
  */
 export const useShowContext = <RecordType extends RaRecord = any>(
-    props?: Partial<ShowControllerResult<RecordType>>
-): ShowControllerResult<RecordType> => {
+    props?: any
+): Partial<ShowControllerResult<RecordType>> => {
     // Can't find a way to specify the RecordType when ShowContext is declared
-    // @ts-ignore
-    const context = useContext<ShowControllerResult<RecordType>>(ShowContext);
+    const context = useContext(ShowContext);
 
     // Props take precedence over the context
     return useMemo(
         () =>
             defaults(
                 {},
-                props != null ? extractShowContextProps(props) : {},
+                props != null ? extractShowContextProps<RecordType>(props) : {},
                 context
             ),
         [context, props]
@@ -48,19 +47,15 @@ export const useShowContext = <RecordType extends RaRecord = any>(
  *
  * @returns {ShowControllerResult} show controller props
  */
-const extractShowContextProps = ({
+const extractShowContextProps = <RecordType extends RaRecord = any>({
     record,
-    data,
     defaultTitle,
     isFetching,
     isLoading,
     isPending,
     resource,
-}: any) => ({
-    // Necessary for actions (EditActions) which expect a data prop containing the record
-    // @deprecated - to be removed in 4.0d
-    record: record || data,
-    data: record || data,
+}: Partial<ShowControllerResult<RecordType>>) => ({
+    record,
     defaultTitle,
     isFetching,
     isLoading,

--- a/packages/ra-core/src/controller/show/useShowContext.tsx
+++ b/packages/ra-core/src/controller/show/useShowContext.tsx
@@ -1,5 +1,4 @@
-import { useContext, useMemo } from 'react';
-import defaults from 'lodash/defaults';
+import { useContext } from 'react';
 
 import { RaRecord } from '../../types';
 import { ShowContext } from './ShowContext';
@@ -8,55 +7,21 @@ import { ShowControllerResult } from './useShowController';
 /**
  * Hook to read the show controller props from the ShowContext.
  *
- * Mostly used within a <ShowContext.Provider> (e.g. as a descendent of <Show>).
- *
- * But you can also use it without a <ShowContext.Provider>. In this case, it is up to you
- * to pass all the necessary props.
- *
- * The given props will take precedence over context values.
- *
- * @typedef {Object} ShowControllerResult
+ * Used within a <ShowContextProvider> (e.g. as a descendent of <Show>).
  *
  * @returns {ShowControllerResult} create controller props
  *
  * @see useShowController for how it is filled
- *
  */
-export const useShowContext = <RecordType extends RaRecord = any>(
-    props?: any
-): ShowControllerResult<RecordType> => {
+export const useShowContext = <
+    RecordType extends RaRecord = any
+>(): ShowControllerResult<RecordType> => {
     const context = useContext(ShowContext);
     // Props take precedence over the context
-    return useMemo(
-        () =>
-            defaults(
-                {},
-                props != null ? extractShowContextProps<RecordType>(props) : {},
-                context
-            ),
-        [context, props]
-    );
+    if (!context) {
+        throw new Error(
+            'useShowContext must be used inside a ShowContextProvider'
+        );
+    }
+    return context;
 };
-
-/**
- * Extract only the show controller props
- *
- * @param {Object} props props passed to the useShowContext hook
- *
- * @returns {ShowControllerResult} show controller props
- */
-const extractShowContextProps = <RecordType extends RaRecord = any>({
-    record,
-    defaultTitle,
-    isFetching,
-    isLoading,
-    isPending,
-    resource,
-}: Partial<ShowControllerResult<RecordType>>) => ({
-    record,
-    defaultTitle,
-    isFetching,
-    isLoading,
-    isPending,
-    resource,
-});

--- a/packages/ra-core/src/controller/show/useShowContext.tsx
+++ b/packages/ra-core/src/controller/show/useShowContext.tsx
@@ -24,10 +24,8 @@ import { ShowControllerResult } from './useShowController';
  */
 export const useShowContext = <RecordType extends RaRecord = any>(
     props?: any
-): Partial<ShowControllerResult<RecordType>> => {
-    // Can't find a way to specify the RecordType when ShowContext is declared
+): ShowControllerResult<RecordType> => {
     const context = useContext(ShowContext);
-
     // Props take precedence over the context
     return useMemo(
         () =>

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -144,13 +144,13 @@ export interface ShowControllerBaseResult<RecordType extends RaRecord = any> {
     refetch: UseGetOneHookValue<RecordType>['refetch'];
 }
 
-interface ShowControllerLoadingResult<RecordType extends RaRecord = any>
+export interface ShowControllerLoadingResult<RecordType extends RaRecord = any>
     extends ShowControllerBaseResult<RecordType> {
     record: undefined;
     error: null;
     isPending: true;
 }
-interface ShowControllerLoadingErrorResult<
+export interface ShowControllerLoadingErrorResult<
     RecordType extends RaRecord = any,
     TError = Error
 > extends ShowControllerBaseResult<RecordType> {
@@ -158,7 +158,7 @@ interface ShowControllerLoadingErrorResult<
     error: TError;
     isPending: false;
 }
-interface ShowControllerRefetchErrorResult<
+export interface ShowControllerRefetchErrorResult<
     RecordType extends RaRecord = any,
     TError = Error
 > extends ShowControllerBaseResult<RecordType> {
@@ -166,7 +166,7 @@ interface ShowControllerRefetchErrorResult<
     error: TError;
     isPending: false;
 }
-interface ShowControllerSuccessResult<RecordType extends RaRecord = any>
+export interface ShowControllerSuccessResult<RecordType extends RaRecord = any>
     extends ShowControllerBaseResult<RecordType> {
     record: RecordType;
     error: null;

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -55,13 +55,23 @@ export const useShowController = <RecordType extends RaRecord = any>(
     const { disableAuthentication, id: propsId, queryOptions = {} } = props;
     useAuthenticated({ enabled: !disableAuthentication });
     const resource = useResourceContext(props);
+    if (!resource) {
+        throw new Error(
+            `useShowController requires a non-empty resource prop or context`
+        );
+    }
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();
     const notify = useNotify();
     const redirect = useRedirect();
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
-    const id = propsId != null ? propsId : decodeURIComponent(routeId);
+    if (!routeId && !propsId) {
+        throw new Error(
+            'useShowController requires an id prop or a route with an /:id? parameter.'
+        );
+    }
+    const id = propsId != null ? propsId : decodeURIComponent(routeId!);
     const { meta, ...otherQueryOptions } = queryOptions;
 
     const {
@@ -126,7 +136,7 @@ export interface ShowControllerProps<RecordType extends RaRecord = any> {
 }
 
 export interface ShowControllerResult<RecordType extends RaRecord = any> {
-    defaultTitle: string;
+    defaultTitle?: string;
     // Necessary for actions (EditActions) which expect a data prop containing the record
     // @deprecated - to be removed in 4.0d
     data?: RecordType;

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -116,6 +116,7 @@ export const useShowController = <RecordType extends RaRecord = any>(
                 : '',
     });
 
+    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'."
     return {
         defaultTitle,
         error,
@@ -135,16 +136,46 @@ export interface ShowControllerProps<RecordType extends RaRecord = any> {
     resource?: string;
 }
 
-export interface ShowControllerResult<RecordType extends RaRecord = any> {
+export interface ShowControllerBaseResult<RecordType extends RaRecord = any> {
     defaultTitle?: string;
-    // Necessary for actions (EditActions) which expect a data prop containing the record
-    // @deprecated - to be removed in 4.0d
-    data?: RecordType;
-    error?: any;
     isFetching: boolean;
     isLoading: boolean;
-    isPending: boolean;
     resource: string;
     record?: RecordType;
     refetch: UseGetOneHookValue<RecordType>['refetch'];
 }
+
+interface ShowControllerLoadingResult<RecordType extends RaRecord = any>
+    extends ShowControllerBaseResult<RecordType> {
+    record: undefined;
+    error: null;
+    isPending: true;
+}
+interface ShowControllerLoadingErrorResult<
+    RecordType extends RaRecord = any,
+    TError = Error
+> extends ShowControllerBaseResult<RecordType> {
+    record: undefined;
+    error: TError;
+    isPending: false;
+}
+interface ShowControllerRefetchErrorResult<
+    RecordType extends RaRecord = any,
+    TError = Error
+> extends ShowControllerBaseResult<RecordType> {
+    record: RecordType;
+    error: TError;
+    isPending: false;
+}
+interface ShowControllerSuccessResult<RecordType extends RaRecord = any>
+    extends ShowControllerBaseResult<RecordType> {
+    record: RecordType;
+    error: null;
+    isPending: false;
+}
+
+export type ShowControllerResult<RecordType extends RaRecord = any> =
+    | ShowControllerLoadingResult<RecordType>
+    | ShowControllerLoadingErrorResult<RecordType>
+    | ShowControllerRefetchErrorResult<RecordType>
+    | ShowControllerSuccessResult<RecordType>;

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -116,7 +116,6 @@ export const useShowController = <RecordType extends RaRecord = any>(
                 : '',
     });
 
-    // @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'."
     return {
         defaultTitle,
         error,
@@ -126,7 +125,7 @@ export const useShowController = <RecordType extends RaRecord = any>(
         record,
         refetch,
         resource,
-    };
+    } as ShowControllerResult<RecordType>;
 };
 
 export interface ShowControllerProps<RecordType extends RaRecord = any> {

--- a/packages/ra-core/src/dataProvider/HttpError.ts
+++ b/packages/ra-core/src/dataProvider/HttpError.ts
@@ -2,7 +2,7 @@ class HttpError extends Error {
     constructor(
         public readonly message,
         public readonly status,
-        public readonly body = null
+        public readonly body: any = null
     ) {
         super(message);
         Object.setPrototypeOf(this, HttpError.prototype);

--- a/packages/ra-core/src/form/choices/ChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/ChoicesContext.ts
@@ -12,14 +12,14 @@ export const ChoicesContext = createContext<ChoicesContextValue | undefined>(
 );
 
 export type ChoicesContextValue<RecordType extends RaRecord = any> = {
-    allChoices: RecordType[];
-    availableChoices: RecordType[];
+    allChoices?: RecordType[];
+    availableChoices?: RecordType[];
     displayedFilters: any;
     error?: any;
     filter?: FilterPayload;
     filterValues: any;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
     hideFilter: (filterName: string) => void;
     isFetching: boolean;
     isLoading: boolean;
@@ -28,7 +28,7 @@ export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     perPage: number;
     refetch: (() => void) | UseGetListHookValue<RecordType>['refetch'];
     resource: string;
-    selectedChoices: RecordType[];
+    selectedChoices?: RecordType[];
     setFilters: (
         filters: any,
         displayedFilters?: any,
@@ -39,7 +39,7 @@ export type ChoicesContextValue<RecordType extends RaRecord = any> = {
     setSort: (sort: SortPayload) => void;
     showFilter: (filterName: string, defaultValue: any) => void;
     sort: SortPayload;
-    source: string;
-    total: number;
+    source?: string;
+    total?: number;
     isFromReference: boolean;
 };

--- a/packages/ra-core/src/form/choices/useChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/useChoicesContext.ts
@@ -5,7 +5,7 @@ import { ChoicesContext, ChoicesContextValue } from './ChoicesContext';
 
 export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
     options: Partial<ChoicesContextValue> & { choices?: ChoicesType[] } = {}
-): ChoicesContextValue => {
+): ChoicesContextValue<ChoicesType> => {
     const context = useContext(ChoicesContext) as ChoicesContextValue<
         ChoicesType
     >;

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -37,7 +37,7 @@ export const BulkDeleteWithConfirmButton = (
         ...rest
     } = props;
     const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
-    const { selectedIds, onUnselectItems } = useListContext(props);
+    const { selectedIds, onUnselectItems } = useListContext();
     const [isOpen, setOpen] = useSafeSetState(false);
     const notify = useNotify();
     const resource = useResourceContext(props);
@@ -138,9 +138,7 @@ export const BulkDeleteWithConfirmButton = (
 
 const sanitizeRestProps = ({
     classes,
-    filterValues,
     label,
-    selectedIds,
     ...rest
 }: Omit<
     BulkDeleteWithConfirmButtonProps,

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -29,7 +29,7 @@ export const BulkDeleteWithUndoButton = (
         ...rest
     } = props;
     const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
-    const { selectedIds, onUnselectItems } = useListContext(props);
+    const { selectedIds, onUnselectItems } = useListContext();
 
     const notify = useNotify();
     const resource = useResourceContext(props);
@@ -93,9 +93,7 @@ const defaultIcon = <ActionDelete />;
 
 const sanitizeRestProps = ({
     classes,
-    filterValues,
     label,
-    selectedIds,
     ...rest
 }: Omit<BulkDeleteWithUndoButtonProps, 'resource' | 'icon'>) => rest;
 

--- a/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkExportButton.tsx
@@ -6,9 +6,9 @@ import {
     fetchRelatedRecords,
     useDataProvider,
     useNotify,
-    Identifier,
     Exporter,
     useListContext,
+    useResourceContext,
 } from 'ra-core';
 
 import { Button, ButtonProps } from './Button';
@@ -45,11 +45,8 @@ export const BulkExportButton = (props: BulkExportButtonProps) => {
         meta,
         ...rest
     } = props;
-    const {
-        exporter: exporterFromContext,
-        resource,
-        selectedIds,
-    } = useListContext(props);
+    const resource = useResourceContext(props);
+    const { exporter: exporterFromContext, selectedIds } = useListContext();
     const exporter = customExporter || exporterFromContext;
     const dataProvider = useDataProvider();
     const notify = useNotify();
@@ -93,19 +90,15 @@ export const BulkExportButton = (props: BulkExportButtonProps) => {
 const defaultIcon = <DownloadIcon />;
 
 const sanitizeRestProps = ({
-    filterValues,
-    selectedIds,
     resource,
     ...rest
 }: Omit<BulkExportButtonProps, 'exporter' | 'label' | 'meta'>) => rest;
 
 interface Props {
     exporter?: Exporter;
-    filterValues?: any;
     icon?: JSX.Element;
     label?: string;
     onClick?: (e: Event) => void;
-    selectedIds?: Identifier[];
     resource?: string;
     meta?: any;
 }

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -29,7 +29,7 @@ export const BulkUpdateWithConfirmButton = (
     const resource = useResourceContext(props);
     const unselectAll = useUnselectAll(resource);
     const [isOpen, setOpen] = useState(false);
-    const { selectedIds } = useListContext(props);
+    const { selectedIds } = useListContext();
 
     const {
         confirmTitle = 'ra.message.bulk_update_title',
@@ -138,7 +138,6 @@ export const BulkUpdateWithConfirmButton = (
 };
 
 const sanitizeRestProps = ({
-    filterValues,
     label,
     onSuccess,
     onError,

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -22,7 +22,7 @@ import { BulkActionProps } from '../types';
 export const BulkUpdateWithUndoButton = (
     props: BulkUpdateWithUndoButtonProps
 ) => {
-    const { selectedIds } = useListContext(props);
+    const { selectedIds } = useListContext();
 
     const notify = useNotify();
     const resource = useResourceContext(props);
@@ -99,9 +99,7 @@ export const BulkUpdateWithUndoButton = (
 const defaultIcon = <ActionUpdate />;
 
 const sanitizeRestProps = ({
-    filterValues,
     label,
-    selectedIds,
     onSuccess,
     onError,
     ...rest

--- a/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
@@ -32,10 +32,6 @@ describe('<ExportButton />', () => {
 
         await waitFor(() => {
             expect(dataProvider.getList).toHaveBeenCalledWith('test', {
-                sort: {
-                    field: 'id',
-                    order: 'ASC',
-                },
                 filter: { filters: 'override' },
                 pagination: { page: 1, perPage: 1000 },
                 meta: { pass: 'meta' },

--- a/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
@@ -32,7 +32,10 @@ describe('<ExportButton />', () => {
 
         await waitFor(() => {
             expect(dataProvider.getList).toHaveBeenCalledWith('test', {
-                sort: null,
+                sort: {
+                    field: 'id',
+                    order: 'ASC',
+                },
                 filter: { filters: 'override' },
                 pagination: { page: 1, perPage: 1000 },
                 meta: { pass: 'meta' },

--- a/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 import expect from 'expect';
-import { CoreAdminContext, testDataProvider } from 'ra-core';
+import {
+    CoreAdminContext,
+    testDataProvider,
+    ListContextProvider,
+} from 'ra-core';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { ExportButton } from './ExportButton';
@@ -18,12 +22,19 @@ describe('<ExportButton />', () => {
         render(
             <CoreAdminContext dataProvider={dataProvider}>
                 <ThemeProvider theme={theme}>
-                    <ExportButton
-                        resource="test"
-                        filterValues={{ filters: 'override' }}
-                        exporter={exporter}
-                        meta={{ pass: 'meta' }}
-                    />
+                    <ListContextProvider
+                        value={
+                            {
+                                resource: 'test',
+                                filterValues: { filters: 'override' },
+                            } as any
+                        }
+                    >
+                        <ExportButton
+                            exporter={exporter}
+                            meta={{ pass: 'meta' }}
+                        />
+                    </ListContextProvider>
                 </ThemeProvider>
             </CoreAdminContext>
         );

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -7,9 +7,7 @@ import {
     useDataProvider,
     useNotify,
     useListContext,
-    SortPayload,
     Exporter,
-    FilterPayload,
     useResourceContext,
 } from 'ra-core';
 import { Button, ButtonProps } from './Button';
@@ -30,7 +28,7 @@ export const ExportButton = (props: ExportButtonProps) => {
         sort,
         exporter: exporterFromContext,
         total,
-    } = useListContext(props);
+    } = useListContext();
     const resource = useResourceContext(props);
     const exporter = customExporter || exporterFromContext;
     const dataProvider = useDataProvider();
@@ -93,7 +91,6 @@ export const ExportButton = (props: ExportButtonProps) => {
 const defaultIcon = <DownloadIcon />;
 
 const sanitizeRestProps = ({
-    filterValues,
     resource,
     ...rest
 }: Omit<
@@ -103,13 +100,11 @@ const sanitizeRestProps = ({
 
 interface Props {
     exporter?: Exporter;
-    filterValues?: FilterPayload;
     icon?: JSX.Element;
     label?: string;
     maxResults?: number;
     onClick?: (e: Event) => void;
     resource?: string;
-    sort?: SortPayload;
     meta?: any;
 }
 

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -8,7 +8,6 @@ import {
     useNotify,
     useListContext,
     Exporter,
-    useResourceContext,
 } from 'ra-core';
 import { Button, ButtonProps } from './Button';
 

--- a/packages/ra-ui-materialui/src/button/ExportButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ExportButton.tsx
@@ -25,11 +25,11 @@ export const ExportButton = (props: ExportButtonProps) => {
     const {
         filter,
         filterValues,
+        resource,
         sort,
         exporter: exporterFromContext,
         total,
     } = useListContext();
-    const resource = useResourceContext(props);
     const exporter = customExporter || exporterFromContext;
     const dataProvider = useDataProvider();
     const notify = useNotify();

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
@@ -142,7 +142,6 @@ export const UpdateWithConfirmButton = (
 };
 
 const sanitizeRestProps = ({
-    filterValues,
     label,
     ...rest
 }: Omit<

--- a/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
@@ -97,9 +97,7 @@ export const UpdateWithUndoButton = (props: UpdateWithUndoButtonProps) => {
 const defaultIcon = <ActionUpdate />;
 
 const sanitizeRestProps = ({
-    filterValues,
     label,
-    selectedIds,
     ...rest
 }: Omit<UpdateWithUndoButtonProps, 'resource' | 'icon' | 'data'>) => rest;
 

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -54,9 +54,7 @@ export const Create = <
     RecordType extends Omit<RaRecord, 'id'> = any,
     ResultRecordType extends RaRecord = RecordType & { id: Identifier }
 >(
-    props: CreateProps<RecordType, Error, ResultRecordType> & {
-        children: ReactNode;
-    }
+    props: CreateProps<RecordType, Error, ResultRecordType>
 ): ReactElement => {
     useCheckMinimumRequiredProps('Create', ['children'], props);
     const {

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { Identifier, RaRecord, useCheckMinimumRequiredProps } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { RaRecord, CreateControllerProps, useCreateContext } from 'ra-core';
+import { useCreateContext } from 'ra-core';
 import clsx from 'clsx';
 
 import { CreateProps } from '../types';
@@ -20,7 +19,7 @@ export const CreateView = (props: CreateViewProps) => {
         ...rest
     } = props;
 
-    const { resource, defaultTitle } = useCreateContext(props);
+    const { resource, defaultTitle } = useCreateContext();
 
     return (
         <Root
@@ -45,11 +44,7 @@ export const CreateView = (props: CreateViewProps) => {
     );
 };
 
-interface CreateViewProps<RecordType extends RaRecord = any>
-    extends CreateProps<RecordType>,
-        Omit<CreateControllerProps<RecordType>, 'resource'> {
-    children: ReactNode;
-}
+export type CreateViewProps = CreateProps;
 
 CreateView.propTypes = {
     actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -52,7 +52,7 @@ import { EditBase } from 'ra-core';
  * export default App;
  */
 export const Edit = <RecordType extends RaRecord = any>(
-    props: EditProps<RecordType> & { children: ReactNode }
+    props: EditProps<RecordType>
 ) => {
     useCheckMinimumRequiredProps('Edit', ['children'], props);
     const {

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { useCheckMinimumRequiredProps, RaRecord } from 'ra-core';
 import { EditProps } from '../types';

--- a/packages/ra-ui-materialui/src/detail/EditActions.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { RaRecord, useResourceDefinition } from 'ra-core';
+import { useResourceDefinition } from 'ra-core';
 import { ShowButton } from '../button';
 import TopToolbar from '../layout/TopToolbar';
 

--- a/packages/ra-ui-materialui/src/detail/EditActions.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { RaRecord, useEditContext, useResourceDefinition } from 'ra-core';
+import { RaRecord, useResourceDefinition } from 'ra-core';
 import { ShowButton } from '../button';
 import TopToolbar from '../layout/TopToolbar';
 
@@ -31,12 +31,11 @@ import TopToolbar from '../layout/TopToolbar';
  *     );
  */
 export const EditActions = ({ className, ...rest }: EditActionsProps) => {
-    const { record } = useEditContext(rest);
     const { hasShow } = useResourceDefinition(rest);
 
     return (
         <TopToolbar className={className} {...sanitizeRestProps(rest)}>
-            {hasShow && <ShowButton record={record} />}
+            {hasShow && <ShowButton />}
         </TopToolbar>
     );
 };
@@ -53,7 +52,6 @@ const sanitizeRestProps = ({
 
 export interface EditActionsProps {
     className?: string;
-    data?: RaRecord;
     hasCreate?: boolean;
     hasEdit?: boolean;
     hasList?: boolean;
@@ -63,7 +61,6 @@ export interface EditActionsProps {
 
 EditActions.propTypes = {
     className: PropTypes.string,
-    data: PropTypes.object,
     hasCreate: PropTypes.bool,
     hasEdit: PropTypes.bool,
     hasShow: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -28,7 +28,7 @@ export const EditView = (props: EditViewProps) => {
     } = props;
 
     const { hasShow } = useResourceDefinition();
-    const { resource, defaultTitle, record } = useEditContext(props);
+    const { resource, defaultTitle, record } = useEditContext();
 
     const finalActions =
         typeof actions === 'undefined' && hasShow ? (
@@ -64,11 +64,7 @@ export const EditView = (props: EditViewProps) => {
     );
 };
 
-interface EditViewProps
-    extends EditProps,
-        Omit<EditControllerProps, 'resource'> {
-    children: ReactNode;
-}
+export type EditViewProps = EditProps;
 
 EditView.propTypes = {
     actions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import { Card, CardContent } from '@mui/material';
 import clsx from 'clsx';
 import {
-    EditControllerProps,
     ComponentPropType,
     useEditContext,
     useResourceDefinition,

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -23,7 +23,7 @@ export const ShowView = (props: ShowViewProps) => {
         ...rest
     } = props;
 
-    const { resource, defaultTitle, record } = useShowContext(props);
+    const { resource, defaultTitle, record } = useShowContext();
     const { hasEdit } = useResourceDefinition(props);
 
     const finalActions =

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -151,7 +151,7 @@ export interface ReferenceArrayFieldViewProps
 
 export const ReferenceArrayFieldView: FC<ReferenceArrayFieldViewProps> = props => {
     const { children, pagination, className, sx } = props;
-    const { isPending, total } = useListContext(props);
+    const { isPending, total } = useListContext();
 
     return (
         <Root className={className} sx={sx}>

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -156,14 +156,13 @@ export const ReferenceManyFieldView: FC<ReferenceManyFieldViewProps> = props => 
     );
 };
 
-export interface ReferenceManyFieldViewProps
-    extends Omit<
-            ReferenceManyFieldProps,
-            'resource' | 'page' | 'perPage' | 'sort'
-        >,
-        ListControllerResult {
-    children: ReactElement;
-}
+export type ReferenceManyFieldViewProps = Omit<
+    ReferenceManyFieldProps,
+    'resource' | 'page' | 'perPage' | 'sort'
+> &
+    ListControllerResult & {
+        children: ReactElement;
+    };
 
 ReferenceManyFieldView.propTypes = {
     children: PropTypes.element,

--- a/packages/ra-ui-materialui/src/input/DatagridInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DatagridInput.tsx
@@ -104,6 +104,8 @@ export const DatagridInput = (props: DatagridInputProps) => {
         () => ({
             ...choicesContext,
             data: availableChoices,
+            total: availableChoices.length,
+            error: null,
             onSelect,
             onToggleItem,
             onUnselectItems,
@@ -120,6 +122,7 @@ export const DatagridInput = (props: DatagridInputProps) => {
     );
     return (
         <div className={clsx('ra-input', `ra-input-${source}`, className)}>
+            {/* @ts-ignore FIXME cannot find another way to fix this error: "Types of property 'isPending' are incompatible: Type 'boolean' is not assignable to type 'false'." */}
             <ListContextProvider value={listContext}>
                 {filters ? (
                     Array.isArray(filters) ? (

--- a/packages/ra-ui-materialui/src/input/DatagridInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DatagridInput.tsx
@@ -104,7 +104,7 @@ export const DatagridInput = (props: DatagridInputProps) => {
         () => ({
             ...choicesContext,
             data: availableChoices,
-            total: availableChoices.length,
+            total: availableChoices?.length,
             error: null,
             onSelect,
             onToggleItem,

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
@@ -8,12 +8,7 @@ import Typography from '@mui/material/Typography';
 import { lighten } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
-import {
-    useTranslate,
-    sanitizeListRestProps,
-    useListContext,
-    Identifier,
-} from 'ra-core';
+import { useTranslate, sanitizeListRestProps, useListContext } from 'ra-core';
 
 import TopToolbar from '../layout/TopToolbar';
 
@@ -24,7 +19,7 @@ export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
         className,
         ...rest
     } = props;
-    const { selectedIds = [], onUnselectItems } = useListContext(props);
+    const { selectedIds = [], onUnselectItems } = useListContext();
 
     const translate = useTranslate();
 
@@ -75,7 +70,6 @@ BulkActionsToolbar.propTypes = {
 export interface BulkActionsToolbarProps {
     children?: ReactNode;
     label?: string;
-    selectedIds?: Identifier[];
     className?: string;
 }
 

--- a/packages/ra-ui-materialui/src/list/ListActions.tsx
+++ b/packages/ra-ui-materialui/src/list/ListActions.tsx
@@ -3,7 +3,6 @@ import { cloneElement, useMemo, useContext, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import {
     sanitizeListRestProps,
-    Identifier,
     SortPayload,
     Exporter,
     useListContext,
@@ -46,14 +45,7 @@ import { FilterButton } from './filter';
  * );
  */
 export const ListActions = (props: ListActionsProps) => {
-    const {
-        className,
-        filters: filtersProp,
-        hasCreate: _,
-        selectedIds = defaultSelectedIds,
-        onUnselectItems = defaultOnUnselectItems,
-        ...rest
-    } = props;
+    const { className, filters: filtersProp, hasCreate: _, ...rest } = props;
 
     const {
         sort,
@@ -62,7 +54,7 @@ export const ListActions = (props: ListActionsProps) => {
         exporter,
         showFilter,
         total,
-    } = useListContext({ ...props, selectedIds, onUnselectItems });
+    } = useListContext();
     const resource = useResourceContext(props);
     const { hasCreate } = useResourceDefinition(props);
     const filters = useContext(FilterContext) || filtersProp;
@@ -118,8 +110,6 @@ ListActions.propTypes = {
     filterValues: PropTypes.object,
     hasCreate: PropTypes.bool,
     resource: PropTypes.string,
-    onUnselectItems: PropTypes.func,
-    selectedIds: PropTypes.arrayOf(PropTypes.any),
     showFilter: PropTypes.func,
     total: PropTypes.number,
 };
@@ -134,11 +124,6 @@ export interface ListActionsProps extends ToolbarProps {
     filterValues?: any;
     permanentFilter?: any;
     hasCreate?: boolean;
-    selectedIds?: Identifier[];
-    onUnselectItems?: () => void;
     showFilter?: (filterName: string, defaultValue: any) => void;
     total?: number;
 }
-
-const defaultSelectedIds = [];
-const defaultOnUnselectItems = () => null;

--- a/packages/ra-ui-materialui/src/list/ListGuesser.tsx
+++ b/packages/ra-ui-materialui/src/list/ListGuesser.tsx
@@ -84,7 +84,7 @@ export const ListGuesser = <RecordType extends RaRecord = any>(
 const ListViewGuesser = (
     props: Omit<ListViewProps, 'children'> & { enableLog?: boolean }
 ) => {
-    const { data } = useListContext(props);
+    const { data } = useListContext();
     const resource = useResourceContext();
     const [child, setChild] = useState(null);
     const {

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -42,7 +42,7 @@ export const ListView = <RecordType extends RaRecord = any>(
         isPending,
         filterValues,
         resource,
-    } = useListContext<RecordType>(props);
+    } = useListContext<RecordType>();
 
     if (!children || (!data && isPending && emptyWhileLoading)) {
         return null;

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -22,7 +22,7 @@ import {
     RaRecord,
     RecordContextProvider,
     sanitizeListRestProps,
-    useListContext,
+    useListContextWithProps,
     useResourceContext,
     useGetRecordRepresentation,
     useCreatePath,
@@ -86,7 +86,9 @@ export const SimpleList = <RecordType extends RaRecord = any>(
         rowStyle,
         ...rest
     } = props;
-    const { data, isPending, total } = useListContext<RecordType>(props);
+    const { data, isPending, total } = useListContextWithProps<RecordType>(
+        props
+    );
     const resource = useResourceContext(props);
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -3,7 +3,7 @@ import { Chip, Stack, StackProps, styled } from '@mui/material';
 import PropTypes from 'prop-types';
 import {
     sanitizeListRestProps,
-    useListContext,
+    useListContextWithProps,
     useResourceContext,
     RaRecord,
     RecordContextProvider,
@@ -59,7 +59,7 @@ export const SingleFieldList = (props: SingleFieldListProps) => {
         direction = 'row',
         ...rest
     } = props;
-    const { data, total, isPending } = useListContext(props);
+    const { data, total, isPending } = useListContextWithProps(props);
     const resource = useResourceContext(props);
     const createPath = useCreatePath();
 

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -10,6 +10,7 @@ import {
     useGetList,
     useList,
     TestMemoryRouter,
+    SortPayload,
 } from 'ra-core';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import defaultMessages from 'ra-language-english';
@@ -326,7 +327,7 @@ export const ColumnStyles = () => (
     </Wrapper>
 );
 
-const sort = { field: 'id', order: 'DESC' };
+const sort = { field: 'id', order: 'DESC' } as SortPayload;
 
 const MyCustomList = () => {
     const { data, total, isLoading } = useGetList('books', {

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -14,7 +14,7 @@ import {
 import PropTypes from 'prop-types';
 import {
     sanitizeListRestProps,
-    useListContext,
+    useListContextWithProps,
     Identifier,
     RaRecord,
     SortPayload,
@@ -146,7 +146,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
         selectedIds,
         setSort,
         total,
-    } = useListContext(props);
+    } = useListContextWithProps(props);
 
     const hasBulkActions = !!bulkActionButtons !== false;
 
@@ -234,7 +234,7 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
                 className={clsx(DatagridClasses.root, className)}
             >
                 {bulkActionButtons !== false ? (
-                    <BulkActionsToolbar selectedIds={selectedIds}>
+                    <BulkActionsToolbar>
                         {isValidElement(bulkActionButtons)
                             ? bulkActionButtons
                             : defaultBulkActionButtons}

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Children, isValidElement, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
-    useListContext,
+    useListContextWithProps,
     useResourceContext,
     Identifier,
     RaRecord,
@@ -32,9 +32,13 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
     } = props;
     const resource = useResourceContext(props);
     const translate = useTranslate();
-    const { sort, data, onSelect, selectedIds, setSort } = useListContext(
-        props
-    );
+    const {
+        sort,
+        data,
+        onSelect,
+        selectedIds,
+        setSort,
+    } = useListContextWithProps(props);
     const { expandSingle } = useDatagridContext();
 
     const updateSortCallback = useCallback(

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -1,6 +1,5 @@
 import React, {
     isValidElement,
-    cloneElement,
     createElement,
     useState,
     useEffect,

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import expect from 'expect';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { createTheme } from '@mui/material/styles';
+import { ListContextProvider, ListControllerResult } from 'ra-core';
 
 import { AdminContext } from '../../AdminContext';
 import { FilterButton } from './FilterButton';
@@ -11,18 +12,21 @@ import { Basic, WithAutoCompleteArrayInput } from './FilterButton.stories';
 const theme = createTheme();
 
 describe('<FilterButton />', () => {
-    const defaultProps = {
+    const defaultListContext = ({
         resource: 'post',
-        filters: [
-            <TextInput source="title" label="Title" />,
-            <TextInput source="customer.name" label="Name" />,
-        ],
         displayedFilters: {
             title: true,
             'customer.name': true,
         },
         showFilter: () => {},
         filterValues: {},
+    } as unknown) as ListControllerResult;
+
+    const defaultProps = {
+        filters: [
+            <TextInput source="title" label="Title" />,
+            <TextInput source="customer.name" label="Name" />,
+        ],
     };
 
     beforeAll(() => {
@@ -40,10 +44,12 @@ describe('<FilterButton />', () => {
             );
             const { getByLabelText, queryByText } = render(
                 <AdminContext theme={theme}>
-                    <FilterButton
-                        {...defaultProps}
-                        filters={defaultProps.filters.concat(hiddenFilter)}
-                    />
+                    <ListContextProvider value={defaultListContext}>
+                        <FilterButton
+                            {...defaultProps}
+                            filters={defaultProps.filters.concat(hiddenFilter)}
+                        />
+                    </ListContextProvider>
                 </AdminContext>
             );
 
@@ -56,18 +62,26 @@ describe('<FilterButton />', () => {
         it('should display the filter button if all filters are shown and there is a filter value', () => {
             render(
                 <AdminContext theme={theme}>
-                    <FilterButton
-                        {...defaultProps}
-                        filters={[
-                            <TextInput source="title" label="Title" />,
-                            <TextInput source="customer.name" label="Name" />,
-                        ]}
-                        displayedFilters={{
-                            title: true,
-                            'customer.name': true,
+                    <ListContextProvider
+                        value={{
+                            ...defaultListContext,
+                            displayedFilters: {
+                                title: true,
+                                'customer.name': true,
+                            },
+                            filterValues: { title: 'foo' },
                         }}
-                        filterValues={{ title: 'foo' }}
-                    />
+                    >
+                        <FilterButton
+                            filters={[
+                                <TextInput source="title" label="Title" />,
+                                <TextInput
+                                    source="customer.name"
+                                    label="Name"
+                                />,
+                            ]}
+                        />
+                    </ListContextProvider>
                 </AdminContext>
             );
             expect(
@@ -83,10 +97,11 @@ describe('<FilterButton />', () => {
             );
             const { getByLabelText, queryByText } = render(
                 <AdminContext theme={theme}>
-                    <FilterButton
-                        {...defaultProps}
-                        filters={defaultProps.filters.concat(hiddenFilter)}
-                    />
+                    <ListContextProvider value={defaultListContext}>
+                        <FilterButton
+                            filters={defaultProps.filters.concat(hiddenFilter)}
+                        />
+                    </ListContextProvider>
                 </AdminContext>
             );
 
@@ -172,14 +187,22 @@ describe('<FilterButton />', () => {
         it('should not display save query in filter button', async () => {
             const { queryByText } = render(
                 <AdminContext theme={theme}>
-                    <FilterButton
-                        {...defaultProps}
-                        filterValues={{ title: 'foo' }}
-                        filters={[
-                            <TextInput source="Returned" label="Returned" />,
-                        ]}
-                        disableSaveQuery
-                    />
+                    <ListContextProvider
+                        value={{
+                            ...defaultListContext,
+                            filterValues: { title: 'foo' },
+                        }}
+                    >
+                        <FilterButton
+                            filters={[
+                                <TextInput
+                                    source="Returned"
+                                    label="Returned"
+                                />,
+                            ]}
+                            disableSaveQuery
+                        />
+                    </ListContextProvider>
                 </AdminContext>
             );
             expect(

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -42,7 +42,7 @@ export const FilterButton = (props: FilterButtonProps): JSX.Element => {
         setFilters,
         showFilter,
         sort,
-    } = useListContext(props);
+    } = useListContext();
     const hasFilterValues = !isEqual(filterValues, {});
     const validSavedQueries = extractValidSavedQueries(savedQueries);
     const hasSavedCurrentQuery = validSavedQueries.some(savedQuery =>
@@ -248,22 +248,17 @@ const sanitizeRestProps = ({
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 FilterButton.propTypes = {
-    resource: PropTypes.string,
-    filters: PropTypes.arrayOf(PropTypes.node),
-    displayedFilters: PropTypes.object,
-    filterValues: PropTypes.object,
-    showFilter: PropTypes.func,
     className: PropTypes.string,
+    disableSaveQuery: PropTypes.bool,
+    filters: PropTypes.arrayOf(PropTypes.node),
+    resource: PropTypes.string,
 };
 
 export interface FilterButtonProps extends HtmlHTMLAttributes<HTMLDivElement> {
     className?: string;
-    resource?: string;
-    filterValues?: any;
-    showFilter?: (filterName: string, defaultValue: any) => void;
-    displayedFilters?: any;
-    filters?: ReactNode[];
     disableSaveQuery?: boolean;
+    filters?: ReactNode[];
+    resource?: string;
 }
 
 const PREFIX = 'RaFilterButton';

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.spec.tsx
@@ -2,9 +2,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import expect from 'expect';
 import {
     ListContext,
+    ListContextProvider,
     minLength,
     ResourceContextProvider,
     testDataProvider,
+    ListControllerResult,
 } from 'ra-core';
 import * as React from 'react';
 
@@ -23,13 +25,12 @@ import {
 } from './FilterForm';
 
 describe('<FilterForm />', () => {
-    const defaultProps = {
+    const defaultListContext = ({
         resource: 'post',
-        filters: [],
-        setFilters: () => {},
+        showFilter: () => {},
         hideFilter: () => {},
         displayedFilters: {},
-    };
+    } as unknown) as ListControllerResult;
 
     beforeAll(() => {
         window.scrollTo = jest.fn();
@@ -52,12 +53,15 @@ describe('<FilterForm />', () => {
 
         render(
             <AdminContext>
-                <FilterForm
-                    {...defaultProps}
-                    setFilters={setFilters}
-                    filters={filters}
-                    displayedFilters={displayedFilters}
-                />
+                <ListContextProvider
+                    value={{
+                        ...defaultListContext,
+                        setFilters,
+                        displayedFilters,
+                    }}
+                >
+                    <FilterForm filters={filters} />
+                </ListContextProvider>
             </AdminContext>
         );
         expect(screen.queryAllByLabelText('Title')).toHaveLength(1);
@@ -84,12 +88,15 @@ describe('<FilterForm />', () => {
         expect(() => {
             render(
                 <AdminContext>
-                    <FilterForm
-                        {...defaultProps}
-                        setFilters={setFilters}
-                        filters={filters}
-                        displayedFilters={displayedFilters}
-                    />
+                    <ListContextProvider
+                        value={{
+                            ...defaultListContext,
+                            setFilters,
+                            displayedFilters,
+                        }}
+                    >
+                        <FilterForm filters={filters} />
+                    </ListContextProvider>
                 </AdminContext>
             );
         }).not.toThrow();
@@ -105,12 +112,15 @@ describe('<FilterForm />', () => {
 
         render(
             <AdminContext>
-                <FilterForm
-                    {...defaultProps}
-                    filters={filters}
-                    displayedFilters={displayedFilters}
-                    setFilters={setFilters}
-                />
+                <ListContextProvider
+                    value={{
+                        ...defaultListContext,
+                        setFilters,
+                        displayedFilters,
+                    }}
+                >
+                    <FilterForm filters={filters} />
+                </ListContextProvider>
             </AdminContext>
         );
         fireEvent.change(screen.queryByLabelText('Title') as Element, {
@@ -140,12 +150,15 @@ describe('<FilterForm />', () => {
 
         render(
             <AdminContext>
-                <FilterForm
-                    {...defaultProps}
-                    filters={filters}
-                    displayedFilters={displayedFilters}
-                    setFilters={setFilters}
-                />
+                <ListContextProvider
+                    value={{
+                        ...defaultListContext,
+                        setFilters,
+                        displayedFilters,
+                    }}
+                >
+                    <FilterForm filters={filters} />
+                </ListContextProvider>
             </AdminContext>
         );
         fireEvent.change(screen.queryByLabelText('Title') as HTMLElement, {
@@ -202,12 +215,15 @@ describe('<FilterForm />', () => {
 
         render(
             <AdminContext>
-                <FilterForm
-                    {...defaultProps}
-                    filters={filters}
-                    displayedFilters={displayedFilters}
-                    setFilters={setFilters}
-                />
+                <ListContextProvider
+                    value={{
+                        ...defaultListContext,
+                        setFilters,
+                        displayedFilters,
+                    }}
+                >
+                    <FilterForm filters={filters} />
+                </ListContextProvider>
             </AdminContext>
         );
         fireEvent.change(screen.queryByLabelText('Title') as Element, {

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import {
     FormGroupsProvider,
-    ListFilterContextValue,
     SourceContextProvider,
     SourceContextValue,
     useListContext,
@@ -34,9 +33,7 @@ import { FilterContext } from '../FilterContext';
 export const FilterForm = (props: FilterFormProps) => {
     const { defaultValues, filters: filtersProps, ...rest } = props;
 
-    const { setFilters, displayedFilters, filterValues } = useListContext(
-        props
-    );
+    const { setFilters, displayedFilters, filterValues } = useListContext();
     const filters = useContext(FilterContext) || filtersProps;
 
     const mergedInitialValuesWithDefaultValues = mergeInitialValuesWithDefaultValues(
@@ -105,7 +102,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
     const { className, filters, ...rest } = props;
     const resource = useResourceContext(props);
     const form = useFormContext();
-    const { displayedFilters = {}, hideFilter } = useListContext(props);
+    const { displayedFilters = {}, hideFilter } = useListContext();
 
     useEffect(() => {
         filters.forEach((filter: JSX.Element) => {
@@ -180,11 +177,7 @@ FilterFormBase.propTypes = {
 };
 
 const sanitizeRestProps = ({
-    displayedFilters,
-    filterValues,
     hasCreate,
-    hideFilter,
-    setFilters,
     resource,
     ...props
 }: Partial<FilterFormBaseProps> & { hasCreate?: boolean }) => props;
@@ -192,12 +185,11 @@ const sanitizeRestProps = ({
 export type FilterFormBaseProps = Omit<
     HtmlHTMLAttributes<HTMLFormElement>,
     'children'
-> &
-    Partial<ListFilterContextValue> & {
-        className?: string;
-        resource?: string;
-        filters?: ReactNode[];
-    };
+> & {
+    className?: string;
+    resource?: string;
+    filters?: ReactNode[];
+};
 
 export const mergeInitialValuesWithDefaultValues = (
     initialValues,

--- a/packages/ra-ui-materialui/src/list/pagination/Pagination.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/Pagination.spec.tsx
@@ -48,12 +48,14 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: 2,
-                            page: 2,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: 2,
+                                page: 2,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -69,12 +71,14 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: 2,
-                            page: 2,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: 2,
+                                page: 2,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -90,12 +94,14 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: 2,
-                            page: 1,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: 2,
+                                page: 1,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -114,13 +120,15 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: undefined,
-                            page: 1,
-                            hasNextPage: true,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: undefined,
+                                page: 1,
+                                hasNextPage: true,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -136,13 +144,15 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: undefined,
-                            page: 2,
-                            hasNextPage: false,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: undefined,
+                                page: 2,
+                                hasNextPage: false,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -158,13 +168,15 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: undefined,
-                            page: 2,
-                            hasPreviousPage: true,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: undefined,
+                                page: 2,
+                                hasPreviousPage: true,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -180,13 +192,15 @@ describe('<Pagination />', () => {
             render(
                 <ThemeProvider theme={theme}>
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            perPage: 1,
-                            total: undefined,
-                            page: 1,
-                            hasPreviousPage: false,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                perPage: 1,
+                                total: undefined,
+                                page: 1,
+                                hasPreviousPage: false,
+                            } as any
+                        }
                     >
                         <Pagination rowsPerPageOptions={[1]} />
                     </ListPaginationContext.Provider>
@@ -205,12 +219,14 @@ describe('<Pagination />', () => {
             render(
                 <DeviceTestWrapper width="sm">
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            page: 2,
-                            perPage: 5,
-                            total: 15,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                page: 2,
+                                perPage: 5,
+                                total: 15,
+                            } as any
+                        }
                     >
                         <Pagination />
                     </ListPaginationContext.Provider>
@@ -227,12 +243,14 @@ describe('<Pagination />', () => {
             render(
                 <DeviceTestWrapper width="lg">
                     <ListPaginationContext.Provider
-                        value={{
-                            ...defaultProps,
-                            page: 2,
-                            perPage: 5,
-                            total: 15,
-                        }}
+                        value={
+                            {
+                                ...defaultProps,
+                                page: 2,
+                                perPage: 5,
+                                total: 15,
+                            } as any
+                        }
                     >
                         <Pagination />
                     </ListPaginationContext.Provider>
@@ -243,35 +261,6 @@ describe('<Pagination />', () => {
                 screen.queryByText('ra.navigation.page_rows_per_page')
             ).not.toBeNull();
         });
-    });
-
-    it('should work outside of a ListContext', () => {
-        render(
-            <ThemeProvider theme={theme}>
-                <Pagination
-                    resource="posts"
-                    setPage={() => null}
-                    isLoading={false}
-                    setPerPage={() => {}}
-                    hasNextPage={undefined}
-                    hasPreviousPage={undefined}
-                    perPage={1}
-                    total={2}
-                    page={1}
-                    rowsPerPageOptions={[1]}
-                />
-            </ThemeProvider>
-        );
-        const nextButton = screen.queryByLabelText(
-            'Go to next page'
-        ) as HTMLButtonElement;
-        expect(nextButton).not.toBeNull();
-        expect(nextButton.disabled).toBe(false);
-        const prevButton = screen.queryByLabelText(
-            'Go to previous page'
-        ) as HTMLButtonElement;
-        expect(prevButton).not.toBeNull();
-        expect(prevButton.disabled).toBe(true);
     });
 
     describe('rowsPerPageOptions', () => {

--- a/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
@@ -13,7 +13,6 @@ import {
     useListPaginationContext,
     sanitizeListRestProps,
     ComponentPropType,
-    ListPaginationContextValue,
 } from 'ra-core';
 
 import { PaginationActions, PaginationActionsProps } from './PaginationActions';
@@ -33,7 +32,7 @@ export const Pagination: FC<PaginationProps> = memo(props => {
         total,
         setPage,
         setPerPage,
-    } = useListPaginationContext(props);
+    } = useListPaginationContext();
     const translate = useTranslate();
     const isSmall = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('md')
@@ -164,9 +163,7 @@ Pagination.propTypes = {
 const DefaultRowsPerPageOptions = [5, 10, 25, 50];
 const emptyArray = [];
 
-export interface PaginationProps
-    extends TablePaginationBaseProps,
-        Partial<ListPaginationContextValue> {
+export interface PaginationProps extends TablePaginationBaseProps {
     rowsPerPageOptions?: Array<number | { label: string; value: number }>;
     actions?: FC<PaginationActionsProps>;
     limit?: ReactElement;

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -77,8 +77,4 @@ export interface ShowProps<RecordType extends RaRecord = any> {
     sx?: SxProps;
 }
 
-export interface BulkActionProps {
-    filterValues?: any;
-    resource?: string;
-    selectedIds?: Identifier[];
-}
+export interface BulkActionProps {}

--- a/packages/ra-ui-materialui/src/types.ts
+++ b/packages/ra-ui-materialui/src/types.ts
@@ -17,6 +17,7 @@ export interface EditProps<
 > {
     actions?: ReactElement | false;
     aside?: ReactElement;
+    children: ReactNode;
     className?: string;
     component?: ElementType;
     disableAuthentication?: boolean;
@@ -42,6 +43,7 @@ export interface CreateProps<
 > {
     actions?: ReactElement | false;
     aside?: ReactElement;
+    children: ReactNode;
     className?: string;
     component?: ElementType;
     disableAuthentication?: boolean;


### PR DESCRIPTION
With strictNullChecks turned on, this PR reduces TS compilation errors on ra-core from 180 to 60 (-67%)

Refs #9622

## Page Contexts Are Now Types Instead of Interfaces

The return type of page controllers is now a type. If you were using an interface extending one of:

- `ListControllerResult`,
- `InfiniteListControllerResult`,
- `EditControllerResult`,
- `ShowControllerResult`, or
- `CreateControllerResult`,

you'll have to change it to a type:

```diff
import { ListControllerResult } from 'react-admin';

-interface MyListControllerResult extends ListControllerResult {
+type MyListControllerResult = ListControllerResult & {
    customProp: string;
};
```

## TypeScript: Stronger Types For Page Contexts

The return type of page context hooks is now smarter. This concerns the following hooks:

- `useListContext`,
- `useEditContext`,
- `useShowContext`, and
- `useCreateContext`

Depending on the fetch status of the data, the type of the `data`, `error`, and `isPending` properties will be more precise:

- Loading: `{ data: undefined, error: undefined, isPending: true }`
- Success: `{ data: <Data>, error: undefined, isPending: false }`
- Error: `{ data: undefined, error: <Error>, isPending: false }`
- Error After Refetch: `{ data: <Data>, error: <Error>, isPending: false }`

This means that TypeScript may complain if you use the `data` property without checking if it's defined first. You'll have to update your code to handle the different states:

```diff
const MyCustomList = () => {
    const { data, error, isPending } = useListContext();
    if (isPending) return <Loading />;
+   if (error) return <Error />;
    return (
        <ul>
            {data.map(record => (
                <li key={record.id}>{record.name}</li>
            ))}
        </ul>
    );
};
```

Besides, these hooks will now throw an error when called outside of a page context. This means that you can't use them in a custom component that is not a child of a `<List>`, `<ListBase>`, `<Edit>`, `<EditBase>`, `<Show>`, `<ShowBase>`, `<Create>`, or `<CreateBase>` component.