### PR TITLE
Documentation/stacked filters default value

### DIFF
--- a/docs/StackedFilters.md
+++ b/docs/StackedFilters.md
@@ -129,7 +129,7 @@ For instance, if the user adds the `views` filter with the `eq` operator and a v
 In your filter declaration, you can provide an `operator`, an `input` and a `defaultValue`.
 The **input** is a react object taking `source` as prop and rendering the input you will need to fill for your filter.
 
-**Tip:** The **defaultValue** of a filter is not the same as the `defaultValue` of an `operator`.
+**Tip:** The the `defaultValue` of an `operator` takes priority over the **defaultValue** of a filter.
 
 ## Filter Configuration Builders
 


### PR DESCRIPTION
## Problem

In the `StackedFilters` documentation, the `defaultValue` **tip**  is not perfectly understandable

## Solution

Update this doc

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date
