### PR TITLE
[Doc] Warn about `<AutoSave>` incompatibility with `warnWhenUnsavedChanges`

### DIFF
--- a/docs/AutoSave.md
+++ b/docs/AutoSave.md
@@ -23,6 +23,8 @@ Note that you **must** set the `<Form resetOptions>` prop to `{ keepDirtyValues:
 
 If you're using it in an `<Edit>` page, you must also use a `pessimistic` or `optimistic` [`mutationMode`](https://marmelab.com/react-admin/Edit.html#mutationmode) - `<AutoSave>` doesn't work with the default `mutationMode="undoable"`.
 
+Note that `<AutoSave>` does not currently work with [`warnWhenUnsavedChanges`](http://react-admin.garcia.cloud/Forms.html#warning-about-unsaved-changes).
+
 {% raw %}
 ```tsx
 import { AutoSave } from '@react-admin/ra-form-layout';


### PR DESCRIPTION
## Problem

 `<AutoSave>` is currently incompatible with `warnWhenUnsavedChanges`.

## Solution

Warn about it in the documentation.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

