### PR TITLE
Add support for embedding and prefetching

### DIFF
--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -514,7 +514,7 @@ const dataProvider = {
         if (params.meta?.embed) {
             query += `?_embed=${params.meta.embed.join(',')}`;
         }
-        const data = await httpClient(query);
+        const { json: data } = await httpClient(query);
         return { data };
     },
     // ...
@@ -579,7 +579,7 @@ const dataProvider = {
         if (params.meta?.prefetch) {
             query += `?_embed=${params.meta.prefetch.join(',')}`;
         }
-        const data = await httpClient(query);
+        const { json: data } = await httpClient(query);
         const prefetched = {};
         if (params.meta?.prefetch) {
             params.meta.prefetch.forEach(name => {

--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -502,7 +502,7 @@ For example, the [JSON server](https://github.com/typicode/json-server?tab=readm
 GET /posts/123?_embed=author
 ```
 
-The JSON Server Data Provider therefore passes the `meta.embed` query parameter to the API:
+The [JSON Server Data Provider](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-json-server) therefore passes the `meta.embed` query parameter to the API:
 
 ```tsx
 const apiUrl = 'https://my.api.com/';
@@ -570,7 +570,7 @@ GET /posts/123?_embed=author
 }
 ```
 
-To add support for prefetching, the JSON Server Data Provider extracts the embedded data from the response, and puts them in the `meta.prefetched` property:
+To add support for prefetching, the [JSON Server Data Provider](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-json-server) extracts the embedded data from the response, and puts them in the `meta.prefetched` property:
 
 ```jsx
 const dataProvider = {
@@ -680,7 +680,7 @@ This will cause the Edit view to blink on load. If you have this problem, modify
 const { data } = dataProvider.getOne('posts', { id: 123, meta: { page: 'getOne' } })
 ```
 
-This also explains why using [Embedded relationships](./DataProviders.md#emb$) may make the navigation slower, as the `getList` and `getOne` methods will return different shapes.
+This also explains why using [Embedding relationships](./DataProviders.md#embedding-relationships) may make the navigation slower, as the `getList` and `getOne` methods will return different shapes.
 
 ## `fetchJson`: Built-In HTTP Client
 

--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -672,7 +672,15 @@ const { data } = dataProvider.getOne('posts', { id: 123 })
 // }
 ```
 
-This will cause the Edit view to blink on load. If you have this problem, modify your Data Provider to return the same shape for all methods. 
+This will cause the Edit view to blink on load. If you have this problem, modify your Data Provider to return the same shape for all methods.
+
+**Note**: If the `getList` and `getOne` methods user different `meta` parameters, they won't share the cache. You can use this as an escape hatch to avoid flickering in the Edit view.
+
+```jsx
+const { data } = dataProvider.getOne('posts', { id: 123, meta: { page: 'getOne' } })
+```
+
+This also explains why using [Embedded relationships](./DataProviders.md#emb$) may make the navigation slower, as the `getList` and `getOne` methods will return different shapes.
 
 ## `fetchJson`: Built-In HTTP Client
 

--- a/docs/DataProviderWriting.md
+++ b/docs/DataProviderWriting.md
@@ -674,7 +674,7 @@ const { data } = dataProvider.getOne('posts', { id: 123 })
 
 This will cause the Edit view to blink on load. If you have this problem, modify your Data Provider to return the same shape for all methods.
 
-**Note**: If the `getList` and `getOne` methods user different `meta` parameters, they won't share the cache. You can use this as an escape hatch to avoid flickering in the Edit view.
+**Note**: If the `getList` and `getOne` methods use different `meta` parameters, they won't share the cache. You can use this as an escape hatch to avoid flickering in the Edit view.
 
 ```jsx
 const { data } = dataProvider.getOne('posts', { id: 123, meta: { page: 'getOne' } })

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -295,7 +295,7 @@ GET /posts/123?embed=author
 Data providers implementing this feature often use the `meta` key in the query parameters to pass the embed parameter to the API.
 
 ```jsx
-const { data } = useGetOne('posts', { id: 123, meta: { embed: 'author' } });
+const { data } = useGetOne('posts', { id: 123, meta: { embed: ['author'] } });
 ```
 
 Leveraging embeds can reduce the number of requests made by react-admin to the API, and thus improve the app's performance.
@@ -306,7 +306,7 @@ For example, this allows you to display data from a related resource without mak
 ```diff
 const PostList = () => (
 -   <List>
-+   <List queryOptions={{ meta: { embed: "author" } }}>
++   <List queryOptions={{ meta: { embed: ["author"] } }}>
         <Datagrid>
             <TextField source="title" />
 -           <ReferenceField source="author_id" reference="authors>
@@ -327,6 +327,11 @@ Refer to your data provider's documentation to verify if it supports this featur
 
 Some API backends can return related records in the same response as the main record. For instance, an API may return a post and its author in a single response:
 
+
+```jsx
+const { data, meta } = useGetOne('posts', { id: 123, meta: { prefetch: ['author']} });
+```
+
 ```json
 {
     "data": {
@@ -344,19 +349,14 @@ Some API backends can return related records in the same response as the main re
 
 This is called *prefetching* or *preloading*.
 
-React-admin can use this feature to populate its cache with related records, and avoid subsequent requests to the API. The prefetched records must be returned un the `meta.prefetched` key of the data provider response.
-
-```jsx
-const { data, meta } = useGetOne('posts', { id: 123 });
-console.log(meta.prefetched.authors); // [{ id: 456, name: "John Doe" }]
-```
+React-admin can use this feature to populate its cache with related records, and avoid subsequent requests to the API. The prefetched records must be returned in the `meta.prefetched` key of the data provider response.
 
 For example, you can use prefetching to display the author's name in a post list without making an additional request:
 
 {% raw %}
 ```jsx
 const PostList = () => (
-    <List queryOptions={{ meta: { prefetch: 'author' }}}>
+    <List queryOptions={{ meta: { prefetch: ['author'] }}}>
         <Datagrid>
             <TextField source="title" />
             {/** renders without an additional request */}
@@ -367,7 +367,7 @@ const PostList = () => (
 ```
 {% endraw %}
 
-The way to *ask* for embedded resources isn't normalized and depends on the API. The above example uses the `meta.prefetch` quert parameter. Some APIs may use [the `embed` query parameter](#embedding-relationships) to indicate that the author must be added to the response.
+The way to *ask* for embedded resources isn't normalized and depends on the API. The above example uses the `meta.prefetch` query parameter. Some APIs may use [the `embed` query parameter](#embedding-relationships) to indicate prefetching.
 
  Refer to your data provider's documentation to verify if it supports prefetching. If you're writing your own data provider, check the [Writing a Data Provider](./DataProviderWriting.md#embedded-data) documentation for more details.
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -309,6 +309,7 @@ const { data } = useGetOne('authors', { id: 456 });
 
 This feature allow you to prefetch related records by passing a custom query parameter:
 
+{% raw %}
 ```jsx
 const PostList = () => (
     <List queryOptions={{ meta: { embed: 'author' } }}>
@@ -320,6 +321,7 @@ const PostList = () => (
     </List>
 );
 ```
+{% endraw %}
 
 The way to *ask* for embedded resources isn't normalized and depends on the API. For example, `ra-data-fakerest` uses a `meta: { embed }` key in the query to indicate that the author must be embedded.
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -284,7 +284,7 @@ GET /posts/123?embed=author
 {
     "id": 123,
     "title": "Hello, world",
-    "authorId": 456,
+    "author_id": 456,
     "author": {
         "id": 456,
         "name": "John Doe"
@@ -296,7 +296,7 @@ In such cases, the data provider response should put the related record(s) in th
 
 ```jsx
 const { data, meta } = dataProvider.getOne('posts', { id: 123 })
-console.log(data); // { id: 123, title: "Hello, world", authorId: 456 }
+console.log(data); // { id: 123, title: "Hello, world", author_id: 456 }
 console.log(meta._embed); // { authors: [{ id: 456, name: "John Doe" }] }
 ```
 
@@ -307,8 +307,6 @@ const { data } = useGetOne('authors', { id: 456 });
 // will return immediately with the author data, without making a network request
 ```
 
-The way to *ask* for embedded resources isn't normalized and depends on the API. For example, `ra-data-fakerest` uses a `meta: { embed }` key in the query to indicate that the author must be embedded.
-
 This feature allow you to prefetch related records by passing a custom query parameter:
 
 ```jsx
@@ -317,11 +315,15 @@ const PostList = () => (
         <Datagrid>
             <TextField source="title" />
             {/** renders without an additional request */}
-            <ReferenceField source="authorId" />
+            <ReferenceField source="author_id" />
         </Datagrid>
     </List>
 );
 ```
+
+The way to *ask* for embedded resources isn't normalized and depends on the API. For example, `ra-data-fakerest` uses a `meta: { embed }` key in the query to indicate that the author must be embedded.
+
+ Refer to your data provider's documentation to verify if this feature is supported. If you're writing your own data provider, check the [Writing a Data Provider](./DataProviderWriting.md#embedded-data) documentation for more details.
 
 ## Adding Lifecycle Callbacks
 

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -314,8 +314,11 @@ This feature allow you to prefetch related records by passing a custom query par
 ```jsx
 const PostList = () => (
     <List queryOptions={{ meta: { embed: 'author' } }}>
-        <TextField source="title" />
-        <ReferenceField source="authorId" /> {/** renders without an additional request */}
+        <Datagrid>
+            <TextField source="title" />
+            {/** renders without an additional request */}
+            <ReferenceField source="authorId" />
+        </Datagrid>
     </List>
 );
 ```

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -851,6 +851,7 @@ React-admin takes advantage of the Single-Page-Application architecture, impleme
 - **Query Deduplication**: React-admin identifies instances where multiple components on a page call the same data provider query for identical data. In such cases, it ensures only a single call to the data provider is made.
 - **Query Aggregation**: React-admin intercepts all calls to `dataProvider.getOne()` for related data when a `<ReferenceField>` is used in a list. It aggregates and deduplicates the requested ids, and issues a single `dataProvider.getMany()` request. This technique effectively addresses the n+1 query problem, reduces server queries, and accelerates list view rendering.
 - **Opt-In Query Cache**: React-admin provides an option to prevent refetching an API endpoint for a specified duration, which can be used when you're confident that the API response will remain consistent over time.
+- **Embedded Data** and **Prefetching**: Data providers can return data from related resources in the same response as the requested resource. React-admin uses this feature to avoid additional network requests and to display related data immediately.
 
 ## Undo
 

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -325,6 +325,12 @@ Then you can render the author name like this:
 <TextField source="author.name" />
 ```
 
+This is particularly handy if your data provider supports [Relationship Embedding](./DataProviders.md#embedding-relationships).
+
+```jsx
+const { data } = useGetOne('posts', { id: 123, meta: { embed: ['author'] } });
+```
+
 ## Setting A Field Label
 
 <iframe src="https://www.youtube-nocookie.com/embed/fWc7c0URQMQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="aspect-ratio: 16 / 9;width:100%;margin-bottom:1em;"></iframe>

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -259,7 +259,7 @@ const PostList = () => (
 
 **Note**: For prefetching to function correctly, your data provider must support [Relationships Embedding](./DataProviders.md#embedding-relationships). Refer to your data provider's documentation to verify if this feature is supported.
 
-**Note**: Prefetching is only useful the first time a record is fetched. After that, [react-admin's internal cache](./Features.md#fast) and the Stale-While-Revalidate policy makes it useless. For instance, if a user displays a post list, react-admin prefills the cache for the show view of each post. So when the user clicks on a post to display its show view, the page will display immediately, without waiting for the getOne call to complete.
+**Note**: Prefetching is a frontend performance feature, designed to avoid flickers and repaints. It doesn't always prevent `<ReferenceField>` to fetch the data. For instance, when coming to a show view from a list view, the main record is already in the cache, so the page renders immediately, and both the page controller and the `<ReferenceField>` controller fetch the data in parallel. The embedded data from the page controller arrives after the first render of the `<ReferenceField>`, so the data provider fetches the related data anyway. But from a user perspective, the page displays immediately, including the `<ReferenceField>`.
 
 ## Rendering More Than One Field
 

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -243,6 +243,7 @@ When you know that a page will contain a `<ReferenceField>`, you can configure t
 
 For example, the following code prefetches the authors referenced by the posts:
 
+{% raw %}
 ```jsx
 const PostList = () => (
     <List queryOptions={{ meta: { embed: 'author' } }}>
@@ -254,6 +255,7 @@ const PostList = () => (
     </List>
 );
 ```
+{% endraw %}
 
 **Note**: For prefetching to function correctly, your data provider must support [Relationships Embedding](./DataProviders.md#embedding-relationships). Refer to your data provider's documentation to verify if this feature is supported.
 

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -239,14 +239,14 @@ Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField
 
 ## Prefetching
 
-When you know that a page will contain a `<ReferenceField>`, you can configure the main page query to prefetch the referenced records to avoid a flicker when the data arrives. To do so, pass a `meta` parameter to the page query to enable relationship embedding.
+When you know that a page will contain a `<ReferenceField>`, you can configure the main page query to prefetch the referenced records to avoid a flicker when the data arrives. To do so, pass a `meta.prefetch` parameter to the page query.
 
 For example, the following code prefetches the authors referenced by the posts:
 
 {% raw %}
 ```jsx
 const PostList = () => (
-    <List queryOptions={{ meta: { embed: 'author' } }}>
+    <List queryOptions={{ meta: { prefetch: ['author'] } }}>
         <Datagrid>
             <TextField source="title" />
             {/** renders without an additional request */}
@@ -257,9 +257,9 @@ const PostList = () => (
 ```
 {% endraw %}
 
-**Note**: For prefetching to function correctly, your data provider must support [Relationships Embedding](./DataProviders.md#embedding-relationships). Refer to your data provider's documentation to verify if this feature is supported.
+**Note**: For prefetching to function correctly, your data provider must support [Prefetching Relationships](./DataProviders.md#prefetching-relationships). Refer to your data provider's documentation to verify if this feature is supported.
 
-**Note**: Prefetching is a frontend performance feature, designed to avoid flickers and repaints. It doesn't always prevent `<ReferenceField>` to fetch the data. For instance, when coming to a show view from a list view, the main record is already in the cache, so the page renders immediately, and both the page controller and the `<ReferenceField>` controller fetch the data in parallel. The embedded data from the page controller arrives after the first render of the `<ReferenceField>`, so the data provider fetches the related data anyway. But from a user perspective, the page displays immediately, including the `<ReferenceField>`.
+**Note**: Prefetching is a frontend performance feature, designed to avoid flickers and repaints. It doesn't always prevent `<ReferenceField>` to fetch the data. For instance, when coming to a show view from a list view, the main record is already in the cache, so the page renders immediately, and both the page controller and the `<ReferenceField>` controller fetch the data in parallel. The prefetched data from the page controller arrives after the first render of the `<ReferenceField>`, so the data provider fetches the related data anyway. But from a user perspective, the page displays immediately, including the `<ReferenceField>`. If you want to avoid the `<ReferenceField>` to fetch the data, you can use the React Query Client's `staleTime` option.
 
 ## Rendering More Than One Field
 

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -237,6 +237,28 @@ React-admin accumulates and deduplicates the ids of the referenced records to ma
 
 Then react-admin renders the `<PostList>` with a loader for the `<ReferenceField>`, fetches the API for the related users in one call (`dataProvider.getMany('users', { ids: [789,735] }`), and re-renders the list once the data arrives. This accelerates the rendering and minimizes network load.
 
+## Prefetching
+
+When you know that a page will contain a `<ReferenceField>`, you can configure the main page query to prefetch the referenced records to avoid a flicker when the data arrives. To do so, pass a `meta` parameter to the page query to enable relationship embedding.
+
+For example, the following code prefetches the authors referenced by the posts:
+
+```jsx
+const PostList = () => (
+    <List queryOptions={{ meta: { embed: 'author' } }}>
+        <Datagrid>
+            <TextField source="title" />
+            {/** renders without an additional request */}
+            <ReferenceField source="author_id" />
+        </Datagrid>
+    </List>
+);
+```
+
+**Note**: For prefetching to function correctly, your data provider must support [Relationships Embedding](./DataProviders.md#embedding-relationships). Refer to your data provider's documentation to verify if this feature is supported.
+
+**Note**: Prefetching is only useful the first time a record is fetched. After that, [react-admin's internal cache](./Features.md#fast) and the Stale-While-Revalidate policy makes it useless. For instance, if a user displays a post list, react-admin prefills the cache for the show view of each post. So when the user clicks on a post to display its show view, the page will display immediately, without waiting for the getOne call to complete.
+
 ## Rendering More Than One Field
 
 You often need to render more than one field of the reference table (e.g. if the `users` table has a `first_name` and a `last_name` field).

--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -148,7 +148,11 @@ const CommentMobileList = () => (
 );
 
 const CommentList = () => (
-    <ListBase perPage={6} exporter={exporter}>
+    <ListBase
+        perPage={6}
+        exporter={exporter}
+        queryOptions={{ meta: { embed: 'post' } }}
+    >
         <ListView />
     </ListBase>
 );

--- a/examples/simple/src/comments/CommentList.tsx
+++ b/examples/simple/src/comments/CommentList.tsx
@@ -151,7 +151,7 @@ const CommentList = () => (
     <ListBase
         perPage={6}
         exporter={exporter}
-        queryOptions={{ meta: { embed: 'post' } }}
+        queryOptions={{ meta: { prefetch: ['post'] } }}
     >
         <ListView />
     </ListBase>

--- a/examples/simple/src/comments/CommentShow.tsx
+++ b/examples/simple/src/comments/CommentShow.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
 const CommentShow = () => (
-    <Show>
+    <Show queryOptions={{ meta: { embed: 'post' } }}>
         <SimpleShowLayout>
             <TextField source="id" />
             <ReferenceField source="post_id" reference="posts">

--- a/examples/simple/src/comments/CommentShow.tsx
+++ b/examples/simple/src/comments/CommentShow.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
 const CommentShow = () => (
-    <Show queryOptions={{ meta: { embed: 'post' } }}>
+    <Show queryOptions={{ meta: { prefetch: ['post'] } }}>
         <SimpleShowLayout>
             <TextField source="id" />
             <ReferenceField source="post_id" reference="posts">

--- a/examples/simple/src/dataProvider.tsx
+++ b/examples/simple/src/dataProvider.tsx
@@ -32,7 +32,7 @@ const addTagsSearchSupport = (dataProvider: DataProvider) => ({
             // partial pagination
             return dataProvider
                 .getList(resource, params)
-                .then(({ data, total }) => ({
+                .then(({ data, total, meta }) => ({
                     data,
                     pageInfo: {
                         hasNextPage:
@@ -40,6 +40,7 @@ const addTagsSearchSupport = (dataProvider: DataProvider) => ({
                             (total || 0),
                         hasPreviousPage: params.pagination.page > 1,
                     },
+                    meta,
                 }));
         }
         if (resource === 'tags') {

--- a/packages/ra-core/src/dataProvider/populateQueryCache.ts
+++ b/packages/ra-core/src/dataProvider/populateQueryCache.ts
@@ -1,0 +1,47 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+export type PopulateQueryCacheOptions = {
+    data: Record<string, any[]>;
+    queryClient: QueryClient;
+    staleTime?: number;
+};
+
+/**
+ * Populate react-query's query cache with a data dictionnary
+ * @example
+ * const data = {
+ *    posts: [{ id: 1, title: 'Hello, world' }, { id: 2, title: 'FooBar' }],
+ *    comments: [{ id: 1, post_id: 1, body: 'Nice post!' }],
+ * };
+ * populateQueryCache({ data, queryClient });
+ * // setQueryData(['posts', 'getOne', { id: '1' }], { id: 1, title: 'Hello, world' });
+ * // setQueryData(['posts', 'getOne', { id: '2' }], { id: 2, title: 'FooBar' });
+ * // setQueryData(['posts', 'getMany', { ids: ['1', '2'] }], [{ id: 1, title: 'Hello, world' }, { id: 2, title: 'FooBar' }]);
+ * // setQueryData(['comments', 'getOne', { id: '1' }], { id: 1, post_id: 1, body: 'Nice post!' });
+ * // setQueryData(['comments', 'getMany', { ids: ['1'] }], [{ id: 1, post_id: 1, body: 'Nice post!' });
+ */
+export const populateQueryCache = ({
+    data,
+    queryClient,
+    staleTime = 500, // ms
+}: PopulateQueryCacheOptions) => {
+    // setQueryData doesn't accept a stale time option
+    // So we set an updatedAt in the future to make sure the data is considered stale
+    const updatedAt = Date.now() + staleTime;
+    Object.keys(data).forEach(resource => {
+        data[resource].forEach(record => {
+            if (!record || record.id == null) return;
+            queryClient.setQueryData(
+                [resource, 'getOne', { id: String(record.id) }],
+                record,
+                { updatedAt }
+            );
+        });
+        const recordIds = data[resource].map(record => String(record.id));
+        queryClient.setQueryData(
+            [resource, 'getMany', { ids: recordIds }],
+            data[resource],
+            { updatedAt }
+        );
+    });
+};

--- a/packages/ra-core/src/dataProvider/populateQueryCache.ts
+++ b/packages/ra-core/src/dataProvider/populateQueryCache.ts
@@ -7,7 +7,8 @@ export type PopulateQueryCacheOptions = {
 };
 
 /**
- * Populate react-query's query cache with a data dictionnary
+ * Populate react-query's query cache with a data dictionary
+ *
  * @example
  * const data = {
  *    posts: [{ id: 1, title: 'Hello, world' }, { id: 2, title: 'FooBar' }],

--- a/packages/ra-core/src/dataProvider/populateQueryCache.ts
+++ b/packages/ra-core/src/dataProvider/populateQueryCache.ts
@@ -24,7 +24,7 @@ export type PopulateQueryCacheOptions = {
 export const populateQueryCache = ({
     data,
     queryClient,
-    staleTime = 500, // ms
+    staleTime = 1000, // ms
 }: PopulateQueryCacheOptions) => {
     // setQueryData doesn't accept a stale time option
     // So we set an updatedAt in the future to make sure the data isn't considered stale

--- a/packages/ra-core/src/dataProvider/populateQueryCache.ts
+++ b/packages/ra-core/src/dataProvider/populateQueryCache.ts
@@ -27,7 +27,7 @@ export const populateQueryCache = ({
     staleTime = 500, // ms
 }: PopulateQueryCacheOptions) => {
     // setQueryData doesn't accept a stale time option
-    // So we set an updatedAt in the future to make sure the data is considered stale
+    // So we set an updatedAt in the future to make sure the data isn't considered stale
     const updatedAt = Date.now() + staleTime;
     Object.keys(data).forEach(resource => {
         data[resource].forEach(record => {

--- a/packages/ra-core/src/dataProvider/useDataProvider.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDataProvider.spec.tsx
@@ -6,8 +6,8 @@ import expect from 'expect';
 import { useDataProvider } from './useDataProvider';
 import { CoreAdminContext } from '../core';
 import { GetListResult } from '..';
-import { ReferenceFieldBase } from '../controller/field/ReferenceFieldBase';
-import { RecordContextProvider, useRecordContext } from '../controller/record';
+
+import { Prefetching } from './useDataProvider.stories';
 
 const UseGetOne = () => {
     const [data, setData] = useState();
@@ -353,41 +353,7 @@ describe('useDataProvider', () => {
             }),
             getMany,
         } as any;
-
-        const Author = () => {
-            const author = useRecordContext();
-            if (!author) return null;
-            return <>{author.name}</>;
-        };
-
-        const FetchPost = () => {
-            const dataProvider = useDataProvider();
-            const [post, setPost] = useState<any>();
-            useEffect(() => {
-                async function fetch() {
-                    const { data } = await dataProvider.getOne('posts', {
-                        id: 1,
-                    });
-                    setPost(data);
-                }
-                fetch();
-            }, [dataProvider]);
-            if (!post) return null;
-            return (
-                <RecordContextProvider value={post}>
-                    <div>{post.title}</div>
-                    <ReferenceFieldBase reference="authors" source="author_id">
-                        <Author />
-                    </ReferenceFieldBase>
-                </RecordContextProvider>
-            );
-        };
-
-        render(
-            <CoreAdminContext dataProvider={dataProvider}>
-                <FetchPost />
-            </CoreAdminContext>
-        );
+        render(<Prefetching dataProvider={dataProvider} />);
 
         await screen.findByText('My post title');
         await screen.findByText('John Doe');

--- a/packages/ra-core/src/dataProvider/useDataProvider.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDataProvider.spec.tsx
@@ -339,17 +339,15 @@ describe('useDataProvider', () => {
     });
 
     it('should allow prefetching', async () => {
-        const getMany = jest.fn();
+        const getMany = jest
+            .fn()
+            .mockResolvedValue({ data: [{ id: 1, name: 'John Doe' }] });
         const dataProvider = {
             getOne: async () => ({
                 data: { id: 1, title: 'My post title', author_id: 1 },
                 meta: {
                     prefetched: {
                         authors: [{ id: 1, name: 'John Doe' }],
-                        comments: [
-                            { id: 1, body: 'Comment 1', post_id: 1 },
-                            { id: 2, body: 'Comment 2', post_id: 2 },
-                        ],
                     },
                 },
             }),

--- a/packages/ra-core/src/dataProvider/useDataProvider.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDataProvider.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { useState, useEffect } from 'react';
+
+import { useDataProvider } from './useDataProvider';
+import { CoreAdminContext } from '../core';
+import { ReferenceFieldBase } from '../controller/field/ReferenceFieldBase';
+import { RecordContextProvider, WithRecord } from '../controller/record';
+
+export default {
+    title: 'ra-core/dataProvider/useDataProvider',
+};
+
+const FetchPost = () => {
+    const dataProvider = useDataProvider();
+    const [post, setPost] = useState<any>();
+    useEffect(() => {
+        async function fetch() {
+            const { data } = await dataProvider.getOne('posts', {
+                id: 1,
+            });
+            setPost(data);
+        }
+        fetch();
+    }, [dataProvider]);
+    if (!post) return null;
+    return (
+        <RecordContextProvider value={post}>
+            <div>{post.title}</div>
+            <ReferenceFieldBase reference="authors" source="author_id">
+                <WithRecord render={author => author.name} />
+            </ReferenceFieldBase>
+        </RecordContextProvider>
+    );
+};
+
+export const Prefetching = ({
+    dataProvider = {
+        getOne: async () => {
+            console.log('getList called');
+            return {
+                data: { id: 1, title: 'My post title', author_id: 1 },
+                meta: {
+                    prefetched: {
+                        authors: [{ id: 1, name: 'John Doe' }],
+                    },
+                },
+            };
+        },
+        getMany: async () => {
+            console.log('getMany called');
+            return { data: [{ id: 1, name: 'John Doe' }] };
+        },
+    } as any,
+}) => (
+    <CoreAdminContext dataProvider={dataProvider}>
+        <FetchPost />
+    </CoreAdminContext>
+);

--- a/packages/ra-core/src/dataProvider/useDataProvider.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDataProvider.stories.tsx
@@ -10,7 +10,7 @@ export default {
     title: 'ra-core/dataProvider/useDataProvider',
 };
 
-const FetchPost = () => {
+const PostWithAuthor = () => {
     const dataProvider = useDataProvider();
     const [post, setPost] = useState<any>();
     useEffect(() => {
@@ -53,6 +53,6 @@ export const Prefetching = ({
     } as any,
 }) => (
     <CoreAdminContext dataProvider={dataProvider}>
-        <FetchPost />
+        <PostWithAuthor />
     </CoreAdminContext>
 );

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -114,9 +114,9 @@ export const useDataProvider = <
                                 ) {
                                     validateResponseFormat(response, type);
                                 }
-                                if (response?.meta?._embed) {
+                                if (response?.meta?.prefetched) {
                                     populateQueryCache({
-                                        data: response?.meta._embed,
+                                        data: response?.meta.prefetched,
                                         queryClient,
                                     });
                                 }

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -1,4 +1,5 @@
 import { useContext, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import DataProviderContext from './DataProviderContext';
 import { defaultDataProvider } from './defaultDataProvider';
@@ -6,6 +7,7 @@ import validateResponseFormat from './validateResponseFormat';
 import { DataProvider } from '../types';
 import useLogoutIfAccessDenied from '../auth/useLogoutIfAccessDenied';
 import { reactAdminFetchActions } from './dataFetchActions';
+import { populateQueryCache } from './populateQueryCache';
 
 /**
  * Hook for getting a dataProvider
@@ -80,6 +82,7 @@ export const useDataProvider = <
 >(): TDataProvider => {
     const dataProvider = (useContext(DataProviderContext) ||
         defaultDataProvider) as unknown as TDataProvider;
+    const queryClient = useQueryClient();
 
     const logoutIfAccessDenied = useLogoutIfAccessDenied();
 
@@ -110,6 +113,12 @@ export const useDataProvider = <
                                     reactAdminFetchActions.includes(type)
                                 ) {
                                     validateResponseFormat(response, type);
+                                }
+                                if (response?.meta?._embed) {
+                                    populateQueryCache({
+                                        data: response?.meta._embed,
+                                        queryClient,
+                                    });
                                 }
                                 return response;
                             })

--- a/packages/ra-core/src/dataProvider/useDataProvider.ts
+++ b/packages/ra-core/src/dataProvider/useDataProvider.ts
@@ -155,7 +155,7 @@ export const useDataProvider = <
                 };
             },
         });
-    }, [dataProvider, logoutIfAccessDenied]);
+    }, [dataProvider, logoutIfAccessDenied, queryClient]);
 
     return dataProviderProxy;
 };

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -179,6 +179,7 @@ export interface GetOneParams<RecordType extends RaRecord = any> {
 }
 export interface GetOneResult<RecordType extends RaRecord = any> {
     data: RecordType;
+    meta?: any;
 }
 
 export interface GetManyParams<RecordType extends RaRecord = any> {
@@ -188,6 +189,7 @@ export interface GetManyParams<RecordType extends RaRecord = any> {
 }
 export interface GetManyResult<RecordType extends RaRecord = any> {
     data: RecordType[];
+    meta?: any;
 }
 
 export interface GetManyReferenceParams {
@@ -217,6 +219,7 @@ export interface UpdateParams<RecordType extends RaRecord = any> {
 }
 export interface UpdateResult<RecordType extends RaRecord = any> {
     data: RecordType;
+    meta?: any;
 }
 
 export interface UpdateManyParams<T = any> {
@@ -226,6 +229,7 @@ export interface UpdateManyParams<T = any> {
 }
 export interface UpdateManyResult<RecordType extends RaRecord = any> {
     data?: RecordType['id'][];
+    meta?: any;
 }
 
 export interface CreateParams<T = any> {
@@ -234,6 +238,7 @@ export interface CreateParams<T = any> {
 }
 export interface CreateResult<RecordType extends RaRecord = any> {
     data: RecordType;
+    meta?: any;
 }
 
 export interface DeleteParams<RecordType extends RaRecord = any> {
@@ -243,6 +248,7 @@ export interface DeleteParams<RecordType extends RaRecord = any> {
 }
 export interface DeleteResult<RecordType extends RaRecord = any> {
     data: RecordType;
+    meta?: any;
 }
 
 export interface DeleteManyParams<RecordType extends RaRecord = any> {
@@ -251,6 +257,7 @@ export interface DeleteManyParams<RecordType extends RaRecord = any> {
 }
 export interface DeleteManyResult<RecordType extends RaRecord = any> {
     data?: RecordType['id'][];
+    meta?: any;
 }
 
 export type DataProviderResult<RecordType extends RaRecord = any> =

--- a/packages/ra-data-fakerest/README.md
+++ b/packages/ra-data-fakerest/README.md
@@ -129,6 +129,70 @@ This data provider uses [FakeRest](https://github.com/marmelab/FakeRest) under t
 - filtering numbers and dates greater or less than a value
 - embedding related resources
 
+## Embedding
+
+`ra-data-fakerest` supports [Embedded Relationships](https://marmelab.com/react-admin/DataProviders.html#embedding-relationships). Use the `meta.embed` query parameter to specify the relationships that you want to embed. 
+
+```jsx
+dataProvider.getOne('posts', { id: 1, meta: { embed: ['author'] } });
+// { 
+//    data: { id: 1, title: 'FooBar', author: { id: 1, name: 'John Doe' } },
+// }
+```
+
+You can embed more than one related record, so the `embed` value must be an array. The name of the embedded resource must be singular for a many-to-one relationship, and plural for a one-to-many relationship.
+
+```
+{ meta: { embed: ['author', 'comments'] } }
+```
+
+You can leverage this feature in the page components to avoid multiple requests to the data provider:
+
+```jsx
+const PostList = () => (
+    <List queryOptions={{ meta: { embed: ['author'] } }}>
+        <Datagrid>
+            <TextField source="title" />
+            <TextField source="author.name" />
+        </Datagrid>
+    </List>
+);
+```
+
+Embedding Relationships is supported in `getList`, `getOne`, `getMany`, and `getManyReference` queries.
+
+## Prefetching
+
+`ra-data-fakerest` also supports [Prefetching Relationships](https://marmelab.com/react-admin/DataProviders.html#prefetching-relationships) to pre-populate the query cache with related resources. Use the `meta.prefetch` query parameter to specify the relationships that you want to prefetch.
+
+```jsx
+dataProvider.getOne('posts', { id: 1, meta: { prefetch: ['author'] } });
+// { 
+//    data: { id: 1, title: 'FooBar' },
+//    meta: {
+//      prefetched: {
+//        authors: [{ id: 1, name: 'John Doe' }]
+//      }
+//    }
+// }
+```
+
+Prefetching is useful to avoid additional requests when rendering a list of resources with related resources using a `<ReferenceField>` component:
+
+```jsx
+const PostList = () => (
+    <List queryOptions={{ meta: { prefetch: ['author'] } }}>
+        <Datagrid>
+            <TextField source="title" />
+            {/** renders without an additional request */}
+            <ReferenceField source="author_id" />
+        </Datagrid>
+    </List>
+);
+```
+
+Prefetching Relationships is supported in `getList`, `getOne`, `getMany`, and `getManyReference` queries.
+
 ## License
 
 This data provider is licensed under the MIT License, and sponsored by [marmelab](https://marmelab.com).

--- a/packages/ra-data-fakerest/README.md
+++ b/packages/ra-data-fakerest/README.md
@@ -168,7 +168,7 @@ Embedding Relationships is supported in `getList`, `getOne`, `getMany`, and `get
 ```jsx
 dataProvider.getOne('posts', { id: 1, meta: { prefetch: ['author'] } });
 // { 
-//    data: { id: 1, title: 'FooBar' },
+//    data: { id: 1, title: 'FooBar', author_id: 1 },
 //    meta: {
 //      prefetched: {
 //        authors: [{ id: 1, name: 'John Doe' }]

--- a/packages/ra-data-fakerest/README.md
+++ b/packages/ra-data-fakerest/README.md
@@ -146,7 +146,7 @@ You can embed more than one related record, so the `embed` value must be an arra
 { meta: { embed: ['author', 'comments'] } }
 ```
 
-You can leverage this feature in the page components to avoid multiple requests to the data provider:
+You can leverage this feature in page components to avoid multiple requests to the data provider:
 
 ```jsx
 const PostList = () => (

--- a/packages/ra-data-json-server/README.md
+++ b/packages/ra-data-json-server/README.md
@@ -56,7 +56,7 @@ const App = () => (
 export default App;
 ```
 
-### Adding Custom Headers
+## Adding Custom Headers
 
 The provider function accepts an HTTP client function as second argument. By default, they use react-admin's `fetchUtils.fetchJson()` as HTTP client. It's similar to HTML5 `fetch()`, except it handles JSON decoding and HTTP error codes automatically.
 
@@ -99,6 +99,38 @@ const httpClient = (url, options = {}) => {
 ```
 
 Now all the requests to the REST API will contain the `Authorization: SRTRDFVESGNJYTUKTYTHRG` header.
+
+## Embedding
+
+`ra-data-json-server` supports [Embedded Relationships](https://marmelab.com/react-admin/DataProviders.html#embedding-relationships). Use the `meta.embed` query parameter to specify the relationships that you want to embed. 
+
+```jsx
+dataProvider.getOne('posts', { id: 1, meta: { embed: 'author' } });
+// { 
+//    data: { id: 1, title: 'FooBar', author: { id: 1, name: 'John Doe' } },
+// }
+```
+
+The name of the embedded resource must be singular for a many-to-one relationship, and plural for a one-to-many relationship.
+
+```
+{ meta: { embed: 'comments' } }
+```
+
+You can leverage this feature in page components to avoid multiple requests to the data provider:
+
+```jsx
+const PostList = () => (
+    <List queryOptions={{ meta: { embed: 'author' } }}>
+        <Datagrid>
+            <TextField source="title" />
+            <TextField source="author.name" />
+        </Datagrid>
+    </List>
+);
+```
+
+Embedding Relationships is supported in `getList`, `getOne`, `getMany`, and `getManyReference` queries.
 
 ## License
 


### PR DESCRIPTION
## Problem

Pages aggregating data from more than one resource always have to fetch more than one API endpoint in cascade, and with a slow backend this leads to an incomplete and blinking UI.

For example, the Comment list page in the simple example shows the post for each comment. So it has to fetch `dataProvider.getList('comments')`, then `dataProvider.getMany('posts', { ids: [comment postIds] })` (via `<ReferenceField>`).

<img width="994" alt="image" src="https://github.com/user-attachments/assets/d1ad1e38-18bd-4220-8cfb-9c60664a206c">

Some backends are capable of embedding related records (e.g. the post of a comment). However, populating the cache based on these embeds is cumbersome.

## Solution

- Allow developers to embed related data in the main data
- Allow developers to prefetch related records and populate the cache with it

## TODO

- [x] Allow every data provider method to return a response `meta`
- [x] Update `useDataProvider` to populate query cache when a response contains a `meta: { prefetched }`
- [x] Add support for embedding and prefetching to `ra-data-fakerest`
- [x] Add support for embedding to `ra-data-json-server`
- ~~[ ] Add support for embedding and prefetching to `ra-data-simplerest`~~(out of scope)
- [x] Update the simple example to use `prefetch` in the comment list and show views.
- [x] add tests
- [x] Add doc

```jsx
const CommentList = () => (
    <ListBase queryOptions={{ meta: { prefetch: ['post'] } }}>
        <ListView />
    </ListBase>
);
```

<img width="988" alt="image" src="https://github.com/user-attachments/assets/14e5bbf8-9d62-4eb8-897e-2fe120434a4c">

