### PR TITLE
Fix `<List>` should not render Error component on fetch error

### DIFF
--- a/packages/ra-ui-materialui/src/layout/AppBar.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.stories.tsx
@@ -13,7 +13,14 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
-import { I18nContextProvider, AuthContext, TestMemoryRouter } from 'ra-core';
+import {
+    I18nContextProvider,
+    AuthContext,
+    PreferencesEditorContextProvider,
+    StoreContextProvider,
+    TestMemoryRouter,
+    memoryStore,
+} from 'ra-core';
 
 import { AppBar } from './AppBar';
 import { Title } from './Title';
@@ -50,10 +57,14 @@ const Wrapper = ({ children, theme = createTheme(defaultTheme) }) => (
     <TestMemoryRouter>
         <QueryClientProvider client={new QueryClient()}>
             <MuiThemeProvider theme={theme}>
-                <AuthContext.Provider value={undefined as any}>
-                    {children}
-                </AuthContext.Provider>
-                <Content />
+                <StoreContextProvider value={memoryStore()}>
+                    <PreferencesEditorContextProvider>
+                        <AuthContext.Provider value={undefined as any}>
+                            {children}
+                        </AuthContext.Provider>
+                        <Content />
+                    </PreferencesEditorContextProvider>
+                </StoreContextProvider>
             </MuiThemeProvider>
         </QueryClientProvider>
     </TestMemoryRouter>

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -157,7 +157,6 @@ const Root = styled('div', {
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    margin: 'auto',
     [theme.breakpoints.down('md')]: {
         padding: '1em',
     },

--- a/packages/ra-ui-materialui/src/layout/Layout.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.stories.tsx
@@ -1,76 +1,29 @@
 import {
+    AppBar as RaAppBar,
     Box,
     ListItemIcon,
     ListItemText,
     MenuItem,
     MenuList,
     Skeleton,
-    ThemeProvider,
-    createTheme,
 } from '@mui/material';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import PeopleIcon from '@mui/icons-material/People';
-import {
-    AuthContext,
-    PreferencesEditorContextProvider,
-    StoreContextProvider,
-    memoryStore,
-    TestMemoryRouter,
-} from 'ra-core';
+import { Resource } from 'ra-core';
 import * as React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { defaultTheme } from '../theme/defaultTheme';
+import { AdminContext } from '../AdminContext';
+import { AdminUI } from '..';
 import { Layout } from './Layout';
-import { Title } from './Title';
 
 export default {
     title: 'ra-ui-materialui/layout/Layout',
 };
 
-const Content = () => (
-    <Box>
-        <Skeleton
-            variant="text"
-            width="auto"
-            sx={{ fontSize: '2rem', mx: 2 }}
-            animation={false}
-        />
-        <Skeleton
-            variant="rectangular"
-            width="auto"
-            height={1500}
-            sx={{ mx: 2 }}
-            animation={false}
-        />
-    </Box>
-);
+export const Basic = () => <Wrapper layout={Layout} />;
 
-const Wrapper = ({
-    children = <Content />,
-    theme = createTheme(defaultTheme),
-    layout: LayoutComponent = Layout,
-}) => (
-    <TestMemoryRouter>
-        <QueryClientProvider client={new QueryClient()}>
-            <ThemeProvider theme={theme}>
-                <StoreContextProvider value={memoryStore()}>
-                    <PreferencesEditorContextProvider>
-                        <AuthContext.Provider value={undefined as any}>
-                            <LayoutComponent>
-                                {children}
-                                <Title title="React Admin" />
-                            </LayoutComponent>
-                        </AuthContext.Provider>
-                    </PreferencesEditorContextProvider>
-                </StoreContextProvider>
-            </ThemeProvider>
-        </QueryClientProvider>
-    </TestMemoryRouter>
-);
-
-const Menu = () => (
+const CustomMenu = () => (
     <MenuList>
         <MenuItem>
             <ListItemIcon>
@@ -93,12 +46,82 @@ const Menu = () => (
     </MenuList>
 );
 
-const BasicLayout = ({ children }) => <Layout menu={Menu}>{children}</Layout>;
-export const Basic = () => <Wrapper layout={BasicLayout} />;
-
-const AppBarAlwaysOnLayout = ({ children }) => (
-    <Layout appBarAlwaysOn menu={Menu}>
-        {children}
-    </Layout>
+export const Menu = () => (
+    <Wrapper
+        layout={({ children }) => <Layout menu={CustomMenu}>{children}</Layout>}
+    />
 );
-export const AppBarAlwaysOn = () => <Wrapper layout={AppBarAlwaysOnLayout} />;
+
+export const AppBar = () => (
+    <Wrapper
+        layout={({ children }) => (
+            <Layout appBar={() => <RaAppBar>Custom AppBar</RaAppBar>}>
+                {children}
+            </Layout>
+        )}
+    />
+);
+
+export const AppBarAlwaysOn = () => (
+    <Wrapper
+        layout={({ children }) => <Layout appBarAlwaysOn>{children}</Layout>}
+    />
+);
+
+export const ErrorDefault = () => (
+    <Wrapper
+        layout={Layout}
+        content={() => {
+            throw new Error('Client error');
+        }}
+    />
+);
+
+export const ErrorCustom = () => (
+    <Wrapper
+        layout={({ children }) => (
+            <Layout
+                error={({ error }) => (
+                    <div>
+                        <h1>Custom error</h1>
+                        <p>{error.message}</p>
+                    </div>
+                )}
+            >
+                {children}
+            </Layout>
+        )}
+        content={() => {
+            throw new Error('Client error');
+        }}
+    />
+);
+
+const DefaultContent = () => (
+    <Box>
+        <Skeleton
+            variant="text"
+            width="auto"
+            sx={{ fontSize: '2rem', mx: 2 }}
+            animation={false}
+        />
+        <Skeleton
+            variant="rectangular"
+            width="auto"
+            height={1500}
+            sx={{ mx: 2 }}
+            animation={false}
+        />
+    </Box>
+);
+
+const Wrapper = ({
+    layout: LayoutComponent,
+    content: ContentComponent = DefaultContent,
+}) => (
+    <AdminContext>
+        <AdminUI layout={LayoutComponent}>
+            <Resource name="posts" list={ContentComponent} />
+        </AdminUI>
+    </AdminContext>
+);

--- a/packages/ra-ui-materialui/src/list/List.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/List.spec.tsx
@@ -13,6 +13,7 @@ import { defaultTheme } from '../theme/defaultTheme';
 import { List } from './List';
 import { Filter } from './filter';
 import { TextInput } from '../input';
+import { Notification } from '../layout';
 
 const theme = createTheme(defaultTheme);
 
@@ -270,13 +271,11 @@ describe('<List />', () => {
         });
     });
 
-    it('should render a list page with an error message when there is an error', async () => {
+    it('should render a list page with an error notification when there is an error', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         const Datagrid = () => <div>datagrid</div>;
         const dataProvider = {
-            getList: jest.fn(() =>
-                Promise.reject({ error: { key: 'error.unknown' } })
-            ),
+            getList: jest.fn(() => Promise.reject(new Error('Lorem ipsum'))),
         } as any;
         render(
             <CoreAdminContext dataProvider={dataProvider}>
@@ -284,11 +283,12 @@ describe('<List />', () => {
                     <List resource="posts">
                         <Datagrid />
                     </List>
+                    <Notification />
                 </ThemeProvider>
             </CoreAdminContext>
         );
         await waitFor(() => {
-            expect(screen.getByText('ra.page.error'));
+            expect(screen.getByText('Lorem ipsum'));
         });
     });
 });

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -11,7 +11,6 @@ import { ListToolbar } from './ListToolbar';
 import { Pagination as DefaultPagination } from './pagination';
 import { ListActions as DefaultActions } from './ListActions';
 import { Empty } from './Empty';
-import { Error } from '../layout';
 
 const defaultActions = <DefaultActions />;
 const defaultPagination = <DefaultPagination />;
@@ -51,11 +50,7 @@ export const ListView = <RecordType extends RaRecord = any>(
                 />
             )}
             <Content className={ListClasses.content}>{children}</Content>
-            {error ? (
-                <Error error={error} resetErrorBoundary={() => {}} />
-            ) : (
-                pagination !== false && pagination
-            )}
+            {!error && pagination !== false && pagination}
         </div>
     );
 


### PR DESCRIPTION
The `<Error>` component is designed for runtime errors. We shouldn't use it for fetch errors. Besides, developers often want to customize the Error component. It wan't possible to do so with List. Finally, both `Error` and `List` set the page title, which resulted in an incorrect title.

## Before

![image](https://github.com/marmelab/react-admin/assets/99944/0c30b34d-1763-4bc4-bc6f-27459c1d2eaf)


## After

![image](https://github.com/marmelab/react-admin/assets/99944/9e315fb8-77d9-4ba7-aa63-822889bc52c4)


This also reverts #9904, which did nothing. 