### PR TITLE
Fix useUpdate throws an error when record id is a valid falsy value such as zero

### DIFF
--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -91,6 +91,38 @@ describe('useUpdate', () => {
             });
         });
 
+        it('accepts falsy value that are not null nor undefined as the record id', async () => {
+            const dataProvider = {
+                update: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1 } } as any)
+                ),
+            } as any;
+            let localUpdate;
+            const Dummy = () => {
+                const [update] = useUpdate('foo', {
+                    id: 0,
+                    data: { bar: 'baz' },
+                    previousData: { id: 0, bar: 'bar' },
+                });
+                localUpdate = update;
+                return <span />;
+            };
+
+            render(
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdate();
+            await waitFor(() => {
+                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                    id: 0,
+                    data: { bar: 'baz' },
+                    previousData: { id: 0, bar: 'bar' },
+                });
+            });
+        });
+
         it('replaces hook call time params by and callback time params', async () => {
             const dataProvider = {
                 update: jest.fn(() =>

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -203,7 +203,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
                     'useUpdate mutation requires a non-empty resource'
                 );
             }
-            if (!callTimeId) {
+            if (callTimeId == null) {
                 throw new Error('useUpdate mutation requires a non-empty id');
             }
             if (!callTimeData) {


### PR DESCRIPTION
# Problem

`useUpdate` throws an error when record id is a valid falsy value such as zero

Introduced in https://github.com/marmelab/react-admin/pull/9741

# Solution

Fix the condition to check only for `null` or `undefined`