### PR TITLE
[Doc] Remove more references to ra-enterprise webm videos

### DIFF
--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -421,8 +421,6 @@ const CustomerEdit = () => (
 Renders children (Inputs) inside a Material UI `<Accordion>` element without a Card style. To be used as child of a `<SimpleForm>` or a `<TabbedForm>` element.
 
 <video controls autoplay playsinline muted loop>
-  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.webm" type="video/webm"/>
-  <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
   <source src="https://react-admin-ee.marmelab.com/assets/ra-accordion-section-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>

--- a/docs/DatagridAG.md
+++ b/docs/DatagridAG.md
@@ -507,7 +507,6 @@ const CarList = () => {
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 
@@ -873,7 +872,6 @@ By default, `<DatagridAG>` renders pagination controls at the bottom of the list
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-without-pagination.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/EditableDatagrid.md
+++ b/docs/EditableDatagrid.md
@@ -586,7 +586,6 @@ You can let end users customize what fields are displayed in the `<EditableDatag
 
 <video controls autoplay playsinline muted loop>
   <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-configurable.mp4" type="video/mp4"/>
-  <source src="https://react-admin-ee.marmelab.com/assets/ra-editable-datagrid-configurable.webm" type="video/webm"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/StackedFilters.md
+++ b/docs/StackedFilters.md
@@ -8,7 +8,6 @@ title: "The StackedFilters Component"
 This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component provides an alternative filter UI for `<List>` pages. It introduces the concept of operators to allow richer filtering.
 
 <video controls autoplay playsinline muted loop width="100%">
-  <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.webm" type="video/webm"/>
   <source src="https://react-admin-ee.marmelab.com/assets/ra-form-layout/latest/stackedfilters-overview.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>


### PR DESCRIPTION
## Problem

Some references to webm videos still remained after https://github.com/marmelab/react-admin/pull/10127

## Solution

Remove them

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
