### PR TITLE
[DOC] Add missing parameter in NextJs integration example

### DIFF
--- a/docs/NextJs.md
+++ b/docs/NextJs.md
@@ -212,6 +212,7 @@ async function handler(request: Request) {
                 request.headers.get('content-type') ?? 'application/json',
             // supabase authentication
             apiKey: process.env.SUPABASE_SERVICE_ROLE ?? '',
+            Authorization: "Bearer " + process.env.SUPABASE_SERVICE_ROLE ?? '',
         },
     };
 
@@ -260,6 +261,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ["content-type"]: req.headers["content-type"] ?? "application/json",
       // supabase authentication
       apiKey: process.env.SUPABASE_SERVICE_ROLE ?? '',
+      Authorization: "Bearer " + process.env.SUPABASE_SERVICE_ROLE ?? '',
     },
   };
   if (req.body) {


### PR DESCRIPTION
Official supabase document describes to add Authorization token. [document](https://supabase.com/docs/guides/api/quickstart)

## Problem

I could not update supabase rows after follow this [nextjs integration example](https://marmelab.com/react-admin/NextJs.html).

Turns out  I need to add authorization token too, when RLS is set.

## Solution

_Describe the solution this PR implements_

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
  Document fix
- [ ] The PR includes one or several **stories** (if not possible, describe why)
  Document fix
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
