### PR TITLE
Fix List shows empty page too often

### DIFF
--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -33,8 +33,17 @@ export const ListView = <RecordType extends RaRecord = any>(
         empty = defaultEmpty,
         ...rest
     } = props;
-    const { defaultTitle, data, error, isPending, filterValues, resource } =
-        useListContext<RecordType>();
+    const {
+        defaultTitle,
+        data,
+        error,
+        isPending,
+        filterValues,
+        resource,
+        total,
+        hasNextPage,
+        hasPreviousPage,
+    } = useListContext<RecordType>();
 
     if (!children || (!data && isPending && emptyWhileLoading)) {
         return null;
@@ -58,9 +67,16 @@ export const ListView = <RecordType extends RaRecord = any>(
         empty !== false && <div className={ListClasses.noResults}>{empty}</div>;
 
     const shouldRenderEmptyPage =
+        // the list is not loading data for the first time
         !isPending &&
-        data?.length === 0 &&
+        // the API returned no data (using either normal or partial pagination)
+        (total === 0 ||
+            (total == null &&
+                hasPreviousPage === false &&
+                hasNextPage === false)) &&
+        // the user didn't set any filters
         !Object.keys(filterValues).length &&
+        // there is an empty page component
         empty !== false;
 
     return (


### PR DESCRIPTION
## Problem

The default empty list page, which is an invite to create new elements, appears even when some elements already exist.

Here is a repro that can be tested in the [simple example](https://stackblitz.com/github/marmelab/react-admin/tree/master/examples/simple):

1. Go to the post list (in a large screen to show the datagrid version)
2. Select all rows using the top left checkbox
3. Hit the bulk delete button

The empty page shows up, even though there are remaining posts (in the following page).

![image](https://github.com/user-attachments/assets/95fbffc8-22f4-4ec9-baff-d0dd30973611)


## Cause

This bug was introduced by #8945, which fixed a bug with partial pagination.

The condition for displaying the empty page is wrong, as it only counts the number of results in the current page (`data.length`) instead of the total number of results:

https://github.com/marmelab/react-admin/blob/e6129b2d1aded97f55bf40bf1d5602cc42a03113/packages/ra-ui-materialui/src/list/ListView.tsx#L60-L64
