### PR TITLE
Add a “SELECT ALL” button in the `<BulkActionsToolbar>`

### DIFF
--- a/packages/ra-core/src/controller/list/ListContext.tsx
+++ b/packages/ra-core/src/controller/list/ListContext.tsx
@@ -24,7 +24,9 @@ import { ListControllerResult } from './useListController';
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
  * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
+ * @prop {boolean}  areAllSelected boolean to indicate if the list is already fully selected
  * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
+ * @prop {Function} onSelectAll callback to select all the records, e.g. onSelectAll()
  * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
  * @prop {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
  * @prop {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'

--- a/packages/ra-core/src/controller/list/useListContextWithProps.ts
+++ b/packages/ra-core/src/controller/list/useListContextWithProps.ts
@@ -33,7 +33,9 @@ import { RaRecord } from '../../types';
  * @prop {Function} showFilter a callback to show one of the filters, e.g. showFilter('title', defaultValue)
  * @prop {Function} hideFilter a callback to hide one of the filters, e.g. hideFilter('title')
  * @prop {Array}    selectedIds an array listing the ids of the selected rows, e.g. [123, 456]
+ * @prop {boolean}  areAllSelected boolean to indicate if the list is already fully selected
  * @prop {Function} onSelect callback to change the list of selected rows, e.g. onSelect([456, 789])
+ * @prop {Function} onSelectAll callback to select all the records, e.g. onSelectAll()
  * @prop {Function} onToggleItem callback to toggle the selection of a given record based on its id, e.g. onToggleItem(456)
  * @prop {Function} onUnselectItems callback to clear the selection, e.g. onUnselectItems();
  * @prop {string}   defaultTitle the translated title based on the resource, e.g. 'Posts'
@@ -81,6 +83,7 @@ const extractListContextProps = <RecordType extends RaRecord = any>({
     isLoading,
     isPending,
     onSelect,
+    onSelectAll,
     onToggleItem,
     onUnselectItems,
     page,
@@ -88,6 +91,7 @@ const extractListContextProps = <RecordType extends RaRecord = any>({
     refetch,
     resource,
     selectedIds,
+    areAllSelected,
     setFilters,
     setPage,
     setPerPage,
@@ -107,6 +111,7 @@ const extractListContextProps = <RecordType extends RaRecord = any>({
     isLoading,
     isPending,
     onSelect,
+    onSelectAll,
     onToggleItem,
     onUnselectItems,
     page,
@@ -114,6 +119,7 @@ const extractListContextProps = <RecordType extends RaRecord = any>({
     refetch,
     resource,
     selectedIds,
+    areAllSelected,
     setFilters,
     setPage,
     setPerPage,

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -87,7 +87,11 @@ const englishMessages: TranslationMessages = {
         },
         message: {
             about: 'About',
+            access_denied:
+                "You don't have the right permissions to access this page",
             are_you_sure: 'Are you sure?',
+            authentication_error:
+                'The authentication server returned an error and your credentials could not be checked.',
             auth_error:
                 'An error occurred while validating the authentication token.',
             bulk_delete_content:
@@ -103,19 +107,16 @@ const englishMessages: TranslationMessages = {
             delete_title: 'Delete %{name} #%{id}',
             details: 'Details',
             error: "A client error occurred and your request couldn't be completed.",
-
             invalid_form: 'The form is not valid. Please check for errors',
             loading: 'Please wait',
             no: 'No',
             not_found:
                 'Either you typed a wrong URL, or you followed a bad link.',
-            yes: 'Yes',
+            too_many_elements:
+                'Warning: There are too many elements to select them all. Only the first %{max} elements were selected.',
             unsaved_changes:
                 "Some of your changes weren't saved. Are you sure you want to ignore them?",
-            access_denied:
-                "You don't have the right permissions to access this page",
-            authentication_error:
-                'The authentication server returned an error and your credentials could not be checked.',
+            yes: 'Yes',
         },
         navigation: {
             clear_filters: 'Clear filters',

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
@@ -10,6 +10,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { useTranslate, sanitizeListRestProps, useListContext } from 'ra-core';
 
 import TopToolbar from '../layout/TopToolbar';
+import { Button } from '../button';
 
 export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
     const {
@@ -18,13 +19,22 @@ export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
         className,
         ...rest
     } = props;
-    const { selectedIds = [], onUnselectItems } = useListContext();
+    const {
+        selectedIds = [],
+        onUnselectItems,
+        onSelectAll,
+        areAllSelected,
+    } = useListContext();
 
     const translate = useTranslate();
 
     const handleUnselectAllClick = useCallback(() => {
         onUnselectItems();
     }, [onUnselectItems]);
+
+    const handleSelectAll = useCallback(() => {
+        onSelectAll();
+    }, [onSelectAll]);
 
     return (
         <Root className={className}>
@@ -52,6 +62,13 @@ export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
                             smart_count: selectedIds.length,
                         })}
                     </Typography>
+                    {areAllSelected && (
+                        <Button
+                            label={translate('ra.action.select_all')}
+                            onClick={handleSelectAll}
+                            sx={{ ml: 1 }}
+                        />
+                    )}
                 </div>
                 <TopToolbar className={BulkActionsToolbarClasses.topToolbar}>
                     {children}
@@ -65,6 +82,7 @@ export interface BulkActionsToolbarProps {
     children?: ReactNode;
     label?: string;
     className?: string;
+    selectAllLimit?: number;
 }
 
 const PREFIX = 'RaBulkActionsToolbar';

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -32,6 +32,7 @@ import { Loading } from '../layout';
  * - perPage: Pagination Size
  * - queryOptions
  * - sort: Default Sort Field & Order
+ * - selectAllLimit: The number of items selected by the "SELECT ALL" button of the bulk actions toolbar
  * - title
  * - sx: CSS API
  *
@@ -68,6 +69,7 @@ export const List = <RecordType extends RaRecord = any>({
     resource,
     sort,
     storeKey,
+    selectAllLimit = 250,
     ...rest
 }: ListProps<RecordType>): ReactElement => (
     <ListBase<RecordType>
@@ -83,6 +85,7 @@ export const List = <RecordType extends RaRecord = any>({
         resource={resource}
         sort={sort}
         storeKey={storeKey}
+        selectAllLimit={selectAllLimit}
     >
         <ListView<RecordType> {...rest} />
     </ListBase>


### PR DESCRIPTION
## Problem

The Datagrid already allows to select all the records of a given page. But sometimes users want to select all records across all pages, e.g. to delete all the records of a resource. Also, when not in a datagrid (e.g. contact list in CRM demo), there is no way to select all records.

## Solution

In the bulk actions toolbar, add a “select all” link close to the number of selected items.

Already started in #9043, but needs a different approach

## To do

- [x] Add a "Select all" button
- [x] make it customizable (selectAllLimit)
- [x] document is the jsDoc
- [ ] document
- make it for the:
    - [x] List
    - [ ] ReferenceManyField
    - [ ] ReferenceArrayField
    - [ ] InfiniteList

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date