### PR TITLE
Reject promise in checkError with logoutUser: false and without redirectTo causes an error #10172

### DIFF
--- a/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
+++ b/packages/ra-core/src/auth/useLogoutIfAccessDenied.ts
@@ -103,12 +103,17 @@ const useLogoutIfAccessDenied = (): LogoutIfAccessDenied => {
                     if (logoutUser) {
                         logout({}, redirectTo);
                     } else {
-                        if (redirectTo.startsWith('http')) {
-                            // absolute link (e.g. https://my.oidc.server/login)
-                            window.location.href = redirectTo;
+                        if (redirectTo != null) {
+                            if (redirectTo.startsWith('http')) {
+                                // absolute link (e.g. https://my.oidc.server/login)
+                                window.location.href = redirectTo;
+                            } else {
+                                // internal location
+                                navigate(redirectTo);
+                            }
                         } else {
-                            // internal location
-                            navigate(redirectTo);
+                            // If there is not redirect return false saying loguout is not successful
+                            return false;
                         }
                     }
 


### PR DESCRIPTION
Add null check for redirect and When redirect  is not provided, I returned false and let the called handles the redirect.

This may not be ideal solution, happy to  discuss as this is my my first contribution.

Fixes #10172