### PR TITLE
Fix(crm): Replace see more button with a link in activity log

### DIFF
--- a/examples/crm/src/activity/ActivityLogNote.tsx
+++ b/examples/crm/src/activity/ActivityLogNote.tsx
@@ -1,8 +1,8 @@
-import Button from '@mui/material/Button';
 import ListItem from '@mui/material/ListItem';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { ReactNode, useState } from 'react';
+import { MouseEventHandler, ReactNode, useState } from 'react';
+import { Link } from 'react-admin';
 
 type ActivityLogContactNoteCreatedProps = {
     header: ReactNode;
@@ -19,6 +19,11 @@ export function ActivityLogNote({
 
     const slicedText =
         text.length > maxDisplayLength ? text.slice(0, maxDisplayLength) : null;
+
+    const handleToggleSeeMore: MouseEventHandler = e => {
+        e.preventDefault();
+        setSeeMore(oldSeeMore => !oldSeeMore);
+    };
 
     return (
         <ListItem>
@@ -39,12 +44,14 @@ export function ActivityLogNote({
                 </Typography>
 
                 {slicedText && (
-                    <Button
-                        size="small"
-                        onClick={() => setSeeMore(oldSeeMore => !oldSeeMore)}
+                    <Typography
+                        component={Link}
+                        to="#"
+                        variant="body2"
+                        onClick={handleToggleSeeMore}
                     >
                         {seeMore ? 'See less' : 'See more'}
-                    </Button>
+                    </Typography>
                 )}
             </Stack>
         </ListItem>

--- a/examples/crm/src/activity/ActivityLogNote.tsx
+++ b/examples/crm/src/activity/ActivityLogNote.tsx
@@ -1,8 +1,8 @@
+import Link from '@mui/material/Link';
 import ListItem from '@mui/material/ListItem';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { MouseEventHandler, ReactNode, useState } from 'react';
-import { Link } from 'react-admin';
 
 type ActivityLogContactNoteCreatedProps = {
     header: ReactNode;
@@ -44,14 +44,13 @@ export function ActivityLogNote({
                 </Typography>
 
                 {slicedText && (
-                    <Typography
-                        component={Link}
-                        to="#"
+                    <Link
+                        href="#"
                         variant="body2"
                         onClick={handleToggleSeeMore}
                     >
                         {seeMore ? 'See less' : 'See more'}
-                    </Typography>
+                    </Link>
                 )}
             </Stack>
         </ListItem>


### PR DESCRIPTION
## Problem

Uses can make a mistake between see more and load more buttons on activity log

## Solution

Replace see more button to a see more link

## How To Test

Go to activity log on dashboard or on any company