### PR TITLE
Fix(crm): Ask for confirm when deleting a deal

### DIFF
--- a/examples/crm/src/deals/DealEdit.tsx
+++ b/examples/crm/src/deals/DealEdit.tsx
@@ -3,7 +3,15 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { Edit, SimpleForm, useRecordContext, useRedirect } from 'react-admin';
+import {
+    DeleteWithConfirmButton,
+    Edit,
+    SaveButton,
+    SimpleForm,
+    Toolbar,
+    useRecordContext,
+    useRedirect,
+} from 'react-admin';
 import { Link } from 'react-router-dom';
 import { Deal } from '../types';
 import { DealInputs } from './DealInputs';
@@ -20,7 +28,7 @@ export const DealEdit = ({ open, id }: { open: boolean; id?: string }) => {
             {!!id ? (
                 <Edit id={id} redirect="show">
                     <EditHeader />
-                    <SimpleForm>
+                    <SimpleForm toolbar={<EditToolbar />}>
                         <DealInputs />
                     </SimpleForm>
                 </Edit>
@@ -62,5 +70,15 @@ function EditHeader() {
                 </Stack>
             </Stack>
         </DialogTitle>
+    );
+}
+
+function EditToolbar() {
+    return (
+        <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <SaveButton />
+
+            <DeleteWithConfirmButton />
+        </Toolbar>
     );
 }


### PR DESCRIPTION
## Problem

Deleting a deal does not ask for confirm from edit page

## Solution

Add confirm modal when deleting a deal

## How To Test

Try to delete a deal from edit page

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
