### PR TITLE
[Doc] Update `<Calendar>` doc to explain custom event format

### DIFF
--- a/docs/Calendar.md
+++ b/docs/Calendar.md
@@ -403,6 +403,8 @@ You will need to:
 
 Here is an example:
 
+{% raw %}
+
 ```tsx
 import { DatesSetArg } from '@fullcalendar/core';
 import { add, set, sub } from 'date-fns';
@@ -465,6 +467,8 @@ const EventListEventFormat = () => {
     );
 };
 ```
+
+{% endraw %}
 
 ## `<Calendar>`
 


### PR DESCRIPTION
## Problem

`<Calendar>` and `<CompleteCalendar>`'s enterprise doc was updated but the OSS was not.

## Solution

Update OSS doc

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date
