### PR TITLE
[Doc] Fix `useRegisterMutationMiddleware` documentation

### DIFF
--- a/docs/useRegisterMutationMiddleware.md
+++ b/docs/useRegisterMutationMiddleware.md
@@ -40,9 +40,12 @@ const MyComponent = () => {
         // Do something before the mutation
 
         // Call the next middleware
-        await next(resource, params);
+        const result = await next(resource, params);
 
         // Do something after the mutation
+
+        // Always return the result
+        return result;
     }
     const memoizedMiddleWare = React.useCallback(createMiddleware, []);
     useRegisterMutationMiddleware(memoizedMiddleWare);
@@ -67,9 +70,12 @@ const middlware = async (resource, params, next) => {
     // Do something before the mutation
 
     // Call the next middleware
-    await next(resource, params);
+    const result = await next(resource, params);
 
     // Do something after the mutation
+
+    // Always return the result
+    return result;
 }
 ```
 
@@ -100,7 +106,7 @@ const ThumbnailInput = () => {
         const b64 = await convertFileToBase64(params.data.thumbnail);
         // Update the parameters that will be sent to the dataProvider call
         const newParams = { ...params, data: { ...data, thumbnail: b64 } };
-        await next(resource, newParams);
+        return next(resource, newParams);
     }, []);
     useRegisterMutationMiddleware(middleware);
 


### PR DESCRIPTION
## Problem

Code examples in [React-admin - useRegisterMutationMiddleware](https://marmelab.com/react-admin/useRegisterMutationMiddleware.html)  are erroneous because they do not return the next mutation result, although this is necessary for most main mutations handled by react admin (either create or update).

## Solution

Fix the documentation.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
~~- [ ] The PR includes one or several **stories** (if not possible, describe why)~~
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
