### PR TITLE
Fix pnpm error Module not found: Can't resolve '@mui/utils'

### DIFF
--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -28,6 +28,7 @@
     "devDependencies": {
         "@mui/icons-material": "^5.15.20",
         "@mui/material": "^5.15.20",
+        "@mui/utils": "^5.15.20",
         "@testing-library/react": "^15.0.7",
         "@types/dompurify": "^3.0.2",
         "@types/react": "^18.3.3",
@@ -54,6 +55,7 @@
     "peerDependencies": {
         "@mui/icons-material": "^5.15.20",
         "@mui/material": "^5.15.20",
+        "@mui/utils": "^5.15.20",
         "ra-core": "^5.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17599,6 +17599,7 @@ __metadata:
   dependencies:
     "@mui/icons-material": "npm:^5.15.20"
     "@mui/material": "npm:^5.15.20"
+    "@mui/utils": "npm:^5.15.20"
     "@tanstack/react-query": "npm:^5.8.4"
     "@testing-library/react": "npm:^15.0.7"
     "@types/dompurify": "npm:^3.0.2"
@@ -17637,6 +17638,7 @@ __metadata:
   peerDependencies:
     "@mui/icons-material": ^5.15.20
     "@mui/material": ^5.15.20
+    "@mui/utils": ^5.15.20
     ra-core: ^5.0.0
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0


### PR DESCRIPTION
## Problem

Fixes #10260

`@mui/utils` is used here https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/theme/defaultTheme.ts#L2

But it is not explicitly declared as peerDependency here https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/package.json#L54

## Solution

Explicitly declare it as peerDependency

## How To Test

Add a dependency on react-admin using pnpm 9.3.0

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
