### PR TITLE
Access control: pessimistic rendering in CRUD views

### DIFF
--- a/packages/ra-core/src/auth/WithPermissions.stories.tsx
+++ b/packages/ra-core/src/auth/WithPermissions.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { AuthProvider } from '../types';
+import { CoreAdminContext } from '../core';
+import { TestMemoryRouter, WithPermissions } from '..';
+
+export default {
+    title: 'ra-core/auth/WithPermissions',
+};
+
+export const NoAuthProvider = () => (
+    <TestMemoryRouter>
+        <CoreAdminContext>
+            <WithPermissions component={StateInspector} />
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+export const NoAuthProviderGetPermissions = ({
+    loading = () => <p>Loading...</p>,
+}: {
+    loading: React.ComponentType;
+}) => (
+    <TestMemoryRouter>
+        <CoreAdminContext
+            authProvider={{
+                login: () => Promise.reject('bad method'),
+                logout: () => Promise.reject('bad method'),
+                checkAuth: () =>
+                    new Promise(resolve => setTimeout(resolve, 300)),
+                checkError: () => Promise.reject('bad method'),
+            }}
+        >
+            <WithPermissions component={StateInspector} loading={loading} />
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+export const WithAuthProviderAndGetPermissions = ({
+    loading = () => <p>Loading...</p>,
+    authProvider = {
+        login: () => Promise.reject('bad method'),
+        logout: () => Promise.reject('bad method'),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        checkError: () => Promise.reject('bad method'),
+        getPermissions: () =>
+            new Promise(resolve => setTimeout(resolve, 300, 'admin')),
+    },
+}: {
+    loading: React.ComponentType;
+    authProvider?: AuthProvider;
+}) => (
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={authProvider}>
+            <WithPermissions component={StateInspector} loading={loading} />
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+const StateInspector = ({ permissions }: { permissions: any }) => (
+    <div>
+        {permissions === 'admin' ? (
+            <p>Sensitive data</p>
+        ) : (
+            <p>Non sensitive data</p>
+        )}
+    </div>
+);

--- a/packages/ra-core/src/auth/index.ts
+++ b/packages/ra-core/src/auth/index.ts
@@ -20,6 +20,7 @@ export * from './useCanAccessCallback';
 export * from './useCheckAuth';
 export * from './useGetIdentity';
 export * from './useHandleAuthCallback';
+export * from './useIsAuthPending';
 export * from './useRequireAccess';
 export * from './addRefreshAuthToAuthProvider';
 export * from './addRefreshAuthToDataProvider';

--- a/packages/ra-core/src/auth/useIsAuthPending.ts
+++ b/packages/ra-core/src/auth/useIsAuthPending.ts
@@ -1,0 +1,43 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useResourceContext } from '../core';
+import { HintedString } from '../types';
+import useAuthProvider from './useAuthProvider';
+
+/**
+ * A hook that returns true if the authProvider is currently checking the authentication status or the user's access rights.
+ * @param params
+ * @param params.action The action to check access for
+ * @param params.resource The resource to check access for (optional). Defaults to the resource of the current ResourceContext.
+ * @returns {boolean} true if the authProvider is currently checking the authentication status or the user's access rights, false otherwise.
+ */
+export const useIsAuthPending = (params: UseIsAuthPendingParams) => {
+    const { action, ...props } = params;
+    const queryClient = useQueryClient();
+    const authProvider = useAuthProvider();
+    const resource = useResourceContext(props);
+
+    if (!authProvider) {
+        return false;
+    }
+
+    const authQueryState = queryClient.getQueryState(['auth', 'checkAuth', {}]);
+    const canAccessQueryState = queryClient.getQueryState([
+        'auth',
+        'canAccess',
+        { action, resource },
+    ]);
+
+    if (
+        authQueryState?.status === 'pending' ||
+        (authProvider.canAccess && canAccessQueryState?.status === 'pending')
+    ) {
+        return true;
+    }
+
+    return false;
+};
+
+export type UseIsAuthPendingParams = {
+    resource?: string;
+    action: HintedString<'list' | 'create' | 'edit' | 'show' | 'delete'>;
+};

--- a/packages/ra-core/src/controller/create/CreateBase.spec.tsx
+++ b/packages/ra-core/src/controller/create/CreateBase.spec.tsx
@@ -1,47 +1,25 @@
 import * as React from 'react';
 import expect from 'expect';
-import { useEffect } from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 
-import { CoreAdminContext } from '../../core';
 import { testDataProvider } from '../../dataProvider';
-import { useSaveContext } from '../saveContext';
-import { CreateBase } from './CreateBase';
+import {
+    AccessControl,
+    NoAuthProvider,
+    WithAuthProviderNoAccessControl,
+} from './CreateBase.stories';
 
 describe('CreateBase', () => {
-    const defaultProps = {
-        hasCreate: true,
-        hasEdit: true,
-        hasList: true,
-        hasShow: true,
-        id: 12,
-        resource: 'posts',
-        debounce: 200,
-    };
-
     it('should give access to the save function', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn((_, { data }) =>
                 Promise.resolve({ data: { id: 1, ...data } })
             ),
         });
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            useEffect(() => {
-                saveContext.save({ test: 'test' });
-            }, []); // eslint-disable-line
-
-            return null;
-        };
-        render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
-        );
+        render(<NoAuthProvider dataProvider={dataProvider} />);
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(dataProvider.create).toHaveBeenCalledWith('posts', {
@@ -52,30 +30,21 @@ describe('CreateBase', () => {
 
     it('should allow to override the onSuccess function', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn((_, { data }) =>
                 Promise.resolve({ data: { id: 1, ...data } })
             ),
         });
         const onSuccess = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return <button aria-label="save" onClick={handleClick} />;
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps} mutationOptions={{ onSuccess }}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationOptions={{ onSuccess }}
+            />
         );
 
-        getByLabelText('save').click();
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(onSuccess).toHaveBeenCalledWith(
@@ -91,6 +60,7 @@ describe('CreateBase', () => {
 
     it('should allow to override the onSuccess function at call time', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn((_, { data }) =>
                 Promise.resolve({ data: { id: 1, ...data } })
             ),
@@ -98,27 +68,15 @@ describe('CreateBase', () => {
         const onSuccess = jest.fn();
         const onSuccessOverride = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            const handleClick = () => {
-                saveContext.save(
-                    { test: 'test' },
-                    { onSuccess: onSuccessOverride }
-                );
-            };
-
-            return <button aria-label="save" onClick={handleClick} />;
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps} mutationOptions={{ onSuccess }}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
+        const { getByText } = render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationOptions={{ onSuccess }}
+                callTimeOptions={{ onSuccess: onSuccessOverride }}
+            />
         );
 
-        getByLabelText('save').click();
+        getByText('save').click();
 
         await waitFor(() => {
             expect(onSuccessOverride).toHaveBeenCalledWith(
@@ -136,28 +94,19 @@ describe('CreateBase', () => {
     it('should allow to override the onError function', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn(() => Promise.reject({ message: 'test' })),
         });
         const onError = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return <button aria-label="save" onClick={handleClick} />;
-        };
         render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps} mutationOptions={{ onError }}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationOptions={{ onError }}
+            />
         );
 
-        screen.getByLabelText('save').click();
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(onError).toHaveBeenCalledWith(
@@ -170,32 +119,21 @@ describe('CreateBase', () => {
 
     it('should allow to override the onError function at call time', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn(() => Promise.reject({ message: 'test' })),
         });
         const onError = jest.fn();
         const onErrorOverride = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            const handleClick = () => {
-                saveContext.save(
-                    { test: 'test' },
-                    { onError: onErrorOverride }
-                );
-            };
-
-            return <button aria-label="save" onClick={handleClick} />;
-        };
         render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps} mutationOptions={{ onError }}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationOptions={{ onError }}
+                callTimeOptions={{ onError: onErrorOverride }}
+            />
         );
 
-        screen.getByLabelText('save').click();
+        screen.getByText('save').click();
 
         await waitFor(() => {
             expect(onErrorOverride).toHaveBeenCalledWith(
@@ -209,6 +147,7 @@ describe('CreateBase', () => {
 
     it('should allow to override the transform function', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn((_, { data }) =>
                 Promise.resolve({ data: { id: 1, ...data } })
             ),
@@ -217,24 +156,11 @@ describe('CreateBase', () => {
             .fn()
             .mockReturnValueOnce({ test: 'test transformed' });
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return <button aria-label="save" onClick={handleClick} />;
-        };
         render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps} transform={transform}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
+            <NoAuthProvider dataProvider={dataProvider} transform={transform} />
         );
 
-        screen.getByLabelText('save').click();
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(transform).toHaveBeenCalledWith({ test: 'test' });
@@ -248,6 +174,7 @@ describe('CreateBase', () => {
 
     it('should allow to override the transform function at call time', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             create: jest.fn((_, { data }) =>
                 Promise.resolve({ data: { id: 1, ...data } })
             ),
@@ -257,27 +184,17 @@ describe('CreateBase', () => {
             .fn()
             .mockReturnValueOnce({ test: 'test transformed' });
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-
-            const handleClick = () => {
-                saveContext.save(
-                    { test: 'test' },
-                    { transform: transformOverride }
-                );
-            };
-
-            return <button aria-label="save" onClick={handleClick} />;
-        };
         render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <CreateBase {...defaultProps} transform={transform}>
-                    <Child />
-                </CreateBase>
-            </CoreAdminContext>
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                transform={transform}
+                callTimeOptions={{
+                    transform: transformOverride,
+                }}
+            />
         );
 
-        screen.getByLabelText('save').click();
+        screen.getByText('save').click();
 
         await waitFor(() => {
             expect(transformOverride).toHaveBeenCalledWith({ test: 'test' });
@@ -288,5 +205,67 @@ describe('CreateBase', () => {
             });
         });
         expect(transform).not.toHaveBeenCalled();
+    });
+
+    it('should show the view immediately if authProvider is not provided', () => {
+        const dataProvider = testDataProvider();
+        render(<NoAuthProvider dataProvider={dataProvider} />);
+        screen.getByText('save');
+    });
+    it('should wait for the authentication resolution before showing the view', async () => {
+        let resolveAuth: () => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+        };
+        const dataProvider = testDataProvider();
+        render(
+            <WithAuthProviderNoAccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        await screen.findByText('save');
+    });
+    it('should wait for both the authentication and authorization resolution before showing the view', async () => {
+        let resolveAuth: () => void;
+        let resolveCanAccess: (value: boolean) => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+            canAccess: jest.fn(
+                () =>
+                    new Promise<boolean>(resolve => {
+                        resolveCanAccess = resolve;
+                    })
+            ),
+        };
+        const dataProvider = testDataProvider();
+        render(
+            <AccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        await screen.findByText('Authentication loading...');
+        await waitFor(() => {
+            expect(authProvider.canAccess).toHaveBeenCalled();
+        });
+        resolveCanAccess!(true);
+        await screen.findByText('save');
     });
 });

--- a/packages/ra-core/src/controller/create/CreateBase.stories.tsx
+++ b/packages/ra-core/src/controller/create/CreateBase.stories.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import {
+    AuthProvider,
+    CoreAdminContext,
+    CreateBase,
+    CreateBaseProps,
+    DataProvider,
+    SaveHandlerCallbacks,
+    testDataProvider,
+    useSaveContext,
+} from '../..';
+
+export default {
+    title: 'ra-core/controller/CreateBase',
+};
+
+export const NoAuthProvider = ({
+    dataProvider = defaultDataProvider,
+    callTimeOptions,
+    ...props
+}: {
+    dataProvider?: DataProvider;
+    callTimeOptions?: SaveHandlerCallbacks;
+} & Partial<CreateBaseProps>) => (
+    <CoreAdminContext dataProvider={dataProvider}>
+        <CreateBase {...defaultProps} {...props}>
+            <Child callTimeOptions={callTimeOptions} />
+        </CreateBase>
+    </CoreAdminContext>
+);
+
+export const WithAuthProviderNoAccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkError: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <CreateBase
+            {...defaultProps}
+            loading={<div>Authentication loading...</div>}
+        >
+            <Child />
+        </CreateBase>
+    </CoreAdminContext>
+);
+
+export const AccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkError: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        canAccess: () => new Promise(resolve => setTimeout(resolve, 300, true)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <CreateBase
+            {...defaultProps}
+            loading={<div>Authentication loading...</div>}
+        >
+            <Child />
+        </CreateBase>
+    </CoreAdminContext>
+);
+
+const defaultDataProvider = testDataProvider({
+    // @ts-ignore
+    create: (_, { data }) => Promise.resolve({ data: { id: 1, ...data } }),
+});
+
+const defaultProps = {
+    hasCreate: true,
+    hasEdit: true,
+    hasList: true,
+    hasShow: true,
+    id: 12,
+    resource: 'posts',
+};
+
+const Child = ({
+    callTimeOptions,
+}: {
+    callTimeOptions?: SaveHandlerCallbacks;
+}) => {
+    const saveContext = useSaveContext();
+
+    const handleClick = () => {
+        if (!saveContext || !saveContext.save) return;
+        saveContext.save({ test: 'test' }, callTimeOptions);
+    };
+
+    return <button onClick={handleClick}>save</button>;
+};

--- a/packages/ra-core/src/controller/create/CreateBase.tsx
+++ b/packages/ra-core/src/controller/create/CreateBase.tsx
@@ -63,7 +63,8 @@ export const CreateBase = <
     }
 
     return (
-        <OptionalResourceContextProvider value={controllerProps.resource}>
+        // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
+        <OptionalResourceContextProvider value={props.resource}>
             <CreateContextProvider value={controllerProps}>
                 {children}
             </CreateContextProvider>

--- a/packages/ra-core/src/controller/edit/EditBase.spec.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.spec.tsx
@@ -1,65 +1,40 @@
 import * as React from 'react';
 import expect from 'expect';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { EditBase } from './EditBase';
-import { CoreAdminContext } from '../../core';
 import { testDataProvider } from '../../dataProvider';
-import { useSaveContext } from '../saveContext';
-import { useRecordContext } from '../';
+import {
+    AccessControl,
+    NoAuthProvider,
+    WithAuthProviderNoAccessControl,
+} from './EditBase.stories';
 
 describe('EditBase', () => {
-    const defaultProps = {
-        hasCreate: true,
-        hasEdit: true,
-        hasList: true,
-        hasShow: true,
-        id: 12,
-        resource: 'posts',
-        debounce: 200,
-    };
-
     it('should give access to the save function', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             getOne: () =>
-                // @ts-ignore
                 Promise.resolve({ data: { id: 12, test: 'previous' } }),
             update: jest.fn((_, { id, data, previousData }) =>
                 Promise.resolve({ data: { id, ...previousData, ...data } })
             ),
         });
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
         render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase {...defaultProps} mutationMode="pessimistic">
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+            />
         );
 
         await waitFor(() => {
             screen.getByText('previous');
         });
-        screen.getByLabelText('save').click();
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(dataProvider.update).toHaveBeenCalledWith('posts', {
-                id: defaultProps.id,
+                id: 12,
                 data: { test: 'test' },
                 previousData: { id: 12, test: 'previous' },
             });
@@ -68,8 +43,8 @@ describe('EditBase', () => {
 
     it('should allow to override the onSuccess function', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             getOne: () =>
-                // @ts-ignore
                 Promise.resolve({ data: { id: 12, test: 'previous' } }),
             update: jest.fn((_, { id, data, previousData }) =>
                 Promise.resolve({ data: { id, ...previousData, ...data } })
@@ -77,37 +52,18 @@ describe('EditBase', () => {
         });
         const onSuccess = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase
-                    {...defaultProps}
-                    mutationMode="pessimistic"
-                    mutationOptions={{ onSuccess }}
-                >
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+                mutationOptions={{ onSuccess }}
+            />
         );
 
         await waitFor(() => {
             screen.getByText('previous');
         });
-        getByLabelText('save').click();
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(onSuccess).toHaveBeenCalledWith(
@@ -127,8 +83,8 @@ describe('EditBase', () => {
 
     it('should allow to override the onSuccess function at call time', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             getOne: () =>
-                // @ts-ignore
                 Promise.resolve({ data: { id: 12, test: 'previous' } }),
             update: jest.fn((_, { id, data, previousData }) =>
                 Promise.resolve({ data: { id, ...previousData, ...data } })
@@ -137,40 +93,19 @@ describe('EditBase', () => {
         const onSuccess = jest.fn();
         const onSuccessOverride = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save(
-                    { test: 'test' },
-                    { onSuccess: onSuccessOverride }
-                );
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase
-                    {...defaultProps}
-                    mutationMode="pessimistic"
-                    mutationOptions={{ onSuccess }}
-                >
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+                mutationOptions={{ onSuccess }}
+                callTimeOptions={{ onSuccess: onSuccessOverride }}
+            />
         );
 
         await waitFor(() => {
             screen.getByText('previous');
         });
-        getByLabelText('save').click();
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(onSuccessOverride).toHaveBeenCalledWith(
@@ -200,37 +135,16 @@ describe('EditBase', () => {
         });
         const onError = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase
-                    {...defaultProps}
-                    mutationMode="pessimistic"
-                    mutationOptions={{ onError }}
-                >
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+                mutationOptions={{ onError }}
+            />
         );
 
-        await waitFor(() => {
-            screen.getByText('previous');
-        });
-        getByLabelText('save').click();
+        await screen.findByText('previous');
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(onError).toHaveBeenCalledWith(
@@ -256,40 +170,17 @@ describe('EditBase', () => {
         const onError = jest.fn();
         const onErrorOverride = jest.fn();
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save(
-                    { test: 'test' },
-                    { onError: onErrorOverride }
-                );
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase
-                    {...defaultProps}
-                    mutationMode="pessimistic"
-                    mutationOptions={{ onError }}
-                >
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+                mutationOptions={{ onError }}
+                callTimeOptions={{ onError: onErrorOverride }}
+            />
         );
 
-        await waitFor(() => {
-            screen.getByText('previous');
-        });
-        getByLabelText('save').click();
+        await screen.findByText('previous');
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(onErrorOverride).toHaveBeenCalledWith(
@@ -307,8 +198,8 @@ describe('EditBase', () => {
 
     it('should allow to override the transform function', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             getOne: () =>
-                // @ts-ignore
                 Promise.resolve({ data: { id: 12, test: 'previous' } }),
             update: jest.fn((_, { id, data, previousData }) =>
                 Promise.resolve({ data: { id, ...previousData, ...data } })
@@ -319,37 +210,16 @@ describe('EditBase', () => {
             test: 'test transformed',
         }));
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save({ test: 'test' });
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase
-                    {...defaultProps}
-                    mutationMode="pessimistic"
-                    transform={transform}
-                >
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+                transform={transform}
+            />
         );
 
-        await waitFor(() => {
-            screen.getByText('previous');
-        });
-        getByLabelText('save').click();
+        await screen.findByText('previous');
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(transform).toHaveBeenCalledWith(
@@ -359,7 +229,7 @@ describe('EditBase', () => {
         });
         await waitFor(() => {
             expect(dataProvider.update).toHaveBeenCalledWith('posts', {
-                id: defaultProps.id,
+                id: 12,
                 data: { test: 'test transformed' },
                 previousData: { id: 12, test: 'previous' },
             });
@@ -368,8 +238,8 @@ describe('EditBase', () => {
 
     it('should allow to override the transform function at call time', async () => {
         const dataProvider = testDataProvider({
+            // @ts-ignore
             getOne: () =>
-                // @ts-ignore
                 Promise.resolve({ data: { id: 12, test: 'previous' } }),
             update: jest.fn((_, { id, data, previousData }) =>
                 Promise.resolve({ data: { id, ...previousData, ...data } })
@@ -381,40 +251,19 @@ describe('EditBase', () => {
             test: 'test transformed',
         }));
 
-        const Child = () => {
-            const saveContext = useSaveContext();
-            const record = useRecordContext();
-
-            const handleClick = () => {
-                saveContext.save(
-                    { test: 'test' },
-                    { transform: transformOverride }
-                );
-            };
-
-            return (
-                <>
-                    <p>{record?.test}</p>
-                    <button aria-label="save" onClick={handleClick} />
-                </>
-            );
-        };
-        const { getByLabelText } = render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <EditBase
-                    {...defaultProps}
-                    mutationMode="pessimistic"
-                    transform={transform}
-                >
-                    <Child />
-                </EditBase>
-            </CoreAdminContext>
+        render(
+            <NoAuthProvider
+                dataProvider={dataProvider}
+                mutationMode="pessimistic"
+                transform={transform}
+                callTimeOptions={{
+                    transform: transformOverride,
+                }}
+            />
         );
 
-        await waitFor(() => {
-            screen.getByText('previous');
-        });
-        getByLabelText('save').click();
+        await screen.findByText('previous');
+        fireEvent.click(screen.getByText('save'));
 
         await waitFor(() => {
             expect(transformOverride).toHaveBeenCalledWith(
@@ -424,11 +273,92 @@ describe('EditBase', () => {
         });
         await waitFor(() => {
             expect(dataProvider.update).toHaveBeenCalledWith('posts', {
-                id: defaultProps.id,
+                id: 12,
                 data: { test: 'test transformed' },
                 previousData: { id: 12, test: 'previous' },
             });
         });
         expect(transform).not.toHaveBeenCalled();
+    });
+
+    it('should load data immediately if authProvider is not provided', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getOne: jest.fn(() =>
+                Promise.resolve({ data: { id: 12, test: 'Hello' } })
+            ),
+        });
+        render(<NoAuthProvider dataProvider={dataProvider} />);
+        expect(dataProvider.getOne).toHaveBeenCalled();
+        await screen.findByText('Hello');
+    });
+    it('should wait for the authentication resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getOne: jest.fn(() =>
+                Promise.resolve({ data: { id: 12, test: 'Hello' } })
+            ),
+        });
+        render(
+            <WithAuthProviderNoAccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getOne).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        await screen.findByText('Hello');
+    });
+    it('should wait for both the authentication and authorization resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        let resolveCanAccess: (value: boolean) => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+            canAccess: jest.fn(
+                () =>
+                    new Promise<boolean>(resolve => {
+                        resolveCanAccess = resolve;
+                    })
+            ),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getOne: jest.fn(() =>
+                Promise.resolve({ data: { id: 12, test: 'Hello' } })
+            ),
+        });
+        render(
+            <AccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getOne).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        expect(dataProvider.getOne).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        await waitFor(() => {
+            expect(authProvider.canAccess).toHaveBeenCalled();
+        });
+        resolveCanAccess!(true);
+        await screen.findByText('Hello');
     });
 });

--- a/packages/ra-core/src/controller/edit/EditBase.stories.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.stories.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import {
+    AuthProvider,
+    CoreAdminContext,
+    EditBase,
+    EditBaseProps,
+    DataProvider,
+    SaveHandlerCallbacks,
+    testDataProvider,
+    useSaveContext,
+    useRecordContext,
+} from '../..';
+
+export default {
+    title: 'ra-core/controller/EditBase',
+};
+
+export const NoAuthProvider = ({
+    dataProvider = defaultDataProvider,
+    callTimeOptions,
+    ...props
+}: {
+    dataProvider?: DataProvider;
+    callTimeOptions?: SaveHandlerCallbacks;
+} & Partial<EditBaseProps>) => (
+    <CoreAdminContext dataProvider={dataProvider}>
+        <EditBase {...defaultProps} {...props}>
+            <Child callTimeOptions={callTimeOptions} />
+        </EditBase>
+    </CoreAdminContext>
+);
+
+export const WithAuthProviderNoAccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkError: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <EditBase
+            {...defaultProps}
+            loading={<div>Authentication loading...</div>}
+        >
+            <Child />
+        </EditBase>
+    </CoreAdminContext>
+);
+
+export const AccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkError: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        canAccess: () => new Promise(resolve => setTimeout(resolve, 300, true)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <EditBase
+            {...defaultProps}
+            loading={<div>Authentication loading...</div>}
+        >
+            <Child />
+        </EditBase>
+    </CoreAdminContext>
+);
+
+const defaultDataProvider = testDataProvider({
+    // @ts-ignore
+    getOne: () => Promise.resolve({ data: { id: 12, test: 'Hello' } }),
+});
+
+const defaultProps = {
+    id: 12,
+    resource: 'posts',
+};
+
+const Child = ({
+    callTimeOptions,
+}: {
+    callTimeOptions?: SaveHandlerCallbacks;
+}) => {
+    const saveContext = useSaveContext();
+    const record = useRecordContext();
+
+    const handleClick = () => {
+        if (!saveContext || !saveContext.save) return;
+        saveContext.save({ test: 'test' }, callTimeOptions);
+    };
+
+    return (
+        <>
+            <p>{record?.test}</p>
+            <button onClick={handleClick}>save</button>
+        </>
+    );
+};

--- a/packages/ra-core/src/controller/edit/EditBase.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.tsx
@@ -53,7 +53,8 @@ export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
     }
 
     return (
-        <OptionalResourceContextProvider value={controllerProps.resource}>
+        // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
+        <OptionalResourceContextProvider value={props.resource}>
             <EditContextProvider value={controllerProps}>
                 {children}
             </EditContextProvider>

--- a/packages/ra-core/src/controller/edit/EditBase.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.tsx
@@ -36,12 +36,12 @@ import { useIsAuthPending } from '../../auth';
  *     </EditBase>
  * );
  */
-export const EditBase = <RecordType extends RaRecord = any>({
+export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
     children,
     loading = null,
     ...props
-}: EditBaseProps<RecordType>) => {
-    const controllerProps = useEditController<RecordType>(props);
+}: EditBaseProps<RecordType, ErrorType>) => {
+    const controllerProps = useEditController<RecordType, ErrorType>(props);
 
     const isAuthPending = useIsAuthPending({
         resource: controllerProps.resource,
@@ -61,8 +61,10 @@ export const EditBase = <RecordType extends RaRecord = any>({
     );
 };
 
-export interface EditBaseProps<RecordType extends RaRecord = RaRecord>
-    extends EditControllerProps<RecordType> {
+export interface EditBaseProps<
+    RecordType extends RaRecord = RaRecord,
+    ErrorType = Error,
+> extends EditControllerProps<RecordType, ErrorType> {
     children: ReactNode;
     loading?: ReactNode;
 }

--- a/packages/ra-core/src/controller/list/InfiniteListBase.spec.tsx
+++ b/packages/ra-core/src/controller/list/InfiniteListBase.spec.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { Basic } from './InfiniteListBase.stories';
+import {
+    AccessControl,
+    Basic,
+    NoAuthProvider,
+    WithAuthProviderNoAccessControl,
+} from './InfiniteListBase.stories';
 import { render, screen, waitFor } from '@testing-library/react';
+import { testDataProvider } from '../../dataProvider';
 
 describe('InfiniteListBase', () => {
     it('should fetch a list of records on mount, put it in a ListContext, and render its children', async () => {
@@ -25,5 +31,85 @@ describe('InfiniteListBase', () => {
         await screen.findByText('And Then There Were None'); // #6
         // first page is still visible
         await screen.findByText('The Lord of the Rings'); // #5
+    });
+    it('should load data immediately if authProvider is not provided', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'Hello' }], total: 1 })
+            ),
+        });
+        render(<NoAuthProvider dataProvider={dataProvider} />);
+        expect(dataProvider.getList).toHaveBeenCalled();
+        await screen.findByText('Hello');
+    });
+    it('should wait for the authentication resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'Hello' }], total: 1 })
+            ),
+        });
+        render(
+            <WithAuthProviderNoAccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        await screen.findByText('Hello');
+    });
+    it('should wait for both the authentication and authorization resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        let resolveCanAccess: (value: boolean) => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+            canAccess: jest.fn(
+                () =>
+                    new Promise<boolean>(resolve => {
+                        resolveCanAccess = resolve;
+                    })
+            ),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'Hello' }], total: 1 })
+            ),
+        });
+        render(
+            <AccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        await waitFor(() => {
+            expect(authProvider.canAccess).toHaveBeenCalled();
+        });
+        resolveCanAccess!(true);
+        await screen.findByText('Hello');
     });
 });

--- a/packages/ra-core/src/controller/list/InfiniteListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/InfiniteListBase.stories.tsx
@@ -5,6 +5,7 @@ import { InfiniteListBase } from './InfiniteListBase';
 import { CoreAdminContext } from '../../core';
 import { useListContext } from './useListContext';
 import { useInfinitePaginationContext } from './useInfinitePaginationContext';
+import { AuthProvider, DataProvider } from '../..';
 
 export default {
     title: 'ra-core/controller/list/InfiniteListBase',
@@ -40,7 +41,7 @@ const data = {
     ],
 };
 
-const dataProvider = fakeRestProvider(data, undefined, 300);
+const defaultDataProvider = fakeRestProvider(data, undefined, 300);
 
 const BookListView = () => {
     const { data, isPending, sort, setSort, filterValues, setFilters } =
@@ -63,7 +64,7 @@ const BookListView = () => {
             <button onClick={toggleSort}>Toggle Sort</button>
             <button onClick={toggleFilter}>Toggle Filter</button>
             <ul>
-                {data.map((record: any) => (
+                {data?.map((record: any) => (
                     <li key={record.id}>{record.title}</li>
                 ))}
             </ul>
@@ -103,10 +104,69 @@ const InfinitePagination = () => {
 };
 
 export const Basic = () => (
-    <CoreAdminContext dataProvider={dataProvider}>
+    <CoreAdminContext dataProvider={defaultDataProvider}>
         <InfiniteListBase resource="books" perPage={5}>
             <BookListView />
             <InfinitePagination />
+        </InfiniteListBase>
+    </CoreAdminContext>
+);
+
+export const NoAuthProvider = ({
+    dataProvider = defaultDataProvider,
+}: {
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext dataProvider={dataProvider}>
+        <InfiniteListBase resource="books" perPage={5}>
+            <BookListView />
+        </InfiniteListBase>
+    </CoreAdminContext>
+);
+
+export const WithAuthProviderNoAccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        checkError: () => Promise.resolve(),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <InfiniteListBase
+            resource="books"
+            perPage={5}
+            loading={<div>Authentication loading...</div>}
+        >
+            <BookListView />
+        </InfiniteListBase>
+    </CoreAdminContext>
+);
+
+export const AccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        checkError: () => Promise.resolve(),
+        canAccess: () => new Promise(resolve => setTimeout(resolve, 300, true)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <InfiniteListBase
+            resource="books"
+            perPage={5}
+            loading={<div>Authentication loading...</div>}
+        >
+            <BookListView />
         </InfiniteListBase>
     </CoreAdminContext>
 );

--- a/packages/ra-core/src/controller/list/InfiniteListBase.tsx
+++ b/packages/ra-core/src/controller/list/InfiniteListBase.tsx
@@ -60,7 +60,8 @@ export const InfiniteListBase = <RecordType extends RaRecord = any>({
     }
 
     return (
-        <OptionalResourceContextProvider value={controllerProps.resource}>
+        // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
+        <OptionalResourceContextProvider value={props.resource}>
             <ListContextProvider value={controllerProps}>
                 <InfinitePaginationContext.Provider
                     value={{

--- a/packages/ra-core/src/controller/list/ListBase.spec.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.spec.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+    AccessControl,
+    NoAuthProvider,
+    WithAuthProviderNoAccessControl,
+} from './ListBase.stories';
+import { testDataProvider } from '../../dataProvider';
+
+describe('ListBase', () => {
+    it('should load data immediately if authProvider is not provided', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'Hello' }], total: 1 })
+            ),
+        });
+        render(<NoAuthProvider dataProvider={dataProvider} />);
+        expect(dataProvider.getList).toHaveBeenCalled();
+        await screen.findByText('Hello');
+    });
+    it('should wait for the authentication resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'Hello' }], total: 1 })
+            ),
+        });
+        render(
+            <WithAuthProviderNoAccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        await screen.findByText('Hello');
+    });
+    it('should wait for both the authentication and authorization resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        let resolveCanAccess: (value: boolean) => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+            canAccess: jest.fn(
+                () =>
+                    new Promise<boolean>(resolve => {
+                        resolveCanAccess = resolve;
+                    })
+            ),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getList: jest.fn(() =>
+                Promise.resolve({ data: [{ id: 1, title: 'Hello' }], total: 1 })
+            ),
+        });
+        render(
+            <AccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        expect(dataProvider.getList).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        await waitFor(() => {
+            expect(authProvider.canAccess).toHaveBeenCalled();
+        });
+        resolveCanAccess!(true);
+        await screen.findByText('Hello');
+    });
+});

--- a/packages/ra-core/src/controller/list/ListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.stories.tsx
@@ -4,6 +4,7 @@ import fakeRestProvider from 'ra-data-fakerest';
 import { ListBase } from './ListBase';
 import { CoreAdminContext } from '../../core';
 import { useListContext } from './useListContext';
+import { AuthProvider, DataProvider } from '../..';
 
 export default {
     title: 'ra-core/controller/list/ListBase',
@@ -39,7 +40,7 @@ const data = {
     ],
 };
 
-const dataProvider = fakeRestProvider(data, true, 300);
+const defaultDataProvider = fakeRestProvider(data, true, 300);
 
 const BookListView = () => {
     const {
@@ -111,8 +112,67 @@ const BookListView = () => {
     );
 };
 
-export const SetParams = () => (
+export const NoAuthProvider = ({
+    dataProvider = defaultDataProvider,
+}: {
+    dataProvider?: DataProvider;
+}) => (
     <CoreAdminContext dataProvider={dataProvider}>
+        <ListBase resource="books" perPage={5}>
+            <BookListView />
+        </ListBase>
+    </CoreAdminContext>
+);
+
+export const WithAuthProviderNoAccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        checkError: () => Promise.resolve(),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <ListBase
+            resource="books"
+            perPage={5}
+            loading={<div>Authentication loading...</div>}
+        >
+            <BookListView />
+        </ListBase>
+    </CoreAdminContext>
+);
+
+export const AccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        checkError: () => Promise.resolve(),
+        canAccess: () => new Promise(resolve => setTimeout(resolve, 300, true)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <ListBase
+            resource="books"
+            perPage={5}
+            loading={<div>Authentication loading...</div>}
+        >
+            <BookListView />
+        </ListBase>
+    </CoreAdminContext>
+);
+
+export const SetParams = () => (
+    <CoreAdminContext dataProvider={defaultDataProvider}>
         <ListBase resource="books" perPage={5}>
             <BookListView />
         </ListBase>
@@ -132,9 +192,12 @@ const ListMetadataInspector = () => {
 export const WithResponseMetadata = () => (
     <CoreAdminContext
         dataProvider={{
-            ...dataProvider,
+            ...defaultDataProvider,
             getList: async (resource, params) => {
-                const result = await dataProvider.getList(resource, params);
+                const result = await defaultDataProvider.getList(
+                    resource,
+                    params
+                );
                 return {
                     ...result,
                     meta: {

--- a/packages/ra-core/src/controller/list/ListBase.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.tsx
@@ -56,7 +56,8 @@ export const ListBase = <RecordType extends RaRecord = any>({
     }
 
     return (
-        <OptionalResourceContextProvider value={controllerProps.resource}>
+        // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
+        <OptionalResourceContextProvider value={props.resource}>
             <ListContextProvider value={controllerProps}>
                 {children}
             </ListContextProvider>

--- a/packages/ra-core/src/controller/show/ShowBase.spec.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.spec.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { testDataProvider } from '../../dataProvider';
+import {
+    AccessControl,
+    NoAuthProvider,
+    WithAuthProviderNoAccessControl,
+} from './ShowBase.stories';
+
+describe('ShowBase', () => {
+    it('should load data immediately if authProvider is not provided', async () => {
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getOne: jest.fn(() =>
+                Promise.resolve({ data: { id: 12, test: 'Hello' } })
+            ),
+        });
+        render(<NoAuthProvider dataProvider={dataProvider} />);
+        expect(dataProvider.getOne).toHaveBeenCalled();
+        await screen.findByText('Hello');
+    });
+    it('should wait for the authentication resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getOne: jest.fn(() =>
+                Promise.resolve({ data: { id: 12, test: 'Hello' } })
+            ),
+        });
+        render(
+            <WithAuthProviderNoAccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getOne).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        await screen.findByText('Hello');
+    });
+    it('should wait for both the authentication and authorization resolution before loading data', async () => {
+        let resolveAuth: () => void;
+        let resolveCanAccess: (value: boolean) => void;
+        const authProvider = {
+            login: () => Promise.resolve(),
+            logout: () => Promise.resolve(),
+            checkError: () => Promise.resolve(),
+            checkAuth: () =>
+                new Promise<void>(resolve => {
+                    resolveAuth = resolve;
+                }),
+            canAccess: jest.fn(
+                () =>
+                    new Promise<boolean>(resolve => {
+                        resolveCanAccess = resolve;
+                    })
+            ),
+        };
+        const dataProvider = testDataProvider({
+            // @ts-ignore
+            getOne: jest.fn(() =>
+                Promise.resolve({ data: { id: 12, test: 'Hello' } })
+            ),
+        });
+        render(
+            <AccessControl
+                authProvider={authProvider}
+                dataProvider={dataProvider}
+            />
+        );
+        expect(dataProvider.getOne).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        resolveAuth!();
+        expect(dataProvider.getOne).not.toHaveBeenCalled();
+        await screen.findByText('Authentication loading...');
+        await waitFor(() => {
+            expect(authProvider.canAccess).toHaveBeenCalled();
+        });
+        resolveCanAccess!(true);
+        await screen.findByText('Hello');
+    });
+});

--- a/packages/ra-core/src/controller/show/ShowBase.stories.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.stories.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import {
+    AuthProvider,
+    CoreAdminContext,
+    ShowBase,
+    ShowBaseProps,
+    DataProvider,
+    testDataProvider,
+    useRecordContext,
+} from '../..';
+
+export default {
+    title: 'ra-core/controller/ShowBase',
+};
+
+export const NoAuthProvider = ({
+    dataProvider = defaultDataProvider,
+    ...props
+}: {
+    dataProvider?: DataProvider;
+} & Partial<ShowBaseProps>) => (
+    <CoreAdminContext dataProvider={dataProvider}>
+        <ShowBase {...defaultProps} {...props}>
+            <Child />
+        </ShowBase>
+    </CoreAdminContext>
+);
+
+export const WithAuthProviderNoAccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkError: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <ShowBase
+            {...defaultProps}
+            loading={<div>Authentication loading...</div>}
+        >
+            <Child />
+        </ShowBase>
+    </CoreAdminContext>
+);
+
+export const AccessControl = ({
+    authProvider = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        checkError: () => Promise.resolve(),
+        checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
+        canAccess: () => new Promise(resolve => setTimeout(resolve, 300, true)),
+    },
+    dataProvider = defaultDataProvider,
+}: {
+    authProvider?: AuthProvider;
+    dataProvider?: DataProvider;
+}) => (
+    <CoreAdminContext authProvider={authProvider} dataProvider={dataProvider}>
+        <ShowBase
+            {...defaultProps}
+            loading={<div>Authentication loading...</div>}
+        >
+            <Child />
+        </ShowBase>
+    </CoreAdminContext>
+);
+
+const defaultDataProvider = testDataProvider({
+    // @ts-ignore
+    getOne: () => Promise.resolve({ data: { id: 12, test: 'Hello' } }),
+});
+
+const defaultProps = {
+    id: 12,
+    resource: 'posts',
+};
+
+const Child = () => {
+    const record = useRecordContext();
+
+    return <p>{record?.test}</p>;
+};

--- a/packages/ra-core/src/controller/show/ShowBase.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.tsx
@@ -52,7 +52,8 @@ export const ShowBase = <RecordType extends RaRecord = any>({
     }
 
     return (
-        <OptionalResourceContextProvider value={controllerProps.resource}>
+        // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
+        <OptionalResourceContextProvider value={props.resource}>
             <ShowContextProvider value={controllerProps}>
                 {children}
             </ShowContextProvider>

--- a/packages/ra-core/src/core/CoreAdminRoutes.tsx
+++ b/packages/ra-core/src/core/CoreAdminRoutes.tsx
@@ -117,6 +117,7 @@ export const CoreAdminRoutes = (props: CoreAdminRoutesProps) => {
                                             <WithPermissions
                                                 authParams={defaultAuthParams}
                                                 component={dashboard}
+                                                loading={LoadingPage}
                                             />
                                         ) : (
                                             <NavigateToFirstResource

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ReactElement } from 'react';
 import {
     CreateBase,
-    CreateControllerProps,
+    CreateBaseProps,
     Identifier,
     RaRecord,
     useCheckMinimumRequiredProps,
@@ -70,6 +70,7 @@ export const Create = <
         disableAuthentication,
         hasEdit,
         hasShow,
+        loading = defaultLoading,
         ...rest
     } = props;
     return (
@@ -82,7 +83,7 @@ export const Create = <
             disableAuthentication={disableAuthentication}
             hasEdit={hasEdit}
             hasShow={hasShow}
-            loading={defaultLoading}
+            loading={loading}
         >
             <CreateView {...rest} />
         </CreateBase>
@@ -93,11 +94,7 @@ export interface CreateProps<
     RecordType extends Omit<RaRecord, 'id'> = any,
     MutationOptionsError = Error,
     ResultRecordType extends RaRecord = RecordType & { id: Identifier },
-> extends CreateControllerProps<
-            RecordType,
-            MutationOptionsError,
-            ResultRecordType
-        >,
-        CreateViewProps {}
+> extends CreateBaseProps<RecordType, ResultRecordType, MutationOptionsError>,
+        Omit<CreateViewProps, 'children'> {}
 
 const defaultLoading = <Loading />;

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -9,6 +9,7 @@ import {
 } from 'ra-core';
 
 import { CreateView, CreateViewProps } from './CreateView';
+import { Loading } from '../layout';
 
 /**
  * Page component for the Create view
@@ -81,6 +82,7 @@ export const Create = <
             disableAuthentication={disableAuthentication}
             hasEdit={hasEdit}
             hasShow={hasShow}
+            loading={defaultLoading}
         >
             <CreateView {...rest} />
         </CreateBase>
@@ -97,3 +99,5 @@ export interface CreateProps<
             ResultRecordType
         >,
         CreateViewProps {}
+
+const defaultLoading = <Loading />;

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -6,6 +6,7 @@ import {
     EditControllerProps,
 } from 'ra-core';
 import { EditView, EditViewProps } from './EditView';
+import { Loading } from '../layout';
 
 /**
  * Page component for the Edit view
@@ -77,6 +78,7 @@ export const Edit = <RecordType extends RaRecord = any>(
             redirect={redirect}
             transform={transform}
             disableAuthentication={disableAuthentication}
+            loading={defaultLoading}
         >
             <EditView {...rest} />
         </EditBase>
@@ -86,3 +88,5 @@ export const Edit = <RecordType extends RaRecord = any>(
 export interface EditProps<RecordType extends RaRecord = any, ErrorType = Error>
     extends EditControllerProps<RecordType, ErrorType>,
         EditViewProps {}
+
+const defaultLoading = <Loading />;

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -3,7 +3,7 @@ import {
     EditBase,
     useCheckMinimumRequiredProps,
     RaRecord,
-    EditControllerProps,
+    EditBaseProps,
 } from 'ra-core';
 import { EditView, EditViewProps } from './EditView';
 import { Loading } from '../layout';
@@ -66,6 +66,7 @@ export const Edit = <RecordType extends RaRecord = any>(
         redirect,
         transform,
         disableAuthentication,
+        loading = defaultLoading,
         ...rest
     } = props;
     return (
@@ -78,7 +79,7 @@ export const Edit = <RecordType extends RaRecord = any>(
             redirect={redirect}
             transform={transform}
             disableAuthentication={disableAuthentication}
-            loading={defaultLoading}
+            loading={loading}
         >
             <EditView {...rest} />
         </EditBase>
@@ -86,7 +87,7 @@ export const Edit = <RecordType extends RaRecord = any>(
 };
 
 export interface EditProps<RecordType extends RaRecord = any, ErrorType = Error>
-    extends EditControllerProps<RecordType, ErrorType>,
-        EditViewProps {}
+    extends EditBaseProps<RecordType, ErrorType>,
+        Omit<EditViewProps, 'children'> {}
 
 const defaultLoading = <Loading />;

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ReactElement } from 'react';
 import { ShowBase, RaRecord, ShowControllerProps } from 'ra-core';
 import { ShowView, ShowViewProps } from './ShowView';
+import { Loading } from '../layout';
 
 /**
  * Page component for the Show view
@@ -67,6 +68,7 @@ export const Show = <RecordType extends RaRecord = any>({
         disableAuthentication={disableAuthentication}
         queryOptions={queryOptions}
         resource={resource}
+        loading={defaultLoading}
     >
         <ShowView {...rest} />
     </ShowBase>
@@ -75,3 +77,5 @@ export const Show = <RecordType extends RaRecord = any>({
 export interface ShowProps<RecordType extends RaRecord = any>
     extends ShowControllerProps<RecordType>,
         ShowViewProps {}
+
+const defaultLoading = <Loading />;

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import { ShowBase, RaRecord, ShowControllerProps } from 'ra-core';
+import { ShowBase, RaRecord, ShowBaseProps } from 'ra-core';
 import { ShowView, ShowViewProps } from './ShowView';
 import { Loading } from '../layout';
 
@@ -61,6 +61,7 @@ export const Show = <RecordType extends RaRecord = any>({
     resource,
     queryOptions,
     disableAuthentication,
+    loading = defaultLoading,
     ...rest
 }: ShowProps<RecordType>): ReactElement => (
     <ShowBase<RecordType>
@@ -68,14 +69,14 @@ export const Show = <RecordType extends RaRecord = any>({
         disableAuthentication={disableAuthentication}
         queryOptions={queryOptions}
         resource={resource}
-        loading={defaultLoading}
+        loading={loading}
     >
         <ShowView {...rest} />
     </ShowBase>
 );
 
 export interface ShowProps<RecordType extends RaRecord = any>
-    extends ShowControllerProps<RecordType>,
-        ShowViewProps {}
+    extends ShowBaseProps<RecordType>,
+        Omit<ShowViewProps, 'children'> {}
 
 const defaultLoading = <Loading />;

--- a/packages/ra-ui-materialui/src/list/InfiniteList.tsx
+++ b/packages/ra-ui-materialui/src/list/InfiniteList.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import {
-    InfiniteListBase,
-    InfiniteListControllerProps,
-    RaRecord,
-} from 'ra-core';
+import { InfiniteListBase, InfiniteListBaseProps, RaRecord } from 'ra-core';
 
 import { InfinitePagination } from './pagination';
 import { ListView, ListViewProps } from './ListView';
@@ -70,6 +66,7 @@ export const InfiniteList = <RecordType extends RaRecord = any>({
     exporter,
     filter = defaultFilter,
     filterDefaultValues,
+    loading = defaultLoading,
     pagination = defaultPagination,
     perPage = 10,
     queryOptions,
@@ -85,7 +82,7 @@ export const InfiniteList = <RecordType extends RaRecord = any>({
         exporter={exporter}
         filter={filter}
         filterDefaultValues={filterDefaultValues}
-        loading={defaultLoading}
+        loading={loading}
         perPage={perPage}
         queryOptions={queryOptions}
         resource={resource}
@@ -101,5 +98,5 @@ const defaultFilter = {};
 const defaultLoading = <Loading />;
 
 export interface InfiniteListProps<RecordType extends RaRecord = any>
-    extends InfiniteListControllerProps<RecordType>,
+    extends InfiniteListBaseProps<RecordType>,
         ListViewProps {}

--- a/packages/ra-ui-materialui/src/list/InfiniteList.tsx
+++ b/packages/ra-ui-materialui/src/list/InfiniteList.tsx
@@ -8,6 +8,7 @@ import {
 
 import { InfinitePagination } from './pagination';
 import { ListView, ListViewProps } from './ListView';
+import { Loading } from '../layout';
 
 /**
  * Infinite List page component
@@ -84,6 +85,7 @@ export const InfiniteList = <RecordType extends RaRecord = any>({
         exporter={exporter}
         filter={filter}
         filterDefaultValues={filterDefaultValues}
+        loading={defaultLoading}
         perPage={perPage}
         queryOptions={queryOptions}
         resource={resource}
@@ -96,6 +98,7 @@ export const InfiniteList = <RecordType extends RaRecord = any>({
 
 const defaultPagination = <InfinitePagination />;
 const defaultFilter = {};
+const defaultLoading = <Loading />;
 
 export interface InfiniteListProps<RecordType extends RaRecord = any>
     extends InfiniteListControllerProps<RecordType>,

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import { ListBase, ListControllerProps, RaRecord } from 'ra-core';
+import { ListBase, ListBaseProps, RaRecord } from 'ra-core';
 
 import { ListView, ListViewProps } from './ListView';
 import { Loading } from '../layout';
@@ -62,6 +62,7 @@ export const List = <RecordType extends RaRecord = any>({
     exporter,
     filter = defaultFilter,
     filterDefaultValues,
+    loading = defaultLoading,
     perPage = 10,
     queryOptions,
     resource,
@@ -76,7 +77,7 @@ export const List = <RecordType extends RaRecord = any>({
         exporter={exporter}
         filter={filter}
         filterDefaultValues={filterDefaultValues}
-        loading={defaultLoading}
+        loading={loading}
         perPage={perPage}
         queryOptions={queryOptions}
         resource={resource}
@@ -88,7 +89,7 @@ export const List = <RecordType extends RaRecord = any>({
 );
 
 export interface ListProps<RecordType extends RaRecord = any>
-    extends ListControllerProps<RecordType>,
+    extends ListBaseProps<RecordType>,
         ListViewProps {}
 
 const defaultFilter = {};

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import { ListBase, ListControllerProps, RaRecord } from 'ra-core';
 
 import { ListView, ListViewProps } from './ListView';
+import { Loading } from '../layout';
 
 /**
  * List page component
@@ -75,6 +76,7 @@ export const List = <RecordType extends RaRecord = any>({
         exporter={exporter}
         filter={filter}
         filterDefaultValues={filterDefaultValues}
+        loading={defaultLoading}
         perPage={perPage}
         queryOptions={queryOptions}
         resource={resource}
@@ -90,3 +92,4 @@ export interface ListProps<RecordType extends RaRecord = any>
         ListViewProps {}
 
 const defaultFilter = {};
+const defaultLoading = <Loading />;


### PR DESCRIPTION
## Problem

All CRUD views currently starts to render optimistically even though authentication and optionally authorization checks are pending. This is a security issue.

## Solution

Make sure the base components for all CRUD views verify that no auth checks are pending before rendering.
Introduce a loading prop accepting a ReactNode on those components that is displayed while auth checks are pending.

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date
