### PR TITLE
[TypeScript] Fix data provider packages export non-strict types

### DIFF
--- a/packages/ra-core/src/core/CoreAdminUI.tsx
+++ b/packages/ra-core/src/core/CoreAdminUI.tsx
@@ -152,8 +152,8 @@ export interface CoreAdminUIProps {
         resetErrorBoundary,
     }: {
         errorInfo?: ErrorInfo;
-        error?: Error;
-        resetErrorBoundary?: (args) => void;
+        error: Error;
+        resetErrorBoundary: (args) => void;
     }) => ReactElement;
 
     /**

--- a/packages/ra-data-fakerest/src/index.ts
+++ b/packages/ra-data-fakerest/src/index.ts
@@ -3,6 +3,7 @@ import { DataProvider } from 'ra-core';
 
 /* eslint-disable no-console */
 function log(type, resource, params, response) {
+    // @ts-ignore
     if (console.group) {
         // Better logging in Chrome
         console.groupCollapsed(type, resource, JSON.stringify(params));

--- a/packages/ra-data-fakerest/tsconfig.json
+++ b/packages/ra-data-fakerest/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/ra-data-graphql/src/buildApolloClient.ts
+++ b/packages/ra-data-graphql/src/buildApolloClient.ts
@@ -5,7 +5,7 @@ import {
     InMemoryCache,
 } from '@apollo/client';
 
-export default (options: Partial<ApolloClientOptions<unknown>>) => {
+export default (options?: Partial<ApolloClientOptions<unknown>>) => {
     if (!options) {
         return new ApolloClient({
             cache: new InMemoryCache().restore({}),

--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -74,7 +74,11 @@ export const defaultOptions = {
 };
 
 const getOptions = (
-    options: GetQueryOptions | GetMutationOptions | GetWatchQueryOptions,
+    options:
+        | GetQueryOptions
+        | GetMutationOptions
+        | GetWatchQueryOptions
+        | undefined,
     raFetchMethod: string,
     resource: string
 ) => {

--- a/packages/ra-data-graphql/src/introspection.ts
+++ b/packages/ra-data-graphql/src/introspection.ts
@@ -1,5 +1,6 @@
 import {
     getIntrospectionQuery,
+    IntrospectionField,
     IntrospectionObjectType,
     IntrospectionQuery,
     IntrospectionSchema,
@@ -51,8 +52,8 @@ export type IntrospectionResult = {
 
 const fetchSchema = (
     client: ApolloClient<unknown>
-): Promise<IntrospectionSchema> => {
-    return client
+): Promise<IntrospectionSchema> =>
+    client
         .query<IntrospectionQuery>({
             fetchPolicy: 'network-only',
             query: gql`
@@ -60,12 +61,11 @@ const fetchSchema = (
             `,
         })
         .then(({ data: { __schema } }) => __schema);
-};
 
 const getQueriesFromSchema = (
     schema: IntrospectionSchema
-): IntrospectionObjectType[] => {
-    return schema.types.reduce((acc, type) => {
+): IntrospectionField[] =>
+    schema.types.reduce((acc, type) => {
         if (
             type.name !== schema.queryType?.name &&
             type.name !== schema.mutationType?.name &&
@@ -76,19 +76,17 @@ const getQueriesFromSchema = (
 
         return [...acc, ...((type as IntrospectionObjectType).fields || [])];
     }, []);
-};
 
-const getTypesFromSchema = (schema: IntrospectionSchema) => {
-    return schema.types.filter(
+const getTypesFromSchema = (schema: IntrospectionSchema) =>
+    schema.types.filter(
         type =>
             type.name !== (schema.queryType && schema.queryType.name) &&
             type.name !== (schema.mutationType && schema.mutationType.name)
     );
-};
 
 const getResources = (
     types: IntrospectionType[],
-    queries: IntrospectionObjectType[],
+    queries: IntrospectionField[],
     options: IntrospectionOptions
 ): IntrospectedResource[] => {
     const filteredResources = types.filter(type =>
@@ -101,7 +99,7 @@ const getResources = (
 
 const isResource = (
     type: IntrospectionType,
-    queries: IntrospectionObjectType[],
+    queries: IntrospectionField[],
     options: IntrospectionOptions
 ) => {
     if (isResourceIncluded(type, options)) return true;
@@ -150,10 +148,10 @@ export const isResourceExcluded = (
 
 const buildResource = (
     type: IntrospectionObjectType,
-    queries: IntrospectionObjectType[],
+    queries: IntrospectionField[],
     options: IntrospectionOptions
-): IntrospectedResource => {
-    return ALL_TYPES.reduce(
+): IntrospectedResource =>
+    ALL_TYPES.reduce(
         (acc, raFetchMethod) => {
             const query = queries.find(
                 ({ name }) =>
@@ -170,4 +168,3 @@ const buildResource = (
         },
         { type }
     );
-};

--- a/packages/ra-data-graphql/tsconfig.json
+++ b/packages/ra-data-graphql/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": [
         "**/*.spec.ts",

--- a/packages/ra-data-json-server/tsconfig.json
+++ b/packages/ra-data-json-server/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/ra-data-localforage/tsconfig.json
+++ b/packages/ra-data-localforage/tsconfig.json
@@ -5,7 +5,8 @@
         "rootDir": "src",
         "declaration": true,
         "declarationMap": true,
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true,
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/ra-data-localstorage/src/index.ts
+++ b/packages/ra-data-localstorage/src/index.ts
@@ -55,7 +55,7 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
 
     window?.addEventListener('storage', event => {
         if (event.key === localStorageKey) {
-            const newData = JSON.parse(event.newValue);
+            const newData = event.newValue ? JSON.parse(event.newValue) : {};
             data = newData;
             baseDataProvider = fakeRestProvider(
                 newData,

--- a/packages/ra-data-localstorage/tsconfig.json
+++ b/packages/ra-data-localstorage/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -39,8 +39,8 @@ export default (
     countHeader: string = 'Content-Range'
 ): DataProvider => ({
     getList: (resource, params) => {
-        const { page, perPage } = params.pagination;
-        const { field, order } = params.sort;
+        const { page, perPage } = params.pagination || { page: 1, perPage: 10 };
+        const { field, order } = params.sort || { field: 'id', order: 'ASC' };
 
         const rangeStart = (page - 1) * perPage;
         const rangeEnd = page * perPage - 1;
@@ -73,10 +73,11 @@ export default (
                 total:
                     countHeader === 'Content-Range'
                         ? parseInt(
-                              headers.get('content-range').split('/').pop(),
+                              headers.get('content-range')!.split('/').pop() ||
+                                  '',
                               10
                           )
-                        : parseInt(headers.get(countHeader.toLowerCase())),
+                        : parseInt(headers.get(countHeader.toLowerCase())!),
             };
         });
     },
@@ -136,10 +137,11 @@ export default (
                 total:
                     countHeader === 'Content-Range'
                         ? parseInt(
-                              headers.get('content-range').split('/').pop(),
+                              headers.get('content-range')!.split('/').pop() ||
+                                  '',
                               10
                           )
-                        : parseInt(headers.get(countHeader.toLowerCase())),
+                        : parseInt(headers.get(countHeader.toLowerCase())!),
             };
         });
     },

--- a/packages/ra-data-simple-rest/tsconfig.json
+++ b/packages/ra-data-simple-rest/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": "src",
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js"],
     "include": ["src"]


### PR DESCRIPTION
Since third-party data providers stem from ours, we should provide data providers that compile with strictNullChecks