### PR TITLE
[Doc] Fix links to react-dropzone doc pages

### DIFF
--- a/docs/FileInput.md
+++ b/docs/FileInput.md
@@ -143,7 +143,7 @@ If `multiple` is set to `false` and additional files are dropped, all files besi
 
 ## `options`
 
-`<FileInput>` accepts an `options` prop into which you can pass all the [react-dropzone properties](https://react-dropzone.netlify.com/#proptypes).
+`<FileInput>` accepts an `options` prop into which you can pass all the [react-dropzone properties](https://react-dropzone.js.org/#src).
 
 ## `placeholder`
 

--- a/docs/ImageInput.md
+++ b/docs/ImageInput.md
@@ -138,7 +138,7 @@ If `multiple` is set to `false` and additional files are dropped, all files besi
 
 ## `options`
 
-`<ImageInput>` accepts an `options` prop into which you can pass all the [react-dropzone properties](https://react-dropzone.netlify.com/#proptypes).
+`<ImageInput>` accepts an `options` prop into which you can pass all the [react-dropzone properties](https://react-dropzone.js.org/#src).
 
 ## `placeholder`
 


### PR DESCRIPTION
## Problem

Some links to the react-dropzone docs are dead (e.g. https://react-dropzone.netlify.com/#proptypes)

## Solution

Update the links to the new doc location


## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
