### PR TITLE
Fix(crm): Set edit and create dialog title for Deal as h6

### DIFF
--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -80,7 +80,13 @@ export const DealCreate = ({ open }: { open: boolean }) => {
                 sx={{ '& .RaCreate-main': { mt: 0 } }}
             >
                 <DialogCloseButton onClose={handleClose} />
-                <DialogTitle>Create a new deal</DialogTitle>
+                <DialogTitle
+                    sx={{
+                        paddingBottom: 0,
+                    }}
+                >
+                    Create a new deal
+                </DialogTitle>
                 <Form
                     defaultValues={{
                         sales_id: identity?.id,

--- a/examples/crm/src/deals/DealEdit.tsx
+++ b/examples/crm/src/deals/DealEdit.tsx
@@ -81,13 +81,7 @@ function EditHeader() {
                 justifyContent="space-between"
                 spacing={1}
             >
-                <Typography component="span" flexGrow={1}>
-                    Edit{' '}
-                    <Typography component="strong" fontWeight={700}>
-                        {deal.name}
-                    </Typography>{' '}
-                    deal
-                </Typography>
+                <Typography variant="h6">Edit {deal.name} deal</Typography>
 
                 <Stack direction="row" spacing={1} sx={{ pr: 3 }}>
                     <Button component={Link} to={`/deals/${deal.id}/show`}>


### PR DESCRIPTION
## Problem

Dialogs for Deal CRUD are small

## Solution

Set dialog titles as h6

![image](https://github.com/user-attachments/assets/e342ef0b-84bb-4f7c-bd7e-bdd27410bb7c)
