### PR TITLE
[Doc] Fix wrong link in `CreateButton` usage

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -97,7 +97,7 @@ It also supports [all the other `<Button>` props](#button).
 
 **Tip**: If you want to link to the Create view manually, use the `/{resource}/create` location.
 
-**Tip:** To allow users to edit a record without leaving the current view, use the [`<EditInDialogButton>`](./EditInDialogButton.md) component.
+**Tip:** To allow users to create a record without leaving the current view, use the [`<CreateInDialogButton>`](./CreateInDialogButton.md) component.
 
 #### `sx`: CSS API
 


### PR DESCRIPTION
## Problem

On #10039, a batch with a mistake was applied. 
Wrong applied comment: https://github.com/marmelab/react-admin/pull/10039#discussion_r1687593274

## Solution

Fix that documentation
