### PR TITLE
Fix Datagrid uses wrong element for "Select All" label

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkUpdateButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateButton.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen } from '@testing-library/react';
+import { MutationMode } from './BulkUpdateButton.stories';
+
+describe('BulkUpdateButton', () => {
+    describe('mutationMode', () => {
+        it('should ask confirmation before updating in pessimistic mode', async () => {
+            render(<MutationMode />);
+            await screen.findByText('War and Peace');
+            const checkbox = await screen.findByLabelText('Select all');
+            checkbox.click();
+            await screen.getByText('10 items selected');
+            const button = screen.getByLabelText('Update Pessimistic');
+            button.click();
+            await screen.findByText(
+                'Are you sure you want to update these 10 items?'
+            );
+            const confirmButton = await screen.findByText('Confirm');
+            confirmButton.click();
+            await screen.findByText('10 elements updated');
+            expect(
+                screen.queryByText(
+                    'Are you sure you want to update these 10 items?'
+                )
+            ).toBeNull();
+        });
+    });
+});

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
@@ -186,10 +186,7 @@ describe('<ReferenceArrayInput />', () => {
                 .getByLabelText('ra.action.select_row')
                 .querySelector('input');
         const getCheckboxAll = () =>
-            screen
-                .getByLabelText('ra.action.select_all')
-                .querySelector('input');
-
+            screen.getByLabelText('ra.action.select_all');
         await waitFor(() => {
             expect(getCheckbox1().checked).toEqual(true);
             expect(getCheckbox2().checked).toEqual(false);

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -111,9 +111,14 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
                         className={DatagridClasses.headerCell}
                     >
                         <Checkbox
-                            aria-label={translate('ra.action.select_all', {
-                                _: 'Select all',
-                            })}
+                            inputProps={{
+                                'aria-label': translate(
+                                    'ra.action.select_all',
+                                    {
+                                        _: 'Select all',
+                                    }
+                                ),
+                            }}
                             className="select-all"
                             color="primary"
                             checked={

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -114,9 +114,7 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
                             inputProps={{
                                 'aria-label': translate(
                                     'ra.action.select_all',
-                                    {
-                                        _: 'Select all',
-                                    }
+                                    { _: 'Select all' }
                                 ),
                             }}
                             className="select-all"


### PR DESCRIPTION
## Problem

The "Select all" checkbox in the `<Datagrid>` header doesn't have the label on the correct element

<img width="771" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/121d53d3-480c-4bb9-8f7a-0bf20333f1c8">

## Before

```html
<span class="..." aria-label="Select all">
   <input class="..." type="checkbox" data-indeterminate="false">
```

## After

```html
<span class="...">
    <input class="..." type="checkbox" data-indeterminate="false" aria-label="Select all">
```

## How to test

Check out the BulkUpdateButton story. I also added a unit test. 