### PR TITLE
[TypeScript] Fix useGetOne and useGetMany params type when id param is undefined

### DIFF
--- a/examples/crm/src/contacts/TagsListEdit.tsx
+++ b/examples/crm/src/contacts/TagsListEdit.tsx
@@ -44,7 +44,7 @@ export const TagsListEdit = () => {
     const { data: tags, isPending: isPendingRecordTags } = useGetMany<Tag>(
         'tags',
         { ids: record?.tags },
-        { enabled: record && record.tags && record.tags.length > 0 }
+        { enabled: !!(record && record.tags && record.tags.length > 0) }
     );
     const [update] = useUpdate<Contact>();
     const [create] = useCreate<Tag>();

--- a/examples/crm/src/contacts/TagsListEdit.tsx
+++ b/examples/crm/src/contacts/TagsListEdit.tsx
@@ -44,7 +44,7 @@ export const TagsListEdit = () => {
     const { data: tags, isPending: isPendingRecordTags } = useGetMany<Tag>(
         'tags',
         { ids: record?.tags },
-        { enabled: !!(record && record.tags && record.tags.length > 0) }
+        { enabled: record && record.tags && record.tags.length > 0 }
     );
     const [update] = useUpdate<Contact>();
     const [create] = useCreate<Tag>();

--- a/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetMany.spec.tsx
@@ -411,7 +411,7 @@ describe('useGetMany', () => {
             };
             // no render needed, only checking types
         });
-        it('should accept empty id param when disabled', () => {
+        it('should accept empty id param', () => {
             const _Dummy = () => {
                 type Post = {
                     id: number;
@@ -424,11 +424,9 @@ describe('useGetMany', () => {
                     id: number;
                     name: string;
                 };
-                const { data, error, isPending } = useGetMany<Tag>(
-                    'posts',
-                    { ids: comment?.tag_ids },
-                    { enabled: !!comment } // without this line, TS would complain about comment?.post_id potentially being undefined
-                );
+                const { data, error, isPending } = useGetMany<Tag>('posts', {
+                    ids: comment?.tag_ids,
+                });
                 if (isPending || error) return null;
                 return (
                     <ul>

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -51,23 +51,11 @@ import { useEvent } from '../util';
  *     )}</ul>;
  * };
  */
-export function useGetMany<RecordType extends RaRecord = any>(
+export const useGetMany = <RecordType extends RaRecord = any>(
     resource: string,
-    params: GetManyParams<RecordType>,
-    options?: UseGetManyOptions<RecordType>
-): UseGetManyHookValue<RecordType>;
-export function useGetMany<RecordType extends RaRecord = any>(
-    resource: string,
-    params: Omit<GetManyParams<RecordType>, 'ids'> & {
-        ids?: RecordType['id'][];
-    },
-    options: UseGetManyOptions<RecordType> & { enabled: boolean }
-): UseGetManyHookValue<RecordType>;
-export function useGetMany<RecordType extends RaRecord = any>(
-    resource: string,
-    params: GetManyParams<RecordType>,
+    params: Partial<GetManyParams<RecordType>>,
     options: UseGetManyOptions<RecordType> = {}
-): UseGetManyHookValue<RecordType> {
+): UseGetManyHookValue<RecordType> => {
     const { ids, meta } = params;
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
@@ -76,6 +64,7 @@ export function useGetMany<RecordType extends RaRecord = any>(
         onError = noop,
         onSuccess = noop,
         onSettled = noop,
+        enabled,
         ...queryOptions
     } = options;
     const onSuccessEvent = useEvent(onSuccess);
@@ -127,6 +116,7 @@ export function useGetMany<RecordType extends RaRecord = any>(
             }
         },
         retry: false,
+        enabled: enabled ?? ids != null,
         ...queryOptions,
     });
 
@@ -186,7 +176,7 @@ export function useGetMany<RecordType extends RaRecord = any>(
     ]);
 
     return result;
-}
+};
 
 const noop = () => undefined;
 

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -51,11 +51,23 @@ import { useEvent } from '../util';
  *     )}</ul>;
  * };
  */
-export const useGetMany = <RecordType extends RaRecord = any>(
+export function useGetMany<RecordType extends RaRecord = any>(
     resource: string,
-    params: Partial<GetManyParams> = {},
+    params: GetManyParams,
+    options?: UseGetManyOptions<RecordType>
+): UseGetManyHookValue<RecordType>;
+export function useGetMany<RecordType extends RaRecord = any>(
+    resource: string,
+    params: Omit<GetManyParams, 'ids'> & {
+        ids?: RecordType['id'][];
+    },
+    options: UseGetManyOptions<RecordType> & { enabled: boolean }
+): UseGetManyHookValue<RecordType>;
+export function useGetMany<RecordType extends RaRecord = any>(
+    resource: string,
+    params: GetManyParams,
     options: UseGetManyOptions<RecordType> = {}
-): UseGetManyHookValue<RecordType> => {
+): UseGetManyHookValue<RecordType> {
     const { ids, meta } = params;
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
@@ -174,7 +186,7 @@ export const useGetMany = <RecordType extends RaRecord = any>(
     ]);
 
     return result;
-};
+}
 
 const noop = () => undefined;
 

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -53,19 +53,19 @@ import { useEvent } from '../util';
  */
 export function useGetMany<RecordType extends RaRecord = any>(
     resource: string,
-    params: GetManyParams,
+    params: GetManyParams<RecordType>,
     options?: UseGetManyOptions<RecordType>
 ): UseGetManyHookValue<RecordType>;
 export function useGetMany<RecordType extends RaRecord = any>(
     resource: string,
-    params: Omit<GetManyParams, 'ids'> & {
+    params: Omit<GetManyParams<RecordType>, 'ids'> & {
         ids?: RecordType['id'][];
     },
     options: UseGetManyOptions<RecordType> & { enabled: boolean }
 ): UseGetManyHookValue<RecordType>;
 export function useGetMany<RecordType extends RaRecord = any>(
     resource: string,
-    params: GetManyParams,
+    params: GetManyParams<RecordType>,
     options: UseGetManyOptions<RecordType> = {}
 ): UseGetManyHookValue<RecordType> {
     const { ids, meta } = params;

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -68,7 +68,7 @@ import { useEvent } from '../util';
  */
 export const useGetManyAggregate = <RecordType extends RaRecord = any>(
     resource: string,
-    params: GetManyParams<RecordType>,
+    params: Partial<GetManyParams<RecordType>>,
     options: UseGetManyAggregateOptions<RecordType> = {}
 ): UseGetManyHookValue<RecordType> => {
     const dataProvider = useDataProvider();
@@ -78,6 +78,7 @@ export const useGetManyAggregate = <RecordType extends RaRecord = any>(
         onError = noop,
         onSuccess = noop,
         onSettled = noop,
+        enabled,
         ...queryOptions
     } = options;
     const onSuccessEvent = useEvent(onSuccess);
@@ -133,6 +134,7 @@ export const useGetManyAggregate = <RecordType extends RaRecord = any>(
                 });
             }),
         placeholderData,
+        enabled: enabled ?? ids != null,
         retry: false,
         ...queryOptions,
     });

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -68,7 +68,7 @@ import { useEvent } from '../util';
  */
 export const useGetManyAggregate = <RecordType extends RaRecord = any>(
     resource: string,
-    params: GetManyParams,
+    params: GetManyParams<RecordType>,
     options: UseGetManyAggregateOptions<RecordType> = {}
 ): UseGetManyHookValue<RecordType> => {
     const dataProvider = useDataProvider();

--- a/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
@@ -299,4 +299,40 @@ describe('useGetOne', () => {
             expect(abort).toHaveBeenCalled();
         });
     });
+    describe('TypeScript', () => {
+        it('should return the parametric type', () => {
+            type Foo = { id: number; name: string };
+            const _Dummy = () => {
+                const { data, error, isPending } = useGetOne<Foo>('posts', {
+                    id: 1,
+                });
+                if (isPending || error) return null;
+                return <div>{data.name}</div>;
+            };
+            // no render needed, only checking types
+        });
+        it('should accept empty id param when disabled', () => {
+            const _Dummy = () => {
+                type Comment = {
+                    id: number;
+                    post_id: number;
+                };
+                const { data: comment } = useGetOne<Comment>('comments', {
+                    id: 1,
+                });
+                type Post = {
+                    id: number;
+                    title: string;
+                };
+                const { data, error, isPending } = useGetOne<Post>(
+                    'posts',
+                    { id: comment?.post_id },
+                    { enabled: !!comment } // without this line, TS would complain about comment?.post_id potentially being undefined
+                );
+                if (isPending || error) return null;
+                return <div>{data.title}</div>;
+            };
+            // no render needed, only checking types
+        });
+    });
 });

--- a/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetOne.spec.tsx
@@ -311,7 +311,7 @@ describe('useGetOne', () => {
             };
             // no render needed, only checking types
         });
-        it('should accept empty id param when disabled', () => {
+        it('should accept empty id param', () => {
             const _Dummy = () => {
                 type Comment = {
                     id: number;
@@ -324,11 +324,9 @@ describe('useGetOne', () => {
                     id: number;
                     title: string;
                 };
-                const { data, error, isPending } = useGetOne<Post>(
-                    'posts',
-                    { id: comment?.post_id },
-                    { enabled: !!comment } // without this line, TS would complain about comment?.post_id potentially being undefined
-                );
+                const { data, error, isPending } = useGetOne<Post>('posts', {
+                    id: comment?.post_id,
+                });
                 if (isPending || error) return null;
                 return <div>{data.title}</div>;
             };

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -47,11 +47,21 @@ import { useEvent } from '../util';
  *     return <div>User {data.username}</div>;
  * };
  */
-export const useGetOne = <RecordType extends RaRecord = any>(
+export function useGetOne<RecordType extends RaRecord = any>(
+    resource: string,
+    params: GetOneParams<RecordType>,
+    options?: UseGetOneOptions<RecordType>
+): UseGetOneHookValue<RecordType>;
+export function useGetOne<RecordType extends RaRecord = any>(
+    resource: string,
+    params: Omit<GetOneParams<RecordType>, 'id'> & { id?: RecordType['id'] },
+    options: UseGetOneOptions<RecordType> & { enabled: boolean }
+): UseGetOneHookValue<RecordType>;
+export function useGetOne<RecordType extends RaRecord = any>(
     resource: string,
     { id, meta }: GetOneParams<RecordType>,
     options: UseGetOneOptions<RecordType> = {}
-): UseGetOneHookValue<RecordType> => {
+): UseGetOneHookValue<RecordType> {
     const dataProvider = useDataProvider();
     const {
         onError = noop,
@@ -109,7 +119,7 @@ export const useGetOne = <RecordType extends RaRecord = any>(
     ]);
 
     return result;
-};
+}
 
 const noop = () => undefined;
 

--- a/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
+++ b/packages/ra-core/src/dataProvider/withLifecycleCallbacks.ts
@@ -202,7 +202,7 @@ export const withLifecycleCallbacks = (
 
         getMany: async function <RecordType extends RaRecord = any>(
             resource: string,
-            params: GetManyParams
+            params: GetManyParams<RecordType>
         ) {
             let newParams = params;
 

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -99,7 +99,7 @@ export type DataProvider<ResourceType extends string = string> = {
 
     getMany: <RecordType extends RaRecord = any>(
         resource: ResourceType,
-        params: GetManyParams & QueryFunctionContext
+        params: GetManyParams<RecordType> & QueryFunctionContext
     ) => Promise<GetManyResult<RecordType>>;
 
     getManyReference: <RecordType extends RaRecord = any>(
@@ -172,8 +172,8 @@ export interface GetOneResult<RecordType extends RaRecord = any> {
     data: RecordType;
 }
 
-export interface GetManyParams {
-    ids: Identifier[];
+export interface GetManyParams<RecordType extends RaRecord = any> {
+    ids: RecordType['id'][];
     meta?: any;
     signal?: AbortSignal;
 }

--- a/packages/ra-data-localforage/src/index.ts
+++ b/packages/ra-data-localforage/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-anonymous-default-export */
 import fakeRestProvider from 'ra-data-fakerest';
-
 import {
     CreateParams,
     DataProvider,
@@ -111,7 +110,7 @@ export default async (
         ) => baseDataProvider.getOne<RecordType>(resource, params),
         getMany: <RecordType extends RaRecord = any>(
             resource: string,
-            params: GetManyParams
+            params: GetManyParams<RecordType>
         ) => baseDataProvider.getMany<RecordType>(resource, params),
         getManyReference: <RecordType extends RaRecord = any>(
             resource: string,


### PR DESCRIPTION
## Problem

TypeScript complains when `useGetOne` is called with an undefined `id`. This is fine, except when using the `enabled` option:

<img width="1013" alt="image" src="https://github.com/marmelab/react-admin/assets/99944/4f6d231f-cca7-4030-a8da-352b03b7e33c">

This is a consequence of the strictNullCheck flag in ra-core. 

## Solutions

1. Use type overloads to allow optional id when enabled is specified. This forces the developer to set teh enabled flag when id may be undefined - not ideal.
2. Change input type for the data provider hooks to allow an undefined id, and set the enabled flag in the hook accordingly. this offers a better DX as TypeScript won't complain but user land code won't break either. 

We choose solution 2. 