### PR TITLE
Allow <Title /> to be nonConfigurable

### DIFF
--- a/docs/Title.md
+++ b/docs/Title.md
@@ -121,3 +121,15 @@ const CustomPage = () => (
 );
 ```
 
+If you want to disable configuring the page title even while in [Configurable mode](./AppBar.md#configurable), you can pass `preferenceKey=false`.
+
+```jsx
+import { Title } from 'react-admin';
+
+const CustomPageWithNonConfigurableTitle = () => (
+    <>
+        <Title title="My Custom Page" preferenceKey={false} />
+        <div>Content</div>
+    </>
+);
+```

--- a/packages/ra-ui-materialui/src/layout/PageTitle.tsx
+++ b/packages/ra-ui-materialui/src/layout/PageTitle.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { useTranslate } from 'ra-core';
 
-export const PageTitle = ({
-    title,
-    defaultTitle,
-    className,
-    nonConfigurable,
-    ...rest
-}: any) => {
+export const PageTitle = ({ title, defaultTitle, className, ...rest }: any) => {
     const translate = useTranslate();
 
     return (

--- a/packages/ra-ui-materialui/src/layout/PageTitle.tsx
+++ b/packages/ra-ui-materialui/src/layout/PageTitle.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
-import { useRecordContext, useTranslate, usePreference } from 'ra-core';
+import { useTranslate } from 'ra-core';
 
-export const PageTitle = ({ title, defaultTitle, className, ...rest }: any) => {
-    const [titleFromPreferences] = usePreference();
+export const PageTitle = ({
+    title,
+    defaultTitle,
+    className,
+    nonConfigurable,
+    ...rest
+}: any) => {
     const translate = useTranslate();
-    const record = useRecordContext();
 
-    return titleFromPreferences ? (
-        <span className={className} {...rest}>
-            {translate(titleFromPreferences, {
-                ...record,
-                _: titleFromPreferences,
-            })}
-        </span>
-    ) : (
+    return (
         <span className={className}>
             {!title ? (
                 <span {...rest}>{defaultTitle}</span>

--- a/packages/ra-ui-materialui/src/layout/PageTitleConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/layout/PageTitleConfigurable.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
-import { usePreferenceInput } from 'ra-core';
+import {
+    usePreferenceInput,
+    usePreference,
+    useRecordContext,
+    useTranslate,
+} from 'ra-core';
 import { TextField } from '@mui/material';
 
 import { Configurable } from '../preferences';
@@ -34,7 +39,24 @@ export const PageTitleConfigurable = ({ preferenceKey, ...props }) => {
                 },
             }}
         >
-            <PageTitle {...props} />
+            <PageTitleConfigurableInner {...props} />
         </Configurable>
+    );
+};
+
+const PageTitleConfigurableInner = ({ className, ...rest }: any) => {
+    const [titleFromPreferences] = usePreference();
+    const translate = useTranslate();
+    const record = useRecordContext();
+
+    return titleFromPreferences ? (
+        <span className={className} {...rest}>
+            {translate(titleFromPreferences, {
+                ...record,
+                _: titleFromPreferences,
+            })}
+        </span>
+    ) : (
+        <PageTitle className={className} {...rest} />
     );
 };

--- a/packages/ra-ui-materialui/src/layout/PageTitleConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/layout/PageTitleConfigurable.tsx
@@ -27,7 +27,12 @@ export const PageTitleEditor = () => {
     );
 };
 
-export const PageTitleConfigurable = ({ preferenceKey, ...props }) => {
+export const PageTitleConfigurable = ({
+    preferenceKey,
+    title,
+    defaultTitle,
+    ...props
+}) => {
     const { pathname } = useLocation();
     return (
         <Configurable
@@ -39,24 +44,30 @@ export const PageTitleConfigurable = ({ preferenceKey, ...props }) => {
                 },
             }}
         >
-            <PageTitleConfigurableInner {...props} />
+            <PageTitleConfigurableInner
+                title={title}
+                defaultTitle={defaultTitle}
+                {...props}
+            />
         </Configurable>
     );
 };
 
-const PageTitleConfigurableInner = props => {
+const PageTitleConfigurableInner = ({ title, defaultTitle, ...props }) => {
     const [titleFromPreferences] = usePreference();
     const translate = useTranslate();
     const record = useRecordContext();
 
     return titleFromPreferences ? (
-        <span className={props.className}>
+        <span className={props.className} {...props}>
             {translate(titleFromPreferences, {
                 ...record,
                 _: titleFromPreferences,
             })}
         </span>
     ) : (
-        <PageTitle {...props} />
+        <>
+            <PageTitle title={title} defaultTitle={defaultTitle} {...props} />
+        </>
     );
 };

--- a/packages/ra-ui-materialui/src/layout/PageTitleConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/layout/PageTitleConfigurable.tsx
@@ -44,19 +44,19 @@ export const PageTitleConfigurable = ({ preferenceKey, ...props }) => {
     );
 };
 
-const PageTitleConfigurableInner = ({ className, ...rest }: any) => {
+const PageTitleConfigurableInner = props => {
     const [titleFromPreferences] = usePreference();
     const translate = useTranslate();
     const record = useRecordContext();
 
     return titleFromPreferences ? (
-        <span className={className} {...rest}>
+        <span className={props.className}>
             {translate(titleFromPreferences, {
                 ...record,
                 _: titleFromPreferences,
             })}
         </span>
     ) : (
-        <PageTitle className={className} {...rest} />
+        <PageTitle {...props} />
     );
 };

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { ReactElement } from 'react';
 import { createPortal } from 'react-dom';
+import { useLocation } from 'react-router-dom';
 import { RaRecord, TitleComponent, warning } from 'ra-core';
 
 import { PageTitle } from './PageTitle';
@@ -9,6 +10,7 @@ import { PageTitleConfigurable } from './PageTitleConfigurable';
 
 export const Title = (props: TitleProps) => {
     const { defaultTitle, title, preferenceKey, ...rest } = props;
+    const { pathname } = useLocation();
     const [container, setContainer] = useState<HTMLElement | null>(() =>
         typeof document !== 'undefined'
             ? document.getElementById('react-admin-title')
@@ -32,16 +34,17 @@ export const Title = (props: TitleProps) => {
 
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 
-    const pageTitle = preferenceKey ? (
-        <PageTitleConfigurable
-            title={title}
-            defaultTitle={defaultTitle}
-            preferenceKey={preferenceKey}
-            {...rest}
-        />
-    ) : (
-        <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
-    );
+    const pageTitle =
+        preferenceKey !== undefined ? (
+            <PageTitleConfigurable
+                title={title}
+                defaultTitle={defaultTitle}
+                preferenceKey={preferenceKey || `${pathname}.title`}
+                {...rest}
+            />
+        ) : (
+            <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
+        );
 
     return <>{createPortal(pageTitle, container)}</>;
 };

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { ReactElement } from 'react';
 import { createPortal } from 'react-dom';
-import { useLocation } from 'react-router-dom';
 import { RaRecord, TitleComponent, warning } from 'ra-core';
 
 import { PageTitle } from './PageTitle';
@@ -10,7 +9,6 @@ import { PageTitleConfigurable } from './PageTitleConfigurable';
 
 export const Title = (props: TitleProps) => {
     const { defaultTitle, title, preferenceKey, ...rest } = props;
-    const { pathname } = useLocation();
     const [container, setContainer] = useState<HTMLElement | null>(() =>
         typeof document !== 'undefined'
             ? document.getElementById('react-admin-title')

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -4,10 +4,17 @@ import { ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { RaRecord, TitleComponent, warning } from 'ra-core';
 
+import { PageTitle } from './PageTitle';
 import { PageTitleConfigurable } from './PageTitleConfigurable';
 
 export const Title = (props: TitleProps) => {
-    const { defaultTitle, title, preferenceKey, ...rest } = props;
+    const {
+        defaultTitle,
+        title,
+        preferenceKey,
+        nonConfigurable,
+        ...rest
+    } = props;
     const [container, setContainer] = useState<HTMLElement | null>(() =>
         typeof document !== 'undefined'
             ? document.getElementById('react-admin-title')
@@ -31,19 +38,18 @@ export const Title = (props: TitleProps) => {
 
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 
-    return (
-        <>
-            {createPortal(
-                <PageTitleConfigurable
-                    title={title}
-                    defaultTitle={defaultTitle}
-                    preferenceKey={preferenceKey}
-                    {...rest}
-                />,
-                container
-            )}
-        </>
+    const pageTitle = nonConfigurable ? (
+        <PageTitle {...rest} />
+    ) : (
+        <PageTitleConfigurable
+            title={title}
+            defaultTitle={defaultTitle}
+            preferenceKey={preferenceKey}
+            {...rest}
+        />
     );
+
+    return <>{createPortal(pageTitle, container)}</>;
 };
 
 export interface TitleProps {
@@ -52,4 +58,5 @@ export interface TitleProps {
     record?: Partial<RaRecord>;
     title?: string | ReactElement;
     preferenceKey?: string;
+    nonConfigurable?: boolean;
 }

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -39,7 +39,7 @@ export const Title = (props: TitleProps) => {
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 
     const pageTitle = nonConfigurable ? (
-        <PageTitle {...rest} />
+        <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
     ) : (
         <PageTitleConfigurable
             title={title}

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -35,15 +35,15 @@ export const Title = (props: TitleProps) => {
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 
     const pageTitle =
-        preferenceKey !== undefined ? (
+        preferenceKey === false ? (
+            <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
+        ) : (
             <PageTitleConfigurable
                 title={title}
                 defaultTitle={defaultTitle}
-                preferenceKey={preferenceKey || `${pathname}.title`}
+                preferenceKey={preferenceKey}
                 {...rest}
             />
-        ) : (
-            <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
         );
 
     return <>{createPortal(pageTitle, container)}</>;
@@ -54,5 +54,5 @@ export interface TitleProps {
     defaultTitle?: TitleComponent;
     record?: Partial<RaRecord>;
     title?: string | ReactElement;
-    preferenceKey?: string;
+    preferenceKey?: string | false;
 }

--- a/packages/ra-ui-materialui/src/layout/Title.tsx
+++ b/packages/ra-ui-materialui/src/layout/Title.tsx
@@ -8,13 +8,7 @@ import { PageTitle } from './PageTitle';
 import { PageTitleConfigurable } from './PageTitleConfigurable';
 
 export const Title = (props: TitleProps) => {
-    const {
-        defaultTitle,
-        title,
-        preferenceKey,
-        nonConfigurable,
-        ...rest
-    } = props;
+    const { defaultTitle, title, preferenceKey, ...rest } = props;
     const [container, setContainer] = useState<HTMLElement | null>(() =>
         typeof document !== 'undefined'
             ? document.getElementById('react-admin-title')
@@ -38,15 +32,15 @@ export const Title = (props: TitleProps) => {
 
     warning(!defaultTitle && !title, 'Missing title prop in <Title> element');
 
-    const pageTitle = nonConfigurable ? (
-        <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
-    ) : (
+    const pageTitle = preferenceKey ? (
         <PageTitleConfigurable
             title={title}
             defaultTitle={defaultTitle}
             preferenceKey={preferenceKey}
             {...rest}
         />
+    ) : (
+        <PageTitle title={title} defaultTitle={defaultTitle} {...rest} />
     );
 
     return <>{createPortal(pageTitle, container)}</>;
@@ -58,5 +52,4 @@ export interface TitleProps {
     record?: Partial<RaRecord>;
     title?: string | ReactElement;
     preferenceKey?: string;
-    nonConfigurable?: boolean;
 }

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -44,10 +44,8 @@ export const NonConfigurable = () => (
         <PreferencesEditorContextProvider>
             <Inspector />
             <InspectorButton />
-            <>
-                <TitlePortal variant="body1" />
-                <Title title="Hello, world" preferenceKey={undefined} />
-            </>
+            <TitlePortal variant="body1" />
+            <Title title="Hello, world" preferenceKey={undefined} />
         </PreferencesEditorContextProvider>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -39,20 +39,15 @@ export const Sx = () => (
     </TestMemoryRouter>
 );
 
-export const NonConfigurable = ({ preferenceKey = 'title' }) => (
+export const NonConfigurable = () => (
     <TestMemoryRouter>
         <PreferencesEditorContextProvider>
             <Inspector />
             <InspectorButton />
-            <Configurable
-                editor={<PageTitleEditor />}
-                preferenceKey={preferenceKey}
-            >
-                <>
-                    <TitlePortal variant="body1" />
-                    <Title title="Hello, world" nonConfigurable />
-                </>
-            </Configurable>
+            <>
+                <TitlePortal variant="body1" />
+                <Title title="Hello, world" preferenceKey={undefined} />
+            </>
         </PreferencesEditorContextProvider>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { PreferencesEditorContextProvider, TestMemoryRouter } from 'ra-core';
+import {
+    PreferencesEditorContextProvider,
+    RecordContextProvider,
+    TestMemoryRouter,
+} from 'ra-core';
 
 import { TitlePortal } from './TitlePortal';
 import { Title } from './Title';
@@ -32,6 +36,17 @@ export const Sx = () => (
     <TestMemoryRouter>
         <PreferencesEditorContextProvider>
             <TitlePortal sx={{ color: 'primary.main' }} />
+            <Title title="Hello, world" />
+        </PreferencesEditorContextProvider>
+    </TestMemoryRouter>
+);
+
+export const Configurable = () => (
+    <TestMemoryRouter>
+        <PreferencesEditorContextProvider>
+            <Inspector />
+            <InspectorButton />
+            <TitlePortal variant="body1" />
             <Title title="Hello, world" />
         </PreferencesEditorContextProvider>
     </TestMemoryRouter>

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -35,3 +35,10 @@ export const Sx = () => (
         </PreferencesEditorContextProvider>
     </TestMemoryRouter>
 );
+
+export const NonConfigurable = () => (
+    <TestMemoryRouter>
+        <TitlePortal variant="body1" />
+        <Title title="Hello, world" nonConfigurable />
+    </TestMemoryRouter>
+);

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -45,7 +45,7 @@ export const NonConfigurable = () => (
             <Inspector />
             <InspectorButton />
             <TitlePortal variant="body1" />
-            <Title title="Hello, world" preferenceKey={undefined} />
+            <Title title="Hello, world" preferenceKey={false} />
         </PreferencesEditorContextProvider>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
-import { TestMemoryRouter } from 'ra-core';
-import { PreferencesEditorContextProvider } from 'ra-core';
+import { PreferencesEditorContextProvider, TestMemoryRouter } from 'ra-core';
 
 import { TitlePortal } from './TitlePortal';
 import { Title } from './Title';
+import { InspectorButton } from '../preferences/InspectorButton';
+import { Inspector } from '../preferences/Inspector';
+import { Configurable } from '../preferences/Configurable';
+import { PageTitleEditor } from './PageTitleConfigurable';
 
 export default {
     title: 'ra-ui-materialui/layout/TitlePortal',
@@ -36,9 +39,20 @@ export const Sx = () => (
     </TestMemoryRouter>
 );
 
-export const NonConfigurable = () => (
+export const NonConfigurable = ({ preferenceKey = 'title' }) => (
     <TestMemoryRouter>
-        <TitlePortal variant="body1" />
-        <Title title="Hello, world" nonConfigurable />
+        <PreferencesEditorContextProvider>
+            <Inspector />
+            <InspectorButton />
+            <Configurable
+                editor={<PageTitleEditor />}
+                preferenceKey={preferenceKey}
+            >
+                <>
+                    <TitlePortal variant="body1" />
+                    <Title title="Hello, world" nonConfigurable />
+                </>
+            </Configurable>
+        </PreferencesEditorContextProvider>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/TitlePortal.stories.tsx
@@ -5,8 +5,6 @@ import { TitlePortal } from './TitlePortal';
 import { Title } from './Title';
 import { InspectorButton } from '../preferences/InspectorButton';
 import { Inspector } from '../preferences/Inspector';
-import { Configurable } from '../preferences/Configurable';
-import { PageTitleEditor } from './PageTitleConfigurable';
 
 export default {
     title: 'ra-ui-materialui/layout/TitlePortal',


### PR DESCRIPTION
This addresses https://github.com/marmelab/react-admin/issues/8776

Testing:

Added storybook entry


<img width="944" alt="Screenshot 2024-05-08 at 9 51 04 AM" src="https://github.com/marmelab/react-admin/assets/5480811/49b3a9ac-e862-4a6c-a70e-40ba8f2d0f69">

