### PR TITLE
Refactor middlewares to handle optimistic cases

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -79,7 +79,7 @@ export const useCreateController = <
         mutationOptions;
     const {
         registerMutationMiddleware,
-        mutateWithMiddlewares,
+        getMutateWithMiddlewares,
         unregisterMutationMiddleware,
     } = useMutationMiddlewares();
 
@@ -134,7 +134,7 @@ export const useCreateController = <
         },
         ...otherMutationOptions,
         returnPromise: true,
-        mutateWithMiddlewares,
+        getMutateWithMiddlewares,
     });
 
     const save = useCallback(

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -91,7 +91,7 @@ export const useEditController = <
     } = mutationOptions;
     const {
         registerMutationMiddleware,
-        mutateWithMiddlewares,
+        getMutateWithMiddlewares,
         unregisterMutationMiddleware,
     } = useMutationMiddlewares();
     const {
@@ -192,7 +192,7 @@ export const useEditController = <
             ...otherMutationOptions,
             mutationMode,
             returnPromise: mutationMode === 'pessimistic',
-            mutateWithMiddlewares,
+            getMutateWithMiddlewares,
         }
     );
 

--- a/packages/ra-core/src/controller/saveContext/useRegisterMutationMiddleware.spec.tsx
+++ b/packages/ra-core/src/controller/saveContext/useRegisterMutationMiddleware.spec.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+    SaveContextProvider,
+    useMutationMiddlewares,
+    useRegisterMutationMiddleware,
+} from '../..';
+
+describe('useRegisterMutationMiddleware', () => {
+    it('should register and unregister middlewares correctly', async () => {
+        const middleware = jest.fn((next: () => void) => next());
+        const save = jest.fn();
+        const Middleware = () => {
+            useRegisterMutationMiddleware(middleware);
+            return null;
+        };
+        const Parent = () => {
+            const [mount, setMount] = React.useState(true);
+            const middlewaresFunctions = useMutationMiddlewares();
+
+            return (
+                <SaveContextProvider value={middlewaresFunctions}>
+                    {mount && <Middleware />}
+                    <button onClick={() => setMount(!mount)}>
+                        Toggle middleware
+                    </button>
+                    <button
+                        onClick={() => {
+                            const saveWithMiddlewares =
+                                middlewaresFunctions.getMutateWithMiddlewares(
+                                    save
+                                );
+                            saveWithMiddlewares();
+                        }}
+                    >
+                        Save
+                    </button>
+                </SaveContextProvider>
+            );
+        };
+
+        render(<Parent />);
+        fireEvent.click(screen.getByText('Save'));
+        await waitFor(() => {
+            expect(save).toHaveBeenCalledTimes(1);
+        });
+        expect(middleware).toHaveBeenCalledTimes(1);
+        save.mockClear();
+        middleware.mockClear();
+        fireEvent.click(screen.getByText('Toggle middleware'));
+        fireEvent.click(screen.getByText('Save'));
+        await waitFor(() => {
+            expect(save).toHaveBeenCalledTimes(1);
+        });
+        expect(middleware).not.toHaveBeenCalled();
+    });
+
+    it('should execute middlewares registered even if they have been unregistered as an optimistic side effect', async () => {
+        const middleware = jest.fn((next: () => void) => next());
+        const save = jest.fn();
+        const Middleware = () => {
+            useRegisterMutationMiddleware(middleware);
+            return <span>Middleware</span>;
+        };
+        const Parent = () => {
+            const [mount, setMount] = React.useState(true);
+            const middlewaresFunctions = useMutationMiddlewares();
+
+            return (
+                <SaveContextProvider value={middlewaresFunctions}>
+                    {mount && <Middleware />}
+                    <button
+                        onClick={() => {
+                            const saveWithMiddlewares =
+                                middlewaresFunctions.getMutateWithMiddlewares(
+                                    save
+                                );
+                            // Mimic optimistic side effect such as redirect which would unregister the middleware
+                            setMount(false);
+                            setTimeout(() => {
+                                saveWithMiddlewares();
+                            }, 250);
+                        }}
+                    >
+                        Save
+                    </button>
+                </SaveContextProvider>
+            );
+        };
+
+        render(<Parent />);
+        fireEvent.click(screen.getByText('Save'));
+        await waitFor(() => {
+            expect(screen.queryByText('Middleware')).toBeNull();
+            expect(save).not.toHaveBeenCalled();
+        });
+        await waitFor(() => {
+            expect(save).toHaveBeenCalledTimes(1);
+        });
+        expect(middleware).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -7,6 +7,10 @@ import { testDataProvider } from './testDataProvider';
 import { useCreate } from './useCreate';
 import { useGetList } from './useGetList';
 import { CoreAdminContext } from '../core';
+import {
+    WithMiddlewaresError,
+    WithMiddlewaresSuccess,
+} from './useCreate.stories';
 
 describe('useCreate', () => {
     it('returns a callback that can be used with create arguments', async () => {
@@ -179,6 +183,51 @@ describe('useCreate', () => {
         createButton.click();
         await waitFor(() => {
             expect(screen.queryByText('ghi')).not.toBeNull();
+        });
+    });
+
+    describe('middlewares', () => {
+        it('it accepts middlewares and displays result and success side effects when dataProvider promise resolves', async () => {
+            render(<WithMiddlewaresSuccess timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+
+        it('it accepts middlewares and displays error and error side effects when dataProvider promise rejects', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<WithMiddlewaresError timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(screen.queryByText('something went wrong')).toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(
+                    screen.queryByText('something went wrong')
+                ).not.toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
         });
     });
 });

--- a/packages/ra-core/src/dataProvider/useCreate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.stories.tsx
@@ -186,6 +186,7 @@ const WithMiddlewaresSuccessCore = () => {
             data: { title: 'Hello World' },
         },
         {
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
@@ -265,6 +266,7 @@ const WithMiddlewaresErrorCore = () => {
             data: { title: 'Hello World' },
         },
         {
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,

--- a/packages/ra-core/src/dataProvider/useCreate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.stories.tsx
@@ -3,26 +3,24 @@ import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
 
 import { CoreAdminContext } from '../core';
-import { useUpdate } from './useUpdate';
+import { useCreate } from './useCreate';
 import { useGetOne } from './useGetOne';
 
-export default { title: 'ra-core/dataProvider/useUpdate/pessimistic' };
+export default { title: 'ra-core/dataProvider/useCreate' };
 
 export const SuccessCase = ({ timeout = 1000 }) => {
-    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const posts: { id: number; title: string; author: string }[] = [];
     const dataProvider = {
         getOne: (resource, params) => {
             return Promise.resolve({
                 data: posts.find(p => p.id === params.id),
             });
         },
-        update: (resource, params) => {
+        create: (resource, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
-                    const post = posts.find(p => p.id === params.id);
-                    if (post) {
-                        post.title = params.data.title;
-                    }
+                    const post = { id: posts.length + 1, ...params.data };
+                    posts.push(post);
                     resolve({ data: post });
                 }, timeout);
             });
@@ -41,17 +39,19 @@ export const SuccessCase = ({ timeout = 1000 }) => {
 const SuccessCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
-    const { data, refetch } = useGetOne('posts', { id: 1 });
-    const [update, { isPending }] = useUpdate();
+    const { data, refetch } = useGetOne(
+        'posts',
+        { id: 1 },
+        { enabled: success === 'success' }
+    );
+    const [create, { isPending }] = useCreate();
     const handleClick = () => {
-        update(
+        create(
             'posts',
             {
-                id: 1,
                 data: { title: 'Hello World' },
             },
             {
-                mutationMode: 'pessimistic',
                 onSuccess: () => setSuccess('success'),
             }
         );
@@ -61,12 +61,10 @@ const SuccessCore = () => {
             <dl>
                 <dt>title</dt>
                 <dd>{data?.title}</dd>
-                <dt>author</dt>
-                <dd>{data?.author}</dd>
             </dl>
             <div>
                 <button onClick={handleClick} disabled={isPending}>
-                    Update title
+                    Create post
                 </button>
                 &nbsp;
                 <button onClick={() => refetch()}>Refetch</button>
@@ -78,14 +76,14 @@ const SuccessCore = () => {
 };
 
 export const ErrorCase = ({ timeout = 1000 }) => {
-    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const posts: { id: number; title: string; author: string }[] = [];
     const dataProvider = {
         getOne: (resource, params) => {
             return Promise.resolve({
                 data: posts.find(p => p.id === params.id),
             });
         },
-        update: () => {
+        create: () => {
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
                     reject(new Error('something went wrong'));
@@ -107,18 +105,20 @@ const ErrorCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
-    const { data, refetch } = useGetOne('posts', { id: 1 });
-    const [update, { isPending }] = useUpdate();
+    const { data, refetch } = useGetOne(
+        'posts',
+        { id: 1 },
+        { enabled: success === 'success' }
+    );
+    const [create, { isPending }] = useCreate();
     const handleClick = () => {
         setError(undefined);
-        update(
+        create(
             'posts',
             {
-                id: 1,
                 data: { title: 'Hello World' },
             },
             {
-                mutationMode: 'pessimistic',
                 onSuccess: () => setSuccess('success'),
                 onError: e => setError(e),
             }
@@ -129,12 +129,10 @@ const ErrorCore = () => {
             <dl>
                 <dt>title</dt>
                 <dd>{data?.title}</dd>
-                <dt>author</dt>
-                <dd>{data?.author}</dd>
             </dl>
             <div>
                 <button onClick={handleClick} disabled={isPending}>
-                    Update title
+                    Create post
                 </button>
                 &nbsp;
                 <button onClick={() => refetch()}>Refetch</button>
@@ -147,20 +145,18 @@ const ErrorCore = () => {
 };
 
 export const WithMiddlewaresSuccess = ({ timeout = 1000 }) => {
-    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const posts: { id: number; title: string; author: string }[] = [];
     const dataProvider = {
         getOne: (resource, params) => {
             return Promise.resolve({
                 data: posts.find(p => p.id === params.id),
             });
         },
-        update: (resource, params) => {
+        create: (resource, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
-                    const post = posts.find(p => p.id === params.id);
-                    if (post) {
-                        post.title = params.data.title;
-                    }
+                    const post = { id: posts.length + 1, ...params.data };
+                    posts.push(post);
                     resolve({ data: post });
                 }, timeout);
             });
@@ -179,15 +175,17 @@ export const WithMiddlewaresSuccess = ({ timeout = 1000 }) => {
 const WithMiddlewaresSuccessCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
-    const { data, refetch } = useGetOne('posts', { id: 1 });
-    const [update, { isPending }] = useUpdate(
+    const { data, refetch } = useGetOne(
+        'posts',
+        { id: 1 },
+        { enabled: success === 'success' }
+    );
+    const [create, { isPending }] = useCreate(
         'posts',
         {
-            id: 1,
             data: { title: 'Hello World' },
         },
         {
-            mutationMode: 'pessimistic',
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
@@ -197,14 +195,12 @@ const WithMiddlewaresSuccessCore = () => {
         }
     );
     const handleClick = () => {
-        update(
+        create(
             'posts',
             {
-                id: 1,
                 data: { title: 'Hello World' },
             },
             {
-                mutationMode: 'pessimistic',
                 onSuccess: () => setSuccess('success'),
             }
         );
@@ -214,12 +210,10 @@ const WithMiddlewaresSuccessCore = () => {
             <dl>
                 <dt>title</dt>
                 <dd>{data?.title}</dd>
-                <dt>author</dt>
-                <dd>{data?.author}</dd>
             </dl>
             <div>
                 <button onClick={handleClick} disabled={isPending}>
-                    Update title
+                    Create post
                 </button>
                 &nbsp;
                 <button onClick={() => refetch()}>Refetch</button>
@@ -231,14 +225,14 @@ const WithMiddlewaresSuccessCore = () => {
 };
 
 export const WithMiddlewaresError = ({ timeout = 1000 }) => {
-    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const posts: { id: number; title: string; author: string }[] = [];
     const dataProvider = {
         getOne: (resource, params) => {
             return Promise.resolve({
                 data: posts.find(p => p.id === params.id),
             });
         },
-        update: () => {
+        create: () => {
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
                     reject(new Error('something went wrong'));
@@ -260,15 +254,17 @@ const WithMiddlewaresErrorCore = () => {
     const isMutating = useIsMutating();
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
-    const { data, refetch } = useGetOne('posts', { id: 1 });
-    const [update, { isPending }] = useUpdate(
+    const { data, refetch } = useGetOne(
+        'posts',
+        { id: 1 },
+        { enabled: success === 'success' }
+    );
+    const [create, { isPending }] = useCreate(
         'posts',
         {
-            id: 1,
             data: { title: 'Hello World' },
         },
         {
-            mutationMode: 'pessimistic',
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
@@ -279,14 +275,12 @@ const WithMiddlewaresErrorCore = () => {
     );
     const handleClick = () => {
         setError(undefined);
-        update(
+        create(
             'posts',
             {
-                id: 1,
                 data: { title: 'Hello World' },
             },
             {
-                mutationMode: 'pessimistic',
                 onSuccess: () => setSuccess('success'),
                 onError: e => setError(e),
             }
@@ -297,12 +291,10 @@ const WithMiddlewaresErrorCore = () => {
             <dl>
                 <dt>title</dt>
                 <dd>{data?.title}</dd>
-                <dt>author</dt>
-                <dd>{data?.author}</dd>
             </dl>
             <div>
                 <button onClick={handleClick} disabled={isPending}>
-                    Update title
+                    Create post
                 </button>
                 &nbsp;
                 <button onClick={() => refetch()}>Refetch</button>

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -85,7 +85,7 @@ export const useCreate = <
     const hasCallTimeOnError = useRef(false);
     const hasCallTimeOnSuccess = useRef(false);
     const hasCallTimeOnSettled = useRef(false);
-    const { mutateWithMiddlewares, ...mutationOptions } = options;
+    const { getMutateWithMiddlewares, ...mutationOptions } = options;
     const mutation = useMutation<
         ResultRecordType,
         MutationError,
@@ -106,15 +106,14 @@ export const useCreate = <
                     'useCreate mutation requires a non-empty data object'
                 );
             }
-            if (mutateWithMiddlewares) {
-                return mutateWithMiddlewares(
-                    dataProvider.create.bind(dataProvider),
-                    callTimeResource,
-                    {
-                        data: callTimeData,
-                        meta: callTimeMeta,
-                    }
-                ).then(({ data }) => data);
+            if (getMutateWithMiddlewares) {
+                const createWithMiddlewares = getMutateWithMiddlewares(
+                    dataProvider.create.bind(dataProvider)
+                );
+                return createWithMiddlewares(callTimeResource, {
+                    data: callTimeData,
+                    meta: callTimeMeta,
+                }).then(({ data }) => data);
             }
             return dataProvider
                 .create<RecordType, ResultRecordType>(callTimeResource, {
@@ -226,11 +225,12 @@ export type UseCreateOptions<
     'mutationFn'
 > & {
     returnPromise?: boolean;
-    mutateWithMiddlewares?: <
+    getMutateWithMiddlewares?: <
         CreateFunctionType extends
             DataProvider['create'] = DataProvider['create'],
     >(
-        mutate: CreateFunctionType,
+        mutate: CreateFunctionType
+    ) => (
         ...Params: Parameters<CreateFunctionType>
     ) => ReturnType<CreateFunctionType>;
 };

--- a/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
@@ -190,7 +190,7 @@ const WithMiddlewaresSuccessCore = () => {
         },
         {
             mutationMode: 'optimistic',
-            mutateWithMiddlewares: async (mutate, resource, params) => {
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
                     data: { title: `${params.data.title} from middleware` },
@@ -270,7 +270,7 @@ const WithMiddlewaresErrorCore = () => {
         },
         {
             mutationMode: 'optimistic',
-            mutateWithMiddlewares: async (mutate, resource, params) => {
+            mutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
                     data: { title: `${params.data.title} from middleware` },

--- a/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
@@ -190,6 +190,7 @@ const WithMiddlewaresSuccessCore = () => {
         },
         {
             mutationMode: 'optimistic',
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
@@ -270,6 +271,7 @@ const WithMiddlewaresErrorCore = () => {
         },
         {
             mutationMode: 'optimistic',
+            // @ts-ignore
             mutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,

--- a/packages/ra-core/src/dataProvider/useUpdate.pessimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.pessimistic.stories.tsx
@@ -188,6 +188,7 @@ const WithMiddlewaresSuccessCore = () => {
         },
         {
             mutationMode: 'pessimistic',
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
@@ -269,6 +270,7 @@ const WithMiddlewaresErrorCore = () => {
         },
         {
             mutationMode: 'pessimistic',
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,

--- a/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
@@ -248,6 +248,7 @@ const WithMiddlewaresCore = () => {
         },
         {
             mutationMode: 'undoable',
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
@@ -356,6 +357,7 @@ const WithMiddlewaresErrorCore = () => {
         },
         {
             mutationMode: 'undoable',
+            // @ts-ignore
             getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,

--- a/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
@@ -248,7 +248,7 @@ const WithMiddlewaresCore = () => {
         },
         {
             mutationMode: 'undoable',
-            mutateWithMiddlewares: async (mutate, resource, params) => {
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
                     data: { title: `${params.data.title} from middleware` },
@@ -356,7 +356,7 @@ const WithMiddlewaresErrorCore = () => {
         },
         {
             mutationMode: 'undoable',
-            mutateWithMiddlewares: async (mutate, resource, params) => {
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
                 return mutate(resource, {
                     ...params,
                     data: { title: `${params.data.title} from middleware` },


### PR DESCRIPTION
## Problem

By the time optimistic and undoable mutations dataProvider calls are really executed, the calling component might have been unmounted leading to the middlewares being unregistered and hence, not applied.

## Solution

When the mutation is called, keep the current callbacks in a closure