### PR TITLE
Hide `<AutoCompleteInput>` "Create" option for empty input

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -357,29 +357,38 @@ export const CreateLabel = () => (
     <Wrapper>
         <AutocompleteInput
             source="author"
-            choices={[
-                { id: 1, name: 'Leo Tolstoy' },
-                { id: 2, name: 'Victor Hugo' },
-                { id: 3, name: 'William Shakespeare' },
-                { id: 4, name: 'Charles Baudelaire' },
-                { id: 5, name: 'Marcel Proust' },
-            ]}
+            choices={choicesForCreationSupport}
             onCreate={filter => {
-                const newAuthorName = window.prompt(
-                    'Enter a new author',
-                    filter
-                );
+                if (!filter) return;
 
-                if (newAuthorName) {
-                    const newAuthor = {
-                        id: choicesForCreationSupport.length + 1,
-                        name: newAuthorName,
-                    };
-                    choicesForCreationSupport.push(newAuthor);
-                    return newAuthor;
-                }
+                const newOption = {
+                    id: choicesForCreationSupport.length + 1,
+                    name: filter,
+                };
+                choicesForCreationSupport.push(newOption);
+                return newOption;
             }}
             createLabel="Start typing to create a new item"
+        />
+    </Wrapper>
+);
+
+export const CreateItemLabel = () => (
+    <Wrapper>
+        <AutocompleteInput
+            source="author"
+            choices={choicesForCreationSupport}
+            onCreate={filter => {
+                if (!filter) return;
+
+                const newOption = {
+                    id: choicesForCreationSupport.length + 1,
+                    name: filter,
+                };
+                choicesForCreationSupport.push(newOption);
+                return newOption;
+            }}
+            createItemLabel="Add a new author: %{item}"
         />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -133,7 +133,7 @@ export const AutocompleteInput = <
         closeText = 'ra.action.close',
         create,
         createLabel,
-        createItemLabel,
+        createItemLabel = 'ra.action.create_item',
         createValue,
         debounce: debounceDelay = 250,
         defaultValue,
@@ -465,7 +465,13 @@ If you provided a React element for the optionText prop, you must also provide t
             event?.type === 'change' ||
             !doesQueryMatchSelection(newInputValue)
         ) {
-            setFilterValue(newInputValue);
+            const createOptionLabel = translate(createItemLabel, {
+                item: filterValue,
+                _: createItemLabel,
+            });
+            const isCreate = newInputValue === createOptionLabel;
+            const valueToSet = isCreate ? filterValue : newInputValue;
+            setFilterValue(valueToSet);
             debouncedSetFilter(newInputValue);
         }
         if (reason === 'clear') {
@@ -513,7 +519,7 @@ If you provided a React element for the optionText prop, you must also provide t
         // add create option if necessary
         const { inputValue } = params;
         if (onCreate || create) {
-            if (inputValue === '') {
+            if (inputValue === '' && createLabel) {
                 // create option with createLabel
                 filteredOptions = filteredOptions.concat(getCreateItem(''));
             } else if (!doesQueryMatchSuggestion(filterValue)) {


### PR DESCRIPTION
## Problem

The “create option on-the-fly” UI of Autocomplete inputs is confusing. I can create an option with "" as value.
Fixes #10043

## Solution

- [x] Don’t display “Create” on the input unless the user types something
- [x] Fix the brief flash of `Create xxx` -> `xxx`

## How To Test

- run `ONLY=ra-ui-materialui make storybook`
- go to `http://localhost:9010/?path=/story/ra-ui-materialui-input-autocompleteinput--on-create`
- clear the input and see that you cannot create an empty option

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
~- [ ] The PR includes one or several **stories** (if not possible, describe why)~
~- [ ] The **documentation** is up to date~

## Screencasts

Before flash fix:
[Capture vidéo du 2024-09-25 19-42-25.webm](https://github.com/user-attachments/assets/824e9575-9473-4dff-8663-f06d8d4d6f1d)
After:
[Capture vidéo du 2024-09-25 19-43-16.webm](https://github.com/user-attachments/assets/12f1c759-60f6-4f12-90a9-2d7aa8fcaf7e)