### PR TITLE
Feat(crm): Display gender icon + newseletter info for Contact

### DIFF
--- a/examples/crm/src/contacts/ContactAside.tsx
+++ b/examples/crm/src/contacts/ContactAside.tsx
@@ -1,7 +1,7 @@
 import EmailIcon from '@mui/icons-material/Email';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import PhoneIcon from '@mui/icons-material/Phone';
-import { Box, Divider, Stack, Typography } from '@mui/material';
+import { Box, Divider, Stack, SvgIcon, Typography } from '@mui/material';
 import {
     DateField,
     EditButton,
@@ -47,6 +47,16 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
                     <EmailIcon color="disabled" fontSize="small" />
                     <EmailField source="email" />
                 </Stack>
+            )}
+            {record.has_newsletter && (
+                <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    mb={0.5}
+                    pl={3.5}
+                >
+                    Subscribed to newsletter
+                </Typography>
             )}
 
             {record.linkedin_url && (
@@ -97,7 +107,16 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
             <SelectField
                 source="gender"
                 choices={contactGender}
-                optionText="label"
+                optionText={choice => (
+                    <Stack direction="row" alignItems="center" gap={1}>
+                        <SvgIcon
+                            component={choice.icon}
+                            color="disabled"
+                            fontSize="small"
+                        ></SvgIcon>
+                        <span>{choice.label}</span>
+                    </Stack>
+                )}
                 optionValue="value"
             />
             <Typography variant="subtitle2" mt={2}>

--- a/examples/crm/src/root/defaultConfiguration.ts
+++ b/examples/crm/src/root/defaultConfiguration.ts
@@ -1,3 +1,7 @@
+import Man2Icon from '@mui/icons-material/Man2';
+import WcIcon from '@mui/icons-material/Wc';
+import Woman2Icon from '@mui/icons-material/Woman2';
+
 export const defaultLogo =
     'https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg';
 
@@ -56,7 +60,7 @@ export const defaultTaskTypes = [
 ];
 
 export const defaultContactGender = [
-    { value: 'male', label: 'He/Him' },
-    { value: 'female', label: 'She/Her' },
-    { value: 'nonbinary', label: 'They/Them' },
+    { value: 'male', label: 'He/Him', icon: Man2Icon },
+    { value: 'female', label: 'She/Her', icon: Woman2Icon },
+    { value: 'nonbinary', label: 'They/Them', icon: WcIcon },
 ];

--- a/examples/crm/src/types.ts
+++ b/examples/crm/src/types.ts
@@ -6,6 +6,7 @@ import {
     DEAL_CREATED,
     DEAL_NOTE_CREATED,
 } from './consts';
+import { SvgIconComponent } from '@mui/icons-material';
 
 export interface Sale extends RaRecord {
     first_name: string;
@@ -171,4 +172,5 @@ export interface NoteStatus {
 export interface ContactGender {
     value: string;
     label: string;
+    icon: SvgIconComponent;
 }


### PR DESCRIPTION
## Problem

I can subscribe/unsubscribe a contact to a newsletter but I should edit the contact to know if he is subscribed or not.

## Solution

In the contact sidebar, display “Subscribed to newsletter” if the toggle is true, don’t display anything if the toggle is false.
Display it after the email, without icon.

Harmonize “Personal info” by adding an icon before the gender.



![image](https://github.com/user-attachments/assets/23b49835-93bb-437a-a249-d020a49d3595)
