### PR TITLE
[ui-materialui] Add support for `<Edit emptyWhileLoading>`

### DIFF
--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -315,6 +315,8 @@ Below is an example of an `<Edit>` page, including a 'create a new customer' but
   Your browser does not support the video tag.
 </video>
 
+{% raw %}
+
 ```tsx
 import React, { useCallback, useState } from 'react';
 import {
@@ -405,3 +407,5 @@ const EmployerEdit = () => (
     </Edit>
 );
 ```
+
+{% endraw %}

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -295,3 +295,113 @@ const CompanyShow = () => (
 {% endraw %}
 
 In the above example, `<CreateInDialogButton>` is used to create a new employee for the current company. [The `<WithRecord>` component](./WithRecord.md) helps to set the new employee company id by default.
+
+## Standalone Usage
+
+`<CreateDialog>` also offer the ability to work standalone, without using the Router's location.
+
+To allow for standalone usage, they require the following props:
+
+-   `isOpen`: a boolean holding the open/close state
+-   `open`: a function that will be called when a component needs to open the dialog (e.g. a button)
+-   `close`: a function that will be called when a component needs to close the dialog (e.g. the dialog's close button)
+
+**Tip:** These props are exactly the same as what is stored inside a `FormDialogContext`. This means that you can also rather provide your own `FormDialogContext` with these values, and render your dialog component inside it, to activate standalone mode.
+
+Below is an example of an `<Edit>` page, including a 'create a new customer' button, that opens a fully controlled `<CreateDialog>`.
+
+<video controls autoplay playsinline muted loop>
+  <source src="https://react-admin-ee.marmelab.com/assets/FullyControlledCreateDialog.mp4" type="video/mp4"/>
+  Your browser does not support the video tag.
+</video>
+
+```tsx
+import React, { useCallback, useState } from 'react';
+import {
+    Button,
+    Datagrid,
+    DateField,
+    DateInput,
+    Edit,
+    ReferenceManyField,
+    required,
+    SelectField,
+    SelectInput,
+    SimpleForm,
+    TextField,
+    TextInput,
+    useRecordContext,
+} from 'react-admin';
+import { CreateDialog } from '@react-admin/ra-form-layout';
+
+const sexChoices = [
+    { id: 'male', name: 'Male' },
+    { id: 'female', name: 'Female' },
+];
+
+const CustomerForm = (props: any) => (
+    <SimpleForm defaultValues={{ firstname: 'John', name: 'Doe' }} {...props}>
+        <TextInput source="first_name" validate={required()} />
+        <TextInput source="last_name" validate={required()} />
+        <DateInput source="dob" label="born" validate={required()} />
+        <SelectInput source="sex" choices={sexChoices} />
+    </SimpleForm>
+);
+
+const EmployerSimpleFormWithFullyControlledDialogs = () => {
+    const record = useRecordContext();
+
+    const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+    const openCreateDialog = useCallback(() => {
+        setIsCreateDialogOpen(true);
+    }, []);
+    const closeCreateDialog = useCallback(() => {
+        setIsCreateDialogOpen(false);
+    }, []);
+
+    return (
+        <SimpleForm>
+            <TextInput source="name" validate={required()} />
+            <TextInput source="address" validate={required()} />
+            <TextInput source="city" validate={required()} />
+            <Button
+                label="Create a new customer"
+                onClick={() => openCreateDialog()}
+                size="medium"
+                variant="contained"
+                sx={{ mb: 4 }}
+            />
+            <CreateDialog
+                fullWidth
+                maxWidth="md"
+                record={{ employer_id: record?.id }} // pre-populates the employer_id to link the new customer to the current employer
+                isOpen={isCreateDialogOpen}
+                open={openCreateDialog}
+                close={closeCreateDialog}
+                resource="customers"
+            >
+                <CustomerForm />
+            </CreateDialog>
+            <ReferenceManyField
+                label="Customers"
+                reference="customers"
+                target="employer_id"
+            >
+                <Datagrid>
+                    <TextField source="id" />
+                    <TextField source="first_name" />
+                    <TextField source="last_name" />
+                    <DateField source="dob" label="born" />
+                    <SelectField source="sex" choices={sexChoices} />
+                </Datagrid>
+            </ReferenceManyField>
+        </SimpleForm>
+    );
+};
+
+const EmployerEdit = () => (
+    <Edit>
+        <EmployerSimpleFormWithFullyControlledDialogs />
+    </Edit>
+);
+```

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -222,6 +222,57 @@ const PostEdit = () => (
 );
 ```
 
+## `emptyWhileLoading`
+
+By default, `<Edit>` renders its child component even before the `dataProvider.getOne()` call returns. And default layout components (`<Datagrid>` and `<SimpleList>`) return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
+
+But if you use a custom child component that expects the record context to be defined, your component will throw an error. For instance, the following will fail on load with a "ReferenceError: data is not defined" error:
+
+```jsx
+import { Edit, useEditContext } from 'react-admin';
+import { Stack, Typography } from '@mui/icons-material/Star';
+
+const SimpleBookEdit = () => {
+    const { record } = useEditContext();
+    return (
+        <Typography>
+            <i>{record.title}</i>, by {record.author} ({record.year})
+        </Typography>
+    );
+}
+
+const BookEdit = () => (
+    <Edit>
+        <SimpleBookEdit />
+    </Edit>
+);
+```
+
+You can handle this case by getting the `isPending` variable from the [`useEditContext`](./useEditContext.md) hook:
+
+```jsx
+const SimpleBookEdit = () => {
+    const { record, isPending } = useEditContext();
+    if (isPending) return null;
+    return (
+        <Typography>
+            <i>{record.title}</i>, by {record.author} ({record.year})
+        </Typography>
+    );
+}
+```
+
+The `<Edit emptyWhileLoading>` prop provides a convenient shortcut for that use case. When enabled, `<Edit>` won't render its child until `data` is defined.
+
+```diff
+const BookEdit = () => (
+-   <Edit>
++   <Edit emptyWhileLoading>
+        <SimpleBookEdit />
+    </Edit>
+);
+```
+
 ## `id`
 
 Components based on `<Edit>` are often used as `<Resource edit>` props, and therefore rendered when the URL matches `/[resource]/[id]`. The `<Edit>` component generates a call to `dataProvider.update()` using the id from the URL by default.

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -340,6 +340,8 @@ Below is an example of an `<Edit>` page, including a 'create a new customer' but
   Your browser does not support the video tag.
 </video>
 
+{% raw %}
+
 ```tsx
 import React, { useCallback, useState } from 'react';
 import {
@@ -430,3 +432,5 @@ const EmployerEdit = () => (
     </Edit>
 );
 ```
+
+{% endraw %}

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -320,3 +320,113 @@ const CompanyShow = () => (
 ```
 
 Check [the `<EditInDialogButton>` component](./EditInDialogButton.md) for more details.
+
+## Standalone Usage
+
+`<EditDialog>` also offer the ability to work standalone, without using the Router's location.
+
+To allow for standalone usage, they require the following props:
+
+-   `isOpen`: a boolean holding the open/close state
+-   `open`: a function that will be called when a component needs to open the dialog (e.g. a button)
+-   `close`: a function that will be called when a component needs to close the dialog (e.g. the dialog's close button)
+
+**Tip:** These props are exactly the same as what is stored inside a `FormDialogContext`. This means that you can also rather provide your own `FormDialogContext` with these values, and render your dialog component inside it, to activate standalone mode.
+
+Below is an example of an `<Edit>` page, including a 'create a new customer' button, that opens a fully controlled `<EditDialog>`.
+
+<video controls autoplay playsinline muted loop>
+  <source src="https://react-admin-ee.marmelab.com/assets/FullyControlledCreateDialog.mp4" type="video/mp4"/>
+  Your browser does not support the video tag.
+</video>
+
+```tsx
+import React, { useCallback, useState } from 'react';
+import {
+    Button,
+    Datagrid,
+    DateField,
+    DateInput,
+    Edit,
+    ReferenceManyField,
+    required,
+    SelectField,
+    SelectInput,
+    SimpleForm,
+    TextField,
+    TextInput,
+    useRecordContext,
+} from 'react-admin';
+import { EditDialog } from '@react-admin/ra-form-layout';
+
+const sexChoices = [
+    { id: 'male', name: 'Male' },
+    { id: 'female', name: 'Female' },
+];
+
+const CustomerForm = (props: any) => (
+    <SimpleForm defaultValues={{ firstname: 'John', name: 'Doe' }} {...props}>
+        <TextInput source="first_name" validate={required()} />
+        <TextInput source="last_name" validate={required()} />
+        <DateInput source="dob" label="born" validate={required()} />
+        <SelectInput source="sex" choices={sexChoices} />
+    </SimpleForm>
+);
+
+const EmployerSimpleFormWithFullyControlledDialogs = () => {
+    const record = useRecordContext();
+
+    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+    const openEditDialog = useCallback(() => {
+        setIsEditDialogOpen(true);
+    }, []);
+    const closeEditDialog = useCallback(() => {
+        setIsEditDialogOpen(false);
+    }, []);
+
+    return (
+        <SimpleForm>
+            <TextInput source="name" validate={required()} />
+            <TextInput source="address" validate={required()} />
+            <TextInput source="city" validate={required()} />
+            <ReferenceManyField
+                label="Customers"
+                reference="customers"
+                target="employer_id"
+            >
+                <Datagrid>
+                    <TextField source="id" />
+                    <TextField source="first_name" />
+                    <TextField source="last_name" />
+                    <DateField source="dob" label="born" />
+                    <SelectField source="sex" choices={sexChoices} />
+                    <Button
+                        label="Edit customer"
+                        onClick={() => openEditDialog()}
+                        size="medium"
+                        variant="contained"
+                        sx={{ mb: 4 }}
+                    />
+                </Datagrid>
+            </ReferenceManyField>
+            <EditDialog
+                fullWidth
+                maxWidth="md"
+                record={{ employer_id: record?.id }} // pre-populates the employer_id to link the new customer to the current employer
+                isOpen={isEditDialogOpen}
+                open={openEditDialog}
+                close={closeEditDialog}
+                resource="customers"
+            >
+                <CustomerForm />
+            </EditDialog>
+        </SimpleForm>
+    );
+};
+
+const EmployerEdit = () => (
+    <Edit>
+        <EmployerSimpleFormWithFullyControlledDialogs />
+    </Edit>
+);
+```

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -479,7 +479,7 @@ import * as React from "react";
 import { Edit, SimpleForm, TextInput, SelectInput } from "react-admin";
 
 export const BookEdit = () => (
-  <Edit>
+  <Edit emptyWhileLoading>
     <SimpleForm>
       <TextInput source="title" />
       <TextInput source="author" />
@@ -495,4 +495,7 @@ export const BookEdit = () => (
 
 React-admin components are not magic, they are React components designed to let you focus on the business logic and avoid repetitive tasks. 
 
-Tip: Actually, `<Edit>` does more than the code it replaces in the previous example: it handles notification and redirection upon submission, it sets the page title, and handles the error logic.
+**Tip:** Actually, `<Edit>` does more than the code it replaces in the previous example: it handles notification and redirection upon submission, it sets the page title, and handles the error logic.
+
+**Tip**: With `emptyWhileLoading` turned on, the `<Edit>` component doesn't render its child component until the record is available. Without this flag, the Field components would render even during the loading phase, and may break if they aren't planned to work with an empty record context.
+You could grab the `isPending` state from the `EditContext` instead, but `emptyWhileLoading` is usually more convenient.

--- a/docs/ReferenceManyInput.md
+++ b/docs/ReferenceManyInput.md
@@ -72,7 +72,7 @@ const ProductEdit = () => (
 
 `<ReferenceManyInput>` persists the changes in the reference records (variants in the above example) after persisting the changes in the main resource (product in the above example). This means that you can also use `<ReferenceManyInput>` in `<Create>` views.
 
-**Tip**: `<ReferenceManyInput>` cannot be used with `undoable` mutations. You have to set `mutationMode="optimistic"` or `mutationMode="pessimistic"` in the parent `<Edit>` or `<Create>`, as in the example above.
+**Tip**: `<ReferenceManyInput>` cannot be used with `undoable` mutations. You have to set `mutationMode="optimistic"` or `mutationMode="pessimistic"` in the parent `<Edit>`, as in the example above.
 
 ## Props
 

--- a/docs/ReferenceManyInput.md
+++ b/docs/ReferenceManyInput.md
@@ -297,5 +297,6 @@ const ProductEdit = () => (
 ## Limitations
 
 -   `<ReferenceManyInput>` cannot be used inside an `<ArrayInput>` or a `<ReferenceOneInput>`.
+-   `<ReferenceManyInput>` cannot be used with `undoable` mutations in a `<Create>` view.
 -   `<ReferenceManyInput>` cannot have a `<ReferenceOneInput>` or a `<ReferenceManyToManyInput>` as one of its children.
 -   `<ReferenceManyInput>` does not support server side validation.

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -239,3 +239,45 @@ export const Default = () => (
         </Admin>
     </TestMemoryRouter>
 );
+
+export const emptyWhileLoading = () => {
+    // getOne: () => new Promise(() => setTimeout(dataProvider.getOne, 1000)),
+    const customDataProvider = {
+        getOne: () =>
+            new Promise(resolve =>
+                setTimeout(
+                    () =>
+                        resolve({
+                            data: {
+                                id: 1,
+                                title: 'War and Peace',
+                                author: 'Leo Tolstoy',
+                                summary:
+                                    "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                                year: 1869,
+                            },
+                        }),
+                    2000
+                )
+            ),
+    } as any;
+    return (
+        <TestMemoryRouter initialEntries={['/books/1/Edit']}>
+            <Admin dataProvider={customDataProvider}>
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit emptyWhileLoading>
+                            <SimpleForm>
+                                <TextInput source="title" />
+                                <TextInput source="author" />
+                                <TextInput source="summary" />
+                                <TextInput source="year" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </Admin>
+        </TestMemoryRouter>
+    );
+};

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -16,6 +16,7 @@ export const EditView = (props: EditViewProps) => {
         children,
         className,
         component: Content = Card,
+        emptyWhileLoading = false,
         title,
         ...rest
     } = props;
@@ -25,7 +26,7 @@ export const EditView = (props: EditViewProps) => {
 
     const finalActions =
         typeof actions === 'undefined' && hasShow ? defaultActions : actions;
-    if (!children) {
+    if (!children || (!record && emptyWhileLoading)) {
         return null;
     }
 
@@ -58,6 +59,7 @@ export interface EditViewProps
     actions?: ReactElement | false;
     aside?: ReactElement;
     component?: ElementType;
+    emptyWhileLoading?: boolean;
     title?: string | ReactElement | false;
     sx?: SxProps;
 }


### PR DESCRIPTION
## Problem

The Show and List components support that prop, not the Edit.

## Solution

Add support for `<Edit emptyWhileLoading>`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
~- [ ] The PR includes **unit tests** (if not possible, describe why)~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
