### PR TITLE
Fix(crm): Use pessimistic update when saving a deal to avoid old data to display

### DIFF
--- a/examples/crm/src/deals/DealEdit.tsx
+++ b/examples/crm/src/deals/DealEdit.tsx
@@ -1,3 +1,4 @@
+import { Button, DialogContent, Stack } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import Typography from '@mui/material/Typography';
@@ -12,10 +13,9 @@ import {
     useRedirect,
 } from 'react-admin';
 import { Link } from 'react-router-dom';
+import { DialogCloseButton } from '../misc/DialogCloseButton';
 import { Deal } from '../types';
 import { DealInputs } from './DealInputs';
-import { DialogContent, Stack, Button } from '@mui/material';
-import { DialogCloseButton } from '../misc/DialogCloseButton';
 
 export const DealEdit = ({ open, id }: { open: boolean; id?: string }) => {
     const redirect = useRedirect();
@@ -32,11 +32,10 @@ export const DealEdit = ({ open, id }: { open: boolean; id?: string }) => {
             {!!id ? (
                 <EditBase
                     id={id}
+                    mutationMode="pessimistic"
                     mutationOptions={{
                         onSuccess: () => {
-                            notify('Deal updated', {
-                                undoable: true,
-                            });
+                            notify('Deal updated');
                             redirect(
                                 `/deals/${id}/show`,
                                 undefined,

--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -28,12 +28,12 @@ import {
 import ArchiveIcon from '@mui/icons-material/Archive';
 import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import { CompanyAvatar } from '../companies/CompanyAvatar';
+import { DialogCloseButton } from '../misc/DialogCloseButton';
 import { NotesIterator } from '../notes';
 import { useConfigurationContext } from '../root/ConfigurationContext';
 import { Deal } from '../types';
 import { ContactList } from './ContactList';
 import { findDealLabel } from './deal';
-import { DialogCloseButton } from '../misc/DialogCloseButton';
 
 export const DealShow = ({ open, id }: { open: boolean; id?: string }) => {
     const redirect = useRedirect();
@@ -178,7 +178,7 @@ const DealShowContent = () => {
                         </Box>
                     </Box>
 
-                    <Box mt={2} mb={2} style={{ whiteSpace: 'pre-line' }}>
+                    <Box mt={2} mb={2} sx={{ whiteSpace: 'pre-line' }}>
                         <Typography color="textSecondary" variant="caption">
                             Description
                         </Typography>


### PR DESCRIPTION
## Problem

In the CRM demo, when I save a deal, I expect the show view to update with the new data.The updated content is first displayed, then removed by the older one, and the, once the update is persisted is shown back.

## Solution

Use pessimistic mode

## How To Test

Edit a deal

[Capture vidéo du 25-07-2024 17:13:18.webm](https://github.com/user-attachments/assets/daf72f09-aa49-4104-98c1-628326bac653)
