### PR TITLE
Add avatar icon as login property w/ default.

### DIFF
--- a/packages/ra-ui-materialui/src/auth/Login.stories.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import AccountBoxIcon from '@mui/icons-material/AccountBox';
+import { AdminContext } from '../AdminContext';
+import { Login } from './Login';
+
+export default { title: 'ra-ui-materialui/auth/Login' };
+
+export const DefaultLogin = () => {
+    return (
+        <Wrapper>
+            <Login />
+        </Wrapper>
+    );
+};
+
+export const CustomIcon = () => {
+    return (
+        <Wrapper>
+            <Login avatarIcon={<AccountBoxIcon />} />
+        </Wrapper>
+    );
+};
+
+const Wrapper = ({ children }) => {
+    const authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkAuth: () => Promise.reject(),
+        checkError: () => Promise.resolve(),
+        getPermissions: () => Promise.resolve(),
+    };
+    return <AdminContext authProvider={authProvider}>{children}</AdminContext>;
+};

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -33,7 +33,7 @@ export const Login = (props: LoginProps) => {
         avatarIcon = defaultAvatarIcon,
         ...rest
     } = props;
-    const containerRef = useRef<HTMLDivElement>();
+    const containerRef = useRef<HTMLDivElement>(null);
     let backgroundImageLoaded = false;
     const checkAuth = useCheckAuth();
     const navigate = useNavigate();

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -27,8 +27,13 @@ import { LoginForm as DefaultLoginForm } from './LoginForm';
  *     );
  */
 export const Login = (props: LoginProps) => {
-    const { children = defaultLoginForm, backgroundImage, ...rest } = props;
-    const containerRef = useRef<HTMLDivElement>(null);
+    const {
+        children = defaultLoginForm,
+        backgroundImage,
+        avatarIcon = defaultAvatarIcon,
+        ...rest
+    } = props;
+    const containerRef = useRef<HTMLDivElement>();
     let backgroundImageLoaded = false;
     const checkAuth = useCheckAuth();
     const navigate = useNavigate();
@@ -68,9 +73,7 @@ export const Login = (props: LoginProps) => {
         <Root {...rest} ref={containerRef}>
             <Card className={LoginClasses.card}>
                 <div className={LoginClasses.avatar}>
-                    <Avatar className={LoginClasses.icon}>
-                        <LockIcon />
-                    </Avatar>
+                    <Avatar className={LoginClasses.icon}>{avatarIcon}</Avatar>
                 </div>
                 {children}
             </Card>
@@ -80,7 +83,10 @@ export const Login = (props: LoginProps) => {
 
 const defaultLoginForm = <DefaultLoginForm />;
 
+const defaultAvatarIcon = <LockIcon />;
+
 export interface LoginProps extends HtmlHTMLAttributes<HTMLDivElement> {
+    avatarIcon?: ReactNode;
     backgroundImage?: string;
     children?: ReactNode;
     className?: string;


### PR DESCRIPTION
This is a pull request for issue #9916. It adds an avatarIcon property to the Login component w/ a default of the Lock icon. This allows for overriding the icon without having to copy the complete component.

Ideally, this would be included as part of a v4 point release. This is my first pull request, so please let me know if there is anything else needed.

--

Fix https://github.com/marmelab/react-admin/issues/9916