### PR TITLE
Update `<Datagrid>` and `<SimpleList>` empty message when a filter is active

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -113,6 +113,8 @@ export interface TranslationMessages extends StringMap {
         navigation: {
             [key: string]: StringMap | string;
             no_results: string;
+            no_filtered_results: string;
+            clear_filters: string;
             no_more_results: string;
             page_out_of_boundaries: string;
             page_out_from_end: string;

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -112,7 +112,8 @@ const englishMessages: TranslationMessages = {
                 "Some of your changes weren't saved. Are you sure you want to ignore them?",
         },
         navigation: {
-            no_results: 'No results found',
+            clear_filters: 'Clear filters.',
+            no_results: 'No %{resource} found using the current filters.',
             no_more_results:
                 'The page number %{page} is out of boundaries. Try the previous page.',
             page_out_of_boundaries: 'Page number %{page} out of boundaries',

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -112,8 +112,8 @@ const englishMessages: TranslationMessages = {
                 "Some of your changes weren't saved. Are you sure you want to ignore them?",
         },
         navigation: {
-            clear_filters: 'Clear filters.',
-            no_filtred_results:
+            clear_filters: 'Clear filters',
+            no_filtered_results:
                 'No %{resource} found using the current filters.',
             no_results: 'No %{resource} found',
             no_more_results:

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -113,7 +113,9 @@ const englishMessages: TranslationMessages = {
         },
         navigation: {
             clear_filters: 'Clear filters.',
-            no_results: 'No %{resource} found using the current filters.',
+            no_filtred_results:
+                'No %{resource} found using the current filters.',
+            no_results: 'No %{resource} found',
             no_more_results:
                 'The page number %{page} is out of boundaries. Try the previous page.',
             page_out_of_boundaries: 'Page number %{page} out of boundaries',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -118,7 +118,9 @@ const frenchMessages: TranslationMessages = {
         },
         navigation: {
             clear_filters: 'Effacer les filtres.',
-            no_results: 'Aucun résultat trouvé avec les filtres actuels.',
+            no_filtred_results:
+                'Aucun résultat trouvé avec les filtres actuels.',
+            no_results: 'Aucun résultat',
             no_more_results:
                 'La page numéro %{page} est en dehors des limites. Essayez la page précédente.',
             page_out_of_boundaries: 'La page %{page} est en dehors des limites',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -117,7 +117,8 @@ const frenchMessages: TranslationMessages = {
                 "Certains changements n'ont pas été enregistrés. Êtes-vous sûr(e) de vouloir quitter cette page ?",
         },
         navigation: {
-            no_results: 'Aucun résultat',
+            clear_filters: 'Effacer les filtres.',
+            no_results: 'Aucun %{resource} trouvé avec les filtres actuels.',
             no_more_results:
                 'La page numéro %{page} est en dehors des limites. Essayez la page précédente.',
             page_out_of_boundaries: 'La page %{page} est en dehors des limites',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -118,7 +118,7 @@ const frenchMessages: TranslationMessages = {
         },
         navigation: {
             clear_filters: 'Effacer les filtres.',
-            no_results: 'Aucun %{resource} trouvé avec les filtres actuels.',
+            no_results: 'Aucun résultat trouvé avec les filtres actuels.',
             no_more_results:
                 'La page numéro %{page} est en dehors des limites. Essayez la page précédente.',
             page_out_of_boundaries: 'La page %{page} est en dehors des limites',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -117,8 +117,8 @@ const frenchMessages: TranslationMessages = {
                 "Certains changements n'ont pas été enregistrés. Êtes-vous sûr(e) de vouloir quitter cette page ?",
         },
         navigation: {
-            clear_filters: 'Effacer les filtres.',
-            no_filtred_results:
+            clear_filters: 'Effacer les filtres',
+            no_filtered_results:
                 'Aucun résultat trouvé avec les filtres actuels.',
             no_results: 'Aucun résultat',
             no_more_results:

--- a/packages/ra-ui-materialui/src/list/ListNoResults.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.spec.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NoFilter, WithFilter } from './ListNoResults.stories';
+
+describe('List?oResults', () => {
+    it('should display no results found message when no filter', async () => {
+        render(<NoFilter />);
+        await screen.findByText('No results found.');
+    });
+
+    it('should display no results found message and a clear filter link when there is a filter', async () => {
+        render(<WithFilter />);
+        await screen.findByText('No results found with the current filters.');
+        screen.getByText('Clear filters').click();
+        await screen.findByText('{"id":1}');
+    });
+});

--- a/packages/ra-ui-materialui/src/list/ListNoResults.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { NoFilter, WithFilter } from './ListNoResults.stories';
 
-describe('List?oResults', () => {
+describe('ListNoResults', () => {
     it('should display no results found message when no filter', async () => {
         render(<NoFilter />);
         await screen.findByText('No results found.');

--- a/packages/ra-ui-materialui/src/list/ListNoResults.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { useList, ListContextProvider } from 'ra-core';
+import { ListNoResults } from './ListNoResults';
+
+export default {
+    title: 'ra-ui-materialui/list/ListNoResults',
+};
+
+export const NoFilter = () => {
+    const context = useList<any>({ data: [] });
+    return (
+        <ListContextProvider value={context}>
+            {context.data?.length === 0 && <ListNoResults />}
+        </ListContextProvider>
+    );
+};
+
+export const WithFilter = () => {
+    const context = useList<any>({ data: [{ id: 1 }], filter: { id: 2 } });
+    return (
+        <ListContextProvider value={context}>
+            {context.data?.length === 0 ? (
+                <ListNoResults />
+            ) : (
+                <ul>
+                    {context.data?.map(record => (
+                        <li key={record.id}>{JSON.stringify(record)}</li>
+                    ))}
+                </ul>
+            )}
+        </ListContextProvider>
+    );
+};

--- a/packages/ra-ui-materialui/src/list/ListNoResults.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useList, ListContextProvider } from 'ra-core';
+import { ThemeProvider, createTheme } from '@mui/material';
 import { ListNoResults } from './ListNoResults';
 
 export default {
@@ -18,16 +19,18 @@ export const NoFilter = () => {
 export const WithFilter = () => {
     const context = useList<any>({ data: [{ id: 1 }], filter: { id: 2 } });
     return (
-        <ListContextProvider value={context}>
-            {context.data?.length === 0 ? (
-                <ListNoResults />
-            ) : (
-                <ul>
-                    {context.data?.map(record => (
-                        <li key={record.id}>{JSON.stringify(record)}</li>
-                    ))}
-                </ul>
-            )}
-        </ListContextProvider>
+        <ThemeProvider theme={createTheme()}>
+            <ListContextProvider value={context}>
+                {context.data?.length === 0 ? (
+                    <ListNoResults />
+                ) : (
+                    <ul>
+                        {context.data?.map(record => (
+                            <li key={record.id}>{JSON.stringify(record)}</li>
+                        ))}
+                    </ul>
+                )}
+            </ListContextProvider>
+        </ThemeProvider>
     );
 };

--- a/packages/ra-ui-materialui/src/list/ListNoResults.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.tsx
@@ -8,14 +8,16 @@ import { Link } from '@mui/material';
 export const ListNoResults = memo(() => {
     const translate = useTranslate();
     const resource = useResourceContext();
-    const { setFilters } = useListController({ resource });
+    const { filterValues, setFilters } = useListController({ resource });
     return (
         <CardContent>
             <Typography variant="body2">
                 {translate('ra.navigation.no_results', { resource })}{' '}
-                <Link component="button" onClick={() => setFilters({}, [])}>
-                    {translate('ra.navigation.clear_filters')}
-                </Link>
+                {filterValues && Object.keys(filterValues).length > 0 && (
+                    <Link component="button" onClick={() => setFilters({}, [])}>
+                        {translate('ra.navigation.clear_filters')}
+                    </Link>
+                )}
             </Typography>
         </CardContent>
     );

--- a/packages/ra-ui-materialui/src/list/ListNoResults.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.tsx
@@ -16,7 +16,7 @@ export const ListNoResults = memo(() => {
                     <>
                         {translate('ra.navigation.no_filtred_results', {
                             resource,
-                        })}
+                        })}{' '}
                         <Link
                             component="button"
                             onClick={() => setFilters({}, [])}

--- a/packages/ra-ui-materialui/src/list/ListNoResults.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.tsx
@@ -2,15 +2,20 @@ import * as React from 'react';
 import { memo } from 'react';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
-import { useResourceContext, useTranslate } from 'ra-core';
+import { useListController, useResourceContext, useTranslate } from 'ra-core';
+import { Link } from '@mui/material';
 
 export const ListNoResults = memo(() => {
     const translate = useTranslate();
     const resource = useResourceContext();
+    const { setFilters } = useListController({ resource });
     return (
         <CardContent>
             <Typography variant="body2">
-                {translate('ra.navigation.no_results', { resource })}
+                {translate('ra.navigation.no_results', { resource })}{' '}
+                <Link component="button" onClick={() => setFilters({}, [])}>
+                    {translate('ra.navigation.clear_filters')}
+                </Link>
             </Typography>
         </CardContent>
     );

--- a/packages/ra-ui-materialui/src/list/ListNoResults.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.tsx
@@ -12,11 +12,20 @@ export const ListNoResults = memo(() => {
     return (
         <CardContent>
             <Typography variant="body2">
-                {translate('ra.navigation.no_results', { resource })}{' '}
-                {filterValues && Object.keys(filterValues).length > 0 && (
-                    <Link component="button" onClick={() => setFilters({}, [])}>
-                        {translate('ra.navigation.clear_filters')}
-                    </Link>
+                {filterValues && Object.keys(filterValues).length > 0 ? (
+                    <>
+                        {translate('ra.navigation.no_filtred_results', {
+                            resource,
+                        })}
+                        <Link
+                            component="button"
+                            onClick={() => setFilters({}, [])}
+                        >
+                            {translate('ra.navigation.clear_filters')}
+                        </Link>
+                    </>
+                ) : (
+                    translate('ra.navigation.no_results', { resource })
                 )}
             </Typography>
         </CardContent>

--- a/packages/ra-ui-materialui/src/list/ListNoResults.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.tsx
@@ -1,33 +1,36 @@
 import * as React from 'react';
-import { memo } from 'react';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import { useListController, useResourceContext, useTranslate } from 'ra-core';
-import { Link } from '@mui/material';
+import { CardContent, Typography } from '@mui/material';
+import { useListContext, useResourceContext, useTranslate } from 'ra-core';
 
-export const ListNoResults = memo(() => {
+import { Button } from '../button';
+
+export const ListNoResults = () => {
     const translate = useTranslate();
     const resource = useResourceContext();
-    const { filterValues, setFilters } = useListController({ resource });
+    const { filterValues, setFilters } = useListContext();
     return (
         <CardContent>
             <Typography variant="body2">
                 {filterValues && Object.keys(filterValues).length > 0 ? (
                     <>
-                        {translate('ra.navigation.no_filtred_results', {
+                        {translate('ra.navigation.no_filtered_results', {
                             resource,
+                            _: 'No results found with the current filters.',
                         })}{' '}
-                        <Link
-                            component="button"
+                        <Button
                             onClick={() => setFilters({}, [])}
-                        >
-                            {translate('ra.navigation.clear_filters')}
-                        </Link>
+                            label={translate('ra.navigation.clear_filters', {
+                                _: 'Clear filters',
+                            })}
+                        />
                     </>
                 ) : (
-                    translate('ra.navigation.no_results', { resource })
+                    translate('ra.navigation.no_results', {
+                        resource,
+                        _: 'No results found.',
+                    })
                 )}
             </Typography>
         </CardContent>
     );
-});
+};

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -162,9 +162,7 @@ describe('<SimpleList />', () => {
                 </Admin>
             </TestMemoryRouter>
         );
-        expect(
-            screen.queryByText('No posts found using the current filters.')
-        ).not.toBeNull();
+        expect(screen.queryByText('No posts found')).not.toBeNull();
     });
 
     it('should display a message when there is no result but filters applied', async () => {

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
-import { ListContext, ResourceContextProvider } from 'ra-core';
+import {
+    ListContext,
+    Resource,
+    ResourceContextProvider,
+    TestMemoryRouter,
+} from 'ra-core';
 
 import { AdminContext } from '../../AdminContext';
 import { SimpleList } from './SimpleList';
 import { TextField } from '../../field/TextField';
 import { NoPrimaryText } from './SimpleList.stories';
+import { Admin } from 'react-admin';
 
 const Wrapper = ({ children }: any) => (
     <AdminContext>
@@ -134,18 +140,29 @@ describe('<SimpleList />', () => {
 
     it('should display a message when there is no result', () => {
         render(
-            <ListContext.Provider
-                value={{
-                    isLoading: false,
-                    data: [],
-                    total: 0,
-                    resource: 'posts',
-                }}
-            >
-                <SimpleList />
-            </ListContext.Provider>
+            <TestMemoryRouter>
+                <Admin>
+                    <Resource
+                        name="posts"
+                        list={
+                            <ListContext.Provider
+                                value={{
+                                    isLoading: false,
+                                    data: [],
+                                    total: 0,
+                                    resource: 'posts',
+                                }}
+                            >
+                                <SimpleList />
+                            </ListContext.Provider>
+                        }
+                    />
+                </Admin>
+            </TestMemoryRouter>
         );
-        expect(screen.queryByText('ra.navigation.no_results')).not.toBeNull();
+        expect(
+            screen.queryByText('No posts found using the current filters.')
+        ).not.toBeNull();
     });
 
     it('should fall back to record representation when no primaryText is provided', async () => {

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-    render,
-    screen,
-    waitFor,
-    within,
-} from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import {
     ListContext,
     Resource,

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-    fireEvent,
     render,
     screen,
     waitFor,

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -171,6 +171,22 @@ describe('<SimpleList />', () => {
             await screen.findByText('No posts found using the current filters.')
         ).not.toBeNull();
         expect(screen.getByText('Clear filters.')).not.toBeNull();
+
+        fireEvent.click(screen.getByText('Clear filters.'));
+
+        await screen.findByText(
+            'Accusantium qui nihil voluptatum quia voluptas maxime ab similique'
+        );
+
+        expect(
+            screen.queryByText('No posts found using the current filters.')
+        ).toBeNull();
+        expect(screen.queryByText('Clear filters.')).toBeNull();
+        expect(
+            screen.queryByText(
+                'In facilis aut aut odit hic doloribus. Fugit possimus perspiciatis sit molestias in. Sunt dignissimos sed quis at vitae veniam amet. Sint sunt perspiciatis quis doloribus aperiam numquam consequatur et. Blanditiis aut earum incidunt eos magnam et voluptatem. Minima iure voluptatum autem. At eaque sit aperiam minima aut in illum.'
+            )
+        ).not.toBeNull();
     });
 
     it('should fall back to record representation when no primaryText is provided', async () => {

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -170,9 +170,9 @@ describe('<SimpleList />', () => {
         expect(
             await screen.findByText('No posts found using the current filters.')
         ).not.toBeNull();
-        expect(screen.getByText('Clear filters.')).not.toBeNull();
+        expect(screen.getByText('Clear filters')).not.toBeNull();
 
-        fireEvent.click(screen.getByText('Clear filters.'));
+        fireEvent.click(screen.getByText('Clear filters'));
 
         await screen.findByText(
             'Accusantium qui nihil voluptatum quia voluptas maxime ab similique'
@@ -181,7 +181,7 @@ describe('<SimpleList />', () => {
         expect(
             screen.queryByText('No posts found using the current filters.')
         ).toBeNull();
-        expect(screen.queryByText('Clear filters.')).toBeNull();
+        expect(screen.queryByText('Clear filters')).toBeNull();
         expect(
             screen.queryByText(
                 'In facilis aut aut odit hic doloribus. Fugit possimus perspiciatis sit molestias in. Sunt dignissimos sed quis at vitae veniam amet. Sint sunt perspiciatis quis doloribus aperiam numquam consequatur et. Blanditiis aut earum incidunt eos magnam et voluptatem. Minima iure voluptatum autem. At eaque sit aperiam minima aut in illum.'

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -1,17 +1,25 @@
 import * as React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from '@testing-library/react';
 import {
     ListContext,
     Resource,
     ResourceContextProvider,
     TestMemoryRouter,
+    useListFilterContext,
 } from 'ra-core';
+import fakerestDataProvider from 'ra-data-fakerest';
 
 import { AdminContext } from '../../AdminContext';
 import { SimpleList } from './SimpleList';
 import { TextField } from '../../field/TextField';
 import { NoPrimaryText } from './SimpleList.stories';
-import { Admin } from 'react-admin';
+import { Admin, List } from 'react-admin';
 
 const Wrapper = ({ children }: any) => (
     <AdminContext>
@@ -163,6 +171,36 @@ describe('<SimpleList />', () => {
         expect(
             screen.queryByText('No posts found using the current filters.')
         ).not.toBeNull();
+    });
+
+    it('should display a message when there is no result but filters applied', async () => {
+        const MyListView = () => {
+            const { setFilters } = useListFilterContext();
+            setFilters({ title: 'foo' }, ['title']);
+            return <SimpleList />;
+        };
+
+        render(
+            <TestMemoryRouter>
+                <Admin
+                    dataProvider={fakerestDataProvider({
+                        posts: [{ id: 1, title: 'bar' }],
+                    })}
+                >
+                    <Resource
+                        name="posts"
+                        list={
+                            <List>
+                                <MyListView />
+                            </List>
+                        }
+                    />
+                </Admin>
+            </TestMemoryRouter>
+        );
+
+        await screen.findByText('No posts found using the current filters.');
+        screen.getByText('Clear filters.');
     });
 
     it('should fall back to record representation when no primaryText is provided', async () => {


### PR DESCRIPTION
## Problem

When coming back to a list page with active filters and no results, the default message (“no results found”) is misleading when the active filters aren’t visible enough.

## Solution

If the list is empty **AND** there is an active filter,

- Replace “No [data] found” with “No [data] found using the current filters. Clear filters.”
- Add a link on “Clear filter” which removes all active filters

## To Do

- [x] Change dictionaries messages
- [x] Add the "Clear filter" button
- [x] Display this button if there is an active filter

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** 
- [x] The PR includes one or several **stories** 
~- [ ] The **documentation** is up to date~

![image](https://github.com/user-attachments/assets/b0e58deb-2953-40bb-8363-beb39fd6287b)
