### PR TITLE
Restore List Scroll Position on Edit and Create Views side effects

### DIFF
--- a/packages/ra-core/src/routing/index.ts
+++ b/packages/ra-core/src/routing/index.ts
@@ -6,5 +6,6 @@ export * from './useBasename';
 export * from './useCreatePath';
 export * from './useRedirect';
 export * from './useScrollToTop';
+export * from './useRestoreScrollPosition';
 export * from './types';
 export * from './TestMemoryRouter';

--- a/packages/ra-core/src/routing/useRedirect.ts
+++ b/packages/ra-core/src/routing/useRedirect.ts
@@ -71,7 +71,7 @@ export const useRedirect = () => {
             } else {
                 // redirection to an internal link
                 navigate(createPath({ resource, id, type: redirectTo }), {
-                    state: { _scrollToTop: true, ...state },
+                    state: { _scrollToTop: redirectTo !== 'list', ...state },
                 });
                 return;
             }

--- a/packages/ra-core/src/routing/useRestoreScrollPosition.ts
+++ b/packages/ra-core/src/routing/useRestoreScrollPosition.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { useStore } from '../store';
+import { debounce } from 'lodash';
+
+/**
+ * A hook that tracks the scroll position and restores it when the component mounts.
+ * @param key The key under which to store the scroll position in the store
+ * @param debounceMs The debounce time in milliseconds
+ *
+ * @example
+ * import { ListBase, useRestoreScrollPosition } from 'ra-core';
+ *
+ * const MyCustomList = (props) => {
+ *    useRestoreScrollPosition('my-list');
+ *   return <ListBase {...props} />;
+ * };
+ */
+export const useRestoreScrollPosition = (key: string, debounceMs = 250) => {
+    const position = useTrackScrollPosition(key, debounceMs);
+
+    useEffect(() => {
+        if (position != null) {
+            window.scrollTo(0, position);
+        }
+        // We only want to run this effect on mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+};
+
+export const useTrackScrollPosition = (key: string, debounceMs = 250) => {
+    const [position, setPosition] = useStore(key);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+        const handleScroll = debounce(() => {
+            setPosition(window.scrollY);
+        }, debounceMs);
+
+        window.addEventListener('scroll', handleScroll);
+
+        return () => {
+            window.removeEventListener('scroll', handleScroll);
+        };
+    }, [debounceMs, setPosition]);
+
+    return position;
+};

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -84,7 +84,7 @@ export const List = <RecordType extends RaRecord = any>({
         sort={sort}
         storeKey={storeKey}
     >
-        <ListView<RecordType> {...rest} />
+        <ListView<RecordType> storeKey={storeKey} {...rest} />
     </ListBase>
 );
 

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -5,7 +5,12 @@ import PropTypes from 'prop-types';
 import { SxProps } from '@mui/system';
 import Card from '@mui/material/Card';
 import clsx from 'clsx';
-import { ComponentPropType, useListContext, RaRecord } from 'ra-core';
+import {
+    ComponentPropType,
+    useListContext,
+    useRestoreScrollPosition,
+    RaRecord,
+} from 'ra-core';
 
 import { Title, TitlePropType } from '../layout/Title';
 import { ListToolbar } from './ListToolbar';
@@ -33,6 +38,7 @@ export const ListView = <RecordType extends RaRecord = any>(
         component: Content = DefaultComponent,
         title,
         empty = defaultEmpty,
+        storeKey,
         ...rest
     } = props;
     const {
@@ -43,6 +49,11 @@ export const ListView = <RecordType extends RaRecord = any>(
         filterValues,
         resource,
     } = useListContext<RecordType>();
+    useRestoreScrollPosition(
+        storeKey
+            ? `${storeKey}/listScrollPosition`
+            : `${resource}/listScrollPosition`
+    );
 
     if (!children || (!data && isPending && emptyWhileLoading)) {
         return null;
@@ -305,6 +316,23 @@ export interface ListViewProps {
      * );
      */
     title?: string | ReactElement;
+
+    /**
+     * The key to use to store the current filter & sort. Pass false to disable.
+     *
+     * @see https://marmelab.com/react-admin/List.html#storekey
+     * @example
+     * const NewerBooks = () => (
+     *     <List
+     *         resource="books"
+     *         storeKey="newerBooks"
+     *         sort={{ field: 'year', order: 'DESC' }}
+     *     >
+     *         ...
+     *     </List>
+     * );
+     */
+    storeKey?: string | false;
 
     /**
      * The CSS styles to apply to the component.


### PR DESCRIPTION
## Problem

When users have a long list page, navigate from it to an edit or create page, the `onSuccess` redirection of those pages redirect them to the list but loose their previous scroll position. This is bad UX.

## Solution

- Introduce the `useRestoreScrollPosition` hook that tracks the page scroll position and restore it when the component mounts.
- Use in the `ra-ui-materialui` `List` component
- Remove the `_scrollToTop` state when redirecting to a list view