### PR TITLE
Fix ReferenceInput in ArrayInput

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.ts
@@ -1,11 +1,12 @@
 import { useCallback, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
-import { FilterPayload, RaRecord, SortPayload } from '../../types';
 import { useGetList, useGetManyAggregate } from '../../dataProvider';
 import { useReferenceParams } from './useReferenceParams';
-import { ChoicesContextValue } from '../../form';
-import { UseQueryOptions } from '@tanstack/react-query';
+import { useWrappedSource } from '../../core';
+import type { FilterPayload, RaRecord, SortPayload } from '../../types';
+import type { ChoicesContextValue } from '../../form';
 
 /**
  * Prepare data for the ReferenceArrayInput components
@@ -46,9 +47,10 @@ export const useReferenceArrayInputController = <
         source,
     } = props;
     const { getValues } = useFormContext();
+    const finalSource = useWrappedSource(source);
     // When we change the defaultValue of the child input using react-hook-form resetField function,
     // useWatch does not seem to get the new value. We fallback to getValues to get it.
-    const value = useWatch({ name: source }) ?? getValues(source);
+    const value = useWatch({ name: finalSource }) ?? getValues(finalSource);
     const { meta, ...otherQueryOptions } = queryOptions;
 
     /**
@@ -161,6 +163,7 @@ export const useReferenceArrayInputController = <
         setPerPage: paramsModifiers.setPerPage,
         setSort: paramsModifiers.setSort,
         showFilter: paramsModifiers.showFilter,
+        // we return source and not finalSource because child inputs (e.g. AutocompleteArrayInput) already call useInput and compute the final source
         source,
         total: total,
         hasNextPage: pageInfo

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -186,6 +186,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
         setPerPage: paramsModifiers.setPerPage,
         setSort: paramsModifiers.setSort,
         showFilter: paramsModifiers.showFilter,
+        // we return source and not finalSource because child inputs (e.g. AutocompleteInput) already call useInput and compute the final source
         source,
         total: finalTotal,
         hasNextPage: pageInfo

--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
 import { useGetList } from '../../dataProvider';
-import { FilterPayload, RaRecord, SortPayload } from '../../types';
 import { useReference } from '../useReference';
-import { ChoicesContextValue } from '../../form';
 import { useReferenceParams } from './useReferenceParams';
-import { UseQueryOptions } from '@tanstack/react-query';
+import { useWrappedSource } from '../../core';
+import type { FilterPayload, RaRecord, SortPayload } from '../../types';
+import type { ChoicesContextValue } from '../../form';
 
 /**
  * A hook for choosing a reference record. Useful for foreign keys.
@@ -68,7 +70,8 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
     });
 
     // selection logic
-    const currentValue = useWatch({ name: source });
+    const finalSource = useWrappedSource(source);
+    const currentValue = useWatch({ name: finalSource });
 
     const isGetMatchingEnabled = enableGetChoices
         ? enableGetChoices(params.filterValues)

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
@@ -18,6 +18,7 @@ import {
     dataProviderWithAuthors,
     SelfReference,
     QueryOptions,
+    InArrayInput,
 } from './ReferenceInput.stories';
 
 describe('<ReferenceInput />', () => {
@@ -275,5 +276,14 @@ describe('<ReferenceInput />', () => {
         await screen.findByText(
             '<ReferenceInput> does not accept a validate prop. Set the validate prop on the child instead.'
         );
+    });
+
+    it('should work in an ArrayInput', async () => {
+        render(<InArrayInput />);
+        await screen.findByDisplayValue('Novels');
+        await screen.findByDisplayValue('War and Peace');
+        await screen.findByDisplayValue('Leo Tolstoy');
+        await screen.findByDisplayValue('Les misérables');
+        await screen.findByDisplayValue('Victor Hugo');
     });
 });

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.stories.tsx
@@ -16,8 +16,15 @@ import { Stack, Divider, Typography, Button, Paper } from '@mui/material';
 import { AdminContext } from '../AdminContext';
 import { Edit } from '../detail';
 import { SimpleForm } from '../form';
-import { SelectInput, RadioButtonGroupInput, TextInput } from '../input';
+import {
+    SelectInput,
+    RadioButtonGroupInput,
+    TextInput,
+    ArrayInput,
+    SimpleFormIterator,
+} from '../input';
 import { ReferenceInput } from './ReferenceInput';
+import { ListGuesser } from '../list/ListGuesser';
 
 export default {
     title: 'ra-ui-materialui/input/ReferenceInput',
@@ -621,6 +628,102 @@ export const QueryOptions = () => (
                 list={AuthorList}
             />
             <Resource name="books" edit={BookEditQueryOptions} />
+        </Admin>
+    </TestMemoryRouter>
+);
+
+const CollectionEdit = () => (
+    <Edit>
+        <SimpleForm>
+            <TextInput source="name" />
+            <ArrayInput source="books">
+                <SimpleFormIterator>
+                    <TextInput source="title" />
+                    <ReferenceInput
+                        reference="authors"
+                        source="author_id"
+                        perPage={1}
+                    />
+                </SimpleFormIterator>
+            </ArrayInput>
+        </SimpleForm>
+    </Edit>
+);
+
+export const InArrayInput = () => (
+    <TestMemoryRouter initialEntries={['/collections/1']}>
+        <Admin
+            dataProvider={fakeRestDataProvider(
+                {
+                    collections: [
+                        {
+                            id: 1,
+                            name: 'Novels',
+                            books: [
+                                {
+                                    title: 'War and Peace',
+                                    author_id: 1,
+                                    summary:
+                                        "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                                    year: 1869,
+                                },
+                                {
+                                    title: 'Les misérables',
+                                    author_id: 2,
+                                    summary:
+                                        'Les Misérables is a French historical novel by Victor Hugo, first published in 1862, that is considered one of the greatest novels of the 19th century.',
+                                    year: 1862,
+                                },
+                            ],
+                        },
+                    ],
+                    authors: [
+                        {
+                            id: 1,
+                            first_name: 'Leo',
+                            last_name: 'Tolstoy',
+                            language: 'Russian',
+                        },
+                        {
+                            id: 2,
+                            first_name: 'Victor',
+                            last_name: 'Hugo',
+                            language: 'French',
+                        },
+                        {
+                            id: 3,
+                            first_name: 'William',
+                            last_name: 'Shakespeare',
+                            language: 'English',
+                        },
+                        {
+                            id: 4,
+                            first_name: 'Charles',
+                            last_name: 'Baudelaire',
+                            language: 'French',
+                        },
+                        {
+                            id: 5,
+                            first_name: 'Marcel',
+                            last_name: 'Proust',
+                            language: 'French',
+                        },
+                    ],
+                },
+                process.env.NODE_ENV === 'development'
+            )}
+        >
+            <Resource
+                name="authors"
+                recordRepresentation={record =>
+                    `${record.first_name} ${record.last_name}`
+                }
+            />
+            <Resource
+                name="collections"
+                list={ListGuesser}
+                edit={CollectionEdit}
+            />
         </Admin>
     </TestMemoryRouter>
 );


### PR DESCRIPTION
## Problem

When rendering a ReferenceInput inside an ArrayInput, the current value is never fetched.

## Analysis

The current value is grabbed by `useReferenceInputController` as follows:

```jsx
const currentValue = useWatch({ name: source });
```

The problem is, the source is no longer modified by the parent ArrayInput. So when using:

```jsx
      <ArrayInput source="basket">
        <SimpleFormIterator>
          <ReferenceInput source="product_id" reference="products" />
          <NumberInput source="quantity" />
        </SimpleFormIterator>
      </ArrayInput>
```

ReferenceInput will get the current value from `product_id` instead of `basket.0.product_id`.

cf https://github.com/marmelab/react-admin/blob/51e8a7c1ac90011b83d8cd8d2c4e39d9d2c4effa/packages/ra-core/src/controller/input/useReferenceInputController.ts#L71

## Solution

Use the `useWrappedSource` hook 

## To Do 

- [x] Fix `<ReferenceInput>`
- [x] Fix `<ReferenceArrayInput>`