### PR TITLE
Feat(crm): Display Forms at a glance

### DIFF
--- a/examples/crm/src/companies/CompanyInputs.tsx
+++ b/examples/crm/src/companies/CompanyInputs.tsx
@@ -38,22 +38,17 @@ export const CompanyInputs = () => {
     return (
         <Stack gap={4} p={1}>
             <CompanyDisplayInputs />
-            <Stack gap={4} flexDirection={isMobile ? 'column' : 'row'}>
-                <CompanyContactInputs />
+            <Stack gap={4} direction={isMobile ? 'column' : 'row'}>
+                <Stack gap={4} flex={1}>
+                    <CompanyContactInputs />
+                    <CompanyContextInputs />
+                </Stack>
                 <Divider
                     orientation={isMobile ? 'horizontal' : 'vertical'}
                     flexItem
                 />
-                <CompanyContextInputs />
-            </Stack>
-
-            <Stack gap={4} flexDirection={isMobile ? 'column' : 'row'}>
-                <CompanyAddressInputs />
-                <Divider
-                    orientation={isMobile ? 'horizontal' : 'vertical'}
-                    flexItem
-                />
-                <Stack gap={1} flex={1}>
+                <Stack gap={4} flex={1}>
+                    <CompanyAddressInputs />
                     <CompanyAdditionalInformationInputs />
                     <CompanyAccountManagerInput />
                 </Stack>
@@ -80,7 +75,7 @@ const CompanyDisplayInputs = () => {
 
 const CompanyContactInputs = () => {
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Contact</Typography>
             <TextInput source="website" helperText={false} validate={isUrl} />
             <TextInput
@@ -96,7 +91,7 @@ const CompanyContactInputs = () => {
 const CompanyContextInputs = () => {
     const { companySectors } = useConfigurationContext();
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Context</Typography>
             <SelectInput
                 source="sector"
@@ -115,7 +110,7 @@ const CompanyContextInputs = () => {
 
 const CompanyAddressInputs = () => {
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Address</Typography>
             <TextInput source="address" helperText={false} />
             <TextInput source="city" helperText={false} />
@@ -128,7 +123,7 @@ const CompanyAddressInputs = () => {
 
 const CompanyAdditionalInformationInputs = () => {
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Additional information</Typography>
             <TextInput source="description" multiline helperText={false} />
             <ArrayInput source="context_links" helperText={false}>
@@ -154,7 +149,7 @@ const CompanyAdditionalInformationInputs = () => {
 
 const CompanyAccountManagerInput = () => {
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Account manager</Typography>
             <ReferenceInput source="sales_id" reference="sales">
                 <SelectInput

--- a/examples/crm/src/contacts/ContactInputs.tsx
+++ b/examples/crm/src/contacts/ContactInputs.tsx
@@ -28,26 +28,21 @@ export const ContactInputs = () => {
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
     return (
-        <Stack gap={4} p={1}>
-            <Stack gap={2}>
-                <Avatar />
-                <Stack gap={4} flexDirection={isMobile ? 'column' : 'row'}>
+        <Stack gap={2} p={1}>
+            <Avatar />
+            <Stack gap={4} direction={isMobile ? 'column' : 'row'}>
+                <Stack gap={4} flex={1}>
                     <ContactIdentityInputs />
-                    <Divider
-                        orientation={isMobile ? 'horizontal' : 'vertical'}
-                        flexItem
-                    />
                     <ContactPositionInputs />
                 </Stack>
-            </Stack>
-
-            <Stack gap={4} flexDirection={isMobile ? 'column' : 'row'}>
-                <ContactPersonalInformationInputs />
                 <Divider
                     orientation={isMobile ? 'horizontal' : 'vertical'}
                     flexItem
                 />
-                <ContactMiscInputs />
+                <Stack gap={4} flex={1}>
+                    <ContactPersonalInformationInputs />
+                    <ContactMiscInputs />
+                </Stack>
             </Stack>
         </Stack>
     );
@@ -56,7 +51,7 @@ export const ContactInputs = () => {
 const ContactIdentityInputs = () => {
     const { contactGender } = useConfigurationContext();
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Identity</Typography>
             <RadioButtonGroupInput
                 label={false}
@@ -108,7 +103,7 @@ const ContactPositionInputs = () => {
         }
     };
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Position</Typography>
             <TextInput source="title" helperText={false} />
             <ReferenceInput source="company_id" reference="companies">
@@ -125,7 +120,7 @@ const ContactPositionInputs = () => {
 
 const ContactPersonalInformationInputs = () => {
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Personal info</Typography>
             <TextInput source="email" helperText={false} validate={email()} />
             <Stack gap={1} flexDirection="row">
@@ -170,7 +165,7 @@ const ContactPersonalInformationInputs = () => {
 
 const ContactMiscInputs = () => {
     return (
-        <Stack gap={1} flex={1}>
+        <Stack>
             <Typography variant="h6">Misc</Typography>
             <TextInput
                 source="background"

--- a/examples/crm/src/deals/DealCreate.tsx
+++ b/examples/crm/src/deals/DealCreate.tsx
@@ -73,7 +73,7 @@ export const DealCreate = ({ open }: { open: boolean }) => {
     const { identity } = useGetIdentity();
 
     return (
-        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
+        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
             <Create<Deal>
                 resource="deals"
                 mutationOptions={{ onSuccess }}

--- a/examples/crm/src/deals/DealEdit.tsx
+++ b/examples/crm/src/deals/DealEdit.tsx
@@ -6,6 +6,7 @@ import {
     DeleteButton,
     EditBase,
     Form,
+    ReferenceField,
     SaveButton,
     Toolbar,
     useNotify,
@@ -16,6 +17,7 @@ import { Link } from 'react-router-dom';
 import { DialogCloseButton } from '../misc/DialogCloseButton';
 import { Deal } from '../types';
 import { DealInputs } from './DealInputs';
+import { CompanyAvatar } from '../companies/CompanyAvatar';
 
 export const DealEdit = ({ open, id }: { open: boolean; id?: string }) => {
     const redirect = useRedirect();
@@ -28,7 +30,7 @@ export const DealEdit = ({ open, id }: { open: boolean; id?: string }) => {
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
+        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
             {!!id ? (
                 <EditBase
                     id={id}
@@ -80,7 +82,16 @@ function EditHeader() {
                 justifyContent="space-between"
                 spacing={1}
             >
-                <Typography variant="h6">Edit {deal.name} deal</Typography>
+                <Stack direction="row" alignItems="center" gap={2}>
+                    <ReferenceField
+                        source="company_id"
+                        reference="companies"
+                        link="show"
+                    >
+                        <CompanyAvatar />
+                    </ReferenceField>
+                    <Typography variant="h6">Edit {deal.name} deal</Typography>
+                </Stack>
 
                 <Stack direction="row" spacing={1} sx={{ pr: 3 }}>
                     <Button component={Link} to={`/deals/${deal.id}/show`}>

--- a/examples/crm/src/deals/DealInputs.tsx
+++ b/examples/crm/src/deals/DealInputs.tsx
@@ -1,4 +1,10 @@
-import { Divider } from '@mui/material';
+import {
+    Divider,
+    Stack,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
 import {
     AutocompleteArrayInput,
     AutocompleteInput,
@@ -19,8 +25,44 @@ import { contactInputText, contactOptionText } from '../misc/ContactOption';
 const validateRequired = required();
 
 export const DealInputs = () => {
-    const { dealStages, dealCategories } = useConfigurationContext();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    return (
+        <Stack gap={4} p={1}>
+            <DealInfoInputs />
 
+            <Stack gap={8} flexDirection={isMobile ? 'column' : 'row'}>
+                <DealLinkedToInputs />
+                <Divider
+                    orientation={isMobile ? 'horizontal' : 'vertical'}
+                    flexItem
+                />
+                <DealMiscInputs />
+            </Stack>
+        </Stack>
+    );
+};
+
+const DealInfoInputs = () => {
+    return (
+        <Stack gap={1} flex={1}>
+            <TextInput
+                source="name"
+                label="Deal name"
+                validate={validateRequired}
+                helperText={false}
+            />
+            <TextInput
+                source="description"
+                multiline
+                rows={3}
+                helperText={false}
+            />
+        </Stack>
+    );
+};
+
+const DealLinkedToInputs = () => {
     const [create] = useCreate();
     const notify = useNotify();
     const { identity } = useGetIdentity();
@@ -47,20 +89,8 @@ export const DealInputs = () => {
         }
     };
     return (
-        <>
-            <TextInput
-                source="name"
-                label="Deal name"
-                validate={validateRequired}
-                helperText={false}
-            />
-            <TextInput
-                source="description"
-                multiline
-                rows={3}
-                helperText={false}
-            />
-            <Divider sx={{ my: 2, width: '100%' }} />
+        <Stack gap={1} flex={1}>
+            <Typography variant="h6">Linked to</Typography>
             <ReferenceInput source="company_id" reference="companies">
                 <AutocompleteInput
                     optionText="name"
@@ -78,17 +108,16 @@ export const DealInputs = () => {
                     helperText={false}
                 />
             </ReferenceArrayInput>
-            <Divider sx={{ my: 2, width: '100%' }} />
-            <SelectInput
-                source="stage"
-                choices={dealStages.map(stage => ({
-                    id: stage.value,
-                    name: stage.label,
-                }))}
-                validate={validateRequired}
-                defaultValue="opportunity"
-                helperText={false}
-            />
+        </Stack>
+    );
+};
+
+const DealMiscInputs = () => {
+    const { dealStages, dealCategories } = useConfigurationContext();
+    return (
+        <Stack gap={1} flex={1}>
+            <Typography variant="h6">Misc</Typography>
+
             <SelectInput
                 source="category"
                 label="Category"
@@ -104,13 +133,22 @@ export const DealInputs = () => {
                 validate={validateRequired}
                 helperText={false}
             />
-            <Divider sx={{ my: 2, width: '100%' }} />
             <DateInput
                 source="expected_closing_date"
                 fullWidth
                 validate={[validateRequired]}
                 helperText={false}
             />
-        </>
+            <SelectInput
+                source="stage"
+                choices={dealStages.map(stage => ({
+                    id: stage.value,
+                    name: stage.label,
+                }))}
+                validate={validateRequired}
+                defaultValue="opportunity"
+                helperText={false}
+            />
+        </Stack>
     );
 };

--- a/examples/crm/src/deals/DealShow.tsx
+++ b/examples/crm/src/deals/DealShow.tsx
@@ -16,7 +16,6 @@ import {
     ReferenceField,
     ReferenceManyField,
     ShowBase,
-    TextField,
     useDataProvider,
     useNotify,
     useRecordContext,
@@ -42,7 +41,7 @@ export const DealShow = ({ open, id }: { open: boolean; id?: string }) => {
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
+        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
             <DialogContent sx={{ padding: 0 }}>
                 {!!id ? (
                     <ShowBase id={id}>
@@ -69,34 +68,20 @@ const DealShowContent = ({ handleClose }: { handleClose: () => void }) => {
             <Stack gap={1}>
                 {record.archived_at ? <ArchivedTitle /> : null}
                 <Box display="flex" p={3}>
-                    <Box
-                        width={100}
-                        display="flex"
-                        flexDirection="column"
-                        alignItems="center"
-                    >
-                        <ReferenceField
-                            source="company_id"
-                            reference="companies"
-                            link="show"
-                        >
-                            <CompanyAvatar />
-                        </ReferenceField>
-                        <ReferenceField
-                            source="company_id"
-                            reference="companies"
-                            link="show"
-                        >
-                            <TextField
-                                source="name"
-                                align="center"
-                                component="div"
-                            />
-                        </ReferenceField>
-                    </Box>
                     <Box ml={2} flex="1">
                         <Stack direction="row" justifyContent="space-between">
-                            <Typography variant="h5">{record.name}</Typography>
+                            <Stack direction="row" alignItems="center" gap={2}>
+                                <ReferenceField
+                                    source="company_id"
+                                    reference="companies"
+                                    link="show"
+                                >
+                                    <CompanyAvatar />
+                                </ReferenceField>
+                                <Typography variant="h5">
+                                    {record.name}
+                                </Typography>
+                            </Stack>
                             <Stack gap={1} direction="row" pr={4}>
                                 {record.archived_at ? (
                                     <>
@@ -277,7 +262,7 @@ const ArchiveButton = ({ record }: { record: Deal }) => {
     };
 
     return (
-        <Button onClick={handleClick} startIcon={<ArchiveIcon />}>
+        <Button onClick={handleClick} startIcon={<ArchiveIcon />} size="small">
             Archive
         </Button>
     );
@@ -309,7 +294,11 @@ const UnarchiveButton = ({ record }: { record: Deal }) => {
     };
 
     return (
-        <Button onClick={handleClick} startIcon={<UnarchiveIcon />}>
+        <Button
+            onClick={handleClick}
+            startIcon={<UnarchiveIcon />}
+            size="small"
+        >
             Send back to the board
         </Button>
     );


### PR DESCRIPTION
## Problem

Keyboard navigation is in a different order to that intuitively imagined

## Solution

Reorganises fields into two columns and a vertical separator across the entire column.

## Screenshoots

![image](https://github.com/user-attachments/assets/ae3d4977-076d-447f-b742-8f1084267aa1)


![image](https://github.com/user-attachments/assets/0f99c06e-0202-4120-943e-e3ed6b5ddf2f)

![image](https://github.com/user-attachments/assets/f7d3e540-e563-4c1c-a38c-24d000e85209)
