### PR TITLE
Feat reducer payload

### DIFF
--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -1,5 +1,6 @@
 import { isValidElement, useEffect, useMemo } from 'react';
 import { UseQueryOptions } from 'react-query';
+import { omit } from 'lodash';
 
 import { useAuthenticated } from '../../auth';
 import { useTranslate } from '../../i18n';
@@ -85,6 +86,11 @@ export const useListController = <RecordType extends RaRecord = any>(
     } = useGetList<RecordType>(
         resource,
         {
+            ...omit(query, [
+                'requestSignature',
+                'displayedFilters',
+                'filterValues',
+            ]),
             pagination: {
                 page: query.page,
                 perPage: query.perPage,

--- a/packages/ra-core/src/controller/list/useListParams.ts
+++ b/packages/ra-core/src/controller/list/useListParams.ts
@@ -299,10 +299,7 @@ const parseObject = (query, field) => {
 };
 
 export const parseQueryFromLocation = ({ search }): Partial<ListParams> => {
-    const query = pickBy(
-        parse(search),
-        (v, k) => validQueryParams.indexOf(k) !== -1
-    );
+    const query = parse(search);
     parseObject(query, 'filter');
     parseObject(query, 'displayedFilters');
     return query;

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -63,6 +63,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
         sort = { field: 'id', order: 'DESC' },
         filter = {},
         meta,
+        ...rest
     } = params;
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
@@ -71,10 +72,11 @@ export const useGetList = <RecordType extends RaRecord = any>(
         Error,
         GetListResult<RecordType>
     >(
-        [resource, 'getList', { pagination, sort, filter, meta }],
+        [resource, 'getList', { ...rest, pagination, sort, filter, meta }],
         () =>
             dataProvider
                 .getList<RecordType>(resource, {
+                    ...rest,
                     pagination,
                     sort,
                     filter,


### PR DESCRIPTION
## Problem

To pass custom parameters to `useGetList` API, such as cursor based pagination.

Discussed in https://github.com/marmelab/react-admin/issues/1510#issuecomment-2442929214.

## Solution

* Add full params update action in [queryReducer.ts](https://github.com/marmelab/react-admin/compare/4.x...mytharcher:react-admin:feat-reducer-payload?expand=1#diff-3d648086ae8721ed4e9c3bb8e624685357bad139eae5f76b2e65d7b4990d4b75)
* Pass all custom params to `useGetList` API.

## How To Test

Pass customized parameter from customized pagination component, such as `lastItem`. Here is example:

```
    const onNext = useCallback(() => {
        changeParams({
            payload: {
            filter: filterValues,
            // page,
            // perPage,
            'pagination.pageSize': pageSize,
            'pagination.lastItem': pagination?.lastItem,
            'pagination.scanForward': 1
        }
    }, [filterValues, pagination, pageSize]);
```

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
