### PR TITLE
Update create/update/delete notification messages to include resource name

### DIFF
--- a/examples/demo/src/reviews/ReviewCreate.tsx
+++ b/examples/demo/src/reviews/ReviewCreate.tsx
@@ -10,6 +10,7 @@ import {
     useNotify,
     useRedirect,
     getRecordFromLocation,
+    useGetResourceLabel,
 } from 'react-admin';
 import { useLocation } from 'react-router';
 
@@ -19,10 +20,16 @@ const ReviewCreate = () => {
     const notify = useNotify();
     const redirect = useRedirect();
     const location = useLocation();
+    const getResourceLabel = useGetResourceLabel();
 
     const onSuccess = (_: any) => {
         const record = getRecordFromLocation(location);
-        notify('ra.notification.created');
+        notify('ra.notification.created', {
+            messageArgs: {
+                smart_count: 1,
+                name: getResourceLabel('reviews', 1),
+            },
+        });
         if (record && record.product_id) {
             redirect(`/products/${record.product_id}/reviews`);
         } else {

--- a/examples/demo/src/reviews/ReviewEditToolbar.tsx
+++ b/examples/demo/src/reviews/ReviewEditToolbar.tsx
@@ -37,19 +37,7 @@ const ReviewEditToolbar = (props: ToolbarProps) => {
                 </Fragment>
             ) : (
                 <Fragment>
-                    <SaveButton
-                        mutationOptions={{
-                            onSuccess: () => {
-                                notify('ra.notification.updated', {
-                                    type: 'info',
-                                    messageArgs: { smart_count: 1 },
-                                    undoable: true,
-                                });
-                                redirect('list', 'reviews');
-                            },
-                        }}
-                        type="button"
-                    />
+                    <SaveButton type="button" />
                     <DeleteButton record={record} resource={resource} />
                 </Fragment>
             )}

--- a/examples/simple/src/posts/PostCreate.tsx
+++ b/examples/simple/src/posts/PostCreate.tsx
@@ -26,6 +26,7 @@ import {
     useRedirect,
     useCreate,
     useCreateSuggestionContext,
+    useGetResourceLabel,
 } from 'react-admin';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
@@ -34,6 +35,8 @@ const PostCreateToolbar = () => {
     const notify = useNotify();
     const redirect = useRedirect();
     const { reset } = useFormContext();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = getResourceLabel('posts', 1);
 
     return (
         <Toolbar>
@@ -46,7 +49,10 @@ const PostCreateToolbar = () => {
                     onSuccess: data => {
                         notify('ra.notification.created', {
                             type: 'info',
-                            messageArgs: { smart_count: 1 },
+                            messageArgs: {
+                                smart_count: 1,
+                                name: resourceLabel,
+                            },
                         });
                         redirect('show', 'posts', data.id);
                     },
@@ -63,7 +69,10 @@ const PostCreateToolbar = () => {
                         window.scrollTo(0, 0);
                         notify('ra.notification.created', {
                             type: 'info',
-                            messageArgs: { smart_count: 1 },
+                            messageArgs: {
+                                smart_count: 1,
+                                name: resourceLabel,
+                            },
                         });
                     },
                 }}
@@ -76,7 +85,10 @@ const PostCreateToolbar = () => {
                     onSuccess: data => {
                         notify('ra.notification.created', {
                             type: 'info',
-                            messageArgs: { smart_count: 1 },
+                            messageArgs: {
+                                smart_count: 1,
+                                name: resourceLabel,
+                            },
                         });
                         redirect('show', 'posts', data.id);
                     },

--- a/examples/simple/src/posts/ResetViewsButton.tsx
+++ b/examples/simple/src/posts/ResetViewsButton.tsx
@@ -19,7 +19,11 @@ const ResetViewsButton = () => {
             onSuccess: () => {
                 notify('ra.notification.updated', {
                     type: 'info',
-                    messageArgs: { smart_count: selectedIds.length },
+                    messageArgs: {
+                        smart_count: selectedIds.length,
+                        name: selectedIds.length > 1 ? 'Posts' : 'Post',
+                        nameLcFirst: selectedIds.length > 1 ? 'posts' : 'post',
+                    },
                     undoable: true,
                 });
                 unselectAll();

--- a/examples/simple/src/users/UserCreate.tsx
+++ b/examples/simple/src/users/UserCreate.tsx
@@ -12,13 +12,16 @@ import {
     useNotify,
     usePermissions,
     useUnique,
+    useGetResourceLabel,
 } from 'react-admin';
 
 import Aside from './Aside';
 
-const UserEditToolbar = ({ permissions, ...props }) => {
+const UserCreateToolbar = ({ permissions, ...props }) => {
     const notify = useNotify();
     const { reset } = useFormContext();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = getResourceLabel('users', 1);
 
     return (
         <Toolbar {...props}>
@@ -32,6 +35,7 @@ const UserEditToolbar = ({ permissions, ...props }) => {
                                 type: 'info',
                                 messageArgs: {
                                     smart_count: 1,
+                                    name: resourceLabel,
                                 },
                             });
                             reset();
@@ -60,7 +64,7 @@ const UserCreate = () => {
             <TabbedForm
                 mode="onBlur"
                 warnWhenUnsavedChanges
-                toolbar={<UserEditToolbar permissions={permissions} />}
+                toolbar={<UserCreateToolbar permissions={permissions} />}
             >
                 <TabbedForm.Tab label="user.form.summary" path="">
                     <TextInput

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -5,13 +5,14 @@ import {
     SyntheticEvent,
 } from 'react';
 import { UseMutationOptions } from '@tanstack/react-query';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { useDelete } from '../../dataProvider';
 import { useUnselect } from '../../controller';
 import { useRedirect, RedirectionSideEffect } from '../../routing';
 import { useNotify } from '../../notification';
 import { RaRecord, MutationMode, DeleteParams } from '../../types';
-import { useResourceContext } from '../../core';
+import { useGetResourceLabel, useResourceContext } from '../../core';
 
 /**
  * Prepare a set of callbacks for a delete button guarded by confirmation dialog
@@ -80,6 +81,8 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
     const notify = useNotify();
     const unselect = useUnselect(resource);
     const redirect = useRedirect();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource ? getResourceLabel(resource, 1) : 'Element';
     const [deleteOne, { isPending }] = useDelete<RecordType>(
         resource,
         undefined,
@@ -88,7 +91,11 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
                 setOpen(false);
                 notify(successMessage, {
                     type: 'info',
-                    messageArgs: { smart_count: 1 },
+                    messageArgs: {
+                        smart_count: 1,
+                        name: resourceLabel,
+                        nameLcFirst: lowerFirst(resourceLabel),
+                    },
                     undoable: mutationMode === 'undoable',
                 });
                 record && unselect([record.id]);

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.spec.tsx
@@ -91,7 +91,11 @@ describe('useDeleteWithUndoController', () => {
                     message: successMessage,
                     type: 'info',
                     notificationOptions: {
-                        messageArgs: { smart_count: 1 },
+                        messageArgs: {
+                            smart_count: 1,
+                            name: 'resources.posts.name',
+                            nameLcFirst: 'resources.posts.name',
+                        },
                         undoable: true,
                     },
                 },

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -1,12 +1,13 @@
 import { useCallback, ReactEventHandler } from 'react';
 import { UseMutationOptions } from '@tanstack/react-query';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { useDelete } from '../../dataProvider';
 import { useUnselect } from '../../controller';
 import { useRedirect, RedirectionSideEffect } from '../../routing';
 import { useNotify } from '../../notification';
 import { RaRecord, DeleteParams } from '../../types';
-import { useResourceContext } from '../../core';
+import { useResourceContext, useGetResourceLabel } from '../../core';
 
 /**
  * Prepare callback for a Delete button with undo support
@@ -58,6 +59,8 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
     const notify = useNotify();
     const unselect = useUnselect(resource);
     const redirect = useRedirect();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource ? getResourceLabel(resource, 1) : 'Element';
     const [deleteOne, { isPending }] = useDelete<RecordType>(
         resource,
         undefined,
@@ -65,7 +68,11 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
             onSuccess: () => {
                 notify(successMessage, {
                     type: 'info',
-                    messageArgs: { smart_count: 1 },
+                    messageArgs: {
+                        smart_count: 1,
+                        name: resourceLabel,
+                        nameLcFirst: lowerFirst(resourceLabel),
+                    },
                     undoable: true,
                 });
                 record && unselect([record.id]);

--- a/packages/ra-core/src/controller/create/useCreateController.spec.tsx
+++ b/packages/ra-core/src/controller/create/useCreateController.spec.tsx
@@ -137,7 +137,13 @@ describe('useCreateController', () => {
             {
                 message: 'ra.notification.created',
                 type: 'info',
-                notificationOptions: { messageArgs: { smart_count: 1 } },
+                notificationOptions: {
+                    messageArgs: {
+                        smart_count: 1,
+                        name: 'resources.posts.name',
+                        nameLcFirst: 'resources.posts.name',
+                    },
+                },
             },
         ]);
     });

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { parse } from 'query-string';
 import { useLocation, Location } from 'react-router-dom';
 import { UseMutationOptions } from '@tanstack/react-query';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { useAuthenticated } from '../../auth';
 import {
@@ -82,6 +83,8 @@ export const useCreateController = <
         getMutateWithMiddlewares,
         unregisterMutationMiddleware,
     } = useMutationMiddlewares();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = getResourceLabel(resource, 1);
 
     const [create, { isPending: saving }] = useCreate<
         RecordType,
@@ -95,7 +98,11 @@ export const useCreateController = <
 
             notify('ra.notification.created', {
                 type: 'info',
-                messageArgs: { smart_count: 1 },
+                messageArgs: {
+                    smart_count: 1,
+                    name: resourceLabel,
+                    nameLcFirst: lowerFirst(resourceLabel),
+                },
             });
             redirect(finalRedirectTo, resource, data.id, data);
         },
@@ -174,9 +181,8 @@ export const useCreateController = <
         [create, meta, resource, transform]
     );
 
-    const getResourceLabel = useGetResourceLabel();
     const defaultTitle = translate('ra.page.create', {
-        name: getResourceLabel(resource, 1),
+        name: resourceLabel,
     });
 
     return {

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -374,6 +374,8 @@ describe('useEditController', () => {
                     notificationOptions: {
                         messageArgs: {
                             smart_count: 1,
+                            name: 'resources.posts.name',
+                            nameLcFirst: 'resources.posts.name',
                         },
                         undoable: false,
                     },
@@ -580,6 +582,8 @@ describe('useEditController', () => {
                     notificationOptions: {
                         messageArgs: {
                             smart_count: 1,
+                            name: 'resources.posts.name',
+                            nameLcFirst: 'resources.posts.name',
                         },
                         undoable: false,
                     },

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { useAuthenticated } from '../../auth';
 import { RaRecord, MutationMode, TransformData } from '../../types';
@@ -127,9 +128,11 @@ export const useEditController = <
     }
 
     const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = getResourceLabel(resource, 1);
     const recordRepresentation = getRecordRepresentation(record);
     const defaultTitle = translate('ra.page.edit', {
-        name: getResourceLabel(resource, 1),
+        name: resourceLabel,
+        nameLcFirst: lowerFirst(resourceLabel),
         id,
         record,
         recordRepresentation:
@@ -150,7 +153,11 @@ export const useEditController = <
                 }
                 notify('ra.notification.updated', {
                     type: 'info',
-                    messageArgs: { smart_count: 1 },
+                    messageArgs: {
+                        smart_count: 1,
+                        name: getResourceLabel(resource, 1),
+                        nameLcFirst: lowerFirst(getResourceLabel(resource, 1)),
+                    },
                     undoable: mutationMode === 'undoable',
                 });
                 redirect(redirectTo, resource, data.id, data);

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -148,9 +148,11 @@ const englishMessages: TranslationMessages = {
             logout: 'Logout',
         },
         notification: {
-            updated: 'Element updated |||| %{smart_count} elements updated',
-            created: 'Element created',
-            deleted: 'Element deleted |||| %{smart_count} elements deleted',
+            updated:
+                '%{name} updated |||| %{smart_count} %{nameLcFirst} updated',
+            created: '%{name} created',
+            deleted:
+                '%{name} deleted |||| %{smart_count} %{nameLcFirst} deleted',
             bad_item: 'Incorrect element',
             item_doesnt_exist: 'Element does not exist',
             http_error: 'Server communication error',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -154,9 +154,10 @@ const frenchMessages: TranslationMessages = {
         },
         notification: {
             updated:
-                'Élément mis à jour |||| %{smart_count} éléments mis à jour',
-            created: 'Élément créé',
-            deleted: 'Élément supprimé |||| %{smart_count} éléments supprimés',
+                '%{name} mis à jour |||| %{smart_count} %{nameLcFirst} mis à jour',
+            created: '%{name} créé',
+            deleted:
+                '%{name} supprimé |||| %{smart_count} %{nameLcFirst} supprimés',
             bad_item: 'Élément inconnu',
             item_doesnt_exist: "L'élément n'existe pas",
             http_error: 'Erreur de communication avec le serveur',

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Fragment, ReactElement } from 'react';
 import ActionDelete from '@mui/icons-material/Delete';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { alpha, styled } from '@mui/material/styles';
 import {
@@ -14,6 +15,7 @@ import {
     useSafeSetState,
     RaRecord,
     DeleteManyParams,
+    useGetResourceLabel,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
@@ -43,6 +45,10 @@ export const BulkDeleteWithConfirmButton = (
     const resource = useResourceContext(props);
     const refresh = useRefresh();
     const translate = useTranslate();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource
+        ? getResourceLabel(resource, selectedIds.length)
+        : 'Element' + (selectedIds.length > 1 ? 's' : '');
     const [deleteMany, { isPending }] = useDeleteMany(
         resource,
         { ids: selectedIds, meta: mutationMeta },
@@ -51,7 +57,11 @@ export const BulkDeleteWithConfirmButton = (
                 refresh();
                 notify(successMessage, {
                     type: 'info',
-                    messageArgs: { smart_count: selectedIds.length },
+                    messageArgs: {
+                        smart_count: selectedIds.length,
+                        name: resourceLabel,
+                        nameLcFirst: lowerFirst(resourceLabel),
+                    },
                     undoable: mutationMode === 'undoable',
                 });
                 onUnselectItems();

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.spec.tsx
@@ -57,7 +57,11 @@ describe('<BulkDeleteWithUndoButton />', () => {
                     message: successMessage,
                     type: 'info',
                     notificationOptions: {
-                        messageArgs: { smart_count: 1 },
+                        messageArgs: {
+                            smart_count: 1,
+                            name: 'resources.test.name',
+                            nameLcFirst: 'resources.test.name',
+                        },
                         undoable: true,
                     },
                 },

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -11,7 +11,9 @@ import {
     useListContext,
     RaRecord,
     DeleteManyParams,
+    useGetResourceLabel,
 } from 'ra-core';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { Button, ButtonProps } from './Button';
 import { UseMutationOptions } from '@tanstack/react-query';
@@ -32,10 +34,14 @@ export const BulkDeleteWithUndoButton = (
 
     const notify = useNotify();
     const resource = useResourceContext(props);
+    const getResourceLabel = useGetResourceLabel();
     const refresh = useRefresh();
     const [deleteMany, { isPending }] = useDeleteMany();
 
     const handleClick = e => {
+        const resourceLabel = resource
+            ? getResourceLabel(resource, selectedIds.length)
+            : 'Element' + (selectedIds.length > 1 ? 's' : '');
         deleteMany(
             resource,
             { ids: selectedIds, meta: mutationMeta },
@@ -43,7 +49,11 @@ export const BulkDeleteWithUndoButton = (
                 onSuccess: () => {
                     notify(successMessage, {
                         type: 'info',
-                        messageArgs: { smart_count: selectedIds.length },
+                        messageArgs: {
+                            smart_count: selectedIds.length,
+                            name: resourceLabel,
+                            nameLcFirst: lowerFirst(resourceLabel),
+                        },
                         undoable: true,
                     });
                     onUnselectItems();

--- a/packages/ra-ui-materialui/src/button/BulkUpdateButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateButton.spec.tsx
@@ -18,7 +18,7 @@ describe('BulkUpdateButton', () => {
             );
             const confirmButton = await screen.findByText('Confirm');
             confirmButton.click();
-            await screen.findByText('10 elements updated');
+            await screen.findByText('10 books updated');
             expect(
                 screen.queryByText(
                     'Are you sure you want to update these 10 items?'

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Fragment, useState, ReactElement } from 'react';
 import ActionUpdate from '@mui/icons-material/Update';
-
 import { alpha, styled } from '@mui/material/styles';
 import {
     useListContext,
@@ -13,12 +12,14 @@ import {
     MutationMode,
     RaRecord,
     UpdateManyParams,
+    useGetResourceLabel,
 } from 'ra-core';
+import { UseMutationOptions } from '@tanstack/react-query';
+import { humanize, inflect } from 'inflection';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { Confirm } from '../layout';
 import { Button, ButtonProps } from './Button';
-import { UseMutationOptions } from '@tanstack/react-query';
-import { humanize, inflect } from 'inflection';
 
 export const BulkUpdateWithConfirmButton = (
     props: BulkUpdateWithConfirmButtonProps
@@ -29,6 +30,10 @@ export const BulkUpdateWithConfirmButton = (
     const unselectAll = useUnselectAll(resource);
     const [isOpen, setOpen] = useState(false);
     const { selectedIds } = useListContext();
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource
+        ? getResourceLabel(resource, selectedIds.length)
+        : 'Element' + (selectedIds.length > 1 ? 's' : '');
 
     const {
         confirmTitle = 'ra.message.bulk_update_title',
@@ -41,7 +46,11 @@ export const BulkUpdateWithConfirmButton = (
         onSuccess = () => {
             notify('ra.notification.updated', {
                 type: 'info',
-                messageArgs: { smart_count: selectedIds.length },
+                messageArgs: {
+                    smart_count: selectedIds.length,
+                    name: resourceLabel,
+                    nameLcFirst: lowerFirst(resourceLabel),
+                },
                 undoable: mutationMode === 'undoable',
             });
             unselectAll();

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -12,8 +12,10 @@ import {
     useListContext,
     RaRecord,
     UpdateManyParams,
+    useGetResourceLabel,
 } from 'ra-core';
 import { UseMutationOptions } from '@tanstack/react-query';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { Button, ButtonProps } from './Button';
 
@@ -24,6 +26,10 @@ export const BulkUpdateWithUndoButton = (
 
     const notify = useNotify();
     const resource = useResourceContext(props);
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource
+        ? getResourceLabel(resource, selectedIds.length)
+        : 'Element' + (selectedIds.length > 1 ? 's' : '');
     const unselectAll = useUnselectAll(resource);
     const refresh = useRefresh();
 
@@ -35,7 +41,11 @@ export const BulkUpdateWithUndoButton = (
         onSuccess = () => {
             notify('ra.notification.updated', {
                 type: 'info',
-                messageArgs: { smart_count: selectedIds.length },
+                messageArgs: {
+                    smart_count: selectedIds.length,
+                    name: resourceLabel,
+                    nameLcFirst: lowerFirst(resourceLabel),
+                },
                 undoable: true,
             });
             unselectAll();

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.spec.tsx
@@ -151,7 +151,11 @@ describe('<DeleteWithUndoButton />', () => {
                     message: successMessage,
                     type: 'info',
                     notificationOptions: {
-                        messageArgs: { smart_count: 1 },
+                        messageArgs: {
+                            smart_count: 1,
+                            name: 'resources.comments.name',
+                            nameLcFirst: 'resources.comments.name',
+                        },
                         undoable: true,
                     },
                 },

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Fragment, useState, ReactElement } from 'react';
 import ActionUpdate from '@mui/icons-material/Update';
-
 import { alpha, styled } from '@mui/material/styles';
 import {
     useTranslate,
@@ -12,12 +11,14 @@ import {
     useRecordContext,
     useUpdate,
     UpdateParams,
+    useGetResourceLabel,
 } from 'ra-core';
+import { UseMutationOptions } from '@tanstack/react-query';
+import { humanize, inflect } from 'inflection';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { Confirm } from '../layout';
 import { Button, ButtonProps } from './Button';
-import { UseMutationOptions } from '@tanstack/react-query';
-import { humanize, inflect } from 'inflection';
 
 export const UpdateWithConfirmButton = (
     props: UpdateWithConfirmButtonProps
@@ -27,6 +28,8 @@ export const UpdateWithConfirmButton = (
     const resource = useResourceContext(props);
     const [isOpen, setOpen] = useState(false);
     const record = useRecordContext(props);
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource ? getResourceLabel(resource, 1) : 'Element';
 
     const {
         confirmTitle = 'ra.message.bulk_update_title',
@@ -44,7 +47,11 @@ export const UpdateWithConfirmButton = (
         onSuccess = () => {
             notify('ra.notification.updated', {
                 type: 'info',
-                messageArgs: { smart_count: 1 },
+                messageArgs: {
+                    smart_count: 1,
+                    name: resourceLabel,
+                    nameLcFirst: lowerFirst(resourceLabel),
+                },
                 undoable: mutationMode === 'undoable',
             });
         },

--- a/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
@@ -10,8 +10,10 @@ import {
     useRecordContext,
     useUpdate,
     UpdateParams,
+    useGetResourceLabel,
 } from 'ra-core';
 import { UseMutationOptions } from '@tanstack/react-query';
+import lowerFirst from 'lodash/lowerFirst';
 
 import { Button, ButtonProps } from './Button';
 
@@ -19,6 +21,8 @@ export const UpdateWithUndoButton = (props: UpdateWithUndoButtonProps) => {
     const record = useRecordContext(props);
     const notify = useNotify();
     const resource = useResourceContext(props);
+    const getResourceLabel = useGetResourceLabel();
+    const resourceLabel = resource ? getResourceLabel(resource, 1) : 'Element';
     const refresh = useRefresh();
 
     const {
@@ -37,7 +41,11 @@ export const UpdateWithUndoButton = (props: UpdateWithUndoButtonProps) => {
         onSuccess = () => {
             notify('ra.notification.updated', {
                 type: 'info',
-                messageArgs: { smart_count: 1 },
+                messageArgs: {
+                    smart_count: 1,
+                    name: resourceLabel,
+                    nameLcFirst: lowerFirst(resourceLabel),
+                },
                 undoable: true,
             });
         },


### PR DESCRIPTION
## Problem

The snackbar that confirms the creation/update/deletion use a generic "element" name. It's impersonal and sometimes confusing. 

![Capture d’écran 2024-09-12 à 15 54 20](https://github.com/user-attachments/assets/4c689c1e-aeed-4494-9943-509d7d1dab25)
![Capture d’écran 2024-09-12 à 15 54 12](https://github.com/user-attachments/assets/378e479e-4c43-4dcf-8b77-d6c6789b9101)
![Capture d’écran 2024-09-12 à 15 53 54](https://github.com/user-attachments/assets/1c76cced-7e3a-41d2-899b-6bce1ad5efd1)
![Capture d’écran 2024-09-12 à 15 54 01](https://github.com/user-attachments/assets/e1ef1f1f-f236-44cf-9ad7-76cfc86b6b45)

## Solution

Use the resource name 

![Capture d’écran 2024-09-12 à 15 52 27](https://github.com/user-attachments/assets/d9e852d7-44dd-4811-9e60-dca421e3c000)
![Capture d’écran 2024-09-12 à 15 52 12](https://github.com/user-attachments/assets/80f8e068-724b-4533-836c-7cdfd8929f75)
![Capture d’écran 2024-09-12 à 15 47 48](https://github.com/user-attachments/assets/924bfc30-8eb0-4d1e-ac3f-cd2ceb838703)
![Capture d’écran 2024-09-12 à 15 48 08](https://github.com/user-attachments/assets/2a7d31a3-7d0d-45e5-92ae-3a3f25d6ca99)

French:

![Capture d’écran 2024-09-12 à 15 53 18](https://github.com/user-attachments/assets/089d2340-8533-419c-bb75-769427262e77)
![Capture d’écran 2024-09-12 à 15 53 09](https://github.com/user-attachments/assets/ebe0a439-08ca-48ae-8ed2-4de498549137)
![Capture d’écran 2024-09-12 à 15 52 48](https://github.com/user-attachments/assets/733e5579-3ce5-4841-909d-d25cc565ba5e)
![Capture d’écran 2024-09-12 à 15 52 56](https://github.com/user-attachments/assets/ba490845-2cb9-44b6-9e57-8d923c5ae8c8)

## To be fixed

In languages with gender, there is no way to alter the translation according to the resource gender. 

e.g. If e use the same French translation for `ra.notification.created`, it will only work in one case. 

- "Camion créé"
- "Voiture créé" => missing final "e"

## Breaking change

This may be a breaking change for applications that notify the following messages and use the default `en` and `fr` translations:

- `ra.notification.created`
- `ra.notification.updated`
- `ra.notification.deleted`

These are internal messages, and they shouldn't be used in user land. We should however document the upgrade path. 

## How To Test

1. Launch the simple example
2. Edit a post, and save => see update one notification
3. Edit a post, and delete => delete one notification
4. Select several posts, and delete => delete many notification
5. Create a new post and save => create notification

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

