### PR TITLE
Fix SortButton default translation

### DIFF
--- a/packages/ra-ui-materialui/src/button/SortButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SortButton.tsx
@@ -91,11 +91,16 @@ const SortButton = (props: SortButtonProps) => {
         setAnchorEl(null);
     };
 
+    const fieldLabel = translateLabel({
+        resource,
+        source: sort.field,
+    });
     const buttonLabel = translate(label, {
-        field: translateLabel({
-            resource,
-            source: sort.field,
-        }),
+        field: fieldLabel,
+        field_lower_first:
+            typeof fieldLabel === 'string'
+                ? fieldLabel.charAt(0).toLowerCase() + fieldLabel.slice(1)
+                : undefined,
         order: translate(`ra.sort.${sort.order}`),
         _: label,
     });


### PR DESCRIPTION
## Before

<img width="362" alt="image" src="https://github.com/user-attachments/assets/4dc5e62a-2494-4257-aae6-4a70d5fcdcc5">

This is a regression caused by #10337

## After

<img width="287" alt="image" src="https://github.com/user-attachments/assets/014c5de4-c992-4314-90af-79794861f715">

## How to test

- Launch the ecommerce demo
- Go to the posters list
- See the sort button
