### PR TITLE
Feat(crm): Improve UI for contacts attached to a deal

### DIFF
--- a/examples/crm/src/deals/ContactList.tsx
+++ b/examples/crm/src/deals/ContactList.tsx
@@ -1,45 +1,31 @@
 import * as React from 'react';
 import { useListContext } from 'react-admin';
-import { Box, Link } from '@mui/material';
+import { Link, Stack, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
+import { Avatar } from '../contacts/Avatar';
 
 export const ContactList = () => {
     const { data, error, isPending } = useListContext();
-
     if (isPending || error) return <div style={{ height: '2em' }} />;
     return (
-        <Box
-            component="ul"
-            sx={{
-                listStyle: 'none',
-                padding: 0,
-                margin: 0,
-                display: 'inline-block',
-            }}
-        >
+        <Stack direction="row" flexWrap="wrap" gap={3} mt={1}>
             {data.map(contact => (
-                <Box
-                    component="li"
-                    key={contact.id}
-                    sx={{
-                        display: 'inline',
-                        '&:after': {
-                            content: '", "',
-                        },
-                        '&:last-child:after': {
-                            content: '""',
-                        },
-                    }}
-                >
-                    <Link
-                        component={RouterLink}
-                        to={`/contacts/${contact.id}/show`}
-                        variant="subtitle1"
-                    >
-                        {contact.first_name} {contact.last_name}
-                    </Link>
-                </Box>
+                <Stack direction="row" key={contact.id} gap={1}>
+                    <Avatar record={contact} />
+                    <Stack>
+                        <Link
+                            component={RouterLink}
+                            to={`/contacts/${contact.id}/show`}
+                            variant="body2"
+                        >
+                            {contact.first_name} {contact.last_name}
+                        </Link>
+                        <Typography variant="caption" color="text.secondary">
+                            {contact.title} at {contact.company_name}
+                        </Typography>
+                    </Stack>
+                </Stack>
             ))}
-        </Box>
+        </Stack>
     );
 };

--- a/examples/crm/src/deals/DealCard.tsx
+++ b/examples/crm/src/deals/DealCard.tsx
@@ -70,7 +70,7 @@ export const DealCardContent = ({
                                 currencyDisplay: 'narrowSymbol',
                                 minimumSignificantDigits: 3,
                             })}
-                            , {deal.type}
+                            , {deal.category}
                         </Typography>
                     </Box>
                 </Box>

--- a/examples/crm/src/deals/DealColumn.tsx
+++ b/examples/crm/src/deals/DealColumn.tsx
@@ -23,11 +23,11 @@ export const DealColumn = ({
                 paddingTop: '8px',
                 paddingBottom: '16px',
                 bgcolor: '#eaeaee',
-                '&:first-child': {
+                '&:first-of-type': {
                     paddingLeft: '5px',
                     borderTopLeftRadius: 5,
                 },
-                '&:last-child': {
+                '&:last-of-type': {
                     paddingRight: '5px',
                     borderTopRightRadius: 5,
                 },


### PR DESCRIPTION
## Problem

The company attached to a deal is highlighted by its logo, but the contact isn’t.

## Solution

Display the avatar before contact name and add a margin between to lighten the interface

## Screenshots

Before
![image](https://github.com/user-attachments/assets/53dfecb1-67b0-4b15-b34a-2f7112bd8035)


After
![image](https://github.com/user-attachments/assets/99495778-ab79-4466-8a44-c4579f3695eb)



