### PR TITLE
Fix setSort ignores the sort order when the chosen field is the current one

### DIFF
--- a/packages/ra-core/src/controller/list/queryReducer.spec.ts
+++ b/packages/ra-core/src/controller/list/queryReducer.spec.ts
@@ -227,7 +227,7 @@ describe('Query Reducer', () => {
                 page: 1,
             });
         });
-        it("should set order as the opposite of the one in previous state even if order is specified in the payload when sort hasn't change", () => {
+        it("shouldn't set order as the opposite of the one in previous state if order is specified in the payload", () => {
             const updatedState = queryReducer(
                 {
                     sort: 'foo',
@@ -241,7 +241,7 @@ describe('Query Reducer', () => {
             );
             expect(updatedState).toEqual({
                 sort: 'foo',
-                order: SORT_ASC,
+                order: SORT_DESC,
                 page: 1,
             });
         });

--- a/packages/ra-core/src/controller/list/queryReducer.ts
+++ b/packages/ra-core/src/controller/list/queryReducer.ts
@@ -63,7 +63,9 @@ export const queryReducer: Reducer<ListParams, ActionTypes> = (
             if (action.payload.field === previousState.sort) {
                 return {
                     ...previousState,
-                    order: oppositeOrder(previousState.order),
+                    order:
+                        action.payload.order ??
+                        oppositeOrder(previousState.order),
                     page: 1,
                 };
             }


### PR DESCRIPTION
## Problem

The `setOrder` callback apply the opposite order for the same column, even if `order` is defined

## Solution

Apply `order` defined by the user

