### PR TITLE
Fix `disabled` inputs temporarily erase values

### DIFF
--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -116,10 +116,7 @@ const PostEdit = () => {
                         justifyContent="space-between"
                         fullWidth
                     >
-                        <TextInput
-                            InputProps={{ disabled: true }}
-                            source="id"
-                        />
+                        <TextInput disabled source="id" />
                         <TextInput
                             source="title"
                             validate={required()}

--- a/examples/simple/src/posts/PostEdit.tsx
+++ b/examples/simple/src/posts/PostEdit.tsx
@@ -116,7 +116,10 @@ const PostEdit = () => {
                         justifyContent="space-between"
                         fullWidth
                     >
-                        <TextInput disabled source="id" />
+                        <TextInput
+                            InputProps={{ disabled: true }}
+                            source="id"
+                        />
                         <TextInput
                             source="title"
                             validate={required()}

--- a/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.optimistic.stories.tsx
@@ -77,6 +77,44 @@ const SuccessCore = () => {
     );
 };
 
+export const UndefinedValues = () => {
+    const data = { id: 1, title: 'Hello' };
+    const dataProvider = {
+        getOne: async () => ({ data }),
+        update: () => new Promise(() => {}), // never resolve to see only optimistic update
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <UndefinedValuesCore />
+        </CoreAdminContext>
+    );
+};
+
+const UndefinedValuesCore = () => {
+    const { data } = useGetOne('posts', { id: 1 });
+    const [update, { isPending }] = useUpdate();
+    const handleClick = () => {
+        update(
+            'posts',
+            { id: 1, data: { id: undefined, title: 'world' } },
+            { mutationMode: 'optimistic' }
+        );
+    };
+    return (
+        <>
+            <pre>{JSON.stringify(data)}</pre>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+            </div>
+        </>
+    );
+};
+
 export const ErrorCase = ({ timeout = 1000 }) => {
     const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
     const dataProvider = {

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -16,6 +16,7 @@ import {
     SuccessCase as SuccessCaseOptimistic,
     WithMiddlewaresSuccess as WithMiddlewaresSuccessOptimistic,
     WithMiddlewaresError as WithMiddlewaresErrorOptimistic,
+    UndefinedValues as UndefinedValuesOptimistic,
 } from './useUpdate.optimistic.stories';
 import {
     ErrorCase as ErrorCaseUndoable,
@@ -290,6 +291,12 @@ describe('useUpdate', () => {
                 expect(screen.queryByText('mutating')).toBeNull();
             });
             await screen.findByText('Hello');
+        });
+        it('when optimistic, does not erase values if the payload contains undefined values', async () => {
+            render(<UndefinedValuesOptimistic />);
+            await screen.findByText('{"id":1,"title":"Hello"}');
+            screen.getByText('Update title').click();
+            await screen.findByText('{"id":1,"title":"world"}'); // and not just {"title":"world"}
         });
         it('when undoable, displays result and success side effects right away and fetched on confirm', async () => {
             render(<SuccessCaseUndoable timeout={10} />);

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -132,7 +132,13 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
             }
             return [
                 ...old.slice(0, index),
-                { ...old[index], ...data } as RecordType,
+                {
+                    ...old[index],
+                    // Stringify and parse the data to remove undefined values.
+                    // If we don't do this, an update with { id: undefined } as payload
+                    // would remove the id from the record, which no real data provider does.
+                    ...JSON.parse(JSON.stringify(data)),
+                } as RecordType,
                 ...old.slice(index + 1),
             ];
         };

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -120,6 +120,10 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
         // because setQueryData doesn't accept a stale time option
         const now = Date.now();
         const updatedAt = mode.current === 'undoable' ? now + 5 * 1000 : now;
+        // Stringify and parse the data to remove undefined values.
+        // If we don't do this, an update with { id: undefined } as payload
+        // would remove the id from the record, which no real data provider does.
+        const clonedData = JSON.parse(JSON.stringify(data));
 
         const updateColl = (old: RecordType[]) => {
             if (!old) return old;
@@ -132,13 +136,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
             }
             return [
                 ...old.slice(0, index),
-                {
-                    ...old[index],
-                    // Stringify and parse the data to remove undefined values.
-                    // If we don't do this, an update with { id: undefined } as payload
-                    // would remove the id from the record, which no real data provider does.
-                    ...JSON.parse(JSON.stringify(data)),
-                } as RecordType,
+                { ...old[index], ...clonedData } as RecordType,
                 ...old.slice(index + 1),
             ];
         };
@@ -149,7 +147,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
 
         queryClient.setQueryData(
             [resource, 'getOne', { id: String(id), meta }],
-            (record: RecordType) => ({ ...record, ...data }),
+            (record: RecordType) => ({ ...record, ...clonedData }),
             { updatedAt }
         );
         queryClient.setQueriesData(

--- a/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import expect from 'expect';
 
 import { testDataProvider } from './testDataProvider';
 import { CoreAdminContext } from '../core';
 import { useUpdateMany } from './useUpdateMany';
-import { QueryClient } from '@tanstack/react-query';
+import { UndefinedValues } from './useUpdateMany.stories';
 
 describe('useUpdateMany', () => {
     it('returns a callback that can be used with update arguments', async () => {
@@ -423,6 +424,16 @@ describe('useUpdateMany', () => {
                     pageParams: [],
                 });
             });
+        });
+        it('when optimistic, does not erase values if the payload contains undefined values', async () => {
+            render(<UndefinedValues />);
+            await screen.findByText(
+                '[{"id":1,"title":"foo"},{"id":2,"title":"bar"}]'
+            );
+            screen.getByText('Update title').click();
+            await screen.findByText(
+                '[{"id":1,"title":"world"},{"id":2,"title":"world"}]'
+            ); // and not [{"title":"world"},{"title":"world"}]
         });
     });
 });

--- a/packages/ra-core/src/dataProvider/useUpdateMany.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.stories.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useUpdateMany } from './useUpdateMany';
+import { useGetList } from './useGetList';
+
+export default { title: 'ra-core/dataProvider/useUpdateMany' };
+
+export const UndefinedValues = () => {
+    const data = [
+        { id: 1, title: 'foo' },
+        { id: 2, title: 'bar' },
+    ];
+    const dataProvider = {
+        getList: async () => ({ data, total: 2 }),
+        updateMany: () => new Promise(() => {}), // never resolve to see only optimistic update
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <UndefinedValuesCore />
+        </CoreAdminContext>
+    );
+};
+
+const UndefinedValuesCore = () => {
+    const { data } = useGetList('posts');
+    const [updateMany, { isPending }] = useUpdateMany();
+    const handleClick = () => {
+        updateMany(
+            'posts',
+            {
+                ids: [1, 2],
+                data: { id: undefined, title: 'world' },
+            },
+            { mutationMode: 'optimistic' }
+        );
+    };
+    return (
+        <>
+            <pre>{JSON.stringify(data)}</pre>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+            </div>
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -124,7 +124,13 @@ export const useUpdateMany = <
                 }
                 newCollection = [
                     ...newCollection.slice(0, index),
-                    { ...newCollection[index], ...data },
+                    {
+                        ...newCollection[index],
+                        // Stringify and parse the data to remove undefined values.
+                        // If we don't do this, an update with { id: undefined } as payload
+                        // would remove the id from the record, which no real data provider does.
+                        ...JSON.parse(JSON.stringify(data)),
+                    },
                     ...newCollection.slice(index + 1),
                 ];
             });

--- a/packages/ra-data-fakerest/src/index.ts
+++ b/packages/ra-data-fakerest/src/index.ts
@@ -117,22 +117,27 @@ export default (data, loggingEnabled = false, delay?: number): DataProvider => {
             case 'update':
                 return delayed(
                     {
-                        data: database.updateOne(resource, params.id, {
-                            ...params.data,
-                        }),
+                        data: database.updateOne(
+                            resource,
+                            params.id,
+                            cleanupData(params.data)
+                        ),
                     },
                     delay
                 );
             case 'updateMany':
                 params.ids.forEach(id =>
-                    database.updateOne(resource, id, {
-                        ...params.data,
-                    })
+                    database.updateOne(resource, id, cleanupData(params.data))
                 );
                 return delayed({ data: params.ids }, delay);
             case 'create':
                 return delayed(
-                    { data: database.addOne(resource, { ...params.data }) },
+                    {
+                        data: database.addOne(
+                            resource,
+                            cleanupData(params.data)
+                        ),
+                    },
                     delay
                 );
             case 'delete':
@@ -192,6 +197,17 @@ export default (data, loggingEnabled = false, delay?: number): DataProvider => {
             handle('deleteMany', resource, params),
     };
 };
+
+/**
+ * Clone the data and ignore undefined values.
+ *
+ * If we don't do this, an update with { id: undefined } as payload
+ * would remove the id from the record, which no real data provider does.
+ *
+ * Also, this is a way to ensure we don't keep a reference to the data
+ * and that the data is not mutated.
+ */
+const cleanupData = <T>(data: T): T => JSON.parse(JSON.stringify(data));
 
 class UndefinedResourceError extends Error {
     code: number;


### PR DESCRIPTION
## Problem

React-hook-form sets the value of `disabled` inputs to `undefined`. For most data providers, this isn't a problem (except the disabled field won't be sent in the update).

But FakeRest is local, so it receives the `undefined` value, and uses it to override the existing value. In effect, this erases the value.

```jsx
dataProvider.update(123, data: { id: undefined }); // erases the id with FakeRest
```

I also noticed that we made the same mistake in optimistic updates.

This can be seen e.g. in the simple example, by changing the first input of PostEdit to `<TexuInput source="id" disabled" />`

## Solution

Remove `undefined` values from the edit payload:

- [x] In `ra-data-fakerest`
- [x] in `useUpdate` optimistic update
- [x] in `useUpdateMany` optimistic update

Supersedes #10242
