### PR TITLE
separate test and default data providers

### DIFF
--- a/packages/ra-core/src/dataProvider/defaultDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/defaultDataProvider.ts
@@ -1,32 +1,12 @@
-import { DataProvider } from '../types';
-
 // avoids adding a context in tests
-export const defaultDataProvider: DataProvider = {
-    create: async () => {
-        throw new Error('create is not implemented');
-    },
-    delete: async () => {
-        throw new Error('delete not implemented');
-    },
-    deleteMany: async () => {
-        throw new Error('deleteMany is not implemented');
-    },
-    getList: async () => {
-        throw new Error('getList is not implemented');
-    },
-    getMany: async () => {
-        throw new Error('getMany is not implemented');
-    },
-    getManyReference: async () => {
-        throw new Error('getManyReference is not implemented');
-    },
-    getOne: async () => {
-        throw new Error('getOne is not implemented');
-    },
-    update: async () => {
-        throw new Error('update not implemented');
-    },
-    updateMany: async () => {
-        throw new Error('updateMany not implemented');
-    },
+export const defaultDataProvider = {
+    create: () => Promise.resolve({ data: null }),
+    delete: () => Promise.resolve({ data: null }),
+    deleteMany: () => Promise.resolve({ data: [] }),
+    getList: () => Promise.resolve({ data: [], total: 0 }),
+    getMany: () => Promise.resolve({ data: [] }),
+    getManyReference: () => Promise.resolve({ data: [], total: 0 }),
+    getOne: () => Promise.resolve({ data: { id: 'o' } }),
+    update: () => Promise.resolve({ data: null }),
+    updateMany: () => Promise.resolve({ data: [] }),
 };

--- a/packages/ra-core/src/dataProvider/defaultDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/defaultDataProvider.ts
@@ -1,14 +1,20 @@
-import { DataProvider } from '../types';
+import {
+    CreateResult,
+    DataProvider,
+    DeleteResult,
+    GetOneResult,
+    UpdateResult,
+} from '../types';
 
 // avoids adding a context in tests
 export const defaultDataProvider: DataProvider = {
-    create: () => Promise.resolve({ data: null }),
-    delete: () => Promise.resolve({ data: null }),
+    create: () => Promise.resolve<CreateResult>({ data: null }),
+    delete: () => Promise.resolve<DeleteResult>({ data: null }),
     deleteMany: () => Promise.resolve({ data: [] }),
     getList: () => Promise.resolve({ data: [], total: 0 }),
     getMany: () => Promise.resolve({ data: [] }),
     getManyReference: () => Promise.resolve({ data: [], total: 0 }),
-    getOne: () => Promise.resolve({ data: { id: 'o' } }),
-    update: () => Promise.resolve({ data: null }),
+    getOne: () => Promise.resolve<GetOneResult>({ data: null }),
+    update: () => Promise.resolve<UpdateResult>({ data: null }),
     updateMany: () => Promise.resolve({ data: [] }),
-} as DataProvider;
+};

--- a/packages/ra-core/src/dataProvider/defaultDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/defaultDataProvider.ts
@@ -1,5 +1,7 @@
+import { DataProvider } from '../types';
+
 // avoids adding a context in tests
-export const defaultDataProvider = {
+export const defaultDataProvider: DataProvider = {
     create: () => Promise.resolve({ data: null }),
     delete: () => Promise.resolve({ data: null }),
     deleteMany: () => Promise.resolve({ data: [] }),
@@ -9,4 +11,4 @@ export const defaultDataProvider = {
     getOne: () => Promise.resolve({ data: { id: 'o' } }),
     update: () => Promise.resolve({ data: null }),
     updateMany: () => Promise.resolve({ data: [] }),
-};
+} as DataProvider;

--- a/packages/ra-core/src/dataProvider/testDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/testDataProvider.ts
@@ -1,5 +1,4 @@
 import { DataProvider } from '../types';
-import { defaultDataProvider } from './defaultDataProvider';
 
 /**
  * A dataProvider meant to be used in tests only. You can override any of its methods by passing a partial dataProvider.
@@ -9,9 +8,39 @@ import { defaultDataProvider } from './defaultDataProvider';
  *    getOne: async () => ({ data: { id: 123, title: 'foo' }})
  * })
  */
+
+const defaultTestDataProvider: DataProvider = {
+    create: async () => {
+        throw new Error('create is not implemented');
+    },
+    delete: async () => {
+        throw new Error('delete not implemented');
+    },
+    deleteMany: async () => {
+        throw new Error('deleteMany is not implemented');
+    },
+    getList: async () => {
+        throw new Error('getList is not implemented');
+    },
+    getMany: async () => {
+        throw new Error('getMany is not implemented');
+    },
+    getManyReference: async () => {
+        throw new Error('getManyReference is not implemented');
+    },
+    getOne: async () => {
+        throw new Error('getOne is not implemented');
+    },
+    update: async () => {
+        throw new Error('update not implemented');
+    },
+    updateMany: async () => {
+        throw new Error('updateMany not implemented');
+    },
+};
 export const testDataProvider = (
     overrides?: Partial<DataProvider>
 ): DataProvider => ({
-    ...defaultDataProvider,
+    ...defaultTestDataProvider,
     ...overrides,
 });


### PR DESCRIPTION
## Problem
defaultDataProvider behaviour changed in V5. the change was intended to just support the tests. this affect the end users if they use the exported `defaultDataProvider` in their implementation which means one extra migration step for them and one extra migration documentation entry point react-admin team has to add.

## Solution
Implement testing-related changes for the `defaultDataProvider` in the right place `testDataProvider` and revert the `defaultDataProvider` to its original behaviour (which is dummy responses but at least it doesn't throw)

## Struggles/Challenges
I implemented the refactoring in 30 seconds, then I spent almost half an hour trying to make the `defaultDataProvider` work with the `DataProvider` type but I failed. I would appreciate if one of the core members can explain to me what I miss here or how to correctly type the `defaultDataProvider`.
you can reproduce the issue by just changing `export const defaultDataProvider = {` to `export const defaultDataProvider:DataProvider = {` (and of course import the `DataProvider` type.

I used a workaround `export const defaultDataProvider: DataProvider = {} as DataProvider` but I don't like this. I am still interested to understand this TypeError (I used AI but it couldn't give me logical answer)

## How To Test

giving that this change was intended to keep everything as the same, I assumed that the current tests should be enough for this simple and small refactoring

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests**  (check the above How To Test section)
- [ ] The PR includes one or several **stories** (check the above How To Test section)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
