### PR TITLE
feat: allow base button to be wrapped with tooltip

### DIFF
--- a/packages/ra-ui-materialui/src/button/Button.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ReactNode } from 'react';
-import { createTheme, ThemeProvider, Stack } from '@mui/material';
+import { createTheme, ThemeProvider, Stack, Tooltip } from '@mui/material';
 import type { PaletteColor } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 
@@ -77,6 +77,14 @@ export const WithUserDefinedPalette = () => (
                 <AddIcon />
             </Button>
         </UIWrapper>
+    </ThemeProvider>
+);
+
+export const WithTooltip = () => (
+    <ThemeProvider theme={theme}>
+        <Tooltip title="This is a button">
+            <Button label="button" />
+        </Tooltip>
     </ThemeProvider>
 );
 

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -24,72 +24,79 @@ import { Path, To } from 'react-router';
  * </Button>
  *
  */
-export const Button = <RootComponent extends React.ElementType = 'button'>(
-    inProps: ButtonProps<RootComponent>
-) => {
-    const props = useThemeProps({ props: inProps, name: 'RaButton' });
-    const {
-        alignIcon = 'left',
-        children,
-        className,
-        disabled,
-        label,
-        color = 'primary',
-        size = 'small',
-        to: locationDescriptor,
-        ...rest
-    } = props;
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    (inProps, ref) => {
+        const props = useThemeProps({ props: inProps, name: 'RaButton' });
+        const {
+            alignIcon = 'left',
+            children,
+            className,
+            disabled,
+            label,
+            color = 'primary',
+            size = 'small',
+            to: locationDescriptor,
+            ...rest
+        } = props;
 
-    const translate = useTranslate();
-    const translatedLabel = label ? translate(label, { _: label }) : undefined;
-    const linkParams = getLinkParams(locationDescriptor);
+        const translate = useTranslate();
+        const translatedLabel = label
+            ? translate(label, { _: label })
+            : undefined;
+        const linkParams = getLinkParams(locationDescriptor);
 
-    const isXSmall = useMediaQuery((theme: Theme) =>
-        theme.breakpoints.down('sm')
-    );
+        const isXSmall = useMediaQuery((theme: Theme) =>
+            theme.breakpoints.down('sm')
+        );
 
-    return isXSmall ? (
-        label && !disabled ? (
-            <Tooltip title={translatedLabel}>
+        return isXSmall ? (
+            label && !disabled ? (
+                <Tooltip title={translatedLabel}>
+                    <IconButton
+                        aria-label={translatedLabel}
+                        className={className}
+                        color={color}
+                        size="large"
+                        {...linkParams}
+                        {...rest}
+                    >
+                        {children}
+                    </IconButton>
+                </Tooltip>
+            ) : (
                 <IconButton
-                    aria-label={translatedLabel}
                     className={className}
                     color={color}
+                    disabled={disabled}
                     size="large"
                     {...linkParams}
                     {...rest}
                 >
                     {children}
                 </IconButton>
-            </Tooltip>
+            )
         ) : (
-            <IconButton
+            <StyledButton
+                ref={ref}
                 className={className}
                 color={color}
+                size={size}
+                aria-label={translatedLabel}
                 disabled={disabled}
-                size="large"
+                startIcon={
+                    alignIcon === 'left' && children ? children : undefined
+                }
+                endIcon={
+                    alignIcon === 'right' && children ? children : undefined
+                }
                 {...linkParams}
                 {...rest}
             >
-                {children}
-            </IconButton>
-        )
-    ) : (
-        <StyledButton
-            className={className}
-            color={color}
-            size={size}
-            aria-label={translatedLabel}
-            disabled={disabled}
-            startIcon={alignIcon === 'left' && children ? children : undefined}
-            endIcon={alignIcon === 'right' && children ? children : undefined}
-            {...linkParams}
-            {...rest}
-        >
-            {translatedLabel}
-        </StyledButton>
-    );
-};
+                {translatedLabel}
+            </StyledButton>
+        );
+    }
+);
 
 interface Props<RootComponent extends React.ElementType> {
     alignIcon?: 'left' | 'right';


### PR DESCRIPTION
## Problem

Solves #10223 

## Solution

Adds `React.forwardRef`so that MUI's tooltip can wrap RA custom button component 

## How To Test

This will now work

```tsx
<Tooltip title="This is a button">
  <Button>My Button</Button>
</Tooltip>
```

A `ButtonWithTooltip.tsx` component could be added

