### PR TITLE
[TypeScript] Fix ReferenceField Props type is confusing

### DIFF
--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -81,8 +81,7 @@ export const ReferenceField = <
 export interface ReferenceFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
     ReferenceRecordType extends RaRecord = RaRecord,
-> extends Omit<FieldProps<RecordType>, 'source'>,
-        Required<Pick<FieldProps<RecordType>, 'source'>> {
+> extends FieldProps<RecordType> {
     children?: ReactNode;
     queryOptions?: Partial<
         UseQueryOptions<ReferenceRecordType[], Error> & {


### PR DESCRIPTION
This confusing type was introduced by https://github.com/marmelab/react-admin/commit/43f8e72461869fd6779c00488d52dc36ac1c8183#diff-bcb8a95735be07f07a5fe05f577626392756002e0c6350fcc0e1e8a17dbea8d9, at a moment when `source` was optional. It's no longer necessary. 