### PR TITLE
[v5] [Storybook] Fix some stories appear broken on devices which prefer dark mode

### DIFF
--- a/packages/ra-ui-materialui/src/auth/Logout.stories.tsx
+++ b/packages/ra-ui-materialui/src/auth/Logout.stories.tsx
@@ -15,7 +15,7 @@ const MinimalAdmin = (props: { authenticated: boolean }) => {
         getPermissions: () => Promise.resolve(),
     };
     return (
-        <AdminContext authProvider={authProvider}>
+        <AdminContext authProvider={authProvider} defaultTheme="light">
             <Typography variant="h6">
                 Should {props.authenticated ? '' : 'not '}display logout button
             </Typography>

--- a/packages/ra-ui-materialui/src/button/SaveButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.stories.tsx
@@ -10,7 +10,7 @@ export default {
 };
 
 export const Basic = () => (
-    <AdminContext>
+    <AdminContext defaultTheme="light">
         <Form>
             <SaveButton />
         </Form>
@@ -26,7 +26,7 @@ const MakeFormChange = () => {
 };
 
 export const Dirty = () => (
-    <AdminContext>
+    <AdminContext defaultTheme="light">
         <Form>
             <MakeFormChange />
             <SaveButton />
@@ -35,7 +35,7 @@ export const Dirty = () => (
 );
 
 export const AlwaysEnable = () => (
-    <AdminContext>
+    <AdminContext defaultTheme="light">
         <Form>
             <SaveButton alwaysEnable />
         </Form>
@@ -43,7 +43,7 @@ export const AlwaysEnable = () => (
 );
 
 export const Submitting = () => (
-    <AdminContext>
+    <AdminContext defaultTheme="light">
         <Form onSubmit={() => new Promise(() => {})}>
             <MakeFormChange />
             <SaveButton />

--- a/packages/ra-ui-materialui/src/button/ToggleThemeButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/ToggleThemeButton.stories.tsx
@@ -100,25 +100,3 @@ export const Basic = () => (
         </Admin>
     </TestMemoryRouter>
 );
-
-const MyAppBar = () => (
-    <AppBar>
-        <TitlePortal />
-        <ToggleThemeButton darkTheme={{ palette: { mode: 'dark' } }} />
-    </AppBar>
-);
-const MyLayout = ({ children }) => (
-    <Layout appBar={MyAppBar}>{children}</Layout>
-);
-
-export const Legacy = () => (
-    <TestMemoryRouter initialEntries={['/books']}>
-        <Admin
-            store={memoryStore()}
-            dataProvider={dataProvider}
-            layout={MyLayout}
-        >
-            <Resource name="books" list={BookList} />
-        </Admin>
-    </TestMemoryRouter>
-);

--- a/packages/ra-ui-materialui/src/button/ToggleThemeButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/ToggleThemeButton.stories.tsx
@@ -5,8 +5,6 @@ import fakeRestDataProvider from 'ra-data-fakerest';
 
 import { List, Datagrid } from '../list';
 import { TextField } from '../field';
-import { AppBar, Layout, TitlePortal } from '../layout';
-import { ToggleThemeButton } from './ToggleThemeButton';
 
 export default { title: 'ra-ui-materialui/button/ToggleThemeButton' };
 


### PR DESCRIPTION
The following stories appeared broken when rendered on a device which prefers dark mode:

- http://localhost:9010/?path=/story/ra-ui-materialui-auth-logout--user-authenticated : icon button appears missing
- http://localhost:9010/?path=/story/ra-ui-materialui-button-savebutton--basic : button is not visible at all
- http://localhost:9010/?path=/story/ra-ui-materialui-button-togglethemebutton--legacy : toggle theme button is rendered twice => I guess it's because we no longer support BC in v5, so I simply removed the story

Setting `defaultTheme="light"` fixes them.