### PR TITLE
[Documentation] Mention dialogs in Buttons doc

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -39,7 +39,7 @@ It also supports [all the other `<Button>` props](#button).
 
 **Tip**: If you want to link to the Edit view manually, use the `/{resource}/{record.id}` location.
 
-**Tip:** You are also able to use a [`<EditInDialogButton>`](./EditInDialogButton.md) to opening an `<Edit>` view inside a dialog, hence allowing to edit a record without leaving the current view.
+**Tip:** To allow users to edit a record without leaving the current view, use the [`<EditInDialogButton>`](./EditInDialogButton.md) component.
 
 ### `<ShowButton>`
 
@@ -97,7 +97,7 @@ It also supports [all the other `<Button>` props](#button).
 
 **Tip**: If you want to link to the Create view manually, use the `/{resource}/create` location.
 
-**Tip:** You are also able to use a [`<CreateInDialogButton>`](./CreateInDialogButton.md) to open a `<Create>` view inside a dialog, hence allowing to create a new record without leaving the current view.
+**Tip:** To allow users to edit a record without leaving the current view, use the [`<EditInDialogButton>`](./EditInDialogButton.md) component.
 
 #### `sx`: CSS API
 

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -39,6 +39,8 @@ It also supports [all the other `<Button>` props](#button).
 
 **Tip**: If you want to link to the Edit view manually, use the `/{resource}/{record.id}` location.
 
+**Tip:** You are also able to use a [`<EditInDialogButton>`](./EditInDialogButton.md) to opening an `<Edit>` view inside a dialog, hence allowing to edit a record without leaving the current view.
+
 ### `<ShowButton>`
 
 Opens the Show view of the current record:
@@ -94,6 +96,8 @@ const CommentCreateButton = () => <CreateButton label="Create comment" />;
 It also supports [all the other `<Button>` props](#button).
 
 **Tip**: If you want to link to the Create view manually, use the `/{resource}/create` location.
+
+**Tip:** You are also able to use a [`<CreateInDialogButton>`](./CreateInDialogButton.md) to open a `<Create>` view inside a dialog, hence allowing to create a new record without leaving the current view.
 
 #### `sx`: CSS API
 


### PR DESCRIPTION
## Problem

In the OSS doc for buttons, we (briefly) document EditButton and CreateButton

https://marmelab.com/react-admin/Buttons.html

But there is no mention of the Dialog alternatives (EditInDialog and CreateInDialog).

It’s a pity, because these components have their own doc chapter.

https://marmelab.com/react-admin/EditInDialogButton.html

https://marmelab.com/react-admin/CreateInDialogButton.html

## Solution

Add a reference to the Dialog alternative

## Additional Checks

- ~[ ] The PR targets `master` for a bugfix, or `next` for a feature~
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
