### PR TITLE
Fix `<DateInput>` and `<DateTimeInput>` do not react to form changes

### DIFF
--- a/packages/ra-ui-materialui/src/input/DateInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.spec.tsx
@@ -8,7 +8,12 @@ import { useFormState } from 'react-hook-form';
 import { AdminContext } from '../AdminContext';
 import { SimpleForm } from '../form';
 import { DateInput } from './DateInput';
-import { Basic, ExternalChanges, Parse } from './DateInput.stories';
+import {
+    Basic,
+    ExternalChanges,
+    ExternalChangesWithParse,
+    Parse,
+} from './DateInput.stories';
 
 describe('<DateInput />', () => {
     const defaultProps = {
@@ -247,13 +252,7 @@ describe('<DateInput />', () => {
     });
 
     it('should change its value when the form value has changed', async () => {
-        render(
-            <ExternalChanges
-                simpleFormProps={{
-                    defaultValues: { publishedAt: '2021-09-11' },
-                }}
-            />
-        );
+        render(<ExternalChanges />);
         await screen.findByText('"2021-09-11" (string)');
         const input = screen.getByLabelText('Published at') as HTMLInputElement;
         fireEvent.change(input, {
@@ -265,14 +264,27 @@ describe('<DateInput />', () => {
         await screen.findByText('"2021-10-20" (string)');
     });
 
-    it('should change its value when the form value is reset', async () => {
-        render(
-            <ExternalChanges
-                simpleFormProps={{
-                    defaultValues: { publishedAt: '2021-09-11' },
-                }}
-            />
+    it('should change its value when the form value has changed with a custom parse', async () => {
+        render(<ExternalChangesWithParse />);
+        await screen.findByText(
+            'Sat Sep 11 2021 02:00:00 GMT+0200 (Central European Summer Time)'
         );
+        const input = screen.getByLabelText('Published at') as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { value: '2021-10-30' },
+        });
+        fireEvent.blur(input);
+        await screen.findByText(
+            'Sat Oct 30 2021 02:00:00 GMT+0200 (Central European Summer Time)'
+        );
+        fireEvent.click(screen.getByText('Change value'));
+        await screen.findByText(
+            'Wed Oct 20 2021 02:00:00 GMT+0200 (Central European Summer Time)'
+        );
+    });
+
+    it('should change its value when the form value is reset', async () => {
+        render(<ExternalChanges />);
         await screen.findByText('"2021-09-11" (string)');
         const input = screen.getByLabelText('Published at') as HTMLInputElement;
         fireEvent.change(input, {

--- a/packages/ra-ui-materialui/src/input/DateInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.spec.tsx
@@ -8,7 +8,7 @@ import { useFormState } from 'react-hook-form';
 import { AdminContext } from '../AdminContext';
 import { SimpleForm } from '../form';
 import { DateInput } from './DateInput';
-import { Basic, Parse } from './DateInput.stories';
+import { Basic, ExternalChanges, Parse } from './DateInput.stories';
 
 describe('<DateInput />', () => {
     const defaultProps = {
@@ -244,6 +244,25 @@ describe('<DateInput />', () => {
                 expect.anything()
             );
         });
+    });
+
+    it('should change its value when the form value has changed', async () => {
+        render(
+            <ExternalChanges
+                simpleFormProps={{
+                    defaultValues: { publishedAt: '2021-09-11' },
+                }}
+            />
+        );
+        await screen.findByText('"2021-09-11" (string)');
+        const input = screen.getByLabelText('Published at') as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { value: '2021-10-30' },
+        });
+        fireEvent.blur(input);
+        await screen.findByText('"2021-10-30" (string)');
+        fireEvent.click(screen.getByText('Change value'));
+        await screen.findByText('"2021-10-20" (string)');
     });
 
     describe('error message', () => {

--- a/packages/ra-ui-materialui/src/input/DateInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.spec.tsx
@@ -265,6 +265,25 @@ describe('<DateInput />', () => {
         await screen.findByText('"2021-10-20" (string)');
     });
 
+    it('should change its value when the form value is reset', async () => {
+        render(
+            <ExternalChanges
+                simpleFormProps={{
+                    defaultValues: { publishedAt: '2021-09-11' },
+                }}
+            />
+        );
+        await screen.findByText('"2021-09-11" (string)');
+        const input = screen.getByLabelText('Published at') as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { value: '2021-10-30' },
+        });
+        fireEvent.blur(input);
+        await screen.findByText('"2021-10-30" (string)');
+        fireEvent.click(screen.getByText('Reset'));
+        await screen.findByText('"2021-09-11" (string)');
+    });
+
     describe('error message', () => {
         it('should not be displayed if field is pristine', () => {
             render(<Basic dateInputProps={{ validate: required() }} />);

--- a/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
@@ -118,6 +118,23 @@ export const ExternalChanges = ({
     </Wrapper>
 );
 
+export const ExternalChangesWithParse = ({
+    dateInputProps = {
+        parse: value => new Date(value),
+    },
+    simpleFormProps = {
+        defaultValues: { publishedAt: new Date('2021-09-11') },
+    },
+}: {
+    dateInputProps?: Partial<DateInputProps>;
+    simpleFormProps?: Omit<SimpleFormProps, 'children'>;
+}) => (
+    <Wrapper simpleFormProps={simpleFormProps}>
+        <DateInput source="publishedAt" {...dateInputProps} />
+        <DateHelper source="publishedAt" value={new Date('2021-10-20')} />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({
@@ -137,7 +154,13 @@ const Wrapper = ({
     </AdminContext>
 );
 
-const DateHelper = ({ source, value }: { source: string; value: string }) => {
+const DateHelper = ({
+    source,
+    value,
+}: {
+    source: string;
+    value: string | Date;
+}) => {
     const record = useRecordContext();
     const { resetField, setValue } = useFormContext();
     const currentValue = useWatch({ name: source });
@@ -148,7 +171,7 @@ const DateHelper = ({ source, value }: { source: string; value: string }) => {
                 Record value: {get(record, source)?.toString() ?? '-'}
             </Typography>
             <Typography>
-                Current value: {currentValue?.toString() ?? '-'}
+                Current value: <span>{currentValue?.toString() ?? '-'}</span>
             </Typography>
             <Button
                 onClick={() => {

--- a/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import { minValue } from 'ra-core';
+import { minValue, useRecordContext } from 'ra-core';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { Box, Button, Typography } from '@mui/material';
+import get from 'lodash/get';
 
 import { AdminContext } from '../AdminContext';
 import { Create } from '../detail';
@@ -100,6 +103,19 @@ export const Parse = ({ simpleFormProps }) => (
     </Wrapper>
 );
 
+export const ExternalChanges = ({
+    simpleFormProps = {
+        defaultValues: { publishedAt: '2021-09-11' },
+    },
+}: {
+    simpleFormProps?: Omit<SimpleFormProps, 'children'>;
+}) => (
+    <Wrapper simpleFormProps={simpleFormProps}>
+        <DateInput source="publishedAt" />
+        <DateHelper source="publishedAt" value="2021-10-20" />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({
@@ -118,3 +134,37 @@ const Wrapper = ({
         </Create>
     </AdminContext>
 );
+
+const DateHelper = ({ source, value }: { source: string; value: string }) => {
+    const record = useRecordContext();
+    const { resetField, setValue } = useFormContext();
+    const currentValue = useWatch({ name: source });
+
+    return (
+        <Box>
+            <Typography>
+                Record value: {get(record, source)?.toString() ?? '-'}
+            </Typography>
+            <Typography>
+                Current value: {currentValue?.toString() ?? '-'}
+            </Typography>
+            <Button
+                onClick={() => {
+                    setValue(source, value, { shouldDirty: true });
+                }}
+                type="button"
+            >
+                Change value
+            </Button>
+            <Button
+                color="error"
+                onClick={() => {
+                    resetField(source);
+                }}
+                type="button"
+            >
+                Reset
+            </Button>
+        </Box>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
@@ -104,14 +104,16 @@ export const Parse = ({ simpleFormProps }) => (
 );
 
 export const ExternalChanges = ({
+    dateInputProps = {},
     simpleFormProps = {
         defaultValues: { publishedAt: '2021-09-11' },
     },
 }: {
+    dateInputProps?: Partial<DateInputProps>;
     simpleFormProps?: Omit<SimpleFormProps, 'children'>;
 }) => (
     <Wrapper simpleFormProps={simpleFormProps}>
-        <DateInput source="publishedAt" />
+        <DateInput source="publishedAt" {...dateInputProps} />
         <DateHelper source="publishedAt" value="2021-10-20" />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -71,25 +71,20 @@ export const DateInput = ({
     const valueChangedFromInput = React.useRef(false);
     const localInputRef = React.useRef<HTMLInputElement>();
     const initialDefaultValueRef = React.useRef(field.value);
+    const currentValueRef = React.useRef(field.value);
 
     // update the react-hook-form value if the field value changes
     React.useEffect(() => {
-        const initialDateValue =
-            new Date(initialDefaultValueRef.current).getTime() || null;
-
-        const fieldDateValue = new Date(field.value).getTime() || null;
-
         if (
-            initialDateValue !== fieldDateValue &&
+            currentValueRef.current !== field.value &&
             !valueChangedFromInput.current
         ) {
             setRenderCount(r => r + 1);
-            field.onChange(field.value);
             initialDefaultValueRef.current = field.value;
-            valueChangedFromInput.current = false;
+            currentValueRef.current = field.value;
         }
+        valueChangedFromInput.current = false;
     }, [setRenderCount, field]);
-
     const { onBlur: onBlurFromField } = field;
     const hasFocus = React.useRef(false);
 
@@ -119,6 +114,7 @@ export const DateInput = ({
             if (newValue !== '' && newValue != null && isNewValueValid) {
                 field.onChange(newValue);
                 valueChangedFromInput.current = true;
+                currentValueRef.current = newValue;
             }
         }
     );

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
@@ -10,6 +10,7 @@ import { SimpleForm, Toolbar } from '../form';
 import { DateTimeInput } from './DateTimeInput';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
 import { SaveButton } from '../button';
+import { ExternalChanges } from './DateTimeInput.stories';
 
 describe('<DateTimeInput />', () => {
     const defaultProps = {
@@ -195,6 +196,25 @@ describe('<DateTimeInput />', () => {
                 expect.anything()
             );
         });
+    });
+
+    it('should change its value when the form value has changed', async () => {
+        render(
+            <ExternalChanges
+                simpleFormProps={{
+                    defaultValues: { published: '2021-09-11 20:00:00' },
+                }}
+            />
+        );
+        await screen.findByText('"2021-09-11 20:00:00" (string)');
+        const input = screen.getByLabelText('Published') as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { value: '2021-10-30 09:00:00' },
+        });
+        fireEvent.blur(input);
+        await screen.findByText('"2021-10-30T09:00" (string)');
+        fireEvent.click(screen.getByText('Change value'));
+        await screen.findByText('"2021-10-20 10:00:00" (string)');
     });
 
     describe('error message', () => {

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
@@ -217,6 +217,25 @@ describe('<DateTimeInput />', () => {
         await screen.findByText('"2021-10-20 10:00:00" (string)');
     });
 
+    it('should change its value when the form value is reset', async () => {
+        render(
+            <ExternalChanges
+                simpleFormProps={{
+                    defaultValues: { published: '2021-09-11 20:00:00' },
+                }}
+            />
+        );
+        await screen.findByText('"2021-09-11 20:00:00" (string)');
+        const input = screen.getByLabelText('Published') as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { value: '2021-10-30 09:00:00' },
+        });
+        fireEvent.blur(input);
+        await screen.findByText('"2021-10-30T09:00" (string)');
+        fireEvent.click(screen.getByText('Reset'));
+        await screen.findByText('"2021-09-11 20:00:00" (string)');
+    });
+
     describe('error message', () => {
         it('should not be displayed if field is pristine', () => {
             render(

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.spec.tsx
@@ -10,7 +10,10 @@ import { SimpleForm, Toolbar } from '../form';
 import { DateTimeInput } from './DateTimeInput';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
 import { SaveButton } from '../button';
-import { ExternalChanges } from './DateTimeInput.stories';
+import {
+    ExternalChanges,
+    ExternalChangesWithParse,
+} from './DateTimeInput.stories';
 
 describe('<DateTimeInput />', () => {
     const defaultProps = {
@@ -199,13 +202,7 @@ describe('<DateTimeInput />', () => {
     });
 
     it('should change its value when the form value has changed', async () => {
-        render(
-            <ExternalChanges
-                simpleFormProps={{
-                    defaultValues: { published: '2021-09-11 20:00:00' },
-                }}
-            />
-        );
+        render(<ExternalChanges />);
         await screen.findByText('"2021-09-11 20:00:00" (string)');
         const input = screen.getByLabelText('Published') as HTMLInputElement;
         fireEvent.change(input, {
@@ -217,14 +214,29 @@ describe('<DateTimeInput />', () => {
         await screen.findByText('"2021-10-20 10:00:00" (string)');
     });
 
-    it('should change its value when the form value is reset', async () => {
-        render(
-            <ExternalChanges
-                simpleFormProps={{
-                    defaultValues: { published: '2021-09-11 20:00:00' },
-                }}
-            />
+    it('should change its value when the form value has changed with custom parse', async () => {
+        render(<ExternalChangesWithParse />);
+        await screen.findByText(
+            // Because of the parse that uses the Date object, we check the value displayed and not the form value
+            // to avoid timezone issues
+            'Sat Sep 11 2021 20:00:00 GMT+0200 (Central European Summer Time)'
         );
+        const input = screen.getByLabelText('Published') as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { value: '2021-10-30 09:00:00' },
+        });
+        fireEvent.blur(input);
+        await screen.findByText(
+            'Sat Oct 30 2021 09:00:00 GMT+0200 (Central European Summer Time)'
+        );
+        fireEvent.click(screen.getByText('Change value'));
+        await screen.findByText(
+            'Wed Oct 20 2021 10:00:00 GMT+0200 (Central European Summer Time)'
+        );
+    });
+
+    it('should change its value when the form value is reset', async () => {
+        render(<ExternalChanges />);
         await screen.findByText('"2021-09-11 20:00:00" (string)');
         const input = screen.getByLabelText('Published') as HTMLInputElement;
         fireEvent.change(input, {

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.stories.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
+import { useRecordContext } from 'ra-core';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { Box, Button, Typography } from '@mui/material';
+import get from 'lodash/get';
 
 import { AdminContext } from '../AdminContext';
 import { Create } from '../detail';
-import { SimpleForm } from '../form';
+import { SimpleForm, SimpleFormProps } from '../form';
 import { DateTimeInput } from './DateTimeInput';
 import { FormInspector } from './common';
 
@@ -44,15 +48,68 @@ export const ReadOnly = () => (
     </Wrapper>
 );
 
+export const ExternalChanges = ({
+    simpleFormProps = {
+        defaultValues: { published: '2021-09-11 20:00:00' },
+    },
+}: {
+    simpleFormProps?: Omit<SimpleFormProps, 'children'>;
+}) => (
+    <Wrapper simpleFormProps={simpleFormProps}>
+        <DateTimeInput source="published" />
+        <DateHelper source="published" value="2021-10-20 10:00:00" />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
-const Wrapper = ({ children }) => (
+const Wrapper = ({
+    children,
+    simpleFormProps,
+}: {
+    children: React.ReactNode;
+    simpleFormProps?: Omit<SimpleFormProps, 'children'>;
+}) => (
     <AdminContext i18nProvider={i18nProvider} defaultTheme="light">
         <Create resource="posts">
-            <SimpleForm>
+            <SimpleForm {...simpleFormProps}>
                 {children}
                 <FormInspector name="published" />
             </SimpleForm>
         </Create>
     </AdminContext>
 );
+
+const DateHelper = ({ source, value }: { source: string; value: string }) => {
+    const record = useRecordContext();
+    const { resetField, setValue } = useFormContext();
+    const currentValue = useWatch({ name: source });
+
+    return (
+        <Box>
+            <Typography>
+                Record value: {get(record, source)?.toString() ?? '-'}
+            </Typography>
+            <Typography>
+                Current value: {currentValue?.toString() ?? '-'}
+            </Typography>
+            <Button
+                onClick={() => {
+                    setValue(source, value, { shouldDirty: true });
+                }}
+                type="button"
+            >
+                Change value
+            </Button>
+            <Button
+                color="error"
+                onClick={() => {
+                    resetField(source);
+                }}
+                type="button"
+            >
+                Reset
+            </Button>
+        </Box>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.stories.tsx
@@ -9,7 +9,7 @@ import get from 'lodash/get';
 import { AdminContext } from '../AdminContext';
 import { Create } from '../detail';
 import { SimpleForm, SimpleFormProps } from '../form';
-import { DateTimeInput } from './DateTimeInput';
+import { DateTimeInput, DateTimeInputProps } from './DateTimeInput';
 import { FormInspector } from './common';
 
 export default { title: 'ra-ui-materialui/input/DateTimeInput' };
@@ -61,6 +61,26 @@ export const ExternalChanges = ({
     </Wrapper>
 );
 
+export const ExternalChangesWithParse = ({
+    dateTimeInputProps = {
+        parse: (value: string) => new Date(value),
+    },
+    simpleFormProps = {
+        defaultValues: { published: new Date('2021-09-11 20:00:00') },
+    },
+}: {
+    dateTimeInputProps?: Partial<DateTimeInputProps>;
+    simpleFormProps?: Omit<SimpleFormProps, 'children'>;
+}) => (
+    <Wrapper simpleFormProps={simpleFormProps}>
+        <DateTimeInput source="published" {...dateTimeInputProps} />
+        <DateHelper
+            source="published"
+            value={new Date('2021-10-20 10:00:00')}
+        />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({
@@ -80,7 +100,13 @@ const Wrapper = ({
     </AdminContext>
 );
 
-const DateHelper = ({ source, value }: { source: string; value: string }) => {
+const DateHelper = ({
+    source,
+    value,
+}: {
+    source: string;
+    value: string | Date;
+}) => {
     const record = useRecordContext();
     const { resetField, setValue } = useFormContext();
     const currentValue = useWatch({ name: source });
@@ -91,7 +117,7 @@ const DateHelper = ({ source, value }: { source: string; value: string }) => {
                 Record value: {get(record, source)?.toString() ?? '-'}
             </Typography>
             <Typography>
-                Current value: {currentValue?.toString() ?? '-'}
+                Current value: <span>{currentValue?.toString() ?? '-'}</span>
             </Typography>
             <Button
                 onClick={() => {

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -53,24 +53,18 @@ export const DateTimeInput = ({
     const valueChangedFromInput = React.useRef(false);
     const localInputRef = React.useRef<HTMLInputElement>();
     const initialDefaultValueRef = React.useRef(field.value);
+    const currentValueRef = React.useRef(field.value);
 
     React.useEffect(() => {
-        const initialDateValue =
-            new Date(initialDefaultValueRef.current).getTime() || null;
-
-        const fieldDateValue = new Date(field.value).getTime() || null;
-
         if (
-            initialDateValue !== fieldDateValue &&
+            currentValueRef.current !== field.value &&
             !valueChangedFromInput.current
         ) {
             setRenderCount(r => r + 1);
-            parse
-                ? field.onChange(parse(field.value))
-                : field.onChange(field.value);
             initialDefaultValueRef.current = field.value;
-            valueChangedFromInput.current = false;
+            currentValueRef.current = field.value;
         }
+        valueChangedFromInput.current = false;
     }, [setRenderCount, parse, field]);
 
     const { onBlur: onBlurFromField } = field;
@@ -88,23 +82,17 @@ export const DateTimeInput = ({
             return;
         }
         const target = event.target;
+        const newValue = target.value;
+        const isNewValueValid =
+            newValue === '' || !isNaN(new Date(target.value).getTime());
 
-        const newValue =
-            target.valueAsDate !== undefined &&
-            target.valueAsDate !== null &&
-            !isNaN(new Date(target.valueAsDate).getTime())
-                ? parse
-                    ? parse(target.valueAsDate)
-                    : target.valueAsDate
-                : parse
-                  ? parse(target.value)
-                  : formatDateTime(target.value);
-
-        // Some browsers will return null for an invalid date so we only change react-hook-form value if it's not null
+        // Some browsers will return null for an invalid date
+        // so we only change react-hook-form value if it's not null.
         // The input reset is handled in the onBlur event handler
-        if (newValue !== '' && newValue != null) {
+        if (newValue !== '' && newValue != null && isNewValueValid) {
             field.onChange(newValue);
             valueChangedFromInput.current = true;
+            currentValueRef.current = newValue;
         }
     };
 
@@ -122,20 +110,14 @@ export const DateTimeInput = ({
             return;
         }
 
+        const newValue = localInputRef.current.value;
         // To ensure users can clear the input, we check its value on blur
         // and submit it to react-hook-form
-        const newValue =
-            localInputRef.current.valueAsDate !== undefined &&
-            localInputRef.current.valueAsDate !== null &&
-            !isNaN(new Date(localInputRef.current.valueAsDate).getTime())
-                ? parse
-                    ? parse(localInputRef.current.valueAsDate)
-                    : formatDateTime(localInputRef.current.valueAsDate)
-                : parse
-                  ? parse(localInputRef.current.value)
-                  : formatDateTime(localInputRef.current.value);
+        const isNewValueValid =
+            newValue === '' ||
+            !isNaN(new Date(localInputRef.current.value).getTime());
 
-        if (newValue !== field.value) {
+        if (isNewValueValid && field.value !== newValue) {
             field.onChange(newValue ?? '');
         }
 

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -8,16 +8,6 @@ import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
 
 /**
- * Converts a datetime string without timezone to a date object
- * with timezone, using the browser timezone.
- *
- * @param {string} value Date string, formatted as yyyy-MM-ddThh:mm
- * @return {Date}
- */
-const parseDateTime = (value: string) =>
-    value ? new Date(value) : value === '' ? null : value;
-
-/**
  * Input component for entering a date and a time with timezone, using the browser locale
  */
 export const DateTimeInput = ({
@@ -32,7 +22,6 @@ export const DateTimeInput = ({
     onFocus,
     source,
     resource,
-    parse = parseDateTime,
     validate,
     variant,
     disabled,
@@ -47,25 +36,35 @@ export const DateTimeInput = ({
         validate,
         disabled,
         readOnly,
+        format,
         ...rest,
     });
-    const [renderCount, setRenderCount] = React.useState(1);
-    const valueChangedFromInput = React.useRef(false);
     const localInputRef = React.useRef<HTMLInputElement>();
+    // DateInput is not a really controlled input to ensure users can start entering a date, go to another input and come back to complete it.
+    // This ref stores the value that is passed to the input defaultValue prop to solve this issue.
     const initialDefaultValueRef = React.useRef(field.value);
-    const currentValueRef = React.useRef(field.value);
+    // As the defaultValue prop won't trigger a remount of the HTML input, we will force it by changing the key.
+    const [inputKey, setInputKey] = React.useState(1);
+    // This ref let us track that the last change of the form state value was made by the input itself
+    const wasLastChangedByInput = React.useRef(false);
 
+    // This effect ensures we stays in sync with the react-hook-form state when the value changes from outside the input
+    // for instance by using react-hook-form reset or setValue methods.
     React.useEffect(() => {
-        if (
-            currentValueRef.current !== field.value &&
-            !valueChangedFromInput.current
-        ) {
-            setRenderCount(r => r + 1);
-            initialDefaultValueRef.current = field.value;
-            currentValueRef.current = field.value;
+        // Ignore react-hook-form state changes if it came from the input itself
+        if (wasLastChangedByInput.current) {
+            // Resets the flag to ensure futures changes are handled
+            wasLastChangedByInput.current = false;
+            return;
         }
-        valueChangedFromInput.current = false;
-    }, [setRenderCount, parse, field]);
+
+        // The value has changed from outside the input, we update the input value
+        initialDefaultValueRef.current = field.value;
+        // Trigger a remount of the HTML input
+        setInputKey(r => r + 1);
+        // Resets the flag to ensure futures changes are handled
+        wasLastChangedByInput.current = false;
+    }, [setInputKey, field.value]);
 
     const { onBlur: onBlurFromField } = field;
     const hasFocus = React.useRef(false);
@@ -91,8 +90,8 @@ export const DateTimeInput = ({
         // The input reset is handled in the onBlur event handler
         if (newValue !== '' && newValue != null && isNewValueValid) {
             field.onChange(newValue);
-            valueChangedFromInput.current = true;
-            currentValueRef.current = newValue;
+            // Track the fact that the next react-hook-form state change was triggered by the input itself
+            wasLastChangedByInput.current = true;
         }
     };
 
@@ -137,7 +136,7 @@ export const DateTimeInput = ({
             inputRef={inputRef}
             name={name}
             defaultValue={format(initialDefaultValueRef.current)}
-            key={renderCount}
+            key={inputKey}
             type="datetime-local"
             onChange={handleChange}
             onFocus={handleFocus}


### PR DESCRIPTION
## Problem

`<DateInput>` and `<DateTimeInput>` do not react to form changes. For instance if you use react-hook-form hooks to set the value.

Fixes #10320

## Solution

Make sure we update the internal value when it changes from outside. 

## How To Test

There are two new stories and matching tests:
- DateTimeInput: https://react-admin-storybook-c6qu3ea65-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-input-dateinput--external-changes
- DateInput: http://localhost:9010/?path=/story/ra-ui-materialui-input-dateinput--external-changes


## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
~~- [ ] The **documentation** is up to date~~

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
