### PR TITLE
Fix create-admin-app generated tests

### DIFF
--- a/packages/create-react-admin/src/generateAppTestFile.ts
+++ b/packages/create-react-admin/src/generateAppTestFile.ts
@@ -32,6 +32,7 @@ test("should pass", async () => {
 
 	// Open the first post
 	fireEvent.click(await screen.findByText("Post 1"));
+	fireEvent.click(await screen.findByText("Edit"));
 	// Update its title
 	fireEvent.change(await screen.findByDisplayValue("Post 1"), {
 		target: { value: "Post 1 edited" },
@@ -43,12 +44,13 @@ test("should pass", async () => {
 	fireEvent.click(await screen.findByText("Comments"));
 	// Open the first comment
 	fireEvent.click(await screen.findByText("Comment 1"));
+	fireEvent.click(await screen.findByText("Edit"));
 	// Edit the comment selected post
-	fireEvent.click(await screen.findByDisplayValue("#0"));
-	fireEvent.click(await screen.findByText("#11"));
+	fireEvent.click(await screen.findByDisplayValue("Post 1 edited"));
+	fireEvent.click(await screen.findByText("Post 11"));
 	fireEvent.click(await screen.findByText("Save"));
 	// Check the comment has been updated by finding the post link in the comments list page
-	await screen.findByText("#11", { selector: "a *" });
+	await screen.findByText("Post 11", { selector: "a *" });
 }, 10000);
 
     `


### PR DESCRIPTION
## How to test

1. Build create-react-admin and install the CLI
```sh
make build-create-react-admin install
```

2. Run the CLI from another directory
```sh
../react-admin/node_modules/.bin/create-react-admin
```

3. Select `ra-data-fakerest`, fake `authProvider` and `yarn`
4. Run the tests
```sh
yarn test
```