### PR TITLE
Fix warning about defaultProps in React 18.3

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -288,18 +288,19 @@ And see [the Material UI system documentation](https://mui.com/system/the-sx-pro
 
 This prop defines the text alignment of the field when rendered inside a `<Datagrid>` cell. By default, datagrid values are left-aligned ; for numeric values, it's often better to right-align them. Set `textAlign` to `right` for that.
 
-[`<NumberField>`](./NumberField.md) already uses `textAlign="right"`. Set the default value for this prop if you create a custom numeric field.
-
 ```jsx
-const BasketTotal = () => {
-    const record = useRecordContext();
-    if (!record) return null;
-    const total = record.items.reduce((total, item) => total + item.price, 0);
-    return <span>{total}</span>;
-}
-BasketTotal.defaultProps = {
-    textAlign: 'right',
-};
+import { List, Datagrid, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" textAlign="right" />
+        </Datagrid>
+    </List>
+);
 ```
 
 ## Deep Field Source
@@ -386,9 +387,6 @@ If you want to format a field depending on the value, create another component w
 const FormattedNumberField = ({ source }) => {
     const record = useRecordContext();
     return <NumberField sx={{ color: record && record[source] < 0 ? 'red' : '' }} source={source} />;
-};
-FormattedNumberField.defaultProps = {
-    textAlign: 'right',
 };
 ```
 {% endraw %}

--- a/examples/demo/src/visitors/ColoredNumberField.tsx
+++ b/examples/demo/src/visitors/ColoredNumberField.tsx
@@ -13,6 +13,4 @@ const ColoredNumberField = (props: NumberFieldProps) => {
     );
 };
 
-ColoredNumberField.defaultProps = NumberField.defaultProps;
-
 export default ColoredNumberField;

--- a/examples/demo/src/visitors/MobileGrid.tsx
+++ b/examples/demo/src/visitors/MobileGrid.tsx
@@ -62,6 +62,7 @@ const MobileGrid = () => {
                                         style: 'currency',
                                         currency: 'USD',
                                     }}
+                                    textAlign="right"
                                 />
                             </Typography>
                         </CardContent>

--- a/examples/demo/src/visitors/VisitorList.tsx
+++ b/examples/demo/src/visitors/VisitorList.tsx
@@ -76,6 +76,7 @@ const VisitorList = () => {
                     <ColoredNumberField
                         source="total_spent"
                         options={{ style: 'currency', currency: 'USD' }}
+                        textAlign="right"
                     />
                     <DateField source="latest_purchase" showTime />
                     <BooleanField source="has_newsletter" label="News." />

--- a/packages/ra-ui-materialui/src/field/NumberField.tsx
+++ b/packages/ra-ui-materialui/src/field/NumberField.tsx
@@ -106,11 +106,10 @@ NumberFieldImpl.propTypes = {
 
 // what? TypeScript loses the displayName if we don't set it explicitly
 NumberFieldImpl.displayName = 'NumberFieldImpl';
-NumberFieldImpl.defaultProps = {
-    textAlign: 'right',
-};
 
 export const NumberField = genericMemo(NumberFieldImpl);
+// @ts-expect-error This is a hack that replaces react support for defaultProps. We currently need this for the Datagrid.
+NumberField.textAlign = 'right';
 
 export interface NumberFieldProps<
     RecordType extends Record<string, any> = Record<string, any>

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
@@ -99,6 +99,9 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
     );
 };
 
+// This is a hack that replaces react support for defaultProps. We currently need this for the Datagrid.
+ReferenceManyCount.textAlign = 'right';
+
 export interface ReferenceManyCountProps<RecordType extends RaRecord = RaRecord>
     extends FieldProps<RecordType>,
         Omit<TypographyProps, 'textAlign'> {

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -125,9 +125,7 @@ ReferenceOneField.propTypes = {
     queryOptions: PropTypes.any,
 };
 
-ReferenceOneField.defaultProps = {
-    // disable sorting on this field by default as its default source prop ('id')
-    // will match the default sort ({ field: 'id', order: 'DESC'})
-    // leading to an incorrect sort indicator in a datagrid header
-    sortable: false,
-};
+// disable sorting on this field by default as its default source prop ('id')
+// will match the default sort ({ field: 'id', order: 'DESC'})
+// leading to an incorrect sort indicator in a datagrid header
+ReferenceOneField.sortable = false;

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -122,15 +122,17 @@ export interface FieldProps<
      *
      * @see https://marmelab.com/react-admin/Fields.html#textalign
      * @example
-     * const BasketTotal = () => {
-     *     const record = useRecordContext();
-     *     if (!record) return null;
-     *     const total = record.items.reduce((total, item) => total + item.price, 0);
-     *     return <span>{total}</span>;
-     * }
-     * BasketTotal.defaultProps = {
-     *     textAlign: 'right',
-     * };
+     * import { List, Datagrid, TextField } from 'react-admin';
+     * const PostList = () => (
+     *     <List>
+     *         <Datagrid>
+     *             <TextField source="id" />
+     *             <TextField source="title" />
+     *             <TextField source="author" />
+     *             <TextField source="year" textAlign="right" />
+     *         </Datagrid>
+     *     </List>
+     * );
      */
     textAlign?: TextAlign;
 

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridCell.tsx
@@ -8,7 +8,7 @@ const DatagridCell = React.forwardRef<HTMLTableCellElement, DatagridCellProps>(
     ({ className, field, record, resource, ...rest }, ref) => (
         <TableCell
             className={clsx(className, field.props.cellClassName)}
-            align={field.props.textAlign}
+            align={field.props.textAlign || field.type.textAlign}
             ref={ref}
             {...rest}
         >

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.stories.tsx
@@ -39,8 +39,7 @@ const data = [
     },
 ];
 
-const AuthorField = () => <TextField source="author" />;
-AuthorField.defaultProps = { label: 'Author' };
+const AuthorField = () => <TextField label="Author" source="author" />;
 
 const theme = createTheme();
 

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -45,7 +45,8 @@ export const DatagridHeaderCell = (
                 <Tooltip
                     title={sortLabel}
                     placement={
-                        field.props.textAlign === 'right'
+                        field.props.textAlign === 'right' ||
+                        field.type.textAlign === 'right'
                             ? 'bottom-end'
                             : 'bottom-start'
                     }

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -34,12 +34,13 @@ export const DatagridHeaderCell = (
     return (
         <StyledTableCell
             className={clsx(className, field.props.headerClassName)}
-            align={field.props.textAlign}
+            align={field.props.textAlign || field.type.textAlign}
             variant="head"
             {...rest}
         >
             {updateSort &&
             field.props.sortable !== false &&
+            field.type.sortable !== false &&
             (field.props.sortBy || field.props.source) ? (
                 <Tooltip
                     title={sortLabel}

--- a/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.stories.tsx
@@ -37,9 +37,6 @@ const data = [
     },
 ];
 
-const AuthorField = () => <TextField source="author" />;
-AuthorField.defaultProps = { label: 'Author' };
-
 const theme = createTheme();
 
 export const Basic = () => (


### PR DESCRIPTION
## Problem

React 19 removes support for `defaultProps` and React 18.3 display warnings about it.

## Solution

The temporary solution is to introduce some other static props for `textAlign` and `sortable`

Closes #9815