### PR TITLE
 [Fix] Add replace prop to <Navigate> in NavigateToFirstResource 

### DIFF
--- a/packages/ra-core/src/core/NavigateToFirstResource.tsx
+++ b/packages/ra-core/src/core/NavigateToFirstResource.tsx
@@ -25,6 +25,7 @@ export const NavigateToFirstResource = ({
                     resource,
                     type: 'list',
                 })}
+                replace={true}
             />
         );
     }


### PR DESCRIPTION
## Problem

This PR addresses issue #10262 with navigation in the React Admin application, where users experience redirect loops when transitioning from the admin panel to the first resource.

## Solution

The solution involves adding the `replace={true}` prop to the `<Navigate>` component in the `NavigateToFirstResource`. This change ensures that the navigation history is correctly updated, allowing users to return to their previous page without being redirected again.

Closes #10262

## How To Test

1. Navigate to the non-RA part of the application.
2. Go to the /admin path.
3. Verify that navigating back returns you to the previous page without redirects to the first resource.

## Additional Checks

- [x] The PR targets `next` for a bugfix.
- [ ] The PR includes **unit tests** (not included as this change pertains to routing behavior, which is not easily testable with unit tests)
- [ ] The PR includes one or several **stories** (not applicable, as this change does not require new stories)
- [ ] The **documentation** is up to date.
