### PR TITLE
docs: remove trailing slash on url

### DIFF
--- a/docs/NextJs.md
+++ b/docs/NextJs.md
@@ -201,7 +201,7 @@ async function handler(request: Request) {
     const requestUrl = request.url.split('/api/admin')[1];
 
     // build the CRUD request based on the incoming request
-    const url = `${process.env.SUPABASE_URL}/rest/v1/${requestUrl}`;
+    const url = `${process.env.SUPABASE_URL}/rest/v1${requestUrl}`;
 
     const options: RequestInit = {
         method: request.method,


### PR DESCRIPTION
Remove trailing slash after `v1`

- ❌ `${process.env.SUPABASE_URL}/rest/v1/${requestUrl}`
- ✅ `${process.env.SUPABASE_URL}/rest/v1${requestUrl}`

If this is not removed the resulting URL contains a double slash before the endpoint, e.g

`https://abc123.supabase.co/rest/v1//users?offset=0&limit=10&order=id.asc`