### PR TITLE
Fix `FilterListItem` story shows wrong way of resetting a filter

### DIFF
--- a/packages/ra-ui-materialui/src/list/filter/FilterList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterList.stories.tsx
@@ -301,7 +301,7 @@ const BookListAside = () => (
             <FilterList label="Century" icon={<CategoryIcon />}>
                 <FilterListItem
                     label="21st"
-                    value={{ year_gte: 2000, year_lte: null }}
+                    value={{ year_gte: 2000, year_lte: undefined }}
                 />
                 <FilterListItem
                     label="20th"


### PR DESCRIPTION
## Problem

The `FilterListItem story features an example with an empy value using `null`: 

```jsx
<FilterListItem
    label="21st"
    value={{ year_gte: 2000, year_lte: null }}
/>
```

This example doesn't work, as selecting the "21st" filter item doesn't mark it as active. 

https://react-admin-storybook.vercel.app/?path=/story/ra-ui-materialui-list-filter-filterlist--full-app

## Solution

The right syntax is to use `undefined`:

```jsx
<FilterListItem
    label="21st"
    value={{ year_gte: 2000, year_lte: undefined }}
/>
```