### PR TITLE
`<ArrayInput>` uses `SourceContext` instead of cloning children

### DIFF
--- a/packages/ra-core/src/core/SourceContext.tsx
+++ b/packages/ra-core/src/core/SourceContext.tsx
@@ -14,7 +14,9 @@ export type SourceContextValue =
     | undefined;
 
 /**
- * Context that provides a function that accept a source and return a modified source (prefixed, suffixed, etc.) for fields and inputs.
+ * Context that provides a function that accept a source and return getters for the modified source and label.
+ *
+ * This allows some special inputs to prefix or suffix the source of their children.
  *
  * @example
  * const sourceContext = {
@@ -23,10 +25,10 @@ export type SourceContextValue =
  * }
  * const CoordinatesInput = () => {
  *   return (
- *     <SouceContextProvider value={sourceContext}>
+ *     <SourceContextProvider value={sourceContext}>
  *       <TextInput source="lat" />
  *       <TextInput source="lng" />
- *     </SouceContextProvider>
+ *     </SourceContextProvider>
  *   );
  * };
  */
@@ -34,4 +36,14 @@ export const SourceContext = createContext<SourceContextValue>(undefined);
 
 export const SourceContextProvider = SourceContext.Provider;
 
-export const useSourceContext = () => useContext(SourceContext);
+export const useSourceContext = () => {
+    const context = useContext(SourceContext);
+
+    if (!context) {
+        throw new Error('Inputs must be used inside a react-admin Form');
+    }
+
+    return context;
+};
+
+export const useOptionalSourceContext = () => useContext(SourceContext);

--- a/packages/ra-core/src/core/useWrappedSource.ts
+++ b/packages/ra-core/src/core/useWrappedSource.ts
@@ -12,5 +12,5 @@ import { useSourceContext } from './SourceContext';
  */
 export const useWrappedSource = (source: string) => {
     const sourceContext = useSourceContext();
-    return sourceContext?.getSource(source) ?? source;
+    return sourceContext.getSource(source);
 };

--- a/packages/ra-core/src/form/FormDataConsumer.spec.tsx
+++ b/packages/ra-core/src/form/FormDataConsumer.spec.tsx
@@ -12,7 +12,7 @@ import {
     ArrayInput,
 } from 'ra-ui-materialui';
 import expect from 'expect';
-import { ResourceContextProvider } from '..';
+import { Form, ResourceContextProvider } from '..';
 
 describe('FormDataConsumerView', () => {
     it('does not call its children function with scopedFormData if it did not receive a source containing an index', () => {
@@ -20,13 +20,15 @@ describe('FormDataConsumerView', () => {
         const formData = { id: 123, title: 'A title' };
 
         render(
-            <FormDataConsumerView
-                form="a-form"
-                formData={formData}
-                source="a-field"
-            >
-                {children}
-            </FormDataConsumerView>
+            <Form>
+                <FormDataConsumerView
+                    form="a-form"
+                    formData={formData}
+                    source="a-field"
+                >
+                    {children}
+                </FormDataConsumerView>
+            </Form>
         );
 
         expect(children).toHaveBeenCalledWith({

--- a/packages/ra-core/src/i18n/TestTranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TestTranslationProvider.tsx
@@ -20,7 +20,7 @@ export const testI18nProvider = ({
 }: {
     translate?: I18nProvider['translate'];
     messages?: Record<string, string | ((options?: any) => string)>;
-}): I18nProvider => {
+} = {}): I18nProvider => {
     return {
         translate: messages
             ? (key, options) => {

--- a/packages/ra-core/src/i18n/TranslatableContext.ts
+++ b/packages/ra-core/src/i18n/TranslatableContext.ts
@@ -8,6 +8,16 @@ export interface TranslatableContextValue {
     locales: string[];
     selectedLocale: string;
     selectLocale: SelectTranslatableLocale;
+    getRecordForLocale: GetRecordForLocale;
 }
 
 export type SelectTranslatableLocale = (locale: string) => void;
+
+/**
+ * Returns a record where translatable fields have their values set to the value of the given locale.
+ * This is necessary because the fields rely on the RecordContext to get their values and have no knowledge of the locale.
+ *
+ * Given the record { title: { en: 'title_en', fr: 'title_fr' } } and the locale 'fr',
+ * the record for the locale 'fr' will be { title: 'title_fr' }
+ */
+export type GetRecordForLocale = (record: any, locale: string) => any;

--- a/packages/ra-core/src/i18n/useTranslatable.spec.ts
+++ b/packages/ra-core/src/i18n/useTranslatable.spec.ts
@@ -1,0 +1,40 @@
+import { getRecordForLocale } from './useTranslatable';
+describe('useTranslatable', () => {
+    describe('getRecordForLocale', () => {
+        it('should return a record where translatable fields have their values set to the value of the given locale', () => {
+            // Given the record { title: { en: 'title_en', fr: 'title_fr' } } and the locale 'fr',
+            // the record for the locale 'fr' will be { title: 'title_fr' }
+            const record = {
+                fractal: true,
+                title: { en: 'title_en', fr: 'title_fr' },
+                items: [
+                    { description: { en: 'item1_en', fr: 'item1_fr' } },
+                    { description: { en: 'item2_en', fr: 'item2_fr' } },
+                ],
+            };
+
+            const recordForLocale = getRecordForLocale(record, 'fr');
+
+            expect(recordForLocale).toEqual({
+                fractal: true,
+                title: 'title_fr',
+                items: [
+                    { description: 'item1_fr' },
+                    { description: 'item2_fr' },
+                ],
+            });
+        });
+
+        it('should return the record as is if it is empty', () => {
+            const record = {};
+            const recordForLocale = getRecordForLocale(record, 'fr');
+            expect(recordForLocale).toEqual({});
+        });
+
+        it('should return the record as is if it is undefined', () => {
+            const record = undefined;
+            const recordForLocale = getRecordForLocale(record, 'fr');
+            expect(recordForLocale).toEqual(undefined);
+        });
+    });
+});

--- a/packages/ra-core/src/i18n/useTranslatable.ts
+++ b/packages/ra-core/src/i18n/useTranslatable.ts
@@ -1,4 +1,6 @@
 import { useState, useMemo } from 'react';
+import set from 'lodash/set';
+import get from 'lodash/get';
 import { TranslatableContextValue } from './TranslatableContext';
 import { useLocaleState } from './useLocaleState';
 
@@ -29,6 +31,7 @@ export const useTranslatable = (
             locales,
             selectedLocale,
             selectLocale: setSelectedLocale,
+            getRecordForLocale,
         }),
         [locales, selectedLocale]
     );
@@ -39,4 +42,80 @@ export const useTranslatable = (
 export type UseTranslatableOptions = {
     defaultLocale?: string;
     locales: string[];
+};
+
+/**
+ * Returns a record where translatable fields have their values set to the value of the given locale.
+ * This is necessary because the fields rely on the RecordContext to get their values and have no knowledge of the locale.
+ *
+ * Given the record { title: { en: 'title_en', fr: 'title_fr' } } and the locale 'fr',
+ * the record for the locale 'fr' will be { title: 'title_fr' }
+ */
+export const getRecordForLocale = (record: {} | undefined, locale: string) => {
+    if (!record) {
+        return record;
+    }
+    // Get all paths of the record
+    const paths = getRecordPaths(record);
+
+    // For each path, if a path ends with the locale, set the value of the path without the locale
+    // to the value of the path with the locale
+    const recordForLocale = paths.reduce((acc, path) => {
+        if (path.includes(locale)) {
+            const pathWithoutLocale = path.slice(0, -1);
+            const value = get(record, path);
+            return set(acc, pathWithoutLocale, value);
+        }
+        return acc;
+    }, structuredClone(record));
+
+    return recordForLocale;
+};
+
+// Return all the possible paths of the record as an array of arrays
+// For example, given the record
+//     {
+//         title: { en: 'title_en', fr: 'title_fr' },
+//         items: [
+//             { description: { en: 'item1_en', fr: 'item1_fr' } },
+//             { description: { en: 'item2_en', fr: 'item2_fr' } }
+//         ]
+//     },
+// the paths will be
+//     [
+//         ['title'],
+//         ['title', 'en'],
+//         ['title', 'fr'],
+//         ['items'],
+//         ['items', '0'],
+//         ['items', '0', 'description'],
+//         ['items', '0', 'description', 'en'],
+//         ['items', '0', 'description', 'fr'],
+//         ['items', '1'],
+//         ['items', '1', 'description'],
+//         ['items', '1', 'description', 'en'],
+//         ['items', '1', 'description', 'fr']]
+const getRecordPaths = (
+    record: any = {},
+    path: Array<string> = []
+): Array<Array<string>> => {
+    return Object.entries(record).reduce((acc, [key, value]) => {
+        if (typeof value === 'object') {
+            return [
+                ...acc,
+                [...path, key],
+                ...getRecordPaths(value, [...path, key]),
+            ];
+        }
+        if (Array.isArray(value)) {
+            return value.reduce(
+                (acc, item, index) => [
+                    ...acc,
+                    ...getRecordPaths(item, [...path, key, `${index}`]),
+                ],
+                acc
+            );
+        }
+        return [...acc, [...path, key]];
+    }, []);
 };

--- a/packages/ra-core/src/i18n/useTranslatable.ts
+++ b/packages/ra-core/src/i18n/useTranslatable.ts
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import set from 'lodash/set';
 import get from 'lodash/get';
+import cloneDeep from 'lodash/cloneDeep';
 import { TranslatableContextValue } from './TranslatableContext';
 import { useLocaleState } from './useLocaleState';
 
@@ -67,7 +68,7 @@ export const getRecordForLocale = (record: {} | undefined, locale: string) => {
             return set(acc, pathWithoutLocale, value);
         }
         return acc;
-    }, structuredClone(record));
+    }, cloneDeep(record));
 
     return recordForLocale;
 };

--- a/packages/ra-core/src/i18n/useTranslateLabel.ts
+++ b/packages/ra-core/src/i18n/useTranslateLabel.ts
@@ -2,12 +2,12 @@ import { useCallback, ReactElement } from 'react';
 
 import { useTranslate } from './useTranslate';
 import { getFieldLabelTranslationArgs } from '../util';
-import { useResourceContext, useSourceContext } from '../core';
+import { useResourceContext, useOptionalSourceContext } from '../core';
 
 export const useTranslateLabel = () => {
     const translate = useTranslate();
     const resourceFromContext = useResourceContext();
-    const sourceContext = useSourceContext();
+    const sourceContext = useOptionalSourceContext();
 
     return useCallback(
         ({

--- a/packages/ra-core/src/util/useFieldValue.spec.tsx
+++ b/packages/ra-core/src/util/useFieldValue.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { useFieldValue, UseFieldValueOptions } from './useFieldValue';
 import { RecordContextProvider } from '../controller';
-import { SourceContextProvider } from '..';
 
 describe('useFieldValue', () => {
     const Component = (props: UseFieldValueOptions) => {
@@ -64,29 +63,5 @@ describe('useFieldValue', () => {
         );
 
         await screen.findByText('John');
-    });
-
-    it('should return the field value from the record inside a SourceContext', async () => {
-        render(
-            <RecordContextProvider
-                value={{
-                    id: 2,
-                    name: { fr: 'Neuromancien', en: 'Neuromancer' },
-                }}
-            >
-                <SourceContextProvider
-                    value={{
-                        getSource(source) {
-                            return `${source}.fr`;
-                        },
-                        getLabel: source => source,
-                    }}
-                >
-                    <Component source="name" />
-                </SourceContextProvider>
-            </RecordContextProvider>
-        );
-
-        await screen.findByText('Neuromancien');
     });
 });

--- a/packages/ra-core/src/util/useFieldValue.ts
+++ b/packages/ra-core/src/util/useFieldValue.ts
@@ -1,7 +1,6 @@
 import get from 'lodash/get';
 import { Call, Objects } from 'hotscript';
 import { useRecordContext } from '../controller';
-import { useSourceContext } from '../core';
 
 /**
  * A hook that gets the value of a field of the current record.
@@ -23,14 +22,9 @@ export const useFieldValue = <
     params: UseFieldValueOptions<RecordType>
 ) => {
     const { defaultValue, source } = params;
-    const sourceContext = useSourceContext();
     const record = useRecordContext<RecordType>(params);
 
-    return get(
-        record,
-        sourceContext?.getSource(source) ?? source,
-        defaultValue
-    );
+    return get(record, source, defaultValue);
 };
 
 export interface UseFieldValueOptions<

--- a/packages/ra-core/src/util/useFieldValue.ts
+++ b/packages/ra-core/src/util/useFieldValue.ts
@@ -22,6 +22,12 @@ export const useFieldValue = <
     params: UseFieldValueOptions<RecordType>
 ) => {
     const { defaultValue, source } = params;
+    // We use the record from the RecordContext and do not rely on the SourceContext on purpose to
+    // avoid having the wrong source targeting the record.
+    // Indeed, some components may create a sub record context (SimpleFormIterator, TranslatableInputs, etc.). In this case,
+    // it they used the SourceContext as well, they would have the wrong source.
+    // Inputs needs the SourceContext as they rely on the Form value and you can't have nested forms.
+    // Fields needs the RecordContext as they rely on the Record value and you can have nested RecordContext.
     const record = useRecordContext<RecordType>(params);
 
     return get(record, source, defaultValue);

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { ReactNode } from 'react';
-import get from 'lodash/get';
 import {
     ListContextProvider,
-    useRecordContext,
     useList,
     SortPayload,
     FilterPayload,
-    RaRecord,
+    useFieldValue,
 } from 'ra-core';
 
 import { FieldProps } from './types';
@@ -81,9 +79,8 @@ const ArrayFieldImpl = <
 >(
     props: ArrayFieldProps<RecordType>
 ) => {
-    const { children, resource, source, perPage, sort, filter } = props;
-    const record = useRecordContext(props);
-    const data = (get(record, source, emptyArray) as RaRecord[]) || emptyArray;
+    const { children, resource, perPage, sort, filter } = props;
+    const data = useFieldValue(props) || emptyArray;
     const listContext = useList({ data, resource, perPage, sort, filter });
     return (
         <ListContextProvider value={listContext}>

--- a/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
@@ -76,6 +76,7 @@ export const TranslatableFields = (
         selector = <TranslatableFieldsTabs groupKey={groupKey} />,
         children,
         className,
+        resource: resourceProp,
     } = props;
     const record = useRecordContext(props);
     if (!record) {
@@ -100,7 +101,7 @@ export const TranslatableFields = (
                         key={locale}
                         locale={locale}
                         record={record}
-                        resource={resource}
+                        resource={resourceProp}
                         groupKey={groupKey}
                     >
                         {children}

--- a/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
@@ -86,7 +86,7 @@ export const TranslatableFields = (
     const resource = useResourceContext(props);
     if (!resource) {
         throw new Error(
-            `<TranslatableFields> was called outside of a RecordContext and without a record prop. You must set the record prop.`
+            `<TranslatableFields> was called outside of a ResourceContext and without a record prop. You must set the resource prop.`
         );
     }
     const context = useTranslatable({ defaultLocale, locales });

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -75,10 +75,10 @@ export const TranslatableFieldsTabContent = (
             className={className}
             {...other}
         >
-            {Children.map(children, field =>
-                field && isValidElement<any>(field) ? (
-                    <RecordContextProvider value={recordForLocale}>
-                        <SourceContextProvider value={sourceContext}>
+            <RecordContextProvider value={recordForLocale}>
+                <SourceContextProvider value={sourceContext}>
+                    {Children.map(children, field =>
+                        field && isValidElement<any>(field) ? (
                             <div>
                                 {addLabel ? (
                                     <Labeled
@@ -94,10 +94,10 @@ export const TranslatableFieldsTabContent = (
                                     field
                                 )}
                             </div>
-                        </SourceContextProvider>
-                    </RecordContextProvider>
-                ) : null
-            )}
+                        ) : null
+                    )}
+                </SourceContextProvider>
+            </RecordContextProvider>
         </Root>
     );
 };

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -53,6 +53,10 @@ export const TranslatableFieldsTabContent = (
     );
     const addLabel = Children.count(children) > 1;
 
+    // As fields rely on the RecordContext to get their values and have no knowledge of the locale,
+    // we need to create a new record with the values for the current locale only
+    // Given the record { title: { en: 'title_en', fr: 'title_fr' } } and the locale 'fr',
+    // the record for the locale 'fr' will be { title: 'title_fr' }
     const [recordForLocale] = useState(() =>
         getRecordForLocale(record, locale)
     );

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -5,7 +5,7 @@ import {
     useTranslatableContext,
     RaRecord,
     SourceContextProvider,
-    useSourceContext,
+    useOptionalSourceContext,
     getResourceFieldLabelKey,
     RecordContextProvider,
     ResourceContextProvider,
@@ -30,7 +30,7 @@ export const TranslatableFieldsTabContent = (
     } = props;
     const { selectedLocale } = useTranslatableContext();
 
-    const parentSourceContext = useSourceContext();
+    const parentSourceContext = useOptionalSourceContext();
     const sourceContext = React.useMemo(
         () => ({
             getSource: (source: string) =>

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -50,13 +50,10 @@ export const TranslatableFieldsTabContent = (
                 parentSourceContext
                     ? parentSourceContext.getSource(`${source}.${locale}`)
                     : `${source}.${locale}`,
-            getLabel: (source: string) => {
-                const label = parentSourceContext
+            getLabel: (source: string) =>
+                parentSourceContext
                     ? parentSourceContext.getLabel(source)
-                    : getResourceFieldLabelKey(resource, source);
-                console.log(source, label);
-                return label;
-            },
+                    : getResourceFieldLabelKey(resource, source),
         }),
         [locale, parentSourceContext, resource]
     );

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -4,17 +4,12 @@ import {
     isValidElement,
     ReactElement,
     ReactNode,
-    useState,
+    useMemo,
 } from 'react';
 import { styled } from '@mui/material/styles';
-import set from 'lodash/set';
-import get from 'lodash/get';
 import {
     useTranslatableContext,
     RaRecord,
-    SourceContextProvider,
-    useOptionalSourceContext,
-    getResourceFieldLabelKey,
     RecordContextProvider,
 } from 'ra-core';
 import { Labeled } from '../Labeled';
@@ -35,30 +30,16 @@ export const TranslatableFieldsTabContent = (
         className,
         ...other
     } = props;
-    const { selectedLocale } = useTranslatableContext();
-
-    const parentSourceContext = useOptionalSourceContext();
-    const sourceContext = React.useMemo(
-        () => ({
-            getSource: (source: string) =>
-                parentSourceContext
-                    ? parentSourceContext.getSource(`${source}.${locale}`)
-                    : `${source}.${locale}`,
-            getLabel: (source: string) =>
-                parentSourceContext
-                    ? parentSourceContext.getLabel(source)
-                    : getResourceFieldLabelKey(resource, source),
-        }),
-        [locale, parentSourceContext, resource]
-    );
+    const { selectedLocale, getRecordForLocale } = useTranslatableContext();
     const addLabel = Children.count(children) > 1;
 
     // As fields rely on the RecordContext to get their values and have no knowledge of the locale,
     // we need to create a new record with the values for the current locale only
     // Given the record { title: { en: 'title_en', fr: 'title_fr' } } and the locale 'fr',
     // the record for the locale 'fr' will be { title: 'title_fr' }
-    const [recordForLocale] = useState(() =>
-        getRecordForLocale(record, locale)
+    const recordForLocale = useMemo(
+        () => getRecordForLocale(record, locale),
+        [getRecordForLocale, record, locale]
     );
 
     return (
@@ -73,21 +54,19 @@ export const TranslatableFieldsTabContent = (
             {Children.map(children, field =>
                 field && isValidElement<any>(field) ? (
                     <RecordContextProvider value={recordForLocale}>
-                        <SourceContextProvider value={sourceContext}>
-                            <div>
-                                {addLabel ? (
-                                    <Labeled
-                                        resource={resource}
-                                        label={field.props.label}
-                                        source={field.props.source}
-                                    >
-                                        {field}
-                                    </Labeled>
-                                ) : (
-                                    field
-                                )}
-                            </div>
-                        </SourceContextProvider>
+                        <div>
+                            {addLabel ? (
+                                <Labeled
+                                    resource={resource}
+                                    label={field.props.label}
+                                    source={field.props.source}
+                                >
+                                    {field}
+                                </Labeled>
+                            ) : (
+                                field
+                            )}
+                        </div>
                     </RecordContextProvider>
                 ) : null
             )}
@@ -119,31 +98,3 @@ const Root = styled('div', {
     border: `1px solid ${theme.palette.divider}`,
     borderTop: 0,
 }));
-
-const getRecordForLocale = (record: RaRecord, locale: string) => {
-    // Get all paths of the record
-    const paths = getRecordPaths(record);
-
-    // For each path, if a path ends with the locale, set the value of the path without the locale
-    // to the value of the path with the locale
-    const recordForLocale = paths.reduce((acc, path) => {
-        if (path.includes(locale)) {
-            const pathWithoutLocale = path.slice(0, -1);
-            const value = get(record, path);
-            return set(acc, pathWithoutLocale, value);
-        }
-        return acc;
-    }, structuredClone(record));
-
-    return recordForLocale;
-};
-
-const getRecordPaths = (
-    record: any = {},
-    path: Array<string> = []
-): Array<Array<string>> =>
-    Array.isArray(record) || Object(record) !== record
-        ? [path]
-        : Object.entries(record).flatMap(([k, v]) =>
-              getRecordPaths(v, [...path, k])
-          );

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -16,7 +16,12 @@ import { TextInput } from '../TextInput';
 import { ArrayInput } from './ArrayInput';
 import { SimpleFormIterator } from './SimpleFormIterator';
 import { useFormContext } from 'react-hook-form';
-import { GlobalValidation, ValidationInFormTab } from './ArrayInput.stories';
+import {
+    GlobalValidation,
+    ValidationInFormTab,
+    NestedInline,
+    WithReferenceField,
+} from './ArrayInput.stories';
 import { useArrayInput } from './useArrayInput';
 
 describe('<ArrayInput />', () => {
@@ -83,7 +88,7 @@ describe('<ArrayInput />', () => {
         });
     });
 
-    it('should clone each input once per value in the array', () => {
+    it('should render each input once per value in the array', () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
                 <ResourceContextProvider value="bar">
@@ -348,5 +353,25 @@ describe('<ArrayInput />', () => {
             });
             expect(formTab.classList.contains('error')).toBe(true);
         });
+    });
+
+    it('should support nested ArrayInput and inputs that set up SourceContexts', async () => {
+        render(<NestedInline />);
+
+        await screen.findByDisplayValue('Office Jeans');
+        await screen.findByDisplayValue('Jean de bureau');
+        await screen.findByDisplayValue('45.99');
+        expect(
+            await screen.findAllByDisplayValue('For you my love')
+        ).toHaveLength(2);
+        expect(
+            await screen.findAllByDisplayValue('Pour toi mon amour')
+        ).toHaveLength(2);
+    });
+
+    it('should support fields', async () => {
+        render(<WithReferenceField />);
+        await screen.findByText('Russia');
+        await screen.findByText('Italy');
     });
 });

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -7,6 +7,7 @@ import {
     minLength,
     required,
     testDataProvider,
+    useRecordContext,
 } from 'ra-core';
 
 import { AdminContext } from '../../AdminContext';
@@ -17,12 +18,13 @@ import { ArrayInput } from './ArrayInput';
 import { SimpleFormIterator } from './SimpleFormIterator';
 import { useFormContext } from 'react-hook-form';
 import { GlobalValidation, ValidationInFormTab } from './ArrayInput.stories';
+import { useArrayInput } from './useArrayInput';
 
 describe('<ArrayInput />', () => {
     it('should pass its record props to its child', async () => {
-        let childProps;
-        const MockChild = props => {
-            childProps = props;
+        let record;
+        const MockChild = () => {
+            record = useRecordContext();
             return null;
         };
 
@@ -37,7 +39,7 @@ describe('<ArrayInput />', () => {
         );
 
         await waitFor(() => {
-            expect(childProps.record).toEqual({
+            expect(record).toEqual({
                 iAmRecord: true,
             });
         });
@@ -45,8 +47,8 @@ describe('<ArrayInput />', () => {
 
     it('should pass array functions to child', async () => {
         let childProps;
-        const MockChild = props => {
-            childProps = props;
+        const MockChild = () => {
+            childProps = useArrayInput();
             return null;
         };
         render(

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -21,6 +21,7 @@ import {
     ValidationInFormTab,
     NestedInline,
     WithReferenceField,
+    NestedInlineNoTranslation,
 } from './ArrayInput.stories';
 import { useArrayInput } from './useArrayInput';
 
@@ -373,5 +374,14 @@ describe('<ArrayInput />', () => {
         render(<WithReferenceField />);
         await screen.findByText('Russia');
         await screen.findByText('Italy');
+    });
+
+    it('should correctly set inputs and field labels even nested', async () => {
+        render(<NestedInlineNoTranslation />);
+        await screen.findByLabelText('resources.orders.fields.customer');
+        await screen.findByLabelText('resources.orders.fields.date');
+        await screen.findByText('resources.orders.fields.items');
+        await screen.findAllByText('resources.orders.fields.items.name');
+        await screen.findAllByLabelText('resources.orders.fields.items.price');
     });
 });

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -7,7 +7,6 @@ import {
     minLength,
     required,
     testDataProvider,
-    useRecordContext,
 } from 'ra-core';
 
 import { AdminContext } from '../../AdminContext';
@@ -21,30 +20,6 @@ import { GlobalValidation, ValidationInFormTab } from './ArrayInput.stories';
 import { useArrayInput } from './useArrayInput';
 
 describe('<ArrayInput />', () => {
-    it('should pass its record props to its child', async () => {
-        let record;
-        const MockChild = () => {
-            record = useRecordContext();
-            return null;
-        };
-
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <SimpleForm onSubmit={jest.fn}>
-                    <ArrayInput source="foo" record={{ iAmRecord: true }}>
-                        <MockChild />
-                    </ArrayInput>
-                </SimpleForm>
-            </AdminContext>
-        );
-
-        await waitFor(() => {
-            expect(record).toEqual({
-                iAmRecord: true,
-            });
-        });
-    });
-
     it('should pass array functions to child', async () => {
         let childProps;
         const MockChild = () => {

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -500,7 +500,6 @@ export const NestedInlineNoTranslation = () => (
                             <DateInput source="date" helperText={false} />
                             <ArrayInput source="items">
                                 <SimpleFormIterator
-                                    inline
                                     sx={{
                                         '& .MuiStack-root': {
                                             flexWrap: 'wrap',
@@ -520,6 +519,7 @@ export const NestedInlineNoTranslation = () => (
                                             source="name"
                                             sx={{ width: 200 }}
                                         />
+                                        {/* Duplicated so that TranslatableFields adds labels */}
                                         <TextField
                                             source="name"
                                             sx={{ width: 200 }}
@@ -733,7 +733,7 @@ const dataProviderWithCountries = {
                 tags: ['novel', 'war', 'classic'],
             },
         }),
-    getList: (_resource, params) =>
+    getList: () =>
         Promise.resolve({ data: countries, count: countries.length }),
     getMany: (_resource, params) => {
         return Promise.resolve({

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -17,7 +17,7 @@ import { DateInput } from '../DateInput';
 import { NumberInput } from '../NumberInput';
 import { AutocompleteInput } from '../AutocompleteInput';
 import { TranslatableInputs } from '../TranslatableInputs';
-import { ReferenceField, TextField } from '../../field';
+import { ReferenceField, TextField, TranslatableFields } from '../../field';
 import { Labeled } from '../../Labeled';
 
 export default { title: 'ra-ui-materialui/input/ArrayInput' };
@@ -427,6 +427,104 @@ export const NestedInline = () => (
                                             sx={{ width: 200 }}
                                         />
                                     </TranslatableInputs>
+                                    <NumberInput
+                                        source="price"
+                                        helperText={false}
+                                        sx={{ width: 100 }}
+                                    />
+                                    <NumberInput
+                                        source="quantity"
+                                        helperText={false}
+                                        sx={{ width: 100 }}
+                                    />
+                                    <ArrayInput source="extras">
+                                        <SimpleFormIterator
+                                            inline
+                                            disableReordering
+                                        >
+                                            <TextInput
+                                                source="type"
+                                                helperText={false}
+                                                sx={{ width: 100 }}
+                                            />
+                                            <NumberInput
+                                                source="price"
+                                                helperText={false}
+                                                sx={{ width: 100 }}
+                                            />
+                                            <TranslatableInputs
+                                                locales={['en', 'fr']}
+                                            >
+                                                <TextInput
+                                                    source="content"
+                                                    helperText={false}
+                                                    sx={{ width: 200 }}
+                                                />
+                                            </TranslatableInputs>
+                                        </SimpleFormIterator>
+                                    </ArrayInput>
+                                </SimpleFormIterator>
+                            </ArrayInput>
+                        </SimpleForm>
+                    </Edit>
+                )}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
+export const NestedInlineNoTranslation = () => (
+    <TestMemoryRouter initialEntries={['/orders/1']}>
+        <Admin
+            dataProvider={
+                {
+                    getOne: () => Promise.resolve({ data: orderNested }),
+                    update: (_resource, params) => Promise.resolve(params),
+                } as any
+            }
+            i18nProvider={testI18nProvider()}
+        >
+            <Resource
+                name="orders"
+                edit={() => (
+                    <Edit
+                        mutationMode="pessimistic"
+                        mutationOptions={{
+                            onSuccess: data => {
+                                console.log(data);
+                            },
+                        }}
+                    >
+                        <SimpleForm>
+                            <TextInput source="customer" helperText={false} />
+                            <DateInput source="date" helperText={false} />
+                            <ArrayInput source="items">
+                                <SimpleFormIterator
+                                    inline
+                                    sx={{
+                                        '& .MuiStack-root': {
+                                            flexWrap: 'wrap',
+                                        },
+                                    }}
+                                >
+                                    <TranslatableInputs locales={['en', 'fr']}>
+                                        <Labeled source="name">
+                                            <TextField
+                                                source="name"
+                                                sx={{ width: 200 }}
+                                            />
+                                        </Labeled>
+                                    </TranslatableInputs>
+                                    <TranslatableFields locales={['en', 'fr']}>
+                                        <TextField
+                                            source="name"
+                                            sx={{ width: 200 }}
+                                        />
+                                        <TextField
+                                            source="name"
+                                            sx={{ width: 200 }}
+                                        />
+                                    </TranslatableFields>
                                     <NumberInput
                                         source="price"
                                         helperText={false}

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -508,32 +508,21 @@ export const NestedInlineNoTranslation = () => (
                                 >
                                     <TranslatableInputs locales={['en', 'fr']}>
                                         <Labeled source="name">
-                                            <TextField
-                                                source="name"
-                                                sx={{ width: 200 }}
-                                            />
+                                            <TextField source="name" />
                                         </Labeled>
                                     </TranslatableInputs>
                                     <TranslatableFields locales={['en', 'fr']}>
-                                        <TextField
-                                            source="name"
-                                            sx={{ width: 200 }}
-                                        />
+                                        <TextField source="name" />
                                         {/* Duplicated so that TranslatableFields adds labels */}
-                                        <TextField
-                                            source="name"
-                                            sx={{ width: 200 }}
-                                        />
+                                        <TextField source="name" />
                                     </TranslatableFields>
                                     <NumberInput
                                         source="price"
                                         helperText={false}
-                                        sx={{ width: 100 }}
                                     />
                                     <NumberInput
                                         source="quantity"
                                         helperText={false}
-                                        sx={{ width: 100 }}
                                     />
                                     <ArrayInput source="extras">
                                         <SimpleFormIterator
@@ -543,12 +532,10 @@ export const NestedInlineNoTranslation = () => (
                                             <TextInput
                                                 source="type"
                                                 helperText={false}
-                                                sx={{ width: 100 }}
                                             />
                                             <NumberInput
                                                 source="price"
                                                 helperText={false}
-                                                sx={{ width: 100 }}
                                             />
                                             <TranslatableInputs
                                                 locales={['en', 'fr']}
@@ -556,7 +543,6 @@ export const NestedInlineNoTranslation = () => (
                                                 <TextInput
                                                     source="content"
                                                     helperText={false}
-                                                    sx={{ width: 200 }}
                                                 />
                                             </TranslatableInputs>
                                         </SimpleFormIterator>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -16,6 +16,7 @@ import { TextInput } from '../TextInput';
 import { DateInput } from '../DateInput';
 import { NumberInput } from '../NumberInput';
 import { AutocompleteInput } from '../AutocompleteInput';
+import { TranslatableInputs } from '../TranslatableInputs';
 
 export default { title: 'ra-ui-materialui/input/ArrayInput' };
 
@@ -329,12 +330,65 @@ export const Realistic = () => (
     </TestMemoryRouter>
 );
 
+const orderNested = {
+    id: 1,
+    date: '2022-08-30',
+    customer: 'John Doe',
+    items: [
+        {
+            name: { en: 'Office Jeans', fr: 'Jean de bureau' },
+            price: 45.99,
+            quantity: 1,
+            extras: [
+                {
+                    type: 'card',
+                    price: 2.99,
+                    content: {
+                        en: 'For you my love',
+                        fr: 'Pour toi mon amour',
+                    },
+                },
+                {
+                    type: 'gift package',
+                    price: 1.99,
+                },
+                {
+                    type: 'insurance',
+                    price: 5,
+                },
+            ],
+        },
+        {
+            name: {
+                en: 'Black Elegance Jeans',
+                fr: 'Jean élégant noir',
+            },
+            price: 69.99,
+            quantity: 2,
+            extras: [
+                {
+                    type: 'card',
+                    price: 2.99,
+                    content: {
+                        en: 'For you my love',
+                        fr: 'Pour toi mon amour',
+                    },
+                },
+            ],
+        },
+        {
+            name: { en: 'Slim Fit Jeans', fr: 'Jean slim' },
+            price: 55.99,
+            quantity: 1,
+        },
+    ],
+};
 export const NestedInline = () => (
     <TestMemoryRouter initialEntries={['/orders/1']}>
         <Admin
             dataProvider={
                 {
-                    getOne: () => Promise.resolve({ data: order }),
+                    getOne: () => Promise.resolve({ data: orderNested }),
                     update: (_resource, params) => Promise.resolve(params),
                 } as any
             }
@@ -362,11 +416,13 @@ export const NestedInline = () => (
                                         },
                                     }}
                                 >
-                                    <TextInput
-                                        source="name"
-                                        helperText={false}
-                                        sx={{ width: 200 }}
-                                    />
+                                    <TranslatableInputs locales={['en', 'fr']}>
+                                        <TextInput
+                                            source="name"
+                                            helperText={false}
+                                            sx={{ width: 200 }}
+                                        />
+                                    </TranslatableInputs>
                                     <NumberInput
                                         source="price"
                                         helperText={false}
@@ -392,11 +448,15 @@ export const NestedInline = () => (
                                                 helperText={false}
                                                 sx={{ width: 100 }}
                                             />
-                                            <TextInput
-                                                source="content"
-                                                helperText={false}
-                                                sx={{ width: 200 }}
-                                            />
+                                            <TranslatableInputs
+                                                locales={['en', 'fr']}
+                                            >
+                                                <TextInput
+                                                    source="content"
+                                                    helperText={false}
+                                                    sx={{ width: 200 }}
+                                                />
+                                            </TranslatableInputs>
                                         </SimpleFormIterator>
                                     </ArrayInput>
                                 </SimpleFormIterator>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -17,6 +17,8 @@ import { DateInput } from '../DateInput';
 import { NumberInput } from '../NumberInput';
 import { AutocompleteInput } from '../AutocompleteInput';
 import { TranslatableInputs } from '../TranslatableInputs';
+import { ReferenceField, TextField } from '../../field';
+import { Labeled } from '../../Labeled';
 
 export default { title: 'ra-ui-materialui/input/ArrayInput' };
 
@@ -30,10 +32,12 @@ const dataProvider = {
                     {
                         name: 'Leo Tolstoy',
                         role: 'head_writer',
+                        country_id: 1,
                     },
                     {
                         name: 'Alexander Pushkin',
                         role: 'co_writer',
+                        country_id: 2,
                     },
                 ],
                 tags: ['novel', 'war', 'classic'],
@@ -600,6 +604,71 @@ export const ValidationInFormTab = () => (
     <TestMemoryRouter initialEntries={['/books/create']}>
         <Admin dataProvider={dataProvider}>
             <Resource name="books" create={CreateGlobalValidationInFormTab} />
+        </Admin>
+    </TestMemoryRouter>
+);
+
+const countries = [
+    { id: 1, name: 'France' },
+    { id: 2, name: 'Italy' },
+    { id: 3, name: 'Spain' },
+    { id: 4, name: 'Russia' },
+];
+const dataProviderWithCountries = {
+    getOne: () =>
+        Promise.resolve({
+            data: {
+                id: 1,
+                title: 'War and Peace',
+                authors: [
+                    {
+                        name: 'Leo Tolstoy',
+                        role: 'head_writer',
+                        country_id: 4,
+                    },
+                    {
+                        name: 'Alexander Pushkin',
+                        role: 'co_writer',
+                        country_id: 2,
+                    },
+                ],
+                tags: ['novel', 'war', 'classic'],
+            },
+        }),
+    getList: (_resource, params) =>
+        Promise.resolve({ data: countries, count: countries.length }),
+    getMany: (_resource, params) => {
+        return Promise.resolve({
+            data: countries.filter(country => params.ids.includes(country.id)),
+        });
+    },
+} as any;
+
+const EditWithReferenceField = () => (
+    <Edit>
+        <SimpleForm>
+            <ArrayInput source="authors" fullWidth validate={required()}>
+                <SimpleFormIterator>
+                    <TextInput source="name" validate={required()} />
+                    <TextInput source="role" validate={required()} />
+                    <Labeled source="country_id">
+                        <ReferenceField
+                            source="country_id"
+                            reference="countries"
+                        >
+                            <TextField source="name" />
+                        </ReferenceField>
+                    </Labeled>
+                </SimpleFormIterator>
+            </ArrayInput>
+        </SimpleForm>
+    </Edit>
+);
+
+export const WithReferenceField = () => (
+    <TestMemoryRouter initialEntries={['/books/1']}>
+        <Admin dataProvider={dataProviderWithCountries}>
+            <Resource name="books" edit={EditWithReferenceField} />
         </Admin>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { cloneElement, Children, ReactElement, useEffect } from 'react';
+import { ReactElement, useEffect } from 'react';
 import clsx from 'clsx';
 import {
     isRequired,
@@ -150,12 +150,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
     const sourceContext = React.useMemo<SourceContextValue>(
         () => ({
             getSource: (source: string) => {
-                const sourceResult = source
-                    ? `${finalSource}.${source}`
-                    : finalSource;
-                return parentSourceContext
-                    ? parentSourceContext.getSource(sourceResult)
-                    : sourceResult;
+                return source ? `${finalSource}.${source}` : finalSource;
             },
             getLabel: (source: string) =>
                 parentSourceContext

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -149,10 +149,14 @@ export const ArrayInput = (props: ArrayInputProps) => {
 
     const sourceContext = React.useMemo<SourceContextValue>(
         () => ({
-            getSource: (source: string) =>
-                parentSourceContext
-                    ? parentSourceContext.getSource(`${finalSource}.${source}`)
-                    : `${finalSource}.${source}`,
+            getSource: (source: string) => {
+                const sourceResult = source
+                    ? `${finalSource}.${source}`
+                    : finalSource;
+                return parentSourceContext
+                    ? parentSourceContext.getSource(sourceResult)
+                    : sourceResult;
+            },
             getLabel: (source: string) =>
                 parentSourceContext
                     ? parentSourceContext.getLabel(

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.spec.tsx
@@ -127,8 +127,8 @@ describe('<SimpleFormIterator />', () => {
         render(
             <Wrapper>
                 <SimpleForm>
-                    <ArrayInput source="emails" disabled>
-                        <SimpleFormIterator>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator disabled>
                             <TextInput source="email" />
                         </SimpleFormIterator>
                     </ArrayInput>
@@ -194,8 +194,8 @@ describe('<SimpleFormIterator />', () => {
                         emails: [{ email: '' }, { email: '' }],
                     }}
                 >
-                    <ArrayInput source="emails" disabled>
-                        <SimpleFormIterator>
+                    <ArrayInput source="emails">
+                        <SimpleFormIterator disabled>
                             <TextInput source="email" />
                         </SimpleFormIterator>
                     </ArrayInput>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -60,7 +60,7 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
     const finalSource = useWrappedSource('');
     if (!finalSource) {
         throw new Error(
-            'SimpleFormIterator should be wrapped in a SourceContext'
+            'SimpleFormIterator can only be called within an iterator input like ArrayInput'
         );
     }
 

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -15,6 +15,7 @@ import {
     FormDataConsumer,
     RaRecord,
     useRecordContext,
+    useSourceContext,
     useTranslate,
 } from 'ra-core';
 import { UseFieldArrayReturn, useFormContext } from 'react-hook-form';
@@ -56,9 +57,15 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
         fullWidth,
         sx,
     } = props;
-    if (!source) {
-        throw new Error('SimpleFormIterator requires a source prop');
+
+    const sourceContext = useSourceContext();
+    const finalSource = sourceContext?.getSource(source || '') ?? source;
+    if (!finalSource) {
+        throw new Error(
+            'SimpleFormIterator should be wrapped in a SourceContext or requires a source prop'
+        );
     }
+
     const [confirmIsOpen, setConfirmIsOpen] = useState<boolean>(false);
     const { append, fields, move, remove, replace } = useArrayInput(props);
     const { resetField } = useFormContext();
@@ -133,7 +140,7 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
         setConfirmIsOpen(false);
     }, [replace]);
 
-    const records = get(record, source);
+    const records = get(record, finalSource);
 
     const context = useMemo(
         () => ({
@@ -141,9 +148,9 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
             add: addField,
             remove: removeField,
             reOrder: handleReorder,
-            source,
+            source: finalSource,
         }),
-        [addField, fields.length, handleReorder, removeField, source]
+        [addField, fields.length, handleReorder, removeField, finalSource]
     );
     return fields ? (
         <SimpleFormIteratorContext.Provider value={context}>
@@ -165,14 +172,14 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
                             fields={fields}
                             getItemLabel={getItemLabel}
                             index={index}
-                            member={`${source}.${index}`}
+                            member={`${index}`}
                             onRemoveField={removeField}
                             onReorder={handleReorder}
                             record={(records && records[index]) || {}}
                             removeButton={removeButton}
                             reOrderButtons={reOrderButtons}
                             resource={resource}
-                            source={source}
+                            source={finalSource}
                             inline={inline}
                         >
                             {children}

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -46,7 +46,6 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
         children,
         className,
         resource,
-        source,
         disabled,
         disableAdd = false,
         disableClear,
@@ -59,10 +58,10 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
     } = props;
 
     const sourceContext = useSourceContext();
-    const finalSource = sourceContext?.getSource(source || '') ?? source;
+    const finalSource = sourceContext?.getSource('');
     if (!finalSource) {
         throw new Error(
-            'SimpleFormIterator should be wrapped in a SourceContext or requires a source prop'
+            'SimpleFormIterator should be wrapped in a SourceContext'
         );
     }
 
@@ -123,9 +122,9 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
             }
             append(defaultValue);
             // Make sure the newly added inputs are not considered dirty by react-hook-form
-            resetField(`${source}.${fields.length}`, { defaultValue });
+            resetField(`${finalSource}.${fields.length}`, { defaultValue });
         },
-        [append, children, resetField, source, fields.length]
+        [append, children, resetField, finalSource, fields.length]
     );
 
     const handleReorder = useCallback(
@@ -172,14 +171,12 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
                             fields={fields}
                             getItemLabel={getItemLabel}
                             index={index}
-                            member={`${index}`}
                             onRemoveField={removeField}
                             onReorder={handleReorder}
                             record={(records && records[index]) || {}}
                             removeButton={removeButton}
                             reOrderButtons={reOrderButtons}
                             resource={resource}
-                            source={finalSource}
                             inline={inline}
                         >
                             {children}

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -15,8 +15,8 @@ import {
     FormDataConsumer,
     RaRecord,
     useRecordContext,
-    useSourceContext,
     useTranslate,
+    useWrappedSource,
 } from 'ra-core';
 import { UseFieldArrayReturn, useFormContext } from 'react-hook-form';
 
@@ -57,8 +57,7 @@ export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
         sx,
     } = props;
 
-    const sourceContext = useSourceContext();
-    const finalSource = sourceContext?.getSource('');
+    const finalSource = useWrappedSource('');
     if (!finalSource) {
         throw new Error(
             'SimpleFormIterator should be wrapped in a SourceContext'

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
@@ -4,6 +4,7 @@ import { Typography, Stack } from '@mui/material';
 import clsx from 'clsx';
 import {
     RaRecord,
+    RecordContextProvider,
     SourceContextProvider,
     useResourceContext,
     useSourceContext,
@@ -116,15 +117,19 @@ export const SimpleFormIteratorItem = React.forwardRef(
                         </Typography>
                     )}
                     <SourceContextProvider value={sourceContext}>
-                        <Stack
-                            className={clsx(SimpleFormIteratorClasses.form)}
-                            direction={
-                                inline ? { xs: 'column', sm: 'row' } : 'column'
-                            }
-                            gap={inline ? 2 : 0}
-                        >
-                            {children}
-                        </Stack>
+                        <RecordContextProvider value={record}>
+                            <Stack
+                                className={clsx(SimpleFormIteratorClasses.form)}
+                                direction={
+                                    inline
+                                        ? { xs: 'column', sm: 'row' }
+                                        : 'column'
+                                }
+                                gap={inline ? 2 : 0}
+                            >
+                                {children}
+                            </Stack>
+                        </RecordContextProvider>
                     </SourceContextProvider>
                     {!disabled && (
                         <span className={SimpleFormIteratorClasses.action}>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
@@ -30,7 +30,6 @@ export const SimpleFormIteratorItem = React.forwardRef(
             getItemLabel,
             index,
             inline,
-            member,
             record,
             removeButton = <DefaultRemoveItemButton />,
             reOrderButtons = <DefaultReOrderButtons />,
@@ -74,25 +73,18 @@ export const SimpleFormIteratorItem = React.forwardRef(
                 getSource: (source: string) => {
                     if (parentSourceContext) {
                         return parentSourceContext.getSource(
-                            source ? `${member}.${source}` : member
+                            source ? `${index}.${source}` : `${index}`
                         );
                     }
-                    return source ? `${member}.${source}` : member;
+                    return source ? `${index}.${source}` : `${index}`;
                 },
                 getLabel: (source: string) => {
-                    // remove digits, e.g. 'book.authors.2.categories.3.identifier.name' => 'book.authors.categories.identifier.name'
-                    const sanitizedMember = member.replace(/\.\d+/g, '');
-                    // source may be empty for scalar values arrays
-                    const itemSource = source
-                        ? `${sanitizedMember}.${source}`
-                        : sanitizedMember;
-
                     return parentSourceContext
-                        ? parentSourceContext.getLabel(itemSource)
-                        : getResourceFieldLabelKey(resource, itemSource);
+                        ? parentSourceContext.getLabel(source)
+                        : getResourceFieldLabelKey(resource, source);
                 },
             }),
-            [member, parentSourceContext, resource]
+            [index, parentSourceContext, resource]
         );
 
         return (
@@ -142,7 +134,6 @@ export type SimpleFormIteratorItemProps = Partial<ArrayInputContextValue> & {
     getItemLabel?: boolean | GetItemLabelFunc;
     index: number;
     inline?: boolean;
-    member: string;
     onRemoveField: (index: number) => void;
     onReorder: (origin: number, destination: number) => void;
     record: RaRecord;

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
@@ -149,5 +149,5 @@ export type SimpleFormIteratorItemProps = Partial<ArrayInputContextValue> & {
     removeButton?: ReactElement;
     reOrderButtons?: ReactElement;
     resource?: string;
-    source: string;
+    source?: string;
 };

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
@@ -3,7 +3,6 @@ import { ReactElement, ReactNode, useMemo } from 'react';
 import { Typography, Stack } from '@mui/material';
 import clsx from 'clsx';
 import {
-    getResourceFieldLabelKey,
     RaRecord,
     SourceContextProvider,
     useResourceContext,
@@ -71,11 +70,6 @@ export const SimpleFormIteratorItem = React.forwardRef(
         const sourceContext = useMemo(
             () => ({
                 getSource: (source: string) => {
-                    if (!parentSourceContext) {
-                        throw new Error(
-                            'Cannot use SimpleFormIterator outside of an ArrayInput'
-                        );
-                    }
                     if (!source) {
                         // source can be empty for scalar values, e.g.
                         // <ArrayInput source="tags" /> => SourceContext is "tags"
@@ -97,12 +91,17 @@ export const SimpleFormIteratorItem = React.forwardRef(
                     }
                 },
                 getLabel: (source: string) => {
-                    return parentSourceContext
-                        ? parentSourceContext.getLabel(source)
-                        : getResourceFieldLabelKey(resource, source);
+                    // <ArrayInput source="orders" /> => LabelContext is "orders"
+                    //   <SimpleFormIterator> => LabelContext is ALSO "orders"
+                    //      <DateInput source="date" /> => use its parent's getLabel so finalLabel = "orders.date"
+                    //   </SimpleFormIterator>
+                    // </ArrayInput>
+                    //
+                    // we don't prefix with the index to avoid that translation keys contain it
+                    return parentSourceContext.getLabel(source);
                 },
             }),
-            [index, parentSourceContext, resource]
+            [index, parentSourceContext]
         );
 
         return (

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
@@ -58,7 +58,7 @@ const CountryList = () => {
     const { data } = useListContext();
     return (
         <List>
-            {data.map(record => (
+            {data?.map(record => (
                 <ListItem key={record.id} disablePadding>
                     <ListItemText>{record.name}</ListItemText>
                 </ListItem>

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -3,7 +3,13 @@ import { ChangeEvent, memo, useMemo } from 'react';
 import { InputAdornment } from '@mui/material';
 import { SxProps } from '@mui/system';
 import SearchIcon from '@mui/icons-material/Search';
-import { useTranslate, useListFilterContext } from 'ra-core';
+import {
+    useTranslate,
+    useListFilterContext,
+    SourceContextProvider,
+    useResourceContext,
+    SourceContextValue,
+} from 'ra-core';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { TextInput, TextInputProps } from '../../input';
@@ -26,6 +32,7 @@ import { TextInput, TextInputProps } from '../../input';
 export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
     const { filterValues, setFilters } = useListFilterContext();
     const translate = useTranslate();
+    const resource = useResourceContext(props);
 
     const {
         source = 'q',
@@ -60,29 +67,41 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
         e.preventDefault();
     };
 
+    const sourceContext = React.useMemo<SourceContextValue>(
+        () => ({
+            getSource: (source: string) => source,
+            getLabel: (source: string) =>
+                `resources.${resource}.fields.${source}`,
+        }),
+        [resource]
+    );
+
     return (
         <FormProvider {...form}>
-            <form onSubmit={onSubmit}>
-                <TextInput
-                    resettable
-                    helperText={false}
-                    source={source}
-                    InputProps={{
-                        endAdornment: (
-                            <InputAdornment position="end">
-                                <SearchIcon color="disabled" />
-                            </InputAdornment>
-                        ),
-                    }}
-                    onChange={handleChange}
-                    size="small"
-                    label={rest.hiddenLabel ? false : label}
-                    placeholder={
-                        placeholder ?? (rest.hiddenLabel ? label : undefined)
-                    }
-                    {...rest}
-                />
-            </form>
+            <SourceContextProvider value={sourceContext}>
+                <form onSubmit={onSubmit}>
+                    <TextInput
+                        resettable
+                        helperText={false}
+                        source={source}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <SearchIcon color="disabled" />
+                                </InputAdornment>
+                            ),
+                        }}
+                        onChange={handleChange}
+                        size="small"
+                        label={rest.hiddenLabel ? false : label}
+                        placeholder={
+                            placeholder ??
+                            (rest.hiddenLabel ? label : undefined)
+                        }
+                        {...rest}
+                    />
+                </form>
+            </SourceContextProvider>
         </FormProvider>
     );
 });

--- a/test-setup.js
+++ b/test-setup.js
@@ -17,8 +17,3 @@ const { Response, Headers, Request } = require('whatwg-fetch');
 global.Response = Response;
 global.Headers = Headers;
 global.Request = Request;
-
-// jsdom does not support structuredClone
-global.structuredClone = jest.fn(val => {
-    return JSON.parse(JSON.stringify(val));
-});

--- a/test-setup.js
+++ b/test-setup.js
@@ -17,3 +17,8 @@ const { Response, Headers, Request } = require('whatwg-fetch');
 global.Response = Response;
 global.Headers = Headers;
 global.Request = Request;
+
+// jsdom does not support structuredClone
+global.structuredClone = jest.fn(val => {
+    return JSON.parse(JSON.stringify(val));
+});


### PR DESCRIPTION
## Problem

`<ArrayInput>` and `<SimpleFormIterator>` are still cloning their children. Besides, `<SimpleFormIterator>` throws an Error when used without a source prop.

## Solution

Migrate both components to support the `SourceContext` and no longer require cloning their children.

This is a BC so this needs to be done before the v5 release.