### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,14 @@ jobs:
       run: make build
     - name: Type check simple example
       run: cd examples/simple && yarn type-check
+    - name: Zip packages build artifact
+      run: zip packages-build.zip -r packages/*/esm packages/*/lib node_modules/@react-admin/*
+    - name: Upload packages build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: packages-build
+        path: packages-build.zip
+        retention-days: 1
 
   doc-check:
     runs-on: ubuntu-latest
@@ -81,8 +89,12 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn
-      - name: Build
-        run: make build
+      - name: Download packages build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: packages-build
+      - name: Unzip packages build artifact
+        run: unzip -o -u packages-build.zip
       - name: Build e-commerce
         run: make build-demo
         env:
@@ -110,8 +122,12 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn
-      - name: Build
-        run: make build
+      - name: Download packages build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: packages-build
+      - name: Unzip packages build artifact
+        run: unzip -o -u packages-build.zip
       - name: Build crm
         run: make build-crm
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Type check simple example
       run: cd examples/simple && yarn type-check
     - name: Zip packages build artifact
-      run: zip packages-build.zip -r packages/*/dist
+      run: zip packages-build.zip -r examples/data-generator/dist packages/*/dist
     - name: Upload packages build artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,6 @@ jobs:
       run: make lint        
     - name: Build
       run: make build
-    - name: Type check simple example
-      run: cd examples/simple && yarn type-check
     - name: Zip packages build artifact
       run: zip packages-build.zip -r examples/data-generator/dist packages/*/dist
     - name: Upload packages build artifact
@@ -34,6 +32,22 @@ jobs:
         name: packages-build
         path: packages-build.zip
         retention-days: 1
+
+  simple-example-typecheck:
+    runs-on: ubuntu-latest
+    needs: [typecheck]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18.x'
+        cache: 'yarn'
+    - name: Install dependencies
+      run: yarn
+    - name: Type check simple example
+      run: cd examples/simple && yarn type-check
 
   doc-check:
     runs-on: ubuntu-latest
@@ -62,6 +76,7 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
+    needs: [typecheck]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
 
   e-commerce:
     runs-on: ubuntu-latest
+    needs: [typecheck]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -112,6 +113,7 @@ jobs:
 
   crm:
     runs-on: ubuntu-latest
+    needs: [typecheck]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Type check simple example
       run: cd examples/simple && yarn type-check
     - name: Zip packages build artifact
-      run: zip packages-build.zip -r packages/*/esm packages/*/lib node_modules/@react-admin/*
+      run: zip packages-build.zip -r packages/*/dist
     - name: Upload packages build artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
-    needs: [typecheck]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,12 @@ jobs:
         cache: 'yarn'
     - name: Install dependencies
       run: yarn
+    - name: Download packages build artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: packages-build
+    - name: Unzip packages build artifact
+      run: unzip -o -u packages-build.zip
     - name: Type check simple example
       run: cd examples/simple && yarn type-check
 


### PR DESCRIPTION
Parallelize the CI steps to avoid rebuilding the project several times. This should reduce the total number of CI minutes consumed for each build, at the price of a slightly longer build (because we need to reinstall yarn dependencies).

Build time

| Before | After |
| -- | -- |
| 4m 35s | 5m 38s |

Total build time

| Before | After |
| -- | -- |
| 22m 08s | 16m 17s |