### PR TITLE
Fix double decoding of ids in URLs

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.stories.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.stories.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { Route, Routes, useLocation } from 'react-router';
+import {
+    CoreAdminContext,
+    EditController,
+    testDataProvider,
+    TestMemoryRouter,
+} from '../..';
+
+export default {
+    title: 'ra-core/controller/useEditController',
+};
+
+export const EncodedId = ({
+    id = 'test?',
+    url = '/posts/test%3F',
+    dataProvider = testDataProvider({
+        // @ts-expect-error
+        getOne: () => Promise.resolve({ data: { id, title: 'hello' } }),
+    }),
+}) => {
+    return (
+        <TestMemoryRouter initialEntries={[url]}>
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Routes>
+                    <Route
+                        path="/posts/:id"
+                        element={
+                            <EditController resource="posts">
+                                {({ record }) => (
+                                    <>
+                                        <LocationInspector />
+                                        <p>Id: {record && record.id}</p>
+                                        <p>Title: {record && record.title}</p>
+                                    </>
+                                )}
+                            </EditController>
+                        }
+                    />
+                </Routes>
+            </CoreAdminContext>
+        </TestMemoryRouter>
+    );
+};
+
+export const EncodedIdWithPercentage = ({
+    id = 'test%',
+    url = '/posts/test%25',
+    dataProvider = testDataProvider({
+        // @ts-expect-error
+        getOne: () => Promise.resolve({ data: { id, title: 'hello' } }),
+    }),
+}) => {
+    return (
+        <TestMemoryRouter initialEntries={[url]}>
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Routes>
+                    <Route
+                        path="/posts/:id"
+                        element={
+                            <EditController resource="posts">
+                                {({ record }) => (
+                                    <>
+                                        <LocationInspector />
+                                        <p>Id: {record && record.id}</p>
+                                        <p>Title: {record && record.title}</p>
+                                    </>
+                                )}
+                            </EditController>
+                        }
+                    />
+                </Routes>
+            </CoreAdminContext>
+        </TestMemoryRouter>
+    );
+};
+
+const LocationInspector = () => {
+    const location = useLocation();
+    return (
+        <p>
+            Location: <code>{location.pathname}</code>
+        </p>
+    );
+};

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -91,7 +91,7 @@ export const useEditController = <
             'useEditController requires an id prop or a route with an /:id? parameter.'
         );
     }
-    const id = propsId ?? decodeURIComponent(routeId!);
+    const id = propsId ?? routeId;
     const { meta: queryMeta, ...otherQueryOptions } = queryOptions;
     const {
         meta: mutationMeta,

--- a/packages/ra-core/src/controller/show/useShowController.stories.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '../..';
 
 export default {
-    title: 'ra-core/controller/useEditController',
+    title: 'ra-core/controller/useShowController',
 };
 
 export const EncodedId = ({

--- a/packages/ra-core/src/controller/show/useShowController.stories.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.stories.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { Route, Routes, useLocation } from 'react-router';
+import {
+    CoreAdminContext,
+    ShowController,
+    testDataProvider,
+    TestMemoryRouter,
+} from '../..';
+
+export default {
+    title: 'ra-core/controller/useEditController',
+};
+
+export const EncodedId = ({
+    id = 'test?',
+    url = '/posts/test%3F',
+    dataProvider = testDataProvider({
+        // @ts-expect-error
+        getOne: () => Promise.resolve({ data: { id, title: 'hello' } }),
+    }),
+}) => {
+    return (
+        <TestMemoryRouter initialEntries={[url]}>
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Routes>
+                    <Route
+                        path="/posts/:id"
+                        element={
+                            <ShowController resource="posts">
+                                {({ record }) => (
+                                    <>
+                                        <LocationInspector />
+                                        <p>Id: {record && record.id}</p>
+                                        <p>Title: {record && record.title}</p>
+                                    </>
+                                )}
+                            </ShowController>
+                        }
+                    />
+                </Routes>
+            </CoreAdminContext>
+        </TestMemoryRouter>
+    );
+};
+
+export const EncodedIdWithPercentage = ({
+    id = 'test%',
+    url = '/posts/test%25',
+    dataProvider = testDataProvider({
+        // @ts-expect-error
+        getOne: () => Promise.resolve({ data: { id, title: 'hello' } }),
+    }),
+}) => {
+    return (
+        <TestMemoryRouter initialEntries={[url]}>
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Routes>
+                    <Route
+                        path="/posts/:id"
+                        element={
+                            <ShowController resource="posts">
+                                {({ record }) => (
+                                    <>
+                                        <LocationInspector />
+                                        <p>Id: {record && record.id}</p>
+                                        <p>Title: {record && record.title}</p>
+                                    </>
+                                )}
+                            </ShowController>
+                        }
+                    />
+                </Routes>
+            </CoreAdminContext>
+        </TestMemoryRouter>
+    );
+};
+
+const LocationInspector = () => {
+    const location = useLocation();
+    return (
+        <p>
+            Location: <code>{location.pathname}</code>
+        </p>
+    );
+};

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -86,7 +86,7 @@ export const useShowController = <RecordType extends RaRecord = any>(
             'useShowController requires an id prop or a route with an /:id? parameter.'
         );
     }
-    const id = propsId != null ? propsId : decodeURIComponent(routeId!);
+    const id = propsId != null ? propsId : routeId;
     const { meta, ...otherQueryOptions } = queryOptions;
 
     const {


### PR DESCRIPTION
## Problem

Fixes #10158. React-router fixed an issue where params weren't properly decoded. However, react-admin still tried to decode them, leading to invalid ids.

## Solution

Remove the decoding from `useEditController` and `useShowController`

## How To Test

There are new stories and tests

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date