### PR TITLE
Avoid unnecessary rerenders with canAccess hooks when there is no authProvider

### DIFF
--- a/packages/ra-core/src/auth/useCanAccess.spec.tsx
+++ b/packages/ra-core/src/auth/useCanAccess.spec.tsx
@@ -6,17 +6,10 @@ import { QueryClient } from '@tanstack/react-query';
 import { Basic } from './useCanAccess.stories';
 
 describe('useCanAccess', () => {
-    it('should return a loading state on mount', () => {
+    it('should allow access on mount when there is no authProvider', () => {
         render(<Basic authProvider={null} />);
-        expect(screen.queryByText('LOADING')).not.toBeNull();
-    });
-
-    it('should return isPending: true by default after a tick', async () => {
-        render(<Basic authProvider={null} />);
-        expect(screen.queryByText('LOADING')).not.toBeNull();
-        await waitFor(() => {
-            expect(screen.queryByText('LOADING')).toBeNull();
-        });
+        expect(screen.queryByText('LOADING')).toBeNull();
+        screen.getByText('canAccess: YES');
     });
 
     it('should return that the resource is accessible when canAccess return true', async () => {

--- a/packages/ra-core/src/auth/useCanAccess.spec.tsx
+++ b/packages/ra-core/src/auth/useCanAccess.spec.tsx
@@ -6,6 +6,19 @@ import { QueryClient } from '@tanstack/react-query';
 import { Basic } from './useCanAccess.stories';
 
 describe('useCanAccess', () => {
+    it('should return a loading state on mount', () => {
+        render(<Basic />);
+        screen.getByText('LOADING');
+    });
+
+    it('should return isPending: true by default after a tick', async () => {
+        render(<Basic />);
+        screen.getByText('LOADING');
+        await waitFor(() => {
+            expect(screen.queryByText('LOADING')).toBeNull();
+        });
+    });
+
     it('should allow access on mount when there is no authProvider', () => {
         render(<Basic authProvider={null} />);
         expect(screen.queryByText('LOADING')).toBeNull();

--- a/packages/ra-core/src/auth/useCanAccess.stories.tsx
+++ b/packages/ra-core/src/auth/useCanAccess.stories.tsx
@@ -46,7 +46,7 @@ const defaultAuthProvider: AuthProvider = {
     checkError: () => Promise.reject('bad method'),
     getPermissions: () => Promise.reject('bad method'),
     canAccess: ({ action }) =>
-        new Promise(resolve => setTimeout(resolve, 1000, action === 'read')),
+        new Promise(resolve => setTimeout(resolve, 500, action === 'read')),
 };
 
 export const Basic = ({

--- a/packages/ra-core/src/auth/useCanAccess.stories.tsx
+++ b/packages/ra-core/src/auth/useCanAccess.stories.tsx
@@ -45,7 +45,8 @@ const defaultAuthProvider: AuthProvider = {
     checkAuth: () => Promise.reject('bad method'),
     checkError: () => Promise.reject('bad method'),
     getPermissions: () => Promise.reject('bad method'),
-    canAccess: ({ action }) => Promise.resolve(action === 'read'),
+    canAccess: ({ action }) =>
+        new Promise(resolve => setTimeout(resolve, 1000, action === 'read')),
 };
 
 export const Basic = ({
@@ -59,6 +60,18 @@ export const Basic = ({
         authProvider={authProvider != null ? authProvider : undefined}
         queryClient={queryClient}
     >
+        <UseCanAccess action="read" resource="test">
+            {state => <StateInspector state={state} />}
+        </UseCanAccess>
+    </CoreAdminContext>
+);
+
+export const NoAuthProvider = ({
+    queryClient,
+}: {
+    queryClient?: QueryClient;
+}) => (
+    <CoreAdminContext authProvider={undefined} queryClient={queryClient}>
         <UseCanAccess action="read" resource="test">
             {state => <StateInspector state={state} />}
         </UseCanAccess>

--- a/packages/ra-core/src/auth/useCanAccess.ts
+++ b/packages/ra-core/src/auth/useCanAccess.ts
@@ -49,7 +49,7 @@ export const useCanAccess = <ErrorType = Error>(
 ): UseCanAccessResult<ErrorType> => {
     const authProvider = useAuthProvider();
 
-    const result = useQuery({
+    const queryResult = useQuery({
         queryKey: ['auth', 'canAccess', JSON.stringify(params)],
         queryFn: async ({ signal }) => {
             if (!authProvider || !authProvider.canAccess) {
@@ -63,12 +63,46 @@ export const useCanAccess = <ErrorType = Error>(
         ...params,
     });
 
-    return useMemo(() => {
+    const result = useMemo(() => {
+        // Don't check for the authProvider or authProvider.canAccess method in the useMemo
+        // to avoid unnecessary re-renders
         return {
-            ...result,
-            canAccess: result.data,
+            ...queryResult,
+            canAccess: queryResult.data,
         } as UseCanAccessResult<ErrorType>;
-    }, [result]);
+    }, [queryResult]);
+
+    return !authProvider || !authProvider.canAccess
+        ? (emptyQueryObserverResult as UseCanAccessResult<ErrorType>)
+        : result;
+};
+
+const emptyQueryObserverResult = {
+    canAccess: true,
+    data: true,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: 'idle',
+    isError: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isPending: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    status: 'success',
+    refetch: () => Promise.resolve(emptyQueryObserverResult),
 };
 
 export interface UseCanAccessOptions<ErrorType = Error>

--- a/packages/ra-core/src/auth/useCanAccessResources.spec.tsx
+++ b/packages/ra-core/src/auth/useCanAccessResources.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import expect from 'expect';
-import { waitFor, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Basic } from './useCanAccessResources.stories';
 
 describe('useCanAccessResources', () => {
@@ -84,11 +84,7 @@ describe('useCanAccessResources', () => {
     it('should grant access to all resources if no authProvider', async () => {
         render(<Basic authProvider={null} />);
 
-        expect(
-            screen.getByText(JSON.stringify({ canAccess: {}, isPending: true }))
-        );
-
-        await screen.findByText(
+        screen.getByText(
             JSON.stringify({
                 canAccess: {
                     'posts.id': true,
@@ -110,23 +106,15 @@ describe('useCanAccessResources', () => {
         };
         render(<Basic authProvider={authProvider} />);
 
-        expect(
-            screen.getByText(JSON.stringify({ canAccess: {}, isPending: true }))
+        screen.getByText(
+            JSON.stringify({
+                canAccess: {
+                    'posts.id': true,
+                    'posts.title': true,
+                    'posts.author': true,
+                },
+                isPending: false,
+            })
         );
-
-        await waitFor(() => {
-            expect(
-                screen.getByText(
-                    JSON.stringify({
-                        canAccess: {
-                            'posts.id': true,
-                            'posts.title': true,
-                            'posts.author': true,
-                        },
-                        isPending: false,
-                    })
-                )
-            );
-        });
     });
 });

--- a/packages/ra-core/src/auth/useCanAccessResources.spec.tsx
+++ b/packages/ra-core/src/auth/useCanAccessResources.spec.tsx
@@ -16,9 +16,7 @@ describe('useCanAccessResources', () => {
         };
         render(<Basic authProvider={authProvider} />);
 
-        expect(
-            screen.getByText(JSON.stringify({ canAccess: {}, isPending: true }))
-        );
+        screen.getByText('LOADING');
 
         expect(canAccess).toBeCalledTimes(3);
         expect(canAccess).toBeCalledWith({
@@ -39,14 +37,13 @@ describe('useCanAccessResources', () => {
 
         await screen.findByText(
             JSON.stringify({
-                canAccess: {
-                    'posts.id': true,
-                    'posts.title': true,
-                    'posts.author': true,
-                },
-                isPending: false,
+                'posts.id': true,
+                'posts.title': true,
+                'posts.author': true,
             })
         );
+
+        expect(screen.queryByText('LOADING')).toBeNull();
     });
 
     it('should grant access to each resource based on canAccess result', async () => {
@@ -65,33 +62,27 @@ describe('useCanAccessResources', () => {
         };
         render(<Basic authProvider={authProvider} />);
 
-        expect(
-            screen.getByText(JSON.stringify({ canAccess: {}, isPending: true }))
-        );
+        screen.getByText('LOADING');
 
         await screen.findByText(
             JSON.stringify({
-                canAccess: {
-                    'posts.id': false,
-                    'posts.title': true,
-                    'posts.author': true,
-                },
-                isPending: false,
+                'posts.id': false,
+                'posts.title': true,
+                'posts.author': true,
             })
         );
+        expect(screen.queryByText('LOADING')).toBeNull();
     });
 
     it('should grant access to all resources if no authProvider', async () => {
         render(<Basic authProvider={null} />);
+        expect(screen.queryByText('LOADING')).toBeNull();
 
         screen.getByText(
             JSON.stringify({
-                canAccess: {
-                    'posts.id': true,
-                    'posts.title': true,
-                    'posts.author': true,
-                },
-                isPending: false,
+                'posts.id': true,
+                'posts.title': true,
+                'posts.author': true,
             })
         );
     });
@@ -105,15 +96,13 @@ describe('useCanAccessResources', () => {
             getPermissions: () => Promise.reject('bad method'),
         };
         render(<Basic authProvider={authProvider} />);
+        expect(screen.queryByText('LOADING')).toBeNull();
 
         screen.getByText(
             JSON.stringify({
-                canAccess: {
-                    'posts.id': true,
-                    'posts.title': true,
-                    'posts.author': true,
-                },
-                isPending: false,
+                'posts.id': true,
+                'posts.title': true,
+                'posts.author': true,
             })
         );
     });

--- a/packages/ra-core/src/auth/useCanAccessResources.stories.tsx
+++ b/packages/ra-core/src/auth/useCanAccessResources.stories.tsx
@@ -42,7 +42,8 @@ const defaultAuthProvider: AuthProvider = {
     checkAuth: () => Promise.reject('bad method'),
     checkError: () => Promise.reject('bad method'),
     getPermissions: () => Promise.reject('bad method'),
-    canAccess: ({ action }) => Promise.resolve(action === 'read'),
+    canAccess: ({ action }) =>
+        new Promise(resolve => setTimeout(resolve, 1000, action === 'read')),
 };
 
 export const Basic = ({

--- a/packages/ra-core/src/auth/useCanAccessResources.stories.tsx
+++ b/packages/ra-core/src/auth/useCanAccessResources.stories.tsx
@@ -43,7 +43,7 @@ const defaultAuthProvider: AuthProvider = {
     checkError: () => Promise.reject('bad method'),
     getPermissions: () => Promise.reject('bad method'),
     canAccess: ({ action }) =>
-        new Promise(resolve => setTimeout(resolve, 1000, action === 'read')),
+        new Promise(resolve => setTimeout(resolve, 500, action === 'read')),
 };
 
 export const Basic = ({

--- a/packages/ra-core/src/auth/useCanAccessResources.stories.tsx
+++ b/packages/ra-core/src/auth/useCanAccessResources.stories.tsx
@@ -28,12 +28,16 @@ const UseCanAccessResources = ({
     return children({ canAccess, isPending });
 };
 
-const StateInspector = ({
-    result,
-}: {
-    result: UseCanAccessResourcesResult;
-}) => {
-    return <div>{JSON.stringify(result)}</div>;
+const StateInspector = ({ state }: { state: UseCanAccessResourcesResult }) => {
+    return (
+        <div>
+            <span>{state.isPending && 'LOADING'}</span>
+            {state.canAccess !== undefined && (
+                <span>{JSON.stringify(state.canAccess)}</span>
+            )}
+            <span>{state.error && 'ERROR'}</span>
+        </div>
+    );
 };
 
 const defaultAuthProvider: AuthProvider = {
@@ -61,7 +65,7 @@ export const Basic = ({
             action="read"
             resources={['posts.id', 'posts.title', 'posts.author']}
         >
-            {result => <StateInspector result={result} />}
+            {result => <StateInspector state={result} />}
         </UseCanAccessResources>
     </CoreAdminContext>
 );
@@ -76,7 +80,7 @@ export const NoAuthProvider = ({
             action="read"
             resources={['posts.id', 'posts.title', 'posts.author']}
         >
-            {result => <StateInspector result={result} />}
+            {result => <StateInspector state={result} />}
         </UseCanAccessResources>
     </CoreAdminContext>
 );


### PR DESCRIPTION
## Problem

As we use react-query for the canAccess hooks, users may see at least one rerender because it run asynchronously.

## Solution

Detect there is no support for canAccess and return a fake react-query result if needed.

## How To Test

The `useCanAccess` and `useCanAccessResources` have stories with and without an AuthProvider that shows the behavior.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
