### PR TITLE
Fix smart count for no results message

### DIFF
--- a/packages/ra-core/src/core/useGetResourceLabel.spec.tsx
+++ b/packages/ra-core/src/core/useGetResourceLabel.spec.tsx
@@ -8,7 +8,7 @@ describe('useGetResourceLabel', () => {
     test.each([
         [2, 'Posts'],
         [1, 'Post'],
-        [0, 'Post'],
+        [0, 'Posts'],
     ])(
         'should infer the %s and %s version of the resource name',
         (count, expected) => {

--- a/packages/ra-core/src/core/useGetResourceLabel.ts
+++ b/packages/ra-core/src/core/useGetResourceLabel.ts
@@ -1,6 +1,6 @@
 import { useResourceDefinitions } from './useResourceDefinitions';
 import { useTranslate } from '../i18n';
-import { humanize, pluralize, singularize } from 'inflection';
+import { humanize, inflect } from 'inflection';
 
 /**
  * A hook which returns function to get a translated resource name. It will use the label option of the `Resource` component if it was provided.
@@ -39,11 +39,7 @@ export const useGetResourceLabel = (): GetResourceLabel => {
                           smart_count: count,
                           _: resourceDefinition.options.label,
                       })
-                    : humanize(
-                          count > 1
-                              ? pluralize(resource)
-                              : singularize(resource)
-                      ),
+                    : humanize(inflect(resource, count)),
         });
 
         return label;

--- a/packages/ra-ui-materialui/src/list/ListNoResults.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.tsx
@@ -26,7 +26,7 @@ export const ListNoResults = () => {
                     <>
                         {translate('ra.navigation.no_filtered_results', {
                             resource,
-                            name: getResourceLabel(resource, 1),
+                            name: getResourceLabel(resource, 0),
                             _: 'No results found with the current filters.',
                         })}{' '}
                         <Button
@@ -39,7 +39,7 @@ export const ListNoResults = () => {
                 ) : (
                     translate('ra.navigation.no_results', {
                         resource,
-                        name: getResourceLabel(resource, 1),
+                        name: getResourceLabel(resource, 0),
                         _: 'No results found.',
                     })
                 )}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -168,7 +168,7 @@ describe('<SimpleList />', () => {
         });
 
         expect(
-            await screen.findByText('No Post found using the current filters.')
+            await screen.findByText('No Posts found using the current filters.')
         ).not.toBeNull();
         expect(screen.getByText('Clear filters')).not.toBeNull();
 
@@ -179,7 +179,7 @@ describe('<SimpleList />', () => {
         );
 
         expect(
-            screen.queryByText('No Post found using the current filters.')
+            screen.queryByText('No Posts found using the current filters.')
         ).toBeNull();
         expect(screen.queryByText('Clear filters')).toBeNull();
         expect(


### PR DESCRIPTION
## Problem

#10291 introduces translation of the resource name in the no results message. Nevertheless, when there is no results, the smart count used for the translation should be 0.

## Solution

Update smart_count when calling `getResourceLabel` function.
