### PR TITLE
Fix `<SimpleList linkType={false}>` UI

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -197,7 +197,7 @@ export const IconsAvatarsAndLinkType = () => {
                             }
                         />
                     }
-                    label="LinkType False"
+                    label="LinkType"
                 />
                 <Box>
                     <FormControlLabel

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useState } from 'react';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import {
     Resource,
@@ -9,6 +10,7 @@ import {
 } from 'ra-core';
 import defaultMessages from 'ra-language-english';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
+import { Box, FormControlLabel, FormGroup, Switch } from '@mui/material';
 
 import { SimpleList } from './SimpleList';
 import { AdminUI } from '../../AdminUI';
@@ -149,15 +151,99 @@ export const FullApp = () => (
     </Wrapper>
 );
 
-export const LinkTypeFalse = () => (
-    <Wrapper>
-        <SimpleList
-            primaryText={record => record.title}
-            secondaryText={record => record.author}
-            linkType={false}
-        />
-    </Wrapper>
-);
+export const LinkTypeFalse = () => {
+    const [linkType, setLinkType] = useState<false | undefined>(false);
+    const [leftIcon, setLeftIcon] = useState(true);
+    const [leftAvatar, setLeftAvatar] = useState(true);
+    const [rightIcon, setRightIcon] = useState(true);
+    const [rightAvatar, setRightAvatar] = useState(true);
+    return (
+        <Wrapper>
+            <FormGroup
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <Box>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={leftIcon}
+                                onChange={() => setLeftIcon(!leftIcon)}
+                            />
+                        }
+                        label="Left Icon"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={leftAvatar}
+                                onChange={() => setLeftAvatar(!leftAvatar)}
+                            />
+                        }
+                        label="Left Avatar"
+                    />
+                </Box>
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={linkType === false}
+                            onChange={() =>
+                                setLinkType(
+                                    linkType === false ? undefined : false
+                                )
+                            }
+                        />
+                    }
+                    label="LinkType False"
+                />
+                <Box>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={rightAvatar}
+                                onChange={() => setRightAvatar(!rightAvatar)}
+                            />
+                        }
+                        label="Right Avatar"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={rightIcon}
+                                onChange={() => setRightIcon(!rightIcon)}
+                            />
+                        }
+                        label="Right Icon"
+                    />
+                </Box>
+            </FormGroup>
+            <SimpleList
+                primaryText={record => record.title}
+                secondaryText={record => record.author}
+                linkType={linkType}
+                leftIcon={
+                    leftIcon ? record => <span>{record.id}</span> : undefined
+                }
+                rightIcon={
+                    rightIcon ? record => <span>{record.year}</span> : undefined
+                }
+                leftAvatar={
+                    leftAvatar
+                        ? record => <span>{record.title[0]}</span>
+                        : undefined
+                }
+                rightAvatar={
+                    rightAvatar
+                        ? record => <span>{record.author[0]}</span>
+                        : undefined
+                }
+            />
+        </Wrapper>
+    );
+};
 
 export const NoPrimaryText = () => (
     <Wrapper recordRepresentation="title">

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -137,6 +137,28 @@ export const FullApp = () => (
     </AdminContext>
 );
 
+export const AnyLink = () => (
+    <AdminContext
+        dataProvider={dataProvider}
+        i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+    >
+        <AdminUI>
+            <Resource
+                name="books"
+                list={() => (
+                    <List>
+                        <SimpleList
+                            primaryText={record => record.title}
+                            secondaryText={record => record.author}
+                            linkType={false}
+                        />
+                    </List>
+                )}
+            />
+        </AdminUI>
+    </AdminContext>
+);
+
 export const NoPrimaryText = () => (
     <AdminContext
         dataProvider={dataProvider}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -5,15 +5,16 @@ import {
     ListContextProvider,
     TestMemoryRouter,
     ResourceContextProvider,
+    ResourceProps,
 } from 'ra-core';
 import defaultMessages from 'ra-language-english';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import { SimpleList } from './SimpleList';
 import { AdminUI } from '../../AdminUI';
-import { AdminContext } from '../../AdminContext';
+import { AdminContext, AdminContextProps } from '../../AdminContext';
 import { EditGuesser } from '../../detail';
-import { List } from '../List';
+import { List, ListProps } from '../List';
 
 export default { title: 'ra-ui-materialui/list/SimpleList' };
 
@@ -113,9 +114,17 @@ export const Basic = () => (
     </TestMemoryRouter>
 );
 
-const dataProvider = fakeRestDataProvider(data);
+const myDataProvider = fakeRestDataProvider(data);
 
-export const FullApp = () => (
+const Wrapper = ({
+    children,
+    dataProvider = myDataProvider,
+    recordRepresentation,
+}: {
+    children: ListProps['children'];
+    dataProvider?: AdminContextProps['dataProvider'];
+    recordRepresentation?: ResourceProps['recordRepresentation'];
+}) => (
     <AdminContext
         dataProvider={dataProvider}
         i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
@@ -123,60 +132,37 @@ export const FullApp = () => (
         <AdminUI>
             <Resource
                 name="books"
-                list={() => (
-                    <List>
-                        <SimpleList
-                            primaryText={record => record.title}
-                            secondaryText={record => record.author}
-                        />
-                    </List>
-                )}
+                recordRepresentation={recordRepresentation}
+                list={() => <List>{children}</List>}
                 edit={EditGuesser}
             />
         </AdminUI>
     </AdminContext>
+);
+
+export const FullApp = () => (
+    <Wrapper>
+        <SimpleList
+            primaryText={record => record.title}
+            secondaryText={record => record.author}
+        />
+    </Wrapper>
 );
 
 export const AnyLink = () => (
-    <AdminContext
-        dataProvider={dataProvider}
-        i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
-    >
-        <AdminUI>
-            <Resource
-                name="books"
-                list={() => (
-                    <List>
-                        <SimpleList
-                            primaryText={record => record.title}
-                            secondaryText={record => record.author}
-                            linkType={false}
-                        />
-                    </List>
-                )}
-            />
-        </AdminUI>
-    </AdminContext>
+    <Wrapper>
+        <SimpleList
+            primaryText={record => record.title}
+            secondaryText={record => record.author}
+            linkType={false}
+        />
+    </Wrapper>
 );
 
 export const NoPrimaryText = () => (
-    <AdminContext
-        dataProvider={dataProvider}
-        i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
-    >
-        <AdminUI>
-            <Resource
-                name="books"
-                recordRepresentation="title"
-                list={() => (
-                    <List>
-                        <SimpleList />
-                    </List>
-                )}
-                edit={EditGuesser}
-            />
-        </AdminUI>
-    </AdminContext>
+    <Wrapper recordRepresentation="title">
+        <SimpleList />
+    </Wrapper>
 );
 
 export const ErrorInFetch = () => (
@@ -198,30 +184,19 @@ export const ErrorInFetch = () => (
 );
 
 export const FullAppInError = () => (
-    <AdminContext
+    <Wrapper
         dataProvider={
             {
                 getList: () =>
                     Promise.reject(new Error('Error in dataProvider')),
             } as any
         }
-        i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
     >
-        <AdminUI>
-            <Resource
-                name="books"
-                list={() => (
-                    <List>
-                        <SimpleList
-                            primaryText={record => record.title}
-                            secondaryText={record => record.author}
-                        />
-                    </List>
-                )}
-                edit={EditGuesser}
-            />
-        </AdminUI>
-    </AdminContext>
+        <SimpleList
+            primaryText={record => record.title}
+            secondaryText={record => record.author}
+        />
+    </Wrapper>
 );
 
 export const Standalone = () => (

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -151,8 +151,8 @@ export const FullApp = () => (
     </Wrapper>
 );
 
-export const LinkTypeFalse = () => {
-    const [linkType, setLinkType] = useState<false | undefined>(false);
+export const IconsAvatarsAndLinkType = () => {
+    const [linkType, setLinkType] = useState<false | undefined>(undefined);
     const [leftIcon, setLeftIcon] = useState(true);
     const [leftAvatar, setLeftAvatar] = useState(true);
     const [rightIcon, setRightIcon] = useState(true);
@@ -189,7 +189,7 @@ export const LinkTypeFalse = () => {
                 <FormControlLabel
                     control={
                         <Switch
-                            checked={linkType === false}
+                            checked={linkType !== false}
                             onChange={() =>
                                 setLinkType(
                                     linkType === false ? undefined : false

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -129,7 +129,14 @@ export const SimpleList = <RecordType extends RaRecord = any>(
         <Root className={className} {...sanitizeListRestProps(rest)}>
             {data.map((record, rowIndex) => (
                 <RecordContextProvider key={record.id} value={record}>
-                    <ListItem disablePadding>
+                    <ListItem
+                        disablePadding
+                        sx={{
+                            '.MuiListItem-container': {
+                                width: '100%',
+                            },
+                        }}
+                    >
                         <LinkOrNot
                             linkType={linkType}
                             resource={resource}
@@ -275,7 +282,6 @@ const LinkOrNot = (
         id,
         children,
         record,
-        sx,
         ...rest
     } = props;
     const createPath = useCreatePath();
@@ -283,28 +289,13 @@ const LinkOrNot = (
         typeof linkType === 'function' ? linkType(record, id) : linkType;
 
     if (type === false) {
-        return (
-            <ListItemText
-                // @ts-ignore
-                component="div"
-                sx={{
-                    px: 2,
-                    py: 1,
-                    m: 0,
-                    ...sx,
-                }}
-                {...rest}
-            >
-                {children}
-            </ListItemText>
-        );
+        return <ListItem {...rest}>{children}</ListItem>;
     }
     return (
         // @ts-ignore
         <ListItemButton
             component={Link}
             to={createPath({ resource, id, type })}
-            sx={sx}
             {...rest}
         >
             {children}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -275,6 +275,7 @@ const LinkOrNot = (
         id,
         children,
         record,
+        sx,
         ...rest
     } = props;
     const createPath = useCreatePath();
@@ -286,6 +287,12 @@ const LinkOrNot = (
             <ListItemText
                 // @ts-ignore
                 component="div"
+                sx={{
+                    paddingX: 2,
+                    paddingY: 1,
+                    margin: 0,
+                    ...sx,
+                }}
                 {...rest}
             >
                 {children}
@@ -297,6 +304,7 @@ const LinkOrNot = (
         <ListItemButton
             component={Link}
             to={createPath({ resource, id, type })}
+            sx={{ ...sx }}
             {...rest}
         >
             {children}


### PR DESCRIPTION
## Problem

`linkType` should only remove the onClick action but it breaks the UI.

### Without `linkType`
![image](https://github.com/user-attachments/assets/d4f99e0e-7563-4716-83bb-03856857d17e)
### With `linkType={false}`
![image](https://github.com/user-attachments/assets/b6074acc-34f4-43c9-a9f5-0a678722123b)

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes one or several **stories** (if not possible, describe why)
