### PR TITLE
[Dev] Speed up unit tests by not using MUI Icons barrel files

### DIFF
--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -38,7 +38,8 @@ import { useCreatePath } from '../routing';
  * @example <caption>Custom PrevNextButton</caption>
  *
  * import { UsePrevNextControllerProps, useTranslate } from 'ra-core';
- * import { NavigateBefore, NavigateNext } from '@mui/icons-material';
+ * import NavigateBefore from '@mui/icons-material/NavigateBefore';
+ * import NavigateNext from '@mui/icons-material/NavigateNext';
  * import ErrorIcon from '@mui/icons-material/Error';
  * import { Link } from 'react-router-dom';
  * import { CircularProgress, IconButton } from '@mui/material';

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
@@ -5,7 +5,8 @@ import {
     usePrevNextController,
     UsePrevNextControllerProps,
 } from 'ra-core';
-import { NavigateBefore, NavigateNext } from '@mui/icons-material';
+import NavigateBefore from '@mui/icons-material/NavigateBefore';
+import NavigateNext from '@mui/icons-material/NavigateNext';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Link } from 'react-router-dom';
 import {

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { SvgIconComponent } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import DoneIcon from '@mui/icons-material/Done';
 import ClearIcon from '@mui/icons-material/Clear';
-import { Tooltip, Typography, TypographyProps } from '@mui/material';
+import { Tooltip, Typography, TypographyProps, SvgIcon } from '@mui/material';
 import { useTranslate, useFieldValue } from 'ra-core';
 import { genericMemo } from './genericMemo';
 import { FieldProps, fieldPropTypes } from './types';
@@ -99,8 +98,8 @@ export interface BooleanFieldProps<
         Omit<TypographyProps, 'textAlign'> {
     valueLabelTrue?: string;
     valueLabelFalse?: string;
-    TrueIcon?: SvgIconComponent | null;
-    FalseIcon?: SvgIconComponent | null;
+    TrueIcon?: typeof SvgIcon | null;
+    FalseIcon?: typeof SvgIcon | null;
     looseValue?: boolean;
 }
 

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import { Typography } from '@mui/material';
-import { FavoriteBorder, Favorite } from '@mui/icons-material';
+import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
+import Favorite from '@mui/icons-material/Favorite';
 import { required, testDataProvider, useRecordContext } from 'ra-core';
 import { useFormContext } from 'react-hook-form';
 

--- a/packages/ra-ui-materialui/src/layout/Menu.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.stories.tsx
@@ -18,15 +18,13 @@ import {
     List,
     Tooltip,
 } from '@mui/material';
-import {
-    Dashboard,
-    PieChartOutlined,
-    PeopleOutlined,
-    Inventory,
-    ExpandLess,
-    ExpandMore,
-    QrCode,
-} from '@mui/icons-material';
+import Dashboard from '@mui/icons-material/Dashboard';
+import PieChartOutlined from '@mui/icons-material/PieChartOutlined';
+import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
+import Inventory from '@mui/icons-material/Inventory';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import QrCode from '@mui/icons-material/QrCode';
 import { Route } from 'react-router-dom';
 
 import { Layout, Menu, Title } from '.';


### PR DESCRIPTION
Following the advice at https://mui.com/material-ui/guides/minimizing-bundle-size/#development-environment, I fixed the few named imports from `@mui/material-icons` and replaced them with default imports for individual icons.

The results are spectacular. The `npx jest` command now takes a fraction of the time. 

On my laptop:

* Before: 118s
* After: 41s

On the CI:

* Before: 4m58s
* After: 3m28s