### PR TITLE
Fix `useFormGroup` doesn't return validation errors with react-hook-form 7.53.0

### DIFF
--- a/packages/ra-core/src/form/useFormGroup.ts
+++ b/packages/ra-core/src/form/useFormGroup.ts
@@ -69,13 +69,14 @@ export const useFormGroup = (name: string): FormGroupState => {
     const { dirtyFields, touchedFields, validatingFields, errors } =
         useFormState();
 
-    // dirtyFields, touchedFields and validatingFields are objects with keys being the field names
+    // dirtyFields, touchedFields, validatingFields and errors are objects with keys being the field names
     // Ex: { title: true }
     // However, they are not correctly serialized when using JSON.stringify
     // To avoid our effects to not be triggered when they should, we extract the keys and use that as a dependency
     const dirtyFieldsNames = Object.keys(dirtyFields);
     const touchedFieldsNames = Object.keys(touchedFields);
     const validatingFieldsNames = Object.keys(validatingFields);
+    const errorsNames = Object.keys(errors);
 
     const formGroups = useFormGroups();
     const [state, setState] = useState<FormGroupState>({
@@ -121,7 +122,8 @@ export const useFormGroup = (name: string): FormGroupState => {
         [
             // eslint-disable-next-line react-hooks/exhaustive-deps
             JSON.stringify(dirtyFieldsNames),
-            errors,
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+            JSON.stringify(errorsNames),
             // eslint-disable-next-line react-hooks/exhaustive-deps
             JSON.stringify(touchedFieldsNames),
             // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problem

With the latest version of react-hook-form (7.53.0 at the time of writing), `useFormGroup` no longer returns validation errors correctly.

This causes issues such as the TabbedForm Tab header not being colored in red when there is a validation error on one of the inputs inside the Tab.

## Solution

An issue was opened on RHF repo to let them know about this regression: https://github.com/react-hook-form/react-hook-form/issues/12217

However, it seems this issue also highlights that we may not being using the form state correctly to compute the form group state, hence we figured we may as well improve the `useFormGroup` hook to be compatible with all versions of RHF.

## How To Test

1. Update RHF to its latest version `yarn up react-hook-form`
2. Run the test `TabbedForm.spec.tsx > should set the style of any Tab button with errors on submit` and make sure it passes

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why) -> we can rely on existing unit tests
- [x] The PR includes one or several **stories** (if not possible, describe why) -> not necessary
- [x] The **documentation** is up to date -> no change necessary

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
