### PR TITLE
Avoid double queries strict mode

### DIFF
--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -475,6 +475,15 @@ It's up to you to use this `meta` parameter in your data provider.
 
 All data provider queries can be called with an extra `signal` parameter. This parameter will receive an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to abort the request.
 
+To enable this feature, your data provider must have a `supportAbortSignal` property set to `true`. This is necessary to avoid queries to be sent twice in `development` mode when rendering your application inside [`<React.StrictMode>`](https://react.dev/reference/react/StrictMode).
+
+```tsx
+const dataProvider = simpleRestProvider('https://myapi.com');
+dataProvider.supportAbortSignal = true;
+// You can set this property depending on the production mode, e.g in Vite
+dataProvider.supportAbortSignal = import.meta.env.MODE === 'production';
+```
+
 When React Admin calls a data provider query method, it wraps it using [React Query](https://tanstack.com/query/v5/docs/react/overview), which supports automatic [Query Cancellation](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation) thanks to the `signal` parameter.
 
 You can also benefit from this feature if you wrap your calls to the dataProvider with `useQuery`, and pass the `signal` parameter to the dataProvider:

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -859,3 +859,16 @@ const dataProvider = withLifecycleCallbacks(
 ```
 
 Feel free to read the [Cloudinary Get Started doc](https://cloudinary.com/documentation/programmable_media_overview) to learn more.
+
+## Query Cancellation
+
+React-admin supports [Query Cancellation](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation) through an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
+
+To enable this feature, your data provider must have a `supportAbortSignal` property set to `true`. This is necessary to avoid queries to be sent twice in `development` mode when rendering your application inside [`<React.StrictMode>`](https://react.dev/reference/react/StrictMode).
+
+```tsx
+const dataProvider = simpleRestProvider('https://myapi.com');
+dataProvider.supportAbortSignal = true;
+// You can set this property depending on the production mode, e.g in Vite
+dataProvider.supportAbortSignal = import.meta.env.MODE === 'production';
+```

--- a/examples/demo/src/dataProvider/index.ts
+++ b/examples/demo/src/dataProvider/index.ts
@@ -14,7 +14,7 @@ export default (type: string) => {
     // the login page. By the time they come back to the admin as a signed-in user,
     // the fake server will be initialized.
     const dataProviderWithGeneratedData = new Proxy(defaultDataProvider, {
-        get(target, name) {
+        get(_, name) {
             if (name === 'supportAbortSignal') {
                 return supportAbortSignal;
             }

--- a/examples/demo/src/dataProvider/index.ts
+++ b/examples/demo/src/dataProvider/index.ts
@@ -5,7 +5,6 @@ export default (type: string) => {
     // The fake servers require to generate data, which can take some time.
     // Here we start the server initialization but we don't wait for it to finish
     let dataProviderPromise = getDataProvider(type);
-    let supportAbortSignal: boolean | undefined = false;
 
     // Instead we return this proxy which may be called immediately by react-admin if the
     // user is already signed-in. In this case, we simply wait for the dataProvider promise
@@ -16,11 +15,10 @@ export default (type: string) => {
     const dataProviderWithGeneratedData = new Proxy(defaultDataProvider, {
         get(_, name) {
             if (name === 'supportAbortSignal') {
-                return supportAbortSignal;
+                return import.meta.env.MODE === 'production';
             }
             return (resource: string, params: any) => {
                 return dataProviderPromise.then(dataProvider => {
-                    supportAbortSignal = dataProvider.supportAbortSignal;
                     return dataProvider[name.toString()](resource, params);
                 });
             };

--- a/examples/demo/src/dataProvider/rest.ts
+++ b/examples/demo/src/dataProvider/rest.ts
@@ -8,9 +8,6 @@ const delayedDataProvider = new Proxy(restProvider, {
         if (name === 'then') {
             return self;
         }
-        if (name === 'supportAbortSignal') {
-            return restProvider.supportAbortSignal;
-        }
         return (resource: string, params: any) =>
             new Promise(resolve =>
                 setTimeout(
@@ -22,5 +19,4 @@ const delayedDataProvider = new Proxy(restProvider, {
     },
 });
 
-delayedDataProvider.supportAbortSignal = import.meta.env.MODE === 'production';
 export default delayedDataProvider;

--- a/examples/demo/src/dataProvider/rest.ts
+++ b/examples/demo/src/dataProvider/rest.ts
@@ -3,19 +3,24 @@ import simpleRestProvider from 'ra-data-simple-rest';
 const restProvider = simpleRestProvider('http://localhost:4000');
 
 const delayedDataProvider = new Proxy(restProvider, {
-    get: (target, name, self) =>
-        name === 'then' // as we await for the dataProvider, JS calls then on it. We must trap that call or else the dataProvider will be called with the then method
-            ? self
-            : (resource: string, params: any) =>
-                  new Promise(resolve =>
-                      setTimeout(
-                          () =>
-                              resolve(
-                                  restProvider[name as string](resource, params)
-                              ),
-                          500
-                      )
-                  ),
+    get: (target, name, self) => {
+        // as we await for the dataProvider, JS calls then on it. We must trap that call or else the dataProvider will be called with the then method
+        if (name === 'then') {
+            return self;
+        }
+        if (name === 'supportAbortSignal') {
+            return restProvider.supportAbortSignal;
+        }
+        return (resource: string, params: any) =>
+            new Promise(resolve =>
+                setTimeout(
+                    () =>
+                        resolve(restProvider[name as string](resource, params)),
+                    500
+                )
+            );
+    },
 });
 
+delayedDataProvider.supportAbortSignal = import.meta.env.MODE === 'production';
 export default delayedDataProvider;

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -79,7 +79,7 @@ describe('useEditController', () => {
         await waitFor(() => {
             expect(getOne).toHaveBeenCalledWith('posts', {
                 id: 'test?',
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
         await waitFor(() => {
@@ -116,7 +116,7 @@ describe('useEditController', () => {
         await waitFor(() => {
             expect(getOne).toHaveBeenCalledWith('posts', {
                 id: 0,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
         await waitFor(() => {
@@ -202,7 +202,7 @@ describe('useEditController', () => {
                 expect(getOne).toHaveBeenCalledWith('posts', {
                     id: 12,
                     meta: { foo: 'bar' },
-                    signal: expect.anything(),
+                    signal: undefined,
                 });
             });
         });

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -88,7 +88,7 @@ describe('<ReferenceFieldBase />', () => {
             expect(getMany).toHaveBeenCalledWith('authors', {
                 ids: [1],
                 meta: { test: true },
-                signal: expect.any(AbortSignal),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.spec.tsx
@@ -110,7 +110,7 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
                     filter: {},
-                    signal: expect.anything(),
+                    signal: undefined,
                 }
             );
         });
@@ -231,7 +231,7 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'DESC' },
                     filter: {},
-                    signal: expect.anything(),
+                    signal: undefined,
                 }
             );
         });
@@ -271,7 +271,7 @@ describe('useReferenceManyFieldController', () => {
                     pagination: { page: 1, perPage: 25 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                    signal: expect.anything(),
+                    signal: undefined,
                 }
             );
         });
@@ -323,7 +323,7 @@ describe('useReferenceManyFieldController', () => {
             pagination: { page: 1, perPage: 25 },
             sort: { field: 'id', order: 'DESC' },
             meta: undefined,
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 });

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.spec.tsx
@@ -105,7 +105,7 @@ describe('useReferenceOneFieldController', () => {
                 pagination: { page: 1, perPage: 1 },
                 sort: { field: 'name', order: 'DESC' },
                 filter: { gender: 'female' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -176,7 +176,7 @@ describe('useReferenceOneFieldController', () => {
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                    signal: expect.anything(),
+                    signal: undefined,
                 }
             );
         });
@@ -219,7 +219,7 @@ describe('useReferenceOneFieldController', () => {
                     pagination: { page: 1, perPage: 1 },
                     sort: { field: 'id', order: 'ASC' },
                     filter: {},
-                    signal: expect.anything(),
+                    signal: undefined,
                 }
             );
         });

--- a/packages/ra-core/src/controller/input/ReferenceInputBase.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputBase.spec.tsx
@@ -124,7 +124,7 @@ describe('<ReferenceInputBase />', () => {
                 pagination: { page: 1, perPage: 25 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { test: true },
-                signal: expect.any(AbortSignal),
+                signal: undefined,
             });
         });
     });
@@ -155,7 +155,7 @@ describe('<ReferenceInputBase />', () => {
             expect(getMany).toHaveBeenCalledWith('posts', {
                 ids: [23],
                 meta: { foo: 'bar' },
-                signal: expect.any(AbortSignal),
+                signal: undefined,
             });
         });
     });
@@ -208,7 +208,7 @@ const AutocompleteInput = (
                 id={`${source}-search`}
                 list={`${source}-choices`}
                 onChange={e => {
-                    const choice = allChoices.find(
+                    const choice = allChoices?.find(
                         choice =>
                             getChoiceText(choice).toString() === e.target.value
                     );
@@ -221,7 +221,7 @@ const AutocompleteInput = (
             />
 
             <datalist id={`${source}-choices`}>
-                {allChoices.map(choice => (
+                {allChoices?.map(choice => (
                     <option
                         key={getChoiceValue(choice)}
                         value={getChoiceText(choice).toString()}

--- a/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceArrayInputController.spec.tsx
@@ -205,7 +205,7 @@ describe('useReferenceArrayInputController', () => {
             },
             filter: {},
             meta: undefined,
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 
@@ -240,7 +240,7 @@ describe('useReferenceArrayInputController', () => {
             },
             filter: {},
             meta: { value: 'a' },
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 
@@ -277,7 +277,7 @@ describe('useReferenceArrayInputController', () => {
             },
             filter: { permanentFilter: 'foo' },
             meta: undefined,
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 
@@ -315,7 +315,7 @@ describe('useReferenceArrayInputController', () => {
                     order: 'DESC',
                 },
                 filter: { q: 'bar' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -342,7 +342,7 @@ describe('useReferenceArrayInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
                 ids: [5, 6],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -373,7 +373,7 @@ describe('useReferenceArrayInputController', () => {
             expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
                 ids: [5, 6],
                 meta: { value: 'a' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -524,7 +524,7 @@ describe('useReferenceArrayInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
                 ids: [5],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
         rerender(
@@ -539,7 +539,7 @@ describe('useReferenceArrayInputController', () => {
         await waitFor(() => {
             expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
                 ids: [5, 6],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -604,7 +604,7 @@ describe('useReferenceArrayInputController', () => {
                 },
                 filter: {},
                 meta: undefined,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
 
@@ -621,7 +621,7 @@ describe('useReferenceArrayInputController', () => {
                 },
                 filter: {},
                 meta: undefined,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
 
@@ -638,7 +638,7 @@ describe('useReferenceArrayInputController', () => {
                 },
                 filter: {},
                 meta: undefined,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -708,7 +708,7 @@ describe('useReferenceArrayInputController', () => {
                     order: 'DESC',
                 },
                 filter: { q: 'hello world' },
-                signal: expect.anything(),
+                signal: undefined,
             });
             expect(enableGetChoices).toHaveBeenCalledWith({ q: 'hello world' });
         });
@@ -740,7 +740,7 @@ describe('useReferenceArrayInputController', () => {
             await waitFor(() => {
                 expect(dataProvider.getMany).toHaveBeenCalledWith('tags', {
                     ids: [5, 6],
-                    signal: expect.anything(),
+                    signal: undefined,
                 });
             });
         });

--- a/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.spec.tsx
@@ -73,7 +73,7 @@ describe('useReferenceInputController', () => {
                 field: 'id',
                 order: 'ASC',
             },
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 
@@ -107,7 +107,7 @@ describe('useReferenceInputController', () => {
                     field: 'title',
                     order: 'ASC',
                 },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -129,7 +129,7 @@ describe('useReferenceInputController', () => {
             expect(dataProvider.getMany).toBeCalledTimes(1);
             expect(dataProvider.getMany).toBeCalledWith('posts', {
                 ids: [1],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -247,7 +247,7 @@ describe('useReferenceInputController', () => {
                 field: 'title',
                 order: 'ASC',
             },
-            signal: expect.anything(),
+            signal: undefined,
         });
 
         fireEvent.click(screen.getByLabelText('Change sort'));
@@ -265,7 +265,7 @@ describe('useReferenceInputController', () => {
                 field: 'body',
                 order: 'DESC',
             },
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 

--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -86,7 +86,7 @@ describe('useInfiniteListController', () => {
                     pagination: { page: 1, perPage: 10 },
                     sort: { field: 'id', order: 'ASC' },
                     meta: { foo: 'bar' },
-                    signal: expect.anything(),
+                    signal: undefined,
                 });
             });
         });

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -69,7 +69,7 @@ describe('useListController', () => {
                     pagination: { page: 1, perPage: 10 },
                     sort: { field: 'id', order: 'ASC' },
                     meta: { foo: 'bar' },
-                    signal: expect.anything(),
+                    signal: undefined,
                 });
             });
         });

--- a/packages/ra-core/src/controller/show/useShowController.spec.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.spec.tsx
@@ -63,7 +63,7 @@ describe('useShowController', () => {
         await waitFor(() => {
             expect(getOne).toHaveBeenCalledWith('posts', {
                 id: 'test?',
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
         await waitFor(() => {
@@ -99,7 +99,7 @@ describe('useShowController', () => {
         await waitFor(() => {
             expect(getOne).toHaveBeenCalledWith('posts', {
                 id: 0,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
         await waitFor(() => {
@@ -171,7 +171,7 @@ describe('useShowController', () => {
             expect(getOne).toHaveBeenCalledWith('posts', {
                 id: '1',
                 meta: { foo: 'bar' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -6,7 +6,7 @@ import {
 import { useResourceContext } from '../core';
 import { useDataProvider } from '../dataProvider';
 import { useStore } from '../store';
-import { FilterPayload, GetListParams, RaRecord, SortPayload } from '../types';
+import { FilterPayload, RaRecord, SortPayload } from '../types';
 import { ListParams, SORT_ASC } from './list';
 import { useRecordContext } from './record';
 import { useCreatePath } from '../routing';
@@ -191,15 +191,13 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
     const { data, error, isFetching, isLoading, isPending } = useQuery({
         queryKey: [resource, 'getList', params],
         queryFn: queryParams => {
-            const dataProviderParams: GetListParams = {
+            return dataProvider.getList(resource, {
                 ...params,
-                signal: undefined,
-            };
-
-            if (dataProvider.supportAbortSignal === true) {
-                dataProviderParams.signal = queryParams.signal;
-            }
-            return dataProvider.getList(resource, dataProviderParams);
+                signal:
+                    dataProvider.supportAbortSignal === true
+                        ? queryParams.signal
+                        : undefined,
+            });
         },
         enabled: !canUseCacheData,
         ...otherQueryOptions,

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -6,7 +6,7 @@ import {
 import { useResourceContext } from '../core';
 import { useDataProvider } from '../dataProvider';
 import { useStore } from '../store';
-import { FilterPayload, RaRecord, SortPayload } from '../types';
+import { FilterPayload, GetListParams, RaRecord, SortPayload } from '../types';
 import { ListParams, SORT_ASC } from './list';
 import { useRecordContext } from './record';
 import { useCreatePath } from '../routing';
@@ -190,8 +190,17 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
     // without displaying the list first
     const { data, error, isFetching, isLoading, isPending } = useQuery({
         queryKey: [resource, 'getList', params],
-        queryFn: ({ signal }) =>
-            dataProvider.getList(resource, { ...params, signal }),
+        queryFn: queryParams => {
+            const dataProviderParams: GetListParams = {
+                ...params,
+                signal: undefined,
+            };
+
+            if (dataProvider.supportAbortSignal === true) {
+                dataProviderParams.signal = queryParams.signal;
+            }
+            return dataProvider.getList(resource, dataProviderParams);
+        },
         enabled: !canUseCacheData,
         ...otherQueryOptions,
     });

--- a/packages/ra-core/src/controller/useReference.spec.tsx
+++ b/packages/ra-core/src/controller/useReference.spec.tsx
@@ -38,7 +38,7 @@ describe('useReference', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: ['1'],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -196,7 +196,7 @@ describe('useReference', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2, 3],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -213,11 +213,11 @@ describe('useReference', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(2);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2],
-                signal: expect.anything(),
+                signal: undefined,
             });
             expect(dataProvider.getMany).toHaveBeenCalledWith('comments', {
                 ids: [3],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -234,7 +234,7 @@ describe('useReference', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-core/src/dataProvider/convertLegacyDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/convertLegacyDataProvider.ts
@@ -24,9 +24,6 @@ const fetchMap = {
     updateMany: UPDATE_MANY,
 };
 
-interface ConvertedDataProvider extends DataProvider {
-    [key: string]: (...params: any) => Promise<any>;
-}
 /**
  * Turn a function-based dataProvider to an object-based one
  *
@@ -38,7 +35,7 @@ interface ConvertedDataProvider extends DataProvider {
  */
 const convertLegacyDataProvider = (
     legacyDataProvider: LegacyDataProvider
-): ConvertedDataProvider => {
+): DataProvider => {
     const proxy = new Proxy(defaultDataProvider, {
         get(_, name) {
             return (resource, params) => {

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -84,10 +84,13 @@ export const useDataProvider = <
     const logoutIfAccessDenied = useLogoutIfAccessDenied();
 
     const dataProviderProxy = useMemo(() => {
-        return new Proxy(dataProvider, {
+        const proxy = new Proxy(dataProvider, {
             get: (target, name) => {
                 if (typeof name === 'symbol' || name === 'then') {
                     return;
+                }
+                if (name === 'supportAbortSignal') {
+                    return target.supportAbortSignal;
                 }
                 return (...args) => {
                     const type = name.toString();
@@ -143,6 +146,7 @@ export const useDataProvider = <
                 };
             },
         });
+        return proxy;
     }, [dataProvider, logoutIfAccessDenied]);
 
     return dataProviderProxy;

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -84,13 +84,13 @@ export const useDataProvider = <
     const logoutIfAccessDenied = useLogoutIfAccessDenied();
 
     const dataProviderProxy = useMemo(() => {
-        const proxy = new Proxy(dataProvider, {
-            get: (target, name) => {
+        return new Proxy(dataProvider, {
+            get: (_, name) => {
                 if (typeof name === 'symbol' || name === 'then') {
                     return;
                 }
                 if (name === 'supportAbortSignal') {
-                    return target.supportAbortSignal;
+                    return dataProvider.supportAbortSignal;
                 }
                 return (...args) => {
                     const type = name.toString();
@@ -146,7 +146,6 @@ export const useDataProvider = <
                 };
             },
         });
-        return proxy;
     }, [dataProvider, logoutIfAccessDenied]);
 
     return dataProviderProxy;

--- a/packages/ra-core/src/dataProvider/useGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetList.spec.tsx
@@ -56,7 +56,7 @@ describe('useGetList', () => {
                 filter: {},
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -132,7 +132,7 @@ describe('useGetList', () => {
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { hello: 'world' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -419,6 +419,7 @@ describe('useGetList', () => {
                     })
             ) as any,
         });
+        dataProvider.supportAbortSignal = true;
         const queryClient = new QueryClient();
         render(
             <CoreAdminContext

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -83,26 +83,23 @@ export const useGetList = <RecordType extends RaRecord = any>(
         GetListResult<RecordType>
     >({
         queryKey: [resource, 'getList', { pagination, sort, filter, meta }],
-        queryFn: queryParams => {
-            const dataProviderParams: GetListParams = {
-                pagination,
-                sort,
-                filter,
-                meta,
-                signal: undefined,
-            };
-
-            if (dataProvider.supportAbortSignal === true) {
-                dataProviderParams.signal = queryParams.signal;
-            }
-            return dataProvider
-                .getList<RecordType>(resource, dataProviderParams)
+        queryFn: queryParams =>
+            dataProvider
+                .getList<RecordType>(resource, {
+                    pagination,
+                    sort,
+                    filter,
+                    meta,
+                    signal:
+                        dataProvider.supportAbortSignal === true
+                            ? queryParams.signal
+                            : undefined,
+                })
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,
                     pageInfo,
-                }));
-        },
+                })),
         ...queryOptions,
     });
 

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -83,20 +83,26 @@ export const useGetList = <RecordType extends RaRecord = any>(
         GetListResult<RecordType>
     >({
         queryKey: [resource, 'getList', { pagination, sort, filter, meta }],
-        queryFn: ({ signal }) =>
-            dataProvider
-                .getList<RecordType>(resource, {
-                    pagination,
-                    sort,
-                    filter,
-                    meta,
-                    signal,
-                })
+        queryFn: queryParams => {
+            const dataProviderParams: GetListParams = {
+                pagination,
+                sort,
+                filter,
+                meta,
+                signal: undefined,
+            };
+
+            if (dataProvider.supportAbortSignal === true) {
+                dataProviderParams.signal = queryParams.signal;
+            }
+            return dataProvider
+                .getList<RecordType>(resource, dataProviderParams)
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,
                     pageInfo,
-                })),
+                }));
+        },
         ...queryOptions,
     });
 

--- a/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
@@ -71,7 +71,7 @@ describe('useGetMany', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -171,7 +171,7 @@ describe('useGetMany', () => {
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1],
                 meta: { hello: 'world' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -378,6 +378,7 @@ describe('useGetMany', () => {
                     })
             ) as any,
         });
+        dataProvider.supportAbortSignal = true;
         const queryClient = new QueryClient();
         render(
             <CoreAdminContext

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -84,17 +84,15 @@ export const useGetMany = <RecordType extends RaRecord = any>(
                 // no need to call the dataProvider
                 return Promise.resolve([]);
             }
-            const dataProviderParams: GetManyParams = {
-                ids,
-                meta,
-                signal: undefined,
-            };
-
-            if (dataProvider.supportAbortSignal === true) {
-                dataProviderParams.signal = queryParams.signal;
-            }
             return dataProvider
-                .getMany<RecordType>(resource, dataProviderParams)
+                .getMany<RecordType>(resource, {
+                    ids,
+                    meta,
+                    signal:
+                        dataProvider.supportAbortSignal === true
+                            ? queryParams.signal
+                            : undefined,
+                })
                 .then(({ data }) => data);
         },
         placeholderData: () => {

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -79,13 +79,22 @@ export const useGetMany = <RecordType extends RaRecord = any>(
                 meta,
             },
         ],
-        queryFn: ({ signal }) => {
+        queryFn: queryParams => {
             if (!ids || ids.length === 0) {
                 // no need to call the dataProvider
                 return Promise.resolve([]);
             }
+            const dataProviderParams: GetManyParams = {
+                ids,
+                meta,
+                signal: undefined,
+            };
+
+            if (dataProvider.supportAbortSignal === true) {
+                dataProviderParams.signal = queryParams.signal;
+            }
             return dataProvider
-                .getMany<RecordType>(resource, { ids, meta, signal })
+                .getMany<RecordType>(resource, dataProviderParams)
                 .then(({ data }) => data);
         },
         placeholderData: () => {

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
@@ -39,7 +39,7 @@ describe('useGetManyAggregate', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -265,7 +265,7 @@ describe('useGetManyAggregate', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2, 3, 4, 5, 6],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -282,11 +282,11 @@ describe('useGetManyAggregate', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(2);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2, 3, 4],
-                signal: expect.anything(),
+                signal: undefined,
             });
             expect(dataProvider.getMany).toHaveBeenCalledWith('comments', {
                 ids: [5, 6],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -303,7 +303,7 @@ describe('useGetManyAggregate', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2, 3, 4],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -344,7 +344,7 @@ describe('useGetManyAggregate', () => {
             expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [1, 2, 3],
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
 
@@ -408,6 +408,7 @@ describe('useGetManyAggregate', () => {
                         })
                 ) as any,
             });
+            dataProvider.supportAbortSignal = true;
             const queryClient = new QueryClient();
             render(
                 <CoreAdminContext
@@ -458,6 +459,7 @@ describe('useGetManyAggregate', () => {
                     })
             ) as any,
         });
+        dataProvider.supportAbortSignal = true;
         const queryClient = new QueryClient();
         const { rerender } = render(
             <CoreAdminContext

--- a/packages/ra-core/src/dataProvider/useGetManyReference.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.spec.tsx
@@ -62,7 +62,7 @@ describe('useGetManyReference', () => {
                 filter: {},
                 pagination: { page: 1, perPage: 10 },
                 sort: { field: 'id', order: 'DESC' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -137,7 +137,7 @@ describe('useGetManyReference', () => {
                 pagination: { page: 1, perPage: 10 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { hello: 'world' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -398,6 +398,7 @@ describe('useGetManyReference', () => {
                     })
             ) as any,
         });
+        dataProvider.supportAbortSignal = true;
         const queryClient = new QueryClient();
         render(
             <CoreAdminContext

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -95,21 +95,26 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
             'getManyReference',
             { target, id, pagination, sort, filter, meta },
         ],
-        queryFn: ({ signal }) => {
+        queryFn: queryParams => {
             if (!target || id == null) {
                 // check at runtime to support partial parameters with the enabled option
                 return Promise.reject(new Error('target and id are required'));
             }
+            const dataProviderParams: GetManyReferenceParams = {
+                target,
+                id,
+                pagination,
+                sort,
+                filter,
+                meta,
+                signal: undefined,
+            };
+
+            if (dataProvider.supportAbortSignal === true) {
+                dataProviderParams.signal = queryParams.signal;
+            }
             return dataProvider
-                .getManyReference<RecordType>(resource, {
-                    target,
-                    id,
-                    pagination,
-                    sort,
-                    filter,
-                    meta,
-                    signal,
-                })
+                .getManyReference<RecordType>(resource, dataProviderParams)
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -100,21 +100,20 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
                 // check at runtime to support partial parameters with the enabled option
                 return Promise.reject(new Error('target and id are required'));
             }
-            const dataProviderParams: GetManyReferenceParams = {
-                target,
-                id,
-                pagination,
-                sort,
-                filter,
-                meta,
-                signal: undefined,
-            };
 
-            if (dataProvider.supportAbortSignal === true) {
-                dataProviderParams.signal = queryParams.signal;
-            }
             return dataProvider
-                .getManyReference<RecordType>(resource, dataProviderParams)
+                .getManyReference<RecordType>(resource, {
+                    target,
+                    id,
+                    pagination,
+                    sort,
+                    filter,
+                    meta,
+                    signal:
+                        dataProvider.supportAbortSignal === true
+                            ? queryParams.signal
+                            : undefined,
+                })
                 .then(({ data, total, pageInfo }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
@@ -46,7 +46,7 @@ describe('useGetOne', () => {
             expect(dataProvider.getOne).toHaveBeenCalledTimes(1);
             expect(dataProvider.getOne).toHaveBeenCalledWith('posts', {
                 id: 1,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -142,7 +142,7 @@ describe('useGetOne', () => {
             expect(dataProvider.getOne).toHaveBeenCalledWith('posts', {
                 id: 1,
                 meta: { hello: 'world' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -279,6 +279,7 @@ describe('useGetOne', () => {
                     })
             ) as any,
         });
+        dataProvider.supportAbortSignal = true;
         const queryClient = new QueryClient();
         render(
             <CoreAdminContext

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -68,10 +68,20 @@ export const useGetOne = <RecordType extends RaRecord = any>(
         // Sometimes the id comes as a number (e.g. when read from a Record in useGetList response).
         // As the react-query cache is type-sensitive, we always stringify the identifier to get a match
         queryKey: [resource, 'getOne', { id: String(id), meta }],
-        queryFn: ({ signal }) =>
-            dataProvider
-                .getOne<RecordType>(resource, { id, meta, signal })
-                .then(({ data }) => data),
+        queryFn: queryParams => {
+            const dataProviderParams: GetOneParams<RecordType> = {
+                id,
+                meta,
+                signal: undefined,
+            };
+
+            if (dataProvider.supportAbortSignal === true) {
+                dataProviderParams.signal = queryParams.signal;
+            }
+            return dataProvider
+                .getOne<RecordType>(resource, dataProviderParams)
+                .then(({ data }) => data);
+        },
         ...queryOptions,
     });
 

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -68,20 +68,17 @@ export const useGetOne = <RecordType extends RaRecord = any>(
         // Sometimes the id comes as a number (e.g. when read from a Record in useGetList response).
         // As the react-query cache is type-sensitive, we always stringify the identifier to get a match
         queryKey: [resource, 'getOne', { id: String(id), meta }],
-        queryFn: queryParams => {
-            const dataProviderParams: GetOneParams<RecordType> = {
-                id,
-                meta,
-                signal: undefined,
-            };
-
-            if (dataProvider.supportAbortSignal === true) {
-                dataProviderParams.signal = queryParams.signal;
-            }
-            return dataProvider
-                .getOne<RecordType>(resource, dataProviderParams)
-                .then(({ data }) => data);
-        },
+        queryFn: queryParams =>
+            dataProvider
+                .getOne<RecordType>(resource, {
+                    id,
+                    meta,
+                    signal:
+                        dataProvider.supportAbortSignal === true
+                            ? queryParams.signal
+                            : undefined,
+                })
+                .then(({ data }) => data),
         ...queryOptions,
     });
 

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.spec.tsx
@@ -52,7 +52,7 @@ describe('useInfiniteGetList', () => {
                 filter: {},
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -120,7 +120,7 @@ describe('useInfiniteGetList', () => {
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { hello: 'world' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -393,6 +393,7 @@ describe('useInfiniteGetList', () => {
                     })
             ) as any,
         });
+        dataProvider.supportAbortSignal = true;
         const queryClient = new QueryClient();
         render(
             <CoreAdminContext

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
@@ -103,22 +103,20 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
         ],
         queryFn: queryParams => {
             const { pageParam = pagination.page } = queryParams;
-            const dataProviderParams: GetListParams = {
-                pagination: {
-                    page: pageParam,
-                    perPage: pagination.perPage,
-                },
-                sort,
-                filter,
-                meta,
-                signal: undefined,
-            };
-
-            if (dataProvider.supportAbortSignal === true) {
-                dataProviderParams.signal = queryParams.signal;
-            }
             return dataProvider
-                .getList<RecordType>(resource, dataProviderParams)
+                .getList<RecordType>(resource, {
+                    pagination: {
+                        page: pageParam,
+                        perPage: pagination.perPage,
+                    },
+                    sort,
+                    filter,
+                    meta,
+                    signal:
+                        dataProvider.supportAbortSignal === true
+                            ? queryParams.signal
+                            : undefined,
+                })
                 .then(({ data, pageInfo, total }) => ({
                     data,
                     total,

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
@@ -101,24 +101,31 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
             'getInfiniteList',
             { pagination, sort, filter, meta },
         ],
-        queryFn: ({ pageParam = pagination.page, signal }) =>
-            dataProvider
-                .getList<RecordType>(resource, {
-                    pagination: {
-                        page: pageParam,
-                        perPage: pagination.perPage,
-                    },
-                    sort,
-                    filter,
-                    meta,
-                    signal,
-                })
+        queryFn: queryParams => {
+            const { pageParam = pagination.page } = queryParams;
+            const dataProviderParams: GetListParams = {
+                pagination: {
+                    page: pageParam,
+                    perPage: pagination.perPage,
+                },
+                sort,
+                filter,
+                meta,
+                signal: undefined,
+            };
+
+            if (dataProvider.supportAbortSignal === true) {
+                dataProviderParams.signal = queryParams.signal;
+            }
+            return dataProvider
+                .getList<RecordType>(resource, dataProviderParams)
                 .then(({ data, pageInfo, total }) => ({
                     data,
                     total,
                     pageParam,
                     pageInfo,
-                })),
+                }));
+        },
         initialPageParam: pagination.page,
         ...queryOptions,
         getNextPageParam: lastLoadedPage => {

--- a/packages/ra-core/src/form/useUnique.spec.tsx
+++ b/packages/ra-core/src/form/useUnique.spec.tsx
@@ -83,7 +83,7 @@ describe('useUnique', () => {
         await waitFor(() =>
             expect(dataProvider.getOne).toHaveBeenCalledWith('users', {
                 id: 1,
-                signal: expect.anything(),
+                signal: undefined,
             })
         );
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -136,6 +136,7 @@ export type DataProvider<ResourceType extends string = string> = {
     ) => Promise<DeleteManyResult<RecordType>>;
 
     [key: string]: any;
+    supportAbortSignal?: boolean;
 };
 
 export interface QueryFunctionContext {
@@ -147,6 +148,7 @@ export interface GetListParams {
     sort?: SortPayload;
     filter?: any;
     meta?: any;
+    signal?: AbortSignal;
 }
 export interface GetListResult<RecordType extends RaRecord = any> {
     data: RecordType[];
@@ -164,6 +166,7 @@ export interface GetInfiniteListResult<RecordType extends RaRecord = any>
 export interface GetOneParams<RecordType extends RaRecord = any> {
     id: RecordType['id'];
     meta?: any;
+    signal?: AbortSignal;
 }
 export interface GetOneResult<RecordType extends RaRecord = any> {
     data: RecordType;
@@ -172,6 +175,7 @@ export interface GetOneResult<RecordType extends RaRecord = any> {
 export interface GetManyParams {
     ids: Identifier[];
     meta?: any;
+    signal?: AbortSignal;
 }
 export interface GetManyResult<RecordType extends RaRecord = any> {
     data: RecordType[];
@@ -184,6 +188,7 @@ export interface GetManyReferenceParams {
     sort: SortPayload;
     filter: any;
     meta?: any;
+    signal?: AbortSignal;
 }
 export interface GetManyReferenceResult<RecordType extends RaRecord = any> {
     data: RecordType[];

--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -228,8 +228,6 @@ const buildGraphQLProvider = (options: Options): DataProvider => {
             callApollo(UPDATE_MANY, resource, params),
     };
 
-    raDataProvider.supportAbortSignal = process.env.NODE_ENV === 'production';
-
     return raDataProvider;
 };
 

--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -213,7 +213,7 @@ const buildGraphQLProvider = (options: Options): DataProvider => {
         );
     };
 
-    const raDataProvider = {
+    const raDataProvider: DataProvider = {
         create: (resource, params) => callApollo(CREATE, resource, params),
         delete: (resource, params) => callApollo(DELETE, resource, params),
         deleteMany: (resource, params) =>
@@ -227,6 +227,8 @@ const buildGraphQLProvider = (options: Options): DataProvider => {
         updateMany: (resource, params) =>
             callApollo(UPDATE_MANY, resource, params),
     };
+
+    raDataProvider.supportAbortSignal = process.env.NODE_ENV === 'production';
 
     return raDataProvider;
 };

--- a/packages/ra-data-json-server/src/index.ts
+++ b/packages/ra-data-json-server/src/index.ts
@@ -33,122 +33,133 @@ import { fetchUtils, DataProvider } from 'ra-core';
  *
  * export default App;
  */
-export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
-    getList: (resource, params) => {
-        const { page, perPage } = params.pagination;
-        const { field, order } = params.sort;
-        const query = {
-            ...fetchUtils.flattenObject(params.filter),
-            _sort: field,
-            _order: order,
-            _start: (page - 1) * perPage,
-            _end: page * perPage,
-        };
-        const url = `${apiUrl}/${resource}?${stringify(query)}`;
+export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => {
+    const dataProvider: DataProvider = {
+        getList: (resource, params) => {
+            const { page, perPage } = params.pagination;
+            const { field, order } = params.sort;
+            const query = {
+                ...fetchUtils.flattenObject(params.filter),
+                _sort: field,
+                _order: order,
+                _start: (page - 1) * perPage,
+                _end: page * perPage,
+            };
+            const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-        return httpClient(url, { signal: params?.signal }).then(
-            ({ headers, json }) => {
-                if (!headers.has('x-total-count')) {
-                    throw new Error(
-                        'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
-                    );
+            return httpClient(url, { signal: params?.signal }).then(
+                ({ headers, json }) => {
+                    if (!headers.has('x-total-count')) {
+                        throw new Error(
+                            'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
+                        );
+                    }
+                    return {
+                        data: json,
+                        total: parseInt(
+                            headers.get('x-total-count').split('/').pop(),
+                            10
+                        ),
+                    };
                 }
-                return {
+            );
+        },
+
+        getOne: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                signal: params?.signal,
+            }).then(({ json }) => ({
+                data: json,
+            })),
+
+        getMany: (resource, params) => {
+            const query = {
+                id: params.ids,
+            };
+            const url = `${apiUrl}/${resource}?${stringify(query)}`;
+            return httpClient(url, { signal: params?.signal }).then(
+                ({ json }) => ({
                     data: json,
-                    total: parseInt(
-                        headers.get('x-total-count').split('/').pop(),
-                        10
-                    ),
-                };
-            }
-        );
-    },
+                })
+            );
+        },
 
-    getOne: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
-            signal: params?.signal,
-        }).then(({ json }) => ({
-            data: json,
-        })),
+        getManyReference: (resource, params) => {
+            const { page, perPage } = params.pagination;
+            const { field, order } = params.sort;
+            const query = {
+                ...fetchUtils.flattenObject(params.filter),
+                [params.target]: params.id,
+                _sort: field,
+                _order: order,
+                _start: (page - 1) * perPage,
+                _end: page * perPage,
+            };
+            const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-    getMany: (resource, params) => {
-        const query = {
-            id: params.ids,
-        };
-        const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        return httpClient(url, { signal: params?.signal }).then(({ json }) => ({
-            data: json,
-        }));
-    },
-
-    getManyReference: (resource, params) => {
-        const { page, perPage } = params.pagination;
-        const { field, order } = params.sort;
-        const query = {
-            ...fetchUtils.flattenObject(params.filter),
-            [params.target]: params.id,
-            _sort: field,
-            _order: order,
-            _start: (page - 1) * perPage,
-            _end: page * perPage,
-        };
-        const url = `${apiUrl}/${resource}?${stringify(query)}`;
-
-        return httpClient(url, { signal: params?.signal }).then(
-            ({ headers, json }) => {
-                if (!headers.has('x-total-count')) {
-                    throw new Error(
-                        'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
-                    );
+            return httpClient(url, { signal: params?.signal }).then(
+                ({ headers, json }) => {
+                    if (!headers.has('x-total-count')) {
+                        throw new Error(
+                            'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
+                        );
+                    }
+                    return {
+                        data: json,
+                        total: parseInt(
+                            headers.get('x-total-count').split('/').pop(),
+                            10
+                        ),
+                    };
                 }
-                return {
-                    data: json,
-                    total: parseInt(
-                        headers.get('x-total-count').split('/').pop(),
-                        10
-                    ),
-                };
-            }
-        );
-    },
+            );
+        },
 
-    update: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
-            method: 'PUT',
-            body: JSON.stringify(params.data),
-        }).then(({ json }) => ({ data: json })),
+        update: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                method: 'PUT',
+                body: JSON.stringify(params.data),
+            }).then(({ json }) => ({ data: json })),
 
-    // json-server doesn't handle filters on UPDATE route, so we fallback to calling UPDATE n times instead
-    updateMany: (resource, params) =>
-        Promise.all(
-            params.ids.map(id =>
-                httpClient(`${apiUrl}/${resource}/${id}`, {
-                    method: 'PUT',
-                    body: JSON.stringify(params.data),
-                })
-            )
-        ).then(responses => ({ data: responses.map(({ json }) => json.id) })),
+        // json-server doesn't handle filters on UPDATE route, so we fallback to calling UPDATE n times instead
+        updateMany: (resource, params) =>
+            Promise.all(
+                params.ids.map(id =>
+                    httpClient(`${apiUrl}/${resource}/${id}`, {
+                        method: 'PUT',
+                        body: JSON.stringify(params.data),
+                    })
+                )
+            ).then(responses => ({
+                data: responses.map(({ json }) => json.id),
+            })),
 
-    create: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}`, {
-            method: 'POST',
-            body: JSON.stringify(params.data),
-        }).then(({ json }) => ({
-            data: { ...params.data, id: json.id } as any,
-        })),
+        create: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}`, {
+                method: 'POST',
+                body: JSON.stringify(params.data),
+            }).then(({ json }) => ({
+                data: { ...params.data, id: json.id } as any,
+            })),
 
-    delete: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
-            method: 'DELETE',
-        }).then(({ json }) => ({ data: json })),
+        delete: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                method: 'DELETE',
+            }).then(({ json }) => ({ data: json })),
 
-    // json-server doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
-    deleteMany: (resource, params) =>
-        Promise.all(
-            params.ids.map(id =>
-                httpClient(`${apiUrl}/${resource}/${id}`, {
-                    method: 'DELETE',
-                })
-            )
-        ).then(responses => ({ data: responses.map(({ json }) => json.id) })),
-});
+        // json-server doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
+        deleteMany: (resource, params) =>
+            Promise.all(
+                params.ids.map(id =>
+                    httpClient(`${apiUrl}/${resource}/${id}`, {
+                        method: 'DELETE',
+                    })
+                )
+            ).then(responses => ({
+                data: responses.map(({ json }) => json.id),
+            })),
+    };
+
+    dataProvider.supportAbortSignal = process.env.NODE_ENV === 'production';
+    return dataProvider;
+};

--- a/packages/ra-data-json-server/src/index.ts
+++ b/packages/ra-data-json-server/src/index.ts
@@ -33,133 +33,126 @@ import { fetchUtils, DataProvider } from 'ra-core';
  *
  * export default App;
  */
-export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => {
-    const dataProvider: DataProvider = {
-        getList: (resource, params) => {
-            const { page, perPage } = params.pagination;
-            const { field, order } = params.sort;
-            const query = {
-                ...fetchUtils.flattenObject(params.filter),
-                _sort: field,
-                _order: order,
-                _start: (page - 1) * perPage,
-                _end: page * perPage,
-            };
-            const url = `${apiUrl}/${resource}?${stringify(query)}`;
+export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
+    getList: (resource, params) => {
+        const { page, perPage } = params.pagination;
+        const { field, order } = params.sort;
+        const query = {
+            ...fetchUtils.flattenObject(params.filter),
+            _sort: field,
+            _order: order,
+            _start: (page - 1) * perPage,
+            _end: page * perPage,
+        };
+        const url = `${apiUrl}/${resource}?${stringify(query)}`;
 
-            return httpClient(url, { signal: params?.signal }).then(
-                ({ headers, json }) => {
-                    if (!headers.has('x-total-count')) {
-                        throw new Error(
-                            'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
-                        );
-                    }
-                    return {
-                        data: json,
-                        total: parseInt(
-                            headers.get('x-total-count').split('/').pop(),
-                            10
-                        ),
-                    };
+        return httpClient(url, { signal: params?.signal }).then(
+            ({ headers, json }) => {
+                if (!headers.has('x-total-count')) {
+                    throw new Error(
+                        'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
+                    );
                 }
-            );
-        },
-
-        getOne: (resource, params) =>
-            httpClient(`${apiUrl}/${resource}/${params.id}`, {
-                signal: params?.signal,
-            }).then(({ json }) => ({
-                data: json,
-            })),
-
-        getMany: (resource, params) => {
-            const query = {
-                id: params.ids,
-            };
-            const url = `${apiUrl}/${resource}?${stringify(query)}`;
-            return httpClient(url, { signal: params?.signal }).then(
-                ({ json }) => ({
+                return {
                     data: json,
-                })
-            );
-        },
+                    total: parseInt(
+                        headers.get('x-total-count').split('/').pop(),
+                        10
+                    ),
+                };
+            }
+        );
+    },
 
-        getManyReference: (resource, params) => {
-            const { page, perPage } = params.pagination;
-            const { field, order } = params.sort;
-            const query = {
-                ...fetchUtils.flattenObject(params.filter),
-                [params.target]: params.id,
-                _sort: field,
-                _order: order,
-                _start: (page - 1) * perPage,
-                _end: page * perPage,
-            };
-            const url = `${apiUrl}/${resource}?${stringify(query)}`;
+    getOne: (resource, params) =>
+        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+            signal: params?.signal,
+        }).then(({ json }) => ({
+            data: json,
+        })),
 
-            return httpClient(url, { signal: params?.signal }).then(
-                ({ headers, json }) => {
-                    if (!headers.has('x-total-count')) {
-                        throw new Error(
-                            'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
-                        );
-                    }
-                    return {
-                        data: json,
-                        total: parseInt(
-                            headers.get('x-total-count').split('/').pop(),
-                            10
-                        ),
-                    };
+    getMany: (resource, params) => {
+        const query = {
+            id: params.ids,
+        };
+        const url = `${apiUrl}/${resource}?${stringify(query)}`;
+        return httpClient(url, { signal: params?.signal }).then(({ json }) => ({
+            data: json,
+        }));
+    },
+
+    getManyReference: (resource, params) => {
+        const { page, perPage } = params.pagination;
+        const { field, order } = params.sort;
+        const query = {
+            ...fetchUtils.flattenObject(params.filter),
+            [params.target]: params.id,
+            _sort: field,
+            _order: order,
+            _start: (page - 1) * perPage,
+            _end: page * perPage,
+        };
+        const url = `${apiUrl}/${resource}?${stringify(query)}`;
+
+        return httpClient(url, { signal: params?.signal }).then(
+            ({ headers, json }) => {
+                if (!headers.has('x-total-count')) {
+                    throw new Error(
+                        'The X-Total-Count header is missing in the HTTP Response. The jsonServer Data Provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?'
+                    );
                 }
-            );
-        },
+                return {
+                    data: json,
+                    total: parseInt(
+                        headers.get('x-total-count').split('/').pop(),
+                        10
+                    ),
+                };
+            }
+        );
+    },
 
-        update: (resource, params) =>
-            httpClient(`${apiUrl}/${resource}/${params.id}`, {
-                method: 'PUT',
-                body: JSON.stringify(params.data),
-            }).then(({ json }) => ({ data: json })),
+    update: (resource, params) =>
+        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(params.data),
+        }).then(({ json }) => ({ data: json })),
 
-        // json-server doesn't handle filters on UPDATE route, so we fallback to calling UPDATE n times instead
-        updateMany: (resource, params) =>
-            Promise.all(
-                params.ids.map(id =>
-                    httpClient(`${apiUrl}/${resource}/${id}`, {
-                        method: 'PUT',
-                        body: JSON.stringify(params.data),
-                    })
-                )
-            ).then(responses => ({
-                data: responses.map(({ json }) => json.id),
-            })),
+    // json-server doesn't handle filters on UPDATE route, so we fallback to calling UPDATE n times instead
+    updateMany: (resource, params) =>
+        Promise.all(
+            params.ids.map(id =>
+                httpClient(`${apiUrl}/${resource}/${id}`, {
+                    method: 'PUT',
+                    body: JSON.stringify(params.data),
+                })
+            )
+        ).then(responses => ({
+            data: responses.map(({ json }) => json.id),
+        })),
 
-        create: (resource, params) =>
-            httpClient(`${apiUrl}/${resource}`, {
-                method: 'POST',
-                body: JSON.stringify(params.data),
-            }).then(({ json }) => ({
-                data: { ...params.data, id: json.id } as any,
-            })),
+    create: (resource, params) =>
+        httpClient(`${apiUrl}/${resource}`, {
+            method: 'POST',
+            body: JSON.stringify(params.data),
+        }).then(({ json }) => ({
+            data: { ...params.data, id: json.id } as any,
+        })),
 
-        delete: (resource, params) =>
-            httpClient(`${apiUrl}/${resource}/${params.id}`, {
-                method: 'DELETE',
-            }).then(({ json }) => ({ data: json })),
+    delete: (resource, params) =>
+        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+            method: 'DELETE',
+        }).then(({ json }) => ({ data: json })),
 
-        // json-server doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
-        deleteMany: (resource, params) =>
-            Promise.all(
-                params.ids.map(id =>
-                    httpClient(`${apiUrl}/${resource}/${id}`, {
-                        method: 'DELETE',
-                    })
-                )
-            ).then(responses => ({
-                data: responses.map(({ json }) => json.id),
-            })),
-    };
-
-    dataProvider.supportAbortSignal = process.env.NODE_ENV === 'production';
-    return dataProvider;
-};
+    // json-server doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
+    deleteMany: (resource, params) =>
+        Promise.all(
+            params.ids.map(id =>
+                httpClient(`${apiUrl}/${resource}/${id}`, {
+                    method: 'DELETE',
+                })
+            )
+        ).then(responses => ({
+            data: responses.map(({ json }) => json.id),
+        })),
+});

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -37,156 +37,169 @@ export default (
     apiUrl: string,
     httpClient = fetchUtils.fetchJson,
     countHeader: string = 'Content-Range'
-): DataProvider => ({
-    getList: (resource, params) => {
-        const { page, perPage } = params.pagination;
-        const { field, order } = params.sort;
+): DataProvider => {
+    const dataProvider: DataProvider = {
+        getList: (resource, params) => {
+            const { page, perPage } = params.pagination;
+            const { field, order } = params.sort;
 
-        const rangeStart = (page - 1) * perPage;
-        const rangeEnd = page * perPage - 1;
+            const rangeStart = (page - 1) * perPage;
+            const rangeEnd = page * perPage - 1;
 
-        const query = {
-            sort: JSON.stringify([field, order]),
-            range: JSON.stringify([rangeStart, rangeEnd]),
-            filter: JSON.stringify(params.filter),
-        };
-        const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        const options =
-            countHeader === 'Content-Range'
-                ? {
-                      // Chrome doesn't return `Content-Range` header if no `Range` is provided in the request.
-                      headers: new Headers({
-                          Range: `${resource}=${rangeStart}-${rangeEnd}`,
-                      }),
-                      signal: params?.signal,
-                  }
-                : { signal: params?.signal };
-
-        return httpClient(url, options).then(({ headers, json }) => {
-            if (!headers.has(countHeader)) {
-                throw new Error(
-                    `The ${countHeader} header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare ${countHeader} in the Access-Control-Expose-Headers header?`
-                );
-            }
-            return {
-                data: json,
-                total:
-                    countHeader === 'Content-Range'
-                        ? parseInt(
-                              headers.get('content-range').split('/').pop(),
-                              10
-                          )
-                        : parseInt(headers.get(countHeader.toLowerCase())),
+            const query = {
+                sort: JSON.stringify([field, order]),
+                range: JSON.stringify([rangeStart, rangeEnd]),
+                filter: JSON.stringify(params.filter),
             };
-        });
-    },
+            const url = `${apiUrl}/${resource}?${stringify(query)}`;
+            const options =
+                countHeader === 'Content-Range'
+                    ? {
+                          // Chrome doesn't return `Content-Range` header if no `Range` is provided in the request.
+                          headers: new Headers({
+                              Range: `${resource}=${rangeStart}-${rangeEnd}`,
+                          }),
+                          signal: params?.signal,
+                      }
+                    : { signal: params?.signal };
 
-    getOne: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
-            signal: params?.signal,
-        }).then(({ json }) => ({
-            data: json,
-        })),
+            return httpClient(url, options).then(({ headers, json }) => {
+                if (!headers.has(countHeader)) {
+                    throw new Error(
+                        `The ${countHeader} header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare ${countHeader} in the Access-Control-Expose-Headers header?`
+                    );
+                }
+                return {
+                    data: json,
+                    total:
+                        countHeader === 'Content-Range'
+                            ? parseInt(
+                                  headers.get('content-range').split('/').pop(),
+                                  10
+                              )
+                            : parseInt(headers.get(countHeader.toLowerCase())),
+                };
+            });
+        },
 
-    getMany: (resource, params) => {
-        const query = {
-            filter: JSON.stringify({ id: params.ids }),
-        };
-        const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        return httpClient(url, { signal: params?.signal }).then(({ json }) => ({
-            data: json,
-        }));
-    },
-
-    getManyReference: (resource, params) => {
-        const { page, perPage } = params.pagination;
-        const { field, order } = params.sort;
-
-        const rangeStart = (page - 1) * perPage;
-        const rangeEnd = page * perPage - 1;
-
-        const query = {
-            sort: JSON.stringify([field, order]),
-            range: JSON.stringify([(page - 1) * perPage, page * perPage - 1]),
-            filter: JSON.stringify({
-                ...params.filter,
-                [params.target]: params.id,
-            }),
-        };
-        const url = `${apiUrl}/${resource}?${stringify(query)}`;
-        const options =
-            countHeader === 'Content-Range'
-                ? {
-                      // Chrome doesn't return `Content-Range` header if no `Range` is provided in the request.
-                      headers: new Headers({
-                          Range: `${resource}=${rangeStart}-${rangeEnd}`,
-                      }),
-                      signal: params?.signal,
-                  }
-                : { signal: params?.signal };
-
-        return httpClient(url, options).then(({ headers, json }) => {
-            if (!headers.has(countHeader)) {
-                throw new Error(
-                    `The ${countHeader} header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare ${countHeader} in the Access-Control-Expose-Headers header?`
-                );
-            }
-            return {
+        getOne: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                signal: params?.signal,
+            }).then(({ json }) => ({
                 data: json,
-                total:
-                    countHeader === 'Content-Range'
-                        ? parseInt(
-                              headers.get('content-range').split('/').pop(),
-                              10
-                          )
-                        : parseInt(headers.get(countHeader.toLowerCase())),
+            })),
+
+        getMany: (resource, params) => {
+            const query = {
+                filter: JSON.stringify({ id: params.ids }),
             };
-        });
-    },
-
-    update: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
-            method: 'PUT',
-            body: JSON.stringify(params.data),
-        }).then(({ json }) => ({ data: json })),
-
-    // simple-rest doesn't handle provide an updateMany route, so we fallback to calling update n times instead
-    updateMany: (resource, params) =>
-        Promise.all(
-            params.ids.map(id =>
-                httpClient(`${apiUrl}/${resource}/${id}`, {
-                    method: 'PUT',
-                    body: JSON.stringify(params.data),
+            const url = `${apiUrl}/${resource}?${stringify(query)}`;
+            return httpClient(url, { signal: params?.signal }).then(
+                ({ json }) => ({
+                    data: json,
                 })
-            )
-        ).then(responses => ({ data: responses.map(({ json }) => json.id) })),
+            );
+        },
 
-    create: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}`, {
-            method: 'POST',
-            body: JSON.stringify(params.data),
-        }).then(({ json }) => ({ data: json })),
+        getManyReference: (resource, params) => {
+            const { page, perPage } = params.pagination;
+            const { field, order } = params.sort;
 
-    delete: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
-            method: 'DELETE',
-            headers: new Headers({
-                'Content-Type': 'text/plain',
-            }),
-        }).then(({ json }) => ({ data: json })),
+            const rangeStart = (page - 1) * perPage;
+            const rangeEnd = page * perPage - 1;
 
-    // simple-rest doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
-    deleteMany: (resource, params) =>
-        Promise.all(
-            params.ids.map(id =>
-                httpClient(`${apiUrl}/${resource}/${id}`, {
-                    method: 'DELETE',
-                    headers: new Headers({
-                        'Content-Type': 'text/plain',
-                    }),
-                })
-            )
-        ).then(responses => ({
-            data: responses.map(({ json }) => json.id),
-        })),
-});
+            const query = {
+                sort: JSON.stringify([field, order]),
+                range: JSON.stringify([
+                    (page - 1) * perPage,
+                    page * perPage - 1,
+                ]),
+                filter: JSON.stringify({
+                    ...params.filter,
+                    [params.target]: params.id,
+                }),
+            };
+            const url = `${apiUrl}/${resource}?${stringify(query)}`;
+            const options =
+                countHeader === 'Content-Range'
+                    ? {
+                          // Chrome doesn't return `Content-Range` header if no `Range` is provided in the request.
+                          headers: new Headers({
+                              Range: `${resource}=${rangeStart}-${rangeEnd}`,
+                          }),
+                          signal: params?.signal,
+                      }
+                    : { signal: params?.signal };
+
+            return httpClient(url, options).then(({ headers, json }) => {
+                if (!headers.has(countHeader)) {
+                    throw new Error(
+                        `The ${countHeader} header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare ${countHeader} in the Access-Control-Expose-Headers header?`
+                    );
+                }
+                return {
+                    data: json,
+                    total:
+                        countHeader === 'Content-Range'
+                            ? parseInt(
+                                  headers.get('content-range').split('/').pop(),
+                                  10
+                              )
+                            : parseInt(headers.get(countHeader.toLowerCase())),
+                };
+            });
+        },
+
+        update: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                method: 'PUT',
+                body: JSON.stringify(params.data),
+            }).then(({ json }) => ({ data: json })),
+
+        // simple-rest doesn't handle provide an updateMany route, so we fallback to calling update n times instead
+        updateMany: (resource, params) =>
+            Promise.all(
+                params.ids.map(id =>
+                    httpClient(`${apiUrl}/${resource}/${id}`, {
+                        method: 'PUT',
+                        body: JSON.stringify(params.data),
+                    })
+                )
+            ).then(responses => ({
+                data: responses.map(({ json }) => json.id),
+            })),
+
+        create: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}`, {
+                method: 'POST',
+                body: JSON.stringify(params.data),
+            }).then(({ json }) => ({ data: json })),
+
+        delete: (resource, params) =>
+            httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                method: 'DELETE',
+                headers: new Headers({
+                    'Content-Type': 'text/plain',
+                }),
+            }).then(({ json }) => ({ data: json })),
+
+        // simple-rest doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
+        deleteMany: (resource, params) =>
+            Promise.all(
+                params.ids.map(id =>
+                    httpClient(`${apiUrl}/${resource}/${id}`, {
+                        method: 'DELETE',
+                        headers: new Headers({
+                            'Content-Type': 'text/plain',
+                        }),
+                    })
+                )
+            ).then(responses => ({
+                data: responses.map(({ json }) => json.id),
+            })),
+    };
+
+    dataProvider.supportAbortSignal = process.env.NODE_ENV === 'production';
+
+    return dataProvider;
+};

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
@@ -143,7 +143,7 @@ describe('<PrevNextButtons />', () => {
                 sort: { field: 'id', order: 'ASC' },
                 filter: {},
                 meta: undefined,
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -652,7 +652,7 @@ describe('<ReferenceField />', () => {
             expect(dataProvider.getMany).toHaveBeenCalledWith('posts', {
                 ids: [123],
                 meta: { foo: 'bar' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
@@ -43,7 +43,7 @@ describe('<ReferenceManyCount />', () => {
             pagination: { page: 1, perPage: 1 },
             sort: { field: 'custom_id', order: 'ASC' },
             meta: undefined,
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
@@ -43,7 +43,7 @@ describe('ReferenceOneField', () => {
                     pagination: { page: 1, perPage: 1 },
                     filter: {},
                     meta: { foo: 'bar' },
-                    signal: expect.anything(),
+                    signal: undefined,
                 }
             );
         });

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.spec.tsx
@@ -242,7 +242,7 @@ describe('<ReferenceArrayInput />', () => {
                 pagination: { page: 1, perPage: 25 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { foo: 'bar' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.spec.tsx
@@ -134,7 +134,7 @@ describe('<ReferenceInput />', () => {
                 pagination: { page: 1, perPage: 25 },
                 sort: { field: 'id', order: 'DESC' },
                 meta: { foo: 'bar' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });
@@ -158,7 +158,7 @@ describe('<ReferenceInput />', () => {
             expect(getMany).toHaveBeenCalledWith('posts', {
                 ids: [23],
                 meta: { foo: 'bar' },
-                signal: expect.anything(),
+                signal: undefined,
             });
         });
     });

--- a/packages/ra-ui-materialui/src/list/Count.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/Count.spec.tsx
@@ -35,7 +35,7 @@ describe('<Count />', () => {
             pagination: { page: 1, perPage: 1 },
             sort: { field: 'custom_id', order: 'ASC' },
             meta: undefined,
-            signal: expect.anything(),
+            signal: undefined,
         });
     });
 });


### PR DESCRIPTION
Fix #9896 

## Testing signal support in the demo

### Not enabled in development

- Run the demo
- Add a breakpoint in simple-rest data provider queries functions and check that `signal` is `undefined`

### Enabled in production

- Build the demo
- Run the demo `yarn preview` command
- Add a breakpoint in simple-rest data provider queries functions and check that `signal` is not `undefined`