### PR TITLE
chore: add a doc check ci job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,10 @@ name: "Test - action"
 
 on: 
   push:
-    paths-ignore:
-      - 'docs/**'
     branches:
       - master
       - next
   pull_request:
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   typecheck:
@@ -28,6 +24,14 @@ jobs:
       run: make lint        
     - name: Build
       run: make build
+
+  doc-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2  
+    - name: Jekyll build
+      run: docker run -v="${PWD}/docs:/site" bretfisher/jekyll build
 
   unit-test:
     runs-on: ubuntu-latest

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -35,7 +35,6 @@ export default App;
 
 In most apps, you need to pass more props to `<Admin>`. Here is a more complete example taken from [the e-commerce demo](https://marmelab.com/react-admin-demo/):
 
-{% raw %}
 ```tsx
 // in src/App.js
 import { Admin, Resource, CustomRoutes } from 'react-admin';
@@ -78,7 +77,6 @@ const App = () => (
     </Admin>
 );
 ```
-{% endraw %}
 
 To make the main app component more concise, a good practice is to move the resources props to separate files. For instance, the previous example can be rewritten as:
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -35,6 +35,7 @@ export default App;
 
 In most apps, you need to pass more props to `<Admin>`. Here is a more complete example taken from [the e-commerce demo](https://marmelab.com/react-admin-demo/):
 
+{% raw %}
 ```tsx
 // in src/App.js
 import { Admin, Resource, CustomRoutes } from 'react-admin';
@@ -77,6 +78,7 @@ const App = () => (
     </Admin>
 );
 ```
+{% endraw %}
 
 To make the main app component more concise, a good practice is to move the resources props to separate files. For instance, the previous example can be rewritten as:
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+liquid:
+  error_mode: strict


### PR DESCRIPTION
**problem**

The CI does not fail when we forget to wrap code snippets with `{% raw %}`/`{% endraw %}`

**solution**

- Add a CI job to build the Jekyll doc
- Change the Jekyll config to fail on Liquid errors