### PR TITLE
Fix `<PrevNextButtons>` index when using paginated results

### DIFF
--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -250,7 +250,7 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
                 : index +
                   (canUseCacheData
                       ? (storedParams.perPage ?? 0) *
-                        ((storedParams.page ?? 0) - 1)
+                        ((storedParams.page ?? 1) - 1)
                       : 0),
         total: canUseCacheData ? queryData?.total : data?.total,
         error,

--- a/packages/ra-core/src/controller/usePrevNextController.ts
+++ b/packages/ra-core/src/controller/usePrevNextController.ts
@@ -244,7 +244,14 @@ export const usePrevNextController = <RecordType extends RaRecord = any>(
                       id: nextId,
                   })
                 : undefined,
-        index: index === -1 ? undefined : index,
+        index:
+            index === -1
+                ? undefined
+                : index +
+                  (canUseCacheData
+                      ? (storedParams.perPage ?? 0) *
+                        ((storedParams.page ?? 0) - 1)
+                      : 0),
         total: canUseCacheData ? queryData?.total : data?.total,
         error,
         isFetching: canUseCacheData ? false : isFetching,

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.spec.tsx
@@ -147,4 +147,55 @@ describe('<PrevNextButtons />', () => {
             });
         });
     });
+
+    describe('pagination', () => {
+        it('should compute the index correctly when opening first record of page 2', async () => {
+            render(<Basic />);
+            await screen.findByText('Deja');
+            fireEvent.click(await screen.findByLabelText('Go to page 2'));
+            const tr = await screen.findByText('Hamill');
+            fireEvent.click(tr);
+            await screen.findByText('11 / 900');
+        });
+        it('should compute the index correctly when opening second record of page 2', async () => {
+            render(<Basic />);
+            await screen.findByText('Deja');
+            fireEvent.click(await screen.findByLabelText('Go to page 2'));
+            const tr = await screen.findByText('Kub');
+            fireEvent.click(tr);
+            await screen.findByText('12 / 900');
+        });
+        it('should compute the index correctly when opening last record of page 2', async () => {
+            render(<Basic />);
+            await screen.findByText('Deja');
+            fireEvent.click(await screen.findByLabelText('Go to page 2'));
+            const tr = await screen.findByText('Langworth');
+            fireEvent.click(tr);
+            await screen.findByText('20 / 900');
+        });
+        it('should compute the index correctly when opening first record of page 3', async () => {
+            render(<Basic />);
+            await screen.findByText('Deja');
+            fireEvent.click(await screen.findByLabelText('Go to page 3'));
+            const tr = await screen.findByText('Spinka');
+            fireEvent.click(tr);
+            await screen.findByText('21 / 900');
+        });
+        it('should compute the index correctly when opening second record of page 3', async () => {
+            render(<Basic />);
+            await screen.findByText('Deja');
+            fireEvent.click(await screen.findByLabelText('Go to page 3'));
+            const tr = await screen.findByText('Lowe');
+            fireEvent.click(tr);
+            await screen.findByText('22 / 900');
+        });
+        it('should compute the index correctly when opening last record of page 3', async () => {
+            render(<Basic />);
+            await screen.findByText('Deja');
+            fireEvent.click(await screen.findByLabelText('Go to page 3'));
+            const tr = await screen.findByText('Grimes');
+            fireEvent.click(tr);
+            await screen.findByText('30 / 900');
+        });
+    });
 });


### PR DESCRIPTION
## Problem

Fix https://github.com/marmelab/react-admin/issues/10136

## Solution

Fix the index computation in case the data comes from the query cache and page > 1

## How To Test

The fix can be tested in Storybook or in the E-commerce Demo

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date -> no need

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
