### PR TITLE
Fix ReferenceManyField executes filter reset filter too often

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -154,7 +154,7 @@ export const useReferenceManyFieldController = <
             filterRef.current = filter;
             setFilterValues(filter);
         }
-    });
+    }, [filter]);
 
     const {
         data,

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -168,7 +168,7 @@ export const useList = <RecordType extends RaRecord = any>(
             filterRef.current = filter;
             setFilterValues(filter);
         }
-    });
+    }, [filter]);
 
     // We do all the data processing (filtering, sorting, paginating) client-side
     useEffect(


### PR DESCRIPTION
## Problem

We used an alternative to `setState` called `safeSetState` that disabled some React linter warnings. This silenced a problem of effect running too often in `useList` and `useReferecneManyFieldController`.

The removal of `safeSetState` in  #10341 revealed the problem, which is now reported by a linter warning (e.g. , https://github.com/marmelab/react-admin/pull/10370/files#diff-66e51c85b7ef7a61bc686a09a730355d6cc188a86670eb5d710d0d41d74ad5fe)

<img width="946" alt="image" src="https://github.com/user-attachments/assets/b2db1f28-e431-4d96-aad7-6ffc749a1b11">


## Solution

Add the required dependencies