### PR TITLE
Fix(crm): Set phone number into split fields + update getCompanyAvatar

### DIFF
--- a/examples/crm/src/contacts/ContactAside.tsx
+++ b/examples/crm/src/contacts/ContactAside.tsx
@@ -73,21 +73,21 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
                     />
                 </Stack>
             )}
-            {record.phone_number1?.number && (
+            {record.phone_1_number && (
                 <Stack direction="row" alignItems="center" gap={1}>
                     <PhoneIcon color="disabled" fontSize="small" />
                     <Box>
-                        <TextField source="phone_number1.number" />{' '}
-                        {record.phone_number1.type !== 'Other' && (
+                        <TextField source="phone_1_number" />{' '}
+                        {record.phone_1_type !== 'Other' && (
                             <TextField
-                                source="phone_number1.type"
+                                source="phone_1_type"
                                 color="textSecondary"
                             />
                         )}
                     </Box>
                 </Stack>
             )}
-            {record.phone_number2?.number && (
+            {record.phone_2_number && (
                 <Stack
                     direction="row"
                     alignItems="center"
@@ -96,10 +96,10 @@ export const ContactAside = ({ link = 'edit' }: { link?: 'edit' | 'show' }) => {
                 >
                     <PhoneIcon color="disabled" fontSize="small" />
                     <Box>
-                        <TextField source="phone_number2.number" />{' '}
-                        {record.phone_number2.type !== 'Other' && (
+                        <TextField source="phone_2_number" />{' '}
+                        {record.phone_2_type !== 'Other' && (
                             <TextField
-                                source="phone_number2.type"
+                                source="phone_2_type"
                                 color="textSecondary"
                             />
                         )}

--- a/examples/crm/src/contacts/ContactInputs.tsx
+++ b/examples/crm/src/contacts/ContactInputs.tsx
@@ -125,12 +125,12 @@ const ContactPersonalInformationInputs = () => {
             <TextInput source="email" helperText={false} validate={email()} />
             <Stack gap={1} flexDirection="row">
                 <TextInput
-                    source="phone_number1.number"
+                    source="phone_1_number"
                     label="Phone number 1"
                     helperText={false}
                 />
                 <SelectInput
-                    source="phone_number1.type"
+                    source="phone_1_type"
                     label="Type"
                     helperText={false}
                     optionText={choice => choice.id}
@@ -140,12 +140,12 @@ const ContactPersonalInformationInputs = () => {
             </Stack>
             <Stack gap={1} flexDirection="row">
                 <TextInput
-                    source="phone_number2.number"
+                    source="phone_2_number"
                     label="Phone number 2"
                     helperText={false}
                 />
                 <SelectInput
-                    source="phone_number2.type"
+                    source="phone_2_type"
                     label="Type"
                     helperText={false}
                     optionText={choice => choice.id}
@@ -179,7 +179,7 @@ const ContactMiscInputs = () => {
                 source="sales_id"
                 sort={{ field: 'last_name', order: 'ASC' }}
                 filter={{
-                    disabled_neq: true,
+                    'disabled@neq': true,
                 }}
             >
                 <SelectInput

--- a/examples/crm/src/contacts/contacts_export.csv
+++ b/examples/crm/src/contacts/contacts_export.csv
@@ -1,2 +1,2 @@
-first_name,last_name,gender,title,company,email,phone_number1.number,phone_number1.type,phone_number2.number,phone_number2.type,background,acquisition,first_seen,last_seen,has_newsletter,status,tags
+first_name,last_name,gender,title,company,email,phone_1_number,phone_1_type,phone_2_number,phone_2_type,background,acquisition,first_seen,last_seen,has_newsletter,status,tags
 John,DOE,male,Developer,Marmelab,john@doe.example,659-980-2015,work,740.645.3807,home,,outbound,2024-07-01,2024-07-01T11:54:49.950Z,FALSE,in-contract,"influencer, developer"

--- a/examples/crm/src/contacts/useContactImport.tsx
+++ b/examples/crm/src/contacts/useContactImport.tsx
@@ -9,10 +9,10 @@ export type ContactImportSchema = {
     title: string;
     company: string;
     email: string;
-    'phone_number1.number': string;
-    'phone_number1.type': string;
-    'phone_number2.number': string;
-    'phone_number2.type': string;
+    phone_1_number: string;
+    phone_1_type: string;
+    phone_2_number: string;
+    phone_2_type: string;
     background: string;
     acquisition: string;
     avatar: string;
@@ -51,7 +51,7 @@ export function useContactImport() {
                 ? await dataProvider.getList(entity, {
                       filter: { name: uncachedEntities },
                       pagination: { page: 1, perPage: 1 },
-                      sort: { field: 'first_name', order: 'ASC' },
+                      sort: { field: 'id', order: 'ASC' },
                   })
                 : { data: [] };
 
@@ -137,10 +137,10 @@ export function useContactImport() {
                         gender,
                         title,
                         email,
-                        'phone_number1.type': phoneNumber1Type,
-                        'phone_number1.number': phoneNumber1Number,
-                        'phone_number2.type': phoneNumber2Type,
-                        'phone_number2.number': phoneNumber2Number,
+                        phone_1_number: phoneNumber1Type,
+                        phone_1_type: phoneNumber1Number,
+                        phone_2_number: phoneNumber2Type,
+                        phone_2_type: phoneNumber2Number,
                         background,
                         acquisition,
                         first_seen,
@@ -168,14 +168,10 @@ export function useContactImport() {
                                 gender,
                                 title,
                                 email,
-                                phone_number1: {
-                                    number: phoneNumber1Number,
-                                    type: phoneNumber1Type,
-                                },
-                                phone_number2: {
-                                    number: phoneNumber2Number,
-                                    type: phoneNumber2Type,
-                                },
+                                phone_1_number: phoneNumber1Number,
+                                phone_1_type: phoneNumber1Type,
+                                phone_2_number: phoneNumber2Number,
+                                phone_2_type: phoneNumber2Type,
                                 background,
                                 acquisition,
                                 first_seen: new Date(first_seen),

--- a/examples/crm/src/dataGenerator/contacts.ts
+++ b/examples/crm/src/dataGenerator/contacts.ts
@@ -68,14 +68,10 @@ export const generateContacts = (db: Db): Contact[] => {
             company_id: company.id,
             company_name: company.name,
             email,
-            phone_number1: {
-                number: phone.phoneNumber(),
-                type: random.arrayElement(['Work', 'Home', 'Other']),
-            },
-            phone_number2: {
-                number: phone.phoneNumber(),
-                type: random.arrayElement(['Work', 'Home', 'Other']),
-            },
+            phone_1_number: phone.phoneNumber(),
+            phone_1_type: random.arrayElement(['Work', 'Home', 'Other']),
+            phone_2_number: phone.phoneNumber(),
+            phone_2_type: random.arrayElement(['Work', 'Home', 'Other']),
             background: lorem.sentence(),
             acquisition: random.arrayElement(['inbound', 'outbound']),
             avatar,

--- a/examples/crm/src/misc/getCompanyAvatar.ts
+++ b/examples/crm/src/misc/getCompanyAvatar.ts
@@ -3,7 +3,10 @@ import { Company } from '../types';
 // Helper function to get the favicon URL
 async function getFaviconUrl(website: string): Promise<string | null> {
     try {
-        const faviconUrl = `${website}/favicon.ico`;
+        // get favicon from domain
+        const url = new URL(website);
+        const domain = url.origin;
+        const faviconUrl = `${domain}/favicon.ico`;
         const response = await fetch(faviconUrl);
         if (response.ok) {
             return faviconUrl;

--- a/examples/crm/src/types.ts
+++ b/examples/crm/src/types.ts
@@ -58,8 +58,10 @@ export interface Contact extends RaRecord {
     sales_id: Identifier;
     status: string;
     background: string;
-    phone_number1: { number: string; type: 'Work' | 'Home' | 'Other' };
-    phone_number2: { number: string; type: 'Work' | 'Home' | 'Other' };
+    phone_1_type: 'Work' | 'Home' | 'Other';
+    phone_1_number: string;
+    phone_2_type: 'Work' | 'Home' | 'Other';
+    phone_2_number: string;
 }
 
 export interface ContactNote extends RaRecord {


### PR DESCRIPTION
## Solution

- getCompanyAvatar: The script won't work if the url isn't properly formatted. 
- Split contact phone number into seperate fields to be atomic-crm compliant



