### PR TITLE
Fix(crm): sales is now required for contacts and companies

### DIFF
--- a/examples/crm/src/companies/CompanyInputs.tsx
+++ b/examples/crm/src/companies/CompanyInputs.tsx
@@ -139,6 +139,7 @@ const CompanyAccountManagerInput = () => {
                     label="Account manager"
                     helperText={false}
                     optionText={saleOptionRenderer}
+                    validate={required()}
                 />
             </ReferenceInput>
         </Stack>

--- a/examples/crm/src/contacts/ContactInputs.tsx
+++ b/examples/crm/src/contacts/ContactInputs.tsx
@@ -185,6 +185,7 @@ const ContactMiscInputs = () => {
                     helperText={false}
                     label="Account manager"
                     optionText={saleOptionRenderer}
+                    validate={required()}
                 />
             </ReferenceInput>
         </Stack>

--- a/examples/crm/src/dataProvider.ts
+++ b/examples/crm/src/dataProvider.ts
@@ -377,7 +377,15 @@ export const dataProvider = withLifecycleCallbacks(
         {
             resource: 'companies',
             beforeCreate: async params => {
-                return await processCompanyLogo(params);
+                const createParams = await processCompanyLogo(params);
+
+                return {
+                    ...createParams,
+                    data: {
+                        ...createParams.data,
+                        created_at: new Date().toISOString(),
+                    },
+                };
             },
             beforeUpdate: async params => {
                 return await processCompanyLogo(params);


### PR DESCRIPTION
## Problem

- If I need to reach a contact or a company, I always want to know which colleague is responsible for them.
- Company creation would create an error with activity log

## Solution

- [x] Account manager is now required for contacts and companies
- [x] Add created_at to company before create

## How To Test

Create or edit a company or a contact
