### PR TITLE
Fix `useCanAccessResources` cannot have react-query options

### DIFF
--- a/packages/ra-core/src/auth/useCanAccessResources.ts
+++ b/packages/ra-core/src/auth/useCanAccessResources.ts
@@ -74,12 +74,18 @@ export const useCanAccessResources = <
                 })
             );
 
+            const canAccessMap = queries.reduce(
+                (acc, { resource, canAccess }) => {
+                    acc[resource] = canAccess;
+                    return acc;
+                },
+                {} as Record<string, boolean>
+            );
+
             const result = resources.reduce(
                 (acc, resource) => ({
                     ...acc,
-                    [resource]:
-                        queries.find(query => query.resource === resource)
-                            ?.canAccess ?? false,
+                    [resource]: canAccessMap[resource],
                 }),
                 {} as Record<string, boolean>
             );

--- a/packages/ra-core/src/auth/useCanAccessResources.ts
+++ b/packages/ra-core/src/auth/useCanAccessResources.ts
@@ -126,7 +126,6 @@ export interface UseCanAccessResourcesOptions<
     resources: string[];
     action: HintedString<'list' | 'create' | 'edit' | 'show' | 'delete'>;
     record?: RecordType;
-    enabled?: boolean;
 }
 
 export type UseCanAccessResourcesResult<ErrorType = Error> =

--- a/packages/ra-core/src/auth/useCanAccessResources.ts
+++ b/packages/ra-core/src/auth/useCanAccessResources.ts
@@ -74,19 +74,11 @@ export const useCanAccessResources = <
                 })
             );
 
-            const canAccessMap = queries.reduce(
+            const result = queries.reduce(
                 (acc, { resource, canAccess }) => {
                     acc[resource] = canAccess;
                     return acc;
                 },
-                {} as Record<string, boolean>
-            );
-
-            const result = resources.reduce(
-                (acc, resource) => ({
-                    ...acc,
-                    [resource]: canAccessMap[resource],
-                }),
                 {} as Record<string, boolean>
             );
 


### PR DESCRIPTION
## Problem

`useCanAccessResources` currently uses `useQueries`. As such, it doesn't accept `useQuery` options like `enabled`.

## Solution

Refactor it to use `useQuery` instead.

## How To Test

- All tests should pass without modification

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
~~- [ ] The PR includes one or several **stories** (if not possible, describe why)~~
~~- [ ] The **documentation** is up to date~~

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
