### PR TITLE
Fix `useDelete` doesn't delete record if its id is zero

### DIFF
--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -167,6 +167,31 @@ describe('useDelete', () => {
         });
     });
 
+    it('should delete record even if id is zero', async () => {
+        const dataProvider = testDataProvider({
+            delete: jest.fn(() => Promise.resolve({ data: { id: 0 } } as any)),
+        });
+        let localDeleteOne;
+        const Dummy = () => {
+            const [deleteOne] = useDelete();
+            localDeleteOne = deleteOne;
+            return <span />;
+        };
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Dummy />
+            </CoreAdminContext>
+        );
+        localDeleteOne('foo', { id: 0, previousData: { id: 0, bar: 'bar' } });
+        await waitFor(() => {
+            expect(dataProvider.delete).toHaveBeenCalledWith('foo', {
+                id: 0,
+                previousData: { id: 0, bar: 'bar' },
+            });
+        });
+    });
+
     describe('mutationOptions', () => {
         it('when pessimistic, executes success side effects on success', async () => {
             const onSuccess = jest.fn();

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -204,7 +204,7 @@ export const useDelete = <
                     'useDelete mutation requires a non-empty resource'
                 );
             }
-            if (!callTimeId) {
+            if (callTimeId === undefined || callTimeId === null) {
                 throw new Error('useDelete mutation requires a non-empty id');
             }
             return dataProvider

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -204,7 +204,7 @@ export const useDelete = <
                     'useDelete mutation requires a non-empty resource'
                 );
             }
-            if (callTimeId === undefined || callTimeId === null) {
+            if (callTimeId == null) {
                 throw new Error('useDelete mutation requires a non-empty id');
             }
             return dataProvider


### PR DESCRIPTION
## Problem

The `useDelete` hook does not delete the record if its id is zero. However, a record with 0 as identifier could exist.
Introduced by #9741 [here](https://github.com/marmelab/react-admin/pull/9741/files#diff-cd53d268c8805400093877effffadd54241b534266a80e1ab0bed1646cf51c59R208)

## Solution

Allow deletion of record with id 0