### PR TITLE
Fix ReviewList scrolls to top when editing a review

### DIFF
--- a/examples/demo/src/reviews/ReviewListDesktop.tsx
+++ b/examples/demo/src/reviews/ReviewListDesktop.tsx
@@ -5,6 +5,7 @@ import {
     DateField,
     Identifier,
     TextField,
+    useCreatePath,
 } from 'react-admin';
 
 import ProductReferenceField from '../products/ProductReferenceField';
@@ -14,6 +15,7 @@ import rowSx from './rowSx';
 
 import BulkAcceptButton from './BulkAcceptButton';
 import BulkRejectButton from './BulkRejectButton';
+import { useNavigate } from 'react-router';
 
 export interface ReviewListDesktopProps {
     selectedRow?: Identifier;
@@ -27,36 +29,52 @@ const ReviewsBulkActionButtons = () => (
     </>
 );
 
-const ReviewListDesktop = ({ selectedRow }: ReviewListDesktopProps) => (
-    <DatagridConfigurable
-        rowClick="edit"
-        rowSx={rowSx(selectedRow)}
-        bulkActionButtons={<ReviewsBulkActionButtons />}
-        sx={{
-            '& .RaDatagrid-thead': {
-                borderLeftColor: 'transparent',
-                borderLeftWidth: 5,
-                borderLeftStyle: 'solid',
-            },
-            '& .column-comment': {
-                maxWidth: '18em',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-            },
-        }}
-    >
-        <DateField source="date" />
-        <CustomerReferenceField source="customer_id" link={false} />
-        <ProductReferenceField source="product_id" link={false} />
-        <StarRatingField
-            size="small"
-            label="resources.reviews.fields.rating"
-            source="rating"
-        />
-        <TextField source="comment" />
-        <TextField source="status" />
-    </DatagridConfigurable>
-);
+const ReviewListDesktop = ({ selectedRow }: ReviewListDesktopProps) => {
+    const navigate = useNavigate();
+    const createPath = useCreatePath();
+    return (
+        <DatagridConfigurable
+            rowClick={(id, resource) => {
+                // As we display the edit view in a drawer, we don't the default rowClick behavior that will scroll to the top of the page
+                // So we navigate manually without specifying the _scrollToTop state
+                navigate(
+                    createPath({
+                        resource,
+                        id,
+                        type: 'edit',
+                    })
+                );
+                // Disable the default rowClick behavior
+                return false;
+            }}
+            rowSx={rowSx(selectedRow)}
+            bulkActionButtons={<ReviewsBulkActionButtons />}
+            sx={{
+                '& .RaDatagrid-thead': {
+                    borderLeftColor: 'transparent',
+                    borderLeftWidth: 5,
+                    borderLeftStyle: 'solid',
+                },
+                '& .column-comment': {
+                    maxWidth: '18em',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                },
+            }}
+        >
+            <DateField source="date" />
+            <CustomerReferenceField source="customer_id" link={false} />
+            <ProductReferenceField source="product_id" link={false} />
+            <StarRatingField
+                size="small"
+                label="resources.reviews.fields.rating"
+                source="rating"
+            />
+            <TextField source="comment" />
+            <TextField source="status" />
+        </DatagridConfigurable>
+    );
+};
 
 export default ReviewListDesktop;


### PR DESCRIPTION
# Problem

When clicking on a review to edit it in the demo, the page scrolls back to the top. This is because, scrolling to the top of the page when navigating is the default.

# Solution

Don't use the default redirect and implement it specifically for this page.

# How to test

- run the demo
- navigate to the review list
- set its page size to `50`
- scroll down
- click on a review

=> Observe the page does not scroll to the top anymore