### PR TITLE
Update `<ReferenceField>` to render a link to the show view when relevant

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { UseQueryOptions } from '@tanstack/react-query';
+
 import { RaRecord } from '../../types';
-import { LinkToType, useCreatePath } from '../../routing';
+import { LinkToType, useGetRouteForRecord } from '../../routing';
 import { UseReferenceResult, useReference } from '../useReference';
-import { useResourceDefinition } from '../../core';
 import { useFieldValue } from '../../util';
 
 export const useReferenceFieldController = <
@@ -30,37 +30,21 @@ export const useReferenceFieldController = <
         },
     });
 
-    const createPath = useCreatePath();
-    const resourceDefinition = useResourceDefinition({ resource: reference });
+    const target = useGetRouteForRecord({
+        record: referenceRecordQuery.referenceRecord,
+        resource: reference,
+        link,
+    });
 
-    const result = useMemo(() => {
-        const defaultLink = resourceDefinition.hasEdit
-            ? 'edit'
-            : resourceDefinition.hasShow
-              ? 'show'
-              : false;
-        const isLinkFalse =
-            link === false || (link == null && defaultLink === false);
-        const linkString =
-            referenceRecordQuery.referenceRecord == null || isLinkFalse
-                ? false
-                : createPath({
-                      resource: reference,
-                      id: referenceRecordQuery.referenceRecord.id,
-                      // @ts-ignore TypeScript doesn't understand that type cannot be false here
-                      type:
-                          typeof link === 'function'
-                              ? link(
-                                    referenceRecordQuery.referenceRecord,
-                                    reference
-                                )
-                              : link ?? defaultLink,
-                  });
-        return {
-            ...referenceRecordQuery,
-            link: linkString,
-        } as const;
-    }, [createPath, link, reference, referenceRecordQuery, resourceDefinition]);
+    const result = useMemo(
+        () =>
+            ({
+                ...referenceRecordQuery,
+                link: target,
+            }) as const,
+        [target, referenceRecordQuery]
+    );
+
     return result;
 };
 

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -40,10 +40,7 @@ export const useReferenceFieldController = <
               ? 'show'
               : false;
         const isLinkFalse =
-            link === false ||
-            (link === 'edit' && !resourceDefinition.hasEdit) ||
-            (link === 'show' && !resourceDefinition.hasShow) ||
-            (link == null && defaultLink === false);
+            link === false || (link == null && defaultLink === false);
         const linkString =
             referenceRecordQuery.referenceRecord == null || isLinkFalse
                 ? false

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { UseQueryOptions } from '@tanstack/react-query';
 
 import { RaRecord } from '../../types';
-import { LinkToType, useGetRouteForRecord } from '../../routing';
+import { LinkToType, useGetPathForRecord } from '../../routing';
 import { UseReferenceResult, useReference } from '../useReference';
 import { useFieldValue } from '../../util';
 
@@ -30,7 +30,7 @@ export const useReferenceFieldController = <
         },
     });
 
-    const target = useGetRouteForRecord({
+    const path = useGetPathForRecord({
         record: referenceRecordQuery.referenceRecord,
         resource: reference,
         link,
@@ -40,9 +40,9 @@ export const useReferenceFieldController = <
         () =>
             ({
                 ...referenceRecordQuery,
-                link: target,
+                link: path,
             }) as const,
-        [target, referenceRecordQuery]
+        [path, referenceRecordQuery]
     );
 
     return result;

--- a/packages/ra-core/src/routing/index.ts
+++ b/packages/ra-core/src/routing/index.ts
@@ -3,6 +3,7 @@ export * from './BasenameContextProvider';
 export * from './RestoreScrollPosition';
 export * from './useBasename';
 export * from './useCreatePath';
+export * from './useGetRouteForRecord';
 export * from './useRedirect';
 export * from './useResetErrorBoundaryOnLocationChange';
 export * from './useScrollToTop';

--- a/packages/ra-core/src/routing/index.ts
+++ b/packages/ra-core/src/routing/index.ts
@@ -3,7 +3,7 @@ export * from './BasenameContextProvider';
 export * from './RestoreScrollPosition';
 export * from './useBasename';
 export * from './useCreatePath';
-export * from './useGetRouteForRecord';
+export * from './useGetPathForRecord';
 export * from './useRedirect';
 export * from './useResetErrorBoundaryOnLocationChange';
 export * from './useScrollToTop';

--- a/packages/ra-core/src/routing/types.ts
+++ b/packages/ra-core/src/routing/types.ts
@@ -3,7 +3,7 @@ import { RaRecord } from '../types';
 export type LinkToFunctionType<RecordType extends RaRecord = RaRecord> = (
     record: RecordType,
     reference: string
-) => string;
+) => string | false | Promise<string | false>;
 
 export type LinkToType<RecordType extends RaRecord = RaRecord> =
     | string

--- a/packages/ra-core/src/routing/useGetPathForRecord.ts
+++ b/packages/ra-core/src/routing/useGetPathForRecord.ts
@@ -58,10 +58,10 @@ export const useGetPathForRecord = <RecordType extends RaRecord = RaRecord>(
         []
     );
 
-    const defaultLink = resourceDefinition.hasEdit
-        ? 'edit'
-        : resourceDefinition.hasShow
-          ? 'show'
+    const defaultLink = resourceDefinition.hasShow
+        ? 'show'
+        : resourceDefinition.hasEdit
+          ? 'edit'
           : false;
 
     const isLinkFalse =

--- a/packages/ra-core/src/routing/useGetPathForRecord.ts
+++ b/packages/ra-core/src/routing/useGetPathForRecord.ts
@@ -38,7 +38,7 @@ import type { LinkToType } from './types';
  *   return path ? <Link to={path}>Edit</Link> : null;
  * };
  */
-export const useGetRouteForRecord = <RecordType extends RaRecord = RaRecord>(
+export const useGetPathForRecord = <RecordType extends RaRecord = RaRecord>(
     options: UseGetRouteForRecordOptions<RecordType>
 ): string | false | undefined => {
     const { link } = options || {};

--- a/packages/ra-core/src/routing/useGetRouteForRecord.ts
+++ b/packages/ra-core/src/routing/useGetRouteForRecord.ts
@@ -1,13 +1,47 @@
+import { useState, useEffect, useCallback } from 'react';
 import { useResourceContext, useResourceDefinition } from '../core';
 import { useCreatePath } from './useCreatePath';
 import { useRecordContext } from '../controller';
 import type { RaRecord } from '../types';
 import type { LinkToType } from './types';
 
+/**
+ * Get a path for a record, based on the current resource and the link type.
+ *
+ * Accepted link types are 'edit', 'show', a route string, false, or a function returning one of these types.
+ *
+ * @example
+ * // basic usage (leverages RecordContext, ResourceContext and ResourceDefinitionContext)
+ * const EditLink = () => {
+ *   const path = useGetRouteForRecord();
+ *   return path ? <Link to={path}>Edit</Link> : null;
+ * };
+ *
+ * // controlled mode
+ * const EditLink = ({ record, resource }) => {
+ *    const path = useGetRouteForRecord({ record, resource, link: 'edit' });
+ *    return path ? <Link to={path}>Edit</Link> : null;
+ * };
+ *
+ * // the link option can be a function
+ * const EditLink = ({ record, resource }) => {
+ *   const path = useGetRouteForRecord({ record, resource, link: (record, resource) => record.canEdit ? 'edit' : false });
+ *   return path ? <Link to={path}>Edit</Link> : null;
+ * };
+ *
+ * // the link option can be a function returning a promise
+ * const EditLink = ({ record, resource }) => {
+ *   const path = useGetRouteForRecord({ record, resource, link: async (record, resource) => {
+ *     const canEdit = await canEditRecord(record, resource);
+ *     return canEdit ? 'edit' : false;
+ *   }});
+ *   return path ? <Link to={path}>Edit</Link> : null;
+ * };
+ */
 export const useGetRouteForRecord = <RecordType extends RaRecord = RaRecord>(
     options: UseGetRouteForRecordOptions<RecordType>
 ): string | false | undefined => {
-    const { link } = options;
+    const { link } = options || {};
     const record = useRecordContext(options);
     const resource = useResourceContext(options);
     if (!resource) {
@@ -18,6 +52,12 @@ export const useGetRouteForRecord = <RecordType extends RaRecord = RaRecord>(
     const createPath = useCreatePath();
     const resourceDefinition = useResourceDefinition({ resource });
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const linkFunc = useCallback(
+        typeof link === 'function' ? link : () => link,
+        []
+    );
+
     const defaultLink = resourceDefinition.hasEdit
         ? 'edit'
         : resourceDefinition.hasShow
@@ -27,18 +67,63 @@ export const useGetRouteForRecord = <RecordType extends RaRecord = RaRecord>(
     const isLinkFalse =
         link === false || (link == null && defaultLink === false);
 
-    if (record == null || isLinkFalse) return false;
-
-    return createPath({
-        resource,
-        id: record.id,
-        // @ts-ignore TypeScript doesn't understand that type cannot be false here
-        type:
-            typeof link === 'function'
-                ? link(record, resource)
-                : link ?? defaultLink,
+    // we initialize the path with the link value
+    const [path, setPath] = useState<string | false | undefined>(() => {
+        if (record == null || isLinkFalse) return false;
+        const linkResult = linkFunc(record, resource) ?? defaultLink;
+        const linkResultIsPromise = isPromise(linkResult);
+        if (linkResultIsPromise) {
+            linkResult.then(resolvedLink => {
+                if (resolvedLink === false) {
+                    // already set to false by default
+                    return;
+                }
+                // update the path when the promise resolves
+                setPath(
+                    createPath({
+                        resource,
+                        id: record.id,
+                        type: resolvedLink,
+                    })
+                );
+            });
+        }
+        return linkResult === false || linkResultIsPromise
+            ? false
+            : createPath({ resource, id: record.id, type: linkResult });
     });
+
+    // update the path if the record changes
+    useEffect(() => {
+        if (record == null || isLinkFalse) {
+            setPath(false);
+            return;
+        }
+        const linkResult = linkFunc(record, resource) ?? defaultLink;
+        const linkResultIsPromise = isPromise(linkResult);
+        if (linkResultIsPromise) {
+            linkResult.then(resolvedLink => {
+                if (resolvedLink === false) {
+                    // already set to false by default
+                    return;
+                }
+                setPath(
+                    createPath({ resource, id: record.id, type: resolvedLink })
+                );
+            });
+        }
+        setPath(
+            linkResult === false || linkResultIsPromise
+                ? false
+                : createPath({ resource, id: record.id, type: linkResult })
+        );
+    }, [createPath, defaultLink, isLinkFalse, linkFunc, record, resource]);
+
+    return path;
 };
+
+const isPromise = (value: any): value is Promise<any> =>
+    value && typeof value.then === 'function';
 
 export interface UseGetRouteForRecordOptions<
     RecordType extends RaRecord = RaRecord,

--- a/packages/ra-core/src/routing/useGetRouteForRecord.ts
+++ b/packages/ra-core/src/routing/useGetRouteForRecord.ts
@@ -1,0 +1,49 @@
+import { useResourceContext, useResourceDefinition } from '../core';
+import { useCreatePath } from './useCreatePath';
+import { useRecordContext } from '../controller';
+import type { RaRecord } from '../types';
+import type { LinkToType } from './types';
+
+export const useGetRouteForRecord = <RecordType extends RaRecord = RaRecord>(
+    options: UseGetRouteForRecordOptions<RecordType>
+): string | false | undefined => {
+    const { link } = options;
+    const record = useRecordContext(options);
+    const resource = useResourceContext(options);
+    if (!resource) {
+        throw new Error(
+            'Cannot generate a link for a record without a resource. You must use useGetRouteForRecord within a ResourceContextProvider, or pass a resource prop.'
+        );
+    }
+    const createPath = useCreatePath();
+    const resourceDefinition = useResourceDefinition({ resource });
+
+    const defaultLink = resourceDefinition.hasEdit
+        ? 'edit'
+        : resourceDefinition.hasShow
+          ? 'show'
+          : false;
+
+    const isLinkFalse =
+        link === false || (link == null && defaultLink === false);
+
+    if (record == null || isLinkFalse) return false;
+
+    return createPath({
+        resource,
+        id: record.id,
+        // @ts-ignore TypeScript doesn't understand that type cannot be false here
+        type:
+            typeof link === 'function'
+                ? link(record, resource)
+                : link ?? defaultLink,
+    });
+};
+
+export interface UseGetRouteForRecordOptions<
+    RecordType extends RaRecord = RaRecord,
+> {
+    resource?: string;
+    record?: RecordType;
+    link?: LinkToType<RecordType>;
+}

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -510,10 +510,13 @@ describe('<ReferenceField />', () => {
             );
         });
 
-        it('should render no link when link view does not exist', async () => {
+        it('should render a link even though link view does not exist', async () => {
             render(<LinkMissingView />);
-            await screen.findByText('9780393966473');
-            expect(screen.queryAllByRole('link')).toHaveLength(0);
+            const referenceField = await screen.findByText('9780393966473');
+            expect(screen.queryAllByRole('link')).toHaveLength(1);
+            expect(referenceField?.parentElement?.getAttribute('href')).toBe(
+                '/book_details/1/show'
+            );
         });
 
         it('should render no link when link is false', async () => {

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -14,6 +14,11 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { ReferenceField } from './ReferenceField';
 import {
     Children,
+    LinkShow,
+    LinkDefaultEditView,
+    LinkDefaultShowView,
+    LinkMissingView,
+    LinkFalse,
     MissingReferenceIdEmptyTextTranslation,
     MissingReferenceEmptyText,
     SXLink,
@@ -477,156 +482,90 @@ describe('<ReferenceField />', () => {
         expect(ErrorIcon?.getAttribute('aria-errormessage')).toBe('boo');
     });
 
-    it('should render a link to specified link type', async () => {
-        const dataProvider = testDataProvider({
-            getMany: jest.fn().mockResolvedValue({
-                data: [{ id: 123, title: 'foo' }],
-            }),
+    describe('link', () => {
+        it('should render a link to specified link type', async () => {
+            render(<LinkShow />);
+            const referenceField = await screen.findByText('9780393966473');
+            expect(screen.queryAllByRole('link')).toHaveLength(1);
+            expect(referenceField?.parentElement?.getAttribute('href')).toBe(
+                '/book_details/1/show'
+            );
         });
-        render(
-            <ThemeProvider theme={theme}>
-                <CoreAdminContext dataProvider={dataProvider}>
-                    <ResourceDefinitionContextProvider
-                        definitions={{
-                            posts: {
-                                name: 'posts',
-                                hasShow: true,
-                            },
-                        }}
-                    >
-                        <ReferenceField
-                            record={record}
-                            resource="comments"
-                            source="postId"
-                            reference="posts"
-                            link="show"
-                        >
-                            <TextField source="title" />
-                        </ReferenceField>
-                    </ResourceDefinitionContextProvider>
-                </CoreAdminContext>
-            </ThemeProvider>
-        );
-        await waitFor(() =>
-            expect(dataProvider.getMany).toHaveBeenCalledTimes(1)
-        );
-        expect(screen.queryByRole('link')?.getAttribute('href')).toBe(
-            '#/posts/123/show'
-        );
-    });
 
-    it('should render no link when view to link to does not exist', async () => {
-        const dataProvider = testDataProvider({
-            getMany: jest.fn().mockResolvedValue({
-                data: [{ id: 123, title: 'foo' }],
-            }),
+        it('should link to edit by default if there is an edit view', async () => {
+            render(<LinkDefaultEditView />);
+            const referenceField = await screen.findByText('9780393966473');
+            expect(screen.queryAllByRole('link')).toHaveLength(1);
+            expect(referenceField?.parentElement?.getAttribute('href')).toBe(
+                '/book_details/1'
+            );
         });
-        render(
-            <ThemeProvider theme={theme}>
-                <CoreAdminContext dataProvider={dataProvider}>
-                    <ResourceDefinitionContextProvider
-                        definitions={{
-                            posts: {
-                                name: 'posts',
-                                hasShow: false,
-                            },
-                        }}
-                    >
-                        <ReferenceField
-                            record={record}
-                            resource="comments"
-                            source="postId"
-                            reference="posts"
-                            link="show"
-                        >
-                            <TextField source="title" />
-                        </ReferenceField>
-                    </ResourceDefinitionContextProvider>
-                </CoreAdminContext>
-            </ThemeProvider>
-        );
-        await waitFor(() =>
-            expect(dataProvider.getMany).toHaveBeenCalledTimes(1)
-        );
-        expect(screen.queryAllByRole('link')).toHaveLength(0);
-    });
 
-    it('should render no link when link is false', async () => {
-        const dataProvider = testDataProvider({
-            getMany: jest.fn().mockResolvedValue({
-                data: [{ id: 123, title: 'foo' }],
-            }),
+        it('should link to edit by default if there is no edit view but a show view', async () => {
+            render(<LinkDefaultShowView />);
+            const referenceField = await screen.findByText('9780393966473');
+            expect(screen.queryAllByRole('link')).toHaveLength(1);
+            expect(referenceField?.parentElement?.getAttribute('href')).toBe(
+                '/book_details/1/show'
+            );
         });
-        render(
-            <ThemeProvider theme={theme}>
-                <CoreAdminContext dataProvider={dataProvider}>
-                    <ResourceDefinitionContextProvider
-                        definitions={{
-                            posts: {
-                                name: 'posts',
-                                hasEdit: true,
-                            },
-                        }}
-                    >
-                        <ReferenceField
-                            record={record}
-                            resource="comments"
-                            source="postId"
-                            reference="posts"
-                            link={false}
-                        >
-                            <TextField source="title" />
-                        </ReferenceField>
-                    </ResourceDefinitionContextProvider>
-                </CoreAdminContext>
-            </ThemeProvider>
-        );
-        await waitFor(() =>
-            expect(dataProvider.getMany).toHaveBeenCalledTimes(1)
-        );
-        expect(screen.queryAllByRole('link')).toHaveLength(0);
-    });
 
-    it('should call the link function with the referenced record', async () => {
-        const dataProvider = testDataProvider({
-            getMany: jest.fn().mockResolvedValue({
-                data: [{ id: 123, title: 'foo' }],
-            }),
+        it('should render no link when link view does not exist', async () => {
+            render(<LinkMissingView />);
+            await screen.findByText('9780393966473');
+            expect(screen.queryAllByRole('link')).toHaveLength(0);
         });
-        const link = jest.fn().mockReturnValue('/posts/123');
 
-        render(
-            <ThemeProvider theme={theme}>
-                <CoreAdminContext dataProvider={dataProvider}>
-                    <ResourceDefinitionContextProvider
-                        definitions={{
-                            posts: {
-                                name: 'posts',
-                                hasEdit: true,
-                            },
-                        }}
-                    >
-                        <ReferenceField
-                            record={record}
-                            resource="comments"
-                            source="postId"
-                            reference="posts"
-                            link={link}
+        it('should render no link when link is false', async () => {
+            render(<LinkFalse />);
+            await screen.findByText('9780393966473');
+            expect(screen.queryAllByRole('link')).toHaveLength(0);
+        });
+
+        it('should call the link function with the referenced record', async () => {
+            const dataProvider = testDataProvider({
+                getMany: jest.fn().mockResolvedValue({
+                    data: [{ id: 123, title: 'foo' }],
+                }),
+            });
+            const link = jest.fn().mockReturnValue('/posts/123');
+
+            render(
+                <ThemeProvider theme={theme}>
+                    <CoreAdminContext dataProvider={dataProvider}>
+                        <ResourceDefinitionContextProvider
+                            definitions={{
+                                posts: {
+                                    name: 'posts',
+                                    hasEdit: true,
+                                },
+                            }}
                         >
-                            <TextField source="title" />
-                        </ReferenceField>
-                    </ResourceDefinitionContextProvider>
-                </CoreAdminContext>
-            </ThemeProvider>
-        );
-        await waitFor(() =>
-            expect(dataProvider.getMany).toHaveBeenCalledTimes(1)
-        );
-        expect(screen.queryByRole('link')?.getAttribute('href')).toBe(
-            '#/posts/123'
-        );
+                            <ReferenceField
+                                record={record}
+                                resource="comments"
+                                source="postId"
+                                reference="posts"
+                                link={link}
+                            >
+                                <TextField source="title" />
+                            </ReferenceField>
+                        </ResourceDefinitionContextProvider>
+                    </CoreAdminContext>
+                </ThemeProvider>
+            );
+            await waitFor(() =>
+                expect(dataProvider.getMany).toHaveBeenCalledTimes(1)
+            );
+            expect(screen.queryByRole('link')?.getAttribute('href')).toBe(
+                '#/posts/123'
+            );
 
-        expect(link).toHaveBeenCalledWith({ id: 123, title: 'foo' }, 'posts');
+            expect(link).toHaveBeenCalledWith(
+                { id: 123, title: 'foo' },
+                'posts'
+            );
+        });
     });
 
     it('should accept multiple children', async () => {

--- a/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
@@ -57,22 +57,24 @@ const defaultDataProvider = {
         }),
 } as any;
 const defaultRecord = { id: 1, title: 'War and Peace', detail_id: 1 };
+const defaultResourceDefinitions = {
+    book_details: {
+        name: 'book_details',
+        hasShow: true,
+        hasEdit: true,
+    },
+};
 
 const Wrapper = ({
     children,
     dataProvider = defaultDataProvider,
     record = defaultRecord,
+    resourceDefinitions = defaultResourceDefinitions,
 }: any) => (
     <TestMemoryRouter initialEntries={['/books/1/show']}>
         <CoreAdminContext dataProvider={dataProvider}>
             <ResourceDefinitionContextProvider
-                definitions={{
-                    book_details: {
-                        name: 'book_details',
-                        hasShow: true,
-                        hasEdit: true,
-                    },
-                }}
+                definitions={resourceDefinitions}
             >
                 <ResourceContextProvider value="books">
                     <RecordContextProvider value={record}>
@@ -171,7 +173,7 @@ export const MissingReferenceEmptyText = () => (
     </Wrapper>
 );
 
-export const Link = () => (
+export const LinkShow = () => (
     <Wrapper>
         <ReferenceField source="detail_id" reference="book_details" link="show">
             <TextField source="ISBN" />
@@ -179,30 +181,77 @@ export const Link = () => (
     </Wrapper>
 );
 
-export const LinkWithoutEditView = () => (
-    <TestMemoryRouter initialEntries={['/books/1/show']}>
-        <CoreAdminContext dataProvider={defaultDataProvider}>
-            <ResourceDefinitionContextProvider
-                definitions={{
-                    book_details: {
-                        name: 'book_details',
-                        hasEdit: false,
-                    },
-                }}
-            >
-                <ResourceContextProvider value="books">
-                    <RecordContextProvider value={defaultRecord}>
-                        <ReferenceField
-                            source="detail_id"
-                            reference="book_details"
-                        >
-                            <TextField source="ISBN" />
-                        </ReferenceField>
-                    </RecordContextProvider>
-                </ResourceContextProvider>
-            </ResourceDefinitionContextProvider>
-        </CoreAdminContext>
-    </TestMemoryRouter>
+export const LinkMissingView = () => (
+    <Wrapper
+        resourceDefinitions={{
+            book_details: {
+                name: 'book_details',
+                hasShow: false,
+            },
+        }}
+    >
+        <ReferenceField source="detail_id" reference="book_details" link="show">
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
+);
+
+export const LinkFalse = () => (
+    <Wrapper>
+        <ReferenceField
+            source="detail_id"
+            reference="book_details"
+            link={false}
+        >
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
+);
+
+export const LinkDefaultEditView = () => (
+    <Wrapper
+        resourceDefinitions={{
+            book_details: {
+                name: 'book_details',
+                hasEdit: true,
+            },
+        }}
+    >
+        <ReferenceField source="detail_id" reference="book_details">
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
+);
+
+export const LinkDefaultShowView = () => (
+    <Wrapper
+        resourceDefinitions={{
+            book_details: {
+                name: 'book_details',
+                hasShow: true,
+            },
+        }}
+    >
+        <ReferenceField source="detail_id" reference="book_details">
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
+);
+
+export const LinkDefaultNoDetailView = () => (
+    <Wrapper
+        resourceDefinitions={{
+            book_details: {
+                name: 'book_details',
+                hasShow: false,
+                hasEdit: false,
+            },
+        }}
+    >
+        <ReferenceField source="detail_id" reference="book_details">
+            <TextField source="ISBN" />
+        </ReferenceField>
+    </Wrapper>
 );
 
 export const Children = () => (

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -5,7 +5,6 @@ import { styled } from '@mui/material/styles';
 import ErrorIcon from '@mui/icons-material/Error';
 import {
     LinkToType,
-    RecordContextProvider,
     useGetRecordRepresentation,
     useTranslate,
     RaRecord,
@@ -146,25 +145,21 @@ export const ReferenceFieldView = <
     if (link) {
         return (
             <Root className={className} sx={sx}>
-                <RecordContextProvider value={referenceRecord}>
-                    <Link
-                        to={link}
-                        className={ReferenceFieldClasses.link}
-                        onClick={stopPropagation}
-                        state={{ _scrollToTop: true }}
-                    >
-                        {child}
-                    </Link>
-                </RecordContextProvider>
+                <Link
+                    to={link}
+                    className={ReferenceFieldClasses.link}
+                    onClick={stopPropagation}
+                    state={{ _scrollToTop: true }}
+                >
+                    {child}
+                </Link>
             </Root>
         );
     }
 
     return (
         <Root className={className} sx={sx}>
-            <RecordContextProvider value={referenceRecord}>
-                {child}
-            </RecordContextProvider>
+            {child}
         </Root>
     );
 };

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -6,7 +6,7 @@ import {
     useRecordContext,
     ResourceContextProvider,
     LinkToType,
-    useCreatePath,
+    useGetPathForRecord,
     useTranslate,
     SortPayload,
     RaRecord,
@@ -42,11 +42,10 @@ export const ReferenceOneField = <
         emptyText,
         sort,
         filter,
-        link = false,
+        link,
         queryOptions,
     } = props;
     const record = useRecordContext<RecordType>(props);
-    const createPath = useCreatePath();
     const translate = useTranslate();
 
     const controllerProps = useReferenceOneFieldController<ReferenceRecordType>(
@@ -61,24 +60,18 @@ export const ReferenceOneField = <
         }
     );
 
-    const resourceLinkPath =
-        !record || link === false
-            ? false
-            : createPath({
-                  resource: reference,
-                  id: controllerProps.referenceRecord?.id,
-                  type:
-                      typeof link === 'function'
-                          ? link(record, reference)
-                          : link,
-              });
+    const path = useGetPathForRecord({
+        record: controllerProps.referenceRecord,
+        resource: reference,
+        link,
+    });
 
     const context = useMemo<UseReferenceFieldControllerResult>(
         () => ({
             ...controllerProps,
-            link: resourceLinkPath,
+            link: path,
         }),
-        [controllerProps, resourceLinkPath]
+        [controllerProps, path]
     );
     return !record ||
         (!controllerProps.isPending &&
@@ -111,7 +104,7 @@ export interface ReferenceOneFieldProps<
     sort?: SortPayload;
     source?: string;
     filter?: any;
-    link?: LinkToType<RecordType>;
+    link?: LinkToType<ReferenceRecordType>;
     queryOptions?: Omit<
         UseQueryOptions<{
             data: ReferenceRecordType[];

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -10,6 +10,7 @@ import {
     useTranslate,
     SortPayload,
     RaRecord,
+    RecordContextProvider,
     ReferenceFieldContextProvider,
     UseReferenceFieldControllerResult,
 } from 'ra-core';
@@ -90,9 +91,11 @@ export const ReferenceOneField = <
     ) : (
         <ResourceContextProvider value={reference}>
             <ReferenceFieldContextProvider value={context}>
-                <ReferenceFieldView reference={reference} source={source}>
-                    {children}
-                </ReferenceFieldView>
+                <RecordContextProvider value={context.referenceRecord}>
+                    <ReferenceFieldView reference={reference} source={source}>
+                        {children}
+                    </ReferenceFieldView>
+                </RecordContextProvider>
             </ReferenceFieldContextProvider>
         </ResourceContextProvider>
     );

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -18,7 +18,7 @@ import {
     useResourceContext,
     useTranslate,
     useRecordContext,
-    useGetRouteForRecord,
+    useGetPathForRecord,
 } from 'ra-core';
 import { useNavigate } from 'react-router-dom';
 
@@ -122,7 +122,7 @@ const DatagridRow: React.ForwardRefExoticComponent<
               ? // rowClick doesn't have the same signature as linkTo, so we need to adapt
                 (record, resource) => rowClick(record?.id, resource, record)
               : rowClick;
-    const target = useGetRouteForRecord({ record, resource, link: linkType });
+    const path = useGetPathForRecord({ record, resource, link: linkType });
 
     const handleClick = useCallback(
         async event => {
@@ -135,14 +135,14 @@ const DatagridRow: React.ForwardRefExoticComponent<
                 handleToggleSelection(event);
                 return;
             }
-            if (target === false || target == null) {
+            if (path === false || path == null) {
                 return;
             }
-            navigate(target, {
+            navigate(path, {
                 state: { _scrollToTop: true },
             });
         },
-        [rowClick, navigate, handleToggleExpand, handleToggleSelection, target]
+        [rowClick, navigate, handleToggleExpand, handleToggleSelection, path]
     );
 
     return (


### PR DESCRIPTION
## Problem

`<ReferenceField>` renders a link to the edit view by default. When a resource has a show view but no edit view, and the developer hasn't specified the `link` type, a `<ReferenceField>` targeting that resource doesn't show any link. 

Also, when there is a conflict between the `<ReferenceField link>` and the associated `<Resource>` (e.g. when the developer specified that the `ReferenceField` should link to the `edit` view even though the `Resource` doesn't defined such a view), react-admin ignores the developer choice and removes the link. Yet the developer may want to link to a nested `CustomRoute` that matches the `link`. 

## Solution

Make `<ReferenceField>` default to `show` when `link` is undefined and there are both an edit and a show view. 

Make `<ReferenceField>` smarter so that it can link to the show view if it exists. 

Make `<ReferenceField>` always honor the `link` prop.

**Before**

|    link                  | default  | edit    | show    | false   |
|--------------------------|--------- |---------|---------|---------|
| Resource hasShow hasEdit | edit     | edit    | show    | no link |
| Resource  hasEdit        | edit     | edit    | no link | no link |
| Resource hasShow         | no link  | no link | show    | no link |
| Resource                 | no link  | no link | no link | no link |

**This PR**

|    link                  | default  | edit    | show    | false   |
|--------------------------|--------- |---------|---------|---------|
| Resource hasShow hasEdit | **show**   | edit  | show  | no link |
| Resource  hasEdit        | edit   | edit  | **show** | no link |
| Resource hasShow         | **show**   | **edit**  | show  | no link |
| Resource                 | no link | **edit**  | **show**  | no link |

The link behavior of `<Datagrid rowClick>`, `<ReferenceField link>` and `<ReferenceOneField link>` is now consistent. 