### PR TITLE
Fix `<SimpleList>` always returns empty when controlled

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -120,7 +120,7 @@ export const SimpleList = <RecordType extends RaRecord = any>(
         }
     };
 
-    if (data == null || total == null || data.length === 0 || total === 0) {
+    if (data == null || data.length === 0 || total === 0) {
         if (empty) {
             return empty;
         }

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -375,10 +375,12 @@ export const Standalone = () => (
                 getList: () => Promise.resolve({ data, total: 4 }) as any,
             })}
         >
-            <h1>Static</h1>
-            <MyCustomList />
-            <h1>Dynamic (with useList)</h1>
-            <MyCustomListInteractive />
+            <ResourceContextProvider value="books">
+                <h1>Static</h1>
+                <MyCustomList />
+                <h1>Dynamic (with useList)</h1>
+                <MyCustomListInteractive />
+            </ResourceContextProvider>
         </CoreAdminContext>
     </ThemeProvider>
 );


### PR DESCRIPTION
`<SimpleList data={data}>` always renders an empty list regardless of the data. 

Test the [ra-ui-material-ui/list/simplelist/basic](https://react-admin-storybook-git-next-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-list-simplelist--basic) story to see the bug.

## Cause

Even when the `data` prop is set, this condition forces the rendering of the empty component because `total` is also undefined. 

https://github.com/marmelab/react-admin/blob/a402c381f52a29aafa23708d9c9468c312e4ccd6/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx#L123-L129

The condition is different in `<Datagrid>`:

https://github.com/marmelab/react-admin/blob/a402c381f52a29aafa23708d9c9468c312e4ccd6/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx#L219-L225

## Solution

Remove the test on `total` in `<SimpleList>` empty clause