### PR TITLE
add @groovestack/ra-data-graphql-supabase to data provider list docs

### DIFF
--- a/docs/DataProviderList.md
+++ b/docs/DataProviderList.md
@@ -74,6 +74,7 @@ If you can't find a Data Provider for your backend below, no worries! [Writing a
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v3/v4](https://strapi.io/)**: [nazirov91/ra-strapi-rest](https://github.com/nazirov91/ra-strapi-rest)
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v4](https://strapi.io/)**: [garridorafa/ra-strapi-v4-rest](https://github.com/garridorafa/ra-strapi-v4-rest)
 * ![supabase Logo](./img/backend-logos/supabase.svg "supabase Logo")**[Supabase](https://supabase.io/)**: [marmelab/ra-supabase](https://github.com/marmelab/ra-supabase/blob/main/packages/ra-supabase/README.md)
+* ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[Supabase](https://supabase.io/) (GraphQL)**: [@groovestack/ra-data-graphql-supabase](https://github.com/maxschridde1494/ra-data-graphql-supabase)
 * ![surrealDB Logo](./img/backend-logos/surrealdb.svg "surrealDB Logo")**[SurrealDB](https://surrealdb.com/)**: [djedi23/ra-surrealdb](https://github.com/djedi23/ra-surrealdb)
 * ![treeql Logo](./img/backend-logos/treeql.png "treeql Logo")**[TreeQL / PHP-CRUD-API](https://treeql.org/)**: [nkappler/ra-data-treeql](https://github.com/nkappler/ra-data-treeql)
 * ![wooCommerce Logo](./img/backend-logos/wooCommerce.png "wooCommerce Logo")**[WooCommerce REST API](https://woocommerce.github.io/woocommerce-rest-api-docs)**: [zackha/ra-data-woocommerce](https://github.com/zackha/ra-data-woocommerce)


### PR DESCRIPTION
I recently decided to test out [supabase](https://supabase.com/) for a quick microservice my team was spinning out. We use react-admin for a lot of custom dashboards so I decided to run with vite, react-admin and cloudflare pages on the front end. The combo of supabase and react-admin proved to be powerful--fast, flexible, robust. I also wanted to try out the auto generated supabase GQL interface (via [pg_graphql](https://supabase.github.io/pg_graphql/)). I noticed there is a REST supabase dataprovider in [ra-supabase](https://github.com/marmelab/ra-supabase), but couldn't find a GQL dataprovider so I went ahead and wrote one ([repo here](https://github.com/maxschridde1494/ra-data-graphql-supabase)).

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The **documentation** is up to date