### PR TITLE
[Doc] Fix typo in TabbedForm and TabbedShowLayout

### DIFF
--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -510,7 +510,7 @@ export const TagEdit = () => (
 
 - `label`: the label of the tab
 - `path`: the path of the tab in the URL (ignored when `syncWithLocation={false}`)
-- `count`: the number of items in the tab (dislayed close to the label)
+- `count`: the number of items in the tab (displayed close to the label)
 - `sx`: custom styles to apply to the tab
 - `children`: the content of the tab (usually a list of inputs)
 

--- a/docs/TabbedShowLayout.md
+++ b/docs/TabbedShowLayout.md
@@ -86,7 +86,7 @@ It accepts the following props:
 - `label`: The string displayed for each tab
 - `icon`: The icon to show before the label (optional). Must be a component.
 - `path`: The string used for custom urls (optional)
-- `count`: the number of items in the tab (dislayed close to the label)
+- `count`: the number of items in the tab (displayed close to the label)
 
 ```jsx
 // in src/posts.js


### PR DESCRIPTION
## Problem

There are some typos in TabbedForm and TabbedShowLayout pages.

## Solution

Fix the typos.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
  - why: I fixed only docs.
- [ ] The PR includes one or several **stories** (if not possible, describe why)
  - why: I fixed only docs.
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
