### PR TITLE
Feat(crm): Wording start deal

### DIFF
--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -107,11 +107,6 @@ export const DealCreate = ({ open }: { open: boolean }) => {
                             validate={validateRequired}
                         />
                     </ReferenceInput>
-                    <DateInput
-                        source="start_at"
-                        defaultValue={new Date()}
-                        fullWidth
-                    />
                     <SelectInput
                         source="stage"
                         choices={stageChoices}
@@ -124,6 +119,13 @@ export const DealCreate = ({ open }: { open: boolean }) => {
                         choices={typeChoices}
                     />
                     <NumberInput source="amount" defaultValue={0} />
+                    <DateInput
+                        source="start_at"
+                        defaultValue={new Date()}
+                        fullWidth
+                        label="Starting date"
+                        readOnly
+                    />
                 </SimpleForm>
             </Create>
         </Dialog>

--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -84,7 +84,7 @@ const DealShowContent = () => {
                     <Box display="flex" mt={2}>
                         <Box display="flex" mr={5} flexDirection="column">
                             <Typography color="textSecondary" variant="body2">
-                                Start
+                                Starting date
                             </Typography>
                             <Typography variant="subtitle1">
                                 {format(record.start_at, 'PP')}


### PR DESCRIPTION
Change `start_at` label for deals.
Set `start_at` input as read-only.