### PR TITLE
Fix Datagrid header tooltip sometimes indicates the wrong sort order

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -7,10 +7,15 @@ import { TableCellProps } from '@mui/material/TableCell';
 import {
     FieldTitle,
     useTranslate,
-    SortPayload,
     useResourceContext,
     useTranslateLabel,
 } from 'ra-core';
+import type { SortPayload } from 'ra-core';
+
+const oppositeOrder: Record<SortPayload['order'], SortPayload['order']> = {
+    ASC: 'DESC',
+    DESC: 'ASC',
+};
 
 export const DatagridHeaderCell = (
     props: DatagridHeaderCellProps
@@ -20,6 +25,13 @@ export const DatagridHeaderCell = (
 
     const translate = useTranslate();
     const translateLabel = useTranslateLabel();
+    const nextSortOrder = field
+        ? sort && sort.field === (field.props.sortBy || field.props.source)
+            ? // active sort field, use opposite order
+              oppositeOrder[sort.order]
+            : // non active sort field, use default order
+              field?.props.sortByOrder ?? 'ASC'
+        : undefined;
     const sortLabel = translate('ra.sort.sort_by', {
         field: field
             ? translateLabel({
@@ -31,7 +43,7 @@ export const DatagridHeaderCell = (
                   source: field.props.source,
               })
             : undefined,
-        order: translate(`ra.sort.${sort?.order === 'ASC' ? 'DESC' : 'ASC'}`),
+        order: translate(`ra.sort.${nextSortOrder}`),
         _: translate('ra.action.sort'),
     });
 


### PR DESCRIPTION
## Problem

The tooltip of the datagrid header indicates the action of the click, which is to change the field and order. 

The indication of the order is sometimes wrong. 

## Solution

Fix it. 