### PR TITLE
Fix(crm): Add concordance between the empty components

### DIFF
--- a/examples/crm/src/companies/CompanyEmpty.tsx
+++ b/examples/crm/src/companies/CompanyEmpty.tsx
@@ -18,7 +18,7 @@ export const CompanyEmpty = () => {
                 No companies found
             </Typography>
             <Typography
-                variant="caption"
+                variant="body2"
                 align="center"
                 color="text.secondary"
                 gutterBottom

--- a/examples/crm/src/companies/CompanyEmpty.tsx
+++ b/examples/crm/src/companies/CompanyEmpty.tsx
@@ -8,23 +8,25 @@ export const CompanyEmpty = () => {
         <Stack
             justifyContent="center"
             alignItems="center"
-            gap={1}
+            gap={3}
             sx={{
                 height: `calc(100dvh - ${appbarHeight}px)`,
             }}
         >
             <img src="./img/empty.svg" alt="No contacts found" />
-            <Typography variant="h6" fontWeight="bold">
-                No companies found
-            </Typography>
-            <Typography
-                variant="body2"
-                align="center"
-                color="text.secondary"
-                gutterBottom
-            >
-                It looks like your company list is empty.
-            </Typography>
+            <Stack gap={0} alignItems="center">
+                <Typography variant="h6" fontWeight="bold">
+                    No companies found
+                </Typography>
+                <Typography
+                    variant="body2"
+                    align="center"
+                    color="text.secondary"
+                    gutterBottom
+                >
+                    It looks like your company list is empty.
+                </Typography>
+            </Stack>
             <Stack spacing={2} direction="row">
                 <CreateButton variant="contained" label="Create Company" />
             </Stack>

--- a/examples/crm/src/contacts/ContactEmpty.tsx
+++ b/examples/crm/src/contacts/ContactEmpty.tsx
@@ -9,23 +9,25 @@ export const ContactEmpty = () => {
         <Stack
             justifyContent="center"
             alignItems="center"
-            gap={1}
+            gap={3}
             sx={{
                 height: `calc(100dvh - ${appbarHeight}px)`,
             }}
         >
             <img src="./img/empty.svg" alt="No contacts found" />
-            <Typography variant="h6" fontWeight="bold">
-                No contacts found
-            </Typography>
-            <Typography
-                variant="body2"
-                align="center"
-                color="text.secondary"
-                gutterBottom
-            >
-                It looks like your contact list is empty.
-            </Typography>
+            <Stack gap={0} alignItems="center">
+                <Typography variant="h6" fontWeight="bold">
+                    No contacts found
+                </Typography>
+                <Typography
+                    variant="body2"
+                    align="center"
+                    color="text.secondary"
+                    gutterBottom
+                >
+                    It looks like your contact list is empty.
+                </Typography>
+            </Stack>
             <Stack spacing={2} direction="row">
                 <CreateButton variant="contained" label="New Contact" />
                 <ContactImportButton />

--- a/examples/crm/src/deals/DealEmpty.tsx
+++ b/examples/crm/src/deals/DealEmpty.tsx
@@ -25,7 +25,7 @@ export const DealEmpty = () => {
         <Stack
             justifyContent="center"
             alignItems="center"
-            gap={2}
+            gap={1}
             sx={{
                 height: `calc(100dvh - ${appbarHeight}px)`,
             }}

--- a/examples/crm/src/deals/DealEmpty.tsx
+++ b/examples/crm/src/deals/DealEmpty.tsx
@@ -25,7 +25,7 @@ export const DealEmpty = () => {
         <Stack
             justifyContent="center"
             alignItems="center"
-            gap={1}
+            gap={3}
             sx={{
                 height: `calc(100dvh - ${appbarHeight}px)`,
             }}
@@ -33,17 +33,19 @@ export const DealEmpty = () => {
             <img src="./img/empty.svg" alt="No contacts found" />
             {contacts && contacts.length > 0 ? (
                 <>
-                    <Typography variant="h6" fontWeight="bold">
-                        No deals found
-                    </Typography>
-                    <Typography
-                        variant="body2"
-                        align="center"
-                        color="text.secondary"
-                        gutterBottom
-                    >
-                        It looks like your deal list is empty.
-                    </Typography>
+                    <Stack gap={0} alignItems="center">
+                        <Typography variant="h6" fontWeight="bold">
+                            No deals found
+                        </Typography>
+                        <Typography
+                            variant="body2"
+                            align="center"
+                            color="text.secondary"
+                            gutterBottom
+                        >
+                            It looks like your deal list is empty.
+                        </Typography>
+                    </Stack>
                     <Stack spacing={2} direction="row">
                         <CreateButton variant="contained" label="Create deal" />
                     </Stack>


### PR DESCRIPTION
## Problem

The spacing of the empty components is not the same

## Solution

Adds a similar gap and modifies the typography

## How To Test
Clear all data and navigate on `Contact`, `Company` or `Deal` pages.
Object.keys(window._database.collections).forEach(key => {window._database.collections[key].items = []})

![Screenshot from 2024-07-24 10-26-10](https://github.com/user-attachments/assets/abcb26b9-5d04-41d7-a578-e60a11505602)
![Screenshot from 2024-07-24 10-26-12](https://github.com/user-attachments/assets/915bd41b-c086-4d9d-a799-b5fa710299c1)
![Screenshot from 2024-07-24 10-26-27](https://github.com/user-attachments/assets/50bf4a1f-0c7e-48c7-bea0-023457fe3f21)

