### PR TITLE
[Doc] Remove an useless tip from the doc

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -560,8 +560,6 @@ In that case, set the `translateChoice` prop to `false`.
 ```
 {% endraw %}
 
-**Tip**: Like many other inputs, `<AutocompleteArrayInput>` accept a `fullWidth` prop.
-
 **Tip**: To use the `disableCloseOnSelect` prop, you must also set `blurOnSelect={false}`, since this is enabled by default.
 
 ## Fetching Choices


### PR DESCRIPTION
## Problem

The following tip is now useless because this prop is now applied by default

## Solution

Remove the tip