### PR TITLE
[TypeScript] Make types more strict in ra-core, part III

### DIFF
--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -771,6 +771,27 @@ describe('my test suite', () => {
 });
 ```
 
+## TypeScript: `useRecordContext` Returns `undefined` When No Record Is Available
+
+The `useRecordContext` hook reads the current record from the `RecordContext`. This context may be empty (e.g. while the record is being fetched). The return type for `useRecordContext` has been modified to `Record | undefined` instead of `Record` to denote this possibility.
+
+As a consequence, the TypeScript compilation of your project may fail if you don't check the existence of the record before reading it.
+
+To fix this error, your code should handle the case where `useRecordContext` returns `undefined`:
+
+```diff
+const MyComponent = () => {
+    const record = useRecordContext();
++   if (!record) return null;
+    return (
+        <div>
+            <h1>{record.title}</h1>
+            <p>{record.body}</p>
+        </div>
+    );
+};
+```
+
 ## TypeScript: Page Contexts Are Now Types Instead of Interfaces
 
 The return type of page controllers is now a type. If you were using an interface extending one of:

--- a/examples/crm/src/companies/CompanyShow.tsx
+++ b/examples/crm/src/companies/CompanyShow.tsx
@@ -202,7 +202,7 @@ const CreateRelatedContactButton = () => {
         <Button
             component={RouterLink}
             to="/contacts/create"
-            state={{ record: { company_id: company.id } }}
+            state={company ? { record: { company_id: company.id } } : undefined}
             color="primary"
             variant="contained"
             size="small"

--- a/examples/crm/src/contacts/ContactAside.tsx
+++ b/examples/crm/src/contacts/ContactAside.tsx
@@ -48,7 +48,11 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
                 </Typography>
             </Box>
             <Typography variant="body2" mb={3}>
-                {record.gender === 'male' ? 'He/Him' : 'She/Her'}
+                {record
+                    ? record.gender === 'male'
+                        ? 'He/Him'
+                        : 'She/Her'
+                    : ''}
             </Typography>
             <Typography variant="subtitle2">Background</Typography>
             <Divider />

--- a/examples/crm/src/contacts/TagsListEdit.tsx
+++ b/examples/crm/src/contacts/TagsListEdit.tsx
@@ -43,14 +43,16 @@ export const TagsListEdit = () => {
     );
     const { data: tags, isPending: isPendingRecordTags } = useGetMany<Tag>(
         'tags',
-        { ids: record.tags },
+        { ids: record?.tags },
         { enabled: record && record.tags && record.tags.length > 0 }
     );
     const [update] = useUpdate<Contact>();
     const [create] = useCreate<Tag>();
 
     const unselectedTags =
-        allTags && allTags.filter(tag => !record.tags.includes(tag.id));
+        allTags &&
+        record &&
+        allTags.filter(tag => !record.tags.includes(tag.id));
 
     const handleOpen = (event: React.MouseEvent<HTMLDivElement>) => {
         setAnchorEl(event.currentTarget);
@@ -61,6 +63,9 @@ export const TagsListEdit = () => {
     };
 
     const handleDeleteTag = (id: Identifier) => {
+        if (!record) {
+            throw new Error('No contact record found');
+        }
         const tags = record.tags.filter(tagId => tagId !== id);
         update('contacts', {
             id: record.id,
@@ -70,6 +75,9 @@ export const TagsListEdit = () => {
     };
 
     const handleAddTag = (id: Identifier) => {
+        if (!record) {
+            throw new Error('No contact record found');
+        }
         const tags = [...record.tags, id];
         update('contacts', {
             id: record.id,
@@ -93,6 +101,9 @@ export const TagsListEdit = () => {
 
     const handleCreateTag = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
+        if (!record) {
+            throw new Error('No contact record found');
+        }
         setDisabled(true);
         create(
             'tags',

--- a/examples/crm/src/notes/Note.tsx
+++ b/examples/crm/src/notes/Note.tsx
@@ -50,8 +50,8 @@ export const Note = ({
             onSuccess: () => {
                 notify('Note deleted', { type: 'info', undoable: true });
                 update(reference, {
-                    id: record.id,
-                    data: { nb_notes: record.nb_notes - 1 },
+                    id: record?.id,
+                    data: { nb_notes: record?.nb_notes - 1 },
                     previousData: record,
                 });
             },

--- a/examples/demo/src/products/CreateRelatedReviewButton.tsx
+++ b/examples/demo/src/products/CreateRelatedReviewButton.tsx
@@ -7,7 +7,7 @@ const CreateRelatedReviewButton = () => {
     return (
         <CreateButton
             resource="reviews"
-            state={{ record: { product_id: record.id } }}
+            state={record ? { record: { product_id: record.id } } : undefined}
         />
     );
 };

--- a/examples/demo/src/reviews/AcceptButton.tsx
+++ b/examples/demo/src/reviews/AcceptButton.tsx
@@ -22,7 +22,7 @@ const AcceptButton = () => {
 
     const [approve, { isPending }] = useUpdate(
         'reviews',
-        { id: record.id, data: { status: 'accepted' }, previousData: record },
+        { id: record?.id, data: { status: 'accepted' }, previousData: record },
         {
             mutationMode: 'undoable',
             onSuccess: () => {

--- a/examples/demo/src/reviews/RejectButton.tsx
+++ b/examples/demo/src/reviews/RejectButton.tsx
@@ -22,7 +22,7 @@ const RejectButton = () => {
 
     const [reject, { isPending }] = useUpdate(
         'reviews',
-        { id: record.id, data: { status: 'rejected' }, previousData: record },
+        { id: record?.id, data: { status: 'rejected' }, previousData: record },
         {
             mutationMode: 'undoable',
             onSuccess: () => {

--- a/examples/demo/src/visitors/Aside.tsx
+++ b/examples/demo/src/visitors/Aside.tsx
@@ -51,16 +51,18 @@ const EventList = () => {
         {
             pagination: { page: 1, perPage: 100 },
             sort: { field: 'date', order: 'DESC' },
-            filter: { customer_id: record.id },
-        }
+            filter: { customer_id: record?.id },
+        },
+        { enabled: !!record?.id }
     );
     const { data: reviews, total: totalReviews } = useGetList<ReviewRecord>(
         'reviews',
         {
             pagination: { page: 1, perPage: 100 },
             sort: { field: 'date', order: 'DESC' },
-            filter: { customer_id: record.id },
-        }
+            filter: { customer_id: record?.id },
+        },
+        { enabled: !!record?.id }
     );
     const events = mixOrdersAndReviews(orders, reviews);
 
@@ -87,7 +89,7 @@ const EventList = () => {
                             </Box>
                         </Grid>
                         <Grid item xs={6} display="flex" gap={1}>
-                            {totalOrders! > 0 && (
+                            {totalOrders! > 0 && record && (
                                 <>
                                     <order.icon
                                         fontSize="small"
@@ -108,9 +110,7 @@ const EventList = () => {
                                     >
                                         {translate(
                                             'resources.commands.amount',
-                                            {
-                                                smart_count: totalOrders,
-                                            }
+                                            { smart_count: totalOrders }
                                         )}
                                     </Link>
                                 </>
@@ -128,7 +128,7 @@ const EventList = () => {
                             </Box>
                         </Grid>
                         <Grid item xs={6} display="flex" gap={1}>
-                            {totalReviews! > 0 && (
+                            {totalReviews! > 0 && record && (
                                 <>
                                     <review.icon
                                         fontSize="small"

--- a/packages/ra-core/src/auth/AuthContext.tsx
+++ b/packages/ra-core/src/auth/AuthContext.tsx
@@ -4,7 +4,7 @@ import { AuthProvider, UserIdentity } from '../types';
 
 const defaultIdentity: UserIdentity = { id: '' };
 
-const defaultProvider: AuthProvider = {
+export const defaultAuthProvider: AuthProvider = {
     login: () => Promise.resolve(),
     logout: () => Promise.resolve(),
     checkAuth: () => Promise.resolve(),
@@ -13,8 +13,6 @@ const defaultProvider: AuthProvider = {
     getIdentity: () => Promise.resolve(defaultIdentity),
 };
 
-const AuthContext = createContext<AuthProvider>(defaultProvider);
+export const AuthContext = createContext<AuthProvider>(defaultAuthProvider);
 
 AuthContext.displayName = 'AuthContext';
-
-export default AuthContext;

--- a/packages/ra-core/src/auth/index.ts
+++ b/packages/ra-core/src/auth/index.ts
@@ -1,4 +1,3 @@
-import AuthContext from './AuthContext';
 import useAuthProvider from './useAuthProvider';
 import useAuthState from './useAuthState';
 import usePermissions from './usePermissions';
@@ -10,6 +9,7 @@ import useLogoutIfAccessDenied from './useLogoutIfAccessDenied';
 import convertLegacyAuthProvider from './convertLegacyAuthProvider';
 
 export * from './Authenticated';
+export * from './AuthContext';
 export * from './types';
 export * from './useAuthenticated';
 export * from './useCheckAuth';
@@ -19,7 +19,6 @@ export * from './addRefreshAuthToAuthProvider';
 export * from './addRefreshAuthToDataProvider';
 
 export {
-    AuthContext,
     useAuthProvider,
     convertLegacyAuthProvider,
     // low-level hooks for calling a particular verb on the authProvider

--- a/packages/ra-core/src/auth/useAuthProvider.ts
+++ b/packages/ra-core/src/auth/useAuthProvider.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 
 import { AuthProvider } from '../types';
-import AuthContext from './AuthContext';
+import { AuthContext } from './AuthContext';
 
 export const defaultAuthParams = {
     loginUrl: '/login',

--- a/packages/ra-core/src/auth/useCheckAuth.spec.tsx
+++ b/packages/ra-core/src/auth/useCheckAuth.spec.tsx
@@ -6,7 +6,7 @@ import { Location } from 'react-router-dom';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 
 import { useCheckAuth } from './useCheckAuth';
-import AuthContext from './AuthContext';
+import { AuthContext } from './AuthContext';
 
 import { BasenameContextProvider, TestMemoryRouter } from '../routing';
 import { useNotify } from '../notification/useNotify';

--- a/packages/ra-core/src/auth/useGetIdentity.spec.tsx
+++ b/packages/ra-core/src/auth/useGetIdentity.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Basic, ErrorCase, ResetIdentity } from './useGetIdentity.stories';
 import useGetIdentity from './useGetIdentity';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import AuthContext from './AuthContext';
+import { AuthContext } from './AuthContext';
 
 describe('useGetIdentity', () => {
     it('should return the identity', async () => {

--- a/packages/ra-core/src/auth/useGetIdentity.stories.tsx
+++ b/packages/ra-core/src/auth/useGetIdentity.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { useGetIdentity } from './useGetIdentity';
-import AuthContext from './AuthContext';
+import { AuthContext } from './AuthContext';
 
 export default {
     title: 'ra-core/auth/useGetIdentity',

--- a/packages/ra-core/src/auth/useHandleAuthCallback.spec.tsx
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.spec.tsx
@@ -5,7 +5,7 @@ import { Route, Routes } from 'react-router-dom';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 
 import { useHandleAuthCallback } from './useHandleAuthCallback';
-import AuthContext from './AuthContext';
+import { AuthContext } from './AuthContext';
 import { AuthProvider } from '../types';
 
 import { TestMemoryRouter } from '../routing';

--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.spec.tsx
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { Routes, Route } from 'react-router-dom';
 
 import useLogoutIfAccessDenied from './useLogoutIfAccessDenied';
-import AuthContext from './AuthContext';
+import { AuthContext } from './AuthContext';
 import useLogout from './useLogout';
 import { useNotify } from '../notification/useNotify';
 import { AuthProvider } from '../types';

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -68,7 +68,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
 ): UseDeleteWithConfirmControllerReturn => {
     const {
         record,
-        redirect: redirectTo,
+        redirect: redirectTo = 'list',
         mutationMode,
         onClick,
         mutationOptions = {},
@@ -81,11 +81,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
     const redirect = useRedirect();
     const [deleteOne, { isPending }] = useDelete<RecordType>(
         resource,
-        {
-            id: record.id,
-            previousData: record,
-            meta: mutationMeta,
-        },
+        undefined,
         {
             onSuccess: () => {
                 setOpen(false);
@@ -94,7 +90,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
                     messageArgs: { smart_count: 1 },
                     undoable: mutationMode === 'undoable',
                 });
-                unselect([record.id]);
+                record && unselect([record.id]);
                 redirect(redirectTo, resource);
             },
             onError: (error: Error) => {
@@ -133,6 +129,11 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();
+            if (!record) {
+                throw new Error(
+                    'The record cannot be deleted because no record has been passed'
+                );
+            }
             deleteOne(
                 resource,
                 {

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -59,11 +59,7 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
     const redirect = useRedirect();
     const [deleteOne, { isPending }] = useDelete<RecordType>(
         resource,
-        {
-            id: record.id,
-            previousData: record,
-            meta: mutationMeta,
-        },
+        undefined,
         {
             onSuccess: () => {
                 notify('ra.notification.deleted', {
@@ -71,7 +67,7 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
                     messageArgs: { smart_count: 1 },
                     undoable: true,
                 });
-                unselect([record.id]);
+                record && unselect([record.id]);
                 redirect(redirectTo, resource);
             },
             onError: (error: Error) => {
@@ -98,6 +94,11 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
     const handleDelete = useCallback(
         event => {
             event.stopPropagation();
+            if (!record) {
+                throw new Error(
+                    'The record cannot be deleted because no record has been passed'
+                );
+            }
             deleteOne(
                 resource,
                 {

--- a/packages/ra-core/src/controller/field/ReferenceFieldContext.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldContext.tsx
@@ -1,9 +1,9 @@
 import { createContext, useContext } from 'react';
 import type { UseReferenceFieldControllerResult } from './useReferenceFieldController';
 
-export const ReferenceFieldContext = createContext<
-    UseReferenceFieldControllerResult
->(null);
+export const ReferenceFieldContext = createContext<UseReferenceFieldControllerResult | null>(
+    null
+);
 
 export const ReferenceFieldContextProvider = ReferenceFieldContext.Provider;
 

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -26,7 +26,6 @@ export interface UseReferenceArrayFieldControllerParams<
 
 const emptyArray = [];
 const defaultFilter = {};
-const defaultSort = { field: null, order: null };
 
 /**
  * Hook that fetches records from another resource specified
@@ -66,7 +65,7 @@ export const useReferenceArrayFieldController = <
         perPage = 1000,
         record,
         reference,
-        sort = defaultSort,
+        sort,
         source,
         queryOptions = {},
     } = props;
@@ -126,7 +125,7 @@ export const useReferenceArrayFieldController = <
 
     return {
         ...listProps,
-        defaultTitle: null,
+        defaultTitle: undefined,
         refetch,
         resource: reference,
     };

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -78,7 +78,7 @@ export const useReferenceManyFieldController = <
         record,
         target,
         filter = defaultFilter,
-        source,
+        source = 'id',
         page: initialPage,
         perPage: initialPerPage,
         sort: initialSort = { field: 'id', order: 'DESC' },
@@ -223,7 +223,7 @@ export const useReferenceManyFieldController = <
     return {
         sort,
         data,
-        defaultTitle: null,
+        defaultTitle: undefined,
         displayedFilters,
         error,
         filterValues,

--- a/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
@@ -170,7 +170,7 @@ describe('useReferenceInputController', () => {
         );
 
         await waitFor(() => {
-            expect(children.mock.calls.length).toBeGreaterThanOrEqual(4);
+            expect(children.mock.calls.length).toBeGreaterThanOrEqual(3);
         });
         expect(children).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -132,13 +132,15 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
     // We need to delay the update of the referenceRecord and the finalData
     // to the next React state update, because otherwise it can raise a warning
     // with AutocompleteInput saying the current value is not in the list of choices
-    const [referenceRecord, setReferenceRecord] = useState(null);
+    const [referenceRecord, setReferenceRecord] = useState<
+        RecordType | undefined
+    >(undefined);
     useEffect(() => {
         setReferenceRecord(currentReferenceRecord);
     }, [currentReferenceRecord]);
 
     // add current value to possible sources
-    let finalData: RecordType[], finalTotal: number;
+    let finalData: RecordType[], finalTotal: number | undefined;
     if (
         !referenceRecord ||
         possibleValuesData.find(record => record.id === referenceRecord.id)
@@ -166,7 +168,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         sort: currentSort,
         allChoices: finalData,
         availableChoices: possibleValuesData,
-        selectedChoices: [referenceRecord],
+        selectedChoices: referenceRecord ? [referenceRecord] : [],
         displayedFilters: params.displayedFilters,
         error: errorReference || errorPossibleValues,
         filter: params.filter,

--- a/packages/ra-core/src/controller/input/useReferenceParams.ts
+++ b/packages/ra-core/src/controller/input/useReferenceParams.ts
@@ -92,10 +92,11 @@ export const useReferenceParams = ({
     const changeParams = useCallback(action => {
         if (!tempParams.current) {
             // no other changeParams action dispatched this tick
-            tempParams.current = queryReducer(query, action);
+            const newTempParams = queryReducer(query, action);
+            tempParams.current = newTempParams;
             // schedule side effects for next tick
             setTimeout(() => {
-                setParams(tempParams.current);
+                setParams(newTempParams);
                 tempParams.current = undefined;
             }, 0);
         } else {
@@ -178,10 +179,10 @@ export const useReferenceParams = ({
     }, requestSignature); // eslint-disable-line react-hooks/exhaustive-deps
     return [
         {
-            displayedFilters: displayedFilterValues,
             filterValues,
             requestSignature,
             ...query,
+            displayedFilters: displayedFilterValues,
         },
         {
             changeParams,
@@ -270,6 +271,9 @@ export const getNumberOrDefault = (
     possibleNumber: string | number | undefined,
     defaultValue: number
 ) => {
+    if (typeof possibleNumber === 'undefined') {
+        return defaultValue;
+    }
     const parsedNumber =
         typeof possibleNumber === 'string'
             ? parseInt(possibleNumber, 10)

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -157,6 +157,11 @@ export const useListParams = ({
                 tempParams.current = queryReducer(query, action);
                 // schedule side effects for next tick
                 setTimeout(() => {
+                    if (!tempParams.current) {
+                        throw new Error(
+                            'Race condition in changeParams detected'
+                        );
+                    }
                     if (disableSyncWithLocation) {
                         setLocalParams(tempParams.current);
                     } else {
@@ -262,10 +267,10 @@ export const useListParams = ({
 
     return [
         {
-            displayedFilters: displayedFilterValues,
             filterValues,
             requestSignature,
             ...query,
+            displayedFilters: displayedFilterValues,
         },
         {
             changeParams,
@@ -375,6 +380,9 @@ export const getNumberOrDefault = (
     possibleNumber: string | number | undefined,
     defaultValue: number
 ) => {
+    if (typeof possibleNumber === 'undefined') {
+        return defaultValue;
+    }
     const parsedNumber =
         typeof possibleNumber === 'string'
             ? parseInt(possibleNumber, 10)

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -158,9 +158,8 @@ export const useListParams = ({
                 // schedule side effects for next tick
                 setTimeout(() => {
                     if (!tempParams.current) {
-                        throw new Error(
-                            'Race condition in changeParams detected'
-                        );
+                        // the side effects were already processed by another changeParams
+                        return;
                     }
                     if (disableSyncWithLocation) {
                         setLocalParams(tempParams.current);

--- a/packages/ra-core/src/controller/list/useRecordSelection.ts
+++ b/packages/ra-core/src/controller/list/useRecordSelection.ts
@@ -11,9 +11,20 @@ type UseRecordSelectionWithNoStoreArgs = {
     resource?: string;
     disableSyncWithStore: true;
 };
-type UseRecordSelectionArgs =
+
+export type UseRecordSelectionArgs =
     | UseRecordSelectionWithResourceArgs
     | UseRecordSelectionWithNoStoreArgs;
+
+export type UseRecordSelectionResult<RecordType extends RaRecord = any> = [
+    RecordType['id'][],
+    {
+        select: (ids: RecordType['id'][]) => void;
+        unselect: (ids: RecordType['id'][]) => void;
+        toggle: (id: RecordType['id']) => void;
+        clearSelection: () => void;
+    }
+];
 
 /**
  * Get the list of selected items for a resource, and callbacks to change the selection
@@ -25,23 +36,20 @@ type UseRecordSelectionArgs =
  */
 export const useRecordSelection = <RecordType extends RaRecord = any>(
     args: UseRecordSelectionArgs
-): [
-    RecordType['id'][],
-    {
-        select: (ids: RecordType['id'][]) => void;
-        unselect: (ids: RecordType['id'][]) => void;
-        toggle: (id: RecordType['id']) => void;
-        clearSelection: () => void;
-    }
-] => {
+): UseRecordSelectionResult<RecordType> => {
     const { resource = '', disableSyncWithStore = false } = args;
 
     const storeKey = `${resource}.selectedIds`;
 
-    const [localIds, setLocalIds] = useState(defaultSelection);
+    const [localIds, setLocalIds] = useState<RecordType['id'][]>(
+        defaultSelection
+    );
     // As we can't conditionally call a hook, if the storeKey is false,
     // we'll ignore the params variable later on and won't call setParams either.
-    const [storeIds, setStoreIds] = useStore(storeKey, defaultSelection);
+    const [storeIds, setStoreIds] = useStore<RecordType['id'][]>(
+        storeKey,
+        defaultSelection
+    );
     const resetStore = useRemoveFromStore(storeKey);
 
     const ids = disableSyncWithStore ? localIds : storeIds;

--- a/packages/ra-core/src/controller/list/useUnselect.ts
+++ b/packages/ra-core/src/controller/list/useUnselect.ts
@@ -11,8 +11,10 @@ import { Identifier } from '../../types';
  * const unselect = useUnselect('posts');
  * unselect([123, 456]);
  */
-export const useUnselect = (resource: string) => {
-    const [, { unselect }] = useRecordSelection({ resource });
+export const useUnselect = (resource?: string) => {
+    const [, { unselect }] = useRecordSelection(
+        resource ? { resource } : { disableSyncWithStore: true }
+    );
     return useCallback(
         (ids: Identifier[]) => {
             unselect(ids);

--- a/packages/ra-core/src/controller/list/useUnselectAll.ts
+++ b/packages/ra-core/src/controller/list/useUnselectAll.ts
@@ -10,10 +10,10 @@ import { useRecordSelection } from './useRecordSelection';
  * const unselectAll = useUnselectAll('posts');
  * unselectAll();
  */
-export const useUnselectAll = (resource: string) => {
-    const [, { clearSelection }] = useRecordSelection({
-        resource,
-    });
+export const useUnselectAll = (resource?: string) => {
+    const [, { clearSelection }] = useRecordSelection(
+        resource ? { resource } : { disableSyncWithStore: true }
+    );
     return useCallback(() => {
         clearSelection();
     }, [clearSelection]);

--- a/packages/ra-core/src/controller/saveContext/useRegisterMutationMiddleware.ts
+++ b/packages/ra-core/src/controller/saveContext/useRegisterMutationMiddleware.ts
@@ -17,6 +17,9 @@ export const useRegisterMutationMiddleware = <
     } = useSaveContext();
 
     useEffect(() => {
+        if (!registerMutationMiddleware || !unregisterMutationMiddleware) {
+            return;
+        }
         registerMutationMiddleware(callback);
         return () => {
             unregisterMutationMiddleware(callback);

--- a/packages/ra-core/src/controller/useFilterState.ts
+++ b/packages/ra-core/src/controller/useFilterState.ts
@@ -21,10 +21,11 @@ interface UseFilterStateProps {
     setFilter: (v: string) => void;
 }
 
+const defaultFilter = {};
 const defaultFilterToQuery = (v: string) => ({ q: v });
 
 /**
- * Hooks to provide filter state and setFilter which update the query part of the filter
+ * Hooks to provide filter state and setFilter which updates the query part of the filter
  *
  * @example
  *
@@ -59,7 +60,7 @@ export default ({
 }: UseFilterStateOptions): UseFilterStateProps => {
     const permanentFilterProp = useRef(permanentFilter);
     const latestValue = useRef<string>();
-    const [filter, setFilterValue] = useSafeSetState({
+    const [filter, setFilterValue] = useSafeSetState<FilterPayload>({
         ...permanentFilter,
         ...filterToQuery(''),
     });
@@ -76,7 +77,7 @@ export default ({
             permanentFilterProp.current = permanentFilter;
             setFilterValue({
                 ...permanentFilter,
-                ...filterToQuery(latestValue.current),
+                ...filterToQuery(latestValue.current || ''),
             });
         }
     }, [permanentFilterSignature, permanentFilterProp, filterToQuery]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -94,7 +95,7 @@ export default ({
     );
 
     return {
-        filter,
+        filter: filter ?? defaultFilter,
         setFilter,
     };
 };

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -129,7 +129,7 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
         );
     }
 
-    const [storedParams] = useStore<Partial<ListParams>>(
+    const [storedParams] = useStore<ListParams>(
         storeKey || `${resource}.listParams`,
         {
             filter: filterDefaultValues,
@@ -137,6 +137,7 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
             sort: initialSort.field,
             page: 1,
             perPage: 10,
+            displayedFilters: {},
         }
     );
 
@@ -172,8 +173,10 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
     const isRecordIndexFirstInNonFirstPage =
         recordIndexInQueryData === 0 && storedParams.page > 1;
     const isRecordIndexLastInNonLastPage =
-        recordIndexInQueryData === queryData?.data?.length - 1 &&
-        storedParams.page < queryData?.total / storedParams.perPage;
+        queryData?.data && queryData?.total
+            ? recordIndexInQueryData === queryData?.data?.length - 1 &&
+              storedParams.page < queryData?.total / storedParams.perPage
+            : undefined;
     const canUseCacheData =
         record &&
         queryData?.data &&

--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -3,7 +3,11 @@ import { useMemo } from 'react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 
 import { AdminRouter } from '../routing';
-import { AuthContext, convertLegacyAuthProvider } from '../auth';
+import {
+    AuthContext,
+    defaultAuthProvider,
+    convertLegacyAuthProvider,
+} from '../auth';
 import {
     DataProviderContext,
     convertLegacyDataProvider,
@@ -187,9 +191,11 @@ React-admin requires a valid dataProvider function to work.`);
 
     const finalAuthProvider = useMemo(
         () =>
-            authProvider instanceof Function
-                ? convertLegacyAuthProvider(authProvider)
-                : authProvider,
+            authProvider
+                ? authProvider instanceof Function
+                    ? convertLegacyAuthProvider(authProvider)
+                    : authProvider
+                : defaultAuthProvider,
         [authProvider]
     );
 

--- a/packages/ra-core/src/core/CoreAdminRoutes.tsx
+++ b/packages/ra-core/src/core/CoreAdminRoutes.tsx
@@ -48,6 +48,11 @@ export const CoreAdminRoutes = (props: CoreAdminRoutesProps) => {
     }, [checkAuth, requireAuth]);
 
     if (status === 'empty') {
+        if (!Ready) {
+            throw new Error(
+                'The admin is empty. Please provide an empty component, or pass Resource or CustomRoutes as children.'
+            );
+        }
         return <Ready />;
     }
 

--- a/packages/ra-core/src/core/OptionalResourceContextProvider.tsx
+++ b/packages/ra-core/src/core/OptionalResourceContextProvider.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { ReactElement } from 'react';
+import { ResourceContextValue } from './ResourceContext';
+import { ResourceContextProvider } from './ResourceContextProvider';
+
+/**
+ * Wrap children with a ResourceContext provider only if the value is defined.
+ *
+ * Allows a component to work outside of a resource context.
+ *
+ * @example
+ *
+ * import { OptionalResourceContextProvider, EditButton } from 'react-admin';
+ *
+ * const Button = ({ resource }) => (
+ *     <OptionalResourceContextProvider value={resource}>
+ *         <EditButton />
+ *     </OptionalResourceContextProvider>
+ * );
+ */
+export const OptionalResourceContextProvider = ({
+    value,
+    children,
+}: {
+    value?: ResourceContextValue;
+    children: ReactElement;
+}) =>
+    value ? (
+        <ResourceContextProvider value={value}>
+            {children}
+        </ResourceContextProvider>
+    ) : (
+        children
+    );

--- a/packages/ra-core/src/core/index.ts
+++ b/packages/ra-core/src/core/index.ts
@@ -5,6 +5,7 @@ export * from './CoreAdminUI';
 export * from './CustomRoutes';
 export * from './DefaultTitleContext';
 export * from './HasDashboardContext';
+export * from './OptionalResourceContextProvider';
 export * from './Resource';
 export * from './ResourceContext';
 export * from './ResourceContextProvider';

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.tsx
@@ -91,6 +91,9 @@ const useRoutesAndResourcesFromChildren = (
             ...routesAndResources,
         })
     );
+    if (!status) {
+        throw new Error('Status should be defined');
+    }
 
     useEffect(() => {
         const resolveChildFunction = async (
@@ -196,7 +199,7 @@ const useRoutesAndResourcesState = (
  * @param permissions: The permissions
  */
 const useRegisterResources = (
-    resources: (ReactElement<ResourceProps> & ResourceWithRegisterFunction)[],
+    resources: (ReactElement & ResourceWithRegisterFunction)[],
     permissions: any
 ) => {
     const { register, unregister } = useResourceDefinitionContext();
@@ -246,10 +249,10 @@ const getStatus = ({
     customRoutesWithoutLayout,
 }: {
     children: AdminChildren;
-    resources: ReactElement<ResourceProps>[];
-    customRoutesWithLayout: ReactElement<CustomRoutesProps>[];
-    customRoutesWithoutLayout: ReactElement<CustomRoutesProps>[];
-}) => {
+    resources: ReactNode[];
+    customRoutesWithLayout: ReactNode[];
+    customRoutesWithoutLayout: ReactNode[];
+}): AdminRouterStatus => {
     return getSingleChildFunction(children)
         ? 'loading'
         : resources.length > 0 ||
@@ -295,9 +298,9 @@ const getSingleChildFunction = (
 const getRoutesAndResourceFromNodes = (
     children: AdminChildren
 ): RoutesAndResources => {
-    const customRoutesWithLayout = [];
-    const customRoutesWithoutLayout = [];
-    const resources = [];
+    const customRoutesWithLayout: ReactNode[] = [];
+    const customRoutesWithoutLayout: ReactNode[] = [];
+    const resources: (ReactElement & ResourceWithRegisterFunction)[] = [];
 
     if (typeof children === 'function') {
         return {
@@ -339,7 +342,9 @@ const getRoutesAndResourceFromNodes = (
                 customRoutesWithLayout.push(customRoutesElement.props.children);
             }
         } else if ((element.type as any).raName === 'Resource') {
-            resources.push(element as ReactElement<ResourceProps>);
+            resources.push(
+                element as ReactElement & ResourceWithRegisterFunction
+            );
         }
     });
 
@@ -351,9 +356,9 @@ const getRoutesAndResourceFromNodes = (
 };
 
 type RoutesAndResources = {
-    customRoutesWithLayout: ReactElement<CustomRoutesProps>[];
-    customRoutesWithoutLayout: ReactElement<CustomRoutesProps>[];
-    resources: (ReactElement<ResourceProps> & ResourceWithRegisterFunction)[];
+    customRoutesWithLayout: ReactNode[];
+    customRoutesWithoutLayout: ReactNode[];
+    resources: (ReactElement & ResourceWithRegisterFunction)[];
 };
 
 type ResourceWithRegisterFunction = {

--- a/packages/ra-core/src/core/useGetRecordRepresentation.ts
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.ts
@@ -16,7 +16,7 @@ import { useResourceDefinition } from './useResourceDefinition';
  * getRecordRepresentation({ id: 1, title: 'Hello' }); // => "Hello"
  */
 export const useGetRecordRepresentation = (
-    resource: string
+    resource?: string
 ): ((record: any) => ReactNode) => {
     const { recordRepresentation } = useResourceDefinition({ resource });
     return useCallback(

--- a/packages/ra-core/src/form/FormDataConsumer.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.tsx
@@ -67,7 +67,8 @@ export const FormDataConsumerView = <
     const { children, formData, source } = props;
     let ret;
 
-    const finalSource = useWrappedSource(source);
+    const finalSource = useWrappedSource(source || '');
+
     // Passes an empty string here as we don't have the children sources and we just want to know if we are in an iterator
     const matches = ArraySourceRegex.exec(finalSource);
 

--- a/packages/ra-core/src/form/FormGroupContext.ts
+++ b/packages/ra-core/src/form/FormGroupContext.ts
@@ -7,6 +7,8 @@ import { createContext } from 'react';
  *
  * This should only be used through a FormGroupContextProvider.
  */
-export const FormGroupContext = createContext<FormGroupContextValue>(undefined);
+export const FormGroupContext = createContext<FormGroupContextValue | null>(
+    null
+);
 
 export type FormGroupContextValue = string;

--- a/packages/ra-core/src/form/choices/useChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/useChoicesContext.ts
@@ -11,9 +11,9 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
     >;
     const { data, ...list } = useList<ChoicesType>({
         data: options.choices,
-        isLoading: options.isLoading,
-        isPending: options.isPending,
-        isFetching: options.isFetching,
+        isLoading: options.isLoading ?? false,
+        isPending: options.isPending ?? false,
+        isFetching: options.isFetching ?? false,
         // When not in a ChoicesContext, paginating does not make sense (e.g. AutocompleteInput).
         perPage: Infinity,
     });
@@ -33,9 +33,9 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
                 hasPreviousPage:
                     options.hasPreviousPage ?? list.hasPreviousPage,
                 hideFilter: options.hideFilter ?? list.hideFilter,
-                isLoading: list.isLoading, // we must take the one for useList, otherwise the loading state isn't synchronized with the data
-                isPending: list.isPending, // same
-                isFetching: list.isFetching, // same
+                isLoading: list.isLoading ?? false, // we must take the one for useList, otherwise the loading state isn't synchronized with the data
+                isPending: list.isPending ?? false, // same
+                isFetching: list.isFetching ?? false, // same
                 page: options.page ?? list.page,
                 perPage: options.perPage ?? list.perPage,
                 refetch: options.refetch ?? list.refetch,

--- a/packages/ra-core/src/form/useFormGroup.ts
+++ b/packages/ra-core/src/form/useFormGroup.ts
@@ -73,6 +73,7 @@ export const useFormGroup = (name: string): FormGroupState => {
     });
 
     const updateGroupState = useCallback(() => {
+        if (!formGroups) return;
         const fields = formGroups.getGroupFields(name);
         const fieldStates = fields
             .map<FieldState>(field => {
@@ -109,11 +110,13 @@ export const useFormGroup = (name: string): FormGroupState => {
     );
 
     useEffect(() => {
+        if (!formGroups) return;
         // Whenever the group content changes (input are added or removed)
         // we must update its state
-        return formGroups.subscribe(name, () => {
+        const unsubscribe = formGroups.subscribe(name, () => {
             updateGroupState();
         });
+        return unsubscribe;
     }, [formGroups, name, updateGroupState]);
 
     return state;

--- a/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
+++ b/packages/ra-core/src/form/useWarnWhenUnsavedChanges.tsx
@@ -63,9 +63,9 @@ export const useWarnWhenUnsavedChanges = (
                 translate('ra.message.unsaved_changes')
             );
             if (shouldProceed) {
-                blocker.proceed();
+                blocker.proceed && blocker.proceed();
             } else {
-                blocker.reset();
+                blocker.reset && blocker.reset();
             }
         }
         setShouldNotify(false);

--- a/packages/ra-core/src/preferences/PreferencesEditorContextProvider.tsx
+++ b/packages/ra-core/src/preferences/PreferencesEditorContextProvider.tsx
@@ -7,10 +7,10 @@ import {
 
 export const PreferencesEditorContextProvider = ({ children }) => {
     const [isEnabled, setIsEnabled] = useState(false);
-    const [editor, setEditor] = useState<ReactElement>(null);
+    const [editor, setEditor] = useState<ReactElement | null>(null);
     const [preferenceKey, setPreferenceKey] = useState<string>();
-    const [path, setPath] = useState<string>(null);
-    const [title, setTitleString] = useState<string>(null);
+    const [path, setPath] = useState<string | null>(null);
+    const [title, setTitleString] = useState<string | null>(null);
     const [titleOptions, setTitleOptions] = useState<any>();
     const enable = useCallback(() => setIsEnabled(true), []);
     const disable = useCallback(() => {

--- a/packages/ra-core/src/preferences/useSetInspectorTitle.ts
+++ b/packages/ra-core/src/preferences/useSetInspectorTitle.ts
@@ -8,7 +8,13 @@ import { usePreferencesEditor } from './usePreferencesEditor';
  * useSetInspectorTitle('Datagrid');
  */
 export const useSetInspectorTitle = (title: string, options?: any) => {
-    const { setTitle } = usePreferencesEditor();
+    const preferencesEditorContext = usePreferencesEditor();
+    if (!preferencesEditorContext) {
+        throw new Error(
+            'useSetInspectorTitle cannot be called outside of a PreferencesEditorContext'
+        );
+    }
+    const { setTitle } = preferencesEditorContext;
 
     useEffect(() => {
         setTitle(title, options);

--- a/packages/ra-core/src/routing/useCreatePath.ts
+++ b/packages/ra-core/src/routing/useCreatePath.ts
@@ -41,6 +41,14 @@ export const useCreatePath = () => {
     const basename = useBasename();
     return useCallback(
         ({ resource, id, type }: CreatePathParams): string => {
+            if (
+                ['list', 'create', 'edit', 'show'].includes(type) &&
+                !resource
+            ) {
+                throw new Error(
+                    'Cannot create a link without a resource. You must provide the resource name.'
+                );
+            }
             switch (type) {
                 case 'list':
                     return removeDoubleSlashes(`${basename}/${resource}`);
@@ -81,7 +89,7 @@ export type CreatePathType = 'list' | 'edit' | 'show' | 'create' | AnyString;
 
 export interface CreatePathParams {
     type: CreatePathType;
-    resource: string;
+    resource?: string;
     id?: Identifier;
 }
 

--- a/packages/ra-core/tsconfig.json
+++ b/packages/ra-core/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": [
         "**/*.spec.ts",

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.spec.tsx
@@ -70,7 +70,7 @@ describe('<ReferenceArrayField />', () => {
                             record={{ id: 123, barIds: [1, 2] }}
                             reference="bar"
                         >
-                            <SingleFieldList>
+                            <SingleFieldList linkType={false}>
                                 <TextField source="title" />
                             </SingleFieldList>
                         </ReferenceArrayFieldView>
@@ -99,7 +99,7 @@ describe('<ReferenceArrayField />', () => {
                         record={{ id: 123, barIds: [1, 2] }}
                         reference="bar"
                     >
-                        <SingleFieldList>
+                        <SingleFieldList linkType={false}>
                             <TextField source="title" />
                         </SingleFieldList>
                     </ReferenceArrayFieldView>
@@ -130,7 +130,7 @@ describe('<ReferenceArrayField />', () => {
                             reference="bar"
                             source="barIds"
                         >
-                            <SingleFieldList>
+                            <SingleFieldList linkType={false}>
                                 <TextField source="title" />
                             </SingleFieldList>
                         </ReferenceArrayFieldView>
@@ -165,7 +165,7 @@ describe('<ReferenceArrayField />', () => {
                             reference="bar"
                             source="barIds"
                         >
-                            <SingleFieldList>
+                            <SingleFieldList linkType={false}>
                                 <TextField source="title" />
                             </SingleFieldList>
                         </ReferenceArrayFieldView>
@@ -201,7 +201,7 @@ describe('<ReferenceArrayField />', () => {
                             reference="bar"
                             source="barIds"
                         >
-                            <SingleFieldList>
+                            <SingleFieldList linkType={false}>
                                 <TextField source="title" />
                             </SingleFieldList>
                         </ReferenceArrayFieldView>

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -16,6 +16,7 @@ import {
     sanitizeListRestProps,
     useListContextWithProps,
     Identifier,
+    OptionalResourceContextProvider,
     RaRecord,
     SortPayload,
 } from 'ra-core';
@@ -229,60 +230,62 @@ export const Datagrid: FC<DatagridProps> = React.forwardRef((props, ref) => {
      */
     return (
         <DatagridContextProvider value={contextValue}>
-            <DatagridRoot
-                sx={sx}
-                className={clsx(DatagridClasses.root, className)}
-            >
-                {bulkActionButtons !== false ? (
-                    <BulkActionsToolbar>
-                        {isValidElement(bulkActionButtons)
-                            ? bulkActionButtons
-                            : defaultBulkActionButtons}
-                    </BulkActionsToolbar>
-                ) : null}
-                <div className={DatagridClasses.tableWrapper}>
-                    <Table
-                        ref={ref}
-                        className={DatagridClasses.table}
-                        size={size}
-                        {...sanitizeRestProps(rest)}
-                    >
-                        {createOrCloneElement(
-                            header,
-                            {
-                                children,
-                                sort,
-                                data,
-                                hasExpand: !!expand,
-                                hasBulkActions,
-                                isRowSelectable,
-                                onSelect,
-                                resource,
-                                selectedIds,
-                                setSort,
-                            },
-                            children
-                        )}
-                        {createOrCloneElement(
-                            body,
-                            {
-                                expand,
-                                rowClick,
-                                data,
-                                hasBulkActions,
-                                hover,
-                                onToggleItem: handleToggleItem,
-                                resource,
-                                rowSx,
-                                rowStyle,
-                                selectedIds,
-                                isRowSelectable,
-                            },
-                            children
-                        )}
-                    </Table>
-                </div>
-            </DatagridRoot>
+            <OptionalResourceContextProvider value={resource}>
+                <DatagridRoot
+                    sx={sx}
+                    className={clsx(DatagridClasses.root, className)}
+                >
+                    {bulkActionButtons !== false ? (
+                        <BulkActionsToolbar>
+                            {isValidElement(bulkActionButtons)
+                                ? bulkActionButtons
+                                : defaultBulkActionButtons}
+                        </BulkActionsToolbar>
+                    ) : null}
+                    <div className={DatagridClasses.tableWrapper}>
+                        <Table
+                            ref={ref}
+                            className={DatagridClasses.table}
+                            size={size}
+                            {...sanitizeRestProps(rest)}
+                        >
+                            {createOrCloneElement(
+                                header,
+                                {
+                                    children,
+                                    sort,
+                                    data,
+                                    hasExpand: !!expand,
+                                    hasBulkActions,
+                                    isRowSelectable,
+                                    onSelect,
+                                    resource,
+                                    selectedIds,
+                                    setSort,
+                                },
+                                children
+                            )}
+                            {createOrCloneElement(
+                                body,
+                                {
+                                    expand,
+                                    rowClick,
+                                    data,
+                                    hasBulkActions,
+                                    hover,
+                                    onToggleItem: handleToggleItem,
+                                    resource,
+                                    rowSx,
+                                    rowStyle,
+                                    selectedIds,
+                                    isRowSelectable,
+                                },
+                                children
+                            )}
+                        </Table>
+                    </div>
+                </DatagridRoot>
+            </OptionalResourceContextProvider>
         </DatagridContextProvider>
     );
 });


### PR DESCRIPTION
This PR finally turns `strictNullChecks` to `true` in `ra-core`, and solves the remaining 63 TS compilation errors on `ra-core`.

Refs #9622
Follows #9644, #9741 , #9743

## `useRecordContext` Returns `undefined` When No Record Is Available

The `useRecordContext` hook reads the current record from the `RecordContext`. This context may be empty (e.g. while the record is being fetched). The return type for `useRecordContext` has been modified to `Record | undefined` instead of `Record` to denote this possibility.

As a consequence, the TypeScript compilation of your project may fail if you don't check the existence of the record before reading it.

To fix this error, your code should handle the case where `useRecordContext` returns `undefined`:

```diff
const MyComponent = () => {
    const record = useRecordContext();
+   if (!record) return null;
    return (
        <div>
            <h1>{record.title}</h1>
            <p>{record.body}</p>
        </div>
    );
};
```