### PR TITLE
Feat(crm): Update redirect calls to disable scrolling to top for deals dialogs

### DIFF
--- a/examples/crm/src/deals/DealCard.tsx
+++ b/examples/crm/src/deals/DealCard.tsx
@@ -32,7 +32,9 @@ export const DealCardContent = ({
 }) => {
     const redirect = useRedirect();
     const handleClick = () => {
-        redirect(`/deals/${deal.id}/show`);
+        redirect(`/deals/${deal.id}/show`, undefined, undefined, undefined, {
+            _scrollToTop: false,
+        });
     };
 
     return (

--- a/examples/crm/src/deals/DealColumn.tsx
+++ b/examples/crm/src/deals/DealColumn.tsx
@@ -42,7 +42,6 @@ export const DealColumn = ({
                     color="text.secondary"
                     fontSize="small"
                 >
-                    (
                     {totalAmount.toLocaleString('en-US', {
                         notation: 'compact',
                         style: 'currency',
@@ -50,7 +49,6 @@ export const DealColumn = ({
                         currencyDisplay: 'narrowSymbol',
                         minimumSignificantDigits: 3,
                     })}
-                    )
                 </Typography>
             </Stack>
             <Droppable droppableId={stage}>

--- a/examples/crm/src/deals/DealEdit.tsx
+++ b/examples/crm/src/deals/DealEdit.tsx
@@ -20,7 +20,9 @@ export const DealEdit = ({ open, id }: { open: boolean; id?: string }) => {
     const redirect = useRedirect();
 
     const handleClose = () => {
-        redirect('/deals');
+        redirect('/deals', undefined, undefined, undefined, {
+            _scrollToTop: false,
+        });
     };
 
     return (

--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -99,7 +99,7 @@ const DealShowContent = () => {
                             ) : (
                                 <>
                                     <ArchiveButton record={record} />
-                                    <EditButton />
+                                    <EditButton scrollToTop={false} />
                                 </>
                             )}
                         </Stack>


### PR DESCRIPTION

## Problem

If the Deal list contains many items and we have to scroll, we lose the scroll position as soon as we open the view or edit popup.

## Solution

Overloading the scrollToTop option for useRedirection


[Screencast from 2024-07-24 20-43-08.webm](https://github.com/user-attachments/assets/4d0238b8-e68c-4799-b683-9e787f2706f4)

