### PR TITLE
[TypeScript] Add missing parameter to `add` function type of `<SimpleFormIteratorContextValue>`

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorContext.ts
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIteratorContext.ts
@@ -11,7 +11,7 @@ export const SimpleFormIteratorContext = createContext<
 >(undefined);
 
 export type SimpleFormIteratorContextValue = {
-    add: () => void;
+    add: (item?: any) => void;
     remove: (index: number) => void;
     reOrder: (index: number, newIndex: number) => void;
     source: string;


### PR DESCRIPTION
Fix https://github.com/marmelab/react-admin/issues/10355

## Problem

Wrong `add`-function type.

## Solution

Add missing parameter.

There seems to be no mention in the documentation that a function can be given a parameter. However, I'm not able to produce good enough English to put it in the documentation so I didn't try to add it.

## Additional Checks

- [X] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] ~The PR includes **unit tests** (if not possible, describe why)~ (This is just change of type)
- [ ] ~The PR includes one or several **stories** (if not possible, describe why)~ (This is just change of type)
- [ ] The **documentation** is up to date

