### PR TITLE
[Typescript] Fix compilation error in `MenuItemLink`, `ResettableTextField` and `InpectorButton` with latest `@types/react`

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -203,7 +203,10 @@ interface Props {
 }
 
 export type ResettableTextFieldProps = Props &
-    Omit<TextFieldProps, 'onChange'> & {
+    Omit<
+        TextFieldProps,
+        'onChange' | 'onPointerEnterCapture' | 'onPointerLeaveCapture'
+    > & {
         onChange?: (eventOrValue: any) => void;
     };
 

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -142,7 +142,7 @@ export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
 
 export type MenuItemLinkProps = Omit<
     LinkProps & MenuItemProps<'li'>,
-    'placeholder'
+    'placeholder' | 'onPointerEnterCapture' | 'onPointerLeaveCapture'
 > & {
     leftIcon?: ReactElement;
     primaryText?: ReactNode;

--- a/packages/ra-ui-materialui/src/preferences/InspectorButton.tsx
+++ b/packages/ra-ui-materialui/src/preferences/InspectorButton.tsx
@@ -6,7 +6,10 @@ import { useTranslate, usePreferencesEditor } from 'ra-core';
 
 export const InspectorButton = React.forwardRef<
     HTMLButtonElement,
-    IconButtonProps & { label?: string; SvgIconProps?: any }
+    Omit<
+        IconButtonProps,
+        'placeholder' | 'onPointerEnterCapture' | 'onPointerLeaveCapture'
+    > & { label?: string; SvgIconProps?: any }
 >(
     (
         {


### PR DESCRIPTION
Closes #9737

### Problem 
@types/react v18.2.66 update makes some of our components require extra props.

1. `MenuItemLink` - requires `onPointerEnterCapture`, `onPointerLeaveCapture`
2. `ResettableTextField` - requires `onPointerEnterCapture`, `onPointerLeaveCapture`
3. `InspectorButton` - requires `onPointerEnterCapture`, `onPointerLeaveCapture` and `placeholder`

Probably InspectorButton.placeholder issue was introduced even before v18.2.66

This breaks new apps bootstrapped from `create-react-admin` - you'll get typescript error if using these components

### Solution
Explicitly omit these otherwise junk props and allow to use the components without compilation error