### PR TITLE
Fix for ids not being escaped in paths in the Simple Rest Data Provider

### DIFF
--- a/packages/ra-data-simple-rest/src/index.spec.ts
+++ b/packages/ra-data-simple-rest/src/index.spec.ts
@@ -70,7 +70,7 @@ describe('Data Simple REST Client', () => {
     });
     describe('getOne', () => {
         it('should allow numeric id in path', async () => {
-            const httpClient = jest.fn().mockResolvedValue({ id: 'Post#123' });
+            const httpClient = jest.fn().mockResolvedValue({ id: 123 });
             const client = simpleClient('http://localhost:3000', httpClient);
 
             await client.getOne('posts', { id: 123 });
@@ -113,12 +113,12 @@ describe('Data Simple REST Client', () => {
         it('should escape id in path', async () => {
             const httpClient = jest
                 .fn()
-                .mockResolvedValue({ json: { id: 'Post#123' } });
+                .mockResolvedValue({ json: ['Post#123'] });
             const client = simpleClient('http://localhost:3000', httpClient);
 
             await client.updateMany('posts', {
-                data: undefined,
-                ids: [{ id: 'Post#123' }],
+                data: { body: '' },
+                ids: ['Post#123'],
             });
 
             expect(httpClient).toHaveBeenCalledWith(
@@ -165,7 +165,7 @@ describe('Data Simple REST Client', () => {
     });
     describe('deleteMany', () => {
         it('should set the `Content-Type` header to `text/plain`', async () => {
-            const httpClient = jest.fn().mockResolvedValue({ json: { id: 1 } });
+            const httpClient = jest.fn().mockResolvedValue({ json: [1] });
 
             const client = simpleClient('http://localhost:3000', httpClient);
 
@@ -196,11 +196,11 @@ describe('Data Simple REST Client', () => {
         it('should escape id in path', async () => {
             const httpClient = jest
                 .fn()
-                .mockResolvedValue({ json: { id: 'Post#123' } });
+                .mockResolvedValue({ json: ['Post#123'] });
             const client = simpleClient('http://localhost:3000', httpClient);
 
             await client.deleteMany('posts', {
-                ids: [{ id: 'Post#123' }],
+                ids: ['Post#123'],
             });
 
             expect(httpClient).toHaveBeenCalledWith(

--- a/packages/ra-data-simple-rest/src/index.spec.ts
+++ b/packages/ra-data-simple-rest/src/index.spec.ts
@@ -68,6 +68,65 @@ describe('Data Simple REST Client', () => {
             expect(result.total).toEqual(42);
         });
     });
+    describe('getOne', () => {
+        it('should allow numeric id in path', async () => {
+            const httpClient = jest.fn().mockResolvedValue({ id: 'Post#123' });
+            const client = simpleClient('http://localhost:3000', httpClient);
+
+            await client.getOne('posts', { id: 123 });
+
+            expect(httpClient).toHaveBeenCalledWith(
+                'http://localhost:3000/posts/123',
+                expect.any(Object)
+            );
+        });
+        it('should escape id in path', async () => {
+            const httpClient = jest.fn().mockResolvedValue({ id: 'Post#123' });
+            const client = simpleClient('http://localhost:3000', httpClient);
+
+            await client.getOne('posts', { id: 'Post#123' });
+
+            expect(httpClient).toHaveBeenCalledWith(
+                'http://localhost:3000/posts/Post%23123',
+                expect.any(Object)
+            );
+        });
+    });
+    describe('update', () => {
+        it('should escape id in path', async () => {
+            const httpClient = jest.fn().mockResolvedValue({ id: 'Post#123' });
+            const client = simpleClient('http://localhost:3000', httpClient);
+
+            await client.update('posts', {
+                previousData: undefined,
+                id: 'Post#123',
+                data: { body: '' },
+            });
+
+            expect(httpClient).toHaveBeenCalledWith(
+                'http://localhost:3000/posts/Post%23123',
+                expect.any(Object)
+            );
+        });
+    });
+    describe('updateMany', () => {
+        it('should escape id in path', async () => {
+            const httpClient = jest
+                .fn()
+                .mockResolvedValue({ json: { id: 'Post#123' } });
+            const client = simpleClient('http://localhost:3000', httpClient);
+
+            await client.updateMany('posts', {
+                data: undefined,
+                ids: [{ id: 'Post#123' }],
+            });
+
+            expect(httpClient).toHaveBeenCalledWith(
+                'http://localhost:3000/posts/Post%23123',
+                expect.any(Object)
+            );
+        });
+    });
     describe('delete', () => {
         it('should set the `Content-Type` header to `text/plain`', async () => {
             const httpClient = jest.fn().mockResolvedValue({ json: { id: 1 } });
@@ -87,6 +146,20 @@ describe('Data Simple REST Client', () => {
                         'Content-Type': 'text/plain',
                     }),
                 }
+            );
+        });
+        it('should escape id in path', async () => {
+            const httpClient = jest.fn().mockResolvedValue({ id: 'Post#123' });
+            const client = simpleClient('http://localhost:3000', httpClient);
+
+            await client.delete('posts', {
+                previousData: undefined,
+                id: 'Post#123',
+            });
+
+            expect(httpClient).toHaveBeenCalledWith(
+                'http://localhost:3000/posts/Post%23123',
+                expect.any(Object)
             );
         });
     });
@@ -118,6 +191,21 @@ describe('Data Simple REST Client', () => {
                         'Content-Type': 'text/plain',
                     }),
                 }
+            );
+        });
+        it('should escape id in path', async () => {
+            const httpClient = jest
+                .fn()
+                .mockResolvedValue({ json: { id: 'Post#123' } });
+            const client = simpleClient('http://localhost:3000', httpClient);
+
+            await client.deleteMany('posts', {
+                ids: [{ id: 'Post#123' }],
+            });
+
+            expect(httpClient).toHaveBeenCalledWith(
+                'http://localhost:3000/posts/Post%23123',
+                expect.any(Object)
             );
         });
     });

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -156,13 +156,10 @@ export default (
     updateMany: (resource, params) =>
         Promise.all(
             params.ids.map(id =>
-                httpClient(
-                    `${apiUrl}/${resource}/${encodeURIComponent(typeof id === 'object' ? id.id : String(id))}`,
-                    {
-                        method: 'PUT',
-                        body: JSON.stringify(params.data),
-                    }
-                )
+                httpClient(`${apiUrl}/${resource}/${encodeURIComponent(id)}`, {
+                    method: 'PUT',
+                    body: JSON.stringify(params.data),
+                })
             )
         ).then(responses => ({
             data: responses.map(({ json }) => json.id),
@@ -186,15 +183,12 @@ export default (
     deleteMany: (resource, params) =>
         Promise.all(
             params.ids.map(id =>
-                httpClient(
-                    `${apiUrl}/${resource}/${encodeURIComponent(typeof id === 'object' ? id['id'] : String(id))}`,
-                    {
-                        method: 'DELETE',
-                        headers: new Headers({
-                            'Content-Type': 'text/plain',
-                        }),
-                    }
-                )
+                httpClient(`${apiUrl}/${resource}/${encodeURIComponent(id)}`, {
+                    method: 'DELETE',
+                    headers: new Headers({
+                        'Content-Type': 'text/plain',
+                    }),
+                })
             )
         ).then(responses => ({
             data: responses.map(({ json }) => json.id),

--- a/packages/ra-data-simple-rest/src/index.ts
+++ b/packages/ra-data-simple-rest/src/index.ts
@@ -83,7 +83,7 @@ export default (
     },
 
     getOne: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+        httpClient(`${apiUrl}/${resource}/${encodeURIComponent(params.id)}`, {
             signal: params?.signal,
         }).then(({ json }) => ({
             data: json,
@@ -147,7 +147,7 @@ export default (
     },
 
     update: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+        httpClient(`${apiUrl}/${resource}/${encodeURIComponent(params.id)}`, {
             method: 'PUT',
             body: JSON.stringify(params.data),
         }).then(({ json }) => ({ data: json })),
@@ -156,10 +156,13 @@ export default (
     updateMany: (resource, params) =>
         Promise.all(
             params.ids.map(id =>
-                httpClient(`${apiUrl}/${resource}/${id}`, {
-                    method: 'PUT',
-                    body: JSON.stringify(params.data),
-                })
+                httpClient(
+                    `${apiUrl}/${resource}/${encodeURIComponent(typeof id === 'object' ? id.id : String(id))}`,
+                    {
+                        method: 'PUT',
+                        body: JSON.stringify(params.data),
+                    }
+                )
             )
         ).then(responses => ({
             data: responses.map(({ json }) => json.id),
@@ -172,7 +175,7 @@ export default (
         }).then(({ json }) => ({ data: json })),
 
     delete: (resource, params) =>
-        httpClient(`${apiUrl}/${resource}/${params.id}`, {
+        httpClient(`${apiUrl}/${resource}/${encodeURIComponent(params.id)}`, {
             method: 'DELETE',
             headers: new Headers({
                 'Content-Type': 'text/plain',
@@ -183,12 +186,15 @@ export default (
     deleteMany: (resource, params) =>
         Promise.all(
             params.ids.map(id =>
-                httpClient(`${apiUrl}/${resource}/${id}`, {
-                    method: 'DELETE',
-                    headers: new Headers({
-                        'Content-Type': 'text/plain',
-                    }),
-                })
+                httpClient(
+                    `${apiUrl}/${resource}/${encodeURIComponent(typeof id === 'object' ? id['id'] : String(id))}`,
+                    {
+                        method: 'DELETE',
+                        headers: new Headers({
+                            'Content-Type': 'text/plain',
+                        }),
+                    }
+                )
             )
         ).then(responses => ({
             data: responses.map(({ json }) => json.id),


### PR DESCRIPTION
## Problem

Records may have ids with characters that break the Simple REST Data Provider paths if not escaped. 
For example, a record with id "Post#123" has a getOne path of '/posts/Post#123' which is not desired.
IDs like this can occur when using single table inheritance with DynamoDB or with other document data stores.

## Solution

The solution is to escape IDs in paths for getOne, update, updateMany, delete and deleteMany. An example path with escaped id is '/posts/Post%23123'.

Closes #10207

## How To Test

Perform getOne, update, updateMany, delete and deleteMany with records that have escape-requiring ids e.g. 'Post#123'. 

## Additional Checks

- [ x ] The PR targets `master` for a bugfix, or `next` for a feature
- [ x ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ x ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
