### PR TITLE
Add better types to data-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,11 @@ run-tutorial: ## run the tutorial example
 run-demo: ## run the ecommerce example
 	@yarn run-demo
 
-run-demo-watch: ## run the ecommerce example and watch changes in ra dependencies
-	@yarn run-demo-watch
-
 build-demo: ## compile the ecommerce example to static js
 	@yarn build-demo
 
 run-graphql-demo: ## run the ecommerce example with a graphql backend
 	@yarn run-graphql-demo
-
-run-graphql-demo-watch: ## run the ecommerce example with a graphql backend and watch changes in ra dependencies
-	@yarn run-graphql-demo-watch
 
 run-crm: ## run the crm example
 	@yarn run-crm

--- a/examples/data-generator/src/categories.ts
+++ b/examples/data-generator/src/categories.ts
@@ -1,4 +1,4 @@
-export default () => [
+export const generateCategories = (): Category[] => [
     { id: 0, name: 'animals' },
     { id: 1, name: 'beard' },
     { id: 2, name: 'business' },
@@ -13,3 +13,8 @@ export default () => [
     { id: 11, name: 'travel' },
     { id: 12, name: 'water' },
 ];
+
+export type Category = {
+    id: number;
+    name: string;
+};

--- a/examples/data-generator/src/customers.ts
+++ b/examples/data-generator/src/customers.ts
@@ -1,12 +1,8 @@
 import { date, name, internet, address } from 'faker/locale/en';
 
 import { randomDate, weightedBoolean } from './utils';
-import type { Db } from './types';
 
-export const generateCustomers = <Serialized extends boolean = false>(
-    db: Db<Serialized>,
-    { serializeDate }: { serializeDate: Serialized }
-): Customer<Serialized>[] => {
+export const generateCustomers = (): Customer[] => {
     // This is the total number of people pictures available. We only use those pictures for actual customers
     const maxCustomers = 223;
     let numberOfCustomers = 0;
@@ -40,25 +36,20 @@ export const generateCustomers = <Serialized extends boolean = false>(
             city: has_ordered ? address.city() : null,
             stateAbbr: has_ordered ? address.stateAbbr() : null,
             avatar,
-            birthday:
-                birthday != null
-                    ? serializeDate
-                        ? birthday.toISOString()
-                        : birthday
-                    : null,
-            first_seen: serializeDate ? first_seen.toISOString() : first_seen,
-            last_seen: serializeDate ? last_seen.toISOString() : last_seen,
+            birthday: birthday ? birthday.toISOString() : null,
+            first_seen: first_seen.toISOString(),
+            last_seen: last_seen.toISOString(),
             has_ordered: has_ordered,
             latest_purchase: null, // finalize
             has_newsletter: has_ordered ? weightedBoolean(30) : true,
             groups: [], // finalize
             nb_commands: 0,
             total_spent: 0,
-        } as Customer<Serialized>;
+        };
     });
 };
 
-export type Customer<Serialized extends boolean = false> = {
+export type Customer = {
     id: number;
     first_name: string;
     last_name: string;
@@ -68,11 +59,11 @@ export type Customer<Serialized extends boolean = false> = {
     city: string;
     stateAbbr: string;
     avatar: string;
-    birthday: (Serialized extends true ? string : Date) | null;
-    first_seen: Serialized extends true ? string : Date;
-    last_seen: Serialized extends true ? string : Date;
+    birthday: string | null;
+    first_seen: string;
+    last_seen: string;
     has_ordered: boolean;
-    latest_purchase: Serialized extends true ? string : Date;
+    latest_purchase: string;
     has_newsletter: boolean;
     groups: string[];
     nb_commands: number;

--- a/examples/data-generator/src/customers.ts
+++ b/examples/data-generator/src/customers.ts
@@ -1,8 +1,12 @@
 import { date, name, internet, address } from 'faker/locale/en';
 
 import { randomDate, weightedBoolean } from './utils';
+import type { Db } from './types';
 
-export default (db, { serializeDate }) => {
+export const generateCustomers = <Serialized extends boolean = false>(
+    db: Db<Serialized>,
+    { serializeDate }: { serializeDate: Serialized }
+): Customer<Serialized>[] => {
     // This is the total number of people pictures available. We only use those pictures for actual customers
     const maxCustomers = 223;
     let numberOfCustomers = 0;
@@ -37,7 +41,11 @@ export default (db, { serializeDate }) => {
             stateAbbr: has_ordered ? address.stateAbbr() : null,
             avatar,
             birthday:
-                serializeDate && birthday ? birthday.toISOString() : birthday,
+                birthday != null
+                    ? serializeDate
+                        ? birthday.toISOString()
+                        : birthday
+                    : null,
             first_seen: serializeDate ? first_seen.toISOString() : first_seen,
             last_seen: serializeDate ? last_seen.toISOString() : last_seen,
             has_ordered: has_ordered,
@@ -46,6 +54,27 @@ export default (db, { serializeDate }) => {
             groups: [], // finalize
             nb_commands: 0,
             total_spent: 0,
-        };
+        } as Customer<Serialized>;
     });
+};
+
+export type Customer<Serialized extends boolean = false> = {
+    id: number;
+    first_name: string;
+    last_name: string;
+    email: string;
+    address: string;
+    zipcode: string;
+    city: string;
+    stateAbbr: string;
+    avatar: string;
+    birthday: (Serialized extends true ? string : Date) | null;
+    first_seen: Serialized extends true ? string : Date;
+    last_seen: Serialized extends true ? string : Date;
+    has_ordered: boolean;
+    latest_purchase: Serialized extends true ? string : Date;
+    has_newsletter: boolean;
+    groups: string[];
+    nb_commands: number;
+    total_spent: number;
 };

--- a/examples/data-generator/src/finalize.ts
+++ b/examples/data-generator/src/finalize.ts
@@ -1,6 +1,9 @@
+import { Db } from './types';
 import { weightedBoolean } from './utils';
 
-export default function (db) {
+export default function <Serialized extends boolean = false>(
+    db: Db<Serialized>
+) {
     // set latest purchase date
     db.commands.forEach(command => {
         let customer = db.customers[command.customer_id];
@@ -100,3 +103,21 @@ export default function (db) {
         },
     ];
 }
+
+export type Settings = {
+    id: number;
+    configuration: {
+        url: string;
+        mail: {
+            sender: string;
+            transport: {
+                service: string;
+                auth: {
+                    user: string;
+                    pass: string;
+                };
+            };
+        };
+        file_type_whiltelist: string[];
+    };
+}[];

--- a/examples/data-generator/src/finalize.ts
+++ b/examples/data-generator/src/finalize.ts
@@ -1,9 +1,7 @@
 import { Db } from './types';
 import { weightedBoolean } from './utils';
 
-export default function <Serialized extends boolean = false>(
-    db: Db<Serialized>
-) {
+export default function (db: Db) {
     // set latest purchase date
     db.commands.forEach(command => {
         let customer = db.customers[command.customer_id];

--- a/examples/data-generator/src/index.ts
+++ b/examples/data-generator/src/index.ts
@@ -1,31 +1,36 @@
-import { RaRecord } from 'ra-core';
-
-import generateCustomers from './customers';
-import generateCategories from './categories';
-import generateProducts from './products';
-import generateCommands from './commands';
-import generateInvoices from './invoices';
-import generateReviews from './reviews';
+import { generateCustomers, Customer } from './customers';
+import { generateCategories, Category } from './categories';
+import { generateProducts, Product } from './products';
+import { generateCommands, Command, BasketItem } from './commands';
+import { generateInvoices, Invoice } from './invoices';
+import { generateReviews, Review } from './reviews';
 import finalize from './finalize';
+import { Db } from './types';
 
-export interface Db {
-    customers: RaRecord[];
-    categories: RaRecord[];
-    products: RaRecord[];
-    commands: RaRecord[];
-    invoices: RaRecord[];
-    reviews: RaRecord[];
-}
-
-export default (options = { serializeDate: true }): Db => {
-    const db = {} as Db;
-    db.customers = generateCustomers(db, options);
+const generateData = <Serialized extends boolean = false>(options?: {
+    serializeDate: Serialized;
+}): Db<Serialized> => {
+    const db = {} as Db<Serialized>;
+    db.customers = generateCustomers<Serialized>(db, options);
     db.categories = generateCategories();
     db.products = generateProducts(db);
-    db.commands = generateCommands(db, options);
+    db.commands = generateCommands<Serialized>(db, options);
     db.invoices = generateInvoices(db);
     db.reviews = generateReviews(db, options);
     finalize(db);
 
     return db;
+};
+
+export default generateData;
+
+export type {
+    BasketItem,
+    Category,
+    Command,
+    Customer,
+    Db,
+    Invoice,
+    Product,
+    Review,
 };

--- a/examples/data-generator/src/index.ts
+++ b/examples/data-generator/src/index.ts
@@ -7,16 +7,14 @@ import { generateReviews, Review } from './reviews';
 import finalize from './finalize';
 import { Db } from './types';
 
-const generateData = <Serialized extends boolean = false>(options?: {
-    serializeDate: Serialized;
-}): Db<Serialized> => {
-    const db = {} as Db<Serialized>;
-    db.customers = generateCustomers<Serialized>(db, options);
+const generateData = (): Db => {
+    const db = {} as Db;
+    db.customers = generateCustomers();
     db.categories = generateCategories();
     db.products = generateProducts(db);
-    db.commands = generateCommands<Serialized>(db, options);
+    db.commands = generateCommands(db);
     db.invoices = generateInvoices(db);
-    db.reviews = generateReviews(db, options);
+    db.reviews = generateReviews(db);
     finalize(db);
 
     return db;

--- a/examples/data-generator/src/invoices.ts
+++ b/examples/data-generator/src/invoices.ts
@@ -1,8 +1,6 @@
 import type { Db } from './types';
 
-export const generateInvoices = <Serialized extends boolean = false>(
-    db: Db<Serialized>
-): Invoice<Serialized>[] => {
+export const generateInvoices = (db: Db): Invoice[] => {
     let id = 0;
 
     return (
@@ -10,26 +8,23 @@ export const generateInvoices = <Serialized extends boolean = false>(
             .filter(command => command.status !== 'delivered')
             // @ts-ignore
             .sort((a, b) => new Date(a.date) - new Date(b.date))
-            .map(
-                command =>
-                    ({
-                        id: id++,
-                        date: command.date,
-                        command_id: command.id,
-                        customer_id: command.customer_id,
-                        total_ex_taxes: command.total_ex_taxes,
-                        delivery_fees: command.delivery_fees,
-                        tax_rate: command.tax_rate,
-                        taxes: command.taxes,
-                        total: command.total,
-                    } as Invoice<Serialized>)
-            )
+            .map(command => ({
+                id: id++,
+                date: command.date,
+                command_id: command.id,
+                customer_id: command.customer_id,
+                total_ex_taxes: command.total_ex_taxes,
+                delivery_fees: command.delivery_fees,
+                tax_rate: command.tax_rate,
+                taxes: command.taxes,
+                total: command.total,
+            }))
     );
 };
 
-export type Invoice<Serialized extends boolean = false> = {
+export type Invoice = {
     id: number;
-    date: Serialized extends true ? string : Date;
+    date: string;
     command_id: number;
     customer_id: number;
     total_ex_taxes: number;

--- a/examples/data-generator/src/invoices.ts
+++ b/examples/data-generator/src/invoices.ts
@@ -1,4 +1,8 @@
-export default db => {
+import type { Db } from './types';
+
+export const generateInvoices = <Serialized extends boolean = false>(
+    db: Db<Serialized>
+): Invoice<Serialized>[] => {
     let id = 0;
 
     return (
@@ -6,16 +10,31 @@ export default db => {
             .filter(command => command.status !== 'delivered')
             // @ts-ignore
             .sort((a, b) => new Date(a.date) - new Date(b.date))
-            .map(command => ({
-                id: id++,
-                date: command.date,
-                command_id: command.id,
-                customer_id: command.customer_id,
-                total_ex_taxes: command.total_ex_taxes,
-                delivery_fees: command.delivery_fees,
-                tax_rate: command.tax_rate,
-                taxes: command.taxes,
-                total: command.total,
-            }))
+            .map(
+                command =>
+                    ({
+                        id: id++,
+                        date: command.date,
+                        command_id: command.id,
+                        customer_id: command.customer_id,
+                        total_ex_taxes: command.total_ex_taxes,
+                        delivery_fees: command.delivery_fees,
+                        tax_rate: command.tax_rate,
+                        taxes: command.taxes,
+                        total: command.total,
+                    } as Invoice<Serialized>)
+            )
     );
+};
+
+export type Invoice<Serialized extends boolean = false> = {
+    id: number;
+    date: Serialized extends true ? string : Date;
+    command_id: number;
+    customer_id: number;
+    total_ex_taxes: number;
+    delivery_fees: number;
+    tax_rate: number;
+    taxes: number;
+    total: number;
 };

--- a/examples/data-generator/src/products.ts
+++ b/examples/data-generator/src/products.ts
@@ -1,6 +1,7 @@
 import { random, lorem } from 'faker/locale/en';
 
 import { randomFloat, weightedBoolean } from './utils';
+import type { Db } from './types';
 
 const productReferences = {
     animals: [
@@ -162,7 +163,9 @@ const productReferences = {
     ],
 };
 
-export default db => {
+export const generateProducts = <Serialized extends boolean = false>(
+    db: Db<Serialized>
+): Product[] => {
     let id = 0;
 
     return db.categories.reduce(
@@ -204,4 +207,18 @@ export default db => {
         ],
         []
     );
+};
+
+export type Product = {
+    id: number;
+    category_id: number;
+    reference: string;
+    width: number;
+    height: number;
+    price: number;
+    thumbnail: string;
+    image: string;
+    description: string;
+    stock: number;
+    sales: number;
 };

--- a/examples/data-generator/src/products.ts
+++ b/examples/data-generator/src/products.ts
@@ -163,9 +163,7 @@ const productReferences = {
     ],
 };
 
-export const generateProducts = <Serialized extends boolean = false>(
-    db: Db<Serialized>
-): Product[] => {
+export const generateProducts = (db: Db): Product[] => {
     let id = 0;
 
     return db.categories.reduce(

--- a/examples/data-generator/src/reviews.ts
+++ b/examples/data-generator/src/reviews.ts
@@ -2,8 +2,12 @@ import { random, lorem } from 'faker/locale/en';
 import { subDays, isAfter } from 'date-fns';
 
 import { randomDate, weightedArrayElement, weightedBoolean } from './utils';
+import type { Db } from './types';
 
-export default (db, { serializeDate }) => {
+export const generateReviews = <Serialized extends boolean = false>(
+    db: Db<Serialized>,
+    { serializeDate }: { serializeDate: Serialized }
+): Review<Serialized>[] => {
     const today = new Date();
     const aMonthAgo = subDays(today, 30);
 
@@ -51,4 +55,15 @@ export default (db, { serializeDate }) => {
             ],
             []
         );
+};
+
+export type Review<Serialized extends boolean = false> = {
+    id: number;
+    date: Serialized extends true ? string : Date;
+    status: 'accepted' | 'rejected' | 'pending';
+    command_id: number;
+    product_id: number;
+    customer_id: number;
+    rating: number;
+    comment: string;
 };

--- a/examples/data-generator/src/reviews.ts
+++ b/examples/data-generator/src/reviews.ts
@@ -4,10 +4,7 @@ import { subDays, isAfter } from 'date-fns';
 import { randomDate, weightedArrayElement, weightedBoolean } from './utils';
 import type { Db } from './types';
 
-export const generateReviews = <Serialized extends boolean = false>(
-    db: Db<Serialized>,
-    { serializeDate }: { serializeDate: Serialized }
-): Review<Serialized>[] => {
+export const generateReviews = (db: Db): Review[] => {
     const today = new Date();
     const aMonthAgo = subDays(today, 30);
 
@@ -38,7 +35,7 @@ export const generateReviews = <Serialized extends boolean = false>(
 
                         return {
                             id: id++,
-                            date: serializeDate ? date.toISOString() : date,
+                            date: date.toISOString(),
                             status: status,
                             command_id: command.id,
                             product_id: product.product_id,
@@ -57,9 +54,9 @@ export const generateReviews = <Serialized extends boolean = false>(
         );
 };
 
-export type Review<Serialized extends boolean = false> = {
+export type Review = {
     id: number;
-    date: Serialized extends true ? string : Date;
+    date: string;
     status: 'accepted' | 'rejected' | 'pending';
     command_id: number;
     product_id: number;

--- a/examples/data-generator/src/types.ts
+++ b/examples/data-generator/src/types.ts
@@ -6,12 +6,12 @@ import type { Invoice } from './invoices';
 import type { Review } from './reviews';
 import { Settings } from './finalize';
 
-export interface Db<Serialized extends boolean = false> {
-    customers: Customer<Serialized>[];
+export interface Db {
+    customers: Customer[];
     categories: Category[];
     products: Product[];
-    commands: Command<Serialized>[];
-    invoices: Invoice<Serialized>[];
-    reviews: Review<Serialized>[];
+    commands: Command[];
+    invoices: Invoice[];
+    reviews: Review[];
     settings: Settings;
 }

--- a/examples/data-generator/src/types.ts
+++ b/examples/data-generator/src/types.ts
@@ -1,0 +1,17 @@
+import type { Customer } from './customers';
+import type { Category } from './categories';
+import type { Product } from './products';
+import type { Command } from './commands';
+import type { Invoice } from './invoices';
+import type { Review } from './reviews';
+import { Settings } from './finalize';
+
+export interface Db<Serialized extends boolean = false> {
+    customers: Customer<Serialized>[];
+    categories: Category[];
+    products: Product[];
+    commands: Command<Serialized>[];
+    invoices: Invoice<Serialized>[];
+    reviews: Review<Serialized>[];
+    settings: Settings;
+}

--- a/examples/data-generator/src/utils.ts
+++ b/examples/data-generator/src/utils.ts
@@ -1,6 +1,6 @@
 import faker from 'faker/locale/en';
 
-export const weightedArrayElement = (values, weights) =>
+export const weightedArrayElement = <T>(values: T[], weights): T =>
     faker.random.arrayElement(
         values.reduce(
             (acc, value, index) =>

--- a/examples/data-generator/src/utils.ts
+++ b/examples/data-generator/src/utils.ts
@@ -12,12 +12,23 @@ export const weightedArrayElement = (values, weights) =>
 export const weightedBoolean = likelyhood =>
     faker.random.number(99) < likelyhood;
 
-export const randomDate = (minDate?: Date, maxDate?: Date) => {
+export const randomDate = (
+    minDate?: Date | string,
+    maxDate?: Date | string
+) => {
     const minTs =
         minDate instanceof Date
             ? minDate.getTime()
+            : typeof minDate === 'string'
+            ? new Date(minDate).getTime()
             : Date.now() - 5 * 365 * 24 * 60 * 60 * 1000; // 5 years
-    const maxTs = maxDate instanceof Date ? maxDate.getTime() : Date.now();
+    const maxTs =
+        maxDate instanceof Date
+            ? maxDate.getTime()
+            : typeof maxDate === 'string'
+            ? new Date(maxDate).getTime()
+            : Date.now();
+
     const range = maxTs - minTs;
     const randomRange = faker.random.number({ max: range });
     // move it more towards today to account for traffic increase

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -37,7 +37,7 @@
         "recharts": "^2.1.15"
     },
     "scripts": {
-        "dev": "vite --force",
+        "dev": "vite",
         "build": "tsc && vite build",
         "preview": "vite preview"
     },

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -18,7 +18,7 @@
         "graphql": "^15.6.0",
         "graphql-tag": "^2.12.6",
         "inflection": "~1.12.0",
-        "json-graphql-server": "~2.3.0",
+        "json-graphql-server": "~3.0.1",
         "prop-types": "^15.8.1",
         "query-string": "^7.1.1",
         "ra-data-fakerest": "^5.0.0-alpha.0",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -37,7 +37,7 @@
         "recharts": "^2.1.15"
     },
     "scripts": {
-        "dev": "vite",
+        "dev": "vite --force",
         "build": "tsc && vite build",
         "preview": "vite preview"
     },

--- a/examples/demo/src/data-generator-retail.d.ts
+++ b/examples/demo/src/data-generator-retail.d.ts
@@ -1,1 +1,0 @@
-declare module 'data-generator-retail';

--- a/examples/demo/src/fakeServer/graphql.ts
+++ b/examples/demo/src/fakeServer/graphql.ts
@@ -3,7 +3,7 @@ import generateData from 'data-generator-retail';
 import fetchMock from 'fetch-mock';
 
 export default () => {
-    const data = generateData({ serializeDate: false });
+    const data = generateData();
     const restServer = JsonGraphqlServer({ data });
     const handler = restServer.getHandler();
     const handlerWithLogs = (url: string, opts: any) =>

--- a/examples/demo/src/fakeServer/rest.ts
+++ b/examples/demo/src/fakeServer/rest.ts
@@ -3,7 +3,7 @@ import fetchMock from 'fetch-mock';
 import generateData from 'data-generator-retail';
 
 export default () => {
-    const data = generateData({ serializeDate: true });
+    const data = generateData();
     const restServer = new FakeRest.FetchServer('http://localhost:4000');
     if (window) {
         window.restServer = restServer; // give way to update data in the console

--- a/examples/demo/src/orders/OrderList.tsx
+++ b/examples/demo/src/orders/OrderList.tsx
@@ -12,12 +12,12 @@ import {
     List,
     NullableBooleanInput,
     NumberField,
+    NumberInput,
     ReferenceField,
     ReferenceInput,
     SearchInput,
     SelectColumnsButton,
     TextField,
-    TextInput,
     TopToolbar,
     useListContext,
 } from 'react-admin';
@@ -60,9 +60,15 @@ const orderFilters = [
             sx={{ minWidth: 200 }}
         />
     </ReferenceInput>,
-    <DateInput source="date_gte" />,
-    <DateInput source="date_lte" />,
-    <TextInput source="total_gte" />,
+    <DateInput source="date_gte" parse={d => new Date(d).toISOString()} />,
+    <DateInput
+        source="date_lte"
+        parse={d => {
+            console.log(d, new Date(d).toISOString());
+            return new Date(d).toISOString();
+        }}
+    />,
+    <NumberInput source="total_gte" />,
     <NullableBooleanInput source="returned" />,
 ];
 

--- a/examples/demo/src/orders/OrderList.tsx
+++ b/examples/demo/src/orders/OrderList.tsx
@@ -61,13 +61,7 @@ const orderFilters = [
         />
     </ReferenceInput>,
     <DateInput source="date_gte" parse={d => new Date(d).toISOString()} />,
-    <DateInput
-        source="date_lte"
-        parse={d => {
-            console.log(d, new Date(d).toISOString());
-            return new Date(d).toISOString();
-        }}
-    />,
+    <DateInput source="date_lte" parse={d => new Date(d).toISOString()} />,
     <NumberInput source="total_gte" />,
     <NullableBooleanInput source="returned" />,
 ];

--- a/examples/demo/src/types.ts
+++ b/examples/demo/src/types.ts
@@ -1,76 +1,14 @@
-import { Identifier, RaRecord } from 'react-admin';
+import * as DataGenerator from 'data-generator-retail';
 
 export type ThemeName = 'light' | 'dark';
 
-export interface Category extends RaRecord {
-    name: string;
-}
-
-export interface Product extends RaRecord {
-    category_id: Identifier;
-    description: string;
-    height: number;
-    image: string;
-    price: number;
-    reference: string;
-    stock: number;
-    thumbnail: string;
-    width: number;
-}
-
-export interface Customer extends RaRecord {
-    first_name: string;
-    last_name: string;
-    address: string;
-    stateAbbr: string;
-    city: string;
-    zipcode: string;
-    avatar: string;
-    birthday: string;
-    first_seen: string;
-    last_seen: string;
-    has_ordered: boolean;
-    latest_purchase: string;
-    has_newsletter: boolean;
-    groups: string[];
-    nb_commands: number;
-    total_spent: number;
-    email: string;
-}
-
-export type OrderStatus = 'ordered' | 'delivered' | 'cancelled';
-
-export interface Order extends RaRecord {
-    status: OrderStatus;
-    basket: BasketItem[];
-    date: Date;
-    total: number;
-    total_ex_taxes: number;
-    delivery_fees: number;
-    tax_rate: number;
-    taxes: number;
-    customer_id: Identifier;
-    reference: string;
-}
-
-export type BasketItem = {
-    product_id: Identifier;
-    quantity: number;
-};
-
-export interface Invoice extends RaRecord {
-    date: Date;
-}
-
-export type ReviewStatus = 'accepted' | 'pending' | 'rejected';
-
-export interface Review extends RaRecord {
-    date: Date;
-    status: ReviewStatus;
-    customer_id: Identifier;
-    product_id: Identifier;
-    comment: string;
-}
+export type Category = DataGenerator.Category;
+export type Product = DataGenerator.Product;
+export type Customer = DataGenerator.Customer<false>;
+export type Order = DataGenerator.Command<false>;
+export type Invoice = DataGenerator.Invoice<false>;
+export type Review = DataGenerator.Review<false>;
+export type BasketItem = DataGenerator.BasketItem;
 
 declare global {
     interface Window {

--- a/examples/demo/src/types.ts
+++ b/examples/demo/src/types.ts
@@ -4,10 +4,10 @@ export type ThemeName = 'light' | 'dark';
 
 export type Category = DataGenerator.Category;
 export type Product = DataGenerator.Product;
-export type Customer = DataGenerator.Customer<false>;
-export type Order = DataGenerator.Command<false>;
-export type Invoice = DataGenerator.Invoice<false>;
-export type Review = DataGenerator.Review<false>;
+export type Customer = DataGenerator.Customer;
+export type Order = DataGenerator.Command;
+export type Invoice = DataGenerator.Invoice;
+export type Review = DataGenerator.Review;
 export type BasketItem = DataGenerator.BasketItem;
 
 declare global {

--- a/examples/demo/src/visitors/Aside.tsx
+++ b/examples/demo/src/visitors/Aside.tsx
@@ -164,7 +164,7 @@ const EventList = () => {
 
 interface AsideEvent {
     type: string;
-    date: Date;
+    date: string;
     data: OrderRecord | ReviewRecord;
 }
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
         "run-demo": "cd examples/demo && cross-env REACT_APP_DATA_PROVIDER=rest yarn dev",
         "build-demo": "cd examples/demo && cross-env REACT_APP_DATA_PROVIDER=rest yarn build",
         "run-graphql-demo": "cd examples/demo && cross-env REACT_APP_DATA_PROVIDER=graphql yarn dev",
-        "run-demo-watch": "concurrently \"yarn run watch\" \"yarn run run-demo\"",
-        "run-graphql-demo-watch": "concurrently \"yarn run watch\" \"yarn run run-graphql-demo\"",
         "run-crm": "cd examples/crm && yarn dev",
         "build-crm": "cd examples/crm && yarn build",
         "storybook": "storybook dev -p 9010",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,32 +22,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.3.19, @apollo/client@npm:^3.4.13":
-  version: 3.5.7
-  resolution: "@apollo/client@npm:3.5.7"
+"@apollo/client@npm:^3.3.19, @apollo/client@npm:^3.9.11":
+  version: 3.9.11
+  resolution: "@apollo/client@npm:3.9.11"
   dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.0.0"
-    "@wry/context": "npm:^0.6.0"
-    "@wry/equality": "npm:^0.5.0"
-    "@wry/trie": "npm:^0.3.0"
-    graphql-tag: "npm:^2.12.3"
+    "@graphql-typed-document-node/core": "npm:^3.1.1"
+    "@wry/caches": "npm:^1.0.0"
+    "@wry/equality": "npm:^0.5.6"
+    "@wry/trie": "npm:^0.5.0"
+    graphql-tag: "npm:^2.12.6"
     hoist-non-react-statics: "npm:^3.3.2"
-    optimism: "npm:^0.16.1"
+    optimism: "npm:^0.18.0"
     prop-types: "npm:^15.7.2"
+    rehackt: "npm:0.0.6"
+    response-iterator: "npm:^0.2.6"
     symbol-observable: "npm:^4.0.0"
-    ts-invariant: "npm:^0.9.4"
+    ts-invariant: "npm:^0.10.3"
     tslib: "npm:^2.3.0"
-    zen-observable-ts: "npm:^1.2.0"
+    zen-observable-ts: "npm:^1.2.5"
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    react: ^16.8.0 || ^17.0.0
+    graphql: ^15.0.0 || ^16.0.0
+    graphql-ws: ^5.5.5
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     subscriptions-transport-ws: ^0.9.0 || ^0.11.0
   peerDependenciesMeta:
+    graphql-ws:
+      optional: true
     react:
+      optional: true
+    react-dom:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: a865bc9a9e71c8ec42bf4b5f0fd6a32d3630fb38da17eb4e208af65a2d5a76d426ce492cbcfc041348b9802d17eef7f18eb0a1ed318acd259e9b2c6a10fe83ae
+  checksum: c7657a8e0d62f6d1e0b2da7573e9a9397af879946396e86682166596ffb201c22f7677d11cf65ca2ce97acc8ff2ee8e37c077716cd1b6ae9bb0e3a9cdfdecaf4
   languageName: node
   linkType: hard
 
@@ -2617,49 +2625,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/merge@npm:^8.2.1":
-  version: 8.2.1
-  resolution: "@graphql-tools/merge@npm:8.2.1"
+"@graphql-tools/merge@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "@graphql-tools/merge@npm:9.0.3"
   dependencies:
-    "@graphql-tools/utils": "npm:^8.5.1"
-    tslib: "npm:~2.3.0"
+    "@graphql-tools/utils": "npm:^10.0.13"
+    tslib: "npm:^2.4.0"
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 369037651ea0b648f6c3b16366de1d89076a2b6ddbaf4b59e18daacb867558ee6da8bc83c5f42fd70ec77010d6e8cb7243743b44dae33138326e053109fc551d
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: ce2a6763488dbeeb778824780037ce5a00fd8c4a6337078d52c4fb4bcac28759b801ede280014d281472ee92416114e4c0eca621c618db617cb351df7d751570
   languageName: node
   linkType: hard
 
-"@graphql-tools/schema@npm:^8.2.0":
-  version: 8.3.1
-  resolution: "@graphql-tools/schema@npm:8.3.1"
+"@graphql-tools/schema@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "@graphql-tools/schema@npm:10.0.3"
   dependencies:
-    "@graphql-tools/merge": "npm:^8.2.1"
-    "@graphql-tools/utils": "npm:^8.5.1"
-    tslib: "npm:~2.3.0"
-    value-or-promise: "npm:1.0.11"
+    "@graphql-tools/merge": "npm:^9.0.3"
+    "@graphql-tools/utils": "npm:^10.0.13"
+    tslib: "npm:^2.4.0"
+    value-or-promise: "npm:^1.0.12"
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: d2b8f96a371f174a97d4432beb10adfbbcac7b6ccb5f09f45cc7ecb8c4bc9cdadfe30443af26fa87c2c01ad258f97826e84224ff53d3f3a8cc43ef22928af33c
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 420bfa29d00927da085a3e521d7d6de5694f3abcdf5ba18655cc2a6b6145816d74503b13ba3ea15c7c65411023c9d81cfb73e7d49aa35ccfb91943f16ab9db8f
   languageName: node
   linkType: hard
 
-"@graphql-tools/utils@npm:^8.5.1":
-  version: 8.6.1
-  resolution: "@graphql-tools/utils@npm:8.6.1"
+"@graphql-tools/utils@npm:^10.0.13":
+  version: 10.1.3
+  resolution: "@graphql-tools/utils@npm:10.1.3"
   dependencies:
-    tslib: "npm:~2.3.0"
+    "@graphql-typed-document-node/core": "npm:^3.1.1"
+    cross-inspect: "npm:1.0.0"
+    dset: "npm:^3.1.2"
+    tslib: "npm:^2.4.0"
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: cdeb1471a7b5ddc1f37e9f18e933001ded621cba3397bb9ac053ca0eb12d6d992672307343ab0493b5f35a616e8ca12ebf7524009a8fd4e22c77996555bcff9b
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 657e0758b3cfcbccbaa0c5bf81277c03e02bda32070e71e9f7f728ad692893ef0a0c4bc873b6972edf0b96d0d6397df6e55a8db3e2050bd9c00f6a5bf8881858
   languageName: node
   linkType: hard
 
-"@graphql-typed-document-node/core@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "@graphql-typed-document-node/core@npm:3.1.1"
+"@graphql-typed-document-node/core@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "@graphql-typed-document-node/core@npm:3.2.0"
   peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: c186e5adceb0dfdaa770856d2f17c831a474f5927d79f984326ecb3d8680ba3c1ee2314f7def1d863692cd9cbe4dffc8bb52fc74ee0aa9b31e9491f24ef59f90
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 94e9d75c1f178bbae8d874f5a9361708a3350c8def7eaeb6920f2c820e82403b7d4f55b3735856d68e145e86c85cbfe2adc444fdc25519cd51f108697e99346c
   languageName: node
   linkType: hard
 
@@ -7300,30 +7311,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/context@npm:^0.6.0":
-  version: 0.6.1
-  resolution: "@wry/context@npm:0.6.1"
+"@wry/caches@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@wry/caches@npm:1.0.1"
   dependencies:
     tslib: "npm:^2.3.0"
-  checksum: 48eec27b05363e251aea3a6faff1422d735a047473df44841d1dbb83432bea694f41fd225fcca99b60651d9df45d7d748f1af01058e5134ecbb4bc789e0b5141
+  checksum: a7bca3377f1131d3f1080f2e39d0692c9d1ca86bfd55734786f167f46aad28a4c8e772107324e8319843fb8068fdf98abcdea376d8a589316b1f0cdadf81f8b1
   languageName: node
   linkType: hard
 
-"@wry/equality@npm:^0.5.0":
-  version: 0.5.2
-  resolution: "@wry/equality@npm:0.5.2"
+"@wry/context@npm:^0.7.0":
+  version: 0.7.4
+  resolution: "@wry/context@npm:0.7.4"
   dependencies:
     tslib: "npm:^2.3.0"
-  checksum: 0b2300c1294156e1bb2c0d23d679d60374ff3acb550bfa6d26d6518f0b4b9cfffbfb9a0125b405626113acfb3d4c9411e197f873d2dc3c5e6f1b468d61f6550c
+  checksum: 6cc8249b8ba195cda7643bffb30969e33d54a99f118a29dd12f1c34064ee0adf04253cfa0ba5b9893afde0a9588745828962877b9585106f7488e8299757638b
   languageName: node
   linkType: hard
 
-"@wry/trie@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "@wry/trie@npm:0.3.1"
+"@wry/equality@npm:^0.5.6":
+  version: 0.5.7
+  resolution: "@wry/equality@npm:0.5.7"
   dependencies:
     tslib: "npm:^2.3.0"
-  checksum: d44f96045f15d26d295ab7ce10a9b67e5aa4a1a18d2f27ebade680adbda3a7129ea70cd12720b02b88861e7999ac3fbc0fa86f9288c285739e0c3940e9ff8144
+  checksum: 8503ff6d4eb80f303d1387e71e51da59ccfc2160fa6d464618be80946fe43a654ea73f0c5b90d659fc4dfc3e38cbbdd6650d595fe5865be476636e444470853e
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "@wry/trie@npm:0.4.3"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 1a14edba595b1967d0cf38208c2660b2952a8e8a649bb669b67907df48f602c7f2acbe16c1e1b115afa7d7effb9f1a4dbde38eef16ee92e7521a511262a53281
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wry/trie@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 8c8cfcac96ba4bc69dabf02740e19e613f501b398e80bacc32cd95e87228f75ecb41cd1a76a65abae9756c0f61ab3536e0da52de28857456f9381ffdf5995d3e
   languageName: node
   linkType: hard
 
@@ -8452,23 +8481,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.1":
-  version: 1.20.1
-  resolution: "body-parser@npm:1.20.1"
+"body-parser@npm:1.19.2":
+  version: 1.19.2
+  resolution: "body-parser@npm:1.19.2"
   dependencies:
     bytes: "npm:3.1.2"
     content-type: "npm:~1.0.4"
     debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    http-errors: "npm:2.0.0"
+    depd: "npm:~1.1.2"
+    http-errors: "npm:1.8.1"
     iconv-lite: "npm:0.4.24"
-    on-finished: "npm:2.4.1"
-    qs: "npm:6.11.0"
-    raw-body: "npm:2.5.1"
+    on-finished: "npm:~2.3.0"
+    qs: "npm:6.9.7"
+    raw-body: "npm:2.4.3"
     type-is: "npm:~1.6.18"
-    unpipe: "npm:1.0.0"
-  checksum: a202d493e2c10a33fb7413dac7d2f713be579c4b88343cd814b6df7a38e5af1901fc31044e04de176db56b16d9772aa25a7723f64478c20f4d91b1ac223bf3b8
+  checksum: 02158280b090d0ad99dfdc795b7d580762601283e4bcbd29409c11b34d5cfd737f632447a073bc2e79492d303827bd155fef2d63a333cdec18a87846221cee5e
   languageName: node
   linkType: hard
 
@@ -9610,10 +9637,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.5.0":
-  version: 0.5.0
-  resolution: "cookie@npm:0.5.0"
-  checksum: c01ca3ef8d7b8187bae434434582288681273b5a9ed27521d4d7f9f7928fe0c920df0decd9f9d3bbd2d14ac432b8c8cf42b98b3bdd5bfe0e6edddeebebe8b61d
+"cookie@npm:0.4.2":
+  version: 0.4.2
+  resolution: "cookie@npm:0.4.2"
+  checksum: beab41fbd7c20175e3a2799ba948c1dcc71ef69f23fe14eeeff59fc09f50c517b0f77098db87dbb4c55da802f9d86ee86cdc1cd3efd87760341551838d53fca2
   languageName: node
   linkType: hard
 
@@ -9668,7 +9695,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cors@npm:^2.8.4":
+"cors@npm:^2.8.5":
   version: 2.8.5
   resolution: "cors@npm:2.8.5"
   dependencies:
@@ -9763,6 +9790,15 @@ __metadata:
     cross-env: dist/bin/cross-env.js
     cross-env-shell: dist/bin/cross-env-shell.js
   checksum: bf51bad729410ff7d3b36c1df15d4f4dd9df9236449562ab4016d1cfc2b82759626fc8cc0368c6d8bf956c78cac687a3fcb8bae9c56f90320c4fb5b99a6bdf1f
+  languageName: node
+  linkType: hard
+
+"cross-inspect@npm:1.0.0":
+  version: 1.0.0
+  resolution: "cross-inspect@npm:1.0.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 53530865c357c69a5a0543e2f2c61d3d46c9c316a19169372f5094cfb0a7c7e674f2daf2d5253a6731dfd9a8538aa4a4e13c6b4613b6f72b48bb0c41d2015ff4
   languageName: node
   linkType: hard
 
@@ -10413,7 +10449,7 @@ __metadata:
     graphql: "npm:^15.6.0"
     graphql-tag: "npm:^2.12.6"
     inflection: "npm:~1.12.0"
-    json-graphql-server: "npm:~2.3.0"
+    json-graphql-server: "npm:~3.0.1"
     prop-types: "npm:^15.8.1"
     query-string: "npm:^7.1.1"
     ra-data-fakerest: "npm:^5.0.0-alpha.0"
@@ -10469,6 +10505,13 @@ __metadata:
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: bd7633942f57418f5a3b80d5cb53898127bcf53e24cdf5d5f4396be471417671f0fee48a4ebe9a1e9defbde2a31280011af58a57e090ff822f589b443ed4e643
+  languageName: node
+  linkType: hard
+
+"destroy@npm:~1.0.4":
+  version: 1.0.4
+  resolution: "destroy@npm:1.0.4"
+  checksum: eab493808ba17a1fa22c71ef1a4e68d2c4c5222a38040606c966d2ab09117f3a7f3e05c39bffbe41a697f9de552039e43c30e46f0c3eab3faa9f82e800e172a0
   languageName: node
   linkType: hard
 
@@ -10710,6 +10753,13 @@ __metadata:
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: 2d8d4ba64bfaff7931402aa5e8cbb8eba0acbc99fe9ae442300199af021079eafa7171ce90e150821a5cb3d74f0057721fbe7ec201a6044b68c8a7615f8c123f
+  languageName: node
+  linkType: hard
+
+"dset@npm:^3.1.2":
+  version: 3.1.3
+  resolution: "dset@npm:3.1.3"
+  checksum: b1ff68f1f42af373baa85b00b04d89094cd0d7f74f94bd11364cba575f2762ed52a0a0503bbfcc92eccd07c6d55426813c8a7a6cfa020338eaea1f4edfd332c2
   languageName: node
   linkType: hard
 
@@ -11830,56 +11880,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-graphql@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "express-graphql@npm:0.12.0"
+"express-graphql@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "express-graphql@npm:0.9.0"
   dependencies:
     accepts: "npm:^1.3.7"
     content-type: "npm:^1.0.4"
-    http-errors: "npm:1.8.0"
+    http-errors: "npm:^1.7.3"
     raw-body: "npm:^2.4.1"
   peerDependencies:
-    graphql: ^14.7.0 || ^15.3.0
-  checksum: 5211cc46e8a34776611bcbb40abd445e8e40d6b415099cb0be22107b8fdc501a2d101f2e8b5316c43c6e2538f2858c98e59b17ca57f1253004ee96d40f55eefd
+    graphql: ^14.4.1
+  checksum: 0e970ef6bc0d1f7d10d0ff63d518dec37df73c75e15069a7fdde6809b6b24fa928fed186a5fb104c47e98865f11701e2d96958d0d44877b269fa95a31d4ebadc
   languageName: node
   linkType: hard
 
-"express@npm:^4.17.1, express@npm:^4.17.3":
-  version: 4.18.2
-  resolution: "express@npm:4.18.2"
+"express@npm:^4.17.3":
+  version: 4.17.3
+  resolution: "express@npm:4.17.3"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:1.20.1"
+    body-parser: "npm:1.19.2"
     content-disposition: "npm:0.5.4"
     content-type: "npm:~1.0.4"
-    cookie: "npm:0.5.0"
+    cookie: "npm:0.4.2"
     cookie-signature: "npm:1.0.6"
     debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
+    depd: "npm:~1.1.2"
     encodeurl: "npm:~1.0.2"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    finalhandler: "npm:1.2.0"
+    finalhandler: "npm:~1.1.2"
     fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
     merge-descriptors: "npm:1.0.1"
     methods: "npm:~1.1.2"
-    on-finished: "npm:2.4.1"
+    on-finished: "npm:~2.3.0"
     parseurl: "npm:~1.3.3"
     path-to-regexp: "npm:0.1.7"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:6.11.0"
+    qs: "npm:6.9.7"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
-    send: "npm:0.18.0"
-    serve-static: "npm:1.15.0"
+    send: "npm:0.17.2"
+    serve-static: "npm:1.14.2"
     setprototypeof: "npm:1.2.0"
-    statuses: "npm:2.0.1"
+    statuses: "npm:~1.5.0"
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 75af556306b9241bc1d7bdd40c9744b516c38ce50ae3210658efcbf96e3aed4ab83b3432f06215eae5610c123bc4136957dc06e50dfc50b7d4d775af56c4c59c
+  checksum: 8fa8a8ae26bd11082b575ddfecdfe51ca535e048ebcf58455e3f813aacc1712e09a297a511efb0e4843e2d2a413cb8c1cd6b81f79371e50d7b8efb1aa6b8d5af
   languageName: node
   linkType: hard
 
@@ -12256,6 +12305,21 @@ __metadata:
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
   checksum: 64b7e5ff2ad1fcb14931cd012651631b721ce657da24aedb5650ddde9378bf8e95daa451da43398123f5de161a81e79ff5affe4f9f2a6d2df4a813d6d3e254b7
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "finalhandler@npm:1.1.2"
+  dependencies:
+    debug: "npm:2.6.9"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    on-finished: "npm:~2.3.0"
+    parseurl: "npm:~1.3.3"
+    statuses: "npm:~1.5.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 6a96e1f5caab085628c11d9fdceb82ba608d5e426c6913d4d918409baa271037a47f28fbba73279e8ad614f0b8fa71ea791d265e408d760793829edd8c2f4584
   languageName: node
   linkType: hard
 
@@ -13100,7 +13164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:^2.12.3, graphql-tag@npm:^2.12.6":
+"graphql-tag@npm:^2.12.6":
   version: 2.12.6
   resolution: "graphql-tag@npm:2.12.6"
   dependencies:
@@ -13124,6 +13188,13 @@ __metadata:
   version: 15.8.0
   resolution: "graphql@npm:15.8.0"
   checksum: 30cc09b77170a9d1ed68e4c017ec8c5265f69501c96e4f34f8f6613f39a886c96dd9853eac925f212566ed651736334c8fe24ceae6c44e8d7625c95c3009a801
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.8.1":
+  version: 16.8.1
+  resolution: "graphql@npm:16.8.1"
+  checksum: 129c318156b466f440914de80dbf7bc67d17f776f2a088a40cb0da611d19a97c224b1c6d2b13cbcbc6e5776e45ed7468b8432f9c3536724e079b44f1a3d57a8a
   languageName: node
   linkType: hard
 
@@ -13422,16 +13493,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:1.8.0":
-  version: 1.8.0
-  resolution: "http-errors@npm:1.8.0"
+"http-errors@npm:1.8.1, http-errors@npm:^1.7.3":
+  version: 1.8.1
+  resolution: "http-errors@npm:1.8.1"
   dependencies:
     depd: "npm:~1.1.2"
     inherits: "npm:2.0.4"
     setprototypeof: "npm:1.2.0"
     statuses: "npm:>= 1.5.0 < 2"
-    toidentifier: "npm:1.0.0"
-  checksum: 2deb37be07a858370a5c9f150de0e8a14e10410a46aeed2614e9e96ecc5f88e6d79b2b278b6a968635ff0d01142e84131db2afb07504adb73a3e9340acdbd70c
+    toidentifier: "npm:1.0.1"
+  checksum: f01aeecd76260a6fe7f08e192fcbe9b2f39ed20fc717b852669a69930167053b01790998275c6297d44f435cf0e30edd50c05223d1bec9bc484e6cf35b2d6f43
   languageName: node
   linkType: hard
 
@@ -13702,10 +13773,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inflection@npm:^1.12.0":
-  version: 1.13.1
-  resolution: "inflection@npm:1.13.1"
-  checksum: ef67e3947a23180e8e3dddf9c9e87463ccc4bd32417fed869e3440a87901522dcd0f3a71a2ce2c831571b7aacff093219c262ce58a1fb8151dccb1be96136501
+"inflection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "inflection@npm:3.0.0"
+  checksum: 6f7016bc4d037fb8f07c8707edc622772d26467e97af02341fb5b891ca35cde7968726dd5c9b18275202aed17b169e053bc6ed1b3adf541c800c4ffa20236d7c
   languageName: node
   linkType: hard
 
@@ -15256,24 +15327,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-graphql-server@npm:~2.3.0":
-  version: 2.3.0
-  resolution: "json-graphql-server@npm:2.3.0"
+"json-graphql-server@npm:~3.0.1":
+  version: 3.0.1
+  resolution: "json-graphql-server@npm:3.0.1"
   dependencies:
-    "@apollo/client": "npm:^3.4.13"
-    "@graphql-tools/schema": "npm:^8.2.0"
-    cors: "npm:^2.8.4"
-    express: "npm:^4.17.1"
-    express-graphql: "npm:^0.12.0"
-    graphql: "npm:^15.6.0"
+    "@apollo/client": "npm:^3.9.11"
+    "@graphql-tools/schema": "npm:^10.0.3"
+    cors: "npm:^2.8.5"
+    express: "npm:^4.17.3"
+    express-graphql: "npm:^0.9.0"
+    graphql: "npm:^16.8.1"
+    graphql-tag: "npm:^2.12.6"
     graphql-type-json: "npm:^0.3.2"
-    inflection: "npm:^1.12.0"
+    inflection: "npm:^3.0.0"
     lodash.merge: "npm:^4.6.2"
     reify: "npm:^0.20.12"
-    xhr-mock: "npm:^2.5.0"
+    xhr-mock: "npm:^2.5.1"
   bin:
     json-graphql-server: bin/json-graphql-server.js
-  checksum: 345e48c754bd71f285cc1b0180018319735f9d55595b396e2ed16490c52d7ac2ec1789f449afb7b4bfda2e381a78b3367ae56aac5698f6cc82cba9912bb5c3eb
+  checksum: 021d3b913ddcf673f4991f6627b20ad2b908be12d38cc7440733943b713c4cadc951f7eef5cb38507e90861d86e992ec42d007621d967413d5ec4a09ebaeea65
   languageName: node
   linkType: hard
 
@@ -17269,6 +17341,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-finished@npm:~2.3.0":
+  version: 2.3.0
+  resolution: "on-finished@npm:2.3.0"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: c904f9e518b11941eb60279a3cbfaf1289bd0001f600a950255b1dede9fe3df8cd74f38483550b3bb9485165166acb5db500c3b4c4337aec2815c88c96fcc2ea
+  languageName: node
+  linkType: hard
+
 "on-headers@npm:~1.0.2":
   version: 1.0.2
   resolution: "on-headers@npm:1.0.2"
@@ -17314,13 +17395,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.16.1":
-  version: 0.16.1
-  resolution: "optimism@npm:0.16.1"
+"optimism@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "optimism@npm:0.18.0"
   dependencies:
-    "@wry/context": "npm:^0.6.0"
-    "@wry/trie": "npm:^0.3.0"
-  checksum: 8b815d39968d7d89406b160de0a17920921dc3110e5ecbae513caa30ee314ea36db65ede9b278da86101ae0f8556de7226eb02ec5e6d2a67a080fd3af2d331f0
+    "@wry/caches": "npm:^1.0.0"
+    "@wry/context": "npm:^0.7.0"
+    "@wry/trie": "npm:^0.4.3"
+    tslib: "npm:^2.3.0"
+  checksum: 8e97c6d660cb80cf5f444209b9dd29ee6951fa7b344d4c4fc6d4aaf0ad0710dddaf834d0f5d7211b3658b15ef6c6a22cbcb98c7a8121e3fee9666fe0fd62d876
   languageName: node
   linkType: hard
 
@@ -18525,6 +18608,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:6.9.7":
+  version: 6.9.7
+  resolution: "qs@npm:6.9.7"
+  checksum: d0274b3c2daa9e7b350fb695fc4b5f7a1e65e266d5798a07936975f0848bdca6d7ad41cded19ad4af6a6253b97e43b497e988e728eab7a286f277b6dddfbade4
+  languageName: node
+  linkType: hard
+
 "qs@npm:~6.5.2":
   version: 6.5.3
   resolution: "qs@npm:6.5.3"
@@ -18946,15 +19036,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:2.5.1, raw-body@npm:^2.4.1":
-  version: 2.5.1
-  resolution: "raw-body@npm:2.5.1"
+"raw-body@npm:2.4.3":
+  version: 2.4.3
+  resolution: "raw-body@npm:2.4.3"
   dependencies:
     bytes: "npm:3.1.2"
-    http-errors: "npm:2.0.0"
+    http-errors: "npm:1.8.1"
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
-  checksum: 5dad5a3a64a023b894ad7ab4e5c7c1ce34d3497fc7138d02f8c88a3781e68d8a55aa7d4fd3a458616fa8647cc228be314a1c03fb430a07521de78b32c4dd09d2
+  checksum: e25ac143c0638dac75b7228de378f60d9438dd1a9b83ffcc6935d5a1e2d599ad3cdc9d24e80eb8cf07a7ec4f5d57a692d243abdcb2449cf11605ef9e5fe6af06
   languageName: node
   linkType: hard
 
@@ -18967,6 +19057,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^2.4.1":
+  version: 2.5.1
+  resolution: "raw-body@npm:2.5.1"
+  dependencies:
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    unpipe: "npm:1.0.0"
+  checksum: 5dad5a3a64a023b894ad7ab4e5c7c1ce34d3497fc7138d02f8c88a3781e68d8a55aa7d4fd3a458616fa8647cc228be314a1c03fb430a07521de78b32c4dd09d2
   languageName: node
   linkType: hard
 
@@ -19861,6 +19963,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rehackt@npm:0.0.6":
+  version: 0.0.6
+  resolution: "rehackt@npm:0.0.6"
+  peerDependencies:
+    "@types/react": "*"
+    react: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 814c9b80b2680dc0572639ecad1ed1961b23b606e53a00976ee4c4876f6ed736ea702381235ac40ed2a5c826fb55641b46ae23343e4ddd6378ced1da3d51ada7
+  languageName: node
+  linkType: hard
+
 "reify@npm:^0.20.12":
   version: 0.20.12
   resolution: "reify@npm:0.20.12"
@@ -20041,6 +20158,13 @@ __metadata:
     is-core-module: "npm:^2.2.0"
     path-parse: "npm:^1.0.6"
   checksum: ecd5da8e5f3042952bd9fd46725ef850144e7c3d707d963039df677809716660ccf5efa66742fbc6796d280c23d18915384fada76869a9c554e15cf1e6df9278
+  languageName: node
+  linkType: hard
+
+"response-iterator@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "response-iterator@npm:0.2.6"
+  checksum: 60e6b552cd610643269d5d916d270cc8a4bea978cbe4779d6ef8083ac6b89006795508034e4c4ebe204eded75ac32bf243589ba82c1184591dde0674f6db785e
   languageName: node
   linkType: hard
 
@@ -20370,6 +20494,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:0.17.2":
+  version: 0.17.2
+  resolution: "send@npm:0.17.2"
+  dependencies:
+    debug: "npm:2.6.9"
+    depd: "npm:~1.1.2"
+    destroy: "npm:~1.0.4"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:1.8.1"
+    mime: "npm:1.6.0"
+    ms: "npm:2.1.3"
+    on-finished: "npm:~2.3.0"
+    range-parser: "npm:~1.2.1"
+    statuses: "npm:~1.5.0"
+  checksum: 0f92f0fcd298fcdd759dc7d501bfab79635f549ec3b885e26e4a62b3094420b355d73f2d59749b6004019a4c91db983fb1715378aa622f4bf4e21b0b79853e5c
+  languageName: node
+  linkType: hard
+
 "send@npm:0.18.0":
   version: 0.18.0
   resolution: "send@npm:0.18.0"
@@ -20397,6 +20542,18 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 1af427f4fee3fee051f54ffe15f77068cff78a3c96d20f5c1178d20630d3ab122d8350e639d5e13cde8111ef9db9439b871305ffb185e24be0a2149cec230988
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:1.14.2":
+  version: 1.14.2
+  resolution: "serve-static@npm:1.14.2"
+  dependencies:
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    parseurl: "npm:~1.3.3"
+    send: "npm:0.17.2"
+  checksum: 4583f8bec8daa74df58fd7415e6f58039223becbb6c7ac0e6386c4fbe5c825195df92c73f999a1404487ae1d1bd1d20dd7ae11bc19f8788225770d1960bbeaea
   languageName: node
   linkType: hard
 
@@ -20894,7 +21051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:>= 1.5.0 < 2":
+"statuses@npm:>= 1.5.0 < 2, statuses@npm:~1.5.0":
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
@@ -21536,13 +21693,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.0":
-  version: 1.0.0
-  resolution: "toidentifier@npm:1.0.0"
-  checksum: 27a37b8b21126e7216d40c02f410065b1de35b0f844368d0ccaabba7987595703006d45e5c094b086220cbbc5864d4b99766b460110e4bc15b9db574c5c58be2
-  languageName: node
-  linkType: hard
-
 "toidentifier@npm:1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
@@ -21627,12 +21777,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-invariant@npm:^0.9.4":
-  version: 0.9.4
-  resolution: "ts-invariant@npm:0.9.4"
+"ts-invariant@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "ts-invariant@npm:0.10.3"
   dependencies:
     tslib: "npm:^2.1.0"
-  checksum: 67cb364f535f40312e72d317bdc24c34fc09a43b63ecb1eab7285d6dc909f1f9b2dd73906104e510031cf3b1493636c7f0120f211c8f92783ada3be4c57f0f58
+  checksum: 2fbc178d5903d325ee0b87fad38827eac11888b6e86979b06754fd4bcdcf44c2a99b8bcd5d59d149c0464ede55ae810b02a2aee6835ad10efe4dd0e22efd68c0
   languageName: node
   linkType: hard
 
@@ -21703,13 +21853,6 @@ __metadata:
   version: 2.5.2
   resolution: "tslib@npm:2.5.2"
   checksum: 34fa100454708fa8acb7afc2b07d80e0332081e2075ddd912ba959af3b24f969663dac6d602961e57371dc05683badb83b3186ada92c4631ec777e02e3aab608
-  languageName: node
-  linkType: hard
-
-"tslib@npm:~2.3.0":
-  version: 2.3.1
-  resolution: "tslib@npm:2.3.1"
-  checksum: 4efd888895bdb3b987086b2b7793ad1013566f882b0eb7a328384e5ecc0d71cafb16bbeab3196200cbf7f01a73ccc25acc2f131d4ea6ee959be7436a8a306482
   languageName: node
   linkType: hard
 
@@ -22312,10 +22455,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"value-or-promise@npm:1.0.11":
-  version: 1.0.11
-  resolution: "value-or-promise@npm:1.0.11"
-  checksum: 7499b744ae18729cfe5a2211a678a2e023859a49e2cd2f3e28da6f3d84ed94fe3167e828026f8a123927420f075cd69b927be5a5a50b1768ea5c53bf1e75a52f
+"value-or-promise@npm:^1.0.12":
+  version: 1.0.12
+  resolution: "value-or-promise@npm:1.0.12"
+  checksum: b75657b74e4d17552bd88e0c2857020fbab34a4d091dc058db18c470e7da0336067e72c130b3358e3321ac0a6ff11c0b92b67a382318a3705ad5d57de7ff3262
   languageName: node
   linkType: hard
 
@@ -22878,7 +23021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xhr-mock@npm:^2.5.0":
+"xhr-mock@npm:^2.5.1":
   version: 2.5.1
   resolution: "xhr-mock@npm:2.5.1"
   dependencies:
@@ -23078,12 +23221,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zen-observable-ts@npm:^1.2.0":
-  version: 1.2.3
-  resolution: "zen-observable-ts@npm:1.2.3"
+"zen-observable-ts@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "zen-observable-ts@npm:1.2.5"
   dependencies:
     zen-observable: "npm:0.8.15"
-  checksum: fa4c1ebbbbc3e7d41dca6d9dc74cb96440ee4767c50d8f9a3b3f84f823d9832d148f76187cd65c30d9ab4008f88c7248fe8774f7cedf98fbfc2e0a6429ce08f5
+  checksum: 21d586f3d0543e1d6f05d9333a137b407dbf337907c1ee1c2fa7a7da044f7e1262e4baf4ef8902f230c6f5acb561047659eb7df73df33307233cc451efe46db1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

When using the `data-generator-retail` package, the generated is not typed, making consumers declare the generated types themselves.

## Solution

Provide types

Wait for next version of `json-graphql-server` or the GQL demo won't work