### PR TITLE
[Doc] Mention `CreateInDialog` in `ReferenceManyField` doc

### DIFF
--- a/docs/ReferenceManyField.md
+++ b/docs/ReferenceManyField.md
@@ -346,3 +346,45 @@ In these cases, use [the `<ReferenceOneField>` component](./ReferenceOneField.md
 </ReferenceOneField>
 ```
 {% endraw %}
+
+## Adding a related record
+
+To allow users to create a record without leaving the current view, use the [`<CreateInDialogButton>`](./CreateInDialogButton.md) component.
+
+{% raw %}
+```jsx
+import { Edit, SimpleForm, TextInput, ReferenceManyField, WithRecord, Datagrid } from 'react-admin';
+import { CreateInDialogButton } from "@react-admin/ra-form-layout";
+
+const EmployerEdit = () => (
+  <Edit>
+      <SimpleForm>
+          <TextInput source="name" />
+          <TextInput source="address" />
+          <TextInput source="city" />
+          <ReferenceManyField
+              target="employer_id"
+              reference="customers"
+          >
+              <WithRecord
+                  render={record => (
+                      <CreateInDialogButton
+                          record={{ employer_id: record.id }}
+                      >
+                          <SimpleForm>
+                              <TextInput source="first_name" />
+                              <TextInput source="last_name" />
+                          </SimpleForm>
+                      </CreateInDialogButton>
+                  )}
+              />
+              <Datagrid>
+                  <TextField source="first_name" />
+                  <TextField source="last_name" />
+              </Datagrid>
+          </ReferenceManyField>
+      </SimpleForm>
+  </Edit>
+)
+```
+{% endraw %}

--- a/docs/ReferenceManyField.md
+++ b/docs/ReferenceManyField.md
@@ -347,14 +347,14 @@ In these cases, use [the `<ReferenceOneField>` component](./ReferenceOneField.md
 ```
 {% endraw %}
 
-## Adding a related record
+## Adding or editing a related record
 
-To allow users to create a record without leaving the current view, use the [`<CreateInDialogButton>`](./CreateInDialogButton.md) component.
+To allow users to create or edit a record without leaving the current view, use the [`<CreateInDialogButton>`](./CreateInDialogButton.md) or the [`<EditInDialogButton>`](./EditInDialogButton.md) component.
 
 {% raw %}
 ```jsx
 import { Edit, SimpleForm, TextInput, ReferenceManyField, WithRecord, Datagrid } from 'react-admin';
-import { CreateInDialogButton } from "@react-admin/ra-form-layout";
+import { CreateInDialogButton, EditInDialogButton } from "@react-admin/ra-form-layout";
 
 const EmployerEdit = () => (
   <Edit>
@@ -381,6 +381,14 @@ const EmployerEdit = () => (
               <Datagrid>
                   <TextField source="first_name" />
                   <TextField source="last_name" />
+                  <EditInDialogButton>
+                        <SimpleForm
+                          record={{ employer_id: record.id }}
+                        >
+                            <TextInput source="first_name" />
+                            <TextInput source="last_name" />
+                        </SimpleForm>
+                    </EditInDialogButton>
               </Datagrid>
           </ReferenceManyField>
       </SimpleForm>

--- a/docs/ReferenceManyField.md
+++ b/docs/ReferenceManyField.md
@@ -381,14 +381,18 @@ const EmployerEdit = () => (
               <Datagrid>
                   <TextField source="first_name" />
                   <TextField source="last_name" />
-                  <EditInDialogButton>
-                        <SimpleForm
-                          record={{ employer_id: record.id }}
-                        >
+                  <WithRecord
+                    render={record => (
+                      <EditInDialogButton>
+                          <SimpleForm
+                            record={{ employer_id: record.id }}
+                          >
                             <TextInput source="first_name" />
                             <TextInput source="last_name" />
-                        </SimpleForm>
-                    </EditInDialogButton>
+                          </SimpleForm>
+                        </EditInDialogButton>
+                      )}
+                  />
               </Datagrid>
           </ReferenceManyField>
       </SimpleForm>


### PR DESCRIPTION
## Problem

When rendering a list of related records in a ReferenceManyField, editing and creating a related element isn’t straightforward. One can use CreateButton, but the user experience is clunky.

## Solution

Add a “Adding a related record” section, showing the use of CreateInDialog button.

cf [https://react-admin.github.io/ra-enterprise/?path=/story/ra-form-layout-dialogform-createindialogbutton--in-reference-field](https://react-admin.github.io/ra-enterprise/?path=/story/ra-form-layout-dialogform-createindialogbutton--in-reference-field "smartCard-inline")

## Screenshot

![image](https://github.com/user-attachments/assets/be8ee510-ef24-46b4-8709-f36f012d8188)