### PR TITLE
[Doc] Doc needs to be consistent with itself regarding isPending vs isLoading

### DIFF
--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -503,12 +503,12 @@ import { useDataProvider, Loading, Error } from 'react-admin';
 
 const UserProfile = ({ userId }) => {
     const dataProvider = useDataProvider();
-    const { data, isLoading, error } = useQuery({
+    const { data, isPending, error } = useQuery({
         queryKey: ['users', 'getOne', { id: userId }], 
         queryFn: ({ signal }) => dataProvider.getOne('users', { id: userId, signal })
     });
 
-    if (isLoading) return <Loading />;
+    if (isPending) return <Loading />;
     if (error) return <Error />;
     if (!data) return null;
 


### PR DESCRIPTION
The doc states:

> As a consequence, you should always use isPending to determine if you need to show a loading indicator.

It should be consistent with itself.

## Probably there are some additional things needs to be discussed and fixed

1. Some of the stories still uses isLoading
2. useList still uses isLoading here https://github.com/marmelab/react-admin/blob/f2fc70f42ec8f7209e5fa24f12330276a7ddd788/packages/ra-core/src/controller/list/useList.ts#L173
3. In some enterprise components we pass isPending to the isLoading prop which is confusing https://github.com/marmelab/react-admin/blob/f2fc70f42ec8f7209e5fa24f12330276a7ddd788/docs/Features.md?plain=1#L988

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
