### PR TITLE
Update useGetPathForRecordCallback.ts

### DIFF
--- a/packages/ra-core/src/routing/useGetPathForRecordCallback.ts
+++ b/packages/ra-core/src/routing/useGetPathForRecordCallback.ts
@@ -22,7 +22,7 @@ export const useGetPathForRecordCallback = <
                     'Cannot generate a link for a record without a resource. You must use useGetPathForRecordCallback within a ResourceContextProvider, or pass a resource parameter.'
                 );
             }
-            const resourceDefinition = resourceDefinitions[finalResource] ?? {};
+            const resourceDefinition = resourceDefinitions[finalResource] ?? {} as ResourceDefinition;
             const linkFunc = typeof link === 'function' ? link : () => link;
 
             const defaultLink = resourceDefinition.hasShow


### PR DESCRIPTION
## Problem

errors while building:


node_modules/ra-core/src/routing/useGetPathForRecordCallback.ts:28:52 - error TS2339: Property 'hasShow' does not exist on type '{}'.

node_modules/ra-core/src/routing/useGetPathForRecordCallback.ts:30:38 - error TS2339: Property 'hasEdit' does not exist on type '{}'.


## Solution

Definition of empty entry's type

## How To Test

Build the project after the change

