### PR TITLE
Fix: `useInput` should call a custom validator with the final source in respect to the `<SourceContext>`

### DIFF
--- a/packages/ra-core/src/form/useInput.spec.tsx
+++ b/packages/ra-core/src/form/useInput.spec.tsx
@@ -513,6 +513,7 @@ describe('useInput', () => {
                     expect.objectContaining({
                         defaultValue: 'A title',
                         source: 'title',
+                        finalSource: 'title',
                         resource: 'posts',
                     })
                 );
@@ -558,7 +559,8 @@ describe('useInput', () => {
                     { posts: [{ title: 'A new title' }] },
                     expect.objectContaining({
                         defaultValue: 'A title',
-                        source: 'posts.0.title',
+                        source: 'title',
+                        finalSource: 'posts.0.title',
                         resource: 'posts',
                     })
                 );

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -90,7 +90,7 @@ export const useInput = <ValueType = any>(
                 if (!sanitizedValidate) return true;
                 const error = await sanitizedValidate(value, values, {
                     ...props,
-                    source: finalSource,
+                    finalSource,
                 });
 
                 if (!error) return true;

--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -88,7 +88,10 @@ export const useInput = <ValueType = any>(
         rules: {
             validate: async (value, values) => {
                 if (!sanitizedValidate) return true;
-                const error = await sanitizedValidate(value, values, props);
+                const error = await sanitizedValidate(value, values, {
+                    ...props,
+                    source: finalSource,
+                });
 
                 if (!error) return true;
                 // react-hook-form expects errors to be plain strings but our validators can return objects


### PR DESCRIPTION
## Problem

When passing a [custom validator function](https://marmelab.com/react-admin/Validation.html#per-input-validation-custom-function-validator) to an input, the `source` prop it recieves is the original `source` prop declared on the input, instead of the 'final' source computed using the `<SourceContext>`.

This is an issue when the input is inside a component wrapping it with a custom `<SourceContext>`, such as `<SimpleFormIterator>`.

Example:

```tsx
<ArrayInput source="posts">
  <SimpleFormIterator>
    <TextInput source="title" validate={validator} />
  </SimpleFormIterator>
</ArrayInput>
```

In that case, `validator` will be called like so: `validator("value", { posts: [{ title: "value" }] }, { source: "title", /* ... */ })`
Although it should have been: `validator("value", { posts: [{ title: "value" }] }, { source: "posts.0.title", /* ... */ })`

## Solution

Use the `<SourceContext>` and pass a prop called `finalSource` when calling the custom validator in addition to the original `source` prop.

`validator("value", { posts: [{ title: "value" }] }, { source: "title", finalSource: "posts.0.title", /* ... */ })`

## How To Test

Run unit tests.
Alternatively, use a custom validator inside an `<ArrayInput>` in one of the demos.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why) <- did not find it useful for such a technical case
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
