### PR TITLE
Fix(crm): Removed target="_blank" to the sample download link

### DIFF
--- a/examples/crm/src/contacts/ContactImportButton.tsx
+++ b/examples/crm/src/contacts/ContactImportButton.tsx
@@ -203,7 +203,6 @@ export const ContactImportButton = () => {
                                                 label="Download CSV sample"
                                                 color="info"
                                                 to={SAMPLE_URL}
-                                                target="_blank"
                                             />
                                         }
                                     >


### PR DESCRIPTION
## Problem

AdBlock blocked the sample CSV for contact import

## Solution

Removed `target="_blank"` to the sample download link

## How To Test

Download sample CSV in contact import modal.