### PR TITLE
fixes #10301 race condition in link generation

### DIFF
--- a/packages/ra-core/src/routing/useGetPathForRecord.ts
+++ b/packages/ra-core/src/routing/useGetPathForRecord.ts
@@ -107,10 +107,7 @@ export const useGetPathForRecord = <RecordType extends RaRecord = RaRecord>(
                 );
                 return;
             }
-        }
-
-        // Handle the link function case
-        if (typeof link === 'function') {
+        } else if (typeof link === 'function') {
             const linkResult = link(record, resource);
             if (linkResult instanceof Promise) {
                 linkResult.then(resolvedPath => setPath(resolvedPath));
@@ -124,6 +121,14 @@ export const useGetPathForRecord = <RecordType extends RaRecord = RaRecord>(
                           type: linkResult,
                       })
                     : false
+            );
+        } else if (link) {
+            setPath(
+                createPath({
+                    resource,
+                    id: record.id,
+                    type: link,
+                })
             );
         }
     }, [


### PR DESCRIPTION
## Problem

_Describe the problem this PR solves_
fixes an issue (race condition) happening during reference link generation
bug introduced in 5.2.3 -> 5.3.0
https://github.com/marmelab/react-admin/commit/10a1c76f19bb5096f64f95cfb09d0a77a383455e

The issue is somewhat described in 
https://github.com/marmelab/react-admin/issues/10301

Closes #10301

## Solution

`path` is not `set` when async `record` comes in and `link` prop is a `string`

## How To Test

I hope it's clear that the `useEffect` should set this