### PR TITLE
Fix `filter` vs `filters` warning

### DIFF
--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -56,7 +56,11 @@ export const useListController = <RecordType extends RaRecord = any>(
             `useListController requires a non-empty resource prop or context`
         );
     }
-    if (filter && isValidElement(filter)) {
+    if (
+        filter &&
+        (isValidElement(filter) ||
+            (Array.isArray(filter) && filter.some(isValidElement)))
+    ) {
         throw new Error(
             'useListController received a React element as `filter` props. If you intended to set the list filter elements, use the `filters` (with an s) prop instead. The `filter` prop is internal and should not be set by the developer.'
         );


### PR DESCRIPTION
# Problem

When passing an array of inputs to the `filter` prop, the list component behave weirdly and developers might loose time finding that they should have used `filters` instead.

# Solution

Check that developers have pass either an element or an array of elements and throw an error

# How to test

- Open the simple example `PostList` file and change `filters` to `filter`in `PostListDesktop`
- Run the example