### PR TITLE
[Doc] Fix react-query devtools documentation

### DIFF
--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -115,11 +115,11 @@ React-admin uses `react-query` to call the Data Provider. You can view all `reac
 
 ![React-Query DevTools](./img/react-query-devtools.png)
 
-To enable these devtools, add the `<ReactQueryDevtools>` component to a custom layout:
+To enable these devtools, install `@tanstack/react-query-devtools` and add the `<ReactQueryDevtools>` component to a custom layout:
 
 ```jsx
 import { Layout } from 'react-admin';
-import { ReactQueryDevtools } from 'react-query/devtools';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 export const MyLayout = ({ children }) => (
     <Layout>


### PR DESCRIPTION
Solves #10342

## Problem

React-admin v5 uses a new version of TanStack React Query compared to v4. The devtools are not bundled in the package anymore and have to be installed separately. Related documentation was not updated.

## Solution

Update the related docs to match with the new changes.

## How To Test

Follow the steps and confirm devtools is shown.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
  - No unit tests as it's a doc update.
- [x] The PR includes one or several **stories** (if not possible, describe why)
  - No stories as it's a doc update.
- [x] The **documentation** is up to date
