### PR TITLE
Fix <TranslatableInputs> throws error when used with null value

### DIFF
--- a/packages/ra-core/src/i18n/useTranslatable.spec.ts
+++ b/packages/ra-core/src/i18n/useTranslatable.spec.ts
@@ -5,6 +5,7 @@ describe('useTranslatable', () => {
             // Given the record { title: { en: 'title_en', fr: 'title_fr' } } and the locale 'fr',
             // the record for the locale 'fr' will be { title: 'title_fr' }
             const record = {
+                nullEntry: null,
                 fractal: true,
                 title: { en: 'title_en', fr: 'title_fr' },
                 items: [
@@ -16,6 +17,7 @@ describe('useTranslatable', () => {
             const recordForLocale = getRecordForLocale(record, 'fr');
 
             expect(recordForLocale).toEqual({
+                nullEntry: null,
                 fractal: true,
                 title: 'title_fr',
                 items: [

--- a/packages/ra-core/src/i18n/useTranslatable.ts
+++ b/packages/ra-core/src/i18n/useTranslatable.ts
@@ -101,7 +101,7 @@ const getRecordPaths = (
     path: Array<string> = []
 ): Array<Array<string>> => {
     return Object.entries(record).reduce((acc, [key, value]) => {
-        if (typeof value === 'object') {
+        if (value !== null && typeof value === 'object') {
             return [
                 ...acc,
                 [...path, key],


### PR DESCRIPTION
Closes #10107 