### PR TITLE
Fix React requirement is too strict on npm

### DIFF
--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -32,8 +32,8 @@
         "typescript": "^5.1.3"
     },
     "peerDependencies": {
-        "react": "18.0.0",
-        "react-dom": "18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
     },
     "dependencies": {
         "@emotion/react": "^11.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19242,8 +19242,8 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.1.3"
   peerDependencies:
-    react: 18.0.0
-    react-dom: 18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Problem

With `npm`, react-admin v5 requires React 18.0.0... and no other version. 

## Solution

Relax peer dependency of the `react-admin` package