### PR TITLE
Make authProvider.getPermissions optional

### DIFF
--- a/packages/ra-core/src/auth/useGetPermissions.ts
+++ b/packages/ra-core/src/auth/useGetPermissions.ts
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 
 import useAuthProvider from './useAuthProvider';
 
-const getPermissionsWithoutProvider = () => Promise.resolve([]);
-
 /**
  * Get a callback for calling the authProvider.getPermissions() method.
  *
@@ -38,13 +36,15 @@ const getPermissionsWithoutProvider = () => Promise.resolve([]);
 const useGetPermissions = (): GetPermissions => {
     const authProvider = useAuthProvider();
     const getPermissions = useCallback(
-        (params: any = {}) =>
+        (params: any = {}) => {
             // react-query requires the query to return something
-            authProvider
-                ? authProvider
-                      .getPermissions(params)
-                      .then(result => result ?? null)
-                : getPermissionsWithoutProvider(),
+            if (authProvider && authProvider.getPermissions) {
+                return authProvider
+                    .getPermissions(params)
+                    .then(result => result ?? null);
+            }
+            return Promise.resolve([]);
+        },
         [authProvider]
     );
 

--- a/packages/ra-core/src/auth/usePermissions.stories.tsx
+++ b/packages/ra-core/src/auth/usePermissions.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import usePermissions, { UsePermissionsResult } from './usePermissions';
-import { AuthProvider, CoreAdminContext, TestMemoryRouter } from '..';
 import { QueryClient } from '@tanstack/react-query';
+import { AuthProvider, CoreAdminContext, TestMemoryRouter } from '..';
 
 export default {
     title: 'ra-core/auth/usePermissions',

--- a/packages/ra-core/src/auth/usePermissions.stories.tsx
+++ b/packages/ra-core/src/auth/usePermissions.stories.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import usePermissions, { UsePermissionsResult } from './usePermissions';
+import { AuthProvider, CoreAdminContext, TestMemoryRouter } from '..';
+import { QueryClient } from '@tanstack/react-query';
+
+export default {
+    title: 'ra-core/auth/usePermissions',
+};
+
+export const NoAuthProvider = () => (
+    <TestMemoryRouter>
+        <CoreAdminContext>
+            <UsePermissions>{state => inspectState(state)}</UsePermissions>
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+export const NoAuthProviderGetPermissions = () => (
+    <TestMemoryRouter>
+        <CoreAdminContext
+            authProvider={{
+                login: () => Promise.reject('bad method'),
+                logout: () => Promise.reject('bad method'),
+                checkAuth: () => Promise.reject('bad method'),
+                checkError: () => Promise.reject('bad method'),
+            }}
+        >
+            <UsePermissions>{state => inspectState(state)}</UsePermissions>
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+export const WithAuthProviderAndGetPermissions = ({
+    authProvider = {
+        login: () => Promise.reject('bad method'),
+        logout: () => Promise.reject('bad method'),
+        checkAuth: () => Promise.reject('bad method'),
+        checkError: () => Promise.reject('bad method'),
+        getPermissions: () =>
+            new Promise(resolve => setTimeout(resolve, 300, 'admin')),
+    },
+    queryClient,
+}: {
+    authProvider?: AuthProvider;
+    queryClient?: QueryClient;
+}) => (
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={authProvider} queryClient={queryClient}>
+            <UsePermissions>{state => inspectState(state)}</UsePermissions>
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+const UsePermissions = ({
+    children,
+}: {
+    children: (state: UsePermissionsResult<any, Error>) => React.ReactNode;
+}) => {
+    const permissionQueryParams = {
+        retry: false,
+    };
+    const res = usePermissions({}, permissionQueryParams);
+    return children(res);
+};
+
+const inspectState = (state: UsePermissionsResult<any, Error>) => (
+    <div>
+        {state.isPending ? <span>LOADING</span> : null}
+        {state.permissions ? (
+            <span>PERMISSIONS: {state.permissions}</span>
+        ) : null}
+        {state.error ? <span>ERROR</span> : null}
+    </div>
+);

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -51,10 +51,12 @@ const usePermissions = <PermissionsType = any, ErrorType = Error>(
     const { onSuccess, onError, onSettled, ...queryOptions } =
         queryParams ?? {};
 
-    const result = useQuery<PermissionsType, ErrorType>({
+    const queryResult = useQuery<PermissionsType, ErrorType>({
         queryKey: ['auth', 'getPermissions', params],
         queryFn: async ({ signal }) => {
-            if (!authProvider) return Promise.resolve([]);
+            if (!authProvider || !authProvider.getPermissions) {
+                return Promise.resolve([]);
+            }
             const permissions = await authProvider.getPermissions({
                 ...params,
                 signal,
@@ -77,33 +79,37 @@ const usePermissions = <PermissionsType = any, ErrorType = Error>(
     );
 
     useEffect(() => {
-        if (result.data === undefined || result.isFetching) return;
-        onSuccessEvent(result.data);
-    }, [onSuccessEvent, result.data, result.isFetching]);
+        if (queryResult.data === undefined || queryResult.isFetching) return;
+        onSuccessEvent(queryResult.data);
+    }, [onSuccessEvent, queryResult.data, queryResult.isFetching]);
 
     useEffect(() => {
-        if (result.error == null || result.isFetching) return;
-        onErrorEvent(result.error);
-    }, [onErrorEvent, result.error, result.isFetching]);
+        if (queryResult.error == null || queryResult.isFetching) return;
+        onErrorEvent(queryResult.error);
+    }, [onErrorEvent, queryResult.error, queryResult.isFetching]);
 
     useEffect(() => {
-        if (result.status === 'pending' || result.isFetching) return;
-        onSettledEvent(result.data, result.error);
+        if (queryResult.status === 'pending' || queryResult.isFetching) return;
+        onSettledEvent(queryResult.data, queryResult.error);
     }, [
         onSettledEvent,
-        result.data,
-        result.error,
-        result.status,
-        result.isFetching,
+        queryResult.data,
+        queryResult.error,
+        queryResult.status,
+        queryResult.isFetching,
     ]);
 
-    return useMemo(
+    const result = useMemo(
         () => ({
-            ...result,
-            permissions: result.data,
+            ...queryResult,
+            permissions: queryResult.data,
         }),
-        [result]
+        [queryResult]
     );
+
+    return !authProvider || !authProvider.getPermissions
+        ? (fakeQueryResult as UsePermissionsResult<PermissionsType, ErrorType>)
+        : result;
 };
 
 export default usePermissions;
@@ -126,3 +132,31 @@ export type UsePermissionsResult<
 };
 
 const noop = () => {};
+
+const fakeQueryResult = {
+    permissions: undefined,
+    data: undefined,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: 'idle',
+    isError: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isPending: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    status: 'success',
+    refetch: () => Promise.resolve(fakeQueryResult),
+};

--- a/packages/ra-core/src/auth/usePermissions.ts
+++ b/packages/ra-core/src/auth/usePermissions.ts
@@ -55,7 +55,7 @@ const usePermissions = <PermissionsType = any, ErrorType = Error>(
         queryKey: ['auth', 'getPermissions', params],
         queryFn: async ({ signal }) => {
             if (!authProvider || !authProvider.getPermissions) {
-                return Promise.resolve([]);
+                return [];
             }
             const permissions = await authProvider.getPermissions({
                 ...params,

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -65,7 +65,7 @@ export type AuthProvider = {
     checkAuth: (params: any & QueryFunctionContext) => Promise<void>;
     checkError: (error: any) => Promise<void>;
     getIdentity?: (params?: QueryFunctionContext) => Promise<UserIdentity>;
-    getPermissions: (params: any & QueryFunctionContext) => Promise<any>;
+    getPermissions?: (params: any & QueryFunctionContext) => Promise<any>;
     handleCallback?: (
         params?: QueryFunctionContext
     ) => Promise<AuthRedirectResult | void | any>;


### PR DESCRIPTION
## Problem

Even though using permissions in React-Admin is optional, the AuthProvider type required users to implement the `getPermissions` method.

## Solution

Make the `getPermissions` method optional.
This also allows us to optimize the `usePermissions` hook.

## How To Test

Stories and tests

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date
