### PR TITLE
[Doc] Specify that <PredictiveTextInput> is an enterprise component

### DIFF
--- a/docs/TextInput.md
+++ b/docs/TextInput.md
@@ -103,7 +103,7 @@ See [the `<RichTextInput>` documentation](./RichTextInput.md) for more details.
 
 ## Predictive Text Input
 
-An alternative to `<TextInput>` is [`<PredictiveTextInput>`](./PredictiveTextInput.md), which suggests completion for the input value, using your favorite AI backend. Users can accept the completion by pressing the `Tab` key. It's like Intellisense or Copilot for your forms.
+An alternative to `<TextInput>` is the [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component [`<PredictiveTextInput>`](./PredictiveTextInput.md), which suggests completion for the input value, using your favorite AI backend. Users can accept the completion by pressing the `Tab` key. It's like Intellisense or Copilot for your forms.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/PredictiveTextInput.mp4" type="video/mp4"/>


### PR DESCRIPTION
## Problem

When you read the `<PredictiveTextInput>` section of the `<TextInput>` documentation, it is not obvious that this component is an enterprise edition component.
You only can understand it by reading the import of the code snippet

## Solution

Make it clear in the text

## Screenshots

### Before
![image](https://github.com/marmelab/react-admin/assets/131013150/d97a3cd0-7873-4526-9ead-e30033038284)

### After
![image](https://github.com/marmelab/react-admin/assets/131013150/77390bfe-3317-4225-967e-a1c8c2236412)
