### PR TITLE
Fix default Error background in global ErrorBoundary

### DIFF
--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -300,11 +300,13 @@ export const CoreAdminUI = (props: CoreAdminUIProps) => {
             <ErrorBoundary
                 onError={handleError}
                 fallbackRender={({ error, resetErrorBoundary }) => (
-                    <ErrorComponent
-                        error={error}
-                        errorInfo={errorInfo}
-                        resetErrorBoundary={resetErrorBoundary}
-                    />
+                    <div style={{ minHeight: '100vh' }}>
+                        <ErrorComponent
+                            error={error}
+                            errorInfo={errorInfo}
+                            resetErrorBoundary={resetErrorBoundary}
+                        />
+                    </div>
                 )}
             >
                 <Routes>


### PR DESCRIPTION
Supersedes #9904

How to test: In the storybook, got to React-admin > Admin > Default Error

## Before

![image](https://github.com/marmelab/react-admin/assets/99944/a539a95f-0636-45f1-b176-0ebfb881370e)


## After

![image](https://github.com/marmelab/react-admin/assets/99944/a710bcbd-aab0-438d-974e-53c7157b62b0)
