### PR TITLE
Fix JS docs (@typedef)

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateContext.tsx
+++ b/packages/ra-core/src/controller/create/useCreateContext.tsx
@@ -15,7 +15,7 @@ import { CreateControllerResult } from './useCreateController';
  *
  * The given props will take precedence over context values.
  *
- * @typedef {Object} CreateControllerProps
+ * @param {Object} CreateControllerProps
  *
  * @returns {CreateControllerResult} create controller props
  *

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -15,7 +15,7 @@ import { EditControllerResult } from './useEditController';
  *
  * The given props will take precedence over context values.
  *
- * @typedef {Object} EditControllerProps
+ * @param {Object} EditControllerProps
  *
  * @returns {EditControllerResult} edit controller props
  *

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
@@ -35,13 +35,13 @@ export interface UseReferenceOneFieldControllerParams<
  *     target: 'author_id',
  * });
  *
- * @typedef {Object} UseReferenceOneFieldControllerParams
- * @prop {Object} props.record The current resource record
- * @prop {string} props.reference The linked resource name
- * @prop {string} props.target The target resource key
- * @prop {string} props.source The key current record identifier ('id' by default)
- * @prop {Object} props.sort The sort to apply to the referenced records
- * @prop {Object} props.filter The filter to apply to the referenced records
+ * @param {Object} UseReferenceOneFieldControllerParams
+ * @param {Object} props.record The current resource record
+ * @param {string} props.reference The linked resource name
+ * @param {string} props.target The target resource key
+ * @param {string} props.source The key current record identifier ('id' by default)
+ * @param {Object} props.sort The sort to apply to the referenced records
+ * @param {Object} props.filter The filter to apply to the referenced records
  * @returns {UseReferenceResult} The request state. Destructure as { referenceRecord, isLoading, error }.
  */
 export const useReferenceOneFieldController = <

--- a/packages/ra-core/src/controller/list/InfinitePaginationContext.ts
+++ b/packages/ra-core/src/controller/list/InfinitePaginationContext.ts
@@ -6,9 +6,9 @@ import { InfiniteListControllerResult } from './useInfiniteListController';
  *
  * Use the useInfinitePaginationContext() hook to read the pagination callbacks.
  *
- * @typedef {Object} InfinitePaginationContextValue
- * @prop {Function} fetchNextPage a callback to fetch the next page
- * @prop {Function} fetchPreviousPage a callback to fetch the previous page
+ * @param {Object} InfinitePaginationContextValue
+ * @param {Function} fetchNextPage a callback to fetch the next page
+ * @param {Function} fetchPreviousPage a callback to fetch the previous page
 
  * @example
  *

--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -7,34 +7,31 @@ import { ListControllerResult } from './useListController';
  * Use the useListContext() hook to read the context. That's what many
  * List components do in react-admin (e.g. <Datagrid>, <FilterForm>, <Pagination>).
  *
- * @typedef {Object} ListControllerProps
- * @prop {Array}    data an array of the list records, e.g. [{ id: 123, title: 'hello world' }, { ... }]
- * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
- * @prop {boolean}  isFetching boolean that is true on mount, and false once the data was fetched
- * @prop {boolean}  isLoading boolean that is false until the data is available
- * @prop {integer}  page the current page. Starts at 1
- * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
- * @prop {integer}  perPage the number of results per page. Defaults to 25
- * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
- * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
- * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
- * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
- * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
- * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
- * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
- * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
- * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
- * @prop {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
- * @prop {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
- * @prop {Function} refetch a function for triggering a refetch of the list data
- *
- * @typedef Props
- * @prop {ListControllerResult} value
- *
- * @param {Props}
+ * @param {Props}    Props
+ * @param {Object}   ListControllerProps
+ * @param {Array}    data an array of the list records, e.g. [{ id: 123, title: 'hello world' }, { ... }]
+ * @param {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
+ * @param {boolean}  isFetching boolean that is true on mount, and false once the data was fetched
+ * @param {boolean}  isLoading boolean that is false until the data is available
+ * @param {integer}  page the current page. Starts at 1
+ * @param {Function} setPage a callback to change the page, e.g. setPage(3)
+ * @param {integer}  perPage the number of results per page. Defaults to 25
+ * @param {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @param {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
+ * @param {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
+ * @param {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
+ * @param {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
+ * @param {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @param {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
+ * @param {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
+ * @param {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
+ * @param {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
+ * @param {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
+ * @param {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
+ * @param {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {Function} refetch a function for triggering a refetch of the list data
+ * @param {ListControllerResult} value
  *
  * @see useListController
  * @see useListContext

--- a/packages/ra-core/src/controller/list/ListFilterContext.tsx
+++ b/packages/ra-core/src/controller/list/ListFilterContext.tsx
@@ -8,16 +8,15 @@ import { ListControllerResult } from './useListController';
  * Use the useListFilterContext() hook to read the context. That's what many
  * List components do in react-admin (e.g. <FilterForm>, <FilterListItem>).
  *
- * @typedef {Object} ListFilterContextValue
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
- * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
- * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
- * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
- *
- * @typedef Props
- * @prop {ListFilterContextValue} value
+ * @param {Object}   Props
+ * @param {Object}   ListFilterContextValue
+ * @param {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
+ * @param {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
+ * @param {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @param {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
+ * @param {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {ListFilterContextValue} value
  *
  * @param {Props}
  *

--- a/packages/ra-core/src/controller/list/ListPaginationContext.tsx
+++ b/packages/ra-core/src/controller/list/ListPaginationContext.tsx
@@ -8,22 +8,18 @@ import { ListControllerResult } from './useListController';
  * Use the useListPaginationContext() hook to read the pagination information.
  * That's what List components do in react-admin (e.g. <Pagination>).
  *
- * @typedef {Object} ListPaginationContextValue
- * @prop {boolean}  isLoading boolean that is false until the data is available
- * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
- * @prop {integer}  page the current page. Starts at 1
- * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
- * @prop {integer}  perPage the number of results per page. Defaults to 25
- * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
- * @prop {Boolean}  hasPreviousPage true if the current page is not the first one
- * @prop {Boolean}  hasNextPage true if the current page is not the last one
-
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
- *
- * @typedef Props
- * @prop {ListPaginationContextValue} value
- *
- * @param {Props}
+ * @param {Props} Props
+ * @param {Object} ListPaginationContextValue
+ * @param {boolean}  isLoading boolean that is false until the data is available
+ * @param {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
+ * @param {integer}  page the current page. Starts at 1
+ * @param {Function} setPage a callback to change the page, e.g. setPage(3)
+ * @param {integer}  perPage the number of results per page. Defaults to 25
+ * @param {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @param {Boolean}  hasPreviousPage true if the current page is not the first one
+ * @param {Boolean}  hasNextPage true if the current page is not the last one
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {ListPaginationContextValue} value
  *
  * @see useListController
  * @see useListContext

--- a/packages/ra-core/src/controller/list/ListSortContext.tsx
+++ b/packages/ra-core/src/controller/list/ListSortContext.tsx
@@ -8,15 +8,12 @@ import { ListControllerResult } from './useListController';
  * Use the useListSortContext() hook to read the context. That's what many
  * List components do in react-admin (e.g. <SortButton>).
  *
- * @typedef {Object} ListSortContextValue
- * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
- * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
- *
- * @typedef Props
- * @prop {ListSortContextValue} value
- *
- * @param {Props}
+ * @param {Props}    Props
+ * @param {Object}   ListSortContextValue
+ * @param {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
+ * @param {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {ListSortContextValue} value
  *
  * @see useListController
  * @see useListSortContext

--- a/packages/ra-core/src/controller/list/useInfinitePaginationContext.ts
+++ b/packages/ra-core/src/controller/list/useInfinitePaginationContext.ts
@@ -11,9 +11,9 @@ import {
  * Must be used within a <InfinitePaginationContext.Provider> (e.g. as a descendent of <InfiniteList>
  * or <InfiniteListBase>).
  *
- * @typedef {Object} InfinitePaginationContextValue
- * @prop {Function} fetchNextPage a callback to fetch the next page
- * @prop {Function} fetchPreviousPage a callback to fetch the previous page
+ * @param {Object} InfinitePaginationContextValue
+ * @param {Function} fetchNextPage a callback to fetch the next page
+ * @param {Function} fetchPreviousPage a callback to fetch the previous page
  *
  * @returns {InfinitePaginationContextValue} infinite pagination callbacks
  *

--- a/packages/ra-core/src/controller/list/useListContext.ts
+++ b/packages/ra-core/src/controller/list/useListContext.ts
@@ -16,28 +16,28 @@ import { RaRecord } from '../../types';
  *
  * The given props will take precedence over context values.
  *
- * @typedef {Object} ListControllerProps
- * @prop {Object}   data an array of the list records, e.g. [{ id: 123, title: 'hello world' }, { ... }]
- * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
- * @prop {boolean}  isFetching boolean that is true on mount, and false once the data was fetched
- * @prop {boolean}  isLoading boolean that is false until the data is available
- * @prop {integer}  page the current page. Starts at 1
- * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
- * @prop {integer}  perPage the number of results per page. Defaults to 25
- * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
- * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
- * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field : 'name', order: 'ASC' })
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
- * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
- * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
- * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
- * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
- * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
- * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
- * @prop {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
- * @prop {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {Object}   ListControllerProps
+ * @param {Object}   data an array of the list records, e.g. [{ id: 123, title: 'hello world' }, { ... }]
+ * @param {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
+ * @param {boolean}  isFetching boolean that is true on mount, and false once the data was fetched
+ * @param {boolean}  isLoading boolean that is false until the data is available
+ * @param {integer}  page the current page. Starts at 1
+ * @param {Function} setPage a callback to change the page, e.g. setPage(3)
+ * @param {integer}  perPage the number of results per page. Defaults to 25
+ * @param {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @param {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
+ * @param {Function} setSort a callback to change the sort, e.g. setSort({ field : 'name', order: 'ASC' })
+ * @param {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
+ * @param {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
+ * @param {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @param {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
+ * @param {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
+ * @param {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
+ * @param {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
+ * @param {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
+ * @param {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
+ * @param {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListControllerResult} list controller props
  *

--- a/packages/ra-core/src/controller/list/useListFilterContext.ts
+++ b/packages/ra-core/src/controller/list/useListFilterContext.ts
@@ -8,13 +8,13 @@ import { ListFilterContext, ListFilterContextValue } from './ListFilterContext';
  * Must be used within a <ListContextProvider> (e.g. as a descendent of <List>
  * or <ListBase>).
  *
- * @typedef {Object} ListFilterContextValue
- * @prop {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
- * @prop {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
- * @prop {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
- * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
- * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {Object}   ListFilterContextValue
+ * @param {Object}   filterValues a dictionary of filter values, e.g. { title: 'lorem', nationality: 'fr' }
+ * @param {Function} setFilters a callback to update the filters, e.g. setFilters(filters, displayedFilters)
+ * @param {Object}   displayedFilters a dictionary of the displayed filters, e.g. { title: true, nationality: true }
+ * @param {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
+ * @param {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListFilterContextValue} list controller props
  *

--- a/packages/ra-core/src/controller/list/useListPaginationContext.ts
+++ b/packages/ra-core/src/controller/list/useListPaginationContext.ts
@@ -12,15 +12,15 @@ import {
  * Must be used within a <ListContextProvider> (e.g. as a descendent of <List>
  * or <ListBase>).
  *
- * @typedef {Object} ListPaginationContextValue
- * @prop {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
- * @prop {integer}  page the current page. Starts at 1
- * @prop {Function} setPage a callback to change the page, e.g. setPage(3)
- * @prop {integer}  perPage the number of results per page. Defaults to 25
- * @prop {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
- * @prop {Boolean}  hasPreviousPage true if the current page is not the first one
- * @prop {Boolean}  hasNextPage true if the current page is not the last one
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {Object}   ListPaginationContextValue
+ * @param {integer}  total the total number of results for the current filters, excluding pagination. Useful to build the pagination controls. e.g. 23
+ * @param {integer}  page the current page. Starts at 1
+ * @param {Function} setPage a callback to change the page, e.g. setPage(3)
+ * @param {integer}  perPage the number of results per page. Defaults to 25
+ * @param {Function} setPerPage a callback to change the number of results per page, e.g. setPerPage(25)
+ * @param {Boolean}  hasPreviousPage true if the current page is not the first one
+ * @param {Boolean}  hasNextPage true if the current page is not the last one
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListPaginationContextValue} list controller props
  *

--- a/packages/ra-core/src/controller/list/useListSortContext.ts
+++ b/packages/ra-core/src/controller/list/useListSortContext.ts
@@ -8,10 +8,10 @@ import { ListSortContext, ListSortContextValue } from './ListSortContext';
  * Must be used within a <ListContextProvider> (e.g. as a descendent of <List>
  * or <ListBase>).
  *
- * @typedef {Object} ListSortContextValue
- * @prop {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
- * @prop {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
- * @prop {string}   resource the resource name, deduced from the location. e.g. 'posts'
+ * @param {Object}   ListSortContextValue
+ * @param {Object}   sort a sort object { field, order }, e.g. { field: 'date', order: 'DESC' }
+ * @param {Function} setSort a callback to change the sort, e.g. setSort({ field: 'name', order: 'ASC' })
+ * @param {string}   resource the resource name, deduced from the location. e.g. 'posts'
  *
  * @returns {ListSortContextValue} list controller props
  *

--- a/packages/ra-core/src/controller/show/useShowContext.tsx
+++ b/packages/ra-core/src/controller/show/useShowContext.tsx
@@ -15,7 +15,7 @@ import { ShowControllerResult } from './useShowController';
  *
  * The given props will take precedence over context values.
  *
- * @typedef {Object} ShowControllerResult
+ * @param {Object} ShowControllerResult
  *
  * @returns {ShowControllerResult} create controller props
  *

--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -12,9 +12,9 @@ interface UseFilterStateOptions {
 }
 
 /**
- * @typedef UseFilterStateProps
- * @property {Object} filter: The filter object.
- * @property {setFilter} setFilter: Update the filter with the given string
+ * @param {Object} UseFilterStateProps
+ * @param {Object} filter: The filter object.
+ * @param {setFilter} setFilter: Update the filter with the given string
  */
 interface UseFilterStateProps {
     filter: FilterPayload;

--- a/packages/ra-core/src/controller/usePaginationState.ts
+++ b/packages/ra-core/src/controller/usePaginationState.ts
@@ -2,13 +2,13 @@ import { useEffect, useReducer, useCallback, useRef } from 'react';
 import { PaginationPayload } from '../types';
 
 /**
- * @typedef PaginationProps
+ * @param PaginationProps
  * @type {Object}
- * @property {number} page: The page number.
- * @property {number} perPage: The number of item per page.
- * @property {Function} setPage: Set the page number
- * @property {Function} setPerPage: Set the per page number
- * @property {Function} setPagination: Set page and perPage pagination numbers
+ * @param {number} page: The page number.
+ * @param {number} perPage: The number of item per page.
+ * @param {Function} setPage: Set the page number
+ * @param {Function} setPerPage: Set the per page number
+ * @param {Function} setPagination: Set page and perPage pagination numbers
  */
 export interface PaginationHookResult {
     page: number;

--- a/packages/ra-core/src/controller/useReference.ts
+++ b/packages/ra-core/src/controller/useReference.ts
@@ -17,11 +17,11 @@ export interface UseReferenceResult<RecordType extends RaRecord = any> {
 }
 
 /**
- * @typedef UseReferenceResult
+ * @param UseReferenceResult
  * @type {Object}
- * @property {boolean} isFetching: boolean indicating if the reference is loading
- * @property {boolean} isLoading: boolean indicating if the reference has loaded at least once
- * @property {Object} referenceRecord: the referenced record.
+ * @param {boolean} isFetching: boolean indicating if the reference is loading
+ * @param {boolean} isLoading: boolean indicating if the reference has loaded at least once
+ * @param {Object} referenceRecord: the referenced record.
  */
 
 /**

--- a/packages/ra-core/src/controller/useSortState.ts
+++ b/packages/ra-core/src/controller/useSortState.ts
@@ -70,14 +70,14 @@ export const defaultSort = { field: '', order: 'ASC' } as const;
  */
 
 /**
- * @typedef SortProps
+ * @param SortProps
  * @type {Object}
- * @property {Object} sort: the sort object.
- * @property {string} sort.field: the sort object.
- * @property {'ASC' | 'DESC'} sort.order: the sort object.
- * @property {setSort} setSort
- * @property {setSortField} setSortField
- * @property {setSortOrder} setSortOrder
+ * @param {Object} sort: the sort object.
+ * @param {string} sort.field: the sort object.
+ * @param {'ASC' | 'DESC'} sort.order: the sort object.
+ * @param {setSort} setSort
+ * @param {setSortField} setSortField
+ * @param {setSortOrder} setSortOrder
  */
 
 /**

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -16,11 +16,9 @@ import { useEvent } from '../util';
  *
  * @param {string} resource
  * @param {Params} params The create parameters { data }
+ * @param {Object} params.data The record to create, e.g. { title: 'hello, world' }
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
- *
- * @typedef Params
- * @prop params.data The record to create, e.g. { title: 'hello, world' }
  *
  * @returns The current mutation state. Destructure as [create, { data, error, isLoading }].
  *

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -25,13 +25,11 @@ import { useEvent } from '../util';
  *
  * @param {string} resource
  * @param {Params} params The delete parameters { id, previousData }
+ * @param {string} params.id The resource identifier, e.g. 123
+ * @param {Object} params.previousData The record before the update is applied
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
  * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
- *
- * @typedef Params
- * @prop params.id The resource identifier, e.g. 123
- * @prop params.previousData The record before the update is applied
  *
  * @returns The current mutation state. Destructure as [deleteOne, { data, error, isLoading }].
  *

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -25,12 +25,10 @@ import { useEvent } from '../util';
  *
  * @param {string} resource
  * @param {Params} params The delete parameters { ids }
+ * @param {string} params.ids The resource identifiers, e.g. [123, 456]
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
  * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
- *
- * @typedef Params
- * @prop params.ids The resource identifiers, e.g. [123, 456]
  *
  * @returns The current mutation state. Destructure as [deleteMany, { data, error, isLoading }].
  *

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -26,14 +26,12 @@ const MAX_DATA_LENGTH_TO_CACHE = 100;
  *
  * @param {string} resource The resource name, e.g. 'posts'
  * @param {Params} params The getList parameters { pagination, sort, filter, meta }
+ * @param {Object} params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
+ * @param {Object} params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
+ * @param {Object} params.filter The request filters, e.g. { title: 'hello, world' }
+ * @param {Object} params.meta Optional meta parameters
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
- *
- * @typedef Params
- * @prop params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
- * @prop params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
- * @prop params.filter The request filters, e.g. { title: 'hello, world' }
- * @prop params.meta Optional meta parameters
  *
  * @returns The current request state. Destructure as { data, total, error, isLoading, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -24,12 +24,10 @@ import { useDataProvider } from './useDataProvider';
  *
  * @param {string} resource The resource name, e.g. 'posts'
  * @param {Params} params The getMany parameters { ids, meta }
+ * @param {string} params.ids The ids to get, e.g. [123, 456, 789]
+ * @param {Object} params.meta Optional meta parameters
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
- *
- * @typedef Params
- * @prop params.ids The ids to get, e.g. [123, 456, 789]
- * @prop params.meta Optional meta parameters
  *
  * @returns The current request state. Destructure as { data, error, isLoading, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -36,14 +36,12 @@ import { useDataProvider } from './useDataProvider';
  *
  * @param resource The resource name, e.g. 'posts'
  * @param {Params} params The getMany parameters { ids, meta }
+ * @param {string} params.ids The ids to get, e.g. [123, 456, 789]
+ * @param {Object} params.meta Optional meta parameters
  * @param {Object} options Options object to pass to the dataProvider.
  * @param {boolean} options.enabled Flag to conditionally run the query. If it's false, the query will not run
  * @param {Function} options.onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
  * @param {Function} options.onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
- *
- * @typedef Params
- * @prop params.ids The ids to get, e.g. [123, 456, 789]
- * @prop params.meta Optional meta parameters
 
  * @returns The current request state. Destructure as { data, error, isLoading, isFetching, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -28,16 +28,14 @@ import { useDataProvider } from './useDataProvider';
  *
  * @param {string} resource The resource name, e.g. 'posts'
  * @param {Params} params The getManyReference parameters { target, id, pagination, sort, filter, meta }
+ * @param {string} params.target The target resource key, e.g. 'post_id'
+ * @param {string} params.id The identifier of the record to look for in target, e.g. '123'
+ * @param {Object} params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
+ * @param {Object} params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
+ * @param {Object} params.filter The request filters, e.g. { title: 'hello, world' }
+ * @param {Object} params.meta Optional meta parameters
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
- *
- * @typedef Params
- * @prop params.target The target resource key, e.g. 'post_id'
- * @prop params.id The identifier of the record to look for in target, e.g. '123'
- * @prop params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
- * @prop params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
- * @prop params.filter The request filters, e.g. { title: 'hello, world' }
- * @prop params.meta Optional meta parameters
  *
  * @returns The current request state. Destructure as { data, total, error, isLoading, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -17,15 +17,11 @@ import { useDataProvider } from './useDataProvider';
  *
  * @param resource The resource name, e.g. 'posts'
  * @param {Params} params The getOne parameters { id, meta }, e.g. { id: 123 }
+ * @param {string} params.id a resource identifier, e.g. 123
  * @param {Options} options Options object to pass to the react-query queryClient.
- *
- * @typedef Params
- * @prop id a resource identifier, e.g. 123
- *
- * @typedef Options
- * @prop enabled Flag to conditionally run the query. If it's false, the query will not run
- * @prop onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
- * @prop onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
+ * @param {boolean} enabled Flag to conditionally run the query. If it's false, the query will not run
+ * @param {Function} onSuccess Side effect function to be executed upon success, e.g. { onSuccess: { refresh: true } }
+ * @param {Function} onError Side effect function to be executed upon failure, e.g. { onError: error => notify(error.message) }
  *
  * @returns The current request state. Destructure as { data, error, isLoading, refetch }.
  *

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
@@ -19,14 +19,12 @@ import { useDataProvider } from './useDataProvider';
  *
  * @param {string} resource The resource name, e.g. 'posts'
  * @param {Params} params The getList parameters { pagination, sort, filter, meta }
+ * @param {Object} params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
+ * @param {Object} params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
+ * @param {Object} params.filter The request filters, e.g. { title: 'hello, world' }
+ * @param {Object} params.meta Optional meta parameters
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { fetchNextPage(); } }
- *
- * @typedef Params
- * @prop params.pagination The request pagination { page, perPage }, e.g. { page: 1, perPage: 10 }
- * @prop params.sort The request sort { field, order }, e.g. { field: 'id', order: 'DESC' }
- * @prop params.filter The request filters, e.g. { title: 'hello, world' }
- * @prop params.meta Optional meta parameters
  *
  * @returns The current request state. Destructure as { data, total, error, isLoading, isSuccess, hasNextPage, fetchNextPage }.
  *

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -25,15 +25,13 @@ import { useEvent } from '../util';
  *
  * @param {string} resource
  * @param {Params} params The update parameters { id, data, previousData, meta }
+ * @param {string} params.id The resource identifier, e.g. 123
+ * @param {Object} params.data The updates to merge into the record, e.g. { views: 10 }
+ * @param {Object} params.previousData The record before the update is applied
+ * @param {Object} params.meta Optional meta data
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
  * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
- *
- * @typedef Params
- * @prop params.id The resource identifier, e.g. 123
- * @prop params.data The updates to merge into the record, e.g. { views: 10 }
- * @prop params.previousData The record before the update is applied
- * @prop params.meta Optional meta data
  *
  * @returns The current mutation state. Destructure as [update, { data, error, isLoading }].
  *

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -26,14 +26,12 @@ import { Identifier } from '..';
  *
  * @param {string} resource
  * @param {Params} params The updateMany parameters { ids, data, meta }
+ * @param {string} params.ids The resource identifiers, e.g. [123, 456]
+ * @param {Object} params.data The updates to merge into the record, e.g. { views: 10 }
+ * @param {Object} params.meta Optional meta parameters
  * @param {Object} options Options object to pass to the queryClient.
  * May include side effects to be executed upon success or failure, e.g. { onSuccess: () => { refresh(); } }
  * May include a mutation mode (optimistic/pessimistic/undoable), e.g. { mutationMode: 'undoable' }
- *
- * @typedef Params
- * @prop params.ids The resource identifiers, e.g. [123, 456]
- * @prop params.data The updates to merge into the record, e.g. { views: 10 }
- * @prop params.meta Optional meta parameters
  *
  * @returns The current mutation state. Destructure as [updateMany, { data, error, isLoading }].
  *

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
@@ -26,30 +26,29 @@ import {
  *
  * @param {DataProvider} dataProvider The dataProvider to wrap
  * @param {ResourceCallbacks[]} handlers An array of ResourceCallbacks
- *
- * @typedef {Object} ResourceCallbacks
- * @property {string} resource The resource name
- * @property {AfterCreate} [afterCreate] A callback executed after create
- * @property {AfterDelete} [afterDelete] A callback executed after delete
- * @property {AfterDeleteMany} [afterDeleteMany] A callback executed after deleteMany
- * @property {AfterGetList} [afterGetList] A callback executed after getList
- * @property {AfterGetMany} [afterGetMany] A callback executed after getMany
- * @property {AfterGetManyReference} [afterGetManyReference] A callback executed after getManyReference
- * @property {AfterGetOne} [afterGetOne] A callback executed after getOne
- * @property {AfterRead} [afterRead] A callback executed after read (getList, getMany, getManyReference, getOne)
- * @property {AfterSave} [afterSave] A callback executed after save (create, update, updateMany)
- * @property {AfterUpdate} [afterUpdate] A callback executed after update
- * @property {AfterUpdateMany} [afterUpdateMany] A callback executed after updateMany
- * @property {BeforeCreate} [beforeCreate] A callback executed before create
- * @property {BeforeDelete} [beforeDelete] A callback executed before delete
- * @property {BeforeDeleteMany} [beforeDeleteMany] A callback executed before deleteMany
- * @property {BeforeGetList} [beforeGetList] A callback executed before getList
- * @property {BeforeGetMany} [beforeGetMany] A callback executed before getMany
- * @property {BeforeGetManyReference} [beforeGetManyReference] A callback executed before getManyReference
- * @property {BeforeGetOne} [beforeGetOne] A callback executed before getOne
- * @property {BeforeSave} [beforeSave] A callback executed before save (create, update, updateMany)
- * @property {BeforeUpdate} [beforeUpdate] A callback executed before update
- * @property {BeforeUpdateMany} [beforeUpdateMany] A callback executed before updateMany
+ * @param {Object} ResourceCallbacks
+ * @param {string} resource The resource name
+ * @param {AfterCreate} [afterCreate] A callback executed after create
+ * @param {AfterDelete} [afterDelete] A callback executed after delete
+ * @param {AfterDeleteMany} [afterDeleteMany] A callback executed after deleteMany
+ * @param {AfterGetList} [afterGetList] A callback executed after getList
+ * @param {AfterGetMany} [afterGetMany] A callback executed after getMany
+ * @param {AfterGetManyReference} [afterGetManyReference] A callback executed after getManyReference
+ * @param {AfterGetOne} [afterGetOne] A callback executed after getOne
+ * @param {AfterRead} [afterRead] A callback executed after read (getList, getMany, getManyReference, getOne)
+ * @param {AfterSave} [afterSave] A callback executed after save (create, update, updateMany)
+ * @param {AfterUpdate} [afterUpdate] A callback executed after update
+ * @param {AfterUpdateMany} [afterUpdateMany] A callback executed after updateMany
+ * @param {BeforeCreate} [beforeCreate] A callback executed before create
+ * @param {BeforeDelete} [beforeDelete] A callback executed before delete
+ * @param {BeforeDeleteMany} [beforeDeleteMany] A callback executed before deleteMany
+ * @param {BeforeGetList} [beforeGetList] A callback executed before getList
+ * @param {BeforeGetMany} [beforeGetMany] A callback executed before getMany
+ * @param {BeforeGetManyReference} [beforeGetManyReference] A callback executed before getManyReference
+ * @param {BeforeGetOne} [beforeGetOne] A callback executed before getOne
+ * @param {BeforeSave} [beforeSave] A callback executed before save (create, update, updateMany)
+ * @param {BeforeUpdate} [beforeUpdate] A callback executed before update
+ * @param {BeforeUpdateMany} [beforeUpdateMany] A callback executed before updateMany
  *
  * Warnings:
  * - As queries issued in the callbacks are not done through react-query,

--- a/packages/ra-core/src/form/Form.tsx
+++ b/packages/ra-core/src/form/Form.tsx
@@ -32,10 +32,10 @@ import { useAugmentedForm } from './useAugmentedForm';
  *    </Form>
  * );
  *
- * @typedef {Object} Props the props you can use
- * @prop {Object} defaultValues
- * @prop {Function} validate
- * @prop {Function} save
+ * @param {Object} Props the props you can use
+ * @param {Object} defaultValues
+ * @param {Function} validate
+ * @param {Function} save
  *
  * @see useForm
  * @see FormGroupContext

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -19,16 +19,14 @@ import { DeleteWithConfirmButton } from './DeleteWithConfirmButton';
 /**
  * Button used to delete a single record. Added by default by the <Toolbar> of edit and show views.
  *
- * @typedef {Object} Props The props you can use (other props are injected if you used it in the <Toolbar>)
- * @prop {boolean} mutationMode Either 'pessimistic', 'optimistic' or 'undoable'. Determine whether the deletion uses an undo button in a notification or a confirmation dialog. Defaults to 'undoable'.
- * @prop {Object} record The current resource record
- * @prop {string} className
- * @prop {string} label Button label. Defaults to 'ra.action.delete, translated.
- * @prop {boolean} disabled Disable the button.
- * @prop {string} variant Material UI variant for the button. Defaults to 'contained'.
- * @prop {ReactElement} icon Override the icon. Defaults to the Delete icon from Material UI.
- *
- * @param {Props} props
+ * @param {Object} Props The props you can use (other props are injected if you used it in the <Toolbar>)
+ * @param {boolean} mutationMode Either 'pessimistic', 'optimistic' or 'undoable'. Determine whether the deletion uses an undo button in a notification or a confirmation dialog. Defaults to 'undoable'.
+ * @param {Object} record The current resource record
+ * @param {string} className
+ * @param {string} label Button label. Defaults to 'ra.action.delete, translated.
+ * @param {boolean} disabled Disable the button.
+ * @param {string} variant Material UI variant for the button. Defaults to 'contained'.
+ * @param {ReactElement} icon Override the icon. Defaults to the Delete icon from Material UI.
  *
  * @example Usage in the <TopToolbar> of an <Edit> form
  *

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -20,17 +20,15 @@ import {
 /**
  * Submit button for resource forms (Edit and Create).
  *
- * @typedef {Object} Props the props you can use (other props are injected by the <Toolbar>)
- * @prop {string} className
- * @prop {string} label Button label. Defaults to 'ra.action.save', translated.
- * @prop {boolean} disabled Disable the button.
- * @prop {string} variant Material UI variant for the button. Defaults to 'contained'.
- * @prop {ReactElement} icon
- * @prop {function} mutationOptions Object of options passed to react-query.
- * @prop {function} transform Callback to execute before calling the dataProvider. Receives the data from the form, must return that transformed data. Can be asynchronous (and return a Promise)
- * @prop {boolean} alwaysEnable Force enabling the <SaveButton>. If it's not defined, the `<SaveButton>` will be enabled using `react-hook-form`'s `isValidating` state props and form context's `saving` prop (disabled if isValidating or saving, enabled otherwise).
- *
- * @param {Props} props
+ * @param {Object} Props the props you can use (other props are injected by the <Toolbar>)
+ * @param {string} className
+ * @param {string} label Button label. Defaults to 'ra.action.save', translated.
+ * @param {boolean} disabled Disable the button.
+ * @param {string} variant Material UI variant for the button. Defaults to 'contained'.
+ * @param {ReactElement} icon
+ * @param {function} mutationOptions Object of options passed to react-query.
+ * @param {function} transform Callback to execute before calling the dataProvider. Receives the data from the form, must return that transformed data. Can be asynchronous (and return a Promise)
+ * @param {boolean} alwaysEnable Force enabling the <SaveButton>. If it's not defined, the `<SaveButton>` will be enabled using `react-hook-form`'s `isValidating` state props and form context's `saving` prop (disabled if isValidating or saving, enabled otherwise).
  *
  * @example // with custom success side effect
  *

--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -29,13 +29,11 @@ import { Toolbar } from './Toolbar';
  *     </Create>
  * );
  *
- * @typedef {Object} Props the props you can use (other props are injected by Create or Edit)
- * @prop {ReactElement[]} children Input elements
- * @prop {Object} defaultValues
- * @prop {Function} validate
- * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
- *
- * @param {Props} props
+ * @param {Object} Props the props you can use (other props are injected by Create or Edit)
+ * @param {ReactElement[]} children Input elements
+ * @param {Object} defaultValues
+ * @param {Function} validate
+ * @param {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  */
 export const SimpleForm = (props: SimpleFormProps) => {
     const {

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -67,13 +67,11 @@ import { FormTab } from './FormTab';
  *     </Edit>
  * );
  *
- * @typedef {Object} Props the props you can use (other props are injected by Create or Edit)
- * @prop {ReactElement[]} FormTab elements
- * @prop {Object} defaultValues
- * @prop {Function} validate
- * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
- *
- * @param {Props} props
+ * @param {Object} Props the props you can use (other props are injected by Create or Edit)
+ * @param {ReactElement[]} FormTab elements
+ * @param {Object} defaultValues
+ * @param {Function} validate
+ * @param {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  */
 export const TabbedForm = (props: TabbedFormProps) => {
     const formRootPathname = useFormRootPath();

--- a/packages/ra-ui-materialui/src/form/Toolbar.tsx
+++ b/packages/ra-ui-materialui/src/form/Toolbar.tsx
@@ -50,8 +50,8 @@ import { SaveButton, DeleteButton } from '../button';
  *     </Create>
  * );
  *
- * @typedef {Object} Props the props you can use (other props are injected by the <SimpleForm>)
- * @prop {ReactElement[]} children Customize the buttons you want to display in the <Toolbar>.
+ * @param {Object} Props the props you can use (other props are injected by the <SimpleForm>)
+ * @param {ReactElement[]} children Customize the buttons you want to display in the <Toolbar>.
  *
  */
 export const Toolbar = (props: ToolbarProps) => {

--- a/packages/ra-ui-materialui/src/layout/LinearProgress.tsx
+++ b/packages/ra-ui-materialui/src/layout/LinearProgress.tsx
@@ -16,12 +16,10 @@ import { useTimeout } from 'ra-core';
  * @see ReferenceField
  * @see ReferenceInput
  *
- * @typedef {Object} Props the props you can use
- * @prop {Object} classes CSS class names
- * @prop {string} className CSS class applied to the LinearProgress component
- * @prop {integer} timeout Milliseconds to wait before showing the progress bar. One second by default
- *
- * @param {Props} props
+ * @param {Object} Props the props you can use
+ * @param {Object} classes CSS class names
+ * @param {string} className CSS class applied to the LinearProgress component
+ * @param {integer} timeout Milliseconds to wait before showing the progress bar. One second by default
  */
 export const LinearProgress = ({
     timeout = 1000,

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -20,10 +20,10 @@ import { useTranslate, useBasename } from 'ra-core';
  * Displays a menu item with a label and an icon - or only the icon with a tooltip when the sidebar is minimized.
  * It also handles the automatic closing of the menu on tap on mobile.
  *
- * @typedef {Object} Props the props you can use
- * @prop {string|Location} to The menu item's target. It is passed to a React Router NavLink component.
- * @prop {string|ReactNode} primaryText The menu content, displayed when the menu isn't minimized. |
- * @prop {ReactNode} leftIcon The menu icon
+ * @param {Object} Props the props you can use
+ * @param {string|Location} to The menu item's target. It is passed to a React Router NavLink component.
+ * @param {string|ReactNode} primaryText The menu content, displayed when the menu isn't minimized. |
+ * @param {ReactNode} leftIcon The menu icon
  *
  * Additional props are passed down to the underling Material UI <MenuItem> component
  * @see https://material-ui.com/api/menu-item/#menuitem-api


### PR DESCRIPTION
We have many components that have @typedef and @prop in their documentation.

They should only use param

Example

```
  * @typedef Props
  * @property {Object} record: The current resource record
```

To:

```
  * @param {Object} props
  * @param {Object} props.record The current resource record
```