### PR TITLE
Update SelectInput to support an array of strings as choices

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -127,7 +127,7 @@ If you need to *fetch* the options from another resource, you're actually editin
 You can also pass an *array of strings* for the choices:
 
 ```jsx
-const roles = ['admin', 'u001', 'u002', 'u003'];
+const roles = ['Admin', 'Editor', 'Moderator', 'Reviewer'];  
 <AutocompleteArrayInput source="roles" choices={roles} />
 // is equivalent to
 const choices = roles.map(value => ({ id: value, name: value }));

--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -124,13 +124,13 @@ If you need to *fetch* the options from another resource, you're actually editin
 </ReferenceArrayInput>
 ```
 
-If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
+You can also pass an *array of strings* for the choices:
 
 ```jsx
-const possibleValues = ['programming', 'lifestyle', 'photography'];
-const ucfirst = name => name.charAt(0).toUpperCase() + name.slice(1);
-const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }));
-
+const roles = ['admin', 'u001', 'u002', 'u003'];
+<AutocompleteArrayInput source="roles" choices={roles} />
+// is equivalent to
+const choices = roles.map(value => ({ id: value, name: value }));
 <AutocompleteArrayInput source="roles" choices={choices} />
 ```
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -132,13 +132,13 @@ If you need to *fetch* the options from another resource, you're usually editing
 
 See [Selecting a foreign key](#selecting-a-foreign-key) below for more information.
 
-If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
+You can also pass an *array of strings* for the choices:
 
 ```jsx
-const possibleValues = ['tech', 'lifestyle', 'people'];
-const ucfirst = name => name.charAt(0).toUpperCase() + name.slice(1);
-const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }));
-
+const categories = ['tech', 'lifestyle', 'people'];
+<AutocompleteInput source="category" choices={categories} />
+// is equivalent to
+const choices = categories.map(value => ({ id: value, name: value }));
 <AutocompleteInput source="category" choices={choices} />
 ```
 

--- a/docs/CheckboxGroupInput.md
+++ b/docs/CheckboxGroupInput.md
@@ -112,13 +112,13 @@ If you need to *fetch* the options from another resource, you're actually editin
 </ReferenceArrayInput>
 ```
 
-If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
+You can also pass an *array of strings* for the choices:
 
 ```jsx
-const possibleValues = ['programming', 'lifestyle', 'photography'];
-const ucfirst = name => name.charAt(0).toUpperCase() + name.slice(1);
-const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }));
-
+const roles = ['admin', 'u001', 'u002', 'u003'];
+<CheckboxGroupInput source="roles" choices={roles} />
+// is equivalent to
+const choices = roles.map(value => ({ id: value, name: value }));
 <CheckboxGroupInput source="roles" choices={choices} />
 ```
 

--- a/docs/CheckboxGroupInput.md
+++ b/docs/CheckboxGroupInput.md
@@ -115,7 +115,7 @@ If you need to *fetch* the options from another resource, you're actually editin
 You can also pass an *array of strings* for the choices:
 
 ```jsx
-const roles = ['admin', 'u001', 'u002', 'u003'];
+const roles = ['Admin', 'Editor', 'Moderator', 'Reviewer'];
 <CheckboxGroupInput source="roles" choices={roles} />
 // is equivalent to
 const choices = roles.map(value => ({ id: value, name: value }));

--- a/docs/RadioButtonGroupInput.md
+++ b/docs/RadioButtonGroupInput.md
@@ -116,13 +116,13 @@ If you need to *fetch* the options from another resource, you're actually editin
 
 See [Selecting a foreign key](#selecting-a-foreign-key) below for more information.
 
-If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
+You can also pass an *array of strings* for the choices:
 
 ```jsx
-const possibleValues = ['tech', 'lifestyle', 'people'];
-const ucfirst = name => name.charAt(0).toUpperCase() + name.slice(1);
-const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }));
-
+const categories = ['tech', 'lifestyle', 'people'];
+<RadioButtonGroupInput source="category" choices={categories} />
+// is equivalent to
+const choices = categories.map(value => ({ id: value, name: value }));
 <RadioButtonGroupInput source="category" choices={choices} />
 ```
 

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -132,7 +132,7 @@ If you need to *fetch* the options from another resource, you're actually editin
 You can also pass an *array of strings* for the choices:
 
 ```jsx
-const roles = ['admin', 'u001', 'u002', 'u003'];
+const roles = ['Admin', 'Editor', 'Moderator', 'Reviewer'];
 <SelectArrayInput source="roles" choices={roles} />
 // is equivalent to
 const choices = roles.map(value => ({ id: value, name: value }));

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -129,13 +129,13 @@ If you need to *fetch* the options from another resource, you're actually editin
 </ReferenceArrayInput>
 ```
 
-If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
+You can also pass an *array of strings* for the choices:
 
 ```jsx
-const possibleValues = ['programming', 'lifestyle', 'photography'];
-const ucfirst = name => name.charAt(0).toUpperCase() + name.slice(1);
-const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }));
-
+const roles = ['admin', 'u001', 'u002', 'u003'];
+<SelectArrayInput source="roles" choices={roles} />
+// is equivalent to
+const choices = roles.map(value => ({ id: value, name: value }));
 <SelectArrayInput source="roles" choices={choices} />
 ```
 

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -142,13 +142,13 @@ If you need to *fetch* the options from another resource, you're actually editin
 
 See [Selecting a foreign key](#selecting-a-foreign-key) below for more information.
 
-If you have an *array of values* for the options, turn it into an array of objects with the `id` and `name` properties:
+You can also pass an *array of strings* for the choices:
 
 ```jsx
-const possibleValues = ['tech', 'lifestyle', 'people'];
-const ucfirst = name => name.charAt(0).toUpperCase() + name.slice(1);
-const choices = possibleValues.map(value => ({ id: value, name: ucfirst(value) }));
-
+const categories = ['tech', 'lifestyle', 'people'];
+<SelectInput source="category" choices={categories} />
+// is equivalent to
+const choices = categories.map(value => ({ id: value, name: value }));
 <SelectInput source="category" choices={choices} />
 ```
 

--- a/packages/ra-core/src/form/choices/useChoicesContext.ts
+++ b/packages/ra-core/src/form/choices/useChoicesContext.ts
@@ -4,14 +4,20 @@ import { useList } from '../../controller';
 import { ChoicesContext, ChoicesContextValue } from './ChoicesContext';
 
 export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
-    options: Partial<ChoicesContextValue> & { choices?: ChoicesType[] } = {}
+    options: Partial<ChoicesContextValue> & {
+        choices?: ChoicesType[];
+    } = {}
 ): ChoicesContextValue<ChoicesType> => {
     const context = useContext(
         ChoicesContext
     ) as ChoicesContextValue<ChoicesType>;
+    const choices =
+        options.choices && isArrayOfStrings(options.choices)
+            ? convertOptionsToChoices(options.choices)
+            : options.choices;
     // @ts-ignore cannot satisfy the type of useList because of ability to pass partial options
-    const { data, ...list } = useList<ChoicesType>({
-        data: options.choices,
+    const { data, ...list } = useList<any>({
+        data: choices,
         isLoading: options.isLoading ?? false,
         isPending: options.isPending ?? false,
         isFetching: options.isFetching ?? false,
@@ -58,3 +64,13 @@ export const useChoicesContext = <ChoicesType extends RaRecord = RaRecord>(
 
     return result as ChoicesContextValue<ChoicesType>;
 };
+
+const isArrayOfStrings = (choices: any[]): choices is string[] =>
+    Array.isArray(choices) &&
+    choices.every(choice => typeof choice === 'string');
+
+const convertOptionsToChoices = (options: string[]) =>
+    options.map(choice => ({
+        id: choice,
+        name: choice,
+    }));

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -65,7 +65,7 @@ export const StringChoices = () => (
     <Wrapper>
         <AutocompleteArrayInput
             source="roles"
-            choices={['admin', 'u001', 'u002', 'u003']}
+            choices={['Admin', 'Editor', 'Moderator', 'Reviewer']}
         />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -61,6 +61,15 @@ export const Basic = () => (
     </Wrapper>
 );
 
+export const StringChoices = () => (
+    <Wrapper>
+        <AutocompleteArrayInput
+            source="roles"
+            choices={['admin', 'u001', 'u002', 'u003']}
+        />
+    </Wrapper>
+);
+
 export const OnChange = ({
     onChange = (value, records) => console.log({ value, records }),
 }: Pick<AutocompleteArrayInputProps, 'onChange'>) => (

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -110,6 +110,21 @@ export const Basic = ({ onSuccess = console.log }) => (
     </Wrapper>
 );
 
+export const StringChoices = () => (
+    <Wrapper>
+        <AutocompleteInput
+            source="author"
+            choices={[
+                'Leo Tolstoy',
+                'Victor Hugo',
+                'William Shakespeare',
+                'Charles Baudelaire',
+                'Marcel Proust',
+            ]}
+        />
+    </Wrapper>
+);
+
 export const Required = () => (
     <Wrapper>
         <AutocompleteInput

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
@@ -63,7 +63,7 @@ export const StringChoices = () => (
     <Wrapper>
         <CheckboxGroupInput
             source="roles"
-            choices={['admin', 'u001', 'u002', 'u003']}
+            choices={['Admin', 'Editor', 'Moderator', 'Reviewer']}
         />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.stories.tsx
@@ -34,26 +34,38 @@ const choices = [
     { id: 6, name: 'Option 6', details: 'This is option 6' },
 ];
 
-export const Basic = () => (
+const Wrapper = ({ children }) => (
     <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
         <Create
             resource="posts"
             record={{ roles: ['u001', 'u003'] }}
             sx={{ width: 600 }}
         >
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="roles"
-                    choices={[
-                        { id: 'admin', name: 'Admin' },
-                        { id: 'u001', name: 'Editor' },
-                        { id: 'u002', name: 'Moderator' },
-                        { id: 'u003', name: 'Reviewer' },
-                    ]}
-                />
-            </SimpleForm>
+            <SimpleForm>{children}</SimpleForm>
         </Create>
     </AdminContext>
+);
+
+const roleChoices = [
+    { id: 'admin', name: 'Admin' },
+    { id: 'u001', name: 'Editor' },
+    { id: 'u002', name: 'Moderator' },
+    { id: 'u003', name: 'Reviewer' },
+];
+
+export const Basic = () => (
+    <Wrapper>
+        <CheckboxGroupInput source="roles" choices={roleChoices} />
+    </Wrapper>
+);
+
+export const StringChoices = () => (
+    <Wrapper>
+        <CheckboxGroupInput
+            source="roles"
+            choices={['admin', 'u001', 'u002', 'u003']}
+        />
+    </Wrapper>
 );
 
 const dataProvider = testDataProvider({
@@ -104,81 +116,41 @@ export const InsideReferenceArrayInput = () => (
 );
 
 export const Disabled = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="posts"
-            record={{ options: [1, 2] }}
-            sx={{ width: 600 }}
-        >
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="options"
-                    disabled
-                    choices={choices}
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <CheckboxGroupInput source="roles" disabled choices={roleChoices} />
+    </Wrapper>
 );
 
 export const LabelPlacement = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="posts"
-            record={{ options: [1, 2] }}
-            sx={{ width: 600 }}
-        >
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="options"
-                    choices={choices}
-                    labelPlacement="bottom"
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <CheckboxGroupInput
+            source="roles"
+            choices={roleChoices}
+            labelPlacement="bottom"
+        />
+    </Wrapper>
 );
 
 export const Column = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="posts"
-            record={{ options: [1, 2] }}
-            sx={{ width: 600 }}
-        >
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="options"
-                    choices={choices}
-                    row={false}
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <CheckboxGroupInput source="roles" choices={roleChoices} row={false} />
+    </Wrapper>
 );
 
 export const Options = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="posts"
-            record={{ options: [1, 2] }}
-            sx={{ width: 600 }}
-        >
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="options"
-                    choices={choices}
-                    options={{
-                        icon: <FavoriteBorder />,
-                        checkedIcon: <Favorite />,
-                    }}
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <CheckboxGroupInput
+            source="roles"
+            choices={roleChoices}
+            options={{
+                icon: <FavoriteBorder />,
+                checkedIcon: <Favorite />,
+            }}
+        />
+    </Wrapper>
 );
 
-export const CustomOptionText = () => (
+export const OptionText = () => (
     <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
         <Create
             resource="posts"
@@ -188,7 +160,7 @@ export const CustomOptionText = () => (
             <SimpleForm>
                 <CheckboxGroupInput
                     source="options"
-                    optionText={<OptionText />}
+                    optionText={<OptionTextComponent />}
                     choices={choices}
                     row={false}
                     sx={{
@@ -202,7 +174,7 @@ export const CustomOptionText = () => (
     </AdminContext>
 );
 
-const OptionText = () => {
+const OptionTextComponent = () => {
     const record = useRecordContext();
     return (
         <>
@@ -215,33 +187,23 @@ const OptionText = () => {
 };
 
 export const Validate = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create resource="posts" sx={{ width: 600 }}>
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="options"
-                    choices={choices}
-                    validate={[required()]}
-                />
-                <TextInput source="foo" />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <CheckboxGroupInput
+            source="roles"
+            choices={roleChoices}
+            validate={[required()]}
+        />
+    </Wrapper>
 );
 
 export const HelperText = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create resource="posts" sx={{ width: 600 }}>
-            <SimpleForm>
-                <CheckboxGroupInput
-                    source="options"
-                    choices={choices}
-                    validate={[required()]}
-                    helperText="Helper text"
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <CheckboxGroupInput
+            source="roles"
+            choices={roleChoices}
+            helperText="Helper text"
+        />
+    </Wrapper>
 );
 
 export const TranslateChoice = () => {
@@ -331,19 +293,9 @@ const SetFocusButton = ({ source }) => {
 };
 
 export const SetFocus = () => (
-    <AdminContext defaultTheme="light">
-        <Create resource="posts" sx={{ width: 600 }}>
-            <SimpleForm>
-                <TextInput source="title" />
-                <CheckboxGroupInput
-                    source="tags"
-                    choices={[
-                        { id: 'tech', name: 'option.tech' },
-                        { id: 'business', name: 'option.business' },
-                    ]}
-                />
-                <SetFocusButton source="tags" />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <TextInput source="title" />
+        <CheckboxGroupInput source="roles" choices={roleChoices} />
+        <SetFocusButton source="roles" />
+    </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.stories.tsx
@@ -26,6 +26,15 @@ export const Basic = () => (
     </Wrapper>
 );
 
+export const StringChoices = () => (
+    <Wrapper>
+        <RadioButtonGroupInput
+            source="category"
+            choices={['Tech', 'Lifestyle', 'People']}
+        />
+    </Wrapper>
+);
+
 export const Row = () => (
     <Wrapper>
         <RadioButtonGroupInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -26,96 +26,108 @@ export default { title: 'ra-ui-materialui/input/SelectArrayInput' };
 
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
-export const Basic = () => (
+const Wrapper = ({ children }) => (
     <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="users"
-            record={{ roles: ['u001', 'u003'] }}
-            sx={{ width: 600 }}
-        >
-            <SimpleForm>
-                <SelectArrayInput
-                    source="roles"
-                    choices={[
-                        { id: 'admin', name: 'Admin' },
-                        { id: 'u001', name: 'Editor' },
-                        { id: 'u002', name: 'Moderator' },
-                        { id: 'u003', name: 'Reviewer' },
-                    ]}
-                    sx={{ width: 300 }}
-                />
-                <SelectArrayInput
-                    source="roles"
-                    variant="outlined"
-                    choices={[
-                        { id: 'admin', name: 'Admin' },
-                        { id: 'u001', name: 'Editor' },
-                        { id: 'u002', name: 'Moderator' },
-                        { id: 'u003', name: 'Reviewer' },
-                    ]}
-                    sx={{ width: 300 }}
-                />
-                <SelectArrayInput
-                    source="roles"
-                    variant="standard"
-                    choices={[
-                        { id: 'admin', name: 'Admin' },
-                        { id: 'u001', name: 'Editor' },
-                        { id: 'u002', name: 'Moderator' },
-                        { id: 'u003', name: 'Reviewer' },
-                    ]}
-                    sx={{ width: 300 }}
-                />
-            </SimpleForm>
+        <Create resource="posts" sx={{ width: 600 }}>
+            <SimpleForm>{children}</SimpleForm>
         </Create>
     </AdminContext>
+);
+
+export const Basic = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+        />
+    </Wrapper>
+);
+
+export const StringChoices = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={['Admin', 'Editor', 'Moderator', 'Reviewer']}
+        />
+    </Wrapper>
+);
+
+export const Variant = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+        />
+        <SelectArrayInput
+            source="roles"
+            variant="outlined"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+        />
+        <SelectArrayInput
+            source="roles"
+            variant="standard"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+        />
+    </Wrapper>
 );
 
 export const DefaultValue = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create resource="users" sx={{ width: 600 }}>
-            <SimpleForm>
-                <SelectArrayInput
-                    source="roles"
-                    defaultValue={['u001', 'u003']}
-                    choices={[
-                        { id: 'admin', name: 'Admin' },
-                        { id: 'u001', name: 'Editor' },
-                        { id: 'u002', name: 'Moderator' },
-                        { id: 'u003', name: 'Reviewer' },
-                    ]}
-                    sx={{ width: 300 }}
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            defaultValue={['u001', 'u003']}
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+            sx={{ width: 300 }}
+        />
+    </Wrapper>
 );
 
 export const InsideArrayInput = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create resource="users" sx={{ width: 600 }}>
-            <SimpleForm>
-                <ArrayInput
-                    source="items"
-                    label="Items"
-                    defaultValue={[{ data: ['foo'] }]}
-                >
-                    <SimpleFormIterator>
-                        <SelectArrayInput
-                            label="data"
-                            source="data"
-                            choices={[
-                                { id: 'foo', name: 'Foo' },
-                                { id: 'bar', name: 'Bar' },
-                            ]}
-                            defaultValue={['foo']}
-                        />
-                    </SimpleFormIterator>
-                </ArrayInput>
-                <FormInspector name="items" />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <ArrayInput
+            source="items"
+            label="Items"
+            defaultValue={[{ data: ['foo'] }]}
+        >
+            <SimpleFormIterator>
+                <SelectArrayInput
+                    label="data"
+                    source="data"
+                    choices={[
+                        { id: 'foo', name: 'Foo' },
+                        { id: 'bar', name: 'Bar' },
+                    ]}
+                    defaultValue={['foo']}
+                />
+            </SimpleFormIterator>
+        </ArrayInput>
+        <FormInspector name="items" />
+    </Wrapper>
 );
 
 const choices = [
@@ -158,22 +170,14 @@ const CreateRole = () => {
 };
 
 export const CreateProp = () => (
-    <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
-        <Create
-            resource="users"
-            record={{ roles: ['u001', 'u003'] }}
-            sx={{ width: 600 }}
-        >
-            <SimpleForm>
-                <SelectArrayInput
-                    source="roles"
-                    choices={choices}
-                    sx={{ width: 300 }}
-                    create={<CreateRole />}
-                />
-            </SimpleForm>
-        </Create>
-    </AdminContext>
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={choices}
+            defaultValue={['u001', 'u003']}
+            create={<CreateRole />}
+        />
+    </Wrapper>
 );
 
 export const DifferentIdTypes = () => {
@@ -201,7 +205,7 @@ export const DifferentIdTypes = () => {
     );
 };
 
-export const DifferentSizes = () => {
+export const Size = () => {
     const fakeData = {
         bands: [{ id: 1, name: 'band_1', members: [1, '2'] }],
         artists: [

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -7,6 +7,7 @@ import { SimpleForm } from '../form';
 import { SelectInput } from './SelectInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import {
+    StringChoices,
     EmptyText,
     InsideReferenceInput,
     InsideReferenceInputDefaultValue,
@@ -129,6 +130,14 @@ describe('<SelectInput />', () => {
             const options = screen.queryAllByRole('option');
             expect(options.length).toEqual(6);
             expect(options[1].textContent).toEqual('Created');
+        });
+
+        it('should accept strings as choices', () => {
+            render(<StringChoices />);
+            fireEvent.mouseDown(screen.getByLabelText('Gender'));
+            const options = screen.queryAllByRole('option');
+            expect(options.length).toEqual(3);
+            expect(options[1].textContent).toEqual('Male');
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -35,6 +35,12 @@ export const Basic = () => (
     </Wrapper>
 );
 
+export const StringChoices = () => (
+    <Wrapper>
+        <SelectInput source="gender" choices={['Male', 'Female']} />
+    </Wrapper>
+);
+
 export const DefaultValue = () => (
     <Wrapper>
         <SelectInput


### PR DESCRIPTION
## Problem

For `SelectInput` and other selection inputs, sometimes the list of options is simply an array of strings. Doing the conversion to an array of option objects isn't intuitive. 

## Solution

Support string choices by default. 

```jsx
<SelectInput source="gender" choices={['Male', 'Female']} />
```

This concerns the following components:

- `SelectInput`
- `SelectArrayInput`
- `AutocompleteInput`
- `AutocompleteArrayInput`
- `RadioButtonGroupInput`
- `CheckboxGroupInput`