### PR TITLE
Feat(crm): Improve UX for Note form + Harmonize application text size

### DIFF
--- a/examples/crm/src/contacts/ContactShow.tsx
+++ b/examples/crm/src/contacts/ContactShow.tsx
@@ -25,7 +25,7 @@ const ContactShowContent = () => {
     if (isPending || !record) return null;
 
     return (
-        <Box mt={2} display="flex">
+        <Box mt={2} mb={2} display="flex">
             <Box flex="1">
                 <Card>
                     <CardContent>

--- a/examples/crm/src/dashboard/LatestNotes.tsx
+++ b/examples/crm/src/dashboard/LatestNotes.tsx
@@ -88,6 +88,7 @@ export const LatestNotes = () => {
                             </Typography>
                             <div>
                                 <Typography
+                                    variant="body2"
                                     sx={{
                                         display: '-webkit-box',
                                         WebkitLineClamp: 3,

--- a/examples/crm/src/dashboard/Welcome.tsx
+++ b/examples/crm/src/dashboard/Welcome.tsx
@@ -35,12 +35,12 @@ export const Welcome = () => (
             <Typography variant="h5" gutterBottom>
                 CRM demo
             </Typography>
-            <Typography gutterBottom>
+            <Typography variant="body2" gutterBottom>
                 This app runs in the browser, and relies on a mock REST API.
                 Feel free to explore and modify the data - it's local to your
                 computer, and will reset each time you reload.
             </Typography>
-            <Typography gutterBottom>
+            <Typography variant="body2" gutterBottom>
                 It was built using react-admin, an open-source framework. The
                 code for this demo is also open-source. Reading it is a great
                 way to learn react-admin!

--- a/examples/crm/src/deals/ContactList.tsx
+++ b/examples/crm/src/deals/ContactList.tsx
@@ -34,7 +34,7 @@ export const ContactList = () => {
                     <Link
                         component={RouterLink}
                         to={`/contacts/${contact.id}/show`}
-                        variant="subtitle1"
+                        variant="body2"
                     >
                         {contact.first_name} {contact.last_name}
                     </Link>

--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -107,27 +107,27 @@ const DealShowContent = () => {
 
                     <Box display="flex" mt={2}>
                         <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="body2">
+                            <Typography color="textSecondary" variant="caption">
                                 Starting date
                             </Typography>
-                            <Typography variant="subtitle1">
+                            <Typography variant="body2">
                                 {format(record.start_at, 'PP')}
                             </Typography>
                         </Box>
                         <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="body2">
+                            <Typography color="textSecondary" variant="caption">
                                 Expecting closing date
                             </Typography>
-                            <Typography variant="subtitle1">
+                            <Typography variant="body2">
                                 {format(record.expecting_closing_date, 'PP')}
                             </Typography>
                         </Box>
 
                         <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="body2">
+                            <Typography color="textSecondary" variant="caption">
                                 Budget
                             </Typography>
-                            <Typography variant="subtitle1">
+                            <Typography variant="body2">
                                 {record.amount.toLocaleString('en-US', {
                                     notation: 'compact',
                                     style: 'currency',
@@ -139,19 +139,19 @@ const DealShowContent = () => {
                         </Box>
 
                         <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="body2">
+                            <Typography color="textSecondary" variant="caption">
                                 Category
                             </Typography>
-                            <Typography variant="subtitle1">
+                            <Typography variant="body2">
                                 {record.category}
                             </Typography>
                         </Box>
 
                         <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="body2">
+                            <Typography color="textSecondary" variant="caption">
                                 Stage
                             </Typography>
-                            <Typography variant="subtitle1">
+                            <Typography variant="body2">
                                 {findDealLabel(dealStages, record.stage)}
                             </Typography>
                         </Box>
@@ -164,7 +164,7 @@ const DealShowContent = () => {
                             flexDirection="column"
                             minHeight={48}
                         >
-                            <Typography color="textSecondary" variant="body2">
+                            <Typography color="textSecondary" variant="caption">
                                 Contacts
                             </Typography>
                             <ReferenceArrayField
@@ -177,10 +177,12 @@ const DealShowContent = () => {
                     </Box>
 
                     <Box mt={2} mb={2} style={{ whiteSpace: 'pre-line' }}>
-                        <Typography color="textSecondary" variant="body2">
+                        <Typography color="textSecondary" variant="caption">
                             Description
                         </Typography>
-                        <Typography>{record.description}</Typography>
+                        <Typography variant="body2">
+                            {record.description}
+                        </Typography>
                     </Box>
 
                     <Divider />

--- a/examples/crm/src/notes/Note.tsx
+++ b/examples/crm/src/notes/Note.tsx
@@ -8,12 +8,16 @@ import {
     useDelete,
     useUpdate,
     useNotify,
-    FileField,
     Form,
-    TextInput,
-    FileInput,
 } from 'react-admin';
-import { Box, Typography, Tooltip, IconButton, Button } from '@mui/material';
+import {
+    Box,
+    Typography,
+    Tooltip,
+    IconButton,
+    Button,
+    Stack,
+} from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import TrashIcon from '@mui/icons-material/Delete';
 import { SubmitHandler, FieldValues } from 'react-hook-form';
@@ -21,6 +25,7 @@ import { SubmitHandler, FieldValues } from 'react-hook-form';
 import { Status } from '../misc/Status';
 import { ContactNote, DealNote } from '../types';
 import { NoteAttachments } from './NoteAttachments';
+import { NoteInputs } from './NoteInputs';
 
 export const Note = ({
     showStatus,
@@ -53,7 +58,7 @@ export const Note = ({
     };
 
     const handleEnterEditMode = () => {
-        setEditing(true);
+        setEditing(!isEditing);
     };
 
     const handleCancelEdit = () => {
@@ -79,43 +84,56 @@ export const Note = ({
             onMouseEnter={() => setHover(true)}
             onMouseLeave={() => setHover(false)}
         >
-            <Box color="text.secondary">
-                <ReferenceField
-                    record={note}
-                    resource={resource}
-                    source="sales_id"
-                    reference="sales"
-                >
-                    <TextField source="first_name" variant="body1" />
-                </ReferenceField>{' '}
-                <Typography component="span" variant="body1">
-                    added a note on{' '}
-                </Typography>
-                <DateField
-                    source="date"
-                    record={note}
-                    variant="body1"
-                    showTime
-                    locales="en"
-                    options={{
-                        dateStyle: 'full',
-                        timeStyle: 'short',
+            <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+            >
+                <Box color="text.secondary">
+                    <ReferenceField
+                        record={note}
+                        resource={resource}
+                        source="sales_id"
+                        reference="sales"
+                    >
+                        <TextField source="first_name" variant="body1" />
+                    </ReferenceField>{' '}
+                    <Typography component="span" variant="body1">
+                        added a note on{' '}
+                    </Typography>
+                    <DateField
+                        source="date"
+                        record={note}
+                        variant="body1"
+                        showTime
+                        locales="en"
+                        options={{
+                            dateStyle: 'full',
+                            timeStyle: 'short',
+                        }}
+                    />{' '}
+                    {showStatus && <Status status={note.status} />}
+                </Box>
+                <Box
+                    sx={{
+                        visibility: isHover ? 'visible' : 'hidden',
                     }}
-                />{' '}
-                {showStatus && <Status status={note.status} />}
-            </Box>
+                >
+                    <Tooltip title="Edit note">
+                        <IconButton size="small" onClick={handleEnterEditMode}>
+                            <EditIcon />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete note">
+                        <IconButton size="small" onClick={handleDelete}>
+                            <TrashIcon />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
+            </Stack>
             {isEditing ? (
                 <Form onSubmit={handleNoteUpdate} record={note}>
-                    <TextInput
-                        source="text"
-                        label="Update note"
-                        variant="filled"
-                        size="small"
-                        multiline
-                    />
-                    <FileInput source="attachments" multiple>
-                        <FileField source="src" title="title" />
-                    </FileInput>
+                    <NoteInputs showStatus={showStatus} edition />
                     <Box display="flex" justifyContent="flex-end" mt={1}>
                         <Button
                             sx={{ mr: 1 }}
@@ -137,12 +155,10 @@ export const Note = ({
             ) : (
                 <Box
                     sx={{
-                        bgcolor: '#edf3f0',
-                        padding: '1em',
+                        paddingTop: '1em',
                         borderRadius: '10px',
                         display: 'flex',
                         alignItems: 'stretch',
-                        marginBottom: 1,
                     }}
                 >
                     <Box
@@ -162,7 +178,7 @@ export const Note = ({
                                 <Box
                                     component="p"
                                     fontFamily="fontFamily"
-                                    fontSize="body1.fontSize"
+                                    fontSize="body2.fontSize"
                                     lineHeight={1.3}
                                     marginBottom={2.4}
                                     key={index}
@@ -172,29 +188,6 @@ export const Note = ({
                             ))}
 
                         {note.attachments && <NoteAttachments note={note} />}
-                    </Box>
-
-                    <Box
-                        sx={{
-                            marginLeft: 2,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            visibility: isHover ? 'visible' : 'hidden',
-                        }}
-                    >
-                        <Tooltip title="Edit note">
-                            <IconButton
-                                size="small"
-                                onClick={handleEnterEditMode}
-                            >
-                                <EditIcon />
-                            </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Delete note">
-                            <IconButton size="small" onClick={handleDelete}>
-                                <TrashIcon />
-                            </IconButton>
-                        </Tooltip>
                     </Box>
                 </Box>
             )}

--- a/examples/crm/src/notes/Note.tsx
+++ b/examples/crm/src/notes/Note.tsx
@@ -96,15 +96,15 @@ export const Note = ({
                         source="sales_id"
                         reference="sales"
                     >
-                        <TextField source="first_name" variant="body1" />
+                        <TextField source="first_name" variant="body2" />
                     </ReferenceField>{' '}
-                    <Typography component="span" variant="body1">
+                    <Typography component="span" variant="body2">
                         added a note on{' '}
                     </Typography>
                     <DateField
                         source="date"
                         record={note}
-                        variant="body1"
+                        variant="body2"
                         showTime
                         locales="en"
                         options={{
@@ -155,8 +155,7 @@ export const Note = ({
             ) : (
                 <Box
                     sx={{
-                        paddingTop: '1em',
-                        borderRadius: '10px',
+                        paddingTop: '0.5em',
                         display: 'flex',
                         alignItems: 'stretch',
                     }}
@@ -164,6 +163,7 @@ export const Note = ({
                     <Box
                         flex={1}
                         sx={{
+                            maxWidth: '80%',
                             '& p:first-of-type': {
                                 marginTop: 0,
                             },

--- a/examples/crm/src/notes/NoteCreate.tsx
+++ b/examples/crm/src/notes/NoteCreate.tsx
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import {
-    Create,
-    DateTimeInput,
-    FileField,
-    FileInput,
-    FormDataConsumer,
+    CreateBase,
+    Form,
     Identifier,
     RaRecord,
     SaveButton,
-    SelectInput,
-    SimpleForm,
-    TextInput,
-    Toolbar,
     useGetIdentity,
     useListContext,
     useNotify,
@@ -22,21 +15,12 @@ import {
 import { useFormContext } from 'react-hook-form';
 
 import { Stack } from '@mui/material';
-import { Status } from '../misc/Status';
-import { useConfigurationContext } from '../root/ConfigurationContext';
-import { AttachmentNote } from '../types';
+import { NoteInputs } from './NoteInputs';
+import { getCurrentDate } from './note';
 
 const foreignKeyMapping = {
     contacts: 'contact_id',
     deals: 'deal_id',
-};
-
-const getCurrentDate = () => {
-    const now = new Date();
-    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-    now.setSeconds(0);
-    now.setMilliseconds(0);
-    return now.toISOString().slice(0, -1);
 };
 
 export const NoteCreate = ({
@@ -46,64 +30,24 @@ export const NoteCreate = ({
     showStatus?: boolean;
     reference: 'contacts' | 'deals';
 }) => {
-    const { noteStatuses } = useConfigurationContext();
     const resource = useResourceContext();
     const record = useRecordContext();
     const { identity } = useGetIdentity();
 
     if (!record || !identity) return null;
     return (
-        <Create resource={resource} redirect={false}>
-            <SimpleForm
-                toolbar={
-                    <NoteCreateToolbar reference={reference} record={record} />
-                }
-            >
-                <TextInput
-                    source="text"
-                    label="Add a note"
-                    variant="filled"
-                    size="small"
-                    multiline
-                    rows={3}
-                />
-                <FormDataConsumer<{
-                    text: string;
-                    attachments: AttachmentNote[];
-                }>>
-                    {({ formData }) =>
-                        formData.text ? (
-                            <>
-                                <Stack direction="row" spacing={2}>
-                                    {showStatus && (
-                                        <SelectInput
-                                            source="status"
-                                            choices={noteStatuses}
-                                            optionValue="value"
-                                            optionText={optionRenderer}
-                                            isRequired
-                                            defaultValue={'warm'}
-                                        />
-                                    )}
-                                    <DateTimeInput
-                                        source="date"
-                                        label="Date"
-                                        defaultValue={getCurrentDate()}
-                                    />
-                                </Stack>
-                                <FileInput source="attachments" multiple>
-                                    <FileField source="src" title="title" />
-                                </FileInput>
-                            </>
-                        ) : null
-                    }
-                </FormDataConsumer>
-            </SimpleForm>
-        </Create>
+        <CreateBase resource={resource} redirect={false}>
+            <Form>
+                <NoteInputs showStatus={showStatus} />
+                <Stack direction="row" justifyContent={'flex-end'}>
+                    <NoteCreateButton reference={reference} record={record} />
+                </Stack>
+            </Form>
+        </CreateBase>
     );
 };
 
-const NoteCreateToolbar = ({
+const NoteCreateButton = ({
     reference,
     record,
 }: {
@@ -129,28 +73,20 @@ const NoteCreateToolbar = ({
         notify('Note added', { type: 'success' });
     };
     return (
-        <Toolbar>
-            <SaveButton
-                type="button"
-                label="Add this note"
-                icon={<></>}
-                variant="contained"
-                transform={data => ({
-                    ...data,
-                    [foreignKeyMapping[reference]]: record.id,
-                    sales_id: identity.id,
-                    date: data.date || getCurrentDate(),
-                })}
-                mutationOptions={{
-                    onSuccess: handleSuccess,
-                }}
-            />
-        </Toolbar>
+        <SaveButton
+            type="button"
+            label="Add this note"
+            icon={<></>}
+            variant="contained"
+            transform={data => ({
+                ...data,
+                [foreignKeyMapping[reference]]: record.id,
+                sales_id: identity.id,
+                date: data.date || getCurrentDate(),
+            })}
+            mutationOptions={{
+                onSuccess: handleSuccess,
+            }}
+        />
     );
 };
-
-const optionRenderer = (choice: any) => (
-    <div>
-        {choice.label} <Status status={choice.value} />
-    </div>
-);

--- a/examples/crm/src/notes/NoteInputs.tsx
+++ b/examples/crm/src/notes/NoteInputs.tsx
@@ -1,0 +1,77 @@
+import { Collapse, Link, Stack, Typography } from '@mui/material';
+import {
+    DateTimeInput,
+    FileField,
+    FileInput,
+    SelectInput,
+    TextInput,
+} from 'react-admin';
+import { useConfigurationContext } from '../root/ConfigurationContext';
+import { useState } from 'react';
+import { getCurrentDate } from './note';
+import { Status } from '../misc/Status';
+
+export const NoteInputs = ({
+    showStatus,
+    edition,
+}: {
+    showStatus?: boolean;
+    edition?: boolean;
+}) => {
+    const { noteStatuses } = useConfigurationContext();
+    const [displayMore, setDisplayMore] = useState(false);
+    return (
+        <Stack gap={1}>
+            <TextInput
+                source="text"
+                label={edition ? 'Edit note' : 'Add a note'}
+                variant="filled"
+                size="small"
+                multiline
+                minRows={3}
+                helperText={false}
+            />
+            <Typography
+                variant="caption"
+                color="textSecondary"
+                onClick={() => setDisplayMore(!displayMore)}
+                component={Link}
+                sx={{ cursor: 'pointer' }}
+            >
+                {`${displayMore ? 'Hide' : 'Show'} options (attach files, or change details)`}
+            </Typography>
+            <Collapse in={displayMore}>
+                <Stack gap={1}>
+                    <Stack direction="row" spacing={2}>
+                        {showStatus && (
+                            <SelectInput
+                                source="status"
+                                choices={noteStatuses}
+                                optionValue="value"
+                                optionText={optionRenderer}
+                                isRequired
+                                defaultValue={'warm'}
+                                helperText={false}
+                            />
+                        )}
+                        <DateTimeInput
+                            source="date"
+                            label="Date"
+                            defaultValue={getCurrentDate()}
+                            helperText={false}
+                        />
+                    </Stack>
+                    <FileInput source="attachments" multiple>
+                        <FileField source="src" title="title" />
+                    </FileInput>
+                </Stack>
+            </Collapse>
+        </Stack>
+    );
+};
+
+const optionRenderer = (choice: any) => (
+    <div>
+        {choice.label} <Status status={choice.value} />
+    </div>
+);

--- a/examples/crm/src/notes/NoteInputs.tsx
+++ b/examples/crm/src/notes/NoteInputs.tsx
@@ -21,7 +21,7 @@ export const NoteInputs = ({
     const { noteStatuses } = useConfigurationContext();
     const [displayMore, setDisplayMore] = useState(false);
     return (
-        <Stack gap={1}>
+        <>
             <TextInput
                 source="text"
                 label={edition ? 'Edit note' : 'Add a note'}
@@ -31,17 +31,25 @@ export const NoteInputs = ({
                 minRows={3}
                 helperText={false}
             />
-            <Typography
-                variant="caption"
-                color="textSecondary"
-                onClick={() => setDisplayMore(!displayMore)}
-                component={Link}
-                sx={{ cursor: 'pointer' }}
-            >
-                {`${displayMore ? 'Hide' : 'Show'} options (attach files, or change details)`}
-            </Typography>
+            {!displayMore && (
+                <Stack gap={0.5} direction="row">
+                    <Link
+                        variant="caption"
+                        href="#"
+                        onClick={e => {
+                            setDisplayMore(!displayMore);
+                            e.preventDefault();
+                        }}
+                    >
+                        Show options
+                    </Link>
+                    <Typography variant="caption" color="textSecondary">
+                        (attach files, or change details)
+                    </Typography>
+                </Stack>
+            )}
             <Collapse in={displayMore}>
-                <Stack gap={1}>
+                <Stack gap={1} mt={1}>
                     <Stack direction="row" spacing={2}>
                         {showStatus && (
                             <SelectInput
@@ -66,7 +74,7 @@ export const NoteInputs = ({
                     </FileInput>
                 </Stack>
             </Collapse>
-        </Stack>
+        </>
     );
 };
 

--- a/examples/crm/src/notes/NotesIterator.tsx
+++ b/examples/crm/src/notes/NotesIterator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack } from '@mui/material';
+import { Box, Divider, Stack } from '@mui/material';
 import { useListContext } from 'react-admin';
 
 import { Note } from './Note';
@@ -15,18 +15,23 @@ export const NotesIterator = ({
     const { data, error, isPending } = useListContext();
     if (isPending || error) return null;
     return (
-        <>
+        <Box mt={4}>
             <NoteCreate showStatus={showStatus} reference={reference} />
-            <Stack mt={4} gap={3}>
-                {data.map((note, index) => (
-                    <Note
-                        note={note}
-                        isLast={index === data.length - 1}
-                        showStatus={showStatus}
-                        key={index}
-                    />
-                ))}
-            </Stack>
-        </>
+            {data && (
+                <Stack mt={4} gap={3}>
+                    {data.map((note, index) => (
+                        <React.Fragment key={index}>
+                            <Divider />
+                            <Note
+                                note={note}
+                                isLast={index === data.length - 1}
+                                showStatus={showStatus}
+                                key={index}
+                            />
+                        </React.Fragment>
+                    ))}
+                </Stack>
+            )}
+        </Box>
     );
 };

--- a/examples/crm/src/notes/note.ts
+++ b/examples/crm/src/notes/note.ts
@@ -1,0 +1,7 @@
+export const getCurrentDate = () => {
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+    now.setSeconds(0);
+    now.setMilliseconds(0);
+    return now.toISOString().slice(0, -1);
+};

--- a/examples/crm/src/sales/TransferAdminRole.tsx
+++ b/examples/crm/src/sales/TransferAdminRole.tsx
@@ -33,12 +33,12 @@ export function TransferAdminRole() {
                             Transfer Administrator Role
                         </Typography>
 
-                        <Typography component="p">
+                        <Typography component="p" variant="body2">
                             You are an administrator. Only administrators can
                             manage access for account managers.
                         </Typography>
 
-                        <Typography component="p">
+                        <Typography component="p" variant="body2">
                             You can{' '}
                             <Link
                                 onClick={handleShowModal}

--- a/examples/crm/src/tasks/Task.tsx
+++ b/examples/crm/src/tasks/Task.tsx
@@ -170,7 +170,7 @@ export const Task = ({
                     >
                         {task.type && task.type !== 'None' && (
                             <>
-                                <Typography component="strong">
+                                <Typography component="strong" variant="body2">
                                     {task.type}
                                 </Typography>
                                 &nbsp;


### PR DESCRIPTION
## Problem

The new note form is always displayed in deals and contacts. But it has many fields (text, date, temperature, attachment) that push the rest of the content downwards.

## Solution

Display only the text content field and the submit button, and a link above the submit button allowing to display the other fields

## How To Test

Go on any Contact or Deal show view.

## Additional Checks

- [x] Display all text in 14px by default.
- [x] Rework edit note for handling temperature


Before 

![image](https://github.com/user-attachments/assets/7ffb64a6-fe3f-4b8e-8f85-e93f5d5a220c)


After
![image](https://github.com/user-attachments/assets/91920b1e-40ce-4fca-a903-0c3485e930d9)

