### PR TITLE
fix(ra-data-graphql-simple): Unify meta location in buildVariables

### DIFF
--- a/packages/ra-data-graphql-simple/src/buildVariables.test.ts
+++ b/packages/ra-data-graphql-simple/src/buildVariables.test.ts
@@ -19,6 +19,7 @@ describe('buildVariables', () => {
             },
         ],
     };
+
     describe('GET_LIST', () => {
         it('returns correct variables', () => {
             const params = {
@@ -55,8 +56,8 @@ describe('buildVariables', () => {
 
         it('should return correct meta', () => {
             const params = {
-                filter: {},
-                meta: { sparseFields: [] },
+                filter: { views: 100 },
+                meta: { sparseFields: ['field'] },
             };
 
             expect(
@@ -67,8 +68,8 @@ describe('buildVariables', () => {
                     {}
                 )
             ).toEqual({
-                filter: {},
-                meta: { sparseFields: [] },
+                filter: { views: 100 },
+                meta: { sparseFields: ['field'] },
             });
         });
     });
@@ -99,11 +100,11 @@ describe('buildVariables', () => {
                 title: 'Foo',
             });
         });
+
         it('should return correct meta', () => {
             const params = {
-                data: {
-                    meta: { sparseFields: [] },
-                },
+                data: { title: 'Foo' },
+                meta: { sparseFields: ['field'] },
             };
             const queryType = {
                 args: [],
@@ -117,7 +118,8 @@ describe('buildVariables', () => {
                     queryType
                 )
             ).toEqual({
-                meta: { sparseFields: [] },
+                title: 'Foo',
+                meta: { sparseFields: ['field'] },
             });
         });
     });
@@ -153,9 +155,9 @@ describe('buildVariables', () => {
 
         it('should return correct meta', () => {
             const params = {
-                data: {
-                    meta: { sparseFields: [] },
-                },
+                id: 'post1',
+                data: { title: 'Foo' },
+                meta: { sparseFields: ['field'] },
             };
             const queryType = {
                 args: [],
@@ -169,7 +171,9 @@ describe('buildVariables', () => {
                     queryType
                 )
             ).toEqual({
-                meta: { sparseFields: [] },
+                id: 'post1',
+                title: 'Foo',
+                meta: { sparseFields: ['field'] },
             });
         });
     });
@@ -194,7 +198,8 @@ describe('buildVariables', () => {
 
         it('should return correct meta', () => {
             const params = {
-                meta: { sparseFields: [] },
+                ids: ['tag1'],
+                meta: { sparseFields: ['field'] },
             };
 
             expect(
@@ -205,8 +210,10 @@ describe('buildVariables', () => {
                     {}
                 )
             ).toEqual({
-                filter: {},
-                meta: { sparseFields: [] },
+                filter: {
+                    ids: ['tag1'],
+                },
+                meta: { sparseFields: ['field'] },
             });
         });
     });
@@ -238,7 +245,9 @@ describe('buildVariables', () => {
 
         it('should return correct meta', () => {
             const params = {
-                meta: { sparseFields: [] },
+                target: 'author_id',
+                id: 'author1',
+                meta: { sparseFields: ['field'] },
             };
 
             expect(
@@ -249,8 +258,8 @@ describe('buildVariables', () => {
                     {}
                 )
             ).toEqual({
-                filter: {},
-                meta: { sparseFields: [] },
+                filter: { author_id: 'author1' },
+                meta: { sparseFields: ['field'] },
             });
         });
     });
@@ -260,6 +269,7 @@ describe('buildVariables', () => {
             const params = {
                 id: 'post1',
             };
+
             expect(
                 buildVariables(introspectionResult)(
                     { type: { name: 'Post', inputFields: [] } },
@@ -274,8 +284,10 @@ describe('buildVariables', () => {
 
         it('should return correct meta', () => {
             const params = {
-                meta: { sparseFields: [] },
+                id: 'post1',
+                meta: { sparseFields: ['field'] },
             };
+
             expect(
                 buildVariables(introspectionResult)(
                     { type: { name: 'Post', inputFields: [] } },
@@ -284,7 +296,8 @@ describe('buildVariables', () => {
                     {}
                 )
             ).toEqual({
-                meta: { sparseFields: [] },
+                id: 'post1',
+                meta: { sparseFields: ['field'] },
             });
         });
     });
@@ -294,6 +307,7 @@ describe('buildVariables', () => {
             const params = {
                 ids: ['post1'],
             };
+
             expect(
                 buildVariables(introspectionResult)(
                     { type: { name: 'Post', inputFields: [] } },
@@ -315,6 +329,7 @@ describe('buildVariables', () => {
                     title: 'New Title',
                 },
             };
+
             expect(
                 buildVariables(introspectionResult)(
                     { type: { name: 'Post', inputFields: [] } },

--- a/packages/ra-data-graphql-simple/src/buildVariables.ts
+++ b/packages/ra-data-graphql-simple/src/buildVariables.ts
@@ -326,7 +326,7 @@ const buildGetListVariables =
 const buildCreateUpdateVariables = (
     resource: IntrospectedResource,
     raFetchMethod,
-    { id, data }: any,
+    { id, data, meta }: any,
     queryType: IntrospectionField
 ) =>
     Object.keys(data).reduce(
@@ -358,5 +358,5 @@ const buildCreateUpdateVariables = (
                 [key]: data[key],
             };
         },
-        { id }
+        { id, meta }
     );


### PR DESCRIPTION
## Problem

Fixes #10317.
The sparse fields functionality works by reading the `meta.sparseFields` array. But for create and update mutations it looked for the `sparseFields` value in `data.meta`.

## Solution

Return the `meta` object in `buildCreateUpdateVariables` which is used for both create and update mutations.

## How To Test

Can be tested by setting the `meta` object for a create or update mutation and setting sparse fields on it:

```ts
{
  meta: { sparseFields: ['id'] }
}
```

Trigger the mutation and the generated selection should only include fields specified in `sparseFields`.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
  - Not UI related, affects data provider. I'm not aware that it has any stories.
- [x] The **documentation** is up to date
