### PR TITLE
Remove deprecated 'initialValue' from sanitizeInputRestProps

### DIFF
--- a/packages/ra-ui-materialui/src/input/sanitizeInputRestProps.ts
+++ b/packages/ra-ui-materialui/src/input/sanitizeInputRestProps.ts
@@ -9,7 +9,6 @@ export const sanitizeInputRestProps = ({
     error,
     format,
     formatOnBlur,
-    initialValue,
     initializeForm,
     input,
     isEqual,


### PR DESCRIPTION
## Problem

I think (not 100% sure) that 'initialValue' is deprecated so it should also be removed from here?

## Solution

_Describe the solution this PR implements_

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
