### PR TITLE
Update useReferenceInputController.ts

### DIFF
--- a/packages/ra-core/src/controller/input/useReferenceInputController.ts
+++ b/packages/ra-core/src/controller/input/useReferenceInputController.ts
@@ -121,7 +121,7 @@ export const useReferenceInputController = <RecordType extends RaRecord = any>(
             enabled: currentValue != null && currentValue !== '',
             meta,
             ...otherQueryOptions,
-        },
+        } as UseQueryOptions<RecordType[], Error>,
     });
 
     const isPending =


### PR DESCRIPTION
## Problem

Error while building:

`node_modules/ra-core/src/controller/input/useReferenceInputController.ts:121:13 - error TS2322: Type 'Enabled<{ data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, Error, { data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, QueryKey>' is not assignable to type 'Enabled<RecordType[], Error, RecordType[], QueryKey>'.
  Type '(query: Query<{ data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, Error, { data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, QueryKey>) => boolean' is not assignable to type 'Enabled<RecordType[], Error, RecordType[], QueryKey>'.
    Type '(query: Query<{ data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, Error, { data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, QueryKey>) => boolean' is not assignable to type '(query: Query<RecordType[], Error, RecordType[], QueryKey>) => boolean'.
      Types of parameters 'query' and 'query' are incompatible.
        Type 'Query<RecordType[], Error, RecordType[], QueryKey>' is not assignable to type 'Query<{ data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, Error, { data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }, QueryKey>'.
          Property 'data' is missing in type 'RecordType[]' but required in type '{ data: any[]; total?: number; pageInfo?: { hasNextPage?: boolean; hasPreviousPage?: boolean; }; }'.

121             enabled: currentValue != null && currentValue !== '',
                ~~~~~~~
`

## Solution

Define the type of the newly crated object

## How To Test

build the project
