### PR TITLE
Update mutations results types to include `isLoading`

### DIFF
--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -268,5 +268,5 @@ export type UseCreateResult<
         MutationError,
         Partial<UseCreateMutateParams<RecordType>>,
         unknown
-    >,
+    > & { isLoading: boolean },
 ];

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -490,5 +490,5 @@ export type UseDeleteResult<
         MutationError,
         Partial<DeleteParams<RecordType> & { resource?: string }>,
         unknown
-    >,
+    > & { isLoading: boolean },
 ];

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -504,5 +504,5 @@ export type UseDeleteManyResult<
         MutationError,
         Partial<DeleteManyParams<RecordType> & { resource?: string }>,
         unknown
-    >,
+    > & { isLoading: boolean },
 ];

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -551,5 +551,5 @@ export type UseUpdateResult<
         ErrorType,
         Partial<UpdateParams<RecordType> & { resource?: string }>,
         unknown
-    >,
+    > & { isLoading: boolean },
 ];

--- a/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
@@ -59,6 +59,7 @@ const SuccessCore = () => {
         );
         setNotification(true);
     };
+
     return (
         <>
             <dl>

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -523,5 +523,5 @@ export type UseUpdateManyResult<
         MutationError,
         Partial<UpdateManyParams<Partial<RecordType>> & { resource?: string }>,
         unknown
-    >,
+    > & { isLoading: boolean },
 ];


### PR DESCRIPTION
# Problem

Although we did include `isLoading` in the mutations results to avoid breaking changes, we did not update the types.

# Solution

Update the mutations results types