### PR TITLE
Support 'labelRowsPerPage' prop on Pagination

### DIFF
--- a/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
@@ -136,7 +136,10 @@ export const Pagination: FC<PaginationProps> = memo(props => {
                 disabled: !hasNextPage,
             }}
             component="span"
-            labelRowsPerPage={labelRowsPerPage ?? translate('ra.navigation.page_rows_per_page')}
+            labelRowsPerPage={
+                labelRowsPerPage ??
+                translate('ra.navigation.page_rows_per_page')
+            }
             labelDisplayedRows={labelDisplayedRows}
             getItemAriaLabel={labelItem}
             rowsPerPageOptions={rowsPerPageOptions}

--- a/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/Pagination.tsx
@@ -20,6 +20,7 @@ export const Pagination: FC<PaginationProps> = memo(props => {
         rowsPerPageOptions = DefaultRowsPerPageOptions,
         actions,
         limit = null,
+        labelRowsPerPage,
         ...rest
     } = props;
     const {
@@ -135,7 +136,7 @@ export const Pagination: FC<PaginationProps> = memo(props => {
                 disabled: !hasNextPage,
             }}
             component="span"
-            labelRowsPerPage={translate('ra.navigation.page_rows_per_page')}
+            labelRowsPerPage={labelRowsPerPage ?? translate('ra.navigation.page_rows_per_page')}
             labelDisplayedRows={labelDisplayedRows}
             getItemAriaLabel={labelItem}
             rowsPerPageOptions={rowsPerPageOptions}
@@ -151,4 +152,5 @@ export interface PaginationProps extends TablePaginationBaseProps {
     rowsPerPageOptions?: Array<number | { label: string; value: number }>;
     actions?: FC<PaginationActionsProps>;
     limit?: ReactElement;
+    labelRowsPerPage?: string;
 }


### PR DESCRIPTION
I have a use case where I do not want to use the translated text but a conditionally different one.

## Problem

I have a calendar and want to restrict the number of events per month on each call, so I need pagination on that "List" (that just uses a calendar). So, I do not want the pagination label to be called **"Rows per page"** there but rather "Events Shown on Calendar".

I cannot do this as the code is now.

![image](https://github.com/user-attachments/assets/1882b8dd-644a-4c2b-9d95-cbe39c0fb1e4)


## Solution

Support the 'labelRowsPerPage' as a prop that we can use it.

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
