### PR TITLE
Fix FilterButton checked status

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -182,15 +182,10 @@ export const FilterButton = (props: FilterButtonProps) => {
                     (filterElement: JSX.Element, index) => (
                         <FilterButtonMenuItem
                             key={filterElement.props.source}
-                            filter={{
-                                ...filterElement,
-                                props: {
-                                    ...filterElement.props,
-                                    applied: appliedFilters.includes(
-                                        filterElement.props.source
-                                    ),
-                                },
-                            }}
+                            filter={filterElement}
+                            displayed={
+                                !!displayedFilters[filterElement.props.source]
+                            }
                             resource={resource}
                             onShow={handleShow}
                             onHide={handleRemove}

--- a/packages/ra-ui-materialui/src/list/filter/FilterButtonMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButtonMenuItem.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '@mui/material';
 
 export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
     (props, ref) => {
-        const { filter, onShow, onHide, autoFocus } = props;
+        const { filter, onShow, onHide, autoFocus, displayed } = props;
         const resource = useResourceContext(props);
         const handleShow = useCallback(() => {
             onShow({
@@ -26,7 +26,7 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
                 data-key={filter.props.source}
                 data-default-value={filter.props.defaultValue}
                 key={filter.props.source}
-                onClick={filter.props.applied ? handleHide : handleShow}
+                onClick={displayed ? handleHide : handleShow}
                 autoFocus={autoFocus}
                 ref={ref}
                 disabled={filter.props.disabled}
@@ -40,7 +40,8 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
                         marginLeft: 0,
                         marginRight: '7px',
                     }}
-                    defaultChecked={filter.props.applied}
+                    disableRipple
+                    defaultChecked={displayed}
                 />
                 <FieldTitle
                     label={filter.props.label}
@@ -54,6 +55,7 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
 
 export interface FilterButtonMenuItemProps {
     filter: JSX.Element;
+    displayed: boolean;
     onShow: (params: { source: string; defaultValue: any }) => void;
     onHide: (params: { source: string }) => void;
     resource?: string;


### PR DESCRIPTION
## Problem

In the new design of the FilterButton dropdown, the checkbox for a filter is checked is the filter has a value. This isn't intuitive: if a user clicks on the item to have a filter input appear, they expect the checkbox to be displayed next time they open the dropdown.

## Solution

Check the checkbox if the filter is displayed, not applied.

## Problem

_Describe the problem this PR solves_

## Solution

_Describe the solution this PR implements_

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
