### PR TITLE
Fix `<SimpleShowLayout>` uses a wrong translation key for field labels

### DIFF
--- a/packages/ra-core/src/core/SourceContext.tsx
+++ b/packages/ra-core/src/core/SourceContext.tsx
@@ -30,15 +30,21 @@ export type SourceContextValue = {
  *   );
  * };
  */
-export const SourceContext = createContext<SourceContextValue>({
+export const SourceContext = createContext<SourceContextValue | undefined>(
+    undefined
+);
+
+const defaultContextValue = {
     getSource: (source: string) => source,
     getLabel: (source: string) => source,
-});
-
+};
 export const SourceContextProvider = SourceContext.Provider;
 
 export const useSourceContext = () => {
     const context = useContext(SourceContext);
+    if (!context) {
+        return defaultContextValue;
+    }
     return context;
 };
 

--- a/packages/ra-core/src/i18n/useTranslateLabel.spec.tsx
+++ b/packages/ra-core/src/i18n/useTranslateLabel.spec.tsx
@@ -1,177 +1,95 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { useTranslateLabel } from './useTranslateLabel';
-import { TestTranslationProvider } from './TestTranslationProvider';
-import { SourceContextProvider } from '..';
+
+import {
+    Basic,
+    I18nLabelAsKey,
+    I18nNoTranslation,
+    I18nTranslation,
+    InSourceContext,
+    InSourceContextI18nKey,
+    InSourceContextNoTranslation,
+    InSourceContextWithResource,
+    LabelElement,
+    LabelEmpty,
+    LabelFalse,
+    LabelText,
+    Resource,
+    Source,
+} from './useTranslateLabel.stories';
 
 describe('useTranslateLabel', () => {
-    const TranslateLabel = ({
-        source,
-        label,
-        resource,
-    }: {
-        source?: string;
-        label?: string | false | React.ReactElement;
-        resource?: string;
-    }) => {
-        const translateLabel = useTranslateLabel();
-        return (
-            <>
-                {translateLabel({
-                    label,
-                    source,
-                    resource,
-                })}
-            </>
-        );
-    };
+    it('should compose a translation key from the resource and source', () => {
+        render(<Basic />);
+        screen.getByText('resources.posts.fields.title');
+    });
+
+    it('should use the resource in the translation key', () => {
+        render(<Resource />);
+        screen.getByText('resources.comments.fields.title');
+    });
+
+    it('should use the source in the translation key', () => {
+        render(<Source />);
+        screen.getByText('resources.posts.fields.date');
+    });
 
     it('should return null when label is false', () => {
-        render(
-            <TestTranslationProvider>
-                <TranslateLabel label={false} source="title" resource="posts" />
-            </TestTranslationProvider>
-        );
+        render(<LabelFalse />);
         expect(screen.queryByText(/title/)).toBeNull();
     });
 
     it('should return null when label is empty', () => {
-        render(
-            <TestTranslationProvider>
-                <TranslateLabel label="" source="title" resource="posts" />
-            </TestTranslationProvider>
-        );
+        render(<LabelEmpty />);
         expect(screen.queryByText(/title/)).toBeNull();
     });
 
     it('should return the label element when provided', () => {
-        render(
-            <TestTranslationProvider>
-                <TranslateLabel
-                    label={<span>My title</span>}
-                    source="title"
-                    resource="posts"
-                />
-            </TestTranslationProvider>
-        );
+        render(<LabelElement />);
         screen.getByText('My title');
     });
 
     it('should return the label text when provided', () => {
-        render(
-            <TestTranslationProvider messages={{}}>
-                <TranslateLabel
-                    label="My title"
-                    source="title"
-                    resource="posts"
-                />
-            </TestTranslationProvider>
-        );
+        render(<LabelText />);
         screen.getByText('My title');
     });
 
-    it('should return the translated label text when provided', () => {
-        render(
-            <TestTranslationProvider
-                messages={{
-                    test: { title: 'My title' },
-                }}
-            >
-                <TranslateLabel
-                    label="test.title"
-                    source="title"
-                    resource="posts"
-                />
-            </TestTranslationProvider>
-        );
-        screen.getByText('My title');
+    describe('i18n', () => {
+        it('should use the source and resource to create a default translation key', () => {
+            render(<I18nTranslation />);
+            screen.getByText('My Title');
+        });
+
+        it('should use the label as key when provided', () => {
+            render(<I18nLabelAsKey />);
+            screen.getByText('My title');
+        });
+
+        it('should infer a human readable default label when no translation is provided', () => {
+            render(<I18nNoTranslation />);
+            screen.getByText('Title');
+        });
     });
 
-    it('should return the inferred label from source and resource when no label is provided', () => {
-        render(
-            <TestTranslationProvider messages={{}}>
-                <TranslateLabel source="title" resource="posts" />
-            </TestTranslationProvider>
-        );
-        screen.getByText('Title');
-    });
+    describe('SourceContext', () => {
+        it('should call getLabel for the default label', () => {
+            render(<InSourceContext />);
+            screen.getByText('Label for title');
+        });
 
-    it('should return the translated inferred label from source and resource when no label is provided', () => {
-        render(
-            <TestTranslationProvider
-                messages={{
-                    resources: {
-                        posts: {
-                            fields: {
-                                title: 'My Title',
-                            },
-                        },
-                    },
-                }}
-            >
-                <TranslateLabel source="title" resource="posts" />
-            </TestTranslationProvider>
-        );
-        screen.getByText('My Title');
-    });
+        it('should use the getLabel return as translation key', () => {
+            render(<InSourceContextI18nKey />);
+            screen.getByText('test.title');
+        });
 
-    it('should return the inferred label from SourceContext when no label is provided but a SourceContext is present', () => {
-        render(
-            <TestTranslationProvider messages={{}}>
-                <SourceContextProvider
-                    value={{
-                        getSource: source => source,
-                        getLabel: source => `test.${source}`,
-                    }}
-                >
-                    <TranslateLabel source="title" resource="posts" />
-                </SourceContextProvider>
-            </TestTranslationProvider>
-        );
-        screen.getByText('Title');
-    });
+        it('should infer a human readable default label when no translation is provided', () => {
+            render(<InSourceContextNoTranslation />);
+            screen.getByText('Title');
+        });
 
-    it('should return the translated label from SourceContext when no label is provided but a SourceContext is present', () => {
-        render(
-            <TestTranslationProvider
-                messages={{
-                    test: {
-                        title: 'Label for title',
-                    },
-                }}
-            >
-                <SourceContextProvider
-                    value={{
-                        getSource: source => source,
-                        getLabel: source => `test.${source}`,
-                    }}
-                >
-                    <TranslateLabel source="title" />
-                </SourceContextProvider>
-            </TestTranslationProvider>
-        );
-        screen.getByText('Label for title');
-    });
-
-    it('should return the inferred label when a resource prop is provided even when a SourceContext is present', () => {
-        render(
-            <TestTranslationProvider
-                messages={{
-                    test: {
-                        title: 'Label for title',
-                    },
-                }}
-            >
-                <SourceContextProvider
-                    value={{
-                        getSource: source => source,
-                        getLabel: source => `test.${source}`,
-                    }}
-                >
-                    <TranslateLabel source="title" resource="posts" />
-                </SourceContextProvider>
-            </TestTranslationProvider>
-        );
-        screen.getByText('Title');
+        it('should infer a human readable default label when a resource is provided', () => {
+            render(<InSourceContextWithResource />);
+            screen.getByText('Title');
+        });
     });
 });

--- a/packages/ra-core/src/i18n/useTranslateLabel.stories.tsx
+++ b/packages/ra-core/src/i18n/useTranslateLabel.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { useTranslateLabel } from './useTranslateLabel';
+import { TestTranslationProvider } from './TestTranslationProvider';
+import { SourceContextProvider } from '..';
+
+export default {
+    title: 'ra-core/i18n/useTranslateLabel',
+};
+
+const TranslateLabel = ({
+    source,
+    label,
+    resource,
+}: {
+    source?: string;
+    label?: string | false | React.ReactElement;
+    resource?: string;
+}) => {
+    const translateLabel = useTranslateLabel();
+    return (
+        <>
+            {translateLabel({
+                label,
+                source,
+                resource,
+            })}
+        </>
+    );
+};
+export const Basic = () => (
+    <TestTranslationProvider translate={m => m}>
+        <TranslateLabel source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const Source = () => (
+    <TestTranslationProvider translate={m => m}>
+        <TranslateLabel source="date" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const Resource = () => (
+    <TestTranslationProvider translate={m => m}>
+        <TranslateLabel source="title" resource="comments" />
+    </TestTranslationProvider>
+);
+
+export const LabelFalse = () => (
+    <TestTranslationProvider>
+        <TranslateLabel label={false} source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const LabelEmpty = () => (
+    <TestTranslationProvider>
+        <TranslateLabel label="" source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const LabelElement = () => (
+    <TestTranslationProvider>
+        <TranslateLabel
+            label={<span>My title</span>}
+            source="title"
+            resource="posts"
+        />
+    </TestTranslationProvider>
+);
+
+export const LabelText = () => (
+    <TestTranslationProvider messages={{}}>
+        <TranslateLabel label="My title" source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const I18nTranslation = () => (
+    <TestTranslationProvider
+        messages={{
+            resources: {
+                posts: {
+                    fields: {
+                        title: 'My Title',
+                    },
+                },
+            },
+        }}
+    >
+        <TranslateLabel source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const I18nLabelAsKey = () => (
+    <TestTranslationProvider
+        messages={{
+            test: { title: 'My title' },
+        }}
+    >
+        <TranslateLabel label="test.title" source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const I18nNoTranslation = () => (
+    <TestTranslationProvider messages={{}}>
+        <TranslateLabel source="title" resource="posts" />
+    </TestTranslationProvider>
+);
+
+export const InSourceContext = () => (
+    <TestTranslationProvider
+        messages={{
+            test: {
+                title: 'Label for title',
+            },
+        }}
+    >
+        <SourceContextProvider
+            value={{
+                getSource: source => source,
+                getLabel: source => `test.${source}`,
+            }}
+        >
+            <TranslateLabel source="title" />
+        </SourceContextProvider>
+    </TestTranslationProvider>
+);
+
+export const InSourceContextI18nKey = () => (
+    <TestTranslationProvider translate={m => m}>
+        <SourceContextProvider
+            value={{
+                getSource: source => source,
+                getLabel: source => `test.${source}`,
+            }}
+        >
+            <TranslateLabel source="title" />
+        </SourceContextProvider>
+    </TestTranslationProvider>
+);
+
+export const InSourceContextNoTranslation = () => (
+    <TestTranslationProvider messages={{}}>
+        <SourceContextProvider
+            value={{
+                getSource: source => source,
+                getLabel: source => `test.${source}`,
+            }}
+        >
+            <TranslateLabel source="title" />
+        </SourceContextProvider>
+    </TestTranslationProvider>
+);
+
+export const InSourceContextWithResource = () => (
+    <TestTranslationProvider
+        messages={{
+            test: {
+                title: 'Label for title',
+            },
+        }}
+    >
+        <SourceContextProvider
+            value={{
+                getSource: source => source,
+                getLabel: source => `test.${source}`,
+            }}
+        >
+            <TranslateLabel source="title" resource="posts" />
+        </SourceContextProvider>
+    </TestTranslationProvider>
+);

--- a/packages/ra-ui-materialui/src/Labeled.stories.tsx
+++ b/packages/ra-ui-materialui/src/Labeled.stories.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { RecordContextProvider, ResourceContext } from 'ra-core';
+import {
+    I18nContextProvider,
+    RecordContextProvider,
+    ResourceContext,
+} from 'ra-core';
 import { TextField } from './field';
 import { Labeled } from './Labeled';
 import { Box, Stack } from '@mui/material';
@@ -127,4 +131,22 @@ export const FullWidthNoLabel = () => (
             </RecordContextProvider>
         </ResourceContext.Provider>
     </Stack>
+);
+
+export const I18nKey = () => (
+    <I18nContextProvider
+        value={{
+            getLocale: () => 'en',
+            translate: m => m,
+            changeLocale: async () => {},
+        }}
+    >
+        <ResourceContext.Provider value="books">
+            <RecordContextProvider value={record}>
+                <Labeled>
+                    <TextField source="title" />
+                </Labeled>
+            </RecordContextProvider>
+        </ResourceContext.Provider>
+    </I18nContextProvider>
 );

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.spec.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { RecordContextProvider } from 'ra-core';
 import { SimpleShowLayout } from './SimpleShowLayout';
-import { Basic, CustomChild, CustomLabel } from './SimpleShowLayout.stories';
+import {
+    Basic,
+    CustomChild,
+    CustomLabel,
+    I18nKey,
+} from './SimpleShowLayout.stories';
 import { TextField } from '../field';
 
 describe('<SimpleShowLayout />', () => {
@@ -15,20 +20,29 @@ describe('<SimpleShowLayout />', () => {
                 </SimpleShowLayout>
             </RecordContextProvider>
         );
-        expect(screen.queryByText('foo')).not.toBeNull();
-        expect(screen.queryByText('bar')).not.toBeNull();
+        screen.getByText('foo');
+        screen.getByText('bar');
     });
 
     it('should add a label for each field', () => {
         render(<Basic />);
-        expect(screen.queryByText('Title')).not.toBeNull();
-        expect(screen.queryByText('War and Peace')).not.toBeNull();
+        screen.getByText('Title');
+        screen.getByText('War and Peace');
+    });
+
+    it('should translate the labels', () => {
+        render(<I18nKey />);
+        screen.getByText('resources.books.fields.id');
+        screen.getByText('resources.books.fields.title');
+        screen.getByText('resources.books.fields.author');
+        screen.getByText('resources.books.fields.summary');
+        screen.getByText('resources.books.fields.year');
     });
 
     it('should accept custom children', () => {
         render(<CustomChild />);
-        expect(screen.queryByText('War and Peace')).not.toBeNull();
-        expect(screen.queryByText('Leo Tolstoy')).not.toBeNull();
+        screen.getByText('War and Peace');
+        screen.getByText('Leo Tolstoy');
     });
 
     it('should allows to customize or disable the label', () => {

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Grid, Divider as MuiDivider } from '@mui/material';
 import {
+    I18nContextProvider,
     RecordContextProvider,
     ResourceContext,
     useRecordContext,
@@ -172,4 +173,26 @@ export const Nested = () => (
             </SimpleShowLayout>
         </RecordContextProvider>
     </ResourceContext.Provider>
+);
+
+export const I18nKey = () => (
+    <I18nContextProvider
+        value={{
+            getLocale: () => 'en',
+            translate: m => m,
+            changeLocale: async () => {},
+        }}
+    >
+        <ResourceContext.Provider value="books">
+            <RecordContextProvider value={record}>
+                <SimpleShowLayout>
+                    <TextField source="id" />
+                    <TextField source="title" />
+                    <TextField source="author" />
+                    <TextField source="summary" />
+                    <NumberField source="year" />
+                </SimpleShowLayout>
+            </RecordContextProvider>
+        </ResourceContext.Provider>
+    </I18nContextProvider>
 );

--- a/packages/ra-ui-materialui/src/form/SimpleForm.stories.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.stories.tsx
@@ -12,6 +12,8 @@ import { AdminContext } from '../AdminContext';
 import { Edit } from '../detail';
 import { NumberInput, TextInput } from '../input';
 import { SimpleForm } from './SimpleForm';
+import { Labeled } from '../Labeled';
+import { TextField, NumberField } from '../field';
 
 export default { title: 'ra-ui-materialui/forms/SimpleForm' };
 
@@ -83,6 +85,31 @@ export const NoToolbar = () => (
             <TextInput source="title" />
             <TextInput source="author" />
             <NumberInput source="year" />
+        </SimpleForm>
+    </Wrapper>
+);
+
+export const WithFields = () => (
+    <Wrapper
+        i18nProvider={{
+            translate: x => x,
+            changeLocale: async () => {},
+            getLocale: () => 'en',
+        }}
+    >
+        <SimpleForm>
+            <TextInput source="title" />
+            <TextInput source="author" />
+            <NumberInput source="year" />
+            <Labeled>
+                <TextField source="title" />
+            </Labeled>
+            <Labeled>
+                <TextField source="author" />
+            </Labeled>
+            <Labeled>
+                <NumberField source="year" />
+            </Labeled>
         </SimpleForm>
     </Wrapper>
 );


### PR DESCRIPTION
The default SourceContext introduced by 4d9820d5931c3eb992010035c23c00935f194047 breaks default field labels.

Closes #9965