### PR TITLE
Fix(crm): Create a custom dataprovider for unarchive deal

### DIFF
--- a/examples/crm/src/deals/DealArchivedList.tsx
+++ b/examples/crm/src/deals/DealArchivedList.tsx
@@ -20,7 +20,7 @@ export const DealArchivedList = () => {
     } = useGetList('deals', {
         pagination: { page: 1, perPage: 1000 },
         sort: { field: 'archived_at', order: 'DESC' },
-        filter: { sales_id: identity?.id, archived_at_neq: null },
+        filter: { archived_at_neq: null },
     });
     const [openDialog, setOpenDialog] = useState(false);
 

--- a/examples/crm/src/deals/DealList.tsx
+++ b/examples/crm/src/deals/DealList.tsx
@@ -35,9 +35,11 @@ const DealList = () => {
             perPage={100}
             filterDefaultValues={{
                 sales_id: identity?.id,
+            }}
+            filter={{
                 archived_at_eq: null,
             }}
-            sort={{ field: 'updated_at', order: 'DESC' }}
+            sort={{ field: 'index', order: 'DESC' }}
         >
             <DealLayout />
         </ListBase>

--- a/examples/crm/src/deals/stages.ts
+++ b/examples/crm/src/deals/stages.ts
@@ -21,12 +21,7 @@ export const getDealsByStage = (
     // order each column by index
     dealStages.forEach(stage => {
         dealsByStage[stage.value] = dealsByStage[stage.value].sort(
-            (recordA: Deal, recordB: Deal) => {
-                const dateA = new Date(recordA.updated_at);
-                const dateB = new Date(recordB.updated_at);
-
-                return dateB.getTime() - dateA.getTime();
-            }
+            (recordA: Deal, recordB: Deal) => recordA.index - recordB.index
         );
     });
     return dealsByStage;


### PR DESCRIPTION
## Problem

The current Kaban is based on `update_at`, which is problematic because when a position is changed, the map always resets itself first. But we only want to behave when we unarchived a map.

## Solution

Reset sorting to default index. 

When a deal is unarchived, each index of the current stage is reset. We put the unarchived in first position.

## Additional Checks

- [x] Create `unarchiveDeal` custon function in dataprovider
![Screenshot from 2024-07-24 14-52-25](https://github.com/user-attachments/assets/513f1270-ee21-4c3f-a85b-bda8bf2534db)
