### PR TITLE
Fix(WrapperField): source props should not be required

### DIFF
--- a/packages/ra-ui-materialui/src/field/WrapperField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/WrapperField.spec.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import expect from 'expect';
+import * as React from 'react';
+
+import { UrlField } from './UrlField';
+import { WrapperField } from './WrapperField';
+
+const url = 'https://en.wikipedia.org/wiki/HAL_9000';
+
+describe('<WrapperField />', () => {
+    it('should render its children', () => {
+        const record = { id: 123, website: url };
+        const { getByText } = render(
+            <WrapperField label="wrapper">
+                <UrlField record={record} source="website" />
+            </WrapperField>
+        );
+        const link = getByText(url) as HTMLAnchorElement;
+        expect(link.tagName).toEqual('A');
+        expect(link.href).toEqual(url);
+    });
+});

--- a/packages/ra-ui-materialui/src/field/WrapperField.tsx
+++ b/packages/ra-ui-materialui/src/field/WrapperField.tsx
@@ -33,6 +33,7 @@ WrapperField.displayName = 'WrapperField';
 
 export interface WrapperFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
-> extends FieldProps<RecordType> {
+> extends Omit<FieldProps<RecordType>, 'source'> {
+    source?: FieldProps<RecordType>['source'];
     children: ReactNode;
 }


### PR DESCRIPTION
`WrapperField` [documentation](https://marmelab.com/react-admin/WrapperField.html) marks `source` props as not required, however changes in #9620 makes it required. This PR reverts the change for `WrapperField` only