### PR TITLE
Feat(crm): Allow quick task create from Dashboard

### DIFF
--- a/examples/crm/src/dashboard/TasksList.tsx
+++ b/examples/crm/src/dashboard/TasksList.tsx
@@ -12,6 +12,7 @@ import {
 import { TasksIterator } from '../tasks/TasksIterator';
 
 import { Contact } from '../types';
+import { AddTask } from '../tasks/AddTask';
 
 export const TasksList = () => {
     const { identity } = useGetIdentity();
@@ -65,6 +66,7 @@ export const TasksList = () => {
                 </Link>
             </Box>
             <Card sx={{ px: 2, mb: '2em' }}>
+                <AddTask selectContact />
                 <ResourceContextProvider value="tasks">
                     <ListContextProvider value={listContext}>
                         <TasksIterator showContact />

--- a/examples/crm/src/deals/DealInputs.tsx
+++ b/examples/crm/src/deals/DealInputs.tsx
@@ -1,4 +1,4 @@
-import { Divider, Stack } from '@mui/material';
+import { Divider } from '@mui/material';
 import {
     AutocompleteArrayInput,
     AutocompleteInput,
@@ -12,11 +12,9 @@ import {
     useCreate,
     useGetIdentity,
     useNotify,
-    useRecordContext,
 } from 'react-admin';
-import { Avatar } from '../contacts/Avatar';
 import { useConfigurationContext } from '../root/ConfigurationContext';
-import { Contact } from '../types';
+import { contactInputText, contactOptionText } from '../misc/ContactOption';
 
 const validateRequired = required();
 
@@ -116,17 +114,3 @@ export const DealInputs = () => {
         </>
     );
 };
-
-const ContactOptionRender = () => {
-    const record: Contact | undefined = useRecordContext();
-    if (!record) return null;
-    return (
-        <Stack direction="row" gap={1} alignItems="center">
-            <Avatar record={record} />
-            {record.first_name} {record.last_name}
-        </Stack>
-    );
-};
-const contactOptionText = <ContactOptionRender />;
-const contactInputText = (choice: { first_name: string; last_name: string }) =>
-    `${choice.first_name} ${choice.last_name}`;

--- a/examples/crm/src/misc/ContactOption.tsx
+++ b/examples/crm/src/misc/ContactOption.tsx
@@ -1,0 +1,25 @@
+import { Stack, Typography } from '@mui/material';
+import { useRecordContext } from 'react-admin';
+import { Avatar } from '../contacts/Avatar';
+import { Contact } from '../types';
+
+const ContactOptionRender = () => {
+    const record: Contact | undefined = useRecordContext();
+    if (!record) return null;
+    return (
+        <Stack direction="row" gap={1} alignItems="center">
+            <Avatar record={record} />
+            <Stack>
+                {record.first_name} {record.last_name}
+                <Typography variant="caption" color="text.secondary">
+                    {record.title} at {record.company_name}
+                </Typography>
+            </Stack>
+        </Stack>
+    );
+};
+export const contactOptionText = <ContactOptionRender />;
+export const contactInputText = (choice: {
+    first_name: string;
+    last_name: string;
+}) => `${choice.first_name} ${choice.last_name}`;

--- a/examples/crm/src/tasks/AddTask.tsx
+++ b/examples/crm/src/tasks/AddTask.tsx
@@ -11,10 +11,12 @@ import {
 import * as React from 'react';
 import { useState } from 'react';
 import {
+    AutocompleteInput,
     CreateBase,
     DateInput,
     Form,
     RecordRepresentation,
+    ReferenceInput,
     SaveButton,
     SelectInput,
     TextInput,
@@ -24,8 +26,9 @@ import {
 } from 'react-admin';
 import { useConfigurationContext } from '../root/ConfigurationContext';
 import { DialogCloseButton } from '../misc/DialogCloseButton';
+import { contactInputText, contactOptionText } from '../misc/ContactOption';
 
-export const AddTask = () => {
+export const AddTask = ({ selectContact }: { selectContact?: boolean }) => {
     const { taskTypes } = useConfigurationContext();
     const contact = useRecordContext();
     const [open, setOpen] = useState(false);
@@ -64,11 +67,15 @@ export const AddTask = () => {
                     <Form>
                         <DialogCloseButton onClose={() => setOpen(false)} />
                         <DialogTitle id="form-dialog-title">
-                            Create a new task for{' '}
-                            <RecordRepresentation
-                                record={contact}
-                                resource="contacts"
-                            />
+                            {!selectContact
+                                ? 'Create a new task for '
+                                : 'Create a new task'}
+                            {!selectContact && (
+                                <RecordRepresentation
+                                    record={contact}
+                                    resource="contacts"
+                                />
+                            )}
                         </DialogTitle>
                         <DialogContent>
                             <TextInput
@@ -79,6 +86,21 @@ export const AddTask = () => {
                                 multiline
                                 helperText={false}
                             />
+                            {selectContact && (
+                                <ReferenceInput
+                                    source="contact_id"
+                                    reference="contacts"
+                                >
+                                    <AutocompleteInput
+                                        label="Contacts"
+                                        optionText={contactOptionText}
+                                        inputText={contactInputText}
+                                        helperText={false}
+                                        validate={required()}
+                                    />
+                                </ReferenceInput>
+                            )}
+
                             <Stack direction="row" spacing={1} mt={2}>
                                 <DateInput
                                     source="due_date"

--- a/examples/crm/src/tasks/AddTask.tsx
+++ b/examples/crm/src/tasks/AddTask.tsx
@@ -92,7 +92,7 @@ export const AddTask = ({ selectContact }: { selectContact?: boolean }) => {
                                     reference="contacts"
                                 >
                                     <AutocompleteInput
-                                        label="Contacts"
+                                        label="Contact"
                                         optionText={contactOptionText}
                                         inputText={contactInputText}
                                         helperText={false}


### PR DESCRIPTION
## Problem

As a user, I don’t know how create a task

## Solution

Add a button secondary “New task” on the homepage that opens the task creation popup with a contacts selector.

Contacts selector is required.

Contacts selector shouldn’t appears on the other popup (edit, creation from the contacts page)


[Screencast from 2024-07-29 19-11-23.webm](https://github.com/user-attachments/assets/ad892a20-fe26-4995-b80d-f61546e32a5e)
