### PR TITLE
adjusted check for use of the override option

### DIFF
--- a/packages/ra-data-graphql/src/index.ts
+++ b/packages/ra-data-graphql/src/index.ts
@@ -142,7 +142,10 @@ const buildGraphQLProvider = (options: Options): DataProvider => {
         ...otherOptions
     } = merge({}, defaultOptions, options);
 
-    if (override && process.env.NODE_ENV === 'production') {
+    if (
+        Object.keys(override).length > 0 &&
+        process.env.NODE_ENV === 'production'
+    ) {
         console.warn(
             // eslint-disable-line
             'The override option is deprecated. You should instead wrap the buildQuery function provided by the dataProvider you use.'


### PR DESCRIPTION
## Problem

https://github.com/marmelab/react-admin/issues/10052 - the check whether the `override` prop was used is faulty and warns even when not appropriate.

## Solution

As suggested in the comments, instead of checking whether `override` is `!= null`, we check whether it has keys in it. This way, its default value - `{}` won't pass this check, and no warning gets logged.
I used `Object.keys(override).length > 0` instead of `Object.keys(override).length` before I favor explicitness over the somewhat wonky JavaScript coercion. I can change this, though.

## How To Test

Follow the steps described in https://github.com/marmelab/react-admin/issues/10052 with this fixed version.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) - it's quite an effort and I'm not sure it's worth it for a behavior which will disappear once the depcrecated property gets removed, and whose impact is rather neglectable (we're talking about the condition for a log entry here 🙈 ). Additionally, the `make` scripts don't seem to work under Windows, so I had to switch to another platform first, or try to make it run under WSL. I could try that, but I dunno when I find time for such an undertaking.
- [ ] The PR includes one or several **stories** (if not possible, describe why) - no were feature changed, and a log entry isn't really something to be displayed in a story anyway
- [x] The **documentation** is up to date
