### PR TITLE
Make ErrorBoundary take fullHeight of the page

### DIFF
--- a/packages/ra-ui-materialui/src/AdminUI.tsx
+++ b/packages/ra-ui-materialui/src/AdminUI.tsx
@@ -22,7 +22,7 @@ export const AdminUI = ({
     error = Error,
     ...props
 }: AdminUIProps) => (
-    <ScopedCssBaseline enableColorScheme sx={{ height: '100vh' }}>
+    <ScopedCssBaseline enableColorScheme>
         <CoreAdminUI
             layout={layout}
             catchAll={catchAll}

--- a/packages/ra-ui-materialui/src/AdminUI.tsx
+++ b/packages/ra-ui-materialui/src/AdminUI.tsx
@@ -22,7 +22,7 @@ export const AdminUI = ({
     error = Error,
     ...props
 }: AdminUIProps) => (
-    <ScopedCssBaseline enableColorScheme>
+    <ScopedCssBaseline enableColorScheme sx={{ height: '100vh' }}>
         <CoreAdminUI
             layout={layout}
             catchAll={catchAll}

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -157,6 +157,7 @@ const Root = styled('div', {
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    margin: 'auto',
     [theme.breakpoints.down('md')]: {
         padding: '1em',
     },


### PR DESCRIPTION
## Problem

As we can see in the story `react-admin`/`Admin`/`DefaultError`, the background of the error boundary doesn't take full height of the page.

## Screenshots

### Before
___

![image](https://github.com/marmelab/react-admin/assets/131013150/adfe91aa-b459-4bab-aec0-c099c1a08c9c)

---
### After
---

![image](https://github.com/marmelab/react-admin/assets/131013150/57b623f9-9d42-425e-a3e3-b8019a6215b4)
