### PR TITLE
Fix `<Edit>` ignores mutation meta when updating the `getOne` cache

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -151,7 +151,7 @@ export const useEditController = <
                 : '',
     });
 
-    const recordCached = { id, previousData: record, meta: mutationMeta };
+    const recordCached = { id, previousData: record };
 
     const [update, { isPending: saving }] = useUpdate<RecordType, ErrorType>(
         resource,

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -151,7 +151,7 @@ export const useEditController = <
                 : '',
     });
 
-    const recordCached = { id, previousData: record };
+    const recordCached = { id, previousData: record, meta: mutationMeta };
 
     const [update, { isPending: saving }] = useUpdate<RecordType, ErrorType>(
         resource,

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -115,7 +115,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
     // otherwise the other side effects may not applied.
     const hasCallTimeOnSuccess = useRef(false);
 
-    const updateCache = ({ resource, id, data }) => {
+    const updateCache = ({ resource, id, data, meta }) => {
         // hack: only way to tell react-query not to fetch this query for the next 5 seconds
         // because setQueryData doesn't accept a stale time option
         const now = Date.now();
@@ -273,6 +273,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
                     resource: callTimeResource,
                     id: callTimeId,
                     data,
+                    meta: mutationOptions.meta ?? paramsRef.current.meta,
                 });
 
                 if (
@@ -440,6 +441,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
             resource: callTimeResource,
             id: callTimeId,
             data: callTimeData,
+            meta: callTimeMeta,
         });
 
         // run the success callbacks during the next tick


### PR DESCRIPTION
Closes #9542

