### PR TITLE
Fix `<SelectInput resettable>` does not reset the value

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -214,17 +214,24 @@ export const SelectInput = (props: SelectInputProps) => {
     ]);
 
     const handleChange = useCallback(
-        async (eventOrChoice: ChangeEvent<HTMLInputElement> | RaRecord) => {
-            // We might receive an event from the mui component
-            // In this case, it will be the choice id
-            if (eventOrChoice?.target) {
+        async (
+            eventOrChoice: ChangeEvent<HTMLInputElement> | RaRecord | ''
+        ) => {
+            if (typeof eventOrChoice === 'string') {
+                if (eventOrChoice === '') {
+                    // called  by the reset button
+                    field.onChange(emptyValue);
+                }
+            } else if (eventOrChoice?.target) {
+                // We might receive an event from the mui component
+                // In this case, it will be the choice id
                 field.onChange(eventOrChoice);
             } else {
                 // Or we might receive a choice directly, for instance a newly created one
                 field.onChange(getChoiceValue(eventOrChoice));
             }
         },
-        [field, getChoiceValue]
+        [field, getChoiceValue, emptyValue]
     );
 
     const {


### PR DESCRIPTION
## Problem

When clicking the reset button on a `<SelectInput resettable>`, the value comes back to the default one instead of the empty value. 


https://github.com/marmelab/react-admin/assets/99944/9bfbc03d-2f9a-4037-b636-2d855832abc9

