### PR TITLE
Fix `FilterLiveSearch` badly reset

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveSearch.stories.tsx
@@ -8,18 +8,24 @@ import {
 } from '@mui/material';
 import {
     ListContextProvider,
+    Resource,
     ResourceContextProvider,
     TestMemoryRouter,
     useList,
     useListContext,
 } from 'ra-core';
 import * as React from 'react';
+import fakeRestDataProvider from 'ra-data-fakerest';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
 
 import { TextInput } from '../../input';
 import { defaultTheme } from '../../theme/defaultTheme';
 import { FilterButton } from './FilterButton';
 import { FilterForm } from './FilterForm';
 import { FilterLiveSearch } from './FilterLiveSearch';
+import { Datagrid, ListGuesser, TextField, List as RaList } from '../..';
+import { Admin } from '../../../../react-admin/src/Admin';
 
 export default {
     title: 'ra-ui-materialui/list/filter/FilterLiveSearch',
@@ -130,4 +136,102 @@ export const WithFilterButton = () => (
             </Wrapper>
         </ResourceContextProvider>
     </TestMemoryRouter>
+);
+
+const dataProvider = fakeRestDataProvider(
+    {
+        books: [
+            {
+                id: 1,
+                title: 'War and Peace',
+                author: 'Leo Tolstoy',
+                year: 1869,
+            },
+            {
+                id: 2,
+                title: 'Pride and Predjudice',
+                author: 'Jane Austen',
+                year: 1813,
+            },
+            {
+                id: 3,
+                title: 'The Picture of Dorian Gray',
+                author: 'Oscar Wilde',
+                year: 1890,
+            },
+            {
+                id: 4,
+                title: 'Le Petit Prince',
+                author: 'Antoine de Saint-Exupéry',
+                year: 1943,
+            },
+            {
+                id: 5,
+                title: "Alice's Adventures in Wonderland",
+                author: 'Lewis Carroll',
+                year: 1865,
+            },
+            {
+                id: 6,
+                title: 'Madame Bovary',
+                author: 'Gustave Flaubert',
+                year: 1856,
+            },
+            {
+                id: 7,
+                title: 'The Lord of the Rings',
+                author: 'J. R. R. Tolkien',
+                year: 1954,
+            },
+            {
+                id: 8,
+                title: "Harry Potter and the Philosopher's Stone",
+                author: 'J. K. Rowling',
+                year: 1997,
+            },
+            {
+                id: 9,
+                title: 'The Alchemist',
+                author: 'Paulo Coelho',
+                year: 1988,
+            },
+            {
+                id: 10,
+                title: 'A Catcher in the Rye',
+                author: 'J. D. Salinger',
+                year: 1951,
+            },
+            {
+                id: 11,
+                title: 'Ulysses',
+                author: 'James Joyce',
+                year: 1922,
+            },
+        ],
+        countries,
+    },
+    process.env.NODE_ENV === 'development'
+);
+
+const filters = [<FilterLiveSearch source="q" label="Search" alwaysOn />];
+
+const BookList = () => (
+    <RaList filters={filters}>
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+        </Datagrid>
+    </RaList>
+);
+
+export const FullApp = () => (
+    <Admin
+        dataProvider={dataProvider}
+        i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
+    >
+        <Resource name="books" list={BookList} />
+        <Resource name="countries" list={ListGuesser} />
+    </Admin>
 );


### PR DESCRIPTION
## Problem

FilterLiveSearch doesn’t correctly reset. When you reset the input value after switching resource, the applied filter is reset but the input keep the value

## How To Test

- go to [OSS e-commerce demo](https://marmelab.com/react-admin-demo/#/products "‌") > products
- search “toto”
- click on another resource
- click on _Products_ resource
- reset the searchbar value (with the cross icon or with “_Ctrl+A_“ and “<--“)

## Additional Checks

- [x] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The **documentation** is up to date