### PR TITLE
Fix `useGetIdentity` regression

### DIFF
--- a/packages/ra-core/src/auth/useGetIdentity.ts
+++ b/packages/ra-core/src/auth/useGetIdentity.ts
@@ -52,13 +52,11 @@ export const useGetIdentity = (
                 authProvider &&
                 typeof authProvider.getIdentity === 'function'
             ) {
-                const identity = await authProvider.getIdentity();
-                return identity || defaultIdentity;
+                return authProvider.getIdentity();
             } else {
                 return defaultIdentity;
             }
         },
-
         {
             enabled: typeof authProvider?.getIdentity === 'function',
             ...queryParams,


### PR DESCRIPTION
Fix `useGetIdentity` regression introduced by #9644 that makes it returns a `defaultIdentity` even when an `authProvider` supporting `getIdentity` is provided