### PR TITLE
Simplify GQL dataProviders

### DIFF
--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -971,6 +971,42 @@ export const MyRemoveButton = (props: ButtonProps) => {
 }
 ```
 
+## `ra-data-graphql` And `ra-data-graphql-simple` No Longer Return A Promise
+
+The Graphql data providers builders used to return a promise that made admins initialization complicated. This is no longer needed.
+
+```diff
+// in App.js
+import React from 'react';
+import { Component } from 'react';
+import buildGraphQLProvider from 'ra-data-graphql-simple';
+import { Admin, Resource } from 'react-admin';
+
+import { PostCreate, PostEdit, PostList } from './posts';
+
++ const dataProvider = buildGraphQLProvider({ clientOptions: { uri: 'http://localhost:4000' } });
+
+const App = () => {
+-    const [dataProvider, setDataProvider] = React.useState(null);
+-    React.useEffect(() => {
+-        buildGraphQLProvider({ clientOptions: { uri: 'http://localhost:4000' } })
+-            .then(graphQlDataProvider => setDataProvider(() => graphQlDataProvider));
+-    }, []);
+
+-    if (!dataProvider) {
+-        return <div>Loading < /div>;
+-    }
+
+    return (
+        <Admin dataProvider={dataProvider} >
+            <Resource name="Post" list={PostList} edit={PostEdit} create={PostCreate} />
+        </Admin>
+    );
+}
+
+export default App;
+```
+
 ## Upgrading to v4
 
 If you are on react-admin v3, follow the [Upgrading to v4](https://marmelab.com/react-admin/doc/4.16/Upgrade.html) guide before upgrading to v5.

--- a/examples/demo/src/dataProvider/graphql.ts
+++ b/examples/demo/src/dataProvider/graphql.ts
@@ -112,8 +112,8 @@ const customBuildQuery: BuildQueryFactory = introspectionResults => {
     };
 };
 
-export default async () => {
-    const dataProvider = await buildApolloClient({
+export default () => {
+    const dataProvider = buildApolloClient({
         clientOptions: {
             uri: 'http://localhost:4000/graphql',
         },

--- a/packages/ra-data-graphql-simple/README.md
+++ b/packages/ra-data-graphql-simple/README.md
@@ -36,24 +36,13 @@ import { Admin, Resource } from 'react-admin';
 
 import { PostCreate, PostEdit, PostList } from './posts';
 
-const App = () => {
+const dataProvider = buildGraphQLProvider({ buildQuery });
 
-    const [dataProvider, setDataProvider] = React.useState(null);
-    React.useEffect(() => {
-        buildGraphQLProvider({ clientOptions: { uri: 'http://localhost:4000' } })
-            .then(graphQlDataProvider => setDataProvider(() => graphQlDataProvider));
-    }, []);
-
-    if (!dataProvider) {
-        return <div>Loading < /div>;
-    }
-
-    return (
-        <Admin dataProvider= { dataProvider } >
-            <Resource name="Post" list = { PostList } edit = { PostEdit } create = { PostCreate } />
-        </Admin>
-    );
-}
+const App = () => (
+    <Admin dataProvider={dataProvider} >
+        <Resource name="Post" list={PostList} edit={PostEdit} create={PostCreate} />
+    </Admin>
+);
 
 export default App;
 ```

--- a/packages/ra-data-graphql/README.md
+++ b/packages/ra-data-graphql/README.md
@@ -51,24 +51,13 @@ import { Admin, Resource } from 'react-admin';
 import buildQuery from './buildQuery'; // see Specify your queries and mutations section below
 import { PostCreate, PostEdit, PostList } from '../components/admin/posts';
 
-const App = () => {
-    const [dataProvider, setDataProvider] = useState(null);
+const dataProvider = buildGraphQLProvider({ buildQuery });
 
-    useEffect(() => {
-        buildGraphQLProvider({ buildQuery })
-            .then(dataProvider => setDataProvider(dataProvider));
-    }, []);
-
-    if (!dataProvider) {
-        return <div>Loading</div>;
-    }
-
-    return (
-        <Admin dataProvider={dataProvider}>
-            <Resource name="Post" list={PostList} edit={PostEdit} create={PostCreate} />
-        </Admin>
-    );
-}
+const App = () =>  (
+    <Admin dataProvider={dataProvider}>
+        <Resource name="Post" list={PostList} edit={PostEdit} create={PostCreate} />
+    </Admin>
+);
 
 export default App;
 ```

--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -127,10 +127,7 @@ export type Options = {
     watchQuery?: GetWatchQueryOptions;
 };
 
-// @FIXME in v5: This doesn't need to be an async method
-const buildGraphQLProvider = async (
-    options: Options
-): Promise<DataProvider> => {
+const buildGraphQLProvider = (options: Options): DataProvider => {
     const {
         client: clientObject,
         clientOptions,


### PR DESCRIPTION
## Problem

Setting up the GQL dataProviders is cumbersome as the builders return a promise. However, this was only kept for backward compatibility as intropection is now done on the fly.

## Solution

Make builders return the dataProvider synchronously.