### PR TITLE
[Doc] Remove outdated warning about `<SimpleFormIterator>` cloning its children

### DIFF
--- a/docs/SimpleFormIterator.md
+++ b/docs/SimpleFormIterator.md
@@ -185,8 +185,6 @@ import { ArrayInput, SimpleFormIterator, DateInput, TextField, FormDataConsumer,
 </ArrayInput>
 ```
 
-**Caution**: `<SimpleFormIterator>` **clones** its children several times, as it needs to override their actual source for each record. If you use a custom Input element, make sure they accept a custom `source` prop. 
-
 ## `className`
 
 CSS classes passed to the root component. 


### PR DESCRIPTION
## Problem

`<SimpleFormIterator>` doc still says that the component clones its children, which is no longer true since v5.

## Solution

Remove this unnecessary warning from the doc.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
