### PR TITLE
[TypeScript] Fix useGetManyReference return type

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetManyReference.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.spec.tsx
@@ -418,4 +418,31 @@ describe('useGetManyReference', () => {
             expect(abort).toHaveBeenCalled();
         });
     });
+
+    it('should discriminate result type', () => {
+        // this is a TypeScript verification. It should compile.
+        const _ComponentToTest = () => {
+            const { data, error, isPending } = useGetManyReference<{
+                id: number;
+                title: string;
+            }>('posts', {
+                target: 'comments',
+                id: 1,
+            });
+            if (isPending) {
+                return <>Loading</>;
+            }
+            if (error) {
+                return <>Error</>;
+            }
+            return (
+                <ul>
+                    {data.map(post => (
+                        <li key={post.id}>{post.title}</li>
+                    ))}
+                </ul>
+            );
+        };
+        expect(_ComponentToTest).toBeDefined();
+    });
 });

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -180,7 +180,7 @@ export type UseGetManyReferenceHookOptions<RecordType extends RaRecord = any> =
     };
 
 export type UseGetManyReferenceHookValue<RecordType extends RaRecord = any> =
-    Omit<UseQueryResult<RecordType[]>, 'queryKey' | 'queryFn'> & {
+    UseQueryResult<RecordType[]> & {
         total?: number;
         pageInfo?: {
             hasNextPage?: boolean;


### PR DESCRIPTION
The discriminated union of the return type by state doesn't work for this hook because of `Omit`. This `Omit` is an error and shouldn't be here. Removing it solves the problem.

| Before | After | 
| --- | --- |
| <img width="569" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/59b90c12-6fca-4c36-b887-a1cb95fe9c1c"> | <img width="522" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/cc5eead0-1c5b-4028-b586-ce8c339c2b28">|

This problem was introduced in dc1938768b58addce2b1dc8cce63028981b19537