### PR TITLE
feat(ra-ui-materialui): Improve FilterButton UX

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
@@ -43,28 +43,27 @@ describe('<FilterButton />', () => {
     });
 
     describe('filter selection menu', () => {
-        it('should display only hidden filters', () => {
-            const hiddenFilter = (
-                <TextInput source="Returned" label="Returned" />
-            );
-            const { getByLabelText, queryByText } = render(
-                <AdminContext theme={theme}>
-                    <ResourceContextProvider value="posts">
-                        <ListContextProvider value={defaultListContext}>
-                            <FilterButton
-                                filters={defaultProps.filters.concat(
-                                    hiddenFilter
-                                )}
-                            />
-                        </ListContextProvider>
-                    </ResourceContextProvider>
-                </AdminContext>
-            );
+        it('should disable applied filters', async () => {
+            render(<Basic />);
 
-            fireEvent.click(getByLabelText('ra.action.add_filter'));
+            fireEvent.click(await screen.findByLabelText('Add filter'));
 
-            expect(queryByText('Returned')).not.toBeNull();
-            expect(queryByText('Name')).toBeNull();
+            let filters = screen.getAllByRole('menuitem');
+            expect(filters[0]).not.toHaveAttribute('aria-disabled');
+            expect(filters[1]).not.toHaveAttribute('aria-disabled');
+            expect(filters[2]).not.toHaveAttribute('aria-disabled');
+
+            fireEvent.click(filters[0]);
+
+            await screen.findByDisplayValue(
+                'Accusantium qui nihil voluptatum quia voluptas maxime ab similique'
+            );
+            fireEvent.click(screen.getByLabelText('Add filter'));
+
+            filters = screen.getAllByRole('menuitem');
+            expect(filters[0]).toHaveAttribute('aria-disabled', 'true');
+            expect(filters[1]).not.toHaveAttribute('aria-disabled');
+            expect(filters[2]).not.toHaveAttribute('aria-disabled');
         });
 
         it('should display the filter button if all filters are shown and there is a filter value', () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import expect from 'expect';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import {
+    render,
+    fireEvent,
+    screen,
+    waitFor,
+    within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createTheme } from '@mui/material/styles';
 import {
@@ -43,27 +49,29 @@ describe('<FilterButton />', () => {
     });
 
     describe('filter selection menu', () => {
-        it('should disable applied filters', async () => {
+        it('should check applied filters', async () => {
             render(<Basic />);
 
             fireEvent.click(await screen.findByLabelText('Add filter'));
 
-            let filters = screen.getAllByRole('menuitem');
-            expect(filters[0]).not.toHaveAttribute('aria-disabled');
-            expect(filters[1]).not.toHaveAttribute('aria-disabled');
-            expect(filters[2]).not.toHaveAttribute('aria-disabled');
+            let checkboxs = screen.getAllByRole('checkbox');
+            expect(checkboxs).toHaveLength(3);
+            expect(checkboxs[0]).not.toBeChecked();
+            expect(checkboxs[1]).not.toBeChecked();
+            expect(checkboxs[2]).not.toBeChecked();
 
-            fireEvent.click(filters[0]);
+            fireEvent.click(checkboxs[0]);
 
             await screen.findByDisplayValue(
                 'Accusantium qui nihil voluptatum quia voluptas maxime ab similique'
             );
             fireEvent.click(screen.getByLabelText('Add filter'));
 
-            filters = screen.getAllByRole('menuitem');
-            expect(filters[0]).toHaveAttribute('aria-disabled', 'true');
-            expect(filters[1]).not.toHaveAttribute('aria-disabled');
-            expect(filters[2]).not.toHaveAttribute('aria-disabled');
+            checkboxs = screen.getAllByRole('checkbox');
+            expect(checkboxs).toHaveLength(3);
+            expect(checkboxs[0]).toBeChecked();
+            expect(checkboxs[1]).not.toBeChecked();
+            expect(checkboxs[2]).not.toBeChecked();
         });
 
         it('should display the filter button if all filters are shown and there is a filter value', () => {

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.stories.tsx
@@ -196,6 +196,7 @@ export const Basic = (args: { disableSaveQuery?: boolean }) => {
             defaultValue="Accusantium qui nihil voluptatum quia voluptas maxime ab similique"
         />,
         <TextInput label="Nested" source="nested.foo" defaultValue="bar" />,
+        <TextInput label="Body" source="body" />,
     ];
     return (
         <TestMemoryRouter>

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -12,7 +12,6 @@ import {
     MenuItem,
     styled,
     ButtonProps as MuiButtonProps,
-    Box,
     Divider,
 } from '@mui/material';
 import ContentFilter from '@mui/icons-material/FilterList';

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -14,9 +14,10 @@ import {
     ButtonProps as MuiButtonProps,
     Divider,
     ListItemIcon,
+    Checkbox,
 } from '@mui/material';
 import ContentSave from '@mui/icons-material/Save';
-import ActionDelete from '@mui/icons-material/Delete';
+import ClearIcon from '@mui/icons-material/Clear';
 import ContentFilter from '@mui/icons-material/FilterList';
 import lodashGet from 'lodash/get';
 import isEqual from 'lodash/isEqual';
@@ -56,6 +57,7 @@ export const FilterButton = (props: FilterButtonProps) => {
         perPage,
         setFilters,
         showFilter,
+        hideFilter,
         sort,
     } = useListContext();
     const hasFilterValues = !isEqual(filterValues, {});
@@ -122,6 +124,24 @@ export const FilterButton = (props: FilterButtonProps) => {
         [showFilter, setOpen]
     );
 
+    const handleRemove = useCallback(
+        ({ source }) => {
+            hideFilter(source);
+            // We have to fallback to imperative code because the new FilterFormInput
+            // has no way of knowing it has just been displayed (and thus that it should focus its input)
+            setTimeout(() => {
+                const inputElement = document.querySelector(
+                    `input[name='${source}']`
+                ) as HTMLInputElement;
+                if (inputElement) {
+                    inputElement.focus();
+                }
+            }, 50);
+            setOpen(false);
+        },
+        [hideFilter, setOpen]
+    );
+
     // add query dialog state
     const [addSavedQueryDialogOpen, setAddSavedQueryDialogOpen] =
         useState(false);
@@ -175,15 +195,14 @@ export const FilterButton = (props: FilterButtonProps) => {
                             ...filterElement,
                             props: {
                                 ...filterElement.props,
-                                disabled:
-                                    filterElement.props.disabled ??
-                                    appliedFilters.includes(
-                                        filterElement.props.source
-                                    ),
+                                applied: appliedFilters.includes(
+                                    filterElement.props.source
+                                ),
                             },
                         }}
                         resource={resource}
                         onShow={handleShow}
+                        onHide={handleRemove}
                         autoFocus={index === 0}
                     />
                 ))}
@@ -199,7 +218,7 @@ export const FilterButton = (props: FilterButtonProps) => {
                             key={index}
                         >
                             <ListItemIcon>
-                                <ActionDelete fontSize="small" />
+                                <ClearIcon fontSize="small" />
                             </ListItemIcon>
                             {translate(
                                 'ra.saved_queries.remove_label_with_name',
@@ -230,6 +249,15 @@ export const FilterButton = (props: FilterButtonProps) => {
                             }}
                             key={index}
                         >
+                            <Checkbox
+                                size="small"
+                                sx={{
+                                    marginLeft: 0,
+                                    paddingLeft: 0,
+                                    paddingTop: 0,
+                                    paddingBottom: 0,
+                                }}
+                            />
                             {savedQuery.label}
                         </MenuItem>
                     )
@@ -255,7 +283,7 @@ export const FilterButton = (props: FilterButtonProps) => {
                         }}
                     >
                         <ListItemIcon>
-                            <ActionDelete fontSize="small" />
+                            <ClearIcon fontSize="small" />
                         </ListItemIcon>
                         {translate('ra.action.remove_all_filters', {
                             _: 'Remove all filters',

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -12,6 +12,7 @@ import {
     MenuItem,
     styled,
     ButtonProps as MuiButtonProps,
+    Box,
 } from '@mui/material';
 import ContentFilter from '@mui/icons-material/FilterList';
 import lodashGet from 'lodash/get';
@@ -211,6 +212,16 @@ export const FilterButton = (props: FilterButtonProps) => {
                             {savedQuery.label}
                         </MenuItem>
                     )
+                )}
+                {hasFilterValues && (
+                    <Box
+                        sx={{
+                            height: 3,
+                            bgcolor: 'background.default',
+                            margin: 0,
+                            width: '100%',
+                        }}
+                    />
                 )}
                 {hasFilterValues &&
                     !hasSavedCurrentQuery &&

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -13,7 +13,10 @@ import {
     styled,
     ButtonProps as MuiButtonProps,
     Divider,
+    ListItemIcon,
 } from '@mui/material';
+import ContentSave from '@mui/icons-material/Save';
+import ActionDelete from '@mui/icons-material/Delete';
 import ContentFilter from '@mui/icons-material/FilterList';
 import lodashGet from 'lodash/get';
 import isEqual from 'lodash/isEqual';
@@ -75,12 +78,17 @@ export const FilterButton = (props: FilterButtonProps) => {
     }
 
     const hiddenFilters = filters.filter(
-        (filterElement: JSX.Element) =>
-            !filterElement.props.alwaysOn &&
-            !displayedFilters[filterElement.props.source] &&
-            typeof lodashGet(filterValues, filterElement.props.source) ===
-                'undefined'
+        (filterElement: JSX.Element) => !filterElement.props.alwaysOn
     );
+
+    const appliedFilters = hiddenFilters
+        .filter(
+            (filterElement: JSX.Element) =>
+                !!displayedFilters[filterElement.props.source] &&
+                typeof lodashGet(filterValues, filterElement.props.source) !==
+                    'undefined'
+        )
+        .map((filterElement: JSX.Element) => filterElement.props.source);
 
     const handleClickButton = useCallback(
         event => {
@@ -163,7 +171,17 @@ export const FilterButton = (props: FilterButtonProps) => {
                 {hiddenFilters.map((filterElement: JSX.Element, index) => (
                     <FilterButtonMenuItem
                         key={filterElement.props.source}
-                        filter={filterElement}
+                        filter={{
+                            ...filterElement,
+                            props: {
+                                ...filterElement.props,
+                                disabled:
+                                    filterElement.props.disabled ??
+                                    appliedFilters.includes(
+                                        filterElement.props.source
+                                    ),
+                            },
+                        }}
                         resource={resource}
                         onShow={handleShow}
                         autoFocus={index === 0}
@@ -180,6 +198,9 @@ export const FilterButton = (props: FilterButtonProps) => {
                             onClick={showRemoveSavedQueryDialog}
                             key={index}
                         >
+                            <ListItemIcon>
+                                <ActionDelete fontSize="small" />
+                            </ListItemIcon>
                             {translate(
                                 'ra.saved_queries.remove_label_with_name',
                                 {
@@ -218,6 +239,9 @@ export const FilterButton = (props: FilterButtonProps) => {
                     !hasSavedCurrentQuery &&
                     !disableSaveQuery && (
                         <MenuItem onClick={showAddSavedQueryDialog}>
+                            <ListItemIcon>
+                                <ContentSave fontSize="small" />
+                            </ListItemIcon>
                             {translate('ra.saved_queries.new_label', {
                                 _: 'Save current query...',
                             })}
@@ -230,6 +254,9 @@ export const FilterButton = (props: FilterButtonProps) => {
                             setOpen(false);
                         }}
                     >
+                        <ListItemIcon>
+                            <ActionDelete fontSize="small" />
+                        </ListItemIcon>
                         {translate('ra.action.remove_all_filters', {
                             _: 'Remove all filters',
                         })}

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -13,6 +13,7 @@ import {
     styled,
     ButtonProps as MuiButtonProps,
     Box,
+    Divider,
 } from '@mui/material';
 import ContentFilter from '@mui/icons-material/FilterList';
 import lodashGet from 'lodash/get';
@@ -213,16 +214,7 @@ export const FilterButton = (props: FilterButtonProps) => {
                         </MenuItem>
                     )
                 )}
-                {hasFilterValues && (
-                    <Box
-                        sx={{
-                            height: 3,
-                            bgcolor: 'background.default',
-                            margin: 0,
-                            width: '100%',
-                        }}
-                    />
-                )}
+                {hasFilterValues && <Divider />}
                 {hasFilterValues &&
                     !hasSavedCurrentQuery &&
                     !disableSaveQuery && (

--- a/packages/ra-ui-materialui/src/list/filter/FilterButtonMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButtonMenuItem.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { forwardRef, useCallback } from 'react';
 import MenuItem from '@mui/material/MenuItem';
 import { FieldTitle, useResourceContext } from 'ra-core';
+import { Checkbox } from '@mui/material';
 
 export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
     (props, ref) => {
-        const { filter, onShow, autoFocus } = props;
+        const { filter, onShow, onHide, autoFocus } = props;
         const resource = useResourceContext(props);
         const handleShow = useCallback(() => {
             onShow({
@@ -13,6 +14,11 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
                 defaultValue: filter.props.defaultValue,
             });
         }, [filter.props.defaultValue, filter.props.source, onShow]);
+        const handleHide = useCallback(() => {
+            onHide({
+                source: filter.props.source,
+            });
+        }, [filter.props.source, onHide]);
 
         return (
             <MenuItem
@@ -20,11 +26,21 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
                 data-key={filter.props.source}
                 data-default-value={filter.props.defaultValue}
                 key={filter.props.source}
-                onClick={handleShow}
+                onClick={filter.props.applied ? handleHide : handleShow}
                 autoFocus={autoFocus}
                 ref={ref}
                 disabled={filter.props.disabled}
             >
+                <Checkbox
+                    size="small"
+                    sx={{
+                        marginLeft: 0,
+                        paddingLeft: 0,
+                        paddingTop: 0,
+                        paddingBottom: 0,
+                    }}
+                    defaultChecked={filter.props.applied}
+                />
                 <FieldTitle
                     label={filter.props.label}
                     source={filter.props.source}
@@ -38,6 +54,7 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
 export interface FilterButtonMenuItemProps {
     filter: JSX.Element;
     onShow: (params: { source: string; defaultValue: any }) => void;
+    onHide: (params: { source: string }) => void;
     resource?: string;
     autoFocus?: boolean;
 }


### PR DESCRIPTION
## Problem

There is no way to differentiate between filter choices and filter actions (such as save current query) in the FilterButton

when you select a filter, it disappears from the list, which changes the place of each choice item and makes it hard to remember where is the filter you want to enable ; same for the actions (Remove all filters)

## To Do

- [x] Add a divider to separate between the filter choices and filter actions
- [x] Keep all choices in the list at all times, and simply gray out the items when they are not available
- [x] Test icons in the Filter Button Menu items
- [x] Add checkbox before filter names 

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
~- [ ] The **documentation** is up to date~

![image](https://github.com/user-attachments/assets/8c9c6108-b3a2-4531-b4a6-b46744390a7e)

![image](https://github.com/user-attachments/assets/0be6d0eb-2f3b-4d72-a0cd-342e9412c4b1)

![image](https://github.com/user-attachments/assets/eb8d91e1-a6bf-4cc8-9f73-8fb61191cb11)