### PR TITLE
Feat(crm): Redirect on company page when deleting an user from company

### DIFF
--- a/examples/crm/src/companies/CompanyShow.tsx
+++ b/examples/crm/src/companies/CompanyShow.tsx
@@ -29,7 +29,7 @@ import {
     useRecordContext,
     useShowContext,
 } from 'react-admin';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 
 import { ActivityLog } from '../activity/ActivityLog';
 import { Avatar } from '../contacts/Avatar';
@@ -190,7 +190,9 @@ const TabPanel = (props: TabPanelProps) => {
 };
 
 const ContactsIterator = () => {
+    const location = useLocation();
     const { data: contacts, error, isPending } = useListContext<Contact>();
+
     if (isPending || error) return null;
 
     const now = Date.now();
@@ -202,6 +204,7 @@ const ContactsIterator = () => {
                         button
                         component={RouterLink}
                         to={`/contacts/${contact.id}/show`}
+                        state={{ from: location.pathname }}
                     >
                         <ListItemAvatar>
                             <Avatar />

--- a/examples/crm/src/contacts/ContactAside.tsx
+++ b/examples/crm/src/contacts/ContactAside.tsx
@@ -4,6 +4,7 @@ import PhoneIcon from '@mui/icons-material/Phone';
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import {
     DateField,
+    DeleteButton,
     EditButton,
     EmailField,
     FunctionField,
@@ -21,8 +22,10 @@ import { TagsListEdit } from './TagsListEdit';
 
 import { useConfigurationContext } from '../root/ConfigurationContext';
 import { Contact, Sale } from '../types';
+import { useLocation } from 'react-router';
 
 export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
+    const location = useLocation();
     const { contactGender } = useConfigurationContext();
     const record = useRecordContext<Contact>();
     if (!record) return null;
@@ -155,7 +158,7 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
                 <Divider />
                 <TagsListEdit />
             </Box>
-            <Box>
+            <Box mb={3}>
                 <Typography variant="subtitle2">Tasks</Typography>
                 <Divider />
                 <ReferenceManyField
@@ -167,6 +170,7 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
                 </ReferenceManyField>
                 <AddTask />
             </Box>
+            <DeleteButton redirect={location.state?.from || undefined} />
         </Box>
     );
 };

--- a/examples/crm/src/contacts/ContactEdit.tsx
+++ b/examples/crm/src/contacts/ContactEdit.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { EditBase, Form, Toolbar, useEditContext } from 'react-admin';
+import {
+    EditBase,
+    Form,
+    SaveButton,
+    Toolbar,
+    useEditContext,
+} from 'react-admin';
 import { Card, CardContent, Box } from '@mui/material';
 
 import { ContactInputs } from './ContactInputs';
@@ -23,7 +29,9 @@ const ContactEditContent = () => {
                         <CardContent>
                             <ContactInputs />
                         </CardContent>
-                        <Toolbar />
+                        <Toolbar>
+                            <SaveButton />
+                        </Toolbar>
                     </Card>
                 </Form>
             </Box>


### PR DESCRIPTION
## Problem

As a user, I want to delete a contact from the company page easily

## Solution

Add a Delete button at the end of the sidebar of a contact

When the user deletes the contact, and that it comes from the company page, redirect it on the company page else redirect it on the contacts list

Remove “Delete” button on the contact form which is now no longer so necessary

[Screencast from 2024-07-29 17-58-48.webm](https://github.com/user-attachments/assets/bc0d8071-ed96-4401-b52a-5bbc5c757677)

