### PR TITLE
docs: fix Supabase link formatting in `DataProviderList.md`

### DIFF
--- a/docs/DataProviderList.md
+++ b/docs/DataProviderList.md
@@ -75,7 +75,7 @@ If you can't find a Data Provider for your backend below, no worries! [Writing a
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v3/v4](https://strapi.io/)**: [nazirov91/ra-strapi-rest](https://github.com/nazirov91/ra-strapi-rest)
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v4](https://strapi.io/)**: [garridorafa/ra-strapi-v4-rest](https://github.com/garridorafa/ra-strapi-v4-rest)
 * ![supabase Logo](./img/backend-logos/supabase.svg "supabase Logo")**[Supabase](https://supabase.io/)**: [marmelab/ra-supabase](https://github.com/marmelab/ra-supabase/blob/main/packages/ra-supabase/README.md)
-* ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[Supabase](https://supabase.io/) (GraphQL)**: [@groovestack/ra-data-graphql-supabase](https://github.com/maxschridde1494/ra-data-graphql-supabase)
+* ![graphql Logo](./img/backend-logos/graphql.svg "graphql Logo")**[Supabase (GraphQL)](https://supabase.io/)**: [@groovestack/ra-data-graphql-supabase](https://github.com/maxschridde1494/ra-data-graphql-supabase)
 * ![surrealDB Logo](./img/backend-logos/surrealdb.svg "surrealDB Logo")**[SurrealDB](https://surrealdb.com/)**: [djedi23/ra-surrealdb](https://github.com/djedi23/ra-surrealdb)
 * ![treeql Logo](./img/backend-logos/treeql.png "treeql Logo")**[TreeQL / PHP-CRUD-API](https://treeql.org/)**: [nkappler/ra-data-treeql](https://github.com/nkappler/ra-data-treeql)
 * ![wooCommerce Logo](./img/backend-logos/wooCommerce.png "wooCommerce Logo")**[WooCommerce REST API](https://woocommerce.github.io/woocommerce-rest-api-docs)**: [zackha/ra-data-woocommerce](https://github.com/zackha/ra-data-woocommerce)


### PR DESCRIPTION
Updated the Supabase link format for better consistency by moving "(GraphQL)" inside the clickable link text.

## Problem

_Describe the problem this PR solves_

## Solution

_Describe the solution this PR implements_

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
