### PR TITLE
Update all react-admin enterprise edition links in the documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,7 +7,7 @@ about: Something isn't working as expected. Please tell us!
 <!-- Please do not submit support requests or "How to" questions here. For that, 
 - go to Stack Overflow: https://stackoverflow.com/questions/tagged/react-admin),  or
   go to the react-admin discord server https://discord.gg/GeZF9sqh3N for community support or
-- use the Professional Support (https://marmelab.com/ra-enterprise/#support) if you're an Enterprise Edition subscriber. -->
+- use the Professional Support (https://react-admin-ee.marmelab.com/#support) if you're an Enterprise Edition subscriber. -->
 
 **What you were expecting:**
 <!-- Describe what the behavior would be without the bug. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -669,7 +669,7 @@ Note: This release wasn't published to npm, use version 4.10.1 or higher.
 
 We released [`ra-directus`](https://github.com/marmelab/ra-directus/) that contains a `DataProvider` and an `AuthProvider` to work with [Directus](https://directus.io/).
 
-We also released new landing pages for both [React-admin](https://marmelab.com/react-admin/) and the [Enterprise Edition](https://marmelab.com/ra-enterprise/). Check them out!
+We also released new landing pages for both [React-admin](https://marmelab.com/react-admin/) and the [Enterprise Edition](https://react-admin-ee.marmelab.com/). Check them out!
 
 ## v4.8.4
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ And then browse to the URL displayed in your console.
 
 ## Support
 
-- Get commercial support from Marmelab via [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise#support)
+- Get commercial support from Marmelab via [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com#support)
 - Get community support via [Discord](https://discord.gg/GeZF9sqh3N) and [StackOverflow](https://stackoverflow.com/questions/tagged/react-admin). 
 
 ## Versions In This Repository

--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -8,8 +8,8 @@ title: "AccordionForm"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative layout for Edit and Create forms, where Inputs are grouped into expandable panels.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-form-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-form-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-form-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-form-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -73,8 +73,8 @@ By default, each child accordion element handles its expanded state independentl
 You can also use the `<AccordionSection>` component as a child of `<SimpleForm>` for secondary inputs:
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -421,9 +421,9 @@ const CustomerEdit = () => (
 Renders children (Inputs) inside a Material UI `<Accordion>` element without a Card style. To be used as child of a `<SimpleForm>` or a `<TabbedForm>` element.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.webm" type="video/webm"/>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -5,11 +5,11 @@ title: "AccordionForm"
 
 # `<AccordionForm>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative layout for Edit and Create forms, where Inputs are grouped into expandable panels.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative layout for Edit and Create forms, where Inputs are grouped into expandable panels.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-form-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-form-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-form-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-form-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -73,12 +73,12 @@ By default, each child accordion element handles its expanded state independentl
 You can also use the `<AccordionSection>` component as a child of `<SimpleForm>` for secondary inputs:
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-section-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
-Check [the `ra-form-layout` documentation](https://marmelab.com/ra-enterprise/modules/ra-form-layout##accordionform) for more details.
+Check [the `ra-form-layout` documentation](https://react-admin-ee.marmelab.com/modules/ra-form-layout##accordionform) for more details.
 
 ## Props
 
@@ -421,9 +421,9 @@ const CustomerEdit = () => (
 Renders children (Inputs) inside a Material UI `<Accordion>` element without a Card style. To be used as child of a `<SimpleForm>` or a `<TabbedForm>` element.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-section-overview.webm" type="video/webm"/>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -78,7 +78,7 @@ You can also use the `<AccordionSection>` component as a child of `<SimpleForm>`
   Your browser does not support the video tag.
 </video>
 
-Check [the `ra-form-layout` documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout##accordionform) for more details.
+Check [the `ra-form-layout` documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#accordionform) for more details.
 
 ## Props
 

--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -78,7 +78,7 @@ You can also use the `<AccordionSection>` component as a child of `<SimpleForm>`
   Your browser does not support the video tag.
 </video>
 
-Check [the `ra-form-layout` documentation](https://react-admin-ee.marmelab.com/modules/ra-form-layout##accordionform) for more details.
+Check [the `ra-form-layout` documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout##accordionform) for more details.
 
 ## Props
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -337,7 +337,7 @@ The Auth Provider also lets you configure redirections after login/logout, anony
 
 ## `basename`
 
-Use this prop to make all routes and links in your Admin relative to a "base" portion of the URL pathname that they all share. This is required when using the [`BrowserRouter`](https://reactrouter.com/en/main/router-components/browser-router) to serve the application under a sub-path of your domain (for example https://marmelab.com/ra-enterprise-demo), or when embedding react-admin inside a single-page app with its own routing.
+Use this prop to make all routes and links in your Admin relative to a "base" portion of the URL pathname that they all share. This is required when using the [`BrowserRouter`](https://reactrouter.com/en/main/router-components/browser-router) to serve the application under a sub-path of your domain (for example https://react-admin-ee.marmelab.com-demo), or when embedding react-admin inside a single-page app with its own routing.
 
 ```tsx
 import { Admin } from 'react-admin';

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -337,7 +337,7 @@ The Auth Provider also lets you configure redirections after login/logout, anony
 
 ## `basename`
 
-Use this prop to make all routes and links in your Admin relative to a "base" portion of the URL pathname that they all share. This is required when using the [`BrowserRouter`](https://reactrouter.com/en/main/router-components/browser-router) to serve the application under a sub-path of your domain (for example https://react-admin-ee.marmelab.com-demo), or when embedding react-admin inside a single-page app with its own routing.
+Use this prop to make all routes and links in your Admin relative to a "base" portion of the URL pathname that they all share. This is required when using the [`BrowserRouter`](https://reactrouter.com/en/main/router-components/browser-router) to serve the application under a sub-path of your domain (for example https://marmelab.com/ra-enterprise-demo), or when embedding react-admin inside a single-page app with its own routing.
 
 ```tsx
 import { Admin } from 'react-admin';

--- a/docs/AppBar.md
+++ b/docs/AppBar.md
@@ -418,8 +418,8 @@ export const MyAppBar = () => (
 A common use case for app bar customization is to add a site-wide search engine. The `<Search>` component is a good starting point for this.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/AppBar.md
+++ b/docs/AppBar.md
@@ -418,8 +418,8 @@ export const MyAppBar = () => (
 A common use case for app bar customization is to add a site-wide search engine. The `<Search>` component is a good starting point for this.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-demo.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-demo.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -5,7 +5,7 @@ title: "RBAC"
 
 # Role-Based Access Control (RBAC)
 
-React-admin Enterprise Edition contains [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, which adds fine-grained permissions to your admin. This module extends the `authProvider` and adds replacement for many react-admin components that use these permissions.
+React-admin Enterprise Edition contains [the ra-rbac module](https://react-admin-ee.marmelab.com/documentation/ra-rbac)<img class="icon" src="./img/premium.svg" />, which adds fine-grained permissions to your admin. This module extends the `authProvider` and adds replacement for many react-admin components that use these permissions.
 
 <video controls="controls" style="max-width: 96%">
     <source src="./img/ra-rbac.mp4" type="video/mp4" />

--- a/docs/AuthRBAC.md
+++ b/docs/AuthRBAC.md
@@ -5,7 +5,7 @@ title: "RBAC"
 
 # Role-Based Access Control (RBAC)
 
-React-admin Enterprise Edition contains [the ra-rbac module](https://marmelab.com/ra-enterprise/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, which adds fine-grained permissions to your admin. This module extends the `authProvider` and adds replacement for many react-admin components that use these permissions.
+React-admin Enterprise Edition contains [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, which adds fine-grained permissions to your admin. This module extends the `authProvider` and adds replacement for many react-admin components that use these permissions.
 
 <video controls="controls" style="max-width: 96%">
     <source src="./img/ra-rbac.mp4" type="video/mp4" />
@@ -70,7 +70,7 @@ yarn add @react-admin/ra-rbac
 
 Make sure you [enable auth features](https://marmelab.com/react-admin/Authentication.html#enabling-auth-features) by setting an `<Admin authProvider>`, and [disable anonymous access](https://marmelab.com/react-admin/Authentication.html#disabling-anonymous-access) by adding the `<Admin requireAuth>` prop. This will ensure that react-admin waits for the `authProvider` response before rendering anything.
 
-**Tip**: ra-rbac is part of the [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise/), and hosted in a private npm registry. You need to subscribe to one of the Enterprise Edition plans to access this package.
+**Tip**: ra-rbac is part of the [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com/), and hosted in a private npm registry. You need to subscribe to one of the Enterprise Edition plans to access this package.
 
 ## Vocabulary
 

--- a/docs/AutoSave.md
+++ b/docs/AutoSave.md
@@ -5,7 +5,7 @@ title: "The AutoSave Component"
 
 # `<AutoSave>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" />  component enables autosaving of the form. Alternative to [`<SaveButton>`](./SaveButton.md), it's ideal for long data entry tasks, and reduces the risk of data loss.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" />  component enables autosaving of the form. Alternative to [`<SaveButton>`](./SaveButton.md), it's ideal for long data entry tasks, and reduces the risk of data loss.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/AutoSave.webm" type="video/webm"/>

--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -5,15 +5,15 @@ title: "The Breadcrumb Component"
 
 # `<Breadcrumb>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component renders a breadcrumb path that automatically adapts to the page location. It helps users navigate large web applications.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component renders a breadcrumb path that automatically adapts to the page location. It helps users navigate large web applications.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
-Test it live on [the Enterprise Edition demo](https://marmelab.com/ra-enterprise-demo/#/).
+Test it live on [the Enterprise Edition demo](https://react-admin-ee.marmelab.com-demo/#/).
 
 The breadcrumb path can complement and/or replace navigation menus, back buttons, page titles, and site maps. It's a small but effective navigation control.
 
@@ -303,7 +303,7 @@ const MyBreadcrumb = () => (
 
 The `<Breadcrumb.Item>` component is responsible for rendering individual breadcrumb items. It displays the item when the app's location matches the specified `name`. You can nest this component to create breadcrumb paths of varying depths.
 
-![A breadcrumb item](https://marmelab.com/ra-enterprise/modules/assets/breadcrumbItem.png)
+![A breadcrumb item](https://react-admin-ee.marmelab.com/modules/assets/breadcrumbItem.png)
 
 It requires the following props:
 

--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -13,7 +13,7 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
   Your browser does not support the video tag.
 </video>
 
-Test it live on [the Enterprise Edition demo](https://react-admin-ee.marmelab.com-demo/#/).
+Test it live on [the Enterprise Edition demo](https://marmelab.com/ra-enterprise-demo/#/).
 
 The breadcrumb path can complement and/or replace navigation menus, back buttons, page titles, and site maps. It's a small but effective navigation control.
 

--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -8,8 +8,8 @@ title: "The Breadcrumb Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component renders a breadcrumb path that automatically adapts to the page location. It helps users navigate large web applications.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -303,7 +303,7 @@ const MyBreadcrumb = () => (
 
 The `<Breadcrumb.Item>` component is responsible for rendering individual breadcrumb items. It displays the item when the app's location matches the specified `name`. You can nest this component to create breadcrumb paths of varying depths.
 
-![A breadcrumb item](https://react-admin-ee.marmelab.com/modules/assets/breadcrumbItem.png)
+![A breadcrumb item](https://react-admin-ee.marmelab.com/assets/breadcrumbItem.png)
 
 It requires the following props:
 

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -306,7 +306,7 @@ export const PostList = () => (
 
 ### `<BulkUpdateFormButton>`
 
-This component, part of the [enterprise edition](https://marmelab.com/ra-enterprise/modules/ra-form-layout)<img class="icon" src="./img/premium.svg" />, lets users edit multiple records at once. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
+This component, part of the [enterprise edition](https://react-admin-ee.marmelab.com/modules/ra-form-layout)<img class="icon" src="./img/premium.svg" />, lets users edit multiple records at once. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
 
 The button opens a dialog containing the form passed as children. When the form is submitted, it will call the dataProvider's `updateMany` method with the ids of the selected records.
 
@@ -818,17 +818,17 @@ const App = () => (
 
 See [The Menu documentation](./Menu.md) for more details.
 
-**Tip**: If you need a multi-level menu, or a Mega Menu opening panels with custom content, check out [the `ra-navigation`<img class="icon" src="./img/premium.svg" /> module](https://marmelab.com/ra-enterprise/modules/ra-navigation) (part of the [Enterprise Edition](https://marmelab.com/ra-enterprise))
+**Tip**: If you need a multi-level menu, or a Mega Menu opening panels with custom content, check out [the `ra-navigation`<img class="icon" src="./img/premium.svg" /> module](https://react-admin-ee.marmelab.com/modules/ra-navigation) (part of the [Enterprise Edition](https://react-admin-ee.marmelab.com))
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -821,14 +821,14 @@ See [The Menu documentation](./Menu.md) for more details.
 **Tip**: If you need a multi-level menu, or a Mega Menu opening panels with custom content, check out [the `ra-navigation`<img class="icon" src="./img/premium.svg" /> module](https://react-admin-ee.marmelab.com/documentation/ra-navigation) (part of the [Enterprise Edition](https://react-admin-ee.marmelab.com))
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-item.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -306,7 +306,7 @@ export const PostList = () => (
 
 ### `<BulkUpdateFormButton>`
 
-This component, part of the [enterprise edition](https://react-admin-ee.marmelab.com/modules/ra-form-layout)<img class="icon" src="./img/premium.svg" />, lets users edit multiple records at once. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
+This component, part of the [enterprise edition](https://react-admin-ee.marmelab.com/documentation/ra-form-layout)<img class="icon" src="./img/premium.svg" />, lets users edit multiple records at once. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
 
 The button opens a dialog containing the form passed as children. When the form is submitted, it will call the dataProvider's `updateMany` method with the ids of the selected records.
 
@@ -818,7 +818,7 @@ const App = () => (
 
 See [The Menu documentation](./Menu.md) for more details.
 
-**Tip**: If you need a multi-level menu, or a Mega Menu opening panels with custom content, check out [the `ra-navigation`<img class="icon" src="./img/premium.svg" /> module](https://react-admin-ee.marmelab.com/modules/ra-navigation) (part of the [Enterprise Edition](https://react-admin-ee.marmelab.com))
+**Tip**: If you need a multi-level menu, or a Mega Menu opening panels with custom content, check out [the `ra-navigation`<img class="icon" src="./img/premium.svg" /> module](https://react-admin-ee.marmelab.com/documentation/ra-navigation) (part of the [Enterprise Edition](https://react-admin-ee.marmelab.com))
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />

--- a/docs/Calendar.md
+++ b/docs/Calendar.md
@@ -5,11 +5,11 @@ title: "The Calendar Component"
 
 # `<Calendar>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component, part of [the `ra-calendar` module](https://marmelab.com/ra-enterprise/modules/ra-calendar), renders a list of events as a calendar. 
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [the `ra-calendar` module](https://react-admin-ee.marmelab.com/modules/ra-calendar), renders a list of events as a calendar. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-calendar.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-calendar.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -263,7 +263,7 @@ Check the possible values for `CalendarProps` in the [`<Calendar>`](#calendar) a
 
 ### `EditDialogProps`
 
-For content edition, `<CompleteCalendar>` relies on [ra-form-layout's `<EditDialog>`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
+For content edition, `<CompleteCalendar>` relies on [ra-form-layout's `<EditDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
 
 You can customize `<EditDialog>` props like `title`, `redirect`, `onSuccess` and `onFailure` by passing a custom `EditDialogProps` prop.
 
@@ -296,11 +296,11 @@ const EventList = () => (
 ```
 {% endraw %}
 
-Check the possible values for `EditDialogProps` in [the `<EditDialog>` component documentation](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog--editdialog).
+Check the possible values for `EditDialogProps` in [the `<EditDialog>` component documentation](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog).
 
 ### `CreateDialogProps`
 
-For content addition, `<CompleteCalendar>` relies on [ra-form-layout's `<CreateDialog>`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
+For content addition, `<CompleteCalendar>` relies on [ra-form-layout's `<CreateDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
 
 You can customize `<CreateDialog>` props like `title`, `redirect`, `onSuccess` and `onFailure` by passing a custom `CreateDialogProps` prop.
 
@@ -328,7 +328,7 @@ const EventList = () => (
 ```
 {% endraw %}
 
-Check the possible values for `CreateDialogProps` in [the `<CreateDialog>` component documentation](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog--editdialog).
+Check the possible values for `CreateDialogProps` in [the `<CreateDialog>` component documentation](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog).
 
 ### `mutationOptions`
 

--- a/docs/Calendar.md
+++ b/docs/Calendar.md
@@ -263,7 +263,7 @@ Check the possible values for `CalendarProps` in the [`<Calendar>`](#calendar) a
 
 ### `EditDialogProps`
 
-For content edition, `<CompleteCalendar>` relies on [ra-form-layout's `<EditDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
+For content edition, `<CompleteCalendar>` relies on [ra-form-layout's `<EditDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog) to display its child form in a dialog.
 
 You can customize `<EditDialog>` props like `title`, `redirect`, `onSuccess` and `onFailure` by passing a custom `EditDialogProps` prop.
 
@@ -296,11 +296,11 @@ const EventList = () => (
 ```
 {% endraw %}
 
-Check the possible values for `EditDialogProps` in [the `<EditDialog>` component documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog).
+Check the possible values for `EditDialogProps` in [the `<EditDialog>` component documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog).
 
 ### `CreateDialogProps`
 
-For content addition, `<CompleteCalendar>` relies on [ra-form-layout's `<CreateDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
+For content addition, `<CompleteCalendar>` relies on [ra-form-layout's `<CreateDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog) to display its child form in a dialog.
 
 You can customize `<CreateDialog>` props like `title`, `redirect`, `onSuccess` and `onFailure` by passing a custom `CreateDialogProps` prop.
 
@@ -328,7 +328,7 @@ const EventList = () => (
 ```
 {% endraw %}
 
-Check the possible values for `CreateDialogProps` in [the `<CreateDialog>` component documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog).
+Check the possible values for `CreateDialogProps` in [the `<CreateDialog>` component documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog).
 
 ### `mutationOptions`
 

--- a/docs/Calendar.md
+++ b/docs/Calendar.md
@@ -5,7 +5,7 @@ title: "The Calendar Component"
 
 # `<Calendar>`
 
-This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [the `ra-calendar` module](https://react-admin-ee.marmelab.com/modules/ra-calendar), renders a list of events as a calendar. 
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [the `ra-calendar` module](https://react-admin-ee.marmelab.com/documentation/ra-calendar), renders a list of events as a calendar. 
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.webm" type="video/webm" />
@@ -263,7 +263,7 @@ Check the possible values for `CalendarProps` in the [`<Calendar>`](#calendar) a
 
 ### `EditDialogProps`
 
-For content edition, `<CompleteCalendar>` relies on [ra-form-layout's `<EditDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
+For content edition, `<CompleteCalendar>` relies on [ra-form-layout's `<EditDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
 
 You can customize `<EditDialog>` props like `title`, `redirect`, `onSuccess` and `onFailure` by passing a custom `EditDialogProps` prop.
 
@@ -296,11 +296,11 @@ const EventList = () => (
 ```
 {% endraw %}
 
-Check the possible values for `EditDialogProps` in [the `<EditDialog>` component documentation](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog).
+Check the possible values for `EditDialogProps` in [the `<EditDialog>` component documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog).
 
 ### `CreateDialogProps`
 
-For content addition, `<CompleteCalendar>` relies on [ra-form-layout's `<CreateDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
+For content addition, `<CompleteCalendar>` relies on [ra-form-layout's `<CreateDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog) to display its child form in a dialog.
 
 You can customize `<CreateDialog>` props like `title`, `redirect`, `onSuccess` and `onFailure` by passing a custom `CreateDialogProps` prop.
 
@@ -328,7 +328,7 @@ const EventList = () => (
 ```
 {% endraw %}
 
-Check the possible values for `CreateDialogProps` in [the `<CreateDialog>` component documentation](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog--editdialog).
+Check the possible values for `CreateDialogProps` in [the `<CreateDialog>` component documentation](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog--editdialog).
 
 ### `mutationOptions`
 

--- a/docs/Calendar.md
+++ b/docs/Calendar.md
@@ -8,8 +8,8 @@ title: "The Calendar Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [the `ra-calendar` module](https://react-admin-ee.marmelab.com/documentation/ra-calendar), renders a list of events as a calendar. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-calendar.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-calendar.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Community.md
+++ b/docs/Community.md
@@ -55,9 +55,9 @@ If you're stuck with a problem in your react-admin code, you can get help from v
 
 ### Paid Support
 
-Get **support by the core team** in less than 24h on weekdays by subscribing to the [Enterprise Edition](https://marmelab.com/ra-enterprise) of react-admin. There are more than 200 pages of documentation, this team knows them all. And they also know the codebase, so they can help you with tricky problems.
+Get **support by the core team** in less than 24h on weekdays by subscribing to the [Enterprise Edition](https://react-admin-ee.marmelab.com) of react-admin. There are more than 200 pages of documentation, this team knows them all. And they also know the codebase, so they can help you with tricky problems.
 
-This subscription also gives you access to the [Private modules](https://marmelab.com/ra-enterprise/#private-modules)<img class="premium" src="./img/premium.svg" style="width: 15px;margin: 0 0px;box-shadow: none;vertical-align:middle"/>, and helps us keep react-admin free and open-source. Plus it's cheap, so don't stay stuck on a problem for too long!
+This subscription also gives you access to the [Private modules](https://react-admin-ee.marmelab.com/#private-modules)<img class="premium" src="./img/premium.svg" style="width: 15px;margin: 0 0px;box-shadow: none;vertical-align:middle"/>, and helps us keep react-admin free and open-source. Plus it's cheap, so don't stay stuck on a problem for too long!
 
 ### StackOverflow
 

--- a/docs/ContainerLayout.md
+++ b/docs/ContainerLayout.md
@@ -5,11 +5,11 @@ title: "ContainerLayout"
 
 # `<ContainerLayout>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative to react-admin's `<Layout>` for applications with a limited number of resources. It displays the content in a centered container, has no sidebar, and uses the top bar for navigation.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative to react-admin's `<Layout>` for applications with a limited number of resources. It displays the content in a centered container, has no sidebar, and uses the top bar for navigation.
 
-![Container layout](https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/container-layout.png)
+![Container layout](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/container-layout.png)
 
-`<ContainerLayout>` is part of the [ra-navigation](https://marmelab.com/ra-enterprise/modules/ra-navigation#containerlayout) package.
+`<ContainerLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/modules/ra-navigation#containerlayout) package.
 
 ## Usage
 
@@ -72,7 +72,7 @@ const MyLayout = props => <ContainerLayout {...props} maxWidth="md" />;
 
 ## `menu`
 
-By default, `<ContainerLayout>` renders one menu item per resource in the admin. To reorder the menu, omit resources, or add custom pages, pass a custom menu element to the `menu` prop. This element should be [a `<HorizontalMenu>` component](#horizontalmenu) with `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://marmelab.com/ra-enterprise/modules/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
+By default, `<ContainerLayout>` renders one menu item per resource in the admin. To reorder the menu, omit resources, or add custom pages, pass a custom menu element to the `menu` prop. This element should be [a `<HorizontalMenu>` component](#horizontalmenu) with `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://react-admin-ee.marmelab.com/modules/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
 
 ```jsx
 import {
@@ -211,7 +211,7 @@ This menu automatically detects and highlights the current location.
 
 ### Usage
 
-Create a menu component based on `<HorizontalMenu>` and `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://marmelab.com/ra-enterprise/modules/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
+Create a menu component based on `<HorizontalMenu>` and `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://react-admin-ee.marmelab.com/modules/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
 
 ```jsx
 import { HorizontalMenu } from '@react-admin/ra-navigation';

--- a/docs/ContainerLayout.md
+++ b/docs/ContainerLayout.md
@@ -7,7 +7,7 @@ title: "ContainerLayout"
 
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative to react-admin's `<Layout>` for applications with a limited number of resources. It displays the content in a centered container, has no sidebar, and uses the top bar for navigation.
 
-![Container layout](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/container-layout.png)
+![Container layout](https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/container-layout.png)
 
 `<ContainerLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/documentation/ra-navigation#containerlayout) package.
 

--- a/docs/ContainerLayout.md
+++ b/docs/ContainerLayout.md
@@ -9,7 +9,7 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
 
 ![Container layout](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/container-layout.png)
 
-`<ContainerLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/modules/ra-navigation#containerlayout) package.
+`<ContainerLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/documentation/ra-navigation#containerlayout) package.
 
 ## Usage
 
@@ -72,7 +72,7 @@ const MyLayout = props => <ContainerLayout {...props} maxWidth="md" />;
 
 ## `menu`
 
-By default, `<ContainerLayout>` renders one menu item per resource in the admin. To reorder the menu, omit resources, or add custom pages, pass a custom menu element to the `menu` prop. This element should be [a `<HorizontalMenu>` component](#horizontalmenu) with `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://react-admin-ee.marmelab.com/modules/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
+By default, `<ContainerLayout>` renders one menu item per resource in the admin. To reorder the menu, omit resources, or add custom pages, pass a custom menu element to the `menu` prop. This element should be [a `<HorizontalMenu>` component](#horizontalmenu) with `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://react-admin-ee.marmelab.com/documentation/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
 
 ```jsx
 import {
@@ -211,7 +211,7 @@ This menu automatically detects and highlights the current location.
 
 ### Usage
 
-Create a menu component based on `<HorizontalMenu>` and `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://react-admin-ee.marmelab.com/modules/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
+Create a menu component based on `<HorizontalMenu>` and `<HorizontalMenu.Item>` children. Each child should have a `value` corresponding to the [application location](https://react-admin-ee.marmelab.com/documentation/ra-navigation#concepts) of the target, and can have a `to` prop corresponding to the target location if different from the app location.
 
 ```jsx
 import { HorizontalMenu } from '@react-admin/ra-navigation';

--- a/docs/Create.md
+++ b/docs/Create.md
@@ -551,8 +551,8 @@ Note: In order to get the `mutationOptions` being considered, you have to set th
 `<Create>` is designed to be a page component, passed to the `create` prop of the `<Resource>` component. But you may want to let users create a record from another page. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/create-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/create-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Create.md
+++ b/docs/Create.md
@@ -551,8 +551,8 @@ Note: In order to get the `mutationOptions` being considered, you have to set th
 `<Create>` is designed to be a page component, passed to the `create` prop of the `<Resource>` component. But you may want to let users create a record from another page. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/create-dialog.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/create-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -8,8 +8,8 @@ title: "CreateDialog"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a replacement to [the `<Create>` component](./Create.md) allowing users to create records without leaving the context of the list page.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/create-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/create-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -248,8 +248,8 @@ This may not be what you want if you need to display the creation dialog in anot
 In that case, use [the `<CreateInDialogButton>` component](./CreateInDialogButton.md), which doesn't create a route, but renders the dialog when the user clicks on it.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -5,11 +5,11 @@ title: "CreateDialog"
 
 # `<CreateDialog>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers a replacement to [the `<Create>` component](./Create.md) allowing users to create records without leaving the context of the list page.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a replacement to [the `<Create>` component](./Create.md) allowing users to create records without leaving the context of the list page.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/create-dialog.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/create-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/create-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -24,7 +24,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, add the `<CreateDialog>` component as a sibling to a `<List>` component.
 
@@ -248,8 +248,8 @@ This may not be what you want if you need to display the creation dialog in anot
 In that case, use [the `<CreateInDialogButton>` component](./CreateInDialogButton.md), which doesn't create a route, but renders the dialog when the user clicks on it.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -24,7 +24,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, add the `<CreateDialog>` component as a sibling to a `<List>` component.
 

--- a/docs/CreateInDialogButton.md
+++ b/docs/CreateInDialogButton.md
@@ -5,11 +5,11 @@ title: "CreateInDialogButton"
 
 # `<CreateInDialogButton>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers a way to open a `<Create>` view inside a dialog, hence allowing to create a new record without leaving the current view.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a way to open a `<Create>` view inside a dialog, hence allowing to create a new record without leaving the current view.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -27,7 +27,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, put `<CreateInDialogButton>` wherever you would put a `<CreateButton>`, and use the same children as you would for a `<Create>` component (e.g. a `<SimpleForm>`): 
 

--- a/docs/CreateInDialogButton.md
+++ b/docs/CreateInDialogButton.md
@@ -8,8 +8,8 @@ title: "CreateInDialogButton"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a way to open a `<Create>` view inside a dialog, hence allowing to create a new record without leaving the current view.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/CreateInDialogButton.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/CreateInDialogButton.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/CreateInDialogButton.md
+++ b/docs/CreateInDialogButton.md
@@ -27,7 +27,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-showindialogbutton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, put `<CreateInDialogButton>` wherever you would put a `<CreateButton>`, and use the same children as you would for a `<Create>` component (e.g. a `<SimpleForm>`): 
 

--- a/docs/CreateInDialogButton.md
+++ b/docs/CreateInDialogButton.md
@@ -27,7 +27,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, put `<CreateInDialogButton>` wherever you would put a `<CreateButton>`, and use the same children as you would for a `<Create>` component (e.g. a `<SimpleForm>`): 
 

--- a/docs/DataProviderLive.md
+++ b/docs/DataProviderLive.md
@@ -14,7 +14,7 @@ Teams where several people work in parallel on a common task need to allow live 
 
 React-admin offers powerful realtime features to help you build collaborative applications, based on the Publish / Subscribe (PubSub) pattern. The [Realtime documentation](./Realtime.md) explains how to use them.
 
-These features are part of the [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" />.
+These features are part of the [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" />.
 
 ## Realtime Data Provider
 

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -939,7 +939,7 @@ const PostList = () => (
 **Tip**: For even more column customization (resizable columns, column grouping, etc.), check out the [`<DatagridAG>`](./DatagridAG.md) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -953,8 +953,8 @@ The separation between list pages and edit pages is not always relevant. Sometim
 ### `<EditableDatagrid>`: Editable Rows
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -1019,7 +1019,7 @@ Check [the `<EditableDatagrid>` documentation](./EditableDatagrid.md) for more d
 ### `<DatagridAG>`: Spreadsheet-like Interface
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -1047,7 +1047,7 @@ Additionally, `<DatagridAG>` is compatible with the [Enterprise version of ag-gr
 -   And more...
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -1260,7 +1260,7 @@ const PostList = () => (
 **Tip**: For even more column customization (resizable columns, column grouping, etc.), check out the [`<DatagridAG>`](./DatagridAG.md) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -41,7 +41,7 @@ The `<Datagrid>` is an **iterator** component: it gets an array of records from 
 - [`<EditableDatagrid>`](./EditableDatagrid.md)<img class="icon" src="./img/premium.svg" /> lets users edit the content right in the datagrid
 - [`<DatagridAG>`](./DatagridAG.md)<img class="icon" src="./img/premium.svg" /> adds suport for column reordering, aggregation, pivoting, row grouping, infinite scroll, etc.
 
-Both are [Enterprise Edition](https://marmelab.com/ra-enterprise) components.
+Both are [Enterprise Edition](https://react-admin-ee.marmelab.com) components.
 
 ## Props
 
@@ -939,7 +939,7 @@ const PostList = () => (
 **Tip**: For even more column customization (resizable columns, column grouping, etc.), check out the [`<DatagridAG>`](./DatagridAG.md) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -953,8 +953,8 @@ The separation between list pages and edit pages is not always relevant. Sometim
 ### `<EditableDatagrid>`: Editable Rows
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -1019,7 +1019,7 @@ Check [the `<EditableDatagrid>` documentation](./EditableDatagrid.md) for more d
 ### `<DatagridAG>`: Spreadsheet-like Interface
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -1047,7 +1047,7 @@ Additionally, `<DatagridAG>` is compatible with the [Enterprise version of ag-gr
 -   And more...
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -1260,7 +1260,7 @@ const PostList = () => (
 **Tip**: For even more column customization (resizable columns, column grouping, etc.), check out the [`<DatagridAG>`](./DatagridAG.md) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/DatagridAG.md
+++ b/docs/DatagridAG.md
@@ -5,12 +5,12 @@ title: "The DatagridAG Component"
 
 # `<DatagridAG>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component is an alternative datagrid component with advanced features, based on [ag-grid](https://www.ag-grid.com/).
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component is an alternative datagrid component with advanced features, based on [ag-grid](https://www.ag-grid.com/).
 
 > **Note:** This component is still in **alpha** stage. Major changes may still be introduced in the future.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -52,7 +52,7 @@ Additionally, `<DatagridAG>` is compatible with the [Enterprise version of ag-gr
 -   And more...
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -66,7 +66,7 @@ npm install --save @react-admin/ra-datagrid-ag
 yarn add @react-admin/ra-datagrid-ag
 ```
 
-**Tip**: `ra-datagrid-ag` is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+**Tip**: `ra-datagrid-ag` is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, use `<DatagridAG>` as a child of a react-admin `<List>`, `<ReferenceManyField>`, or any other component that creates a `ListContext`.
 
@@ -91,7 +91,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG PostList](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-PostList.png)
+![DatagridAG PostList](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-PostList.png)
 
 Here are the important things to note:
 
@@ -190,7 +190,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG custom columnDefs](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-select-rows.png)
+![DatagridAG custom columnDefs](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-select-rows.png)
 
 Have a look at [the ag-grid documentation](https://www.ag-grid.com/react-data-grid/column-properties/) for the exhaustive list of column properties.
 
@@ -224,7 +224,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG defaultColDef](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-PostList.png)
+![DatagridAG defaultColDef](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-PostList.png)
 
 ## `cellRenderer`
 
@@ -268,7 +268,7 @@ export const CommentList = () => {
 };
 ```
 
-![DatagridAG RA Fields](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-ra-fields.png)
+![DatagridAG RA Fields](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-ra-fields.png)
 
 **Note:** You still need to pass the `source` prop to the field.
 
@@ -419,7 +419,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG Dark](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-dark.png)
+![DatagridAG Dark](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-dark.png)
 
 **Tip:** Remember to import the corresponding stylesheet (e.g. `ag-theme-balham[.min].css` for `ag-theme-balham`).
 
@@ -458,8 +458,8 @@ const CarList = () => {
 ```
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 
@@ -517,7 +517,7 @@ export const PostList = () => {
 
 {% endraw %}
 
-![DatagridAG sx](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-sx.png)
+![DatagridAG sx](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-sx.png)
 
 It can also be helpful to change the default grid's height (`calc(100vh - 96px - ${theme.spacing(1)})`):
 
@@ -547,7 +547,7 @@ export const PostList = () => {
 
 {% endraw %}
 
-![DatagridAG sx height](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-sx-height.png)
+![DatagridAG sx height](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-sx-height.png)
 
 ## Accessing The Grid And Column APIs
 
@@ -617,7 +617,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG flex](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-flex.png)
+![DatagridAG flex](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-flex.png)
 
 Alternatively, you can use the grid's `api` to call `autoSizeAllColumns` to automatically resize all columns to fit their content:
 
@@ -651,7 +651,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG auto size](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-auto-size.png)
+![DatagridAG auto size](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-auto-size.png)
 
 Check out the [Column Sizing](https://www.ag-grid.com/react-data-grid/column-sizing/) documentation for more information and more alternatives.
 
@@ -701,7 +701,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG selected rows](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-selected-rows.png)
+![DatagridAG selected rows](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-selected-rows.png)
 
 Just like with `<Datagrid>`, you can customize the bulk actions by passing a [`bulkActionButtons`](./Datagrid.md#bulkactionbuttons) prop to `<DatagridAG>`.
 
@@ -748,8 +748,8 @@ export const PostList = () => {
 By default, `<DatagridAG>` renders pagination controls at the bottom of the list. You can disable these controls to switch to an infinite pagination mode, where the grid shows the next rows on scroll. Thanks to [ag-grid's DOM virtualization](https://www.ag-grid.com/react-data-grid/dom-virtualisation/), this mode causes no performance problem.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 
@@ -785,7 +785,7 @@ const CarList = () => {
 
 If you have subscribed to the [Enterprise version of ag-grid](https://www.ag-grid.com/react-data-grid/licensing/), you can also add a [Status Bar](https://www.ag-grid.com/react-data-grid/status-bar/) to show the total number of rows.
 
-![DatagridAG with status bar](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-status-bar.png)
+![DatagridAG with status bar](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-status-bar.png)
 
 ```tsx
 import 'ag-grid-community/styles/ag-grid.css';
@@ -825,7 +825,7 @@ const CarList = () => {
 
 By default, editing is enabled on cells, which means you can edit a cell by double-clicking on it, and it will trigger a call to the dataProvider's `update` function.
 
-![DatagridAG edit cell](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-edit-cell.png)
+![DatagridAG edit cell](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-edit-cell.png)
 
 However, if you'd like to update the full row at once instead, you can enable full row editing by passing `editType="fullRow"` to `<DatagridAG>`:
 
@@ -848,7 +848,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG edit row](https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-edit-row.png)
+![DatagridAG edit row](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-edit-row.png)
 
 ## Disabling Cell Edition
 
@@ -964,6 +964,6 @@ const OlympicWinnersList = () => {
 ```
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>

--- a/docs/DatagridAG.md
+++ b/docs/DatagridAG.md
@@ -10,7 +10,7 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
 > **Note:** This component is still in **alpha** stage. Major changes may still be introduced in the future.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -52,7 +52,7 @@ Additionally, `<DatagridAG>` is compatible with the [Enterprise version of ag-gr
 -   And more...
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -91,7 +91,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG PostList](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-PostList.png)
+![DatagridAG PostList](https://react-admin-ee.marmelab.com/assets/DatagridAG-PostList.png)
 
 Here are the important things to note:
 
@@ -190,7 +190,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG custom columnDefs](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-select-rows.png)
+![DatagridAG custom columnDefs](https://react-admin-ee.marmelab.com/assets/DatagridAG-select-rows.png)
 
 Have a look at [the ag-grid documentation](https://www.ag-grid.com/react-data-grid/column-properties/) for the exhaustive list of column properties.
 
@@ -224,7 +224,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG defaultColDef](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-PostList.png)
+![DatagridAG defaultColDef](https://react-admin-ee.marmelab.com/assets/DatagridAG-PostList.png)
 
 ## `cellRenderer`
 
@@ -268,7 +268,7 @@ export const CommentList = () => {
 };
 ```
 
-![DatagridAG RA Fields](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-ra-fields.png)
+![DatagridAG RA Fields](https://react-admin-ee.marmelab.com/assets/DatagridAG-ra-fields.png)
 
 **Note:** You still need to pass the `source` prop to the field.
 
@@ -419,7 +419,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG Dark](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-dark.png)
+![DatagridAG Dark](https://react-admin-ee.marmelab.com/assets/DatagridAG-dark.png)
 
 **Tip:** Remember to import the corresponding stylesheet (e.g. `ag-theme-balham[.min].css` for `ag-theme-balham`).
 
@@ -458,8 +458,8 @@ const CarList = () => {
 ```
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 
@@ -517,7 +517,7 @@ export const PostList = () => {
 
 {% endraw %}
 
-![DatagridAG sx](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-sx.png)
+![DatagridAG sx](https://react-admin-ee.marmelab.com/assets/DatagridAG-sx.png)
 
 It can also be helpful to change the default grid's height (`calc(100vh - 96px - ${theme.spacing(1)})`):
 
@@ -547,7 +547,7 @@ export const PostList = () => {
 
 {% endraw %}
 
-![DatagridAG sx height](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-sx-height.png)
+![DatagridAG sx height](https://react-admin-ee.marmelab.com/assets/DatagridAG-sx-height.png)
 
 ## Accessing The Grid And Column APIs
 
@@ -617,7 +617,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG flex](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-flex.png)
+![DatagridAG flex](https://react-admin-ee.marmelab.com/assets/DatagridAG-flex.png)
 
 Alternatively, you can use the grid's `api` to call `autoSizeAllColumns` to automatically resize all columns to fit their content:
 
@@ -651,7 +651,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG auto size](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-auto-size.png)
+![DatagridAG auto size](https://react-admin-ee.marmelab.com/assets/DatagridAG-auto-size.png)
 
 Check out the [Column Sizing](https://www.ag-grid.com/react-data-grid/column-sizing/) documentation for more information and more alternatives.
 
@@ -701,7 +701,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG selected rows](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-selected-rows.png)
+![DatagridAG selected rows](https://react-admin-ee.marmelab.com/assets/DatagridAG-selected-rows.png)
 
 Just like with `<Datagrid>`, you can customize the bulk actions by passing a [`bulkActionButtons`](./Datagrid.md#bulkactionbuttons) prop to `<DatagridAG>`.
 
@@ -748,8 +748,8 @@ export const PostList = () => {
 By default, `<DatagridAG>` renders pagination controls at the bottom of the list. You can disable these controls to switch to an infinite pagination mode, where the grid shows the next rows on scroll. Thanks to [ag-grid's DOM virtualization](https://www.ag-grid.com/react-data-grid/dom-virtualisation/), this mode causes no performance problem.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 
@@ -785,7 +785,7 @@ const CarList = () => {
 
 If you have subscribed to the [Enterprise version of ag-grid](https://www.ag-grid.com/react-data-grid/licensing/), you can also add a [Status Bar](https://www.ag-grid.com/react-data-grid/status-bar/) to show the total number of rows.
 
-![DatagridAG with status bar](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-status-bar.png)
+![DatagridAG with status bar](https://react-admin-ee.marmelab.com/assets/DatagridAG-status-bar.png)
 
 ```tsx
 import 'ag-grid-community/styles/ag-grid.css';
@@ -825,7 +825,7 @@ const CarList = () => {
 
 By default, editing is enabled on cells, which means you can edit a cell by double-clicking on it, and it will trigger a call to the dataProvider's `update` function.
 
-![DatagridAG edit cell](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-edit-cell.png)
+![DatagridAG edit cell](https://react-admin-ee.marmelab.com/assets/DatagridAG-edit-cell.png)
 
 However, if you'd like to update the full row at once instead, you can enable full row editing by passing `editType="fullRow"` to `<DatagridAG>`:
 
@@ -848,7 +848,7 @@ export const PostList = () => {
 };
 ```
 
-![DatagridAG edit row](https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-edit-row.png)
+![DatagridAG edit row](https://react-admin-ee.marmelab.com/assets/DatagridAG-edit-row.png)
 
 ## Disabling Cell Edition
 
@@ -964,6 +964,6 @@ const OlympicWinnersList = () => {
 ```
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>

--- a/docs/DateInput.md
+++ b/docs/DateInput.md
@@ -57,7 +57,7 @@ If you need to render a UI despite the browser locale, MUI also proposes a [Date
 
 ## Material UI
 
-[React-admin Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> proposes an alternative `<DateInput>` styled with Material UI. 
+[React-admin Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> proposes an alternative `<DateInput>` styled with Material UI. 
 
 ![DateInput with Material UI](./img/DateInput-MUI.png)
 

--- a/docs/DateTimeInput.md
+++ b/docs/DateTimeInput.md
@@ -44,7 +44,7 @@ If you need to implement your own `format` and `parse` functions, make sure the 
 
 ## Material UI
 
-[React-admin Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> proposes an alternative `<DateTimeInput>` styled with Material UI. 
+[React-admin Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> proposes an alternative `<DateTimeInput>` styled with Material UI. 
 
 ![DateTimeInput with Material UI](./img/DateTimeInput-MUI.png)
 

--- a/docs/Demos.md
+++ b/docs/Demos.md
@@ -137,7 +137,7 @@ If you want to see what react-admin is capable of, or if you want to learn from 
         </div>
         <div class="card-footer">
             <div class="links-container">
-                <p><b><a href="https://react-admin-ee.marmelab.com-demo/" class="demo link">Demo</a></b></p>
+                <p><b><a href="https://marmelab.com/ra-enterprise-demo/" class="demo link">Demo</a></b></p>
                 <p><b><a href="https://github.com/marmelab/ra-enterprise-demo" class="source-code link">Source code</a></b></p>
             </div>
         </div>
@@ -249,7 +249,7 @@ Based on the E-commerce demo and upgraded with some React Admin Enterprise featu
 <div style="padding:56.93% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/884005183?h=7f12a85dcf&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></div>
 <br>
 
-* Demo: [https://react-admin-ee.marmelab.com-demo/](https://react-admin-ee.marmelab.com-demo/)
+* Demo: [https://marmelab.com/ra-enterprise-demo/](https://marmelab.com/ra-enterprise-demo/)
 * Source code: [https://github.com/marmelab/ra-enterprise-demo](https://github.com/marmelab/ra-enterprise-demo)
 
 The source shows how to implement the following features:

--- a/docs/Demos.md
+++ b/docs/Demos.md
@@ -137,7 +137,7 @@ If you want to see what react-admin is capable of, or if you want to learn from 
         </div>
         <div class="card-footer">
             <div class="links-container">
-                <p><b><a href="https://marmelab.com/ra-enterprise-demo/" class="demo link">Demo</a></b></p>
+                <p><b><a href="https://react-admin-ee.marmelab.com-demo/" class="demo link">Demo</a></b></p>
                 <p><b><a href="https://github.com/marmelab/ra-enterprise-demo" class="source-code link">Source code</a></b></p>
             </div>
         </div>
@@ -249,7 +249,7 @@ Based on the E-commerce demo and upgraded with some React Admin Enterprise featu
 <div style="padding:56.93% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/884005183?h=7f12a85dcf&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></div>
 <br>
 
-* Demo: [https://marmelab.com/ra-enterprise-demo/](https://marmelab.com/ra-enterprise-demo/)
+* Demo: [https://react-admin-ee.marmelab.com-demo/](https://react-admin-ee.marmelab.com-demo/)
 * Source code: [https://github.com/marmelab/ra-enterprise-demo](https://github.com/marmelab/ra-enterprise-demo)
 
 The source shows how to implement the following features:

--- a/docs/DualListInput.md
+++ b/docs/DualListInput.md
@@ -8,8 +8,8 @@ title: "The DualListInput Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to edit array values, one-to-many or many-to-many relationships by moving items from one list to another.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-relationships-duallistinput.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-relationships-duallistinput.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-relationships-duallistinput.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-relationships-duallistinput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/DualListInput.md
+++ b/docs/DualListInput.md
@@ -57,7 +57,7 @@ The form value for the source must be an array of the selected values, e.g.
 }
 ```
 
-Check [the `ra-relationships` documentation](https://react-admin-ee.marmelab.com/modules/ra-relationships) for more details.
+Check [the `ra-relationships` documentation](https://react-admin-ee.marmelab.com/documentation/ra-relationships) for more details.
 
 ## Props
 

--- a/docs/DualListInput.md
+++ b/docs/DualListInput.md
@@ -5,11 +5,11 @@ title: "The DualListInput Component"
 
 # `<DualListInput>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit array values, one-to-many or many-to-many relationships by moving items from one list to another.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to edit array values, one-to-many or many-to-many relationships by moving items from one list to another.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-relationships-duallistinput.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-relationships-duallistinput.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-relationships-duallistinput.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-relationships-duallistinput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -57,7 +57,7 @@ The form value for the source must be an array of the selected values, e.g.
 }
 ```
 
-Check [the `ra-relationships` documentation](https://marmelab.com/ra-enterprise/modules/ra-relationships) for more details.
+Check [the `ra-relationships` documentation](https://react-admin-ee.marmelab.com/modules/ra-relationships) for more details.
 
 ## Props
 

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -9,23 +9,23 @@ While most of the react-admin components come from the [marmelab/react-admin](ht
 
 ## Enterprise Packages
 
-[React-admin Enterprise Edition](https://marmelab.com/ra-enterprise) provides additional packages:
+[React-admin Enterprise Edition](https://react-admin-ee.marmelab.com) provides additional packages:
 
-- [@react-admin/ra-ai](https://marmelab.com/ra-enterprise/modules/ra-ai): Components powered by Artificial Intelligence (AI) to boost user productivity. Suggest completion for user inputs, fix and improve large chunks of text in React-Admin forms.
-- [@react-admin/ra-audit-log](https://marmelab.com/ra-enterprise/modules/ra-audit-log): Keep track of user actions, and get an overview of the activity of your admin.
-- [@react-admin/ra-calendar](https://marmelab.com/ra-enterprise/modules/ra-calendar): Display and manipulate events, drag and resize appointments, and browse a calendar in react-admin apps.
-- [@react-admin/ra-editable-datagrid](https://marmelab.com/ra-enterprise/modules/ra-editable-datagrid): Enhance the features of react-admin's `<Datagrid>` component, including an "edit-in-place" experience.
-- [@react-admin/ra-enterprise](https://marmelab.com/ra-enterprise/modules/ra-enterprise): Preconfigured components replacing the default react-admin ones to quickly integrate the Enterprise Edition modules.
-- [@react-admin/ra-form-layout](https://marmelab.com/ra-enterprise/modules/ra-form-layout): New form layouts for complex data entry tasks (accordion, wizard, autosave, etc.).
-- [@react-admin/ra-json-schema-form](https://marmelab.com/ra-enterprise/modules/ra-json-schema-form): Build forms based on a JSON Schema description
-- [@react-admin/ra-markdown](https://marmelab.com/ra-enterprise/modules/ra-markdown): Markdown field and Input
-- [@react-admin/ra-navigation](https://marmelab.com/ra-enterprise/modules/ra-navigation): New page layouts, Menus layouts, Smart Breadcrumb, and hooks to handle the user location.
-- [@react-admin/ra-relationships](https://marmelab.com/ra-enterprise/modules/ra-relationships): A set of alternative inputs and fields to edit relationships, including many-to-many relationships using a join table.
-- [@react-admin/ra-rbac](https://marmelab.com/ra-enterprise/modules/ra-rbac): Role-Based Access Control for React-admin apps. This module extends the authProvider to manage roles and fine-grained permissions, and adds replacement for many react-admin components that use these permissions.
-- [@react-admin/ra-realtime](https://marmelab.com/ra-enterprise/modules/ra-realtime): Hooks and UI components for collaborative applications where several people work in parallel. It allows publishing and subscribing to real-time events, updating views when another user pushes a change, notifying end users of events, and preventing data loss when two editors work on the same resource concurrently.
-- [@react-admin/ra-search](https://marmelab.com/ra-enterprise/modules/ra-search): Plug your search engine and let users search across all resources via a smart Omnibox.
-- [@react-admin/ra-tour](https://marmelab.com/ra-enterprise/modules/ra-tour): Guide users through tutorials to showcase and explain important features of your interfaces.
-- [@react-admin/ra-tree](https://marmelab.com/ra-enterprise/modules/ra-tree): Tree hooks and components for react-admin. Allows to display, edit, and rearrange tree structures like directories, categories, etc.
+- [@react-admin/ra-ai](https://react-admin-ee.marmelab.com/modules/ra-ai): Components powered by Artificial Intelligence (AI) to boost user productivity. Suggest completion for user inputs, fix and improve large chunks of text in React-Admin forms.
+- [@react-admin/ra-audit-log](https://react-admin-ee.marmelab.com/modules/ra-audit-log): Keep track of user actions, and get an overview of the activity of your admin.
+- [@react-admin/ra-calendar](https://react-admin-ee.marmelab.com/modules/ra-calendar): Display and manipulate events, drag and resize appointments, and browse a calendar in react-admin apps.
+- [@react-admin/ra-editable-datagrid](https://react-admin-ee.marmelab.com/modules/ra-editable-datagrid): Enhance the features of react-admin's `<Datagrid>` component, including an "edit-in-place" experience.
+- [@react-admin/ra-enterprise](https://react-admin-ee.marmelab.com/modules/ra-enterprise): Preconfigured components replacing the default react-admin ones to quickly integrate the Enterprise Edition modules.
+- [@react-admin/ra-form-layout](https://react-admin-ee.marmelab.com/modules/ra-form-layout): New form layouts for complex data entry tasks (accordion, wizard, autosave, etc.).
+- [@react-admin/ra-json-schema-form](https://react-admin-ee.marmelab.com/modules/ra-json-schema-form): Build forms based on a JSON Schema description
+- [@react-admin/ra-markdown](https://react-admin-ee.marmelab.com/modules/ra-markdown): Markdown field and Input
+- [@react-admin/ra-navigation](https://react-admin-ee.marmelab.com/modules/ra-navigation): New page layouts, Menus layouts, Smart Breadcrumb, and hooks to handle the user location.
+- [@react-admin/ra-relationships](https://react-admin-ee.marmelab.com/modules/ra-relationships): A set of alternative inputs and fields to edit relationships, including many-to-many relationships using a join table.
+- [@react-admin/ra-rbac](https://react-admin-ee.marmelab.com/modules/ra-rbac): Role-Based Access Control for React-admin apps. This module extends the authProvider to manage roles and fine-grained permissions, and adds replacement for many react-admin components that use these permissions.
+- [@react-admin/ra-realtime](https://react-admin-ee.marmelab.com/modules/ra-realtime): Hooks and UI components for collaborative applications where several people work in parallel. It allows publishing and subscribing to real-time events, updating views when another user pushes a change, notifying end users of events, and preventing data loss when two editors work on the same resource concurrently.
+- [@react-admin/ra-search](https://react-admin-ee.marmelab.com/modules/ra-search): Plug your search engine and let users search across all resources via a smart Omnibox.
+- [@react-admin/ra-tour](https://react-admin-ee.marmelab.com/modules/ra-tour): Guide users through tutorials to showcase and explain important features of your interfaces.
+- [@react-admin/ra-tree](https://react-admin-ee.marmelab.com/modules/ra-tree): Tree hooks and components for react-admin. Allows to display, edit, and rearrange tree structures like directories, categories, etc.
 
 ## Third-Party Packages
 

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -11,21 +11,21 @@ While most of the react-admin components come from the [marmelab/react-admin](ht
 
 [React-admin Enterprise Edition](https://react-admin-ee.marmelab.com) provides additional packages:
 
-- [@react-admin/ra-ai](https://react-admin-ee.marmelab.com/modules/ra-ai): Components powered by Artificial Intelligence (AI) to boost user productivity. Suggest completion for user inputs, fix and improve large chunks of text in React-Admin forms.
-- [@react-admin/ra-audit-log](https://react-admin-ee.marmelab.com/modules/ra-audit-log): Keep track of user actions, and get an overview of the activity of your admin.
-- [@react-admin/ra-calendar](https://react-admin-ee.marmelab.com/modules/ra-calendar): Display and manipulate events, drag and resize appointments, and browse a calendar in react-admin apps.
-- [@react-admin/ra-editable-datagrid](https://react-admin-ee.marmelab.com/modules/ra-editable-datagrid): Enhance the features of react-admin's `<Datagrid>` component, including an "edit-in-place" experience.
-- [@react-admin/ra-enterprise](https://react-admin-ee.marmelab.com/modules/ra-enterprise): Preconfigured components replacing the default react-admin ones to quickly integrate the Enterprise Edition modules.
-- [@react-admin/ra-form-layout](https://react-admin-ee.marmelab.com/modules/ra-form-layout): New form layouts for complex data entry tasks (accordion, wizard, autosave, etc.).
-- [@react-admin/ra-json-schema-form](https://react-admin-ee.marmelab.com/modules/ra-json-schema-form): Build forms based on a JSON Schema description
-- [@react-admin/ra-markdown](https://react-admin-ee.marmelab.com/modules/ra-markdown): Markdown field and Input
-- [@react-admin/ra-navigation](https://react-admin-ee.marmelab.com/modules/ra-navigation): New page layouts, Menus layouts, Smart Breadcrumb, and hooks to handle the user location.
-- [@react-admin/ra-relationships](https://react-admin-ee.marmelab.com/modules/ra-relationships): A set of alternative inputs and fields to edit relationships, including many-to-many relationships using a join table.
-- [@react-admin/ra-rbac](https://react-admin-ee.marmelab.com/modules/ra-rbac): Role-Based Access Control for React-admin apps. This module extends the authProvider to manage roles and fine-grained permissions, and adds replacement for many react-admin components that use these permissions.
-- [@react-admin/ra-realtime](https://react-admin-ee.marmelab.com/modules/ra-realtime): Hooks and UI components for collaborative applications where several people work in parallel. It allows publishing and subscribing to real-time events, updating views when another user pushes a change, notifying end users of events, and preventing data loss when two editors work on the same resource concurrently.
-- [@react-admin/ra-search](https://react-admin-ee.marmelab.com/modules/ra-search): Plug your search engine and let users search across all resources via a smart Omnibox.
-- [@react-admin/ra-tour](https://react-admin-ee.marmelab.com/modules/ra-tour): Guide users through tutorials to showcase and explain important features of your interfaces.
-- [@react-admin/ra-tree](https://react-admin-ee.marmelab.com/modules/ra-tree): Tree hooks and components for react-admin. Allows to display, edit, and rearrange tree structures like directories, categories, etc.
+- [@react-admin/ra-ai](https://react-admin-ee.marmelab.com/documentation/ra-ai): Components powered by Artificial Intelligence (AI) to boost user productivity. Suggest completion for user inputs, fix and improve large chunks of text in React-Admin forms.
+- [@react-admin/ra-audit-log](https://react-admin-ee.marmelab.com/documentation/ra-audit-log): Keep track of user actions, and get an overview of the activity of your admin.
+- [@react-admin/ra-calendar](https://react-admin-ee.marmelab.com/documentation/ra-calendar): Display and manipulate events, drag and resize appointments, and browse a calendar in react-admin apps.
+- [@react-admin/ra-editable-datagrid](https://react-admin-ee.marmelab.com/documentation/ra-editable-datagrid): Enhance the features of react-admin's `<Datagrid>` component, including an "edit-in-place" experience.
+- [@react-admin/ra-enterprise](https://react-admin-ee.marmelab.com/documentation/ra-enterprise): Preconfigured components replacing the default react-admin ones to quickly integrate the Enterprise Edition modules.
+- [@react-admin/ra-form-layout](https://react-admin-ee.marmelab.com/documentation/ra-form-layout): New form layouts for complex data entry tasks (accordion, wizard, autosave, etc.).
+- [@react-admin/ra-json-schema-form](https://react-admin-ee.marmelab.com/documentation/ra-json-schema-form): Build forms based on a JSON Schema description
+- [@react-admin/ra-markdown](https://react-admin-ee.marmelab.com/documentation/ra-markdown): Markdown field and Input
+- [@react-admin/ra-navigation](https://react-admin-ee.marmelab.com/documentation/ra-navigation): New page layouts, Menus layouts, Smart Breadcrumb, and hooks to handle the user location.
+- [@react-admin/ra-relationships](https://react-admin-ee.marmelab.com/documentation/ra-relationships): A set of alternative inputs and fields to edit relationships, including many-to-many relationships using a join table.
+- [@react-admin/ra-rbac](https://react-admin-ee.marmelab.com/documentation/ra-rbac): Role-Based Access Control for React-admin apps. This module extends the authProvider to manage roles and fine-grained permissions, and adds replacement for many react-admin components that use these permissions.
+- [@react-admin/ra-realtime](https://react-admin-ee.marmelab.com/documentation/ra-realtime): Hooks and UI components for collaborative applications where several people work in parallel. It allows publishing and subscribing to real-time events, updating views when another user pushes a change, notifying end users of events, and preventing data loss when two editors work on the same resource concurrently.
+- [@react-admin/ra-search](https://react-admin-ee.marmelab.com/documentation/ra-search): Plug your search engine and let users search across all resources via a smart Omnibox.
+- [@react-admin/ra-tour](https://react-admin-ee.marmelab.com/documentation/ra-tour): Guide users through tutorials to showcase and explain important features of your interfaces.
+- [@react-admin/ra-tree](https://react-admin-ee.marmelab.com/documentation/ra-tree): Tree hooks and components for react-admin. Allows to display, edit, and rearrange tree structures like directories, categories, etc.
 
 ## Third-Party Packages
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -696,8 +696,8 @@ You can do the same for error notifications, by passing a custom `onError`  call
 `<Edit>` is designed to be a page component, passed to the `edit` prop of the `<Resource>` component. But you may want to let users edit a record from another page. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/edit-dialog.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/edit-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -696,8 +696,8 @@ You can do the same for error notifications, by passing a custom `onError`  call
 `<Edit>` is designed to be a page component, passed to the `edit` prop of the `<Resource>` component. But you may want to let users edit a record from another page. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/edit-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/edit-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -5,11 +5,11 @@ title: "EditDialog"
 
 # `<EditDialog>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers a replacement to [the `<Edit>` component](./Edit.md) allowing users to update records without leaving the context of the list page.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a replacement to [the `<Edit>` component](./Edit.md) allowing users to update records without leaving the context of the list page.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/edit-dialog.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/edit-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -23,7 +23,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, add the `<EditDialog>` component as a sibling to a `<List>` component.
 
@@ -279,8 +279,8 @@ This may not be what you want if you need to display the edit dialog in another 
 In that case, use [the `<EditInDialogButton>` component](./EditInDialogButton.md), which doesn't create a route, but renders the dialog when the user clicks on it.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -8,8 +8,8 @@ title: "EditDialog"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a replacement to [the `<Edit>` component](./Edit.md) allowing users to update records without leaving the context of the list page.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/edit-dialog.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/edit-dialog.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/edit-dialog.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -279,8 +279,8 @@ This may not be what you want if you need to display the edit dialog in another 
 In that case, use [the `<EditInDialogButton>` component](./EditInDialogButton.md), which doesn't create a route, but renders the dialog when the user clicks on it.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -23,7 +23,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, add the `<EditDialog>` component as a sibling to a `<List>` component.
 

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -5,11 +5,11 @@ title: "EditInDialogButton"
 
 # `<EditInDialogButton>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component renders a button opening an `<Edit>` view inside a dialog, hence allowing to edit a record without leaving the current view.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component renders a button opening an `<Edit>` view inside a dialog, hence allowing to edit a record without leaving the current view.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -27,7 +27,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, put `<EditInDialogButton>` wherever you would put an `<EditButton>`, and use the same children as you would for an [`<Edit>`](./Edit.md) component (e.g. a `<SimpleForm>`): 
 

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -27,7 +27,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-showindialogbutton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, put `<EditInDialogButton>` wherever you would put an `<EditButton>`, and use the same children as you would for an [`<Edit>`](./Edit.md) component (e.g. a `<SimpleForm>`): 
 

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -8,8 +8,8 @@ title: "EditInDialogButton"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component renders a button opening an `<Edit>` view inside a dialog, hence allowing to edit a record without leaving the current view.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -27,7 +27,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-EditInDialogButton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, put `<EditInDialogButton>` wherever you would put an `<EditButton>`, and use the same children as you would for an [`<Edit>`](./Edit.md) component (e.g. a `<SimpleForm>`): 
 

--- a/docs/EditLive.md
+++ b/docs/EditLive.md
@@ -5,7 +5,7 @@ title: "EditLive"
 
 # `<EditLive>`
 
-`<EditLive>` is an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component that renders an Edit view. It displays a warning when the record is updated by another user and offers to refresh the page. Also, it displays a warning when the record is deleted by another user.
+`<EditLive>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component that renders an Edit view. It displays a warning when the record is updated by another user and offers to refresh the page. Also, it displays a warning when the record is deleted by another user.
 
 ![EditLive](./img/EditLive.png)
 

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -949,8 +949,8 @@ Users often need to edit data from several resources in the same form. React-adm
 - [`<ReferenceManyToManyInput>`](./ReferenceManyToManyInput.md) lets users edit a list of related records via an associative table
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -226,7 +226,7 @@ export const BookEdit = () => {
 };
 ```
 
-React-admin proposes alternative form layouts ([`<TabbedForm>`](./TabbedForm.md), [`<AccordionForm>`](./AccordionForm.md), [`<WizardForm>`](./WizardForm.md), [`<CreateDialog>, <EditDialog> & <ShowDialog>`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog-editdialog--showdialog) as well as a headless [`<Form>`](./Form.md) component.
+React-admin proposes alternative form layouts ([`<TabbedForm>`](./TabbedForm.md), [`<AccordionForm>`](./AccordionForm.md), [`<WizardForm>`](./WizardForm.md), [`<CreateDialog>, <EditDialog> & <ShowDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog) as well as a headless [`<Form>`](./Form.md) component.
 
 ### Using Input Components
 
@@ -949,8 +949,8 @@ Users often need to edit data from several resources in the same form. React-adm
 - [`<ReferenceManyToManyInput>`](./ReferenceManyToManyInput.md) lets users edit a list of related records via an associative table
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -226,7 +226,7 @@ export const BookEdit = () => {
 };
 ```
 
-React-admin proposes alternative form layouts ([`<TabbedForm>`](./TabbedForm.md), [`<AccordionForm>`](./AccordionForm.md), [`<WizardForm>`](./WizardForm.md), [`<CreateDialog>, <EditDialog> & <ShowDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog) as well as a headless [`<Form>`](./Form.md) component.
+React-admin proposes alternative form layouts ([`<TabbedForm>`](./TabbedForm.md), [`<AccordionForm>`](./AccordionForm.md), [`<WizardForm>`](./WizardForm.md), [`<CreateDialog>, <EditDialog> & <ShowDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog) as well as a headless [`<Form>`](./Form.md) component.
 
 ### Using Input Components
 

--- a/docs/EditableDatagrid.md
+++ b/docs/EditableDatagrid.md
@@ -7,17 +7,17 @@ title: "The EditableDatagrid Component"
 
 The default react-admin user experience consists of three pages: List, Edit, and Create. However, in some cases, users may prefer to do all CRUD tasks in one page.
 
-`<EditableDatagrid>` is an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component that offers an "edit-in-place" experience, allowing users to edit, create, and delete records in place inside a `<Datagrid>`.
+`<EditableDatagrid>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component that offers an "edit-in-place" experience, allowing users to edit, create, and delete records in place inside a `<Datagrid>`.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 With `<EditableDatagrid>`, when users click on a row in the datagrid, the row content is replaced by the edition form. They can also create new records by clicking on the Create button, which inserts an empty editable row as the first line of the list. Finally, they can delete a record by clicking on the Delete button on each row.
 
-You can test it live in [the Enterprise Edition Storybook](https://react-admin.github.io/ra-enterprise/?path=/story/ra-editable-datagrid-editabledatagrid--undoable) and [the e-commerce demo](https://marmelab.com/ra-enterprise-demo/#/tours/ra-editable-datagrid).
+You can test it live in [the Enterprise Edition Storybook](https://react-admin.github.io/ra-enterprise/?path=/story/ra-editable-datagrid-editabledatagrid--undoable) and [the e-commerce demo](https://react-admin-ee.marmelab.com-demo/#/tours/ra-editable-datagrid).
 
 `<EditableDatagrid>` allows you to use any [Input component](./Inputs.md) to edit the record - including Reference Inputs for foreign keys.
 
@@ -31,7 +31,7 @@ npm install --save @react-admin/ra-editable-datagrid
 yarn add @react-admin/ra-editable-datagrid
 ```
 
-**Tip**: `ra-editable-datagrid` is part of the [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise/), and hosted in a private npm registry. You need to subscribe to one of the Enterprise Edition plans to access this registry.
+**Tip**: `ra-editable-datagrid` is part of the [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com/), and hosted in a private npm registry. You need to subscribe to one of the Enterprise Edition plans to access this registry.
 
 Then, replace `<Datagrid>` with `<EditableDatagrid>` in a react-admin `<List>`, `<ReferenceManyField>`, or any other component that creates a `ListContext`. In addition, pass a form component to be displayed when the user switches to edit or create mode.
 
@@ -574,8 +574,8 @@ const ArtistListWithMeta = () => {
 You can let end users customize what fields are displayed in the `<EditableDatagrid>` by using the `<EditableDatagridConfigurable>` component instead, together with the `<RowFormConfigurable>` component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-configurable.mp4" type="video/mp4"/>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-configurable.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-configurable.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-configurable.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditableDatagrid.md
+++ b/docs/EditableDatagrid.md
@@ -17,7 +17,7 @@ The default react-admin user experience consists of three pages: List, Edit, and
 
 With `<EditableDatagrid>`, when users click on a row in the datagrid, the row content is replaced by the edition form. They can also create new records by clicking on the Create button, which inserts an empty editable row as the first line of the list. Finally, they can delete a record by clicking on the Delete button on each row.
 
-You can test it live in [the Enterprise Edition Storybook](https://react-admin.github.io/ra-enterprise/?path=/story/ra-editable-datagrid-editabledatagrid--undoable) and [the e-commerce demo](https://react-admin-ee.marmelab.com-demo/#/tours/ra-editable-datagrid).
+You can test it live in [the Enterprise Edition Storybook](https://react-admin.github.io/ra-enterprise/?path=/story/ra-editable-datagrid-editabledatagrid--undoable) and [the e-commerce demo](https://marmelab.com/ra-enterprise-demo/#/tours/ra-editable-datagrid).
 
 `<EditableDatagrid>` allows you to use any [Input component](./Inputs.md) to edit the record - including Reference Inputs for foreign keys.
 

--- a/docs/EditableDatagrid.md
+++ b/docs/EditableDatagrid.md
@@ -10,8 +10,8 @@ The default react-admin user experience consists of three pages: List, Edit, and
 `<EditableDatagrid>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component that offers an "edit-in-place" experience, allowing users to edit, create, and delete records in place inside a `<Datagrid>`.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -574,8 +574,8 @@ const ArtistListWithMeta = () => {
 You can let end users customize what fields are displayed in the `<EditableDatagrid>` by using the `<EditableDatagridConfigurable>` component instead, together with the `<RowFormConfigurable>` component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-configurable.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-configurable.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-configurable.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-configurable.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -956,12 +956,12 @@ In detail, revision tracking lets you:
 
 These features are available through the following components:
 
-- [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#simpleformwithrevision)
-- [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#tabbedformwithrevision)
+- [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/documentation/ra-history#simpleformwithrevision)
+- [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/documentation/ra-history#tabbedformwithrevision)
 - [`<RevisionsButton>`](./RevisionsButton.md)
-- [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog)
-- [`<FieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#fielddiff)
-- [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#smartfielddiff)
+- [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionlistwithdetailsindialog)
+- [`<FieldDiff>`](https://react-admin-ee.marmelab.com/documentation/ra-history#fielddiff)
+- [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/documentation/ra-history#smartfielddiff)
 
 ## Audit Log
 
@@ -998,11 +998,11 @@ The Audit Log features let you:
 
 These features are available through the following components:
 
-- [`<Timeline>`](https://react-admin-ee.marmelab.com/modules/ra-audit-log#timeline) shows a list of all recent changes in the admin. It's a great component for dashboards.
-- [`<RecordTimeline>`](https://react-admin-ee.marmelab.com/modules/ra-audit-log#recordtimeline) shows a list of all recent changes for a given record, usually embedded in a `<Show>` or `<Edit>` view.
-- [`<EventList>`](https://react-admin-ee.marmelab.com/modules/ra-audit-log#eventlist) is a ready-to-use List component for navigating in your admin history, complete with filters and pagination.
+- [`<Timeline>`](https://react-admin-ee.marmelab.com/documentation/ra-audit-log#timeline) shows a list of all recent changes in the admin. It's a great component for dashboards.
+- [`<RecordTimeline>`](https://react-admin-ee.marmelab.com/documentation/ra-audit-log#recordtimeline) shows a list of all recent changes for a given record, usually embedded in a `<Show>` or `<Edit>` view.
+- [`<EventList>`](https://react-admin-ee.marmelab.com/documentation/ra-audit-log#eventlist) is a ready-to-use List component for navigating in your admin history, complete with filters and pagination.
 
-And you can use [the `addEventsForMutations` helper](https://react-admin-ee.marmelab.com/modules/ra-audit-log#client-side-tracking) to record user actions:
+And you can use [the `addEventsForMutations` helper](https://react-admin-ee.marmelab.com/documentation/ra-audit-log#client-side-tracking) to record user actions:
 
 ```jsx
 import { addEventsForMutations } from "@react-admin/ra-audit-log";
@@ -1057,7 +1057,7 @@ The user interface offers everything you expect:
 
 Check the following components for more details:
 
-- [`<CompleteCalendar>`](https://react-admin-ee.marmelab.com/modules/ra-calendar#completecalendar)
+- [`<CompleteCalendar>`](https://react-admin-ee.marmelab.com/documentation/ra-calendar#completecalendar)
 - [`<Calendar>`](./Calendar.md)
 
 ## Tree View
@@ -1103,7 +1103,7 @@ Check out the following components for displaying hierarchical data:
 
 - [`<TreeWithDetails>`](./TreeWithDetails.md): A list view for tree structures, with a details panel.
 - [`<TreeInput>`](./TreeInput.md): An input component for tree structures.
-- [`<Tree>`](https://react-admin-ee.marmelab.com/modules/ra-tree#tree-component): A list view for tree structures, with a Material UI skin.
+- [`<Tree>`](https://react-admin-ee.marmelab.com/documentation/ra-tree#tree-component): A list view for tree structures, with a Material UI skin.
 
 ## Application Building Blocks
 
@@ -1121,13 +1121,13 @@ These building blocks include:
 - A smart location framework, simplifying the management of [breadcrumbs](./Breadcrumb.md) and [hierarchical menus](./MultiLevelMenu.md)
 - [Import](https://github.com/benwinding/react-admin-import-csv) / [export](./Buttons.md#exportbutton) buttons
 - An [editable datagrid](./EditableDatagrid.md)
-- A [guided tour system](https://react-admin-ee.marmelab.com/modules/ra-tour)
+- A [guided tour system](https://react-admin-ee.marmelab.com/documentation/ra-tour)
 - A [user menu](./Menu.md)
 - A [rich text editor](./RichTextInput.md),
 - A [markdown editor](./MarkdownInput.md)
 - A [clone button](./Buttons.md#clonebutton)
 - Various navigation menus ([simple](./Menu.md), [hierarchical](./MultiLevelMenu.md), [horizontal](./HorizontalMenu.md), etc.)
-- Various [page](./ContainerLayout.md) and [form](https://react-admin-ee.marmelab.com/modules/ra-form-layout) layouts
+- Various [page](./ContainerLayout.md) and [form](https://react-admin-ee.marmelab.com/documentation/ra-form-layout) layouts
 - ...and many more.
 
 And if you want to create your building blocks, you can use any of the [75+ hooks](./Reference.md#hooks) that carry **headless, reusable logic**. To name a few of them:

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -403,15 +403,15 @@ The basic [`<Datagrid>` component](./Datagrid.md) displays a list of records in 
 The [`<EditableDatagrid>` component](./EditableDatagrid.md) lets users edit records in place, without having to navigate to an edit form. It's a great way to speed up data entry.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 Finally, the [`<DatagridAG>` component](./DatagridAG.md) integrates the powerful [AG Grid](https://www.ag-grid.com/) library to provide a rich set of features, such as cell editing, aggregation, row grouping, master detail, clipboard, pivoting, column filtering, export to excel, context menu, tree data, charting, and more.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -444,16 +444,16 @@ In most admin and B2B apps, the most common task is to look for a record. React-
 </tr>
 <tr style="border:none;background-color:#fff;">
     <td style="width:50%;border:none;text-align:center">
-        <a title="Stacked Filters" href="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm">
+        <a title="Stacked Filters" href="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm">
             <video controls autoplay playsinline muted loop width="90%" style="margin:1rem;box-shadow:0px 4px 4px 0px rgb(0 0 0 / 24%);">
-                <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
+                <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
                     Your browser does not support the video tag.
             </video>
         </a>
         <a href="./FilteringTutorial.html#the-stackedfilters-component" style="display: block;transform: translateY(-10px);"><code>&lt;StackedFilters&gt;</code> Dialog</a>
     </td>
     <td style="width:50%;border:none;text-align:center;vertical-align:top;">
-        <a title="<Search> input" href="https://marmelab.com/ra-enterprise/modules/assets/ra-search-overview.gif"><img src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-overview.gif" /></a>
+        <a title="<Search> input" href="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif"><img src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif" /></a>
         <a href="./FilteringTutorial.html#global-search" style="display: block;transform: translateY(-10px);">Global <code>&lt;Search&gt;</code></a>
     </td>
 </tr>
@@ -796,7 +796,7 @@ const CustomerEdit = () => (
 ```
 {% endraw %}
 
-![JsonSchemaForm](https://marmelab.com/ra-enterprise/modules/assets/jsonschemaform.webp)
+![JsonSchemaForm](https://react-admin-ee.marmelab.com/modules/assets/jsonschemaform.webp)
 
 And if you want something super custom that react-admin doesn't support out of the box, you can always use [react-hook-form](https://react-hook-form.com/) directly.
 
@@ -833,8 +833,8 @@ const PersonEdit = () => (
 
 You can also use the [`<SmartRichTextInput>`](./SmartRichTextInput.md) component, which lets users edit HTML documents in WYSIWYG with superpowers:
 
-<video controls playsinline muted loop poster="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.png" >
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -943,7 +943,7 @@ To learn more about authentication, roles, and permissions, check out the follow
 React-admin lets users **track the changes** made to any record. They can see the **history of revisions**, **compare differences** between any two versions, and **revert to a previous state** if needed.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-history.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-history.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -956,20 +956,20 @@ In detail, revision tracking lets you:
 
 These features are available through the following components:
 
-- [`<SimpleFormWithRevision>`](https://marmelab.com/ra-enterprise/modules/ra-history#simpleformwithrevision)
-- [`<TabbedFormWithRevision>`](https://marmelab.com/ra-enterprise/modules/ra-history#tabbedformwithrevision)
+- [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#simpleformwithrevision)
+- [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#tabbedformwithrevision)
 - [`<RevisionsButton>`](./RevisionsButton.md)
-- [`<RevisionListWithDetailsInDialog>`](https://marmelab.com/ra-enterprise/modules/ra-history#revisionlistwithdetailsindialog)
-- [`<FieldDiff>`](https://marmelab.com/ra-enterprise/modules/ra-history#fielddiff)
-- [`<SmartFieldDiff>`](https://marmelab.com/ra-enterprise/modules/ra-history#smartfielddiff)
+- [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog)
+- [`<FieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#fielddiff)
+- [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#smartfielddiff)
 
 ## Audit Log
 
 Most admin and B2B apps require that user actions are recorded for audit purposes. React-admin provides templates for displaying such audit logs, and helpers to automatically **record user actions**.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-audit-log/latest/ra-audit-log.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-audit-log/latest/ra-audit-log.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-audit-log/latest/ra-audit-log.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-audit-log/latest/ra-audit-log.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -998,11 +998,11 @@ The Audit Log features let you:
 
 These features are available through the following components:
 
-- [`<Timeline>`](https://marmelab.com/ra-enterprise/modules/ra-audit-log#timeline) shows a list of all recent changes in the admin. It's a great component for dashboards.
-- [`<RecordTimeline>`](https://marmelab.com/ra-enterprise/modules/ra-audit-log#recordtimeline) shows a list of all recent changes for a given record, usually embedded in a `<Show>` or `<Edit>` view.
-- [`<EventList>`](https://marmelab.com/ra-enterprise/modules/ra-audit-log#eventlist) is a ready-to-use List component for navigating in your admin history, complete with filters and pagination.
+- [`<Timeline>`](https://react-admin-ee.marmelab.com/modules/ra-audit-log#timeline) shows a list of all recent changes in the admin. It's a great component for dashboards.
+- [`<RecordTimeline>`](https://react-admin-ee.marmelab.com/modules/ra-audit-log#recordtimeline) shows a list of all recent changes for a given record, usually embedded in a `<Show>` or `<Edit>` view.
+- [`<EventList>`](https://react-admin-ee.marmelab.com/modules/ra-audit-log#eventlist) is a ready-to-use List component for navigating in your admin history, complete with filters and pagination.
 
-And you can use [the `addEventsForMutations` helper](https://marmelab.com/ra-enterprise/modules/ra-audit-log#client-side-tracking) to record user actions:
+And you can use [the `addEventsForMutations` helper](https://react-admin-ee.marmelab.com/modules/ra-audit-log#client-side-tracking) to record user actions:
 
 ```jsx
 import { addEventsForMutations } from "@react-admin/ra-audit-log";
@@ -1020,8 +1020,8 @@ const dataProvider = addEventsForMutations(
 If your app needs to display **events**, **appointments**, **time intervals**, or any other kind of time-based data, you can use the [`<Calendar>`](./Calendar.md) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-calendar.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-calendar.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -1057,7 +1057,7 @@ The user interface offers everything you expect:
 
 Check the following components for more details:
 
-- [`<CompleteCalendar>`](https://marmelab.com/ra-enterprise/modules/ra-calendar#completecalendar)
+- [`<CompleteCalendar>`](https://react-admin-ee.marmelab.com/modules/ra-calendar#completecalendar)
 - [`<Calendar>`](./Calendar.md)
 
 ## Tree View
@@ -1103,15 +1103,15 @@ Check out the following components for displaying hierarchical data:
 
 - [`<TreeWithDetails>`](./TreeWithDetails.md): A list view for tree structures, with a details panel.
 - [`<TreeInput>`](./TreeInput.md): An input component for tree structures.
-- [`<Tree>`](https://marmelab.com/ra-enterprise/modules/ra-tree#tree-component): A list view for tree structures, with a Material UI skin.
+- [`<Tree>`](https://react-admin-ee.marmelab.com/modules/ra-tree#tree-component): A list view for tree structures, with a Material UI skin.
 
 ## Application Building Blocks
 
 A UI kit like Material UI provides basic building blocks like a button, a form, a table, etc. React-admin goes one level higher and provides a set of **[application components](./Reference.md#components)** specifically designed for building admin and B2B *applications*.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -1121,13 +1121,13 @@ These building blocks include:
 - A smart location framework, simplifying the management of [breadcrumbs](./Breadcrumb.md) and [hierarchical menus](./MultiLevelMenu.md)
 - [Import](https://github.com/benwinding/react-admin-import-csv) / [export](./Buttons.md#exportbutton) buttons
 - An [editable datagrid](./EditableDatagrid.md)
-- A [guided tour system](https://marmelab.com/ra-enterprise/modules/ra-tour)
+- A [guided tour system](https://react-admin-ee.marmelab.com/modules/ra-tour)
 - A [user menu](./Menu.md)
 - A [rich text editor](./RichTextInput.md),
 - A [markdown editor](./MarkdownInput.md)
 - A [clone button](./Buttons.md#clonebutton)
 - Various navigation menus ([simple](./Menu.md), [hierarchical](./MultiLevelMenu.md), [horizontal](./HorizontalMenu.md), etc.)
-- Various [page](./ContainerLayout.md) and [form](https://marmelab.com/ra-enterprise/modules/ra-form-layout) layouts
+- Various [page](./ContainerLayout.md) and [form](https://react-admin-ee.marmelab.com/modules/ra-form-layout) layouts
 - ...and many more.
 
 And if you want to create your building blocks, you can use any of the [75+ hooks](./Reference.md#hooks) that carry **headless, reusable logic**. To name a few of them:
@@ -1708,7 +1708,7 @@ Building react-admin apps with TypeScript brings more safety and productivity to
 
 ## Sustainable
 
-Last but not least, react-admin is here to stay. That's because the development of the open-source project is **funded by the customers** of the [Enterprise Edition](https://marmelab.com/ra-enterprise/).
+Last but not least, react-admin is here to stay. That's because the development of the open-source project is **funded by the customers** of the [Enterprise Edition](https://react-admin-ee.marmelab.com/).
 
 Maintaining a large open-source project in the long term is a challenge. But the react-admin core team, hosted by [Marmelab](https://marmelab.com), doesn't have to worry about the next funding round, or about paying back venture capital by raising prices. React-admin has zero debt, has already **passed the break-even point**, and the team will only grow as the number of customers grows.
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -403,15 +403,15 @@ The basic [`<Datagrid>` component](./Datagrid.md) displays a list of records in 
 The [`<EditableDatagrid>` component](./EditableDatagrid.md) lets users edit records in place, without having to navigate to an edit form. It's a great way to speed up data entry.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 Finally, the [`<DatagridAG>` component](./DatagridAG.md) integrates the powerful [AG Grid](https://www.ag-grid.com/) library to provide a rich set of features, such as cell editing, aggregation, row grouping, master detail, clipboard, pivoting, column filtering, export to excel, context menu, tree data, charting, and more.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-enterprise.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -444,16 +444,16 @@ In most admin and B2B apps, the most common task is to look for a record. React-
 </tr>
 <tr style="border:none;background-color:#fff;">
     <td style="width:50%;border:none;text-align:center">
-        <a title="Stacked Filters" href="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm">
+        <a title="Stacked Filters" href="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm">
             <video controls autoplay playsinline muted loop width="90%" style="margin:1rem;box-shadow:0px 4px 4px 0px rgb(0 0 0 / 24%);">
-                <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
+                <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
                     Your browser does not support the video tag.
             </video>
         </a>
         <a href="./FilteringTutorial.html#the-stackedfilters-component" style="display: block;transform: translateY(-10px);"><code>&lt;StackedFilters&gt;</code> Dialog</a>
     </td>
     <td style="width:50%;border:none;text-align:center;vertical-align:top;">
-        <a title="<Search> input" href="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif"><img src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif" /></a>
+        <a title="<Search> input" href="https://react-admin-ee.marmelab.com/assets/ra-search-overview.gif"><img src="https://react-admin-ee.marmelab.com/assets/ra-search-overview.gif" /></a>
         <a href="./FilteringTutorial.html#global-search" style="display: block;transform: translateY(-10px);">Global <code>&lt;Search&gt;</code></a>
     </td>
 </tr>
@@ -796,7 +796,7 @@ const CustomerEdit = () => (
 ```
 {% endraw %}
 
-![JsonSchemaForm](https://react-admin-ee.marmelab.com/modules/assets/jsonschemaform.webp)
+![JsonSchemaForm](https://react-admin-ee.marmelab.com/assets/jsonschemaform.webp)
 
 And if you want something super custom that react-admin doesn't support out of the box, you can always use [react-hook-form](https://react-hook-form.com/) directly.
 
@@ -833,8 +833,8 @@ const PersonEdit = () => (
 
 You can also use the [`<SmartRichTextInput>`](./SmartRichTextInput.md) component, which lets users edit HTML documents in WYSIWYG with superpowers:
 
-<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -943,7 +943,7 @@ To learn more about authentication, roles, and permissions, check out the follow
 React-admin lets users **track the changes** made to any record. They can see the **history of revisions**, **compare differences** between any two versions, and **revert to a previous state** if needed.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-history.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-history.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -968,8 +968,8 @@ These features are available through the following components:
 Most admin and B2B apps require that user actions are recorded for audit purposes. React-admin provides templates for displaying such audit logs, and helpers to automatically **record user actions**.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-audit-log/latest/ra-audit-log.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-audit-log/latest/ra-audit-log.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-audit-log/latest/ra-audit-log.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-audit-log/latest/ra-audit-log.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -1020,8 +1020,8 @@ const dataProvider = addEventsForMutations(
 If your app needs to display **events**, **appointments**, **time intervals**, or any other kind of time-based data, you can use the [`<Calendar>`](./Calendar.md) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-calendar.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-calendar.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-calendar.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -1110,8 +1110,8 @@ Check out the following components for displaying hierarchical data:
 A UI kit like Material UI provides basic building blocks like a button, a form, a table, etc. React-admin goes one level higher and provides a set of **[application components](./Reference.md#components)** specifically designed for building admin and B2B *applications*.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid/latest/ra-editable-datagrid-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/FieldsForRelationships.md
+++ b/docs/FieldsForRelationships.md
@@ -304,7 +304,7 @@ Just like for `<ReferenceField>`, `<ReferenceArrayField>` aggregates and dedupli
 
 ## `<ReferenceManyToManyField>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> field displays a many-to-many relationship implemented with two one-to-many relationships and a join table. 
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> field displays a many-to-many relationship implemented with two one-to-many relationships and a join table. 
 
 ```
 ┌──────────────────┐       ┌──────────────┐      ┌───────────────┐

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -34,16 +34,16 @@ One of the most important features of the List page is the ability to filter the
 </tr>
 <tr style="border:none;background-color:#fff;">
     <td style="width:50%;border:none;text-align:center">
-        <a title="Stacked Filters" href="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm">
+        <a title="Stacked Filters" href="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm">
             <video controls autoplay playsinline muted loop width="90%" style="margin:1rem;box-shadow:0px 4px 4px 0px rgb(0 0 0 / 24%);">
-                <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
+                <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
                     Your browser does not support the video tag.
             </video>
         </a>
         <a href="#the-stackedfilters-component" style="display: block;transform: translateY(-10px);">The <code>&lt;StackedFilters&gt;</code> Dialog</a>
     </td>
     <td style="width:50%;border:none;text-align:center;vertical-align:top;">
-        <a title="<Search> input" href="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif"><img src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif" /></a>
+        <a title="<Search> input" href="https://react-admin-ee.marmelab.com/assets/ra-search-overview.gif"><img src="https://react-admin-ee.marmelab.com/assets/ra-search-overview.gif" /></a>
         <a href="#global-search" style="display: block;transform: translateY(-10px);">The Global <code>&lt;Search&gt;</code></a>
     </td>
 </tr>
@@ -221,7 +221,7 @@ Finally, a filter sidebar is the ideal place to display the user's favorite filt
 ## The `<StackedFilters>` Component
 
 <video controls autoplay playsinline muted loop width="100%">
-    <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
+    <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
         Your browser does not support the video tag.
 </video>
 
@@ -280,8 +280,8 @@ Check the [`<StackedFilters>` documentation](./StackedFilters.md) for more infor
 ## Global Search
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -292,8 +292,8 @@ If you want to display a full-text search allowing to look for any record in the
 `<Search>` can plug to any existing search engine (ElasticSearch, Lucene, or custom search engine), and lets you customize the search results to provide quick navigation to related items, turning the search engine into an "Omnibox":
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-demo.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-demo.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -34,16 +34,16 @@ One of the most important features of the List page is the ability to filter the
 </tr>
 <tr style="border:none;background-color:#fff;">
     <td style="width:50%;border:none;text-align:center">
-        <a title="Stacked Filters" href="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm">
+        <a title="Stacked Filters" href="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm">
             <video controls autoplay playsinline muted loop width="90%" style="margin:1rem;box-shadow:0px 4px 4px 0px rgb(0 0 0 / 24%);">
-                <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
+                <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
                     Your browser does not support the video tag.
             </video>
         </a>
         <a href="#the-stackedfilters-component" style="display: block;transform: translateY(-10px);">The <code>&lt;StackedFilters&gt;</code> Dialog</a>
     </td>
     <td style="width:50%;border:none;text-align:center;vertical-align:top;">
-        <a title="<Search> input" href="https://marmelab.com/ra-enterprise/modules/assets/ra-search-overview.gif"><img src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-overview.gif" /></a>
+        <a title="<Search> input" href="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif"><img src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.gif" /></a>
         <a href="#global-search" style="display: block;transform: translateY(-10px);">The Global <code>&lt;Search&gt;</code></a>
     </td>
 </tr>
@@ -221,11 +221,11 @@ Finally, a filter sidebar is the ideal place to display the user's favorite filt
 ## The `<StackedFilters>` Component
 
 <video controls autoplay playsinline muted loop width="100%">
-    <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
+    <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/mp4" />
         Your browser does not support the video tag.
 </video>
 
-Another alternative filter UI is the Stacked Filters dialog, an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> exclusive. It lets users build complex filters by combining a field, an operator, and a value. It's more powerful than the Filter Button/Form Combo, but requires more setup on the data provider.
+Another alternative filter UI is the Stacked Filters dialog, an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> exclusive. It lets users build complex filters by combining a field, an operator, and a value. It's more powerful than the Filter Button/Form Combo, but requires more setup on the data provider.
 
 Here is an example StackedFilters configuration:
 
@@ -280,20 +280,20 @@ Check the [`<StackedFilters>` documentation](./StackedFilters.md) for more infor
 ## Global Search
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 Although list filters allow to make precise queries using per-field criteria, users often prefer simpler interfaces like full-text search. After all, that's what they use every day on search engines, email clients, and in their file explorer.
 
-If you want to display a full-text search allowing to look for any record in the admin using a single form input, check out [the `<Search>` component](./Search.md), an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> exclusive.
+If you want to display a full-text search allowing to look for any record in the admin using a single form input, check out [the `<Search>` component](./Search.md), an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> exclusive.
 
 `<Search>` can plug to any existing search engine (ElasticSearch, Lucene, or custom search engine), and lets you customize the search results to provide quick navigation to related items, turning the search engine into an "Omnibox":
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/IconMenu.md
+++ b/docs/IconMenu.md
@@ -5,11 +5,11 @@ title: "The IconMenu Component"
 
 # `<IconMenu>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative menu user interface. It renders a reduced menu bar with a sliding panel for second-level menu items. This menu saves a lot of screen real estate, and allows for sub menus of any level of complexity.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative menu user interface. It renders a reduced menu bar with a sliding panel for second-level menu items. This menu saves a lot of screen real estate, and allows for sub menus of any level of complexity.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -56,7 +56,7 @@ export const MyLayout = (props) => (
 );
 ```
 
-`<AppLocationContext>` is necessary because `ra-navigation` doesn't use the URL to detect the current location. Instead, page components *declare* their location using a custom hook (`useDefineAppLocation()`). This allows complex site maps, with multiple levels of nesting. Check [the ra-navigation documentation](https://marmelab.com/ra-enterprise/modules/ra-navigation) to learn more about App Location.
+`<AppLocationContext>` is necessary because `ra-navigation` doesn't use the URL to detect the current location. Instead, page components *declare* their location using a custom hook (`useDefineAppLocation()`). This allows complex site maps, with multiple levels of nesting. Check [the ra-navigation documentation](https://react-admin-ee.marmelab.com/modules/ra-navigation) to learn more about App Location.
 
 Finally, pass this custom layout to the `<Admin>` component. You should apply the theme provided by ra-navigation:
 

--- a/docs/IconMenu.md
+++ b/docs/IconMenu.md
@@ -56,7 +56,7 @@ export const MyLayout = (props) => (
 );
 ```
 
-`<AppLocationContext>` is necessary because `ra-navigation` doesn't use the URL to detect the current location. Instead, page components *declare* their location using a custom hook (`useDefineAppLocation()`). This allows complex site maps, with multiple levels of nesting. Check [the ra-navigation documentation](https://react-admin-ee.marmelab.com/modules/ra-navigation) to learn more about App Location.
+`<AppLocationContext>` is necessary because `ra-navigation` doesn't use the URL to detect the current location. Instead, page components *declare* their location using a custom hook (`useDefineAppLocation()`). This allows complex site maps, with multiple levels of nesting. Check [the ra-navigation documentation](https://react-admin-ee.marmelab.com/documentation/ra-navigation) to learn more about App Location.
 
 Finally, pass this custom layout to the `<Admin>` component. You should apply the theme provided by ra-navigation:
 

--- a/docs/IconMenu.md
+++ b/docs/IconMenu.md
@@ -8,8 +8,8 @@ title: "The IconMenu Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative menu user interface. It renders a reduced menu bar with a sliding panel for second-level menu items. This menu saves a lot of screen real estate, and allows for sub menus of any level of complexity.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/IfCanAccess.md
+++ b/docs/IfCanAccess.md
@@ -5,7 +5,7 @@ title: "IfCanAccess"
 
 # `<IfCanAccess>`
 
-This component, part of [the ra-rbac module](https://marmelab.com/ra-enterprise/modules/ra-rbac#ifcanaccess)<img class="icon" src="./img/premium.svg" />, renders its child only if the user has the right permissions.
+This component, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac#ifcanaccess)<img class="icon" src="./img/premium.svg" />, renders its child only if the user has the right permissions.
 
 ## Usage
 

--- a/docs/IfCanAccess.md
+++ b/docs/IfCanAccess.md
@@ -5,7 +5,7 @@ title: "IfCanAccess"
 
 # `<IfCanAccess>`
 
-This component, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac#ifcanaccess)<img class="icon" src="./img/premium.svg" />, renders its child only if the user has the right permissions.
+This component, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/documentation/ra-rbac#ifcanaccess)<img class="icon" src="./img/premium.svg" />, renders its child only if the user has the right permissions.
 
 ## Usage
 

--- a/docs/JsonSchemaForm.md
+++ b/docs/JsonSchemaForm.md
@@ -5,7 +5,7 @@ title: "JsonSchemaForm"
 
 # `<JsonSchemaForm>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to render a form from a JSON Schema description based on [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form).
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to render a form from a JSON Schema description based on [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form).
 
 ## Usage
 
@@ -21,7 +21,7 @@ If you have a JSON Schema description of your form based on [react-jsonschema-fo
 
 For instance, to generate the following form:
 
-![JsonSchemaForm](https://marmelab.com/ra-enterprise/modules/assets/jsonschemaform.webp)
+![JsonSchemaForm](https://react-admin-ee.marmelab.com/modules/assets/jsonschemaform.webp)
 
 Configure the `<Edit>` view with a `<JsonSchemaForm>` child as follows:
 

--- a/docs/JsonSchemaForm.md
+++ b/docs/JsonSchemaForm.md
@@ -21,7 +21,7 @@ If you have a JSON Schema description of your form based on [react-jsonschema-fo
 
 For instance, to generate the following form:
 
-![JsonSchemaForm](https://react-admin-ee.marmelab.com/modules/assets/jsonschemaform.webp)
+![JsonSchemaForm](https://react-admin-ee.marmelab.com/assets/jsonschemaform.webp)
 
 Configure the `<Edit>` view with a `<JsonSchemaForm>` child as follows:
 

--- a/docs/Layout.md
+++ b/docs/Layout.md
@@ -256,8 +256,8 @@ React-admin provides alternative menu layouts that you can use as a base for you
 - [`<IconMenu>`](./IconMenu.md) for a narrow icon bar with dropdown menus
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Layout.md
+++ b/docs/Layout.md
@@ -256,8 +256,8 @@ React-admin provides alternative menu layouts that you can use as a base for you
 - [`<IconMenu>`](./IconMenu.md) for a narrow icon bar with dropdown menus
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-categories.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-categories.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/ListLive.md
+++ b/docs/ListLive.md
@@ -5,7 +5,7 @@ title: "ListLive"
 
 # `<ListLive>`
 
-`<ListLive>` is an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component that fetches a list of records, and refreshes the page when a record is created, updated, or deleted.
+`<ListLive>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component that fetches a list of records, and refreshes the page when a record is created, updated, or deleted.
 
 ![ListLive](./img/ListLive.png)
 

--- a/docs/LongForm.md
+++ b/docs/LongForm.md
@@ -5,7 +5,7 @@ title: "LongForm"
 
 # `<LongForm>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative form layout, to be used as child of `<Create>` or `<Edit>`. Expects `<LongForm.Section>` elements as children.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative form layout, to be used as child of `<Create>` or `<Edit>`. Expects `<LongForm.Section>` elements as children.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/ra-longform-overview.webm" type="video/webm"/>

--- a/docs/MarkdownField.md
+++ b/docs/MarkdownField.md
@@ -38,4 +38,4 @@ const PostShow = () => (
 );
 ```
 
-Check [the `ra-markdown` documentation](https://react-admin-ee.marmelab.com/modules/ra-markdown) for more details.
+Check [the `ra-markdown` documentation](https://react-admin-ee.marmelab.com/documentation/ra-markdown) for more details.

--- a/docs/MarkdownField.md
+++ b/docs/MarkdownField.md
@@ -5,9 +5,9 @@ title: "The MarkdownField Component"
 
 # `<MarkdownField>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to render Markdown data as HTML.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to render Markdown data as HTML.
 
-![MarkdownField preview](https://marmelab.com/ra-enterprise/modules/assets/ra-markdown/latest/markdown-field-preview.png)
+![MarkdownField preview](https://react-admin-ee.marmelab.com/modules/assets/ra-markdown/latest/markdown-field-preview.png)
 
 ```jsx
 import { Show, SimpleShowLayout, TextField } from 'react-admin';
@@ -38,4 +38,4 @@ const PostShow = () => (
 );
 ```
 
-Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.
+Check [the `ra-markdown` documentation](https://react-admin-ee.marmelab.com/modules/ra-markdown) for more details.

--- a/docs/MarkdownField.md
+++ b/docs/MarkdownField.md
@@ -7,7 +7,7 @@ title: "The MarkdownField Component"
 
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to render Markdown data as HTML.
 
-![MarkdownField preview](https://react-admin-ee.marmelab.com/modules/assets/ra-markdown/latest/markdown-field-preview.png)
+![MarkdownField preview](https://react-admin-ee.marmelab.com/assets/ra-markdown/latest/markdown-field-preview.png)
 
 ```jsx
 import { Show, SimpleShowLayout, TextField } from 'react-admin';

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -208,4 +208,4 @@ const Example = () => (
 ```
 {% endraw %}
 
-Check [the `ra-markdown` documentation](https://react-admin-ee.marmelab.com/modules/ra-markdown) for more details.
+Check [the `ra-markdown` documentation](https://react-admin-ee.marmelab.com/documentation/ra-markdown) for more details.

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -5,7 +5,7 @@ title: 'The MarkdownInput Component'
 
 # `<MarkdownInput>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to edit and preview Markdown data, based on [the Toast UI editor](https://nhn.github.io/tui.editor/latest/ToastUIEditor). To be used in Edit and Create views.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to edit and preview Markdown data, based on [the Toast UI editor](https://nhn.github.io/tui.editor/latest/ToastUIEditor). To be used in Edit and Create views.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/markdown-input.webm" type="video/webm"/>
@@ -208,4 +208,4 @@ const Example = () => (
 ```
 {% endraw %}
 
-Check [the `ra-markdown` documentation](https://marmelab.com/ra-enterprise/modules/ra-markdown) for more details.
+Check [the `ra-markdown` documentation](https://react-admin-ee.marmelab.com/modules/ra-markdown) for more details.

--- a/docs/Menu.md
+++ b/docs/Menu.md
@@ -406,8 +406,8 @@ Just use an empty `filter` query parameter to force empty filters:
 If you need to display a menu item with a submenu, you should use [the `<MultiLevelMenu>` component](./MultiLevelMenu.md) instead of `<Menu>`.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-item.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Menu.md
+++ b/docs/Menu.md
@@ -406,8 +406,8 @@ Just use an empty `filter` query parameter to force empty filters:
 If you need to display a menu item with a submenu, you should use [the `<MultiLevelMenu>` component](./MultiLevelMenu.md) instead of `<Menu>`.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/MenuLive.md
+++ b/docs/MenuLive.md
@@ -5,7 +5,7 @@ title: "The MenuLive Component"
 
 # `<MenuLive>`
 
-`<MenuLive>` is an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component that renders a Menu, and displays a badge with the number of updated records on each unactive Menu item.
+`<MenuLive>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component that renders a Menu, and displays a badge with the number of updated records on each unactive Menu item.
 
 ![MenuLive](./img/MenuLive.png)
 

--- a/docs/MultiLevelMenu.md
+++ b/docs/MultiLevelMenu.md
@@ -93,7 +93,7 @@ And then use this `AppLocation` as `name` for `<MultiLevelMenu.Item>`:
 >
 ```
 
-Check [the ra-navigation documentation](https://react-admin-ee.marmelab.com/modules/ra-navigation) to learn more about App Location.
+Check [the ra-navigation documentation](https://react-admin-ee.marmelab.com/documentation/ra-navigation) to learn more about App Location.
 
 Finally, pass this custom layout to the `<Admin>` component
 

--- a/docs/MultiLevelMenu.md
+++ b/docs/MultiLevelMenu.md
@@ -5,15 +5,15 @@ title: "The MultiLevelMenu Component"
 
 # `<MultiLevelMenu>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component adds support for nested sub menus in the left navigation bar.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component adds support for nested sub menus in the left navigation bar.
 
 ![MultiLevelMenu](./img/multilevelmenu.png)
 
 When a React-admin application grows significantly, the default menu might not be the best solution. The `<MultiLevelMenu>` can help unclutter the navigation: it renders a menu with an infinite number of levels and sub-menus. Menu Items that are not at the top level are rendered inside a collapsible panel.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -93,7 +93,7 @@ And then use this `AppLocation` as `name` for `<MultiLevelMenu.Item>`:
 >
 ```
 
-Check [the ra-navigation documentation](https://marmelab.com/ra-enterprise/modules/ra-navigation) to learn more about App Location.
+Check [the ra-navigation documentation](https://react-admin-ee.marmelab.com/modules/ra-navigation) to learn more about App Location.
 
 Finally, pass this custom layout to the `<Admin>` component
 

--- a/docs/MultiLevelMenu.md
+++ b/docs/MultiLevelMenu.md
@@ -12,8 +12,8 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
 When a React-admin application grows significantly, the default menu might not be the best solution. The `<MultiLevelMenu>` can help unclutter the navigation: it renders a menu with an infinite number of levels and sub-menus. Menu Items that are not at the top level are rendered inside a collapsible panel.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-item.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-multilevelmenu-item.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/PredictiveTextInput.md
+++ b/docs/PredictiveTextInput.md
@@ -408,8 +408,8 @@ const getParamsForPrompt = (prompt) => {
 
 If you want AI completions combined with a WYSIWYG editor for rich text, use [`<SmartRichTextInput>`](./SmartRichTextInput.md) instead of `<PredictiveTextInput>`.
 
-<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/PredictiveTextInput.md
+++ b/docs/PredictiveTextInput.md
@@ -5,7 +5,7 @@ title: "The PredictiveTextInput component"
 
 # `<PredictiveTextInput>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative to [`<TextInput>`](./TextInput.md) that suggests completion for the input value. Users can accept the completion by pressing the `Tab` key. It's like Intellisense or Copilot for your forms.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative to [`<TextInput>`](./TextInput.md) that suggests completion for the input value. Users can accept the completion by pressing the `Tab` key. It's like Intellisense or Copilot for your forms.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/PredictiveTextInput.mp4" type="video/mp4"/>
@@ -408,8 +408,8 @@ const getParamsForPrompt = (prompt) => {
 
 If you want AI completions combined with a WYSIWYG editor for rich text, use [`<SmartRichTextInput>`](./SmartRichTextInput.md) instead of `<PredictiveTextInput>`.
 
-<video controls playsinline muted loop poster="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.png" >
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -128,12 +128,12 @@ Read more about the [Architecture choices](./Architecture.md).
 
 ## Support
 
-* Get professional support from Marmelab via [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise)
+* Get professional support from Marmelab via [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com)
 * Get community support via [StackOverflow](https://stackoverflow.com/questions/tagged/react-admin)
 
 ## Enterprise Edition
 
-The [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise) <img class="icon" src="./img/premium.svg" /> offers additional features and services for react-admin:
+The [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com) <img class="icon" src="./img/premium.svg" /> offers additional features and services for react-admin:
 
 - Save weeks of development thanks to the **Private Modules**, valid on an unlimited number of domains and projects.
   - `ra-ai`: Components powered by Artificial Intelligence (AI) to boost user productivity. Suggest completion for user inputs, fix and improve large chunks of text in React-Admin forms.
@@ -156,7 +156,7 @@ The [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise) <img cl
 - Get access to exclusive **Learning Material**, including a Storybook full of examples, and a dedicated demo app.
 - Prioritize your needs in the react-admin **Development Roadmap** thanks to a priority vote.
 
-[![React-admin enterprise Edition](https://marmelab.com/ra-enterprise/assets/ra-enterprise-demo.png)](https://marmelab.com/ra-enterprise/)
+[![React-admin enterprise Edition](https://react-admin-ee.marmelab.com/assets/ra-enterprise-demo.png)](https://react-admin-ee.marmelab.com/)
 
 ## Carbon Footprint
 

--- a/docs/Realtime.md
+++ b/docs/Realtime.md
@@ -12,7 +12,7 @@ React-admin provides hooks and UI components for collaborative applications wher
   Your browser does not support the video tag.
 </video>
 
-These features are provided by the `ra-realtime` package, which is part of the [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> 
+These features are provided by the `ra-realtime` package, which is part of the [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> 
 
 ## Backend Agnostic
 
@@ -303,7 +303,7 @@ npm install --save @react-admin/ra-realtime
 yarn add @react-admin/ra-realtime
 ```
 
-`ra-realtime` is part of the [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise/), and hosted in a private npm registry. You need to subscribe to one of the Enterprise Edition plans to install this package.
+`ra-realtime` is part of the [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com/), and hosted in a private npm registry. You need to subscribe to one of the Enterprise Edition plans to install this package.
 
 You will need a data provider that supports real-time subscriptions. Check out the [Data Provider Requirements](./RealtimeDataProvider.md) section for more information.
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -293,7 +293,6 @@ title: "Index"
 * [`useRegisterMutationMiddleware`](./useRegisterMutationMiddleware.md)
 * [`useRemoveFromStore`](./useRemoveFromStore.md)
 * [`useResetStore`](./useResetStore.md)
-* [`useResourceAppLocation`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useresourceapplocation-access-current-resource-app-location)<img class="icon" src="./img/premium.svg" />
 
 **- S -**
 * [`useSaveContext`](./useSaveContext.md)

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -220,7 +220,7 @@ title: "Index"
 
 **- A -**
 * [`useAppLocationState`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useapplocationstate-retrieve-and-define-app-location)<img class="icon" src="./img/premium.svg" />
-* [`useAppLocationMatcher`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useapplocationmatcher-apply-a-matching-on-the-current-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useAppLocationMatcher`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useapplocationmatcher)<img class="icon" src="./img/premium.svg" />
 * [`useAuthenticated`](./useAuthenticated.md)
 * [`useAuthProvider`](./useAuthProvider.md)
 * [`useAuthState`](./useAuthState.md)
@@ -297,7 +297,7 @@ title: "Index"
 
 **- S -**
 * [`useSaveContext`](./useSaveContext.md)
-* [`useSearch`](https://react-admin-ee.marmelab.com/documentation/ra-search#the-usesearch-hook)<img class="icon" src="./img/premium.svg" />
+* [`useSearch`](https://react-admin-ee.marmelab.com/documentation/ra-search#usesearch)<img class="icon" src="./img/premium.svg" />
 * [`useShowContext`](./useShowContext.md)
 * [`useShowController`](./useShowController.md#useshowcontroller)
 * [`useStore`](./useStore.md)

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -34,7 +34,7 @@ title: "Index"
 * [`<CheckForApplicationUpdate>`](./CheckForApplicationUpdate.md)
 * [`<ChipField>`](./ChipField.md)
 * [`<CloneButton>`](./CloneButton.md)
-* [`<CompleteCalendar>`](https://marmelab.com/ra-enterprise/modules/ra-calendar#completecalendar)<img class="icon" src="./img/premium.svg" />
+* [`<CompleteCalendar>`](https://react-admin-ee.marmelab.com/modules/ra-calendar#completecalendar)<img class="icon" src="./img/premium.svg" />
 * [`<Confirm>`](./Confirm.md)
 * [`<ContainerLayout>`](./ContainerLayout.md)<img class="icon" src="./img/premium.svg" />
 * [`<Count>`](./Count.md)
@@ -69,7 +69,7 @@ title: "Index"
 * [`<Empty>`](./List.md#empty)
 
 **- F -**
-* [`<FieldDiff>`](https://marmelab.com/ra-enterprise/modules/ra-history#fielddiff)<img class="icon" src="./img/premium.svg" />
+* [`<FieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#fielddiff)<img class="icon" src="./img/premium.svg" />
 * [`<FileField>`](./FileField.md)
 * [`<FileInput>`](./FileInput.md)
 * [`<Filter>`](./List.md#filters-filter-inputs)
@@ -123,7 +123,7 @@ title: "Index"
 **- P -**
 * [`<Pagination>`](./List.md#pagination)
 * [`<PasswordInput>`](./PasswordInput.md)
-* [`<PreferencesSetter>`](https://marmelab.com/ra-enterprise/modules/ra-preferences#preferencessetter-setting-preferences-declaratively)<img class="icon" src="./img/premium.svg" />
+* [`<PreferencesSetter>`](https://react-admin-ee.marmelab.com/modules/ra-preferences#preferencessetter-setting-preferences-declaratively)<img class="icon" src="./img/premium.svg" />
 
 **- R -**
 * [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md)
@@ -142,10 +142,10 @@ title: "Index"
 * [`<ReferenceOneInput>`](./ReferenceOneInput.md)
 * [`<Resource>`](./Resource.md)
 * [`<RevisionsButton>`](./RevisionsButton.md)<img class="icon" src="./img/premium.svg" />
-* [`<RevisionListWithDetailsInDialog>`](https://marmelab.com/ra-enterprise/modules/ra-history#revisionlistwithdetailsindialog)<img class="icon" src="./img/premium.svg" />
+* [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog)<img class="icon" src="./img/premium.svg" />
 * [`<RichTextField>`](./RichTextField.md)
 * [`<RichTextInput>`](./RichTextInput.md)
-* [`<RowForm>`](https://marmelab.com/ra-enterprise/modules/ra-editable-datagrid#rowform)<img class="icon" src="./img/premium.svg" />
+* [`<RowForm>`](https://react-admin-ee.marmelab.com/modules/ra-editable-datagrid#rowform)<img class="icon" src="./img/premium.svg" />
 
 **- S -**
 * [`<SaveButton>`](./SaveButton.md)
@@ -160,18 +160,18 @@ title: "Index"
 * [`<Show>`](./Show.md#show)
 * [`<ShowGuesser`](./ShowGuesser.md#showguesser)
 * [`<ShowButton>`](./Buttons.md#showbutton)
-* [`<ShowDialog>`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createdialog-editdialog--showdialog)<img class="icon" src="./img/premium.svg" />
+* [`<ShowDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog)<img class="icon" src="./img/premium.svg" />
 * [`<ShowInDialogButton>`](./ShowInDialogButton.md)<img class="icon" src="./img/premium.svg" />
 * [`<ShowLive>`](./ShowLive.md)<img class="icon" src="./img/premium.svg" />
 * [`<Sidebar>`](./Layout.md#sidebar)
-* [`<SidebarOpenPreferenceSync>`](https://marmelab.com/ra-enterprise/modules/ra-preferences#sidebaropenpreferencesync-store-the-sidebar-openclose-state-in-preferences)<img class="icon" src="./img/premium.svg" />
+* [`<SidebarOpenPreferenceSync>`](https://react-admin-ee.marmelab.com/modules/ra-preferences#sidebaropenpreferencesync-store-the-sidebar-openclose-state-in-preferences)<img class="icon" src="./img/premium.svg" />
 * [`<SimpleForm>`](./SimpleForm.md)
 * [`<SimpleFormIterator>`](./SimpleFormIterator.md)
 * [`<SimpleFormWithRevision>`](./SimpleForm.md#versioning)<img class="icon" src="./img/premium.svg" />
 * [`<SimpleList>`](./SimpleList.md)
 * [`<SimpleShowLayout>`](./SimpleShowLayout.md)
 * [`<SingleFieldList>`](./SingleFieldList.md)
-* [`<SmartFieldDiff>`](https://marmelab.com/ra-enterprise/modules/ra-history#smartfielddiff)<img class="icon" src="./img/premium.svg" />
+* [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#smartfielddiff)<img class="icon" src="./img/premium.svg" />
 * [`<SmartRichTextInput>`](./SmartRichTextInput.md)<img class="icon" src="./img/premium.svg" />
 * [`<SolarLayout>`](./SolarLayout.md)<img class="icon" src="./img/premium.svg" />
 * [`<SolarMenu>`](./SolarLayout.md#solarmenu)<img class="icon" src="./img/premium.svg" />
@@ -190,10 +190,10 @@ title: "Index"
 * [`<Title>`](./Title.md)
 * [`<TitlePortal>`](./AppBar.md#children)
 * [`<ToggleThemeButton>`](./ToggleThemeButton.md)
-* [`<TourProvider>`](https://marmelab.com/ra-enterprise/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
+* [`<TourProvider>`](https://react-admin-ee.marmelab.com/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
 * [`<TranslatableFields>`](./TranslatableFields.md)
 * [`<TranslatableInputs>`](./TranslatableInputs.md)
-* [`<Tree>`](https://marmelab.com/ra-enterprise/modules/ra-tree#tree-component)<img class="icon" src="./img/premium.svg" />
+* [`<Tree>`](https://react-admin-ee.marmelab.com/modules/ra-tree#tree-component)<img class="icon" src="./img/premium.svg" />
 * [`<TreeInput>`](./TreeInput.md)<img class="icon" src="./img/premium.svg" />
 * [`<TreeWithDetails>`](./TreeWithDetails.md)<img class="icon" src="./img/premium.svg" />
 * [`<Toolbar>`](./Toolbar.md)
@@ -219,8 +219,8 @@ title: "Index"
 <div class="pages-index" markdown="1">
 
 **- A -**
-* [`useAppLocationState`](https://marmelab.com/ra-enterprise/modules/ra-navigation#useapplocationstate-retrieve-and-define-app-location)<img class="icon" src="./img/premium.svg" />
-* [`useAppLocationMatcher`](https://marmelab.com/ra-enterprise/modules/ra-navigation#useapplocationmatcher-apply-a-matching-on-the-current-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useAppLocationState`](https://react-admin-ee.marmelab.com/modules/ra-navigation#useapplocationstate-retrieve-and-define-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useAppLocationMatcher`](https://react-admin-ee.marmelab.com/modules/ra-navigation#useapplocationmatcher-apply-a-matching-on-the-current-app-location)<img class="icon" src="./img/premium.svg" />
 * [`useAuthenticated`](./useAuthenticated.md)
 * [`useAuthProvider`](./useAuthProvider.md)
 * [`useAuthState`](./useAuthState.md)
@@ -293,11 +293,11 @@ title: "Index"
 * [`useRegisterMutationMiddleware`](./useRegisterMutationMiddleware.md)
 * [`useRemoveFromStore`](./useRemoveFromStore.md)
 * [`useResetStore`](./useResetStore.md)
-* [`useResourceAppLocation`](https://marmelab.com/ra-enterprise/modules/ra-navigation#useresourceapplocation-access-current-resource-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useResourceAppLocation`](https://react-admin-ee.marmelab.com/modules/ra-navigation#useresourceapplocation-access-current-resource-app-location)<img class="icon" src="./img/premium.svg" />
 
 **- S -**
 * [`useSaveContext`](./useSaveContext.md)
-* [`useSearch`](https://marmelab.com/ra-enterprise/modules/ra-search#the-usesearch-hook)<img class="icon" src="./img/premium.svg" />
+* [`useSearch`](https://react-admin-ee.marmelab.com/modules/ra-search#the-usesearch-hook)<img class="icon" src="./img/premium.svg" />
 * [`useShowContext`](./useShowContext.md)
 * [`useShowController`](./useShowController.md#useshowcontroller)
 * [`useStore`](./useStore.md)
@@ -309,7 +309,7 @@ title: "Index"
 
 **- T -**
 * [`useTheme`](./useTheme.md)
-* [`useTour`](https://marmelab.com/ra-enterprise/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
+* [`useTour`](https://react-admin-ee.marmelab.com/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
 * [`useTranslate`](./useTranslate.md)
 
 **- U -**

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -34,7 +34,7 @@ title: "Index"
 * [`<CheckForApplicationUpdate>`](./CheckForApplicationUpdate.md)
 * [`<ChipField>`](./ChipField.md)
 * [`<CloneButton>`](./CloneButton.md)
-* [`<CompleteCalendar>`](https://react-admin-ee.marmelab.com/modules/ra-calendar#completecalendar)<img class="icon" src="./img/premium.svg" />
+* [`<CompleteCalendar>`](https://react-admin-ee.marmelab.com/documentation/ra-calendar#completecalendar)<img class="icon" src="./img/premium.svg" />
 * [`<Confirm>`](./Confirm.md)
 * [`<ContainerLayout>`](./ContainerLayout.md)<img class="icon" src="./img/premium.svg" />
 * [`<Count>`](./Count.md)
@@ -69,7 +69,7 @@ title: "Index"
 * [`<Empty>`](./List.md#empty)
 
 **- F -**
-* [`<FieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#fielddiff)<img class="icon" src="./img/premium.svg" />
+* [`<FieldDiff>`](https://react-admin-ee.marmelab.com/documentation/ra-history#fielddiff)<img class="icon" src="./img/premium.svg" />
 * [`<FileField>`](./FileField.md)
 * [`<FileInput>`](./FileInput.md)
 * [`<Filter>`](./List.md#filters-filter-inputs)
@@ -123,7 +123,7 @@ title: "Index"
 **- P -**
 * [`<Pagination>`](./List.md#pagination)
 * [`<PasswordInput>`](./PasswordInput.md)
-* [`<PreferencesSetter>`](https://react-admin-ee.marmelab.com/modules/ra-preferences#preferencessetter-setting-preferences-declaratively)<img class="icon" src="./img/premium.svg" />
+* [`<PreferencesSetter>`](https://react-admin-ee.marmelab.com/documentation/ra-preferences#preferencessetter-setting-preferences-declaratively)<img class="icon" src="./img/premium.svg" />
 
 **- R -**
 * [`<RadioButtonGroupInput>`](./RadioButtonGroupInput.md)
@@ -142,10 +142,10 @@ title: "Index"
 * [`<ReferenceOneInput>`](./ReferenceOneInput.md)
 * [`<Resource>`](./Resource.md)
 * [`<RevisionsButton>`](./RevisionsButton.md)<img class="icon" src="./img/premium.svg" />
-* [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog)<img class="icon" src="./img/premium.svg" />
+* [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionlistwithdetailsindialog)<img class="icon" src="./img/premium.svg" />
 * [`<RichTextField>`](./RichTextField.md)
 * [`<RichTextInput>`](./RichTextInput.md)
-* [`<RowForm>`](https://react-admin-ee.marmelab.com/modules/ra-editable-datagrid#rowform)<img class="icon" src="./img/premium.svg" />
+* [`<RowForm>`](https://react-admin-ee.marmelab.com/documentation/ra-editable-datagrid#rowform)<img class="icon" src="./img/premium.svg" />
 
 **- S -**
 * [`<SaveButton>`](./SaveButton.md)
@@ -160,18 +160,18 @@ title: "Index"
 * [`<Show>`](./Show.md#show)
 * [`<ShowGuesser`](./ShowGuesser.md#showguesser)
 * [`<ShowButton>`](./Buttons.md#showbutton)
-* [`<ShowDialog>`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createdialog-editdialog--showdialog)<img class="icon" src="./img/premium.svg" />
+* [`<ShowDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createdialog-editdialog--showdialog)<img class="icon" src="./img/premium.svg" />
 * [`<ShowInDialogButton>`](./ShowInDialogButton.md)<img class="icon" src="./img/premium.svg" />
 * [`<ShowLive>`](./ShowLive.md)<img class="icon" src="./img/premium.svg" />
 * [`<Sidebar>`](./Layout.md#sidebar)
-* [`<SidebarOpenPreferenceSync>`](https://react-admin-ee.marmelab.com/modules/ra-preferences#sidebaropenpreferencesync-store-the-sidebar-openclose-state-in-preferences)<img class="icon" src="./img/premium.svg" />
+* [`<SidebarOpenPreferenceSync>`](https://react-admin-ee.marmelab.com/documentation/ra-preferences#sidebaropenpreferencesync-store-the-sidebar-openclose-state-in-preferences)<img class="icon" src="./img/premium.svg" />
 * [`<SimpleForm>`](./SimpleForm.md)
 * [`<SimpleFormIterator>`](./SimpleFormIterator.md)
 * [`<SimpleFormWithRevision>`](./SimpleForm.md#versioning)<img class="icon" src="./img/premium.svg" />
 * [`<SimpleList>`](./SimpleList.md)
 * [`<SimpleShowLayout>`](./SimpleShowLayout.md)
 * [`<SingleFieldList>`](./SingleFieldList.md)
-* [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#smartfielddiff)<img class="icon" src="./img/premium.svg" />
+* [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/documentation/ra-history#smartfielddiff)<img class="icon" src="./img/premium.svg" />
 * [`<SmartRichTextInput>`](./SmartRichTextInput.md)<img class="icon" src="./img/premium.svg" />
 * [`<SolarLayout>`](./SolarLayout.md)<img class="icon" src="./img/premium.svg" />
 * [`<SolarMenu>`](./SolarLayout.md#solarmenu)<img class="icon" src="./img/premium.svg" />
@@ -190,10 +190,10 @@ title: "Index"
 * [`<Title>`](./Title.md)
 * [`<TitlePortal>`](./AppBar.md#children)
 * [`<ToggleThemeButton>`](./ToggleThemeButton.md)
-* [`<TourProvider>`](https://react-admin-ee.marmelab.com/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
+* [`<TourProvider>`](https://react-admin-ee.marmelab.com/documentation/ra-tour)<img class="icon" src="./img/premium.svg" />
 * [`<TranslatableFields>`](./TranslatableFields.md)
 * [`<TranslatableInputs>`](./TranslatableInputs.md)
-* [`<Tree>`](https://react-admin-ee.marmelab.com/modules/ra-tree#tree-component)<img class="icon" src="./img/premium.svg" />
+* [`<Tree>`](https://react-admin-ee.marmelab.com/documentation/ra-tree#tree-component)<img class="icon" src="./img/premium.svg" />
 * [`<TreeInput>`](./TreeInput.md)<img class="icon" src="./img/premium.svg" />
 * [`<TreeWithDetails>`](./TreeWithDetails.md)<img class="icon" src="./img/premium.svg" />
 * [`<Toolbar>`](./Toolbar.md)
@@ -219,8 +219,8 @@ title: "Index"
 <div class="pages-index" markdown="1">
 
 **- A -**
-* [`useAppLocationState`](https://react-admin-ee.marmelab.com/modules/ra-navigation#useapplocationstate-retrieve-and-define-app-location)<img class="icon" src="./img/premium.svg" />
-* [`useAppLocationMatcher`](https://react-admin-ee.marmelab.com/modules/ra-navigation#useapplocationmatcher-apply-a-matching-on-the-current-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useAppLocationState`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useapplocationstate-retrieve-and-define-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useAppLocationMatcher`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useapplocationmatcher-apply-a-matching-on-the-current-app-location)<img class="icon" src="./img/premium.svg" />
 * [`useAuthenticated`](./useAuthenticated.md)
 * [`useAuthProvider`](./useAuthProvider.md)
 * [`useAuthState`](./useAuthState.md)
@@ -293,11 +293,11 @@ title: "Index"
 * [`useRegisterMutationMiddleware`](./useRegisterMutationMiddleware.md)
 * [`useRemoveFromStore`](./useRemoveFromStore.md)
 * [`useResetStore`](./useResetStore.md)
-* [`useResourceAppLocation`](https://react-admin-ee.marmelab.com/modules/ra-navigation#useresourceapplocation-access-current-resource-app-location)<img class="icon" src="./img/premium.svg" />
+* [`useResourceAppLocation`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#useresourceapplocation-access-current-resource-app-location)<img class="icon" src="./img/premium.svg" />
 
 **- S -**
 * [`useSaveContext`](./useSaveContext.md)
-* [`useSearch`](https://react-admin-ee.marmelab.com/modules/ra-search#the-usesearch-hook)<img class="icon" src="./img/premium.svg" />
+* [`useSearch`](https://react-admin-ee.marmelab.com/documentation/ra-search#the-usesearch-hook)<img class="icon" src="./img/premium.svg" />
 * [`useShowContext`](./useShowContext.md)
 * [`useShowController`](./useShowController.md#useshowcontroller)
 * [`useStore`](./useStore.md)
@@ -309,7 +309,7 @@ title: "Index"
 
 **- T -**
 * [`useTheme`](./useTheme.md)
-* [`useTour`](https://react-admin-ee.marmelab.com/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
+* [`useTour`](https://react-admin-ee.marmelab.com/documentation/ra-tour)<img class="icon" src="./img/premium.svg" />
 * [`useTranslate`](./useTranslate.md)
 
 **- U -**

--- a/docs/ReferenceManyInput.md
+++ b/docs/ReferenceManyInput.md
@@ -5,7 +5,7 @@ title: "The ReferenceManyInput Component"
 
 # `<ReferenceManyInput>`
 
-Use `<ReferenceManyInput>` in an `<Edit>` or `<Create>` view to edit one-to-many relationships, e.g. to edit the variants of a product in the product edition view. It's an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component, part of the `@react-admin/ra-relationships` package. 
+Use `<ReferenceManyInput>` in an `<Edit>` or `<Create>` view to edit one-to-many relationships, e.g. to edit the variants of a product in the product edition view. It's an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of the `@react-admin/ra-relationships` package. 
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/reference-many-input.webm" type="video/webm"/>

--- a/docs/ReferenceManyToManyField.md
+++ b/docs/ReferenceManyToManyField.md
@@ -5,7 +5,7 @@ title: "The ReferenceManyToManyField Component"
 
 # `<ReferenceManyToManyField>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component fetches a list of referenced records by lookup in an associative table, and passes the records down to its child component, which must be an iterator component (e.g. `<SingleFieldList>`).
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component fetches a list of referenced records by lookup in an associative table, and passes the records down to its child component, which must be an iterator component (e.g. `<SingleFieldList>`).
 
 !["ReferenceManyToManyField example showing band's venues"](./img/reference-many-to-many-field.png)
 

--- a/docs/ReferenceManyToManyInput.md
+++ b/docs/ReferenceManyToManyInput.md
@@ -8,7 +8,7 @@ title: "The ReferenceManyToManyInput Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to create, edit or remove relationships between two resources sharing an associative table. The changes in the associative table are sent to the dataProvider _when the user submits the form_, so that they can cancel the changes before submission.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/reference-many-to-many-input.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/reference-many-to-many-input.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/ReferenceManyToManyInput.md
+++ b/docs/ReferenceManyToManyInput.md
@@ -5,10 +5,10 @@ title: "The ReferenceManyToManyInput Component"
 
 # `<ReferenceManyToManyInput>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to create, edit or remove relationships between two resources sharing an associative table. The changes in the associative table are sent to the dataProvider _when the user submits the form_, so that they can cancel the changes before submission.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to create, edit or remove relationships between two resources sharing an associative table. The changes in the associative table are sent to the dataProvider _when the user submits the form_, so that they can cancel the changes before submission.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/reference-many-to-many-input.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/reference-many-to-many-input.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/ReferenceNodeInput.md
+++ b/docs/ReferenceNodeInput.md
@@ -5,7 +5,7 @@ title: "The ReferenceNodeInput Component"
 
 # `<ReferenceNodeInput>` Component
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows users to select one or several nodes from a tree of a reference resource. For instance, this is useful to select a category for a product.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows users to select one or several nodes from a tree of a reference resource. For instance, this is useful to select a category for a product.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/ReferenceNodeInput-TreeInput-basic.webm" type="video/webm"/>

--- a/docs/ReferenceOneInput.md
+++ b/docs/ReferenceOneInput.md
@@ -282,7 +282,7 @@ export const CustomInputs = () => (
 ```
 {% endraw %}
 
-![ReferenceOneInput with custom inputs](https://react-admin-ee.marmelab.com/modules/assets/ra-relationships/latest/reference-one-input-custom-inputs.png)
+![ReferenceOneInput with custom inputs](https://react-admin-ee.marmelab.com/assets/ra-relationships/latest/reference-one-input-custom-inputs.png)
 
 ## Limitations
 

--- a/docs/ReferenceOneInput.md
+++ b/docs/ReferenceOneInput.md
@@ -5,7 +5,7 @@ title: "The ReferenceOneInput Component"
 
 # `<ReferenceOneInput>`
 
-Use `<ReferenceOneInput>` in an `<Edit>` or `<Create>` view to edit a record linked to the current record via a one-to-one relationship, e.g. to edit the details of a book in the book edition view. It's an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component, part of the `@react-admin/ra-relationships` package. 
+Use `<ReferenceOneInput>` in an `<Edit>` or `<Create>` view to edit a record linked to the current record via a one-to-one relationship, e.g. to edit the details of a book in the book edition view. It's an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of the `@react-admin/ra-relationships` package. 
 
 <video controls autoplay playsinline muted loop width="100%">
   <source src="./img/reference-one-input.webm" type="video/webm" />
@@ -282,7 +282,7 @@ export const CustomInputs = () => (
 ```
 {% endraw %}
 
-![ReferenceOneInput with custom inputs](https://marmelab.com/ra-enterprise/modules/assets/ra-relationships/latest/reference-one-input-custom-inputs.png)
+![ReferenceOneInput with custom inputs](https://react-admin-ee.marmelab.com/modules/assets/ra-relationships/latest/reference-one-input-custom-inputs.png)
 
 ## Limitations
 

--- a/docs/Resource.md
+++ b/docs/Resource.md
@@ -324,8 +324,8 @@ export const App = () => (
 ```
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Resource.md
+++ b/docs/Resource.md
@@ -324,8 +324,8 @@ export const App = () => (
 ```
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/RevisionsButton.md
+++ b/docs/RevisionsButton.md
@@ -8,11 +8,11 @@ title: "The RevisionsButton Component"
 This button opens a menu with the list of revisions of the current record. When users select a revision, it opens a diff view, allowing them to see the changes between the current version and the selected revision. The user can then revert to the selected revision by clicking on the "Revert" button.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
-`<RevisionsButton>` is an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-history`](https://marmelab.com/ra-enterprise/modules/ra-history).
+`<RevisionsButton>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-history`](https://react-admin-ee.marmelab.com/modules/ra-history).
 
 ## Usage
 
@@ -24,7 +24,7 @@ npm install --save @react-admin/ra-history
 yarn add @react-admin/ra-history
 ```
 
-Tip: `ra-history` is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+Tip: `ra-history` is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 `<RevisionsButton>` is usually used in the page `actions` of an `<Edit>` component, in conjunction with [`<SimpleFormWithRevision>`](./SimpleForm.md#versioning).
 
@@ -83,8 +83,8 @@ The detail view of a revision includes a diff view to compare the current versio
 
 This element can grab the current record using `useRecordContext`, and the record from the revision selected by the user using `useReferenceRecordContext`. But instead of doing the diff by hand, you can use the two field diff components provided by `ra-history`:
 
--   [`<FieldDiff>`](https://marmelab.com/ra-enterprise/modules/ra-history#fielddiff) displays the diff of a given field. It accepts a react-admin Field component as child.
--   [`<SmartFieldDiff>`](https://marmelab.com/ra-enterprise/modules/ra-history#smartfielddiff) displays the diff of a string field, and uses a word-by-word diffing algorithm to highlight the changes.
+-   [`<FieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#fielddiff) displays the diff of a given field. It accepts a react-admin Field component as child.
+-   [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#smartfielddiff) displays the diff of a string field, and uses a word-by-word diffing algorithm to highlight the changes.
 
 So a custom diff view is usually a layout component with `<FieldDiff>` and `<SmartFieldDiff>` components as children:
 
@@ -169,10 +169,10 @@ const ProductEditActions = () => (
 
 ## Showing the List of Revisions
 
-By default, the `<RevisionsButton>` component only shows the list of revisions when the user clicks on the button. If you want to always show the list of revisions, you can use the [`<RevisionListWithDetailsInDialog>`](https://marmelab.com/ra-enterprise/modules/ra-history#revisionlistwithdetailsindialog) component instead. 
+By default, the `<RevisionsButton>` component only shows the list of revisions when the user clicks on the button. If you want to always show the list of revisions, you can use the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog) component instead. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/RevisionListWithDetailsInDialog.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionListWithDetailsInDialog.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -203,4 +203,4 @@ export const ProductEdit = () => (
 );
 ```
 
-Check the [`<RevisionListWithDetailsInDialog>`](https://marmelab.com/ra-enterprise/modules/ra-history#revisionlistwithdetailsindialog) documentation for more details.
+Check the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog) documentation for more details.

--- a/docs/RevisionsButton.md
+++ b/docs/RevisionsButton.md
@@ -12,7 +12,7 @@ This button opens a menu with the list of revisions of the current record. When 
   Your browser does not support the video tag.
 </video>
 
-`<RevisionsButton>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-history`](https://react-admin-ee.marmelab.com/modules/ra-history).
+`<RevisionsButton>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-history`](https://react-admin-ee.marmelab.com/documentation/ra-history).
 
 ## Usage
 
@@ -83,8 +83,8 @@ The detail view of a revision includes a diff view to compare the current versio
 
 This element can grab the current record using `useRecordContext`, and the record from the revision selected by the user using `useReferenceRecordContext`. But instead of doing the diff by hand, you can use the two field diff components provided by `ra-history`:
 
--   [`<FieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#fielddiff) displays the diff of a given field. It accepts a react-admin Field component as child.
--   [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/modules/ra-history#smartfielddiff) displays the diff of a string field, and uses a word-by-word diffing algorithm to highlight the changes.
+-   [`<FieldDiff>`](https://react-admin-ee.marmelab.com/documentation/ra-history#fielddiff) displays the diff of a given field. It accepts a react-admin Field component as child.
+-   [`<SmartFieldDiff>`](https://react-admin-ee.marmelab.com/documentation/ra-history#smartfielddiff) displays the diff of a string field, and uses a word-by-word diffing algorithm to highlight the changes.
 
 So a custom diff view is usually a layout component with `<FieldDiff>` and `<SmartFieldDiff>` components as children:
 
@@ -169,7 +169,7 @@ const ProductEditActions = () => (
 
 ## Showing the List of Revisions
 
-By default, the `<RevisionsButton>` component only shows the list of revisions when the user clicks on the button. If you want to always show the list of revisions, you can use the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog) component instead. 
+By default, the `<RevisionsButton>` component only shows the list of revisions when the user clicks on the button. If you want to always show the list of revisions, you can use the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionlistwithdetailsindialog) component instead. 
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionListWithDetailsInDialog.mp4" type="video/mp4"/>
@@ -203,4 +203,4 @@ export const ProductEdit = () => (
 );
 ```
 
-Check the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionlistwithdetailsindialog) documentation for more details.
+Check the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionlistwithdetailsindialog) documentation for more details.

--- a/docs/RevisionsButton.md
+++ b/docs/RevisionsButton.md
@@ -8,7 +8,7 @@ title: "The RevisionsButton Component"
 This button opens a menu with the list of revisions of the current record. When users select a revision, it opens a diff view, allowing them to see the changes between the current version and the selected revision. The user can then revert to the selected revision by clicking on the "Revert" button.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/RevisionsButton.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -172,7 +172,7 @@ const ProductEditActions = () => (
 By default, the `<RevisionsButton>` component only shows the list of revisions when the user clicks on the button. If you want to always show the list of revisions, you can use the [`<RevisionListWithDetailsInDialog>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionlistwithdetailsindialog) component instead. 
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionListWithDetailsInDialog.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/RevisionListWithDetailsInDialog.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -255,7 +255,7 @@ export const PostEdit = () => (
 );
 ```
 
-`<SmartRichTextInput>` is available as part of the [ra-ai](https://react-admin-ee.marmelab.com/modules/ra-ai) enterprise package.
+`<SmartRichTextInput>` is available as part of the [ra-ai](https://react-admin-ee.marmelab.com/documentation/ra-ai) enterprise package.
 
 ## Lazy Loading
 

--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -234,8 +234,8 @@ const MyToolbar = ({ editorRef }) => (
 
 Modern AI tools can be a great help for editors. React-admin proposes an AI-powered writing assistant for the `<RichTextInput>` component, called [`<SmartRichTextInput>`](./SmartRichTextInput.md):
 
-<video controls playsinline muted loop poster="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.png" >
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -255,7 +255,7 @@ export const PostEdit = () => (
 );
 ```
 
-`<SmartRichTextInput>` is available as part of the [ra-ai](https://marmelab.com/ra-enterprise/modules/ra-ai) enterprise package.
+`<SmartRichTextInput>` is available as part of the [ra-ai](https://react-admin-ee.marmelab.com/modules/ra-ai) enterprise package.
 
 ## Lazy Loading
 

--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -234,8 +234,8 @@ const MyToolbar = ({ editorRef }) => (
 
 Modern AI tools can be a great help for editors. React-admin proposes an AI-powered writing assistant for the `<RichTextInput>` component, called [`<SmartRichTextInput>`](./SmartRichTextInput.md):
 
-<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Search.md
+++ b/docs/Search.md
@@ -5,7 +5,7 @@ title: "The Search Component"
 
 # `<Search>`
 
-This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/modules/ra-search), lets user do a site-wide search via a smart Omnibox.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/documentation/ra-search), lets user do a site-wide search via a smart Omnibox.
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
@@ -15,7 +15,7 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
 
 `<Search>` renders a global search input. It's designed to be integrated into the top `<AppBar>`.
 
-It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<Search>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://react-admin-ee.marmelab.com/modules/ra-search#addsearchmethod-helper).
+It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<Search>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://react-admin-ee.marmelab.com/documentation/ra-search#addsearchmethod-helper).
 
 ## Usage
 
@@ -76,7 +76,7 @@ export const dataProvider = addSearchMethod(baseDataProvider, [
 ]);
 ```
 
-Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/modules/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
+Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/documentation/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
 
 ### Option 1: With `<Layout>`
 

--- a/docs/Search.md
+++ b/docs/Search.md
@@ -8,8 +8,8 @@ title: "The Search Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/documentation/ra-search), lets user do a site-wide search via a smart Omnibox.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-demo.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-demo.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/Search.md
+++ b/docs/Search.md
@@ -5,17 +5,17 @@ title: "The Search Component"
 
 # `<Search>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://marmelab.com/ra-enterprise/modules/ra-search), lets user do a site-wide search via a smart Omnibox.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/modules/ra-search), lets user do a site-wide search via a smart Omnibox.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-demo.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-demo.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 `<Search>` renders a global search input. It's designed to be integrated into the top `<AppBar>`.
 
-It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<Search>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://marmelab.com/ra-enterprise/modules/ra-search#addsearchmethod-helper).
+It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<Search>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://react-admin-ee.marmelab.com/modules/ra-search#addsearchmethod-helper).
 
 ## Usage
 
@@ -27,7 +27,7 @@ The `<Search>` component is part of the `@react-admin/ra-search` package. To ins
 yarn add '@react-admin/ra-search'
 ```
 
-This requires a valid subscription to [React-admin Enterprise Edition](https://marmelab.com/ra-enterprise).
+This requires a valid subscription to [React-admin Enterprise Edition](https://react-admin-ee.marmelab.com).
 
 ### Implement `dataProvider.search()`
 
@@ -76,7 +76,7 @@ export const dataProvider = addSearchMethod(baseDataProvider, [
 ]);
 ```
 
-Check [the `ra-search` documentation](https://marmelab.com/ra-enterprise/modules/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
+Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/modules/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
 
 ### Option 1: With `<Layout>`
 

--- a/docs/SearchWithResult.md
+++ b/docs/SearchWithResult.md
@@ -5,14 +5,14 @@ title: "The SearchWithResult Component"
 
 # `<SearchWithResult>`
 
-This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/modules/ra-search), renders a search input and the search results directly below the input. It's ideal for dashboards or menu panels.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/documentation/ra-search), renders a search input and the search results directly below the input. It's ideal for dashboards or menu panels.
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
-It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<SearchWithResult>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://react-admin-ee.marmelab.com/modules/ra-search#addsearchmethod-helper).
+It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<SearchWithResult>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://react-admin-ee.marmelab.com/documentation/ra-search#addsearchmethod-helper).
 
 By default, `<SearchWithResult>` will group the search results by target, and show their `content.label` and `content.description`.
 
@@ -98,7 +98,7 @@ export const App = () => (
 );
 ```
 
-Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/modules/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
+Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/documentation/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
 
 ## Props
 
@@ -351,7 +351,7 @@ export const App = () => (
 
 ## Use It With SolarLayout
 
-The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/modules/ra-navigation#solarlayout) menu.
+The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#solarlayout) menu.
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>

--- a/docs/SearchWithResult.md
+++ b/docs/SearchWithResult.md
@@ -5,14 +5,14 @@ title: "The SearchWithResult Component"
 
 # `<SearchWithResult>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://marmelab.com/ra-enterprise/modules/ra-search), renders a search input and the search results directly below the input. It's ideal for dashboards or menu panels.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/modules/ra-search), renders a search input and the search results directly below the input. It's ideal for dashboards or menu panels.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-with-result-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
-It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<SearchWithResult>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://marmelab.com/ra-enterprise/modules/ra-search#addsearchmethod-helper).
+It relies on the `dataProvider` to provide a `search()` method, so you can use it with any search engine (Lucene, ElasticSearch, Solr, Algolia, Google Cloud Search, and many others). And if you don't have a search engine, no problem! `<SearchWithResult>` can also do the search across several resources [via parallel `dataProvider.getList()` queries](https://react-admin-ee.marmelab.com/modules/ra-search#addsearchmethod-helper).
 
 By default, `<SearchWithResult>` will group the search results by target, and show their `content.label` and `content.description`.
 
@@ -26,7 +26,7 @@ The `<SearchWithResult>` component is part of the `@react-admin/ra-search` packa
 yarn add '@react-admin/ra-search'
 ```
 
-This requires a valid subscription to [React-admin Enterprise Edition](https://marmelab.com/ra-enterprise).
+This requires a valid subscription to [React-admin Enterprise Edition](https://react-admin-ee.marmelab.com).
 
 ### Implement `dataProvider.search()`
 
@@ -98,7 +98,7 @@ export const App = () => (
 );
 ```
 
-Check [the `ra-search` documentation](https://marmelab.com/ra-enterprise/modules/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
+Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/modules/ra-search) to learn more about the input and output format of `dataProvider.search()`, as well as the possibilities to customize the `addSearchMethod`.
 
 ## Props
 
@@ -351,10 +351,10 @@ export const App = () => (
 
 ## Use It With SolarLayout
 
-The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://marmelab.com/ra-enterprise/modules/ra-navigation#solarlayout) menu.
+The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/modules/ra-navigation#solarlayout) menu.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/SearchWithResult.md
+++ b/docs/SearchWithResult.md
@@ -8,7 +8,7 @@ title: "The SearchWithResult Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component, part of [`ra-search`](https://react-admin-ee.marmelab.com/documentation/ra-search), renders a search input and the search results directly below the input. It's ideal for dashboards or menu panels.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-with-result-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -354,7 +354,7 @@ export const App = () => (
 The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#solarlayout) menu.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/ShowInDialogButton.md
+++ b/docs/ShowInDialogButton.md
@@ -5,11 +5,11 @@ title: "ShowInDialogButton"
 
 # `<ShowInDialogButton>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component renders a button opening a `<Show>` view inside a dialog, hence allowing to show a record without leaving the current view.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component renders a button opening a `<Show>` view inside a dialog, hence allowing to show a record without leaving the current view.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -25,7 +25,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://marmelab.com/ra-enterprise/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-showindialogbutton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://marmelab.com/ra-enterprise/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-showindialogbutton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, use the `<ShowInDialogButton>` component inside a `RecordContext` (in a `<Datagrid>`, in a `<Show>` or an `<Edit>` view).
 

--- a/docs/ShowInDialogButton.md
+++ b/docs/ShowInDialogButton.md
@@ -25,7 +25,7 @@ npm install --save @react-admin/ra-form-layout
 yarn add @react-admin/ra-form-layout
 ```
 
-**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/modules/ra-form-layout#createindialogbutton-editindialogbutton-and-showindialogbutton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
+**Tip**: [`ra-form-layout`](https://react-admin-ee.marmelab.com/documentation/ra-form-layout#createindialogbutton-editindialogbutton-and-showindialogbutton) is hosted in a private npm registry. You need to subscribe to one of the [Enterprise Edition](https://react-admin-ee.marmelab.com/) plans to access this package.
 
 Then, use the `<ShowInDialogButton>` component inside a `RecordContext` (in a `<Datagrid>`, in a `<Show>` or an `<Edit>` view).
 

--- a/docs/ShowInDialogButton.md
+++ b/docs/ShowInDialogButton.md
@@ -8,8 +8,8 @@ title: "ShowInDialogButton"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component renders a button opening a `<Show>` view inside a dialog, hence allowing to show a record without leaving the current view.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/InDialogButtons.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/ShowLive.md
+++ b/docs/ShowLive.md
@@ -5,7 +5,7 @@ title: "ShowLive"
 
 # `<ShowLive>`
 
-`<ShowLive>` is an [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component that  renders a Show page. It shows a notification and refreshes the page when the record is updated by another user. Also, it displays a warning when the record is deleted by another user.
+`<ShowLive>` is an [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component that  renders a Show page. It shows a notification and refreshes the page when the record is updated by another user. Also, it displays a warning when the record is deleted by another user.
 
 ![ShowLive](./img/ShowLive.png)
 

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -698,7 +698,7 @@ Check [the RBAC `<SimpleForm>` component](./AuthRBAC.md#simpleform) documentatio
 
 ## Versioning
 
-By default, `<SimpleForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep the previous version, you can use the [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#simpleformwithrevision) component instead:
+By default, `<SimpleForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep the previous version, you can use the [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/documentation/ra-history#simpleformwithrevision) component instead:
 
 ```diff
 // in src/posts/PostCreate.js
@@ -723,7 +723,7 @@ This won't change the look and feel of the form. But when the user submits the f
 
 ![SimpleFormWithRevision](https://react-admin-ee.marmelab.com/modules/assets/ra-history/latest/SimpleFormWithRevision.png)
 
-After submitting this dialog, react-admin will update the main record and **create a new revision**. A revision represents the state of the record at a given point in time. It is immutable. A revision also records the date, author, and reason of the change. Past revisions can be accessed via the [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionsbutton) component.
+After submitting this dialog, react-admin will update the main record and **create a new revision**. A revision represents the state of the record at a given point in time. It is immutable. A revision also records the date, author, and reason of the change. Past revisions can be accessed via the [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionsbutton) component.
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
@@ -755,7 +755,7 @@ export const PostEdit = () => (
 );
 ```
 
-Check the [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#simpleformwithrevision) and [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionsbutton) documentation for more details.
+Check the [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/documentation/ra-history#simpleformwithrevision) and [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionsbutton) documentation for more details.
 
 ## Linking Two Inputs
 

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -698,7 +698,7 @@ Check [the RBAC `<SimpleForm>` component](./AuthRBAC.md#simpleform) documentatio
 
 ## Versioning
 
-By default, `<SimpleForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep the previous version, you can use the [`<SimpleFormWithRevision>`](https://marmelab.com/ra-enterprise/modules/ra-history#simpleformwithrevision) component instead:
+By default, `<SimpleForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep the previous version, you can use the [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#simpleformwithrevision) component instead:
 
 ```diff
 // in src/posts/PostCreate.js
@@ -721,12 +721,12 @@ export const PostCreate = () => (
 
 This won't change the look and feel of the form. But when the user submits the form, they will see a dialog asking them for the reason of the change.
 
-![SimpleFormWithRevision](https://marmelab.com/ra-enterprise/modules/assets/ra-history/latest/SimpleFormWithRevision.png)
+![SimpleFormWithRevision](https://react-admin-ee.marmelab.com/modules/assets/ra-history/latest/SimpleFormWithRevision.png)
 
-After submitting this dialog, react-admin will update the main record and **create a new revision**. A revision represents the state of the record at a given point in time. It is immutable. A revision also records the date, author, and reason of the change. Past revisions can be accessed via the [`<RevisionsButton>`](https://marmelab.com/ra-enterprise/modules/ra-history#revisionsbutton) component.
+After submitting this dialog, react-admin will update the main record and **create a new revision**. A revision represents the state of the record at a given point in time. It is immutable. A revision also records the date, author, and reason of the change. Past revisions can be accessed via the [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionsbutton) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -755,7 +755,7 @@ export const PostEdit = () => (
 );
 ```
 
-Check the [`<SimpleFormWithRevision>`](https://marmelab.com/ra-enterprise/modules/ra-history#simpleformwithrevision) and [`<RevisionsButton>`](https://marmelab.com/ra-enterprise/modules/ra-history#revisionsbutton) documentation for more details.
+Check the [`<SimpleFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#simpleformwithrevision) and [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/modules/ra-history#revisionsbutton) documentation for more details.
 
 ## Linking Two Inputs
 

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -721,12 +721,12 @@ export const PostCreate = () => (
 
 This won't change the look and feel of the form. But when the user submits the form, they will see a dialog asking them for the reason of the change.
 
-![SimpleFormWithRevision](https://react-admin-ee.marmelab.com/modules/assets/ra-history/latest/SimpleFormWithRevision.png)
+![SimpleFormWithRevision](https://react-admin-ee.marmelab.com/assets/ra-history/latest/SimpleFormWithRevision.png)
 
 After submitting this dialog, react-admin will update the main record and **create a new revision**. A revision represents the state of the record at a given point in time. It is immutable. A revision also records the date, author, and reason of the change. Past revisions can be accessed via the [`<RevisionsButton>`](https://react-admin-ee.marmelab.com/documentation/ra-history#revisionsbutton) component.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/RevisionsButton.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/RevisionsButton.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/SmartRichTextInput.md
+++ b/docs/SmartRichTextInput.md
@@ -5,10 +5,10 @@ title: "The SmartRichTextInput Component"
 
 # `<SmartRichTextInput>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative to [`<RichTextInput>`](./RichTextInput.md) that allows users to quickly fix, improve, or complete the textarea content using an AI backend.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative to [`<RichTextInput>`](./RichTextInput.md) that allows users to quickly fix, improve, or complete the textarea content using an AI backend.
 
-<video controls playsinline muted loop poster="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.png" >
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/SmartRichTextInput.md
+++ b/docs/SmartRichTextInput.md
@@ -7,8 +7,8 @@ title: "The SmartRichTextInput Component"
 
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative to [`<RichTextInput>`](./RichTextInput.md) that allows users to quickly fix, improve, or complete the textarea content using an AI backend.
 
-<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.png" >
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/SmartRichTextInput.mp4" type="video/mp4" />
+<video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.png" >
+  <source src="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/SolarLayout.md
+++ b/docs/SolarLayout.md
@@ -8,14 +8,14 @@ title: "The SolarLayout Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component is an alternative application layout without top bar, and using a narrow menu to maximize the usable screen real estate. The menu items can reveal a secondary panel to show sub menus, preference forms, a search engine, etc. Ideal for applications with a large number of resources.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-solar-layout.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-solar-layout.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
 On mobile, it shows the AppBar to allow opening the navigation menu:
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-solar-layout-small.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-solar-layout-small.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -65,7 +65,7 @@ However, you can customize these default app locations in your CRUD pages, and y
 
 ## `appBar`
 
-![Screenshot demonstrating the SolarLayout component with a custom appBar](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/solar-layout-with-custom-app-bar.png)
+![Screenshot demonstrating the SolarLayout component with a custom appBar](https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/solar-layout-with-custom-app-bar.png)
 
 You can customize the AppBar that appears on Mobile by setting the `appBar` prop. For instance, here's how you could customize its colors and add some extra content to its far right:
 
@@ -608,7 +608,7 @@ export const App = () => (
 
 The `sx` prop allows you to customize the menu styles using a MUI [SX](./SX.md) object:
 
-![Screenshot demonstrating SolarMenu with a pink background](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/solar-menu-sx-pink.png)
+![Screenshot demonstrating SolarMenu with a pink background](https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/solar-menu-sx-pink.png)
 
 For instance, here is how to change the background color of the menu:
 
@@ -868,7 +868,7 @@ export const App = () => (
 The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#solarlayout) menu.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/SolarLayout.md
+++ b/docs/SolarLayout.md
@@ -19,7 +19,7 @@ On mobile, it shows the AppBar to allow opening the navigation menu:
   Your browser does not support the video tag.
 </video>
 
-`<SolarLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/modules/ra-navigation#solarlayout) package.
+`<SolarLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/documentation/ra-navigation#solarlayout) package.
 
 ## Usage
 
@@ -865,7 +865,7 @@ export const App = () => (
 
 ## Use It With `<SearchWithResult>`
 
-The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/modules/ra-navigation#solarlayout) menu.
+The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/documentation/ra-navigation#solarlayout) menu.
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>

--- a/docs/SolarLayout.md
+++ b/docs/SolarLayout.md
@@ -5,21 +5,21 @@ title: "The SolarLayout Component"
 
 # `<SolarLayout>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component is an alternative application layout without top bar, and using a narrow menu to maximize the usable screen real estate. The menu items can reveal a secondary panel to show sub menus, preference forms, a search engine, etc. Ideal for applications with a large number of resources.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component is an alternative application layout without top bar, and using a narrow menu to maximize the usable screen real estate. The menu items can reveal a secondary panel to show sub menus, preference forms, a search engine, etc. Ideal for applications with a large number of resources.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-solar-layout.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-solar-layout.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
 On mobile, it shows the AppBar to allow opening the navigation menu:
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-solar-layout-small.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-solar-layout-small.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
-`<SolarLayout>` is part of the [ra-navigation](https://marmelab.com/ra-enterprise/modules/ra-navigation#solarlayout) package.
+`<SolarLayout>` is part of the [ra-navigation](https://react-admin-ee.marmelab.com/modules/ra-navigation#solarlayout) package.
 
 ## Usage
 
@@ -65,7 +65,7 @@ However, you can customize these default app locations in your CRUD pages, and y
 
 ## `appBar`
 
-![Screenshot demonstrating the SolarLayout component with a custom appBar](https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/solar-layout-with-custom-app-bar.png)
+![Screenshot demonstrating the SolarLayout component with a custom appBar](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/solar-layout-with-custom-app-bar.png)
 
 You can customize the AppBar that appears on Mobile by setting the `appBar` prop. For instance, here's how you could customize its colors and add some extra content to its far right:
 
@@ -608,7 +608,7 @@ export const App = () => (
 
 The `sx` prop allows you to customize the menu styles using a MUI [SX](./SX.md) object:
 
-![Screenshot demonstrating SolarMenu with a pink background](https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/solar-menu-sx-pink.png)
+![Screenshot demonstrating SolarMenu with a pink background](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/solar-menu-sx-pink.png)
 
 For instance, here is how to change the background color of the menu:
 
@@ -865,10 +865,10 @@ export const App = () => (
 
 ## Use It With `<SearchWithResult>`
 
-The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://marmelab.com/ra-enterprise/modules/ra-navigation#solarlayout) menu.
+The `<SearchWithResult>` component works perfectly when used inside the [`<SolarLayout>`](https://react-admin-ee.marmelab.com/modules/ra-navigation#solarlayout) menu.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-search-with-result-solar-layout-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/StackedFilters.md
+++ b/docs/StackedFilters.md
@@ -5,11 +5,11 @@ title: "The StackedFilters Component"
 
 # `<StackedFilters>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component provides an alternative filter UI for `<List>` pages. It introduces the concept of operators to allow richer filtering.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component provides an alternative filter UI for `<List>` pages. It introduces the concept of operators to allow richer filtering.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/webm"/>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-form-layout/latest/stackedfilters-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -371,7 +371,7 @@ const MyFilterConfig: FiltersConfig = {
 This component is responsible for rendering the filtering form, and is used internally by `<StackedFilters>`. You can use it if you want to use the filter form without the `<FilterButton>` component, e.g. to always show the filter form.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/stacked-filter-form-preview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/stacked-filter-form-preview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/StackedFilters.md
+++ b/docs/StackedFilters.md
@@ -8,8 +8,8 @@ title: "The StackedFilters Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component provides an alternative filter UI for `<List>` pages. It introduces the concept of operators to allow richer filtering.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/webm"/>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-form-layout/latest/stackedfilters-overview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/webm"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -371,7 +371,7 @@ const MyFilterConfig: FiltersConfig = {
 This component is responsible for rendering the filtering form, and is used internally by `<StackedFilters>`. You can use it if you want to use the filter form without the `<FilterButton>` component, e.g. to always show the filter form.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/stacked-filter-form-preview.mp4" type="video/mp4"/>
+  <source src="https://react-admin-ee.marmelab.com/assets/stacked-filter-form-preview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -878,7 +878,7 @@ Check [the RBAC `<TabbedForm>` component](./AuthRBAC.md#tabbedform) documentatio
 
 ## Versioning
 
-By default, `<TabbedForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep track of the previous versions of the record, you can use the [`<TabbedFormWithRevision>`](https://marmelab.com/ra-enterprise/modules/ra-history#tabbedformwithrevision) component instead.
+By default, `<TabbedForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep track of the previous versions of the record, you can use the [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#tabbedformwithrevision) component instead.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/TabbedFormWithRevision.mp4" type="video/mp4"/>
@@ -909,7 +909,7 @@ const ProductEdit = () => (
 );
 ```
 
-Check the [`<TabbedFormWithRevision>`](https://marmelab.com/ra-enterprise/modules/ra-history#tabbedformwithrevision) documentation for more details.
+Check the [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#tabbedformwithrevision) documentation for more details.
 
 ## Linking Two Inputs
 

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -878,7 +878,7 @@ Check [the RBAC `<TabbedForm>` component](./AuthRBAC.md#tabbedform) documentatio
 
 ## Versioning
 
-By default, `<TabbedForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep track of the previous versions of the record, you can use the [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#tabbedformwithrevision) component instead.
+By default, `<TabbedForm>` updates the current record (via `dataProvider.update()`), so the previous version of the record is lost. If you want to keep track of the previous versions of the record, you can use the [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/documentation/ra-history#tabbedformwithrevision) component instead.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/TabbedFormWithRevision.mp4" type="video/mp4"/>
@@ -909,7 +909,7 @@ const ProductEdit = () => (
 );
 ```
 
-Check the [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/modules/ra-history#tabbedformwithrevision) documentation for more details.
+Check the [`<TabbedFormWithRevision>`](https://react-admin-ee.marmelab.com/documentation/ra-history#tabbedformwithrevision) documentation for more details.
 
 ## Linking Two Inputs
 

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -155,7 +155,7 @@ React-admin provides 3 built-in layout components, and you can easily create you
 
 For instance, you can replace the default `<Layout>`, which uses a sidebar for navigation, with a [`<ContainerLayout>`](./ContainerLayout.md), which uses a top bar instead.
 
-![Container layout](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/container-layout.png)
+![Container layout](https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/container-layout.png)
 
 ```jsx
 import { Admin, Resource } from 'react-admin';

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -155,7 +155,7 @@ React-admin provides 3 built-in layout components, and you can easily create you
 
 For instance, you can replace the default `<Layout>`, which uses a sidebar for navigation, with a [`<ContainerLayout>`](./ContainerLayout.md), which uses a top bar instead.
 
-![Container layout](https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/container-layout.png)
+![Container layout](https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/container-layout.png)
 
 ```jsx
 import { Admin, Resource } from 'react-admin';

--- a/docs/TimeInput.md
+++ b/docs/TimeInput.md
@@ -56,7 +56,7 @@ import { TimeInput } from 'react-admin';
 
 ## Material UI
 
-[React-admin Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> proposes an alternative `<TimeInput>` styled with Material UI. 
+[React-admin Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> proposes an alternative `<TimeInput>` styled with Material UI. 
 
 ![TimeInput with Material UI](./img/TimeInput-MUI.png)
 

--- a/docs/TreeInput.md
+++ b/docs/TreeInput.md
@@ -5,7 +5,7 @@ title: "The TreeInput Component"
 
 # `<TreeInput>` Component
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component allows to select one or several nodes from a tree.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows to select one or several nodes from a tree.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/ReferenceNodeInput-TreeInput-basic.webm" type="video/webm"/>

--- a/docs/TreeWithDetails.md
+++ b/docs/TreeWithDetails.md
@@ -5,7 +5,7 @@ title: "The TreeWithDetails Component"
 
 # `<TreeWithDetails>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers a replacement for the `<List>` component when the records form **tree structures** like directories, categories, etc. `<TreeWithDetails>` renders a tree structure and the show view/edition form in the same page.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers a replacement for the `<List>` component when the records form **tree structures** like directories, categories, etc. `<TreeWithDetails>` renders a tree structure and the show view/edition form in the same page.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/treewithdetails.webm" type="video/webm"/>
@@ -68,7 +68,7 @@ const App = () => (
 );
 ```
 
-Check [the `ra-tree` documentation](https://marmelab.com/ra-enterprise/modules/ra-tree#treewithdetails-component) for more details.
+Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/modules/ra-tree#treewithdetails-component) for more details.
 
 ## Selecting a Node
 

--- a/docs/TreeWithDetails.md
+++ b/docs/TreeWithDetails.md
@@ -68,7 +68,7 @@ const App = () => (
 );
 ```
 
-Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/modules/ra-tree#treewithdetails-component) for more details.
+Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/documentation/ra-tree#treewithdetails-component) for more details.
 
 ## Selecting a Node
 

--- a/docs/WizardForm.md
+++ b/docs/WizardForm.md
@@ -8,8 +8,8 @@ title: "WizardForm"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative layout for large Create forms, allowing users to enter data step-by-step.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-wizard-form-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-wizard-form-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-wizard-form-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-wizard-form-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/WizardForm.md
+++ b/docs/WizardForm.md
@@ -5,11 +5,11 @@ title: "WizardForm"
 
 # `<WizardForm>`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> component offers an alternative layout for large Create forms, allowing users to enter data step-by-step.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component offers an alternative layout for large Create forms, allowing users to enter data step-by-step.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-wizard-form-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-wizard-form-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-wizard-form-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-wizard-form-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -21,7 +21,7 @@
             </li>
             <li>
                 <a
-                    href="https://marmelab.com/ra-enterprise/"
+                    href="https://react-admin-ee.marmelab.com/"
                     style="color: #f0c070"
                     >Enterprise Edition</a
                 >

--- a/docs/canAccess.md
+++ b/docs/canAccess.md
@@ -5,7 +5,7 @@ title: "The canAccess helper"
 
 # `canAccess`
 
-This helper function, part of [the ra-rbac module](https://marmelab.com/ra-enterprise/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, can check if the current permissions allow the user to execute an action on a resource (and optionally a record). It requires the user `permissions` array, so it must be used in conjunction with `usePermissions`.
+This helper function, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, can check if the current permissions allow the user to execute an action on a resource (and optionally a record). It requires the user `permissions` array, so it must be used in conjunction with `usePermissions`.
 
 ## Usage
 

--- a/docs/canAccess.md
+++ b/docs/canAccess.md
@@ -5,7 +5,7 @@ title: "The canAccess helper"
 
 # `canAccess`
 
-This helper function, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, can check if the current permissions allow the user to execute an action on a resource (and optionally a record). It requires the user `permissions` array, so it must be used in conjunction with `usePermissions`.
+This helper function, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/documentation/ra-rbac)<img class="icon" src="./img/premium.svg" />, can check if the current permissions allow the user to execute an action on a resource (and optionally a record). It requires the user `permissions` array, so it must be used in conjunction with `usePermissions`.
 
 ## Usage
 

--- a/docs/useCanAccess.md
+++ b/docs/useCanAccess.md
@@ -5,7 +5,7 @@ title: "useCanAccess"
 
 # `useCanAccess`
 
-This hook, part of [the ra-rbac module](https://marmelab.com/ra-enterprise/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, calls the `authProvider.getPermissions()` to get the role definitions, then checks whether the requested action and resource are allowed for the current user. 
+This hook, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, calls the `authProvider.getPermissions()` to get the role definitions, then checks whether the requested action and resource are allowed for the current user. 
 
 ## Usage
 

--- a/docs/useCanAccess.md
+++ b/docs/useCanAccess.md
@@ -5,7 +5,7 @@ title: "useCanAccess"
 
 # `useCanAccess`
 
-This hook, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, calls the `authProvider.getPermissions()` to get the role definitions, then checks whether the requested action and resource are allowed for the current user. 
+This hook, part of [the ra-rbac module](https://react-admin-ee.marmelab.com/documentation/ra-rbac)<img class="icon" src="./img/premium.svg" />, calls the `authProvider.getPermissions()` to get the role definitions, then checks whether the requested action and resource are allowed for the current user. 
 
 ## Usage
 

--- a/docs/useDefineAppLocation.md
+++ b/docs/useDefineAppLocation.md
@@ -5,11 +5,11 @@ title: "useDefineAppLocation"
 
 # `useDefineAppLocation`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook lets you define the app location for a page, used by components like [`<Breadcrumb>`](./Breadcrumb.md) and [`<IconMenu>`](./IconMenu.md) to render the current location.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook lets you define the app location for a page, used by components like [`<Breadcrumb>`](./Breadcrumb.md) and [`<IconMenu>`](./IconMenu.md) to render the current location.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/useDefineAppLocation.md
+++ b/docs/useDefineAppLocation.md
@@ -8,8 +8,8 @@ title: "useDefineAppLocation"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook lets you define the app location for a page, used by components like [`<Breadcrumb>`](./Breadcrumb.md) and [`<IconMenu>`](./IconMenu.md) to render the current location.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/breadcumb-nested-resource.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-navigation/latest/breadcumb-nested-resource.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/useGetListLive.md
+++ b/docs/useGetListLive.md
@@ -5,7 +5,7 @@ title: "useGetListLive"
 
 # `useGetListLive`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook, alternative to [`useGetList`](./useGetList.md), subscribes to live updates on the record list.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook, alternative to [`useGetList`](./useGetList.md), subscribes to live updates on the record list.
 
 ## Usage
 

--- a/docs/useGetLock.md
+++ b/docs/useGetLock.md
@@ -5,7 +5,7 @@ title: "useGetLock"
 
 # `useGetLock`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook gets the lock status for a record. It calls `dataProvider.getLock()` on mount.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook gets the lock status for a record. It calls `dataProvider.getLock()` on mount.
 
 ## Usage
 

--- a/docs/useGetLockLive.md
+++ b/docs/useGetLockLive.md
@@ -5,7 +5,7 @@ title: "useGetLockLive"
 
 # `useGetLockLive`
 
-Use the `useGetLockLive()` hook to get the lock status in real time. This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook calls `dataProvider.getLock()` for the current record on mount, and subscribes to live updates on the `lock/[resource]/[id]` topic.
+Use the `useGetLockLive()` hook to get the lock status in real time. This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook calls `dataProvider.getLock()` for the current record on mount, and subscribes to live updates on the `lock/[resource]/[id]` topic.
 
 This means that if the lock is acquired or released by another user while the current user is on the page, the return value will be updated.
 

--- a/docs/useGetLocks.md
+++ b/docs/useGetLocks.md
@@ -5,7 +5,7 @@ title: "useGetLocks"
 
 # `useGetLocks`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook gets all the locks for a given resource. Calls `dataProvider.getLocks()` on mount.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook gets all the locks for a given resource. Calls `dataProvider.getLocks()` on mount.
 
 ## Usage
 

--- a/docs/useGetLocksLive.md
+++ b/docs/useGetLocksLive.md
@@ -5,7 +5,7 @@ title: "useGetLocksLive"
 
 # `useGetLocksLive`
 
-Use the `useGetLocksLive` hook to get the locks in real time. This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook calls `dataProvider.getLocks()` for the current resource on mount, and subscribes to live updates on the `lock/[resource]` topic.
+Use the `useGetLocksLive` hook to get the locks in real time. This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook calls `dataProvider.getLocks()` for the current resource on mount, and subscribes to live updates on the `lock/[resource]` topic.
 
 This means that if a lock is acquired or released by another user while the current user is on the page, the return value will be updated.
 

--- a/docs/useGetOneLive.md
+++ b/docs/useGetOneLive.md
@@ -5,7 +5,7 @@ title: "useGetOneLive"
 
 # `useGetOneLive`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook, alternative to [`useGetOne`](./useGetOne.md), subscribes to live updates on the record.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook, alternative to [`useGetOne`](./useGetOne.md), subscribes to live updates on the record.
 
 ## Usage
 

--- a/docs/useGetTree.md
+++ b/docs/useGetTree.md
@@ -5,13 +5,13 @@ title: "useGetTree"
 
 # `useGetTree`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook is exposed by [the `ra-tree` module](https://marmelab.com/ra-enterprise/modules/ra-tree), a package dedicated to handling tree structures. It's ideal for fetching a tree structure from the API, e.g. a list of categories.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook is exposed by [the `ra-tree` module](https://react-admin-ee.marmelab.com/modules/ra-tree), a package dedicated to handling tree structures. It's ideal for fetching a tree structure from the API, e.g. a list of categories.
 
 It calls `dataProvider.getTree()` (one of the new `dataProvider` methods supported by `ra-tree`) when the component mounts, and returns the tree nodes in a flat array.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-tree-overview.webm" type="video/webm" />
-  <source src="https://marmelab.com/ra-enterprise/modules/assets/ra-tree-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-tree-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-tree-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
@@ -66,4 +66,4 @@ These methods return Promises for `TreeRecord` objects.
 -   `addChildNode(resource, { parentId, data })`
 -   `deleteBranch(resource, { id, data })`: `id` is the identifier of the node to remove, and `data` its content
 
-Check [the `ra-tree` documentation](https://marmelab.com/ra-enterprise/modules/ra-tree) for more details.
+Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/modules/ra-tree) for more details.

--- a/docs/useGetTree.md
+++ b/docs/useGetTree.md
@@ -10,8 +10,8 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
 It calls `dataProvider.getTree()` (one of the new `dataProvider` methods supported by `ra-tree`) when the component mounts, and returns the tree nodes in a flat array.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-tree-overview.webm" type="video/webm" />
-  <source src="https://react-admin-ee.marmelab.com/modules/assets/ra-tree-overview.mp4" type="video/mp4" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-tree-overview.webm" type="video/webm" />
+  <source src="https://react-admin-ee.marmelab.com/assets/ra-tree-overview.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 

--- a/docs/useGetTree.md
+++ b/docs/useGetTree.md
@@ -5,7 +5,7 @@ title: "useGetTree"
 
 # `useGetTree`
 
-This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook is exposed by [the `ra-tree` module](https://react-admin-ee.marmelab.com/modules/ra-tree), a package dedicated to handling tree structures. It's ideal for fetching a tree structure from the API, e.g. a list of categories.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook is exposed by [the `ra-tree` module](https://react-admin-ee.marmelab.com/documentation/ra-tree), a package dedicated to handling tree structures. It's ideal for fetching a tree structure from the API, e.g. a list of categories.
 
 It calls `dataProvider.getTree()` (one of the new `dataProvider` methods supported by `ra-tree`) when the component mounts, and returns the tree nodes in a flat array.
 
@@ -66,4 +66,4 @@ These methods return Promises for `TreeRecord` objects.
 -   `addChildNode(resource, { parentId, data })`
 -   `deleteBranch(resource, { id, data })`: `id` is the identifier of the node to remove, and `data` its content
 
-Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/modules/ra-tree) for more details.
+Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/documentation/ra-tree) for more details.

--- a/docs/useLock.md
+++ b/docs/useLock.md
@@ -5,7 +5,7 @@ title: "useLock"
 
 # `useLock`
 
-`useLock` is a low-level [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook that returns a callback to call `dataProvider.lock()`, leveraging react-query's `useMutation`.
+`useLock` is a low-level [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook that returns a callback to call `dataProvider.lock()`, leveraging react-query's `useMutation`.
 
 ## Usage
 

--- a/docs/useLockOnCall.md
+++ b/docs/useLockOnCall.md
@@ -5,7 +5,7 @@ title: "useLockOnCall"
 
 # `useLockOnCall`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook gets a callback to lock a record and get a mutation state.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook gets a callback to lock a record and get a mutation state.
 
 `useLockOnCall` calls `dataProvider.lock()` when the callback is called. It relies on `authProvider.getIdentity()` to get the identity of the current user. It guesses the current `resource` and `recordId` from the context (or the route) if not provided. It releases the lock when the component unmounts by calling `dataProvider.unlock()`.
 

--- a/docs/useLockOnMount.md
+++ b/docs/useLockOnMount.md
@@ -5,7 +5,7 @@ title: "useLockOnMount"
 
 # `useLockOnMount`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook locks the current record on mount.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook locks the current record on mount.
 
 `useLockOnMount` calls `dataProvider.lock()` on mount and `dataProvider.unlock()` on unmount to lock and unlock the record. It relies on `authProvider.getIdentity()` to get the identity of the current user. It guesses the current `resource` and `recordId` from the context (or the route) if not provided.
 

--- a/docs/usePermissions.md
+++ b/docs/usePermissions.md
@@ -91,7 +91,7 @@ const GrantAdminPermissionsButton = () => {
 
 ## RBAC
 
-When using [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, the `usePermissions` hook returns an array of permissions.
+When using [the ra-rbac module](https://react-admin-ee.marmelab.com/documentation/ra-rbac)<img class="icon" src="./img/premium.svg" />, the `usePermissions` hook returns an array of permissions.
 
 ```jsx
 import { usePermissions } from "@react-admin/ra-rbac";

--- a/docs/usePermissions.md
+++ b/docs/usePermissions.md
@@ -91,7 +91,7 @@ const GrantAdminPermissionsButton = () => {
 
 ## RBAC
 
-When using [the ra-rbac module](https://marmelab.com/ra-enterprise/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, the `usePermissions` hook returns an array of permissions.
+When using [the ra-rbac module](https://react-admin-ee.marmelab.com/modules/ra-rbac)<img class="icon" src="./img/premium.svg" />, the `usePermissions` hook returns an array of permissions.
 
 ```jsx
 import { usePermissions } from "@react-admin/ra-rbac";

--- a/docs/usePublish.md
+++ b/docs/usePublish.md
@@ -5,7 +5,7 @@ title: "usePublish"
 
 # `usePublish`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook returns a callback to publish an event on a topic. The callback returns a promise that resolves when the event is published.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook returns a callback to publish an event on a topic. The callback returns a promise that resolves when the event is published.
 
 `usePublish` calls `dataProvider.publish()` to publish the event. It leverages react-query's `useMutation` hook to provide a callback.
 

--- a/docs/useSubscribe.md
+++ b/docs/useSubscribe.md
@@ -5,7 +5,7 @@ title: "useSubscribe"
 
 # `useSubscribe`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook subscribes to the events from a topic on mount (and unsubscribe on unmount).
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook subscribes to the events from a topic on mount (and unsubscribe on unmount).
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/useSubscribe.webm" type="video/webm"/>

--- a/docs/useSubscribeCallback.md
+++ b/docs/useSubscribeCallback.md
@@ -5,7 +5,7 @@ title: "useSubscribeCallback"
 
 # `useSubscribeCallback`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook gets a callback to subscribe to events on a topic and optionally unsubscribe on unmount.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook gets a callback to subscribe to events on a topic and optionally unsubscribe on unmount.
 
 This is useful to start a subscription from an event handler, like a button click.
 

--- a/docs/useSubscribeToRecord.md
+++ b/docs/useSubscribeToRecord.md
@@ -5,7 +5,7 @@ title: "useSubscribeToRecord"
 
 # `useSubscribeToRecord`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook is a specialized version of [`useSubscribe`](./useSubscribe.md) that subscribes to events concerning a single record.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook is a specialized version of [`useSubscribe`](./useSubscribe.md) that subscribes to events concerning a single record.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/useSubscribeToRecord.webm" type="video/webm"/>

--- a/docs/useSubscribeToRecordList.md
+++ b/docs/useSubscribeToRecordList.md
@@ -5,7 +5,7 @@ title: "useSubscribeToRecordList"
 
 # `useSubscribeToRecordList`
 
-This [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook is a  specialized version of [`useSubscribe`](./useSubscribe.md) that subscribes to events concerning a list of records.
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook is a  specialized version of [`useSubscribe`](./useSubscribe.md) that subscribes to events concerning a list of records.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/useSubscribeToRecordList.webm" type="video/webm"/>

--- a/docs/useUnlock.md
+++ b/docs/useUnlock.md
@@ -5,7 +5,7 @@ title: "useUnlock"
 
 # `useUnlock`
 
-`useUnlock` is a low-level [Enterprise Edition](https://marmelab.com/ra-enterprise)<img class="icon" src="./img/premium.svg" /> hook that returns a callback to call `dataProvider.unlock()`, leveraging react-query's `useMutation`.
+`useUnlock` is a low-level [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> hook that returns a callback to call `dataProvider.unlock()`, leveraging react-query's `useMutation`.
 
 ## Usage
 

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -97,7 +97,7 @@ export const Error = (
                                     </li>
                                     <li>
                                         Get help from the core team via{' '}
-                                        <a href="https://marmelab.com/ra-enterprise/#fromsww">
+                                        <a href="https://react-admin-ee.marmelab.com/#fromsww">
                                             react-admin Enterprise Edition
                                         </a>
                                     </li>

--- a/packages/react-admin/README.md
+++ b/packages/react-admin/README.md
@@ -167,7 +167,7 @@ And then browse to the URL displayed in your console.
 
 ## Support
 
-You can get professional support from Marmelab via [React-Admin Enterprise Edition](https://marmelab.com/ra-enterprise), or community support via [StackOverflow](https://stackoverflow.com/questions/tagged/react-admin). 
+You can get professional support from Marmelab via [React-Admin Enterprise Edition](https://react-admin-ee.marmelab.com), or community support via [StackOverflow](https://stackoverflow.com/questions/tagged/react-admin). 
 
 ## Versions In This Repository
 


### PR DESCRIPTION
The ra-enterprise website has a new domain. This PR updates all the links in the documentation