### PR TITLE
[DOCS] Add ra-data-nestjs-query to DataProviderList.md

### DIFF
--- a/docs/DataProviderList.md
+++ b/docs/DataProviderList.md
@@ -32,7 +32,6 @@ If you can't find a Data Provider for your backend below, no worries! [Writing a
 * ![sheets Logo](./img/backend-logos/sheets.svg "sheets Logo")**[Google Sheets](https://www.google.com/sheets/about/)**: [marmelab/ra-data-google-sheets](https://github.com/marmelab/ra-data-google-sheets)
 * ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[GraphQL (generic)](https://graphql.org/)**: [marmelab/ra-data-graphql](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql) (uses [Apollo](https://www.apollodata.com/))
 * ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[GraphQL (simple)](https://graphql.org/)**: [marmelab/ra-data-graphql-simple](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql-simple).
-* ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[GraphQL (Nestjs-query)](https://tripss.github.io/nestjs-query/)**: [mrnkr/ra-data-nestjs-query](https://github.com/mrnkr/ra-data-nestjs-query).
 * <div class="flex">
     <span class="avatar">H</span>
     <b><a href="http://stateless.co/hal_specification.html">HAL</a></b>: <a href="https://github.com/b-social/ra-data-hal">b-social/ra-data-hal</a>
@@ -56,6 +55,7 @@ If you can't find a Data Provider for your backend below, no worries! [Writing a
 * ![mixer Logo](./img/backend-logos/github.svg "mixer Logo")**[Mixer](https://github.com/ckoliber/ra-data-mixer)**: [ckoliber/ra-data-mixer](https://github.com/ckoliber/ra-data-mixer)
 * ![moleculer Logo](./img/backend-logos/github.svg "moleculer Logo")**[Moleculer Microservices](https://github.com/RancaguaInnova/moleculer-data-provider)**: [RancaguaInnova/moleculer-data-provider](https://github.com/RancaguaInnova/moleculer-data-provider)
 * ![nestJs Logo](./img/backend-logos/nestjs.png "nestJs Logo")**[NestJS CRUD](https://github.com/nestjsx/crud)**: [rayman1104/ra-data-nestjsx-crud](https://github.com/rayman1104/ra-data-nestjsx-crud)
+* ![Nestjs-query Logo](./img/backend-logos/nestjs-query.svg "Nestjs-query Logo")**[Nestjs-query (GraphQL)](https://tripss.github.io/nestjs-query/)**: [mrnkr/ra-data-nestjs-query](https://github.com/mrnkr/ra-data-nestjs-query)
 * ![oData Logo](./img/backend-logos/odata.png "oData Logo")**[OData](https://www.odata.org/)**: [Groopit/ra-data-odata-server](https://github.com/Groopit/ra-data-odata-server)
 * ![open Logo](./img/backend-logos/open.png "open Logo")**[OpenCRUD](https://www.opencrud.org/)**: [weakky/ra-data-opencrud](https://github.com/Weakky/ra-data-opencrud)
 * ![parse Logo](./img/backend-logos/parse.png "parse Logo")**[Parse](https://parseplatform.org/)**: [almahdi/ra-data-parse](https://github.com/almahdi/ra-data-parse)

--- a/docs/DataProviderList.md
+++ b/docs/DataProviderList.md
@@ -32,6 +32,7 @@ If you can't find a Data Provider for your backend below, no worries! [Writing a
 * ![sheets Logo](./img/backend-logos/sheets.svg "sheets Logo")**[Google Sheets](https://www.google.com/sheets/about/)**: [marmelab/ra-data-google-sheets](https://github.com/marmelab/ra-data-google-sheets)
 * ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[GraphQL (generic)](https://graphql.org/)**: [marmelab/ra-data-graphql](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql) (uses [Apollo](https://www.apollodata.com/))
 * ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[GraphQL (simple)](https://graphql.org/)**: [marmelab/ra-data-graphql-simple](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-graphql-simple).
+* ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[GraphQL (Nestjs-query)](https://tripss.github.io/nestjs-query/)**: [mrnkr/ra-data-nestjs-query](https://github.com/mrnkr/ra-data-nestjs-query).
 * <div class="flex">
     <span class="avatar">H</span>
     <b><a href="http://stateless.co/hal_specification.html">HAL</a></b>: <a href="https://github.com/b-social/ra-data-hal">b-social/ra-data-hal</a>

--- a/docs/img/backend-logos/nestjs-query.svg
+++ b/docs/img/backend-logos/nestjs-query.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?> <!-- Created with Vectornator for iOS (http://vectornator.io/) --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg height="100%" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" xmlns:vectornator="http://vectornator.io" version="1.1" viewBox="0 0 500 500">
+<metadata>
+<vectornator:setting key="DynamicGuides" value="0"/>
+<vectornator:setting key="SnapToPoints" value="0"/>
+<vectornator:setting key="OutlineMode" value="0"/>
+<vectornator:setting key="RulersVisible" value="1"/>
+<vectornator:setting key="CMYKEnabledKey" value="0"/>
+<vectornator:setting key="SnapToEdges" value="0"/>
+<vectornator:setting key="DisplayWhiteBackground" value="0"/>
+<vectornator:setting key="ShowGrid" value="1"/>
+<vectornator:setting key="SnapToGuides" value="1"/>
+<vectornator:setting key="Units" value="Pixels"/>
+<vectornator:setting key="SnapToGrid" value="0"/>
+<vectornator:setting key="GridSpacing" value="50"/>
+<vectornator:setting key="IsolateActiveLayer" value="0"/>
+</metadata>
+<defs/>
+<g id="Layer 2" vectornator:layerName="Layer 2">
+<path stroke="#25c2a0" stroke-width="15" d="M10.0732+149.092C9.87799+124.047+31.7197+103.907+58.8581+104.107C85.9964+104.307+108.155+124.772+108.35+149.817C108.545+174.861+86.7032+195.002+59.5649+194.802C32.4265+194.602+10.2684+174.137+10.0732+149.092Z" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M492.13+351.392C492.325+376.436+470.483+396.577+443.345+396.377C416.207+396.177+394.049+375.712+393.853+350.667C393.658+325.622+415.5+305.482+442.638+305.682C469.777+305.882+491.935+326.347+492.13+351.392Z" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M58.8196+196.132L58.6133+288.458" fill="none" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M443.384+304.352L443.59+212.026" fill="none" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M466.119+106.796C488.984+118.455+496.984+146.63+483.988+169.728C470.993+192.825+441.922+202.098+419.057+190.44C396.192+178.781+388.192+150.606+401.187+127.508C414.183+104.411+443.254+95.1376+466.119+106.796Z" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M36.0844+393.688C13.2195+382.029+5.219+353.854+18.2147+330.756C31.2105+307.658+60.2813+298.385+83.1462+310.044C106.011+321.702+114.012+349.878+101.016+372.975C88.0201+396.073+58.9493+405.346+36.0844+393.688Z" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M397.458+126.244L313.605+82.4736" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M104.745+374.24L188.598+418.01" fill="none" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M229.317+13.8039C252.406+2.56722+280.694+12.6625+292.501+36.3524C304.308+60.0422+295.162+88.3557+272.074+99.5924C248.985+110.829+220.697+100.734+208.89+77.0439C197.083+53.3541+206.229+25.0406+229.317+13.8039Z" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M272.886+486.68C249.797+497.916+221.509+487.821+209.702+464.131C197.895+440.441+207.041+412.128+230.129+400.891C253.218+389.655+281.506+399.75+293.313+423.44C305.12+447.13+295.975+475.443+272.886+486.68Z" fill="#25c2a0" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M207.33+76.9833L121.806+117.602" fill="none" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+<path stroke="#25c2a0" stroke-width="15" d="M294.873+423.5L380.397+382.882" fill="none" stroke-linecap="round" opacity="1" stroke-linejoin="round"/>
+</g>
+<g id="Layer 3" vectornator:layerName="Layer 3">
+<g opacity="1">
+<path d="M141.487+323.423L124.397+323.423L124.397+178.306L141.487+178.306L215.706+294.321L216.487+294.321L216.487+178.306L233.382+178.306L233.382+323.423L216.487+323.423L142.073+207.407L141.487+207.407L141.487+323.423Z" opacity="1" fill="#25c2a0"/>
+<path d="M268.733+261.802L268.733+239.927C268.733+226.515+271.11+214.894+275.862+205.063C280.615+195.233+287.288+187.811+295.882+182.798C304.476+177.785+314.534+175.278+326.058+175.278C343.636+175.278+357.617+180.959+368.001+192.319C378.385+203.68+383.577+219.549+383.577+239.927L383.577+261.802C383.577+283.937+377.392+300.766+365.022+312.29L385.433+340.122L365.706+340.122L351.839+321.177C344.157+324.692+335.563+326.45+326.058+326.45C308.545+326.45+294.612+320.77+284.261+309.409C273.909+298.048+268.733+282.179+268.733+261.802ZM285.628+240.122L285.628+261.606C285.628+268.117+286.295+274.09+287.63+279.526C288.964+284.962+290.853+289.601+293.294+293.442C295.735+297.283+298.616+300.522+301.936+303.159C305.257+305.796+308.951+307.765+313.02+309.067C317.089+310.369+321.435+311.02+326.058+311.02C331.982+311.02+337.321+310.011+342.073+307.993L325.862+285.825L345.784+285.825L355.061+298.618C362.809+289.829+366.683+277.492+366.683+261.606L366.683+240.122C366.683+224.106+362.923+211.867+355.403+203.403C347.884+194.94+338.102+190.708+326.058+190.708C320.198+190.708+314.876+191.717+310.091+193.735C305.306+195.753+301.041+198.797+297.298+202.866C293.554+206.935+290.673+212.16+288.655+218.54C286.637+224.92+285.628+232.114+285.628+240.122Z" opacity="1" fill="#25c2a0"/>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
## Problem

There was no [`Nestjs-query`](https://tripss.github.io/nestjs-query/) data provider available.

## Solution

I wrote one and added it to the list of supported backends.

<img width="1912" alt="Screenshot 2024-08-14 at 12 26 04 PM" src="https://github.com/user-attachments/assets/6c5d2342-aae3-4f36-a660-e6fb35daea87">

## How To Test

https://github.com/marmelab/react-admin?tab=readme-ov-file#documentation-1

Serve the documentation like it is suggested in the `README.md` file and look at the `DataProviderList.md` file. There should be 3 GraphQL data providers in the list, with the last one being the one I added.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] ~The PR includes **unit tests** (if not possible, describe why)~ (N/A)
- [ ] ~The PR includes one or several **stories** (if not possible, describe why)~ (N/A)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
