### PR TITLE
Fix `<TextField>` should call `toString` instead of `JSON.stringify` for non-string values

### DIFF
--- a/packages/ra-ui-materialui/src/field/TextField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/TextField.spec.tsx
@@ -112,4 +112,15 @@ describe('<TextField />', () => {
 
         expect(screen.getByText('Not found')).not.toBeNull();
     });
+
+    it('should call toString on a value that is not a string', () => {
+        const record = {
+            id: 123,
+            type: ['Rock', 'Folk Rock'],
+        };
+        const { queryByText } = render(
+            <TextField record={record} source="type" />
+        );
+        expect(queryByText('Rock,Folk Rock')).not.toBeNull();
+    });
 });

--- a/packages/ra-ui-materialui/src/field/TextField.tsx
+++ b/packages/ra-ui-materialui/src/field/TextField.tsx
@@ -24,7 +24,7 @@ const TextFieldImpl = <
             {...sanitizeFieldRestProps(rest)}
         >
             {value != null && typeof value !== 'string'
-                ? JSON.stringify(value)
+                ? value.toString()
                 : value ||
                   (emptyText ? translate(emptyText, { _: emptyText }) : null)}
         </Typography>


### PR DESCRIPTION
Rationale: `JSON.stringify` displays a 'technical' representation of an object, while `toString` is more optimized to display a string representation of its content (e.g. when it is an Array or a Date).

This also has the benefit of keeping the same behavior as RA v4.