### PR TITLE
[TypeScript] Fix `useResourceDefinition` return type

### DIFF
--- a/packages/ra-core/src/core/useResourceDefinition.ts
+++ b/packages/ra-core/src/core/useResourceDefinition.ts
@@ -30,7 +30,7 @@ export const useResourceDefinition = <
     OptionsType extends ResourceOptions = any
 >(
     props?: UseResourceDefinitionOptions
-): Omit<ResourceDefinition<OptionsType>, 'name'> => {
+): ResourceDefinition<OptionsType> => {
     const resource = useResourceContext(props);
     const resourceDefinitions = useResourceDefinitions();
     const { hasCreate, hasEdit, hasList, hasShow, recordRepresentation } =
@@ -47,7 +47,7 @@ export const useResourceDefinition = <
                 recordRepresentation,
             },
             resource ? resourceDefinitions[resource] : {}
-        );
+        ) as ResourceDefinition<OptionsType>;
     }, [
         resource,
         resourceDefinitions,


### PR DESCRIPTION
**Problem**

`useResourceDefinition` used to return `Omit<ResourceDefinition, 'name'>` which is wrong (because `name` is actually present in the returned value most of the time) and causes issues in existing code using that hook.

**Solution**

Change the return type to be `ResourceDefinition`.