### PR TITLE
Fix `<AutocompleteInput>` clear button does not clear new choice 

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -24,6 +24,7 @@ import {
     OnChange,
     InsideReferenceInputOnChange,
     WithInputProps,
+    OnCreate,
 } from './AutocompleteInput.stories';
 import { act } from '@testing-library/react-hooks';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
@@ -1690,6 +1691,21 @@ describe('<AutocompleteInput />', () => {
         await waitFor(() => {
             expect(input.value).toEqual('');
         });
+    });
+
+    it('should clear the input mutiple tiles with on create set', async () => {
+        render(<OnCreate />);
+
+        const input = (await screen.findByLabelText(
+            'Author'
+        )) as HTMLInputElement;
+        userEvent.type(input, 'New choice');
+        const clear = screen.getByLabelText('Clear value');
+        fireEvent.click(clear);
+        expect(input.value).toEqual('');
+        userEvent.type(input, 'New choice');
+        fireEvent.click(clear);
+        expect(input.value).toEqual('');
     });
 
     it('should handle nullish values', async () => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -1695,16 +1695,30 @@ describe('<AutocompleteInput />', () => {
 
     it('should clear the input mutiple tiles with on create set', async () => {
         render(<OnCreate />);
-
-        const input = (await screen.findByLabelText(
+        let input = (await screen.findByLabelText(
             'Author'
         )) as HTMLInputElement;
+
+        fireEvent.focus(input);
+        expect(screen.getAllByRole('option')).toHaveLength(5);
+        expect(screen.queryByText('Create New choice')).toBeNull();
+
         userEvent.type(input, 'New choice');
-        const clear = screen.getByLabelText('Clear value');
-        fireEvent.click(clear);
+        expect(screen.getAllByRole('option')).toHaveLength(1);
+        expect(screen.getByText('Create New choice')).toBeDefined();
+
+        fireEvent.click(screen.getByLabelText('Clear value'));
         expect(input.value).toEqual('');
+        expect(screen.getAllByRole('option')).toHaveLength(6);
+        expect(screen.queryByText('Create New choice')).toBeNull();
+
         userEvent.type(input, 'New choice');
-        fireEvent.click(clear);
+        expect(screen.getAllByRole('option')).toHaveLength(1);
+        expect(screen.getByText('Create New choice')).toBeDefined();
+
+        fireEvent.click(screen.getByLabelText('Clear value'));
+        expect(screen.getAllByRole('option')).toHaveLength(6);
+        expect(screen.queryByText('Create New choice')).toBeNull();
         expect(input.value).toEqual('');
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -467,7 +467,10 @@ If you provided a React element for the optionText prop, you must also provide t
             setFilterValue(newInputValue);
             debouncedSetFilter(newInputValue);
         }
-
+        if (reason === 'clear') {
+            setFilterValue('');
+            debouncedSetFilter('');
+        }
         onInputChange?.(event, newInputValue, reason);
     };
 
@@ -523,13 +526,14 @@ If you provided a React element for the optionText prop, you must also provide t
         return filteredOptions;
     };
 
-    const handleAutocompleteChange = (
-        event: any,
-        newValue: any,
-        _reason: string
-    ) => {
-        handleChangeWithCreateSupport(newValue != null ? newValue : emptyValue);
-    };
+    const handleAutocompleteChange = useCallback(
+        (event: any, newValue: any, _reason: string) => {
+            handleChangeWithCreateSupport(
+                newValue != null ? newValue : emptyValue
+            );
+        },
+        [emptyValue, handleChangeWithCreateSupport]
+    );
 
     const oneSecondHasPassed = useTimeout(1000, filterValue);
 


### PR DESCRIPTION
Following #10023 

## Problem

Fixes #9993

## How To Test

1. Navigate to [this story](https://react-admin-storybook-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-autocompleteinput--create-label)
2. Fill the input with a choice that does not exist
3. Click the clear button -> it should delete the new choice
4. Fill the input again with a choice that does not exist
5. Click the clear button -> it should now delete the new choice
