### PR TITLE
chore: update react-hook-form to 7.51.2

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -27,7 +27,7 @@
         "react": "^18.0.0",
         "react-admin": "^5.0.0-alpha.1",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.51.3",
         "react-router": "^6.22.0",
         "react-router-dom": "^6.22.0"
     },

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -41,7 +41,7 @@
         "jscodeshift": "^0.15.2",
         "react": "^18.0.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.51.3",
         "react-router": "^6.22.0",
         "react-router-dom": "^6.22.0",
         "react-test-renderer": "^18.2.0",
@@ -54,7 +54,7 @@
     "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.51.3",
         "react-router": "^6.22.0",
         "react-router-dom": "^6.22.0"
     },

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -57,7 +57,7 @@
         "ra-ui-materialui": "^5.0.0-alpha.1",
         "react": "^18.0.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.51.3",
         "rimraf": "^3.0.2",
         "tippy.js": "^6.3.7",
         "typescript": "^5.1.3"

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -43,7 +43,7 @@
         "ra-language-english": "^5.0.0-alpha.1",
         "react": "^18.0.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.51.3",
         "react-is": "^18.2.0",
         "react-router": "^6.22.0",
         "react-router-dom": "^6.22.0",

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -44,7 +44,7 @@
         "ra-i18n-polyglot": "^5.0.0-alpha.1",
         "ra-language-english": "^5.0.0-alpha.1",
         "ra-ui-materialui": "^5.0.0-alpha.1",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.51.3",
         "react-router": "^6.22.0",
         "react-router-dom": "^6.22.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18697,7 +18697,7 @@ __metadata:
     query-string: "npm:^7.1.1"
     react: "npm:^18.0.0"
     react-dom: "npm:^18.2.0"
-    react-hook-form: "npm:^7.43.9"
+    react-hook-form: "npm:^7.51.3"
     react-is: "npm:^18.2.0"
     react-router: "npm:^6.22.0"
     react-router-dom: "npm:^6.22.0"
@@ -18710,7 +18710,7 @@ __metadata:
   peerDependencies:
     react: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
-    react-hook-form: ^7.43.9
+    react-hook-form: ^7.51.3
     react-router: ^6.22.0
     react-router-dom: ^6.22.0
   languageName: unknown
@@ -18877,7 +18877,7 @@ __metadata:
     ra-ui-materialui: "npm:^5.0.0-alpha.1"
     react: "npm:^18.0.0"
     react-dom: "npm:^18.2.0"
-    react-hook-form: "npm:^7.43.9"
+    react-hook-form: "npm:^7.51.3"
     rimraf: "npm:^3.0.2"
     tippy.js: "npm:^6.3.7"
     typescript: "npm:^5.1.3"
@@ -18976,7 +18976,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-dropzone: "npm:^12.0.4"
     react-error-boundary: "npm:^3.1.4"
-    react-hook-form: "npm:^7.43.9"
+    react-hook-form: "npm:^7.51.3"
     react-is: "npm:^18.2.0"
     react-router: "npm:^6.22.0"
     react-router-dom: "npm:^6.22.0"
@@ -19173,7 +19173,7 @@ __metadata:
     ra-i18n-polyglot: "npm:^5.0.0-alpha.1"
     ra-language-english: "npm:^5.0.0-alpha.1"
     ra-ui-materialui: "npm:^5.0.0-alpha.1"
-    react-hook-form: "npm:^7.43.9"
+    react-hook-form: "npm:^7.51.3"
     react-router: "npm:^6.22.0"
     react-router-dom: "npm:^6.22.0"
     rimraf: "npm:^3.0.2"
@@ -19283,12 +19283,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.43.9":
-  version: 7.43.9
-  resolution: "react-hook-form@npm:7.43.9"
+"react-hook-form@npm:^7.51.3":
+  version: 7.51.3
+  resolution: "react-hook-form@npm:7.51.3"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18
-  checksum: 5aab031ae15b32daffb45abe32e00c9d66c511348b68589d4faa6c2309db54b9d2f738b400319b0c2ea87dfd5d85f3760393feafe2bf7a97d608aa736934151f
+  checksum: dd7dfc8514df19a13b7647b3faebdcb1329723afb52454626496eeaa657323d42bab12dc85e6b77d758a166c6427fa87f13c5bd9f5f78666c682e8263117e297
   languageName: node
   linkType: hard
 
@@ -20725,7 +20725,7 @@ __metadata:
     react: "npm:^18.0.0"
     react-admin: "npm:^5.0.0-alpha.1"
     react-dom: "npm:^18.2.0"
-    react-hook-form: "npm:^7.43.9"
+    react-hook-form: "npm:^7.51.3"
     react-router: "npm:^6.22.0"
     react-router-dom: "npm:^6.22.0"
     typescript: "npm:^5.1.3"


### PR DESCRIPTION
## Problem

It becomes difficult to reproduce issues introduced in the latest RHF versions and to ensure compatibility with those

## Solution

Bump to the latest RHF version in our monorepo
Waiting for https://github.com/react-hook-form/react-hook-form/issues/11794