### PR TITLE
[chore] Improve ESLint config to restrict imports from @mui/icons-material and lodash

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
-
 {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "warnOnUnsupportedTypeScriptVersion": false
+        "warnOnUnsupportedTypeScriptVersion": false,
     },
     "extends": ["react-app", "plugin:prettier/recommended"],
     "plugins": [
@@ -11,7 +10,7 @@
         "jsx-a11y",
         "prettier",
         "react",
-        "react-hooks"
+        "react-hooks",
     ],
     "rules": {
         "no-use-before-define": "off",
@@ -23,10 +22,18 @@
                     {
                         "name": "@mui/material",
                         "importNames": ["makeStyles", "createMuiTheme"],
-                        "message": "Please import from @mui/material/styles instead. See https://material-ui.com/guides/minimizing-bundle-size/#option-2 for more information"
-                    }
-                ]
-            }
+                        "message": "Please import from @mui/material/styles instead. See https://material-ui.com/guides/minimizing-bundle-size/#option-2 for more information",
+                    },
+                    {
+                        "name": "@mui/icons-material",
+                        "message": "Named import from @mui/icons-material should be avoided for performance reasons. Use a default import instead. E.g. `import Dashboard from '@mui/icons-material/Dashboard';` instead of `import { Dashboard } from '@mui/icons-material';`.See https://mui.com/material-ui/guides/minimizing-bundle-size/#development-environment for more information.",
+                    },
+                    {
+                        "name": "lodash",
+                        "message": "Named import from lodash should be avoided for performance reasons. Use a default import instead. E.g. `import merge from 'lodash/merge';` instead of `import { merge } from 'lodash';`.",
+                    },
+                ],
+            },
         ],
         "no-redeclare": "off",
         "import/no-anonymous-default-export": "off",
@@ -34,12 +41,12 @@
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": [
             "warn", // or "error"
-            { 
+            {
                 "argsIgnorePattern": "^_",
                 "varsIgnorePattern": "^_",
                 "caughtErrorsIgnorePattern": "^_",
-                "ignoreRestSiblings": true
-            }
-        ]
-    }
+                "ignoreRestSiblings": true,
+            },
+        ],
+    },
 }

--- a/examples/crm/src/types.ts
+++ b/examples/crm/src/types.ts
@@ -1,4 +1,6 @@
-import { SvgIconComponent } from '@mui/icons-material';
+// We only import a type from @mui/icons-material, so we safely disable the rule
+// eslint-disable-next-line no-restricted-imports
+import type { SvgIconComponent } from '@mui/icons-material';
 import { Identifier, RaRecord } from 'react-admin';
 import {
     COMPANY_CREATED,

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -23,7 +23,6 @@ import {
     useResourceDefinition,
     useGetResourceLabel,
 } from '../../core';
-import _ from 'lodash';
 
 /**
  * Prepare data for the Create view


### PR DESCRIPTION
## Problem

Using named imports from `@mui/icons-material` or `lodash` can cause performance issues.
See
- https://mui.com/material-ui/guides/minimizing-bundle-size/#development-environment
- https://github.com/marmelab/react-admin/pull/9828

Currently the project's tooling doesn't protect against such mistakes.

## Solution

Improve the ESLint rules config to mark such imports as errors.

### Alternatives considered

Use a [custom rule](https://github.com/slax57/ast-talk-examples/blob/eslint-solution/eslint/custom-rules/enforce-default-import.js) (in a custom ESLint plugin), which would have had the benefit of automatically suggesting a fix when an error is detected.

But the project is still using the legacy configuration file (as opposed to [new](https://eslint.org/docs/v8.x/use/configure/configuration-files-new)), which makes it cumbersome to declare and use a custom plugin.

The sole benefit of having an automatic fix was not enough to justify spending much time on upgrading to the new configuration system, so I chose to rely on the existing [`no-restricted-imports`](https://eslint.org/docs/v8.x/rules/no-restricted-imports) rule instead.

## How To Test

- For instance, in `packages/ra-ui-materialui/src/layout/AuthenticationError.tsx`, replace `import WarningAmber from '@mui/icons-material/WarningAmber';` by `import { WarningAmber } from '@mui/icons-material';` and check that ESLint raises an error
- For instance, in `packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx`, replace `import get from 'lodash/get';` by `import { get } from 'lodash';` and check that ESLint raises an error

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
