### PR TITLE
Fix race condition between http error notification and server-side validation error notification

### DIFF
--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -44,6 +44,7 @@ React-admin v5 mostly focuses on removing deprecated features and upgrading depe
     - [`warnWhenUnsavedChanges` Changes](#warnwhenunsavedchanges-changes)
     - [Inputs No Longer Require To Be Touched To Display A Validation Error](#inputs-no-longer-require-to-be-touched-to-display-a-validation-error)
     - [`<InputHelperText touched>` Prop Was Removed](#inputhelpertext-touched-prop-was-removed)
+    - [Global Server Side Validation Error Message Must Be Passed Via The `root.serverError` Key](#global-server-side-validation-error-message-must-be-passed-via-the-rootservererror-key)
 - [TypeScript](#typescript)
     - [Fields Components Requires The source Prop](#fields-components-requires-the-source-prop)
     - [`useRecordContext` Returns undefined When No Record Is Available](#userecordcontext-returns-undefined-when-no-record-is-available)
@@ -1003,6 +1004,38 @@ The `<InputHelperText>` component no longer accepts a `touched` prop. This prop 
 
 If you were using this prop, you can safely remove it.
 
+### Global Server Side Validation Error Message Must Be Passed Via The `root.serverError` Key
+
+You can now include a global server-side error message in the response to a failed create or update request. This message will be rendered in a notification. To do so, include the error message in the `root.serverError` key of the `errors` object in the response body:
+
+```diff
+{
+    "body": {
+        "errors": {
++           "root": { "serverError": "Some of the provided values are not valid. Please fix them and retry." },
+            "title": "An article with this title already exists. The title must be unique.",
+            "date": "The date is required",
+            "tags": { "message": "The tag 'agrriculture' doesn't exist" },
+        }
+    }
+}
+```
+
+**Minor BC:** To avoid a race condition between the notifications sent due to both the http error and the validation error, React Admin will no longer display a notification for the http error as soon as the response contains a non-empty `errors` object. If you relied on this behavior to render a global server-side error message, you should now include the message in the `root.serverError` key of the `errors` object.
+
+```diff
+{
+-   "message": "Some of the provided values are not valid. Please fix them and retry.",
+    "body": {
+        "errors": {
++           "root": { "serverError": "Some of the provided values are not valid. Please fix them and retry." },
+            "title": "An article with this title already exists. The title must be unique.",
+            "date": "The date is required",
+            "tags": { "message": "The tag 'agrriculture' doesn't exist" },
+        }
+    }
+}
+```
 
 ## TypeScript
 

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -1021,7 +1021,7 @@ You can now include a global server-side error message in the response to a fail
 }
 ```
 
-**Minor BC:** To avoid a race condition between the notifications sent due to both the http error and the validation error, React Admin will no longer display a notification for the http error as soon as the response contains a non-empty `errors` object. If you relied on this behavior to render a global server-side error message, you should now include the message in the `root.serverError` key of the `errors` object.
+**Minor BC:** To avoid a race condition between the notifications sent due to both the http error and the validation error, React Admin will no longer display a notification for the http error if the response contains a non-empty `errors` object and the mutation mode is `pessimistic`. If you relied on this behavior to render a global server-side error message, you should now include the message in the `root.serverError` key of the `errors` object.
 
 ```diff
 {

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -384,7 +384,7 @@ Server-side validation is supported out of the box for `pessimistic` mode only. 
 
 **Tip**: The shape of the returned validation errors must match the form shape: each key needs to match a `source` prop. The only exception is the `root.serverError` key, which can be used to define a global error message for the form.
 
-**Tip**: The returned validation errors might have any validation format we support (simple strings, translation strings or translation objects with a `message` attribute) for each key. However `root.serverError` must be a plain string.
+**Tip**: The returned validation errors might have any validation format we support (simple strings, translation strings or translation objects with a `message` attribute) for each key. However `root.serverError` does not accept translation objects.
 
 **Tip**: If your data provider leverages React Admin's [`httpClient`](https://marmelab.com/react-admin/DataProviderWriting.html#example-rest-implementation), all error response bodies are wrapped and thrown as `HttpError`. This means your API only needs to return an invalid response with a json body containing the `errors` key.
 

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -367,21 +367,24 @@ const CustomerCreate = () => (
 
 Server-side validation is supported out of the box for `pessimistic` mode only. It requires that the dataProvider throws an error with the following shape:
 
-```
+```json
 {
-    body: {
-        errors: {
-            title: 'An article with this title already exists. The title must be unique.',
-            date: 'The date is required',
-            tags: { message: "The tag 'agrriculture' doesn't exist" },
+    "body": {
+        "errors": {
+            // Global validation error message (optional)
+            "root": { "serverError": "Some of the provided values are not valid. Please fix them and retry." },
+            // Field validation error messages
+            "title": "An article with this title already exists. The title must be unique.",
+            "date": "The date is required",
+            "tags": { "message": "The tag 'agrriculture' doesn't exist" },
         }
     }
 }
 ```
 
-**Tip**: The shape of the returned validation errors must match the form shape: each key needs to match a `source` prop.
+**Tip**: The shape of the returned validation errors must match the form shape: each key needs to match a `source` prop. The only exception is the `root.serverError` key, which can be used to define a global error message for the form.
 
-**Tip**: The returned validation errors might have any validation format we support (simple strings, translation strings or translation objects with a `message` attribute) for each key.
+**Tip**: The returned validation errors might have any validation format we support (simple strings, translation strings or translation objects with a `message` attribute) for each key. However `root.serverError` must be a plain string.
 
 **Tip**: If your data provider leverages React Admin's [`httpClient`](https://marmelab.com/react-admin/DataProviderWriting.html#example-rest-implementation), all error response bodies are wrapped and thrown as `HttpError`. This means your API only needs to return an invalid response with a json body containing the `errors` key.
 
@@ -396,6 +399,7 @@ const apiUrl = 'https://my.api.com/';
 
   {
     "errors": {
+      "root": { "serverError": "Some of the provided values are not valid. Please fix them and retry." },
       "title": "An article with this title already exists. The title must be unique.",
       "date": "The date is required",
       "tags": { "message": "The tag 'agrriculture' doesn't exist" },
@@ -431,6 +435,7 @@ const myDataProvider = {
             body should be something like:
             {
                 errors: {
+                    root: { serverError: "Some of the provided values are not valid. Please fix them and retry." },
                     title: "An article with this title already exists. The title must be unique.",
                     date: "The date is required",
                     tags: { message: "The tag 'agrriculture' doesn't exist" },

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -108,26 +108,34 @@ export const useCreateController = <
             if (onError) {
                 return onError(error, variables, context);
             }
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : (error as Error).message || 'ra.notification.http_error',
-                {
-                    type: 'error',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error instanceof Error ||
-                                  (typeof error === 'object' &&
-                                      error !== null &&
-                                      error.hasOwnProperty('message'))
-                                ? // @ts-ignore
-                                  error.message
-                                : undefined,
-                    },
-                }
-            );
+            // Don't trigger a notification if this is a validation error
+            // (notification will be handled by the useNotifyIsFormInvalid hook)
+            const validationErrors = (error as HttpError)?.body?.errors;
+            const hasValidationErrors =
+                !!validationErrors && Object.keys(validationErrors).length > 0;
+            if (!hasValidationErrors) {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : (error as Error).message ||
+                              'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : error instanceof Error ||
+                                      (typeof error === 'object' &&
+                                          error !== null &&
+                                          error.hasOwnProperty('message'))
+                                    ? // @ts-ignore
+                                      error.message
+                                    : undefined,
+                        },
+                    }
+                );
+            }
         },
         ...otherMutationOptions,
         returnPromise: true,

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -742,6 +742,79 @@ describe('useEditController', () => {
         ]);
     });
 
+    it('should use the default error message in case no message was provided', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: () => Promise.reject({}),
+        } as unknown) as DataProvider;
+
+        let notificationsSpy;
+        const Notification = () => {
+            const { notifications } = useNotificationContext();
+            React.useEffect(() => {
+                notificationsSpy = notifications;
+            }, [notifications]);
+            return null;
+        };
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Notification />
+                <EditController {...defaultProps} mutationMode="pessimistic">
+                    {({ save }) => {
+                        saveCallback = save;
+                        return <div />;
+                    }}
+                </EditController>
+            </CoreAdminContext>
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        await new Promise(resolve => setTimeout(resolve, 10));
+        expect(notificationsSpy).toEqual([
+            {
+                message: 'ra.notification.http_error',
+                type: 'error',
+                notificationOptions: { messageArgs: { _: undefined } },
+            },
+        ]);
+    });
+
+    it('should not trigger a notification in case of a validation error (handled by useNotifyIsFormInvalid)', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        let saveCallback;
+        const dataProvider = ({
+            getOne: () => Promise.resolve({ data: { id: 12 } }),
+            update: () =>
+                Promise.reject({ body: { errors: { foo: 'invalid' } } }),
+        } as unknown) as DataProvider;
+
+        let notificationsSpy;
+        const Notification = () => {
+            const { notifications } = useNotificationContext();
+            React.useEffect(() => {
+                notificationsSpy = notifications;
+            }, [notifications]);
+            return null;
+        };
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Notification />
+                <EditController {...defaultProps} mutationMode="pessimistic">
+                    {({ save }) => {
+                        saveCallback = save;
+                        return <div />;
+                    }}
+                </EditController>
+            </CoreAdminContext>
+        );
+        await act(async () => saveCallback({ foo: 'bar' }));
+        await new Promise(resolve => setTimeout(resolve, 10));
+        expect(notificationsSpy).toEqual([]);
+    });
+
     it('should allow the save onError option to override the failure side effects override', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         let saveCallback;

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -165,7 +165,7 @@ export const useEditController = <
                 const hasValidationErrors =
                     !!validationErrors &&
                     Object.keys(validationErrors).length > 0;
-                if (!hasValidationErrors) {
+                if (!hasValidationErrors || mutationMode !== 'pessimistic') {
                     notify(
                         typeof error === 'string'
                             ? error

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -159,27 +159,35 @@ export const useEditController = <
                 if (onError) {
                     return onError(error, variables, context);
                 }
-                notify(
-                    typeof error === 'string'
-                        ? error
-                        : (error as Error).message ||
-                              'ra.notification.http_error',
-                    {
-                        type: 'error',
-                        messageArgs: {
-                            _:
-                                typeof error === 'string'
-                                    ? error
-                                    : error instanceof Error ||
-                                      (typeof error === 'object' &&
-                                          error !== null &&
-                                          error.hasOwnProperty('message'))
-                                    ? // @ts-ignore
-                                      error.message
-                                    : undefined,
-                        },
-                    }
-                );
+                // Don't trigger a notification if this is a validation error
+                // (notification will be handled by the useNotifyIsFormInvalid hook)
+                const validationErrors = (error as HttpError)?.body?.errors;
+                const hasValidationErrors =
+                    !!validationErrors &&
+                    Object.keys(validationErrors).length > 0;
+                if (!hasValidationErrors) {
+                    notify(
+                        typeof error === 'string'
+                            ? error
+                            : (error as Error).message ||
+                                  'ra.notification.http_error',
+                        {
+                            type: 'error',
+                            messageArgs: {
+                                _:
+                                    typeof error === 'string'
+                                        ? error
+                                        : error instanceof Error ||
+                                          (typeof error === 'object' &&
+                                              error !== null &&
+                                              error.hasOwnProperty('message'))
+                                        ? // @ts-ignore
+                                          error.message
+                                        : undefined,
+                            },
+                        }
+                    );
+                }
             },
             ...otherMutationOptions,
             mutationMode,

--- a/packages/ra-core/src/form/Form.spec.tsx
+++ b/packages/ra-core/src/form/Form.spec.tsx
@@ -19,6 +19,7 @@ import {
     SanitizeEmptyValues,
     NullValue,
     InNonDataRouter,
+    ServerSideValidation,
 } from './Form.stories';
 import { mergeTranslations } from '../i18n';
 
@@ -767,5 +768,27 @@ describe('Form', () => {
         });
         fireEvent.click(screen.getByText('Leave the form'));
         await screen.findByText('Go to form');
+    });
+
+    it('should support server side validation', async () => {
+        render(<ServerSideValidation />);
+        fireEvent.change(screen.getByLabelText('defaultMessage'), {
+            target: { value: '' },
+        });
+        fireEvent.click(screen.getByText('Submit'));
+        await screen.findByText('Required');
+        await screen.findByText('ra.message.invalid_form');
+    });
+
+    it('should support using a custom global message with server side validation', async () => {
+        render(<ServerSideValidation />);
+        fireEvent.change(screen.getByLabelText('customGlobalMessage'), {
+            target: { value: '' },
+        });
+        fireEvent.click(screen.getByText('Submit'));
+        await screen.findByText('Required');
+        await screen.findByText(
+            'There are validation errors. Please fix them.'
+        );
     });
 });

--- a/packages/ra-core/src/form/Form.stories.tsx
+++ b/packages/ra-core/src/form/Form.stories.tsx
@@ -373,7 +373,9 @@ export const ServerSideValidation = () => {
         }
         if (!values.customGlobalMessage) {
             errors.customGlobalMessage = 'ra.validation.required';
-            errors.rootError = 'There are validation errors. Please fix them.';
+            errors.root = {
+                serverError: 'There are validation errors. Please fix them.',
+            };
         }
         return Object.keys(errors).length > 0 ? errors : undefined;
     }, []);

--- a/packages/ra-core/src/form/useNotifyIsFormInvalid.ts
+++ b/packages/ra-core/src/form/useNotifyIsFormInvalid.ts
@@ -26,11 +26,11 @@ export const useNotifyIsFormInvalid = (
             submitCountRef.current = submitCount;
 
             if (Object.keys(errors).length > 0) {
-                const rootError =
-                    typeof errors.rootError?.message === 'string'
-                        ? errors.rootError.message
+                const serverError =
+                    typeof errors.root?.serverError?.message === 'string'
+                        ? errors.root.serverError.message
                         : undefined;
-                notify(rootError || 'ra.message.invalid_form', {
+                notify(serverError || 'ra.message.invalid_form', {
                     type: 'error',
                 });
             }

--- a/packages/ra-core/src/form/useNotifyIsFormInvalid.ts
+++ b/packages/ra-core/src/form/useNotifyIsFormInvalid.ts
@@ -26,7 +26,13 @@ export const useNotifyIsFormInvalid = (
             submitCountRef.current = submitCount;
 
             if (Object.keys(errors).length > 0) {
-                notify('ra.message.invalid_form', { type: 'error' });
+                const rootError =
+                    typeof errors.rootError?.message === 'string'
+                        ? errors.rootError.message
+                        : undefined;
+                notify(rootError || 'ra.message.invalid_form', {
+                    type: 'error',
+                });
             }
         }
     }, [errors, submitCount, notify, enabled]);


### PR DESCRIPTION
### Problem

When validating server side, you can’t provide a global error message and react-admin displays a default non customizable one.

In some cases (depending on the React version) users could use the error's `message` field to render a custom message in the notification, but due to a race condition between the 2 notifications, it would not always work.

### Solution

In `useCreateController` and `useEditController`, check if there are validation errors and if we are in pessimistic mode, and don't notify in this case (as it will be done by `useNotifyIsFormInvalid`).

In `useNotifyIsFormInvalid` notify with the `root.serverError` message if available (otherwise fall back to 'ra.message.invalid_form' like currently).
