### PR TITLE
Make records paths inferred from type compatible with react-hook-form

### DIFF
--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -62,7 +62,6 @@
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "eventemitter3": "^5.0.1",
-        "hotscript": "^1.0.12",
         "inflection": "^3.0.0",
         "jsonexport": "^3.2.0",
         "lodash": "~4.17.5",

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -1,4 +1,5 @@
 import { ComponentType, ReactElement, ReactNode } from 'react';
+import { FieldPath } from 'react-hook-form';
 import { WithPermissionsChildrenParams } from './auth/WithPermissions';
 import { AuthActionType } from './auth/types';
 
@@ -13,9 +14,11 @@ export interface RaRecord<IdentifierType extends Identifier = Identifier>
     id: IdentifierType;
 }
 
+export type SortOrder = 'ASC' | 'DESC';
+
 export interface SortPayload {
     field: string;
-    order: 'ASC' | 'DESC';
+    order: SortOrder;
 }
 export interface FilterPayload {
     [k: string]: any;
@@ -402,3 +405,20 @@ export type FormFunctions = {
 export type HintedString<KnownValues extends string> =
     | (string & {})
     | KnownValues;
+
+// Re-export react-hook-form implementation of FieldPath that returns all possible paths of an object
+// This will allow us to either include the FieldPath implementation from react-hook-form or replace it with our own
+// should we move away from react-hook-form
+// type Post = { title: string; author: { name: string; }; tags: { id: string; name: string} };
+// => Valid paths are "title" | "author" | "author.name" | "tags.id" | "tags.name"
+export type RecordValues = Record<string, any>;
+export type RecordPath<TRecordValues extends RecordValues> =
+    FieldPath<TRecordValues>;
+
+// Returns the union of all possible paths of a type if it is provided, otherwise returns a string
+// Useful for props such as "source" in react-admin components
+export type ExtractRecordPaths<T extends RecordValues> =
+    // Trick that allows to check whether T was provided
+    [T] extends [never] ? string : RecordPath<T>;
+
+export type AnyString = string & {};

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -14,11 +14,9 @@ export interface RaRecord<IdentifierType extends Identifier = Identifier>
     id: IdentifierType;
 }
 
-export type SortOrder = 'ASC' | 'DESC';
-
 export interface SortPayload {
     field: string;
-    order: SortOrder;
+    order: 'ASC' | 'DESC';
 }
 export interface FilterPayload {
     [k: string]: any;
@@ -402,9 +400,7 @@ export type FormFunctions = {
 
 // Type for a string that accept one of the known values but also any other string
 // Useful for IDE autocompletion without preventing custom values
-export type HintedString<KnownValues extends string> =
-    | (string & {})
-    | KnownValues;
+export type HintedString<KnownValues extends string> = AnyString | KnownValues;
 
 // Re-export react-hook-form implementation of FieldPath that returns all possible paths of an object
 // This will allow us to either include the FieldPath implementation from react-hook-form or replace it with our own

--- a/packages/ra-core/src/util/useFieldValue.ts
+++ b/packages/ra-core/src/util/useFieldValue.ts
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
-import { Call, Objects } from 'hotscript';
 import { useRecordContext } from '../controller';
+import { ExtractRecordPaths } from '../types';
 
 /**
  * A hook that gets the value of a field of the current record.
@@ -38,10 +38,6 @@ export interface UseFieldValueOptions<
 > {
     // FIXME: Find a way to throw a type error when defaultValue is not of RecordType[Source] type
     defaultValue?: any;
-    source: Call<Objects.AllPaths, RecordType> extends never
-        ? AnyString
-        : Call<Objects.AllPaths, RecordType>;
+    source: ExtractRecordPaths<RecordType>;
     record?: RecordType;
 }
-
-type AnyString = string & {};

--- a/packages/ra-ui-materialui/package.json
+++ b/packages/ra-ui-materialui/package.json
@@ -68,7 +68,6 @@
         "clsx": "^2.1.1",
         "css-mediaquery": "^0.1.2",
         "dompurify": "^2.4.3",
-        "hotscript": "^1.0.12",
         "inflection": "^3.0.0",
         "jsonexport": "^3.2.0",
         "lodash": "~4.17.5",

--- a/packages/ra-ui-materialui/src/field/FileField.tsx
+++ b/packages/ra-ui-materialui/src/field/FileField.tsx
@@ -2,8 +2,12 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import get from 'lodash/get';
 import Typography from '@mui/material/Typography';
-import { useFieldValue, useTranslate } from 'ra-core';
-import { Call, Objects } from 'hotscript';
+import {
+    ExtractRecordPaths,
+    HintedString,
+    useFieldValue,
+    useTranslate,
+} from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { FieldProps } from './types';
@@ -114,16 +118,13 @@ export interface FileFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
 > extends FieldProps<RecordType> {
     src?: string;
-    title?: Call<Objects.AllPaths, RecordType> extends never
-        ? AnyString
-        : Call<Objects.AllPaths, RecordType> | AnyString;
+    title?: HintedString<ExtractRecordPaths<RecordType>>;
     target?: string;
     download?: boolean | string;
     ping?: string;
     rel?: string;
     sx?: SxProps;
 }
-type AnyString = string & {};
 
 const PREFIX = 'RaFileField';
 

--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -2,8 +2,12 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import { Box, Typography } from '@mui/material';
 import get from 'lodash/get';
-import { useFieldValue, useTranslate } from 'ra-core';
-import { Call, Objects } from 'hotscript';
+import {
+    ExtractRecordPaths,
+    HintedString,
+    useFieldValue,
+    useTranslate,
+} from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 import { FieldProps } from './types';
@@ -111,10 +115,6 @@ export interface ImageFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
 > extends FieldProps<RecordType> {
     src?: string;
-    title?: Call<Objects.AllPaths, RecordType> extends never
-        ? AnyString
-        : Call<Objects.AllPaths, RecordType> | AnyString;
+    title?: HintedString<ExtractRecordPaths<RecordType>>;
     sx?: SxProps;
 }
-
-type AnyString = string & {};

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -1,10 +1,8 @@
 import { ReactElement } from 'react';
 import { TableCellProps } from '@mui/material/TableCell';
-import { Call, Objects } from 'hotscript';
+import { ExtractRecordPaths, HintedString, SortOrder } from 'ra-core';
 
 type TextAlign = TableCellProps['align'];
-type SortOrder = 'ASC' | 'DESC';
-type AnyString = string & {};
 
 export interface FieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
@@ -25,7 +23,7 @@ export interface FieldProps<
      *     </List>
      * );
      */
-    sortBy?: Call<Objects.AllPaths, RecordType> | AnyString;
+    sortBy?: HintedString<ExtractRecordPaths<RecordType>>;
 
     /**
      * The order used for sorting when users click this column head, if sortable.
@@ -57,9 +55,7 @@ export interface FieldProps<
      *     </List>
      * );
      */
-    source: Call<Objects.AllPaths, RecordType> extends never
-        ? AnyString
-        : Call<Objects.AllPaths, RecordType>;
+    source: ExtractRecordPaths<RecordType>;
 
     /**
      * Label to use as column header when using <Datagrid> or <SimpleShowLayout>.

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -1,8 +1,9 @@
 import { ReactElement } from 'react';
 import { TableCellProps } from '@mui/material/TableCell';
-import { ExtractRecordPaths, HintedString, SortOrder } from 'ra-core';
+import { ExtractRecordPaths, HintedString } from 'ra-core';
 
 type TextAlign = TableCellProps['align'];
+type SortOrder = 'ASC' | 'DESC';
 
 export interface FieldProps<
     RecordType extends Record<string, any> = Record<string, any>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12629,13 +12629,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hotscript@npm:^1.0.12":
-  version: 1.0.12
-  resolution: "hotscript@npm:1.0.12"
-  checksum: 3ab48ec3405bda539ed5438e177914f65be0facb1acd1aa725ee716216ca87d2d1916f2b6ac58d8b7e94ad517a349c46fd7c45f24fe9f7fedf4799f12cb410d4
-  languageName: node
-  linkType: hard
-
 "html-encoding-sniffer@npm:^3.0.0":
   version: 3.0.0
   resolution: "html-encoding-sniffer@npm:3.0.0"
@@ -17831,7 +17824,6 @@ __metadata:
     date-fns: "npm:^3.6.0"
     eventemitter3: "npm:^5.0.1"
     expect: "npm:^27.4.6"
-    hotscript: "npm:^1.0.12"
     ignore-styles: "npm:~5.0.1"
     inflection: "npm:^3.0.0"
     jscodeshift: "npm:^0.15.2"
@@ -18105,7 +18097,6 @@ __metadata:
     dompurify: "npm:^2.4.3"
     expect: "npm:^27.4.6"
     file-api: "npm:~0.10.4"
-    hotscript: "npm:^1.0.12"
     ignore-styles: "npm:~5.0.1"
     inflection: "npm:^3.0.0"
     jsonexport: "npm:^3.2.0"


### PR DESCRIPTION
## Problem

Fixes https://github.com/marmelab/react-admin/issues/9849

Records paths inferred from type using `hotscript` aren't compatible with those inferred by `react-hook-form`

## Solution

Declare our own types for path inference that currently just re-export those from `react-hook-form`, making us more resilient to future changes.

## How To Test

- Open the `InvoiceShow` of the CRM demo and add a type parameter to the `TextField` of the Order reference. The `TextField` `source` should be valid and trying to replace it should trigger the IDE autocompletion, showing all `Order` fields

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
