### PR TITLE
[Doc] Update `ra-search` doc for `<Search>` and `<SearchWithResult>` to introduce `queryOptions`

### DIFF
--- a/docs/Search.md
+++ b/docs/Search.md
@@ -161,13 +161,14 @@ export const App = () => (
 
 The `<Search>` component accepts the following props:
 
-| Prop          | Required | Type      | Default                | Description                                                                                        |
-| ------------- | -------- | --------- | ---------------------- | -------------------------------------------------------------------------------------------------- |
-| `children`    | Optional | `Element` | `<SearchResultsPanel>` | A component that will display the results.                                                         |
-| `color`       | Optional | `string`  | `light`                | The color mode for the input, applying light or dark backgrounds. Accept either `light` or `dark`. |
-| `historySize` | Optional | `number`  | 5                      | The number of past queries to keep in history.                                                     |
-| `options`     | Optional | `Object`  | -                      | An object containing options to apply to the search.                                               |
-| `wait`        | Optional | `number`  | 500                    | The delay of debounce for the search to launch after typing in ms.                                 |
+| Prop           | Required | Type                                                                              | Default                | Description                                                                                        |
+| -------------- | -------- | --------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `children`     | Optional | `Element`                                                                         | `<SearchResultsPanel>` | A component that will display the results.                                                         |
+| `color`        | Optional | `string`                                                                          | `light`                | The color mode for the input, applying light or dark backgrounds. Accept either `light` or `dark`. |
+| `historySize`  | Optional | `number`                                                                          | 5                      | The number of past queries to keep in history.                                                     |
+| `options`      | Optional | `Object`                                                                          | -                      | An object containing options to apply to the search.                                               |
+| `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v3/docs/react/reference/useQuery) | -                      | `react-query` options for the search query                                                         |
+| `wait`         | Optional | `number`                                                                          | 500                    | The delay of debounce for the search to launch after typing in ms.                                 |
 
 Additional props are passed down to the Material UI [`<TextField>`](https://mui.com/material-ui/react-text-field/) component.
 
@@ -235,6 +236,18 @@ An object containing options to apply to the search:
 {% raw %}
 ```tsx
 <Search options={{ foo: 'bar' }} />
+```
+{% endraw %}
+
+## `queryOptions`
+
+`<Search>` accepts a [`queryOptions` prop](https://tanstack.com/query/v3/docs/framework/react/reference/useQuery) to pass options to the react-query client.
+This can be useful e.g. to override the default side effects such as `onSuccess` or `onError`.
+
+
+{% raw %}
+```tsx
+<Search queryOptions={{ onSuccess: data => console.log(data) }} />
 ```
 {% endraw %}
 

--- a/docs/SearchWithResult.md
+++ b/docs/SearchWithResult.md
@@ -102,13 +102,14 @@ Check [the `ra-search` documentation](https://react-admin-ee.marmelab.com/docume
 
 ## Props
 
-| Prop         | Required | Type       | Default                                                                         | Description                                                                                        |
-| ------------ | -------- | ---------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `children`   | Optional | `Element`  | `<SearchResultsPanel>`                                                          | A component that will display the results.                                                         |
-| `color`      | Optional | `string`   | The opposite of theme mode. If mode is `light` default is `dark` and vice versa | The color mode for the input, applying light or dark backgrounds. Accept either `light` or `dark`. |
-| `onNavigate` | Optional | `function` | `() => undefined`                                                               | A callback function to run when the user navigate to a result.                                     |
-| `options`    | Optional | `Object`   | -                                                                               | An object containing options to apply to the search.                                               |
-| `wait`       | Optional | `number`   | 500                                                                             | The delay of debounce for the search to launch after typing in ms.                                 |
+| Prop           | Required | Type                                                                              | Default                                                                         | Description                                                                                        |
+| ------------   | -------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `children`     | Optional | `Element`                                                                         | `<SearchResultsPanel>`                                                          | A component that will display the results.                                                         |
+| `color`        | Optional | `string`                                                                          | The opposite of theme mode. If mode is `light` default is `dark` and vice versa | The color mode for the input, applying light or dark backgrounds. Accept either `light` or `dark`. |
+| `onNavigate`   | Optional | `function`                                                                        | `() => undefined`                                                               | A callback function to run when the user navigate to a result.                                     |
+| `options`      | Optional | `Object`                                                                          | -                                                                               | An object containing options to apply to the search.                                               |
+| `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v3/docs/react/reference/useQuery) | -                                                                               | `react-query` options for the search query                                                         |
+| `wait`         | Optional | `number`                                                                          | 500                                                                             | The delay of debounce for the search to launch after typing in ms.                                 |
 
 ## `children`
 
@@ -184,6 +185,18 @@ An object containing options to apply to the search:
 {% raw %}
 ```tsx
 <SearchWithResult options={{ foo: 'bar' }} />
+```
+{% endraw %}
+
+## `queryOptions`
+
+`<SearchWithResult>` accepts a [`queryOptions` prop](https://tanstack.com/query/v3/docs/framework/react/reference/useQuery) to pass options to the react-query client.
+This can be useful e.g. to override the default side effects such as `onSuccess` or `onError`.
+
+
+{% raw %}
+```tsx
+<SearchWithResult queryOptions={{ onSuccess: data => console.log(data) }} />
 ```
 {% endraw %}
 


### PR DESCRIPTION
 ## Problem
RA-Enterprise doc for `ra-search` was update in `<Search>` and `<SearchWithResult>` parts (to introduce `queryOptions`).

## Solution
Update OSS documentation.