### PR TITLE
ui-materialui: Add support for `<Edit emptyWhileLoading>`

### DIFF
--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -263,7 +263,7 @@ const AsideComponent = () => {
 }
 ```
 
-The `<Edit emptyWhileLoading>` prop provides a convenient shortcut for that use case. When enabled, `<Edit>` won't render its child until `data` is defined.
+The `<Edit emptyWhileLoading>` prop provides a convenient shortcut for that use case. When enabled, `<Edit>` won't render its `aside`, `actions` and `title` components until `record` is defined.
 
 ```diff
 const BookEdit = () => (

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -222,6 +222,57 @@ const PostEdit = () => (
 );
 ```
 
+## `emptyWhileLoading`
+
+By default, `<Edit>` renders its child component even before the `dataProvider.getOne()` call returns. And default layout components (`<Datagrid>` and `<SimpleList>`) return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
+
+But if you use a custom child component that expects the record context to be defined, your component will throw an error. For instance, the following will fail on load with a "ReferenceError: data is not defined" error:
+
+```jsx
+import { Edit, useEditContext } from 'react-admin';
+import { Stack, Typography } from '@mui/icons-material/Star';
+
+const SimpleBookEdit = () => {
+    const { record } = useEditContext();
+    return (
+        <Typography>
+            <i>{record.title}</i>, by {record.author} ({record.year})
+        </Typography>
+    );
+}
+
+const BookEdit = () => (
+    <Edit>
+        <SimpleBookEdit />
+    </Edit>
+);
+```
+
+You can handle this case by getting the `isPending` variable from the [`useEditContext`](./useEditContext.md) hook:
+
+```jsx
+const SimpleBookEdit = () => {
+    const { record, isPending } = useEditContext();
+    if (isPending) return null;
+    return (
+        <Typography>
+            <i>{record.title}</i>, by {record.author} ({record.year})
+        </Typography>
+    );
+}
+```
+
+The `<Edit emptyWhileLoading>` prop provides a convenient shortcut for that use case. When enabled, `<Edit>` won't render its child until `data` is defined.
+
+```diff
+const BookEdit = () => (
+-   <Edit>
++   <Edit emptyWhileLoading>
+        <SimpleBookEdit />
+    </Edit>
+);
+```
+
 ## `id`
 
 Components based on `<Edit>` are often used as `<Resource edit>` props, and therefore rendered when the URL matches `/[resource]/[id]`. The `<Edit>` component generates a call to `dataProvider.update()` using the id from the URL by default.

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -66,6 +66,7 @@ You can customize the `<Edit>` component using the following props:
 * `className`: passed to the root component
 * [`component`](#component): override the root component
 * [`disableAuthentication`](#disableauthentication): disable the authentication check
+* [`emptyWhileLoading`](#emptywhileloading): Set to `true` to return `null` while the edit is loading.
 * [`id`](#id): the id of the record to edit
 * [`mutationMode`](#mutationmode): switch to optimistic or pessimistic mutations (undoable by default)
 * [`mutationOptions`](#mutationoptions): options for the `dataProvider.update()` call
@@ -224,7 +225,7 @@ const PostEdit = () => (
 
 ## `emptyWhileLoading`
 
-By default, `<Edit>` renders its child component even before the `dataProvider.getOne()` call returns. And default layout components (`<Datagrid>` and `<SimpleList>`) return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
+By default, `<Edit>` renders its child component even before the `dataProvider.getOne()` call returns. And default layout components return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
 
 But if you use a custom child component that expects the record context to be defined, your component will throw an error. For instance, the following will fail on load with a "ReferenceError: data is not defined" error:
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -225,15 +225,15 @@ const PostEdit = () => (
 
 ## `emptyWhileLoading`
 
-By default, `<Edit>` renders its child component even before the `dataProvider.getOne()` call returns. And default layout components return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
+By default, `<Edit>` doesn't render its child component even before the `dataProvider.getOne()` call returns, but it returns its [`aside`](#aside), [`actions`](#actions) and [`title`](#title) components.
 
-But if you use a custom child component that expects the record context to be defined, your component will throw an error. For instance, the following will fail on load with a "ReferenceError: data is not defined" error:
+If you use one of those components customized with a record, your component will throw an error. For instance, the following will fail on load with a "ReferenceError: record is not defined" error:
 
 ```jsx
 import { Edit, useEditContext } from 'react-admin';
-import { Stack, Typography } from '@mui/icons-material/Star';
+import { Typography } from '@mui/icons-material/Star';
 
-const SimpleBookEdit = () => {
+const AsideComponent = () => {
     const { record } = useEditContext();
     return (
         <Typography>
@@ -243,8 +243,8 @@ const SimpleBookEdit = () => {
 }
 
 const BookEdit = () => (
-    <Edit>
-        <SimpleBookEdit />
+    <Edit aside={AsideComponent}>
+        {/* ... */}
     </Edit>
 );
 ```
@@ -252,7 +252,7 @@ const BookEdit = () => (
 You can handle this case by getting the `isPending` variable from the [`useEditContext`](./useEditContext.md) hook:
 
 ```jsx
-const SimpleBookEdit = () => {
+const AsideComponent = () => {
     const { record, isPending } = useEditContext();
     if (isPending) return null;
     return (
@@ -267,9 +267,9 @@ The `<Edit emptyWhileLoading>` prop provides a convenient shortcut for that use 
 
 ```diff
 const BookEdit = () => (
--   <Edit>
-+   <Edit emptyWhileLoading>
-        <SimpleBookEdit />
+-   <Edit aside={AsideComponent}>
++   <Edit aside={AsideComponent} emptyWhileLoading>
+        {/* ... */}
     </Edit>
 );
 ```

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -479,7 +479,7 @@ import * as React from "react";
 import { Edit, SimpleForm, TextInput, SelectInput } from "react-admin";
 
 export const BookEdit = () => (
-  <Edit emptyWhileLoading>
+  <Edit>
     <SimpleForm>
       <TextInput source="title" />
       <TextInput source="author" />

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -479,7 +479,7 @@ import * as React from "react";
 import { Edit, SimpleForm, TextInput, SelectInput } from "react-admin";
 
 export const BookEdit = () => (
-  <Edit>
+  <Edit emptyWhileLoading>
     <SimpleForm>
       <TextInput source="title" />
       <TextInput source="author" />
@@ -495,4 +495,7 @@ export const BookEdit = () => (
 
 React-admin components are not magic, they are React components designed to let you focus on the business logic and avoid repetitive tasks. 
 
-Tip: Actually, `<Edit>` does more than the code it replaces in the previous example: it handles notification and redirection upon submission, it sets the page title, and handles the error logic.
+**Tip:** Actually, `<Edit>` does more than the code it replaces in the previous example: it handles notification and redirection upon submission, it sets the page title, and handles the error logic.
+
+**Tip**: With `emptyWhileLoading` turned on, the `<Edit>` component doesn't render its child component until the record is available. Without this flag, the Field components would render even during the loading phase, and may break if they aren't planned to work with an empty record context.
+You could grab the `isPending` state from the `EditContext` instead, but `emptyWhileLoading` is usually more convenient.

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -497,5 +497,5 @@ React-admin components are not magic, they are React components designed to let 
 
 **Tip:** Actually, `<Edit>` does more than the code it replaces in the previous example: it handles notification and redirection upon submission, it sets the page title, and handles the error logic.
 
-**Tip**: With `emptyWhileLoading` turned on, the `<Edit>` component doesn't render its child component until the record is available. Without this flag, the Field components would render even during the loading phase, and may break if they aren't planned to work with an empty record context.
+**Tip**: With `emptyWhileLoading` turned on, the `<Edit>` component doesn't render its `aside`, `actions` and `title` components until the record is available. Without this flag, the Field components would render even during the loading phase, and may break if they aren't planned to work with an empty record context.
 You could grab the `isPending` state from the `EditContext` instead, but `emptyWhileLoading` is usually more convenient.

--- a/docs/EditTutorial.md
+++ b/docs/EditTutorial.md
@@ -497,5 +497,5 @@ React-admin components are not magic, they are React components designed to let 
 
 **Tip:** Actually, `<Edit>` does more than the code it replaces in the previous example: it handles notification and redirection upon submission, it sets the page title, and handles the error logic.
 
-**Tip**: With `emptyWhileLoading` turned on, the `<Edit>` component doesn't render its `aside`, `actions` and `title` components until the record is available. Without this flag, the Field components would render even during the loading phase, and may break if they aren't planned to work with an empty record context.
+**Tip**: With `emptyWhileLoading` turned on, the `<Edit>` component doesn't render its `aside`, `actions` and `title` components until the record is available. Without this flag, those components would render even during the loading phase, and may break if they aren't planned to work with an empty record context.
 You could grab the `isPending` state from the `EditContext` instead, but `emptyWhileLoading` is usually more convenient.

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -66,7 +66,7 @@ That's enough to display the post show view above.
 | `className`      | Optional | `string`          |         | passed to the root component
 | `component`      | Optional | `Component`       | `Card`  | The component to render as the root element
 | `disable Authentication` | Optional | `boolean` |         | Set to `true` to disable the authentication check
-| `empty WhileLoading` | Optional | `boolean`     |         | Set to `true` to return `null` while the list is loading
+| `empty WhileLoading` | Optional | `boolean`     |         | Set to `true` to return `null` while the show is loading
 | `id`             | Optional | `string | number` |         | The record id. If not provided, it will be deduced from the URL
 | `queryOptions`   | Optional | `object`          |         | The options to pass to the `useQuery` hook
 | `resource`       | Optional | `string`          |         | The resource name, e.g. `posts`

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -107,7 +107,7 @@ describe('<Edit />', () => {
         });
     });
 
-    it("shoudln't display the Edit child while loading when emptyWhileLoading is true", async () => {
+    it("shoudln't display the Edit aside while loading with the emptyWhileLoading prop", async () => {
         render(<EmptyWhileLoading />);
 
         expect(screen.queryByText('Book Edition')).not.toBeNull();

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -43,7 +43,7 @@ describe('<Edit />', () => {
         } as any;
         const FakeForm = () => {
             const record = useRecordContext();
-            return <>{record.title}</>;
+            return <>{record?.title}</>;
         };
         render(
             <AdminContext dataProvider={dataProvider}>
@@ -71,7 +71,7 @@ describe('<Edit />', () => {
             const { save } = useSaveContext();
             return (
                 <>
-                    <span>{record.title}</span>
+                    <span>{record?.title}</span>
                     <button
                         onClick={() =>
                             save && save({ ...record, title: 'ipsum' })
@@ -132,7 +132,7 @@ describe('<Edit />', () => {
 
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -190,7 +190,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -246,7 +246,7 @@ describe('<Edit />', () => {
 
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -307,7 +307,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -364,7 +364,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save &&
@@ -430,7 +430,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -485,7 +485,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save &&
@@ -557,7 +557,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -623,7 +623,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save &&
@@ -693,7 +693,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save && save({ ...record, title: 'ipsum' })
@@ -758,7 +758,7 @@ describe('<Edit />', () => {
                 const { save } = useSaveContext();
                 return (
                     <>
-                        <span>{record.title}</span>
+                        <span>{record?.title}</span>
                         <button
                             onClick={() =>
                                 save &&
@@ -893,7 +893,12 @@ describe('<Edit />', () => {
                     i18nProvider={i18nProvider}
                 >
                     <ResourceDefinitionContextProvider
-                        definitions={{ foo: { recordRepresentation: 'title' } }}
+                        definitions={{
+                            foo: {
+                                recordRepresentation: 'title',
+                                name: '',
+                            },
+                        }}
                     >
                         <Edit {...defaultEditProps}>
                             <Title />

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -108,23 +108,35 @@ describe('<Edit />', () => {
     });
 
     it("shoudln't display the Edit aside while loading with the emptyWhileLoading prop", async () => {
-        render(<EmptyWhileLoading />);
+        let resolveGetOne;
+        const RenderedComponent = () => {
+            const myDataProvider = {
+                getOne: jest.fn(
+                    () => new Promise(resolve => (resolveGetOne = resolve))
+                ),
+            } as any;
+            return <EmptyWhileLoading myDataProvider={myDataProvider} />;
+        };
+        render(<RenderedComponent />);
 
-        expect(screen.queryByText('Book Edition')).not.toBeNull();
+        await screen.findByText('Book Edition');
         expect(
             screen.queryByText('War and Peace, by Leo Tolstoy (1869)')
         ).toBeNull();
         expect(screen.queryByText('Something went wrong')).toBeNull();
 
-        await waitFor(
-            () => {
-                expect(
-                    screen.queryByText('War and Peace, by Leo Tolstoy (1869)')
-                ).not.toBeNull();
+        resolveGetOne({
+            data: {
+                id: 1,
+                title: 'War and Peace',
+                author: 'Leo Tolstoy',
+                summary:
+                    "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                year: 1869,
             },
-            { timeout: 2500 }
-        );
-        expect(screen.queryByText('Book Edition')).not.toBeNull();
+        });
+
+        await screen.findByText('War and Peace, by Leo Tolstoy (1869)');
         expect(screen.queryByText('Something went wrong')).toBeNull();
     });
 
@@ -908,10 +920,7 @@ describe('<Edit />', () => {
                 >
                     <ResourceDefinitionContextProvider
                         definitions={{
-                            foo: {
-                                recordRepresentation: 'title',
-                                name: '',
-                            },
+                            foo: { recordRepresentation: 'title' },
                         }}
                     >
                         <Edit {...defaultEditProps}>

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -107,7 +107,7 @@ describe('<Edit />', () => {
         });
     });
 
-    it("shoudln't display the record while loading", async () => {
+    it("shoudln't display the Edit child while loading when emptyWhileLoading is true", async () => {
         render(<EmptyWhileLoading />);
         expect(screen.queryByText('Book War and Peace')).toBeNull();
         await new Promise(resolve => setTimeout(resolve, 3000));

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -109,17 +109,23 @@ describe('<Edit />', () => {
 
     it("shoudln't display the Edit child while loading when emptyWhileLoading is true", async () => {
         render(<EmptyWhileLoading />);
+
         expect(screen.queryByText('Book Edition')).not.toBeNull();
-        expect(screen.queryByDisplayValue('Leo Tolstoy')).toBeNull();
+        expect(
+            screen.queryByText('War and Peace, by Leo Tolstoy (1869)')
+        ).toBeNull();
+        expect(screen.queryByText('Something went wrong')).toBeNull();
+
         await waitFor(
             () => {
                 expect(
-                    screen.queryByDisplayValue('Leo Tolstoy')
+                    screen.queryByText('War and Peace, by Leo Tolstoy (1869)')
                 ).not.toBeNull();
             },
             { timeout: 2500 }
         );
         expect(screen.queryByText('Book Edition')).not.toBeNull();
+        expect(screen.queryByText('Something went wrong')).toBeNull();
     });
 
     describe('mutationMode prop', () => {

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -109,9 +109,17 @@ describe('<Edit />', () => {
 
     it("shoudln't display the Edit child while loading when emptyWhileLoading is true", async () => {
         render(<EmptyWhileLoading />);
-        expect(screen.queryByText('Book War and Peace')).toBeNull();
-        await new Promise(resolve => setTimeout(resolve, 3000));
-        expect(screen.queryByText('Book War and Peace')).not.toBeNull();
+        expect(screen.queryByText('Book Edition')).not.toBeNull();
+        expect(screen.queryByDisplayValue('Leo Tolstoy')).toBeNull();
+        await waitFor(
+            () => {
+                expect(
+                    screen.queryByDisplayValue('Leo Tolstoy')
+                ).not.toBeNull();
+            },
+            { timeout: 2500 }
+        );
+        expect(screen.queryByText('Book Edition')).not.toBeNull();
     });
 
     describe('mutationMode prop', () => {

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -27,6 +27,7 @@ import {
     TitleElement,
     NotificationDefault,
     NotificationTranslated,
+    EmptyWhileLoading,
 } from './Edit.stories';
 
 describe('<Edit />', () => {
@@ -104,6 +105,13 @@ describe('<Edit />', () => {
                 previousData: { id: 1234, title: 'lorem' },
             });
         });
+    });
+
+    it("shoudln't display the record while loading", async () => {
+        render(<EmptyWhileLoading />);
+        expect(screen.queryByText('Book War and Peace')).toBeNull();
+        await new Promise(resolve => setTimeout(resolve, 3000));
+        expect(screen.queryByText('Book War and Peace')).not.toBeNull();
     });
 
     describe('mutationMode prop', () => {

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -300,3 +300,45 @@ export const Default = () => (
         </Admin>
     </TestMemoryRouter>
 );
+
+export const emptyWhileLoading = () => {
+    // getOne: () => new Promise(() => setTimeout(dataProvider.getOne, 1000)),
+    const customDataProvider = {
+        getOne: () =>
+            new Promise(resolve =>
+                setTimeout(
+                    () =>
+                        resolve({
+                            data: {
+                                id: 1,
+                                title: 'War and Peace',
+                                author: 'Leo Tolstoy',
+                                summary:
+                                    "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                                year: 1869,
+                            },
+                        }),
+                    2000
+                )
+            ),
+    } as any;
+    return (
+        <TestMemoryRouter initialEntries={['/books/1/Edit']}>
+            <Admin dataProvider={customDataProvider}>
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit emptyWhileLoading>
+                            <SimpleForm>
+                                <TextInput source="title" />
+                                <TextInput source="author" />
+                                <TextInput source="summary" />
+                                <TextInput source="year" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </Admin>
+        </TestMemoryRouter>
+    );
+};

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -301,7 +301,7 @@ export const Default = () => (
     </TestMemoryRouter>
 );
 
-export const emptyWhileLoading = () => {
+export const EmptyWhileLoading = () => {
     // getOne: () => new Promise(() => setTimeout(dataProvider.getOne, 1000)),
     const customDataProvider = {
         getOne: () =>

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import { Box, Card, Stack } from '@mui/material';
+import { Box, Card, Stack, Typography } from '@mui/material';
 
 import { TextInput } from '../input';
 import { SimpleForm } from '../form/SimpleForm';
@@ -328,14 +328,19 @@ export const EmptyWhileLoading = () => {
                 <Resource
                     name="books"
                     edit={() => (
-                        <Edit emptyWhileLoading>
-                            <SimpleForm>
-                                <TextInput source="title" />
-                                <TextInput source="author" />
-                                <TextInput source="summary" />
-                                <TextInput source="year" />
-                            </SimpleForm>
-                        </Edit>
+                        <Box>
+                            <Typography variant="h6" sx={{ mt: 2, mb: -1 }}>
+                                Book Edition
+                            </Typography>
+                            <Edit emptyWhileLoading>
+                                <SimpleForm>
+                                    <TextInput source="title" />
+                                    <TextInput source="author" />
+                                    <TextInput source="summary" />
+                                    <TextInput source="year" />
+                                </SimpleForm>
+                            </Edit>
+                        </Box>
                     )}
                 />
             </Admin>

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -302,7 +302,6 @@ export const Default = () => (
 );
 
 export const EmptyWhileLoading = () => {
-    // getOne: () => new Promise(() => setTimeout(dataProvider.getOne, 1000)),
     const customDataProvider = {
         getOne: () =>
             new Promise(resolve =>

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -355,7 +355,7 @@ const AsideComponentWithRecord = () => {
     const { record } = useEditContext();
     return (
         <Typography>
-            <i>{record.title}</i>, by {record.author} ({record.year})
+            {record.title}, by {record.author} ({record.year})
         </Typography>
     );
 };

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Admin } from 'react-admin';
+import { Admin, type CoreAdminContextProps } from 'react-admin';
 import {
     Resource,
     Form,
@@ -301,7 +301,11 @@ export const Default = () => (
     </TestMemoryRouter>
 );
 
-export const EmptyWhileLoading = () => {
+export const EmptyWhileLoading = ({
+    myDataProvider,
+}: {
+    myDataProvider?: CoreAdminContextProps['dataProvider'];
+}) => {
     const customDataProvider = {
         getOne: () =>
             new Promise(resolve =>
@@ -323,7 +327,7 @@ export const EmptyWhileLoading = () => {
     } as any;
     return (
         <TestMemoryRouter initialEntries={['/books/1/Edit']}>
-            <Admin dataProvider={customDataProvider}>
+            <Admin dataProvider={myDataProvider ?? customDataProvider}>
                 <Resource
                     name="books"
                     edit={() => (

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -332,7 +332,10 @@ export const EmptyWhileLoading = () => {
                             <Typography variant="h6" sx={{ mt: 2, mb: -1 }}>
                                 Book Edition
                             </Typography>
-                            <Edit emptyWhileLoading>
+                            <Edit
+                                emptyWhileLoading
+                                aside={<AsideComponentWithRecord />}
+                            >
                                 <SimpleForm>
                                     <TextInput source="title" />
                                     <TextInput source="author" />
@@ -345,5 +348,14 @@ export const EmptyWhileLoading = () => {
                 />
             </Admin>
         </TestMemoryRouter>
+    );
+};
+
+const AsideComponentWithRecord = () => {
+    const { record } = useEditContext();
+    return (
+        <Typography>
+            <i>{record.title}</i>, by {record.author} ({record.year})
+        </Typography>
     );
 };

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -22,11 +22,11 @@ export const EditView = (props: EditViewProps) => {
     } = props;
 
     const { hasShow } = useResourceDefinition();
-    const { resource, defaultTitle, record } = useEditContext();
+    const { resource, defaultTitle, record, isPending } = useEditContext();
 
     const finalActions =
         typeof actions === 'undefined' && hasShow ? defaultActions : actions;
-    if (!children || (!record && emptyWhileLoading)) {
+    if (!children || (!record && isPending && emptyWhileLoading)) {
         return null;
     }
 

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -16,6 +16,7 @@ export const EditView = (props: EditViewProps) => {
         children,
         className,
         component: Content = Card,
+        emptyWhileLoading = false,
         title,
         ...rest
     } = props;
@@ -25,7 +26,7 @@ export const EditView = (props: EditViewProps) => {
 
     const finalActions =
         typeof actions === 'undefined' && hasShow ? defaultActions : actions;
-    if (!children) {
+    if (!children || (!record && emptyWhileLoading)) {
         return null;
     }
 
@@ -58,6 +59,7 @@ export interface EditViewProps
     actions?: ReactElement | false;
     aside?: ReactElement;
     component?: ElementType;
+    emptyWhileLoading?: boolean;
     title?: string | ReactElement | false;
     sx?: SxProps;
 }


### PR DESCRIPTION
## Problem

The Show and List components support that prop, not the Edit.

## Solution

Add support for `<Edit emptyWhileLoading>`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
~- [ ] The PR includes **unit tests** (if not possible, describe why)~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date
