### PR TITLE
Fix `<SelectArrayInput>` options panel width and placement

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -345,7 +345,6 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                     readOnly={readOnly}
                     data-testid="selectArray"
                     size={size}
-                    MenuProps={defaultMenuProps}
                     {...field}
                     {...options}
                     onChange={handleChangeWithCreateSupport}
@@ -377,13 +376,6 @@ export type SelectArrayInputProps = ChoicesProps &
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
     };
-
-const defaultMenuProps = {
-    anchorOrigin: {
-        vertical: 'bottom' as const,
-        horizontal: 'left' as const,
-    },
-};
 
 const sanitizeRestProps = ({
     alwaysOn,


### PR DESCRIPTION
Closes #10189

## Problem

The options panel is centered and narrow.

![image](https://github.com/user-attachments/assets/99d3e46f-53ad-446d-9aaf-9947b0675488)

## Solution

Make it full width, just like `SelectInput`. 

![image](https://github.com/user-attachments/assets/6d0b5aba-3786-43ed-9137-b9721beba1d0)

## How To Test

- Open the storybook
- Check the SelectarrayInput stories

