### PR TITLE
Fix `<SimpleFormIterator>` adds a left padding when there is no label

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorItem.tsx
@@ -108,7 +108,7 @@ export const SimpleFormIteratorItem = React.forwardRef(
         return (
             <SimpleFormIteratorItemContext.Provider value={context}>
                 <li className={SimpleFormIteratorClasses.line} ref={ref}>
-                    {label != null && (
+                    {label != null && label !== false && (
                         <Typography
                             variant="body2"
                             className={SimpleFormIteratorClasses.index}


### PR DESCRIPTION
## Problem

The inputs created by `SimpleFormIterator` have a left padding that is hard to remove.

## Solution

Remove this padding by default. 

| Before | After |
| --- | --- |
|<img width="899" alt="image" src="https://github.com/user-attachments/assets/6476a5f2-0f34-40b5-a6ed-d489b8dddc09">| <img width="903" alt="image" src="https://github.com/user-attachments/assets/d4510587-96a9-4c10-abe8-d51905a01ef6"> | 

## How To Test

Open the [Storybook at Ra-ui-materialui / input / SimpleFormIteratir / Basic](https://react-admin-storybook.vercel.app/?path=/story/ra-ui-materialui-input-simpleformiterator--basic)

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- ~~[ ] The PR includes **unit tests** (if not possible, describe why)~~(visual only)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

