### PR TITLE
Fix `<FilterLiveSearch>` should react to filter values change

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-import { Basic, HiddenLabel } from './FilterLiveSearch.stories';
+import {
+    Basic,
+    HiddenLabel,
+    WithFilterButton,
+} from './FilterLiveSearch.stories';
 
 describe('FilterLiveSearch', () => {
     it('renders an empty text input', () => {
@@ -29,6 +33,32 @@ describe('FilterLiveSearch', () => {
         expect(screen.queryAllByRole('listitem')).toHaveLength(2);
         fireEvent.click(screen.getByLabelText('ra.action.clear_input_value'));
         expect(screen.queryAllByRole('listitem')).toHaveLength(27);
+    });
+    it('clears the filter when user click on the Remove all filters button', async () => {
+        render(<WithFilterButton />);
+        const filterLiveSearchInput = screen.getByLabelText('ra.action.search');
+        fireEvent.change(filterLiveSearchInput, {
+            target: { value: 'st' },
+        });
+        expect(filterLiveSearchInput.getAttribute('value')).toBe('st');
+        expect(screen.queryAllByRole('listitem')).toHaveLength(2);
+        fireEvent.click(screen.getByLabelText('ra.action.add_filter'));
+        fireEvent.click(await screen.findByText('Remove all filters'));
+        expect(screen.queryAllByRole('listitem')).toHaveLength(27);
+        expect(filterLiveSearchInput.getAttribute('value')).toBe('');
+    });
+    it('updates its value when filter values change', async () => {
+        render(<WithFilterButton />);
+        const filterLiveSearchInput = screen.getByLabelText('ra.action.search');
+        const textInput = screen.getByLabelText('Q');
+        fireEvent.change(textInput, {
+            target: { value: 'st' },
+        });
+        expect(textInput.getAttribute('value')).toBe('st');
+        await waitFor(() => {
+            expect(filterLiveSearchInput.getAttribute('value')).toBe('st');
+        });
+        expect(screen.queryAllByRole('listitem')).toHaveLength(2);
     });
     describe('hiddenLabel', () => {
         it('turns the label into a placeholder', () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
@@ -1,16 +1,25 @@
-import * as React from 'react';
-import { useList, ListContextProvider, useListContext } from 'ra-core';
 import {
     Box,
+    createTheme,
     List,
     ListItem,
     ListItemText,
     ThemeProvider,
-    createTheme,
 } from '@mui/material';
+import {
+    ListContextProvider,
+    ResourceContextProvider,
+    TestMemoryRouter,
+    useList,
+    useListContext,
+} from 'ra-core';
+import * as React from 'react';
 
-import { FilterLiveSearch } from './FilterLiveSearch';
+import { TextInput } from '../../input';
 import { defaultTheme } from '../../theme/defaultTheme';
+import { FilterButton } from './FilterButton';
+import { FilterForm } from './FilterForm';
+import { FilterLiveSearch } from './FilterLiveSearch';
 
 export default {
     title: 'ra-ui-materialui/list/filter/FilterLiveSearch',
@@ -107,4 +116,18 @@ export const Sx = () => (
         <FilterLiveSearch source="q" sx={{ width: 300 }} />
         <CountryList />
     </Wrapper>
+);
+
+const countryFilters = [<TextInput source="q" alwaysOn />];
+export const WithFilterButton = () => (
+    <TestMemoryRouter>
+        <ResourceContextProvider value="countries">
+            <Wrapper>
+                <FilterLiveSearch source="q" />
+                <FilterForm filters={countryFilters} />
+                <FilterButton filters={countryFilters} />
+                <CountryList />
+            </Wrapper>
+        </ResourceContextProvider>
+    </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.tsx
@@ -61,7 +61,7 @@ export const FilterLiveSearch = memo((props: FilterLiveSearchProps) => {
         [filterValues, source]
     );
 
-    const form = useForm({ defaultValues: initialValues });
+    const form = useForm({ values: initialValues });
 
     const onSubmit = e => {
         e.preventDefault();


### PR DESCRIPTION
## Problem

If you have both a `<FilterLiveSearch>` and a `<FilterButton>`, clicking on 'Remove all filters' in the `<FilterButton>` doesn't clear the `<FilterLiveSearch>` text input (although the filters are indeed cleared).

Similarily, updating the filter value for the field targeted by `<FilterLiveSearch source>` doesn't update the `<FilterLiveSearch>` text input (although the filter is applied).

## Solution

Use `values` instead of `defaultValues` when declaring the form for `<FilterLiveSearch>`, which makes it reactive.

## How To Test

- 2 unit tests are added
- 1 story is added (`WithFilterButton`)

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
