### PR TITLE
[Doc] Add a doc section for `<DatagridAg>` inside an `<InfiniteList>`

### DIFF
--- a/docs/DatagridAG.md
+++ b/docs/DatagridAG.md
@@ -140,6 +140,38 @@ export const PostList = () => {
   Your browser does not support the video tag.
 </video>
 
+### Usage Inside An `<InfiniteList>`
+
+`<DatagridAG>` also supports being used as a child of a react-admin `<InfiniteList>`.
+
+It only requires setting the `pagination` prop to `false`, because `<DatagridAG>` will itself detect when it needs to fetch more data, and the `<InfiniteList>` default pagination component would conflict with this behavior.
+
+```tsx
+import '@ag-grid-community/styles/ag-grid.css';
+import '@ag-grid-community/styles/ag-theme-alpine.css';
+import React from 'react';
+import { InfiniteList } from 'react-admin';
+import { DatagridAG } from '@react-admin/ra-datagrid-ag';
+
+export const PostList = () => {
+    const columnDefs = [
+        { field: 'title' },
+        { field: 'published_at' },
+        { field: 'body' },
+    ];
+    return (
+        <InfiniteList pagination={false}>
+            <DatagridAG columnDefs={columnDefs} />
+        </InfiniteList>
+    );
+};
+```
+
+<video controls autoplay playsinline muted loop>
+  <source src="https://react-admin-ee.marmelab.com/assets/DatagridAG-infinite.mp4" type="video/mp4"/>
+  Your browser does not support the video tag.
+</video>
+
 ### Filter Syntax
 
 `<DatagridAG>` displays the data fetched by its parent (usually `<List>`).


### PR DESCRIPTION
## Problem

 `<DatagridAg>` in now usable inside an `<InfiniteList>`

## Solution

Add a doc section for `<DatagridAg>` inside an `<InfiniteList>`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date
