### PR TITLE
Fix(crm): Hide fields labels when empty in deals show

### DIFF
--- a/examples/crm/src/dashboard/DealsChart.tsx
+++ b/examples/crm/src/dashboard/DealsChart.tsx
@@ -18,7 +18,7 @@ export const DealsChart = () => {
     const { data, isPending } = useGetList<Deal>('deals', {
         pagination: { perPage: 100, page: 1 },
         sort: {
-            field: 'start_at',
+            field: 'created_at',
             order: 'ASC',
         },
     });
@@ -27,7 +27,7 @@ export const DealsChart = () => {
         if (!data) return [];
         const dealsByMonth = data.reduce((acc, deal) => {
             const month = startOfMonth(
-                deal.start_at ?? new Date()
+                deal.created_at ?? new Date()
             ).toISOString();
             if (!acc[month]) {
                 acc[month] = [];
@@ -35,6 +35,8 @@ export const DealsChart = () => {
             acc[month].push(deal);
             return acc;
         }, {} as any);
+
+        console.log(dealsByMonth);
 
         const amountByMonth = Object.keys(dealsByMonth).map(month => {
             return {

--- a/examples/crm/src/dashboard/DealsChart.tsx
+++ b/examples/crm/src/dashboard/DealsChart.tsx
@@ -36,8 +36,6 @@ export const DealsChart = () => {
             return acc;
         }, {} as any);
 
-        console.log(dealsByMonth);
-
         const amountByMonth = Object.keys(dealsByMonth).map(month => {
             return {
                 date: format(month, 'MMM'),

--- a/examples/crm/src/dataGenerator/deals.ts
+++ b/examples/crm/src/dataGenerator/deals.ts
@@ -1,13 +1,13 @@
-import { random, lorem } from 'faker/locale/en_US';
 import { add } from 'date-fns';
+import { lorem, random } from 'faker/locale/en_US';
 
-import { Db } from './types';
-import { Deal } from '../types';
-import { randomDate } from './utils';
 import {
     defaultDealCategories,
     defaultDealStages,
 } from '../root/defaultConfiguration';
+import { Deal } from '../types';
+import { Db } from './types';
+import { randomDate } from './utils';
 
 export const generateDeals = (db: Db): Deal[] => {
     const deals = Array.from(Array(50).keys()).map(id => {
@@ -23,7 +23,7 @@ export const generateDeals = (db: Db): Deal[] => {
         ).toISOString();
 
         const start_at = created_at;
-        const expecting_closing_date = randomDate(
+        const expected_closing_date = randomDate(
             new Date(start_at),
             add(new Date(start_at), { months: 6 })
         ).toISOString();
@@ -40,7 +40,7 @@ export const generateDeals = (db: Db): Deal[] => {
             created_at: created_at,
             updated_at: randomDate(new Date(created_at)).toISOString(),
             start_at,
-            expecting_closing_date,
+            expected_closing_date,
             sales_id: company.sales_id,
             index: 0,
             nb_notes: 0,

--- a/examples/crm/src/dataGenerator/deals.ts
+++ b/examples/crm/src/dataGenerator/deals.ts
@@ -22,10 +22,9 @@ export const generateDeals = (db: Db): Deal[] => {
             new Date(company.created_at)
         ).toISOString();
 
-        const start_at = created_at;
         const expected_closing_date = randomDate(
-            new Date(start_at),
-            add(new Date(start_at), { months: 6 })
+            new Date(created_at),
+            add(new Date(created_at), { months: 6 })
         ).toISOString();
 
         return {
@@ -37,9 +36,8 @@ export const generateDeals = (db: Db): Deal[] => {
             stage: random.arrayElement(defaultDealStages).value,
             description: lorem.paragraphs(random.number({ min: 1, max: 4 })),
             amount: random.number(1000) * 100,
-            created_at: created_at,
+            created_at,
             updated_at: randomDate(new Date(created_at)).toISOString(),
-            start_at,
             expected_closing_date,
             sales_id: company.sales_id,
             index: 0,

--- a/examples/crm/src/dataProvider.ts
+++ b/examples/crm/src/dataProvider.ts
@@ -411,7 +411,6 @@ export const dataProvider = withLifecycleCallbacks(
                     ...params,
                     data: {
                         ...params.data,
-                        start_at: new Date().toISOString(),
                         created_at: new Date().toISOString(),
                         updated_at: new Date().toISOString(),
                     },

--- a/examples/crm/src/dataProvider.ts
+++ b/examples/crm/src/dataProvider.ts
@@ -411,6 +411,7 @@ export const dataProvider = withLifecycleCallbacks(
                     ...params,
                     data: {
                         ...params.data,
+                        start_at: new Date().toISOString(),
                         created_at: new Date().toISOString(),
                         updated_at: new Date().toISOString(),
                     },

--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -11,9 +11,9 @@ import {
     useListContext,
     useRedirect,
 } from 'react-admin';
+import { DialogCloseButton } from '../misc/DialogCloseButton';
 import { Deal } from '../types';
 import { DealInputs } from './DealInputs';
-import { DialogCloseButton } from '../misc/DialogCloseButton';
 
 export const DealCreate = ({ open }: { open: boolean }) => {
     const redirect = useRedirect();

--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -92,7 +92,6 @@ export const DealCreate = ({ open }: { open: boolean }) => {
                         sales_id: identity?.id,
                         contact_ids: [],
                         index: 0,
-                        start_at: new Date().toISOString(),
                     }}
                 >
                     <DialogContent>

--- a/examples/crm/src/deals/DealInputs.tsx
+++ b/examples/crm/src/deals/DealInputs.tsx
@@ -108,17 +108,9 @@ export const DealInputs = () => {
             />
             <Divider sx={{ my: 2, width: '100%' }} />
             <DateInput
-                source="expecting_closing_date"
+                source="expected_closing_date"
                 fullWidth
                 validate={[validateRequired]}
-                helperText={false}
-            />
-            <DateInput
-                source="start_at"
-                defaultValue={new Date()}
-                fullWidth
-                label="Starting date"
-                readOnly
                 helperText={false}
             />
         </>

--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -107,21 +107,13 @@ const DealShowContent = () => {
                         </Stack>
                     </Stack>
 
-                    <Box display="flex" mt={2}>
+                    <Box display="flex" mb={2} mt={2}>
                         <Box display="flex" mr={5} flexDirection="column">
                             <Typography color="textSecondary" variant="caption">
-                                Starting date
+                                Expected closing date
                             </Typography>
                             <Typography variant="body2">
-                                {format(record.start_at, 'PP')}
-                            </Typography>
-                        </Box>
-                        <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="caption">
-                                Expecting closing date
-                            </Typography>
-                            <Typography variant="body2">
-                                {format(record.expecting_closing_date, 'PP')}
+                                {format(record.expected_closing_date, 'PP')}
                             </Typography>
                         </Box>
 
@@ -140,14 +132,19 @@ const DealShowContent = () => {
                             </Typography>
                         </Box>
 
-                        <Box display="flex" mr={5} flexDirection="column">
-                            <Typography color="textSecondary" variant="caption">
-                                Category
-                            </Typography>
-                            <Typography variant="body2">
-                                {record.category}
-                            </Typography>
-                        </Box>
+                        {record.category && (
+                            <Box display="flex" mr={5} flexDirection="column">
+                                <Typography
+                                    color="textSecondary"
+                                    variant="caption"
+                                >
+                                    Category
+                                </Typography>
+                                <Typography variant="body2">
+                                    {record.category}
+                                </Typography>
+                            </Box>
+                        )}
 
                         <Box display="flex" mr={5} flexDirection="column">
                             <Typography color="textSecondary" variant="caption">
@@ -159,33 +156,40 @@ const DealShowContent = () => {
                         </Box>
                     </Box>
 
-                    <Box mt={2} mb={2}>
-                        <Box
-                            display="flex"
-                            mr={5}
-                            flexDirection="column"
-                            minHeight={48}
-                        >
-                            <Typography color="textSecondary" variant="caption">
-                                Contacts
-                            </Typography>
-                            <ReferenceArrayField
-                                source="contact_ids"
-                                reference="contacts"
+                    {!!record.contact_ids?.length && (
+                        <Box mb={2}>
+                            <Box
+                                display="flex"
+                                mr={5}
+                                flexDirection="column"
+                                minHeight={48}
                             >
-                                <ContactList />
-                            </ReferenceArrayField>
+                                <Typography
+                                    color="textSecondary"
+                                    variant="caption"
+                                >
+                                    Contacts
+                                </Typography>
+                                <ReferenceArrayField
+                                    source="contact_ids"
+                                    reference="contacts"
+                                >
+                                    <ContactList />
+                                </ReferenceArrayField>
+                            </Box>
                         </Box>
-                    </Box>
+                    )}
 
-                    <Box mt={2} mb={2} sx={{ whiteSpace: 'pre-line' }}>
-                        <Typography color="textSecondary" variant="caption">
-                            Description
-                        </Typography>
-                        <Typography variant="body2">
-                            {record.description}
-                        </Typography>
-                    </Box>
+                    {record.description && (
+                        <Box mt={2} mb={2} sx={{ whiteSpace: 'pre-line' }}>
+                            <Typography color="textSecondary" variant="caption">
+                                Description
+                            </Typography>
+                            <Typography variant="body2">
+                                {record.description}
+                            </Typography>
+                        </Box>
+                    )}
 
                     <Divider />
 

--- a/examples/crm/src/types.ts
+++ b/examples/crm/src/types.ts
@@ -81,7 +81,7 @@ export interface Deal extends RaRecord {
     updated_at: string;
     archived_at?: string;
     start_at: string;
-    expecting_closing_date: string;
+    expected_closing_date: string;
     sales_id: Identifier;
     index: number;
     nb_notes: number;

--- a/examples/crm/src/types.ts
+++ b/examples/crm/src/types.ts
@@ -80,7 +80,6 @@ export interface Deal extends RaRecord {
     created_at: string;
     updated_at: string;
     archived_at?: string;
-    start_at: string;
     expected_closing_date: string;
     sales_id: Identifier;
     index: number;


### PR DESCRIPTION
## Problem

The deal show view can show labels for fields with no value, providing no information

## Solution

- [x] Hide labels on deals show when field is empty or has no value
- [x] Fix a typo with Expected closing date
- [x] Remove start_at from deals

## How To Test

Open deals show and forms

[Capture vidéo du 26-07-2024 11:28:40.webm](https://github.com/user-attachments/assets/5e1de3be-1369-4578-9480-2b8234f518c1)
