### PR TITLE
Feat(crm): Display company name and title for Hot Contact

### DIFF
--- a/examples/crm/src/dashboard/HotContacts.tsx
+++ b/examples/crm/src/dashboard/HotContacts.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Card, Box } from '@mui/material';
+import { Card, Box, Stack, Typography } from '@mui/material';
 import ContactsIcon from '@mui/icons-material/Contacts';
 import { useGetList, Link, SimpleList, useGetIdentity } from 'react-admin';
 import { formatDistance } from 'date-fns';
@@ -43,15 +43,25 @@ export const HotContacts = () => {
                     data={contactData}
                     total={contactTotal}
                     isPending={contactsLoading}
+                    resource="contacts"
                     primaryText={contact =>
                         `${contact.first_name} ${contact.last_name}`
                     }
-                    resource="contacts"
-                    secondaryText={(contact: Contact) =>
-                        formatDistance(contact.last_seen, new Date(), {
-                            addSuffix: true,
-                        })
-                    }
+                    secondaryText={contact => (
+                        <Stack>
+                            <Typography variant="caption">
+                                {contact.title} at {contact.company_name}
+                            </Typography>
+                            <Typography
+                                variant="caption"
+                                color="text.secondary"
+                            >
+                                {formatDistance(contact.last_seen, new Date(), {
+                                    addSuffix: true,
+                                })}
+                            </Typography>
+                        </Stack>
+                    )}
                     leftAvatar={contact => <Avatar record={contact} />}
                     dense
                 />


### PR DESCRIPTION
## Problem

Only with a first and last name and an avatar, it's too complicated to remember who is who in the “Hot contacts” list. Know the company of the contact could help me.

## Solution

In “Hot contacts” section, display the company of the contact.


![Screenshot from 2024-07-29 19-18-47](https://github.com/user-attachments/assets/14d71c56-3646-4f71-adeb-11a409daf6a9)
