### PR TITLE
Fix undo logic not working when doing multiple deletions one by one

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -16,7 +16,7 @@ import {
 } from '..';
 import { CoreAdminContext } from '../../core';
 import { testDataProvider } from '../../dataProvider';
-import undoableEventEmitter from '../../dataProvider/undoableEventEmitter';
+import { useTakeUndoableMutation } from '../../dataProvider/undo/useTakeUndoableMutation';
 import { Form, InputProps, useInput } from '../../form';
 import { useNotificationContext } from '../../notification';
 import { AuthProvider, DataProvider } from '../../types';
@@ -28,6 +28,20 @@ import {
     CanAccess,
     DisableAuthentication,
 } from './useEditController.security.stories';
+
+const Confirm = () => {
+    const takeMutation = useTakeUndoableMutation();
+    return (
+        <button
+            aria-label="confirm"
+            onClick={() => {
+                const mutation = takeMutation();
+                if (!mutation) return;
+                mutation({ isUndo: false });
+            }}
+        />
+    );
+};
 
 describe('useEditController', () => {
     const defaultProps = {
@@ -279,6 +293,7 @@ describe('useEditController', () => {
                                     aria-label="save"
                                     onClick={() => save!({ test: 'updated' })}
                                 />
+                                <Confirm />
                             </>
                         );
                     }}
@@ -297,7 +312,7 @@ describe('useEditController', () => {
             data: { test: 'updated' },
             previousData: { id: 12, test: 'previous' },
         });
-        undoableEventEmitter.emit('end', { isUndo: false });
+        screen.getByLabelText('confirm').click();
         await waitFor(() => {
             screen.getByText('updated');
         });
@@ -888,14 +903,14 @@ describe('useEditController', () => {
                 <EditController {...defaultProps} mutationMode="undoable">
                     {({ save }) => {
                         saveCallback = save;
-                        return <div />;
+                        return <Confirm />;
                     }}
                 </EditController>
             </CoreAdminContext>
         );
         await act(async () => saveCallback({ foo: 'bar' }));
         await new Promise(resolve => setTimeout(resolve, 10));
-        undoableEventEmitter.emit('end', { isUndo: false });
+        screen.getByLabelText('confirm').click();
         await new Promise(resolve => setTimeout(resolve, 10));
         expect(notificationsSpy).toContainEqual({
             message: 'ra.notification.http_error',

--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -6,6 +6,7 @@ import { AdminRouter } from '../routing';
 import { AuthContext, convertLegacyAuthProvider } from '../auth';
 import {
     DataProviderContext,
+    UndoableMutationsContextProvider,
     convertLegacyDataProvider,
     defaultDataProvider,
 } from '../dataProvider';
@@ -211,9 +212,11 @@ React-admin requires a valid dataProvider function to work.`);
                             <AdminRouter basename={basename}>
                                 <I18nContextProvider value={i18nProvider}>
                                     <NotificationContextProvider>
-                                        <ResourceDefinitionContextProvider>
-                                            {children}
-                                        </ResourceDefinitionContextProvider>
+                                        <UndoableMutationsContextProvider>
+                                            <ResourceDefinitionContextProvider>
+                                                {children}
+                                            </ResourceDefinitionContextProvider>
+                                        </UndoableMutationsContextProvider>
                                     </NotificationContextProvider>
                                 </I18nContextProvider>
                             </AdminRouter>

--- a/packages/ra-core/src/dataProvider/index.ts
+++ b/packages/ra-core/src/dataProvider/index.ts
@@ -25,6 +25,7 @@ export * from './useUpdateMany';
 export * from './useDelete';
 export * from './useDeleteMany';
 export * from './useInfiniteGetList';
+export * from './undo/';
 
 export type { Options } from './fetch';
 
@@ -33,5 +34,8 @@ export {
     DataProviderContext,
     fetchUtils,
     HttpError,
+    /**
+     * @deprecated use the useTakeUndoableMutation hook instead
+     */
     undoableEventEmitter,
 };

--- a/packages/ra-core/src/dataProvider/undo/AddUndoableMutationContext.tsx
+++ b/packages/ra-core/src/dataProvider/undo/AddUndoableMutationContext.tsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+import type { UndoableMutation } from './types';
+
+export const AddUndoableMutationContext = createContext<
+    (mutation: UndoableMutation) => void
+>(() => {});

--- a/packages/ra-core/src/dataProvider/undo/TakeUndoableMutationContext.tsx
+++ b/packages/ra-core/src/dataProvider/undo/TakeUndoableMutationContext.tsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+import type { UndoableMutation } from './types';
+
+export const TakeUndoableMutationContext = createContext<
+    () => UndoableMutation | void
+>(() => {});

--- a/packages/ra-core/src/dataProvider/undo/UndoableMutationsContextProvider.tsx
+++ b/packages/ra-core/src/dataProvider/undo/UndoableMutationsContextProvider.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { useState, useCallback } from 'react';
+
+import { AddUndoableMutationContext } from './AddUndoableMutationContext';
+import { TakeUndoableMutationContext } from './TakeUndoableMutationContext';
+import type { UndoableMutation } from './types';
+
+/**
+ * Exposes and manages a queue of undoable mutations
+ *
+ * This context is used in CoreAdminContext so that every react-admin app
+ * can use the useAddUndoableMutation and useTakeUndoableMutation hooks.
+ *
+ * Note: We need a separate queue for mutations (instead of using the
+ * notifications queue) because the mutations are not dequeued when the
+ * notification is displayed, but when it is dismissed.
+ */
+export const UndoableMutationsContextProvider = ({ children }) => {
+    const [mutations, setMutations] = useState<UndoableMutation[]>([]);
+
+    /**
+     * Add a new mutation (pushes a new mutation to the queue).
+     *
+     * Used by optimistic data provider hooks, e.g., useDelete
+     */
+    const addMutation = useCallback((mutation: UndoableMutation) => {
+        setMutations(mutations => [...mutations, mutation]);
+    }, []);
+
+    /**
+     * Get the next mutation to execute (shifts the first mutation from the queue) and returns it.
+     *
+     * Used by the Notification component to process or undo the mutation
+     */
+    const takeMutation = useCallback(() => {
+        if (mutations.length === 0) return;
+        const [mutation, ...rest] = mutations;
+        setMutations(rest);
+        return mutation;
+    }, [mutations]);
+
+    return (
+        <TakeUndoableMutationContext.Provider value={takeMutation}>
+            <AddUndoableMutationContext.Provider value={addMutation}>
+                {children}
+            </AddUndoableMutationContext.Provider>
+        </TakeUndoableMutationContext.Provider>
+    );
+};

--- a/packages/ra-core/src/dataProvider/undo/index.ts
+++ b/packages/ra-core/src/dataProvider/undo/index.ts
@@ -1,5 +1,6 @@
 export * from './AddUndoableMutationContext';
 export * from './TakeUndoableMutationContext';
 export * from './UndoableMutationsContextProvider';
+export * from './types';
 export * from './useAddUndoableMutation';
 export * from './useTakeUndoableMutation';

--- a/packages/ra-core/src/dataProvider/undo/index.ts
+++ b/packages/ra-core/src/dataProvider/undo/index.ts
@@ -1,0 +1,5 @@
+export * from './AddUndoableMutationContext';
+export * from './TakeUndoableMutationContext';
+export * from './UndoableMutationsContextProvider';
+export * from './useAddUndoableMutation';
+export * from './useTakeUndoableMutation';

--- a/packages/ra-core/src/dataProvider/undo/types.ts
+++ b/packages/ra-core/src/dataProvider/undo/types.ts
@@ -1,0 +1,1 @@
+export type UndoableMutation = (params: { isUndo: boolean }) => void;

--- a/packages/ra-core/src/dataProvider/undo/useAddUndoableMutation.tsx
+++ b/packages/ra-core/src/dataProvider/undo/useAddUndoableMutation.tsx
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { AddUndoableMutationContext } from './AddUndoableMutationContext';
+
+export const useAddUndoableMutation = () =>
+    useContext(AddUndoableMutationContext);

--- a/packages/ra-core/src/dataProvider/undo/useTakeUndoableMutation.tsx
+++ b/packages/ra-core/src/dataProvider/undo/useTakeUndoableMutation.tsx
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { TakeUndoableMutationContext } from './TakeUndoableMutationContext';
+
+export const useTakeUndoableMutation = () =>
+    useContext(TakeUndoableMutationContext);

--- a/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
 
 import { CoreAdminContext } from '../core';
-import undoableEventEmitter from './undoableEventEmitter';
+import { useTakeUndoableMutation } from './undo';
 import { useDelete } from './useDelete';
 import { useGetList } from './useGetList';
 
@@ -49,6 +49,7 @@ const SuccessCore = () => {
     const [success, setSuccess] = useState<string>();
     const { data, refetch } = useGetList('posts');
     const [deleteOne, { isPending }] = useDelete();
+    const takeMutation = useTakeUndoableMutation();
     const handleClick = () => {
         deleteOne(
             'posts',
@@ -71,10 +72,10 @@ const SuccessCore = () => {
                     <>
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: false,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
                             }}
                         >
                             Confirm
@@ -82,10 +83,10 @@ const SuccessCore = () => {
                         &nbsp;
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: true,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
                             }}
                         >
                             Cancel
@@ -143,6 +144,7 @@ const ErrorCore = () => {
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
     const { data, refetch } = useGetList('posts');
+    const takeMutation = useTakeUndoableMutation();
     const [deleteOne, { isPending }] = useDelete();
     const handleClick = () => {
         setError(undefined);
@@ -171,10 +173,10 @@ const ErrorCore = () => {
                     <>
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: false,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
                             }}
                         >
                             Confirm
@@ -182,10 +184,10 @@ const ErrorCore = () => {
                         &nbsp;
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: true,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
                             }}
                         >
                             Cancel

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -11,7 +11,7 @@ import {
 } from '@tanstack/react-query';
 
 import { useDataProvider } from './useDataProvider';
-import undoableEventEmitter from './undoableEventEmitter';
+import { useAddUndoableMutation } from './undo/useAddUndoableMutation';
 import {
     RaRecord,
     DeleteManyParams,
@@ -89,6 +89,7 @@ export const useDeleteMany = <
 ): UseDeleteManyResult<RecordType, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
+    const addUndoableMutation = useAddUndoableMutation();
     const { ids } = params;
     const { mutationMode = 'pessimistic', ...mutationOptions } = options;
     const mode = useRef<MutationMode>(mutationMode);
@@ -436,8 +437,9 @@ export const useDeleteMany = <
                 }
             );
         } else {
-            // undoable mutation: register the mutation for later
-            undoableEventEmitter.once('end', ({ isUndo }) => {
+            // Undoable mutation: add the mutation to the undoable queue.
+            // The Notification component will dequeue it when the user confirms or cancels the message.
+            addUndoableMutation(({ isUndo }) => {
                 if (isUndo) {
                     // rollback
                     snapshot.current.forEach(([key, value]) => {

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -11,7 +11,7 @@ import {
 } from '@tanstack/react-query';
 
 import { useDataProvider } from './useDataProvider';
-import undoableEventEmitter from './undoableEventEmitter';
+import { useAddUndoableMutation } from './undo/useAddUndoableMutation';
 import {
     RaRecord,
     UpdateParams,
@@ -91,6 +91,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
 ): UseUpdateResult<RecordType, boolean, ErrorType> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
+    const addUndoableMutation = useAddUndoableMutation();
     const { id, data, meta } = params;
     const {
         mutationMode = 'pessimistic',
@@ -470,8 +471,9 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
                 ...callTimeParams,
             });
         } else {
-            // undoable mutation: register the mutation for later
-            undoableEventEmitter.once('end', ({ isUndo }) => {
+            // Undoable mutation: add the mutation to the undoable queue.
+            // The Notification component will dequeue it when the user confirms or cancels the message.
+            addUndoableMutation(({ isUndo }) => {
                 if (isUndo) {
                     // rollback
                     snapshot.current.forEach(([key, value]) => {

--- a/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.undoable.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
 
 import { CoreAdminContext } from '../core';
-import undoableEventEmitter from './undoableEventEmitter';
+import { useTakeUndoableMutation } from './undo';
 import { useUpdate } from './useUpdate';
 import { useGetOne } from './useGetOne';
 
@@ -43,6 +43,7 @@ const SuccessCore = () => {
     const isMutating = useIsMutating();
     const [notification, setNotification] = useState<boolean>(false);
     const [success, setSuccess] = useState<string>();
+    const takeMutation = useTakeUndoableMutation();
     const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isPending }] = useUpdate();
     const handleClick = () => {
@@ -73,10 +74,10 @@ const SuccessCore = () => {
                     <>
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: false,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
                             }}
                         >
                             Confirm
@@ -84,10 +85,10 @@ const SuccessCore = () => {
                         &nbsp;
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: true,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
                             }}
                         >
                             Cancel
@@ -138,6 +139,7 @@ const ErrorCore = () => {
     const [notification, setNotification] = useState<boolean>(false);
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
+    const takeMutation = useTakeUndoableMutation();
     const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isPending }] = useUpdate();
     const handleClick = () => {
@@ -171,10 +173,10 @@ const ErrorCore = () => {
                     <>
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: false,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
                             }}
                         >
                             Confirm
@@ -182,10 +184,10 @@ const ErrorCore = () => {
                         &nbsp;
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: true,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
                             }}
                         >
                             Cancel
@@ -240,6 +242,7 @@ const WithMiddlewaresCore = () => {
     const isMutating = useIsMutating();
     const [notification, setNotification] = useState<boolean>(false);
     const [success, setSuccess] = useState<string>();
+    const takeMutation = useTakeUndoableMutation();
     const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isPending }] = useUpdate(
         'posts',
@@ -284,10 +287,10 @@ const WithMiddlewaresCore = () => {
                     <>
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: false,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
                             }}
                         >
                             Confirm
@@ -295,10 +298,10 @@ const WithMiddlewaresCore = () => {
                         &nbsp;
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: true,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
                             }}
                         >
                             Cancel
@@ -349,6 +352,7 @@ const WithMiddlewaresErrorCore = () => {
     const [notification, setNotification] = useState<boolean>(false);
     const [success, setSuccess] = useState<string>();
     const [error, setError] = useState<any>();
+    const takeMutation = useTakeUndoableMutation();
     const { data, refetch } = useGetOne('posts', { id: 1 });
     const [update, { isPending }] = useUpdate(
         'posts',
@@ -397,10 +401,10 @@ const WithMiddlewaresErrorCore = () => {
                     <>
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: false,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
                             }}
                         >
                             Confirm
@@ -408,10 +412,10 @@ const WithMiddlewaresErrorCore = () => {
                         &nbsp;
                         <button
                             onClick={() => {
-                                undoableEventEmitter.emit('end', {
-                                    isUndo: true,
-                                });
                                 setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
                             }}
                         >
                             Cancel

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -11,7 +11,7 @@ import {
 } from '@tanstack/react-query';
 
 import { useDataProvider } from './useDataProvider';
-import undoableEventEmitter from './undoableEventEmitter';
+import { useAddUndoableMutation } from './undo/useAddUndoableMutation';
 import {
     RaRecord,
     UpdateManyParams,
@@ -87,6 +87,7 @@ export const useUpdateMany = <
 ): UseUpdateManyResult<RecordType, boolean, MutationError> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
+    const addUndoableMutation = useAddUndoableMutation();
     const { ids, data, meta } = params;
     const { mutationMode = 'pessimistic', ...mutationOptions } = options;
     const mode = useRef<MutationMode>(mutationMode);
@@ -456,8 +457,9 @@ export const useUpdateMany = <
                 }
             );
         } else {
-            // undoable mutation: register the mutation for later
-            undoableEventEmitter.once('end', ({ isUndo }) => {
+            // Undoable mutation: add the mutation to the undoable queue.
+            // The Notification component will dequeue it when the user confirms or cancels the message.
+            addUndoableMutation(({ isUndo }) => {
                 if (isUndo) {
                     // rollback
                     snapshot.current.forEach(([key, value]) => {

--- a/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.spec.tsx
@@ -9,11 +9,11 @@ import {
 } from '@testing-library/react';
 import {
     CoreAdminContext,
-    undoableEventEmitter,
     useRecordContext,
     useSaveContext,
     useEditContext,
     ResourceDefinitionContextProvider,
+    useTakeUndoableMutation,
 } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
@@ -169,6 +169,19 @@ describe('<Edit />', () => {
                     </>
                 );
             };
+            const Confirm = () => {
+                const takeMutation = useTakeUndoableMutation();
+                return (
+                    <button
+                        aria-label="confirm"
+                        onClick={() => {
+                            const mutation = takeMutation();
+                            if (!mutation) return;
+                            mutation({ isUndo: false });
+                        }}
+                    />
+                );
+            };
 
             render(
                 <CoreAdminContext dataProvider={dataProvider}>
@@ -178,6 +191,7 @@ describe('<Edit />', () => {
                         mutationOptions={{ onSuccess }}
                     >
                         <FakeForm />
+                        <Confirm />
                     </Edit>
                 </CoreAdminContext>
             );
@@ -192,7 +206,7 @@ describe('<Edit />', () => {
                 expect(update).toHaveBeenCalledTimes(0);
             });
             act(() => {
-                undoableEventEmitter.emit('end', {});
+                screen.getByLabelText('confirm').click();
             });
             await waitFor(() =>
                 // dataProvider called

--- a/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { ConsecutiveUndoable } from './Notification.stories';
+
+describe('<Notification />', () => {
+    it('should confirm the first undoable notification when a second one starts', async () => {
+        const deleteOne = jest
+            .fn()
+            .mockImplementation((_resource, { id }) =>
+                Promise.resolve({ data: { id } })
+            );
+        const dataProvider = { delete: deleteOne } as any;
+        render(<ConsecutiveUndoable dataProvider={dataProvider} />);
+        await screen.findByText('Post deleted');
+        expect(deleteOne).toHaveBeenCalledTimes(0);
+        await waitFor(() => {
+            expect(deleteOne).toHaveBeenCalledTimes(1);
+        });
+        screen.getByText('ra.action.undo').click();
+        expect(deleteOne).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
@@ -12,12 +12,22 @@ describe('<Notification />', () => {
             );
         const dataProvider = { delete: deleteOne } as any;
         render(<ConsecutiveUndoable dataProvider={dataProvider} />);
-        await screen.findByText('Post deleted');
+        (await screen.findByText('Delete post 1')).click();
+
+        // the notification shows up
+        await screen.findByText('Post 1 deleted');
+        // but the delete hasn't been called yet
         expect(deleteOne).toHaveBeenCalledTimes(0);
-        await waitFor(() => {
-            expect(deleteOne).toHaveBeenCalledTimes(1);
-        });
+
+        screen.getByText('Delete post 2').click();
+
+        // the second notification shows up
+        await screen.findByText('Post 2 deleted');
+        // the first delete has been called
+        expect(deleteOne).toHaveBeenCalledTimes(1);
+
         screen.getByText('ra.action.undo').click();
+        // the second delete hasn't been called
         expect(deleteOne).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { ConsecutiveUndoable } from './Notification.stories';
 

--- a/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
@@ -5,7 +5,7 @@ import {
     useDelete,
     CoreAdminContext,
 } from 'ra-core';
-import { Alert } from '@mui/material';
+import { Alert, Button, Stack } from '@mui/material';
 
 import { Notification } from './Notification';
 
@@ -155,24 +155,26 @@ export const CustomNode = () => (
     </Wrapper>
 );
 
-const DeletePosts = () => {
+const DeletePost = ({ id }) => {
     const [deleteOne] = useDelete();
     const notify = useNotify();
-    const deletePost = id => {
+    const deletePost = () => {
         deleteOne(
             'posts',
             { id },
             {
                 mutationMode: 'undoable',
-                onSuccess: () => notify('Post deleted', { undoable: true }),
+                onSuccess: () =>
+                    notify(`Post ${id} deleted`, { undoable: true }),
             }
         );
     };
-    React.useEffect(() => {
-        deletePost(1);
-        setTimeout(deletePost, 100, 2);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
-    return null;
+
+    return (
+        <Button variant="outlined" onClick={deletePost}>
+            Delete post {id}
+        </Button>
+    );
 };
 
 export const ConsecutiveUndoable = ({
@@ -184,7 +186,10 @@ export const ConsecutiveUndoable = ({
     } as any,
 }) => (
     <CoreAdminContext dataProvider={dataProvider}>
-        <DeletePosts />
+        <Stack spacing={2} direction="row" m={2}>
+            <DeletePost id={1} />
+            <DeletePost id={2} />
+        </Stack>
         <Notification />
     </CoreAdminContext>
 );

--- a/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { useNotify, NotificationContextProvider } from 'ra-core';
+import {
+    useNotify,
+    NotificationContextProvider,
+    useDelete,
+    CoreAdminContext,
+} from 'ra-core';
 import { Alert } from '@mui/material';
 
 import { Notification } from './Notification';
@@ -148,4 +153,38 @@ export const CustomNode = () => (
     <Wrapper>
         <CustomNodeNotification />
     </Wrapper>
+);
+
+const DeletePosts = () => {
+    const [deleteOne] = useDelete();
+    const notify = useNotify();
+    const deletePost = id => {
+        deleteOne(
+            'posts',
+            { id },
+            {
+                mutationMode: 'undoable',
+                onSuccess: () => notify('Post deleted', { undoable: true }),
+            }
+        );
+    };
+    React.useEffect(() => {
+        deletePost(1);
+        setTimeout(deletePost, 100, 2);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    return null;
+};
+
+export const ConsecutiveUndoable = ({
+    dataProvider = {
+        delete: async (_resource, { id }) => {
+            console.log('delete post', id);
+            return { data: { id } };
+        },
+    } as any,
+}) => (
+    <CoreAdminContext dataProvider={dataProvider}>
+        <DeletePosts />
+        <Notification />
+    </CoreAdminContext>
 );


### PR DESCRIPTION
Closes #10269

- [x] Add `UndoableMutationContextProvider` queue and associated hooks
- [x] Use it to take mutations in `Notification`
- [x] Use it to put mutations in data provider mutation hooks
- [x] Deprecate `undoableEventEmitter` (but keep it for BC)
- [x] Add unit tests for the "two mutations in a row" scenario

