### PR TITLE
expand expect with testing-library helper for all tests

### DIFF
--- a/test-setup.js
+++ b/test-setup.js
@@ -1,3 +1,9 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';
+
 // Ignore warnings about act()
 // See https://github.com/testing-library/react-testing-library/issues/281,
 // https://github.com/facebook/react/issues/14769


### PR DESCRIPTION
## Problem

Could not use matcher like `expect(...).toBeDisabled` in test.

## Solution

initialize (import) `@testing-library/jest-dom` in jest test setup.

## How To Test

Try to use testing library expect method, like toBeDisabled or toHaveAttribute.

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
