### PR TITLE
fix(DatagridConfigurable): better detect and handle columns changes

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import {
-    useResourceContext,
     usePreference,
+    useResourceContext,
     useStore,
     useTranslate,
 } from 'ra-core';
+import * as React from 'react';
 
 import { Configurable } from '../../preferences';
 import { Datagrid, DatagridProps } from './Datagrid';
@@ -50,6 +50,11 @@ export const DatagridConfigurable = ({
         ConfigurableDatagridColumn[]
     >(`preferences.${finalPreferenceKey}.availableColumns`, []);
 
+    const [columns, setColumns] = useStore<string[]>(
+        `preferences.${finalPreferenceKey}.columns`,
+        []
+    );
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, setOmit] = useStore<string[] | undefined>(
         `preferences.${finalPreferenceKey}.omit`,
@@ -58,7 +63,7 @@ export const DatagridConfigurable = ({
 
     React.useEffect(() => {
         // first render, or the preference have been cleared
-        const columns = React.Children.toArray(props.children)
+        const newAvailableColumns = React.Children.toArray(props.children)
             .filter(child => React.isValidElement(child))
             .map((child: React.ReactElement, index) => ({
                 index: String(index),
@@ -67,16 +72,82 @@ export const DatagridConfigurable = ({
                     child.props.label && typeof child.props.label === 'string' // this list is serializable, so we can't store ReactElement in it
                         ? child.props.label
                         : child.props.source
-                          ? //  force the label to be the source
-                            undefined
-                          : // no source or label, generate a label
-                            translate('ra.configurable.Datagrid.unlabeled', {
-                                column: index,
-                                _: `Unlabeled column #%{column}`,
-                            }),
+                        ? //  force the label to be the source
+                          undefined
+                        : // no source or label, generate a label
+                          translate('ra.configurable.Datagrid.unlabeled', {
+                              column: index,
+                              _: `Unlabeled column #%{column}`,
+                          }),
             }));
-        if (columns.length !== availableColumns.length) {
-            setAvailableColumns(columns);
+        const hasChanged = newAvailableColumns.some(column => {
+            const availableColumn = availableColumns.find(
+                availableColumn =>
+                    (!!availableColumn.source &&
+                        availableColumn.source === column?.source) ||
+                    (!!availableColumn.label &&
+                        availableColumn.label === column?.label)
+            );
+            return !availableColumn || availableColumn.index !== column.index;
+        });
+        if (hasChanged) {
+            // first we need to update the columns indexes to match the new availableColumns so we keep the same order
+            const newColumnsSortedAsOldColumns = columns.flatMap(column => {
+                const oldColumn = availableColumns.find(
+                    availableColumn => availableColumn.index === column
+                );
+                const newColumn = newAvailableColumns.find(
+                    availableColumn =>
+                        (!!availableColumn.source &&
+                            availableColumn.source === oldColumn?.source) ||
+                        (!!availableColumn.label &&
+                            availableColumn.label === oldColumn?.label)
+                );
+                return newColumn?.index ? [newColumn.index] : [];
+            });
+            setColumns([
+                // we add the old columns in the same order as before
+                ...newColumnsSortedAsOldColumns,
+                // then we add at the new columns which are not omited
+                ...newAvailableColumns
+                    .filter(
+                        c =>
+                            !availableColumns.some(
+                                ac =>
+                                    (!!ac.source && ac.source === c.source) ||
+                                    (!!ac.label && ac.label === c.label)
+                            ) && !omit?.includes(c.source as string)
+                    )
+                    .map(c => c.index),
+            ]);
+
+            // Then we update the available columns to include the new columns while keeping the same order as before
+            const newAvailableColumnsSortedAsBefore = [
+                // First the existing columns, in the same order
+                ...(availableColumns
+                    .map(oldAvailableColumn =>
+                        newAvailableColumns.find(
+                            c =>
+                                (!!c.source &&
+                                    c.source === oldAvailableColumn.source) ||
+                                (!!c.label &&
+                                    c.label === oldAvailableColumn.label)
+                        )
+                    )
+                    .filter(c => !!c) as ConfigurableDatagridColumn[]), // Remove undefined columns
+                // Then the new columns
+                ...newAvailableColumns.filter(
+                    c =>
+                        !availableColumns.some(
+                            oldAvailableColumn =>
+                                (!!oldAvailableColumn.source &&
+                                    oldAvailableColumn.source === c.source) ||
+                                (!!oldAvailableColumn.label &&
+                                    oldAvailableColumn.label === c.label)
+                        )
+                ),
+            ];
+            setAvailableColumns(newAvailableColumnsSortedAsBefore);
             setOmit(omit);
         }
     }, [availableColumns]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
@@ -72,13 +72,13 @@ export const DatagridConfigurable = ({
                     child.props.label && typeof child.props.label === 'string' // this list is serializable, so we can't store ReactElement in it
                         ? child.props.label
                         : child.props.source
-                        ? //  force the label to be the source
-                          undefined
-                        : // no source or label, generate a label
-                          translate('ra.configurable.Datagrid.unlabeled', {
-                              column: index,
-                              _: `Unlabeled column #%{column}`,
-                          }),
+                          ? //  force the label to be the source
+                            undefined
+                          : // no source or label, generate a label
+                            translate('ra.configurable.Datagrid.unlabeled', {
+                                column: index,
+                                _: `Unlabeled column #%{column}`,
+                            }),
             }));
         const hasChanged = newAvailableColumns.some(column => {
             const availableColumn = availableColumns.find(


### PR DESCRIPTION
## Problem

When you change the columns order of a ConfigurableDatagrid, or just if you remove a column and add another one, this is not managed and the column management is broken : aka the displayed columns in the configure list does not control the corresponding columns.

Here is a quick illustration of the issue : https://www.loom.com/share/c5a6afaac36a4111bedf08ece818da17 (in french, sorry)

That's because currently, only a change in the number of columns trigger and update. And even in this case, you may have unexpected results (like the column enabled to be displayed are not the same as before).

## Solution

This changes bring :
* **better detection** : now, if you change the source of a column, add or remove a column (or both), it triggers the update
* **keeps your previous settings** : it keeps the columns you displayed before
* **keeps your order** : it keeps the columns displayed in the order you have set
* **enable non omited new columns** : if you added new columns, and not omited them, they will be displayed at the end

## How To Test

I have tested it multiple times on the following scenarios :
* change the source of a column
* add a column and remove another one at the same time
* change the order of the columns passed to the datagrid
* add a new non omited columns

I have ran the tests for non regression
![image](https://github.com/user-attachments/assets/fe00e65b-1e2f-4c42-bec5-4ade137f18ee)

Also, this PR is live on prod for us now. And this is a very used feature among our users :)

## Additional Checks

- [X] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) : not new feature. tests still pass
- [ ] The PR includes one or several **stories** (if not possible, describe why) : not a new feature. stories are still relevant
- [ ] The **documentation** is up to date : no change needed to the documentation