### PR TITLE
[SimpleList] deprecate linkType, and implement rowClick as for the DataGrid

### DIFF
--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -28,7 +28,7 @@ export const PostList = () => (
             primaryText={record => record.title}
             secondaryText={record => `${record.views} views`}
             tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
-            linkType={record => record.canEdit ? "edit" : "show"}
+            rowClick={record => record.canEdit ? "edit" : "show"}
             rowSx={record => ({ backgroundColor: record.nb_views >= 500 ? '#efe' : 'white' })}
         />
     </List>
@@ -44,7 +44,7 @@ export const PostList = () => (
 | `primaryText` | Optional | mixed | record representation | The primary text to display. |
 | `secondaryText` | Optional | mixed | | The secondary text to display. |
 | `tertiaryText` | Optional | mixed | | The tertiary text to display. |
-| `linkType` | Optional |mixed | `"edit"` | The target of each item click. |
+| `rowClick` | Optional |mixed | `"edit"` | The action to trigger when the user clicks on a row. |
 | `leftAvatar` | Optional | function | | A function returning an `<Avatar>` component to display before the primary text. |
 | `leftIcon` | Optional | function | | A function returning an `<Icon>` component to display before the primary text. |
 | `rightAvatar` | Optional | function | | A function returning an `<Avatar>` component to display after the primary text. |
@@ -80,9 +80,9 @@ This prop should be a function returning an `<Avatar>` component. When present, 
 
 This prop should be a function returning an `<Icon>` component. When present, the `<ListItem>` renders a `<ListIcon>` before the `<ListItemText>`
 
-## `linkType`
+## `rowClick`
 
-The `<SimpleList>` items link to the edition page by default. You can also set the `linkType` prop to `show` directly to link to the `<Show>` page instead.
+The `<SimpleList>` items link to the edition page by default. You can also set the `rowClick` prop to `show` directly to link to the `<Show>` page instead. 
 
 ```jsx
 import { List, SimpleList } from 'react-admin';
@@ -93,17 +93,18 @@ export const PostList = () => (
             primaryText={record => record.title}
             secondaryText={record => `${record.views} views`}
             tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
-            linkType="show"
+            rowClick="show"
         />
     </List>
 );
 ```
 
-`linkType` accepts the following values:
+`rowClick` accepts the following values:
 
-* `linkType="edit"`: links to the edit page. This is the default behavior.
-* `linkType="show"`: links to the show page.
-* `linkType={false}`: does not create any link.
+* `rowClick="edit"`: links to the edit page. This is the default behavior.
+* `rowClick="show"`: links to the show page.
+* `rowClick={false}`: does not link to anything.
+* `rowClick={(id, resource, record) => path}`: path can be any of the above values
 
 ## `primaryText`
 
@@ -254,7 +255,7 @@ export const PostList = () => {
                     primaryText={record => record.title}
                     secondaryText={record => `${record.views} views`}
                     tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
-                    linkType={record => record.canEdit ? "edit" : "show"}   
+                    rowClick={record => record.canEdit ? "edit" : "show"}   
                 />
             ) : (
                 <Datagrid>

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import {
-    useResourceContext,
     usePreference,
+    useResourceContext,
     useStore,
     useTranslate,
 } from 'ra-core';
+import * as React from 'react';
 
 import { Configurable } from '../../preferences';
 import { Datagrid, DatagridProps } from './Datagrid';
@@ -50,6 +50,11 @@ export const DatagridConfigurable = ({
         ConfigurableDatagridColumn[]
     >(`preferences.${finalPreferenceKey}.availableColumns`, []);
 
+    const [columns, setColumns] = useStore<string[]>(
+        `preferences.${finalPreferenceKey}.columns`,
+        []
+    );
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, setOmit] = useStore<string[] | undefined>(
         `preferences.${finalPreferenceKey}.omit`,
@@ -58,7 +63,7 @@ export const DatagridConfigurable = ({
 
     React.useEffect(() => {
         // first render, or the preference have been cleared
-        const columns = React.Children.toArray(props.children)
+        const newAvailableColumns = React.Children.toArray(props.children)
             .filter(child => React.isValidElement(child))
             .map((child: React.ReactElement, index) => ({
                 index: String(index),
@@ -67,16 +72,82 @@ export const DatagridConfigurable = ({
                     child.props.label && typeof child.props.label === 'string' // this list is serializable, so we can't store ReactElement in it
                         ? child.props.label
                         : child.props.source
-                          ? //  force the label to be the source
-                            undefined
-                          : // no source or label, generate a label
-                            translate('ra.configurable.Datagrid.unlabeled', {
-                                column: index,
-                                _: `Unlabeled column #%{column}`,
-                            }),
+                        ? //  force the label to be the source
+                          undefined
+                        : // no source or label, generate a label
+                          translate('ra.configurable.Datagrid.unlabeled', {
+                              column: index,
+                              _: `Unlabeled column #%{column}`,
+                          }),
             }));
-        if (columns.length !== availableColumns.length) {
-            setAvailableColumns(columns);
+        const hasChanged = newAvailableColumns.some(column => {
+            const availableColumn = availableColumns.find(
+                availableColumn =>
+                    (!!availableColumn.source &&
+                        availableColumn.source === column?.source) ||
+                    (!!availableColumn.label &&
+                        availableColumn.label === column?.label)
+            );
+            return !availableColumn || availableColumn.index !== column.index;
+        });
+        if (hasChanged) {
+            // first we need to update the columns indexes to match the new availableColumns so we keep the same order
+            const newColumnsSortedAsOldColumns = columns.flatMap(column => {
+                const oldColumn = availableColumns.find(
+                    availableColumn => availableColumn.index === column
+                );
+                const newColumn = newAvailableColumns.find(
+                    availableColumn =>
+                        (!!availableColumn.source &&
+                            availableColumn.source === oldColumn?.source) ||
+                        (!!availableColumn.label &&
+                            availableColumn.label === oldColumn?.label)
+                );
+                return newColumn?.index ? [newColumn.index] : [];
+            });
+            setColumns([
+                // we add the old columns in the same order as before
+                ...newColumnsSortedAsOldColumns,
+                // then we add at the new columns which are not omited
+                ...newAvailableColumns
+                    .filter(
+                        c =>
+                            !availableColumns.some(
+                                ac =>
+                                    (!!ac.source && ac.source === c.source) ||
+                                    (!!ac.label && ac.label === c.label)
+                            ) && !omit?.includes(c.source as string)
+                    )
+                    .map(c => c.index),
+            ]);
+
+            // Then we update the available columns to include the new columns while keeping the same order as before
+            const newAvailableColumnsSortedAsBefore = [
+                // First the existing columns, in the same order
+                ...(availableColumns
+                    .map(oldAvailableColumn =>
+                        newAvailableColumns.find(
+                            c =>
+                                (!!c.source &&
+                                    c.source === oldAvailableColumn.source) ||
+                                (!!c.label &&
+                                    c.label === oldAvailableColumn.label)
+                        )
+                    )
+                    .filter(c => !!c) as ConfigurableDatagridColumn[]), // Remove undefined columns
+                // Then the new columns
+                ...newAvailableColumns.filter(
+                    c =>
+                        !availableColumns.some(
+                            oldAvailableColumn =>
+                                (!!oldAvailableColumn.source &&
+                                    oldAvailableColumn.source === c.source) ||
+                                (!!oldAvailableColumn.label &&
+                                    oldAvailableColumn.label === c.label)
+                        )
+                ),
+            ];
+            setAvailableColumns(newAvailableColumnsSortedAsBefore);
             setOmit(omit);
         }
     }, [availableColumns]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridConfigurable.tsx
@@ -72,13 +72,13 @@ export const DatagridConfigurable = ({
                     child.props.label && typeof child.props.label === 'string' // this list is serializable, so we can't store ReactElement in it
                         ? child.props.label
                         : child.props.source
-                        ? //  force the label to be the source
-                          undefined
-                        : // no source or label, generate a label
-                          translate('ra.configurable.Datagrid.unlabeled', {
-                              column: index,
-                              _: `Unlabeled column #%{column}`,
-                          }),
+                          ? //  force the label to be the source
+                            undefined
+                          : // no source or label, generate a label
+                            translate('ra.configurable.Datagrid.unlabeled', {
+                                column: index,
+                                _: `Unlabeled column #%{column}`,
+                            }),
             }));
         const hasChanged = newAvailableColumns.some(column => {
             const availableColumn = availableColumns.find(


### PR DESCRIPTION
## Problem

The linkType for SimpleList provides less functionality than the rowClick for DataGrid. And also the inconsistency makes it harder to use.

## Solution

Implement rowClick prop as it works for Datagrid.
Keep the linkType prop working as previously, but show it as deprecated. If both are set, linkType takes precedence (because it will be simpler to remove from the code later that way).

## How To Test

Similar to data grid

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date
