### PR TITLE
Fix DatagridHeader Tooltip when using React element as a field label

### DIFF
--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -504,32 +504,3 @@ export const ErrorInFetch = () => (
         </Admin>
     </TestMemoryRouter>
 );
-
-export const LabelElements = () => (
-    <TestMemoryRouter initialEntries={['/books']}>
-        <Admin dataProvider={dataProvider}>
-            <Resource
-                name="books"
-                list={
-                    <List>
-                        <Datagrid>
-                            <TextField source="id" label={<span>ID</span>} />
-                            <TextField
-                                source="title"
-                                label={<span>TITLE</span>}
-                            />
-                            <TextField
-                                source="author"
-                                label={<span>AUTHOR</span>}
-                            />
-                            <TextField
-                                source="year"
-                                label={<span>YEAR</span>}
-                            />
-                        </Datagrid>
-                    </List>
-                }
-            />
-        </Admin>
-    </TestMemoryRouter>
-);

--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -504,3 +504,32 @@ export const ErrorInFetch = () => (
         </Admin>
     </TestMemoryRouter>
 );
+
+export const LabelElements = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <Admin dataProvider={dataProvider}>
+            <Resource
+                name="books"
+                list={
+                    <List>
+                        <Datagrid>
+                            <TextField source="id" label={<span>ID</span>} />
+                            <TextField
+                                source="title"
+                                label={<span>TITLE</span>}
+                            />
+                            <TextField
+                                source="author"
+                                label={<span>AUTHOR</span>}
+                            />
+                            <TextField
+                                source="year"
+                                label={<span>YEAR</span>}
+                            />
+                        </Datagrid>
+                    </List>
+                }
+            />
+        </Admin>
+    </TestMemoryRouter>
+);

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -29,6 +29,7 @@ import { List } from '../List';
 import { EditGuesser } from '../../detail';
 import { DatagridRowProps } from './DatagridRow';
 import DatagridBody, { DatagridBodyProps } from './DatagridBody';
+import { Admin } from 'react-admin';
 
 export default { title: 'ra-ui-materialui/list/Datagrid' };
 
@@ -552,4 +553,33 @@ export const CustomDatagridRow = () => (
             <TextField source="year" />
         </MyDatagrid>
     </Wrapper>
+);
+
+export const LabelElements = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <Admin dataProvider={dataProvider}>
+            <Resource
+                name="books"
+                list={
+                    <List>
+                        <Datagrid>
+                            <TextField source="id" label={<span>ID</span>} />
+                            <TextField
+                                source="title"
+                                label={<span>TITLE</span>}
+                            />
+                            <TextField
+                                source="author"
+                                label={<span>AUTHOR</span>}
+                            />
+                            <TextField
+                                source="year"
+                                label={<span>YEAR</span>}
+                            />
+                        </Datagrid>
+                    </List>
+                }
+            />
+        </Admin>
+    </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -110,7 +110,7 @@ const ExpandPanel = () => {
     const book = useRecordContext();
     return (
         <div data-testid="ExpandPanel">
-            <i>{book.title}</i>, by {book.author} ({book.year})
+            <i>{book?.title}</i>, by {book?.author} ({book?.year})
         </div>
     );
 };

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -29,7 +29,6 @@ import { List } from '../List';
 import { EditGuesser } from '../../detail';
 import { DatagridRowProps } from './DatagridRow';
 import DatagridBody, { DatagridBodyProps } from './DatagridBody';
-import { Admin } from 'react-admin';
 
 export default { title: 'ra-ui-materialui/list/Datagrid' };
 
@@ -557,7 +556,10 @@ export const CustomDatagridRow = () => (
 
 export const LabelElements = () => (
     <TestMemoryRouter initialEntries={['/books']}>
-        <Admin dataProvider={dataProvider}>
+        <AdminContext
+            dataProvider={dataProvider}
+            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+        >
             <Resource
                 name="books"
                 list={
@@ -580,6 +582,6 @@ export const LabelElements = () => (
                     </List>
                 }
             />
-        </Admin>
+        </AdminContext>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.spec.tsx
@@ -1,9 +1,10 @@
 import expect from 'expect';
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { ResourceContextProvider } from 'ra-core';
 
 import { DatagridHeaderCell } from './DatagridHeaderCell';
-import { ResourceContextProvider } from 'ra-core';
+import { LabelElements } from '../List.stories';
 
 const Wrapper = ({ children }) => (
     <table>
@@ -24,7 +25,7 @@ describe('<DatagridHeaderCell />', () => {
             source?: string;
             label?: React.ReactNode;
         }) => <div />;
-        const { getByText } = render(
+        render(
             <Wrapper>
                 <DatagridHeaderCell
                     sort={{ field: 'title', order: 'ASC' }}
@@ -33,7 +34,18 @@ describe('<DatagridHeaderCell />', () => {
                 />
             </Wrapper>
         );
-        expect(getByText('Label')).not.toBeNull();
+        expect(screen.getByText('Label')).not.toBeNull();
+    });
+    it('should use the default inferred field label in its tooltip when using a React element as the field label', async () => {
+        render(<LabelElements />);
+        await screen.findByText('ID');
+        await screen.findByLabelText('Sort by Id descending');
+        await screen.findByText('TITLE');
+        await screen.findByLabelText('Sort by Title descending');
+        await screen.findByText('AUTHOR');
+        await screen.findByLabelText('Sort by Author descending');
+        await screen.findByText('YEAR');
+        await screen.findByLabelText('Sort by Year descending');
     });
 
     describe('sorting on a column', () => {
@@ -50,7 +62,7 @@ describe('<DatagridHeaderCell />', () => {
         };
 
         it('should be enabled when field has a source', () => {
-            const { getByLabelText } = render(
+            render(
                 <Wrapper>
                     <DatagridHeaderCell
                         sort={{ field: 'title', order: 'ASC' }}
@@ -59,13 +71,13 @@ describe('<DatagridHeaderCell />', () => {
                     />
                 </Wrapper>
             );
-            expect(getByLabelText('ra.action.sort').dataset.field).toBe(
+            expect(screen.getByLabelText('ra.action.sort').dataset.field).toBe(
                 'title'
             );
         });
 
         it('should be enabled when field has a sortBy props', () => {
-            const { getByLabelText } = render(
+            render(
                 <Wrapper>
                     <DatagridHeaderCell
                         sort={{ field: 'title', order: 'ASC' }}
@@ -74,13 +86,13 @@ describe('<DatagridHeaderCell />', () => {
                     />
                 </Wrapper>
             );
-            expect(getByLabelText('ra.action.sort').dataset.field).toBe(
+            expect(screen.getByLabelText('ra.action.sort').dataset.field).toBe(
                 'title'
             );
         });
 
         it('should be change order when field has a sortByOrder props', () => {
-            const { getByLabelText } = render(
+            render(
                 <Wrapper>
                     <DatagridHeaderCell
                         sort={{ field: 'title', order: 'ASC' }}
@@ -89,11 +101,13 @@ describe('<DatagridHeaderCell />', () => {
                     />
                 </Wrapper>
             );
-            expect(getByLabelText('ra.action.sort').dataset.order).toBe('DESC');
+            expect(screen.getByLabelText('ra.action.sort').dataset.order).toBe(
+                'DESC'
+            );
         });
 
         it('should be keep ASC order when field has not sortByOrder props', () => {
-            const { getByLabelText } = render(
+            render(
                 <Wrapper>
                     <DatagridHeaderCell
                         sort={{ field: 'title', order: 'ASC' }}
@@ -102,11 +116,13 @@ describe('<DatagridHeaderCell />', () => {
                     />
                 </Wrapper>
             );
-            expect(getByLabelText('ra.action.sort').dataset.order).toBe('ASC');
+            expect(screen.getByLabelText('ra.action.sort').dataset.order).toBe(
+                'ASC'
+            );
         });
 
         it('should be disabled when field has no sortBy and no source', () => {
-            const { queryAllByLabelText } = render(
+            render(
                 <Wrapper>
                     <DatagridHeaderCell
                         sort={{ field: 'title', order: 'ASC' }}
@@ -115,11 +131,13 @@ describe('<DatagridHeaderCell />', () => {
                     />
                 </Wrapper>
             );
-            expect(queryAllByLabelText('ra.action.sort')).toHaveLength(0);
+            expect(screen.queryAllByLabelText('ra.action.sort')).toHaveLength(
+                0
+            );
         });
 
         it('should be disabled when sortable prop is explicitly set to false', () => {
-            const { queryAllByLabelText } = render(
+            render(
                 <Wrapper>
                     <DatagridHeaderCell
                         sort={{ field: 'title', order: 'ASC' }}
@@ -128,7 +146,9 @@ describe('<DatagridHeaderCell />', () => {
                     />
                 </Wrapper>
             );
-            expect(queryAllByLabelText('ra.action.sort')).toHaveLength(0);
+            expect(screen.queryAllByLabelText('ra.action.sort')).toHaveLength(
+                0
+            );
         });
 
         it('should use cell className if specified', () => {

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { ResourceContextProvider } from 'ra-core';
 
 import { DatagridHeaderCell } from './DatagridHeaderCell';
-import { LabelElements } from '../List.stories';
+import { LabelElements } from './Datagrid.stories';
 
 const Wrapper = ({ children }) => (
     <table>

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { memo } from 'react';
+import { isValidElement, memo } from 'react';
 import clsx from 'clsx';
 import { TableCell, TableSortLabel, Tooltip } from '@mui/material';
 import { TableCellProps } from '@mui/material/TableCell';
@@ -23,7 +23,9 @@ export const DatagridHeaderCell = (
     const sortLabel = translate('ra.sort.sort_by', {
         field: field
             ? translateLabel({
-                  label: field.props.label,
+                  label: isValidElement(field.props.label)
+                      ? undefined
+                      : field.props.label,
                   resource,
                   source: field.props.source,
               })

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import { isValidElement, memo } from 'react';
+import { memo } from 'react';
 import clsx from 'clsx';
 import { TableCell, TableSortLabel, Tooltip } from '@mui/material';
 import { TableCellProps } from '@mui/material/TableCell';
@@ -23,9 +23,10 @@ export const DatagridHeaderCell = (
     const sortLabel = translate('ra.sort.sort_by', {
         field: field
             ? translateLabel({
-                  label: isValidElement(field.props.label)
-                      ? undefined
-                      : field.props.label,
+                  label:
+                      typeof field.props.label === 'string'
+                          ? field.props.label
+                          : undefined,
                   resource,
                   source: field.props.source,
               })


### PR DESCRIPTION
## Problem

When using a React element as `label` for a field, the datagrid header tooltip displays `Sort by [object Oject] descending`.

## Solution

Fallback to the default inferred label

![image](https://github.com/marmelab/react-admin/assets/1122076/2aad8d69-0014-4fa5-b4a1-0be35c76d1e5)
