### PR TITLE
Fix access control basename handling

### DIFF
--- a/packages/ra-core/src/auth/CanAccess.stories.tsx
+++ b/packages/ra-core/src/auth/CanAccess.stories.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
+import { Location } from 'react-router';
+import { QueryClient } from '@tanstack/react-query';
 import { AuthProvider } from '../types';
 import { CoreAdminContext } from '../core';
 import { CanAccess } from './CanAccess';
+import { TestMemoryRouter } from '..';
 
 export default {
     title: 'ra-core/auth/CanAccess',
@@ -19,14 +22,32 @@ const defaultAuthProvider: AuthProvider = {
 
 export const Basic = ({
     authProvider = defaultAuthProvider,
+    basename,
+    locationCallback,
 }: {
     authProvider?: AuthProvider;
+    basename?: string;
+    locationCallback?: (location: Location) => void;
 }) => (
-    <CoreAdminContext authProvider={authProvider}>
-        <CanAccess action="read" resource="test">
-            protected content
-        </CanAccess>
-    </CoreAdminContext>
+    <TestMemoryRouter locationCallback={locationCallback}>
+        <CoreAdminContext
+            authProvider={authProvider}
+            basename={basename}
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: {
+                            retry: false,
+                        },
+                    },
+                })
+            }
+        >
+            <CanAccess action="read" resource="test">
+                protected content
+            </CanAccess>
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );
 
 export const AccessDenied = ({
@@ -34,11 +55,13 @@ export const AccessDenied = ({
 }: {
     authProvider?: AuthProvider;
 }) => (
-    <CoreAdminContext authProvider={authProvider}>
-        <CanAccess action="show" resource="test">
-            protected content
-        </CanAccess>
-    </CoreAdminContext>
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={authProvider}>
+            <CanAccess action="show" resource="test">
+                protected content
+            </CanAccess>
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );
 
 export const CustomLoading = ({
@@ -46,15 +69,17 @@ export const CustomLoading = ({
 }: {
     authProvider?: AuthProvider;
 }) => (
-    <CoreAdminContext authProvider={authProvider}>
-        <CanAccess
-            action="read"
-            resource="test"
-            loading={<div>Please wait...</div>}
-        >
-            protected content
-        </CanAccess>
-    </CoreAdminContext>
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={authProvider}>
+            <CanAccess
+                action="read"
+                resource="test"
+                loading={<div>Please wait...</div>}
+            >
+                protected content
+            </CanAccess>
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );
 
 export const CustomAccessDenied = ({
@@ -62,21 +87,25 @@ export const CustomAccessDenied = ({
 }: {
     authProvider?: AuthProvider;
 }) => (
-    <CoreAdminContext authProvider={authProvider}>
-        <CanAccess
-            action="show"
-            resource="test"
-            accessDenied={<div>Not allowed</div>}
-        >
-            protected content
-        </CanAccess>
-    </CoreAdminContext>
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={authProvider}>
+            <CanAccess
+                action="show"
+                resource="test"
+                accessDenied={<div>Not allowed</div>}
+            >
+                protected content
+            </CanAccess>
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );
 
 export const NoAuthProvider = () => (
-    <CoreAdminContext authProvider={undefined}>
-        <CanAccess action="read" resource="test">
-            protected content
-        </CanAccess>
-    </CoreAdminContext>
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={undefined}>
+            <CanAccess action="read" resource="test">
+                protected content
+            </CanAccess>
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );

--- a/packages/ra-core/src/auth/CanAccess.tsx
+++ b/packages/ra-core/src/auth/CanAccess.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { Navigate } from 'react-router';
 import { useCanAccess, UseCanAccessOptions } from './useCanAccess';
 import { RaRecord } from '../types';
-import { Navigate } from 'react-router';
+import { useBasename } from '../routing';
 
 /**
  * A component that only displays its children after checking whether users are authorized to access the provided resource and action.
@@ -50,4 +51,9 @@ export interface CanAccessProps<
     error?: React.ReactNode;
 }
 
-const DEFAULT_ERROR = <Navigate to="/authentication-error" />;
+const CanAccessDefaultError = () => {
+    const basename = useBasename();
+    return <Navigate to={`${basename}/authentication-error`} />;
+};
+
+const DEFAULT_ERROR = <CanAccessDefaultError />;

--- a/packages/ra-core/src/auth/useRequireAccess.stories.tsx
+++ b/packages/ra-core/src/auth/useRequireAccess.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { QueryClient } from '@tanstack/react-query';
-import { Route, Routes } from 'react-router';
+import { Location, Route, Routes } from 'react-router';
 import { AuthProvider } from '../types';
 import { CoreAdminContext } from '../core';
 import { useRequireAccess, UseRequireAccessResult } from './useRequireAccess';
@@ -50,15 +50,20 @@ const defaultAuthProvider: AuthProvider = {
 
 export const Basic = ({
     authProvider = defaultAuthProvider,
+    basename,
+    locationCallback,
     queryClient,
 }: {
     authProvider?: AuthProvider | null;
+    basename?: string;
+    locationCallback?: (l: Location) => void;
     queryClient?: QueryClient;
 }) => (
-    <TestMemoryRouter>
+    <TestMemoryRouter locationCallback={locationCallback}>
         <CoreAdminContext
             authProvider={authProvider != null ? authProvider : undefined}
             queryClient={queryClient}
+            basename={basename}
         >
             <Routes>
                 <Route

--- a/packages/ra-core/src/auth/useRequireAccess.tsx
+++ b/packages/ra-core/src/auth/useRequireAccess.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
 import { RaRecord } from '../types';
 import {
     useCanAccess,
     UseCanAccessOptions,
     UseCanAccessResult,
 } from './useCanAccess';
-import { useNavigate } from 'react-router';
+import { useBasename } from '../routing';
 
 /**
  * A hook that calls the authProvider.canAccess() method for a provided resource and action (and optionally a record).
@@ -50,20 +51,21 @@ export const useRequireAccess = <
 ) => {
     const { canAccess, data, error, ...rest } = useCanAccess(params);
     const navigate = useNavigate();
+    const basename = useBasename();
 
     useEffect(() => {
         if (rest.isPending) return;
 
         if (canAccess === false) {
-            navigate('/access-denied');
+            navigate(`${basename}/access-denied`);
         }
-    }, [canAccess, navigate, rest.isPending]);
+    }, [basename, canAccess, navigate, rest.isPending]);
 
     useEffect(() => {
         if (error) {
-            navigate('/authentication-error');
+            navigate(`${basename}/authentication-error`);
         }
-    }, [navigate, error]);
+    }, [basename, navigate, error]);
 
     return rest;
 };

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.spec.tsx
@@ -19,6 +19,25 @@ describe('ResourceMenuItem', () => {
         await screen.findByText('resources.posts.name');
         expect(screen.queryByText('resources.users.name')).toBeNull();
     });
+    it('should not render when authProvider.canAccess throws', async () => {
+        render(
+            <AccessControl
+                authProvider={
+                    {
+                        checkAuth: () => Promise.resolve(),
+                        canAccess: ({ resource }) =>
+                            resource === 'posts'
+                                ? Promise.resolve(true)
+                                : Promise.reject(
+                                      new Error('access control error')
+                                  ),
+                    } as any
+                }
+            />
+        );
+        await screen.findByText('resources.posts.name');
+        expect(screen.queryByText('resources.users.name')).toBeNull();
+    });
     it('should not render when authProvider.canAccess returns false with a Function as <Admin> child', async () => {
         render(<AccessControlInsideAdminChildFunction />);
         await screen.findByText('resources.posts.name');

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.stories.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { Resource, testDataProvider, TestMemoryRouter } from 'ra-core';
+import {
+    AuthProvider,
+    Resource,
+    testDataProvider,
+    TestMemoryRouter,
+} from 'ra-core';
 import { Menu } from './Menu';
 import { Layout, LayoutProps } from './Layout';
 import { AdminContext } from '../AdminContext';
@@ -100,12 +105,13 @@ export const AccessControlInsideAdminChildFunction = () => (
     </TestMemoryRouter>
 );
 
-export const AccessControl = () => (
+export const AccessControl = ({
+    authProvider = authProviderForAccessControl,
+}: {
+    authProvider?: AuthProvider;
+}) => (
     <TestMemoryRouter>
-        <AdminContext
-            dataProvider={dataProvider}
-            authProvider={authProviderForAccessControl}
-        >
+        <AdminContext dataProvider={dataProvider} authProvider={authProvider}>
             <AdminUI layout={CustomLayout}>
                 <Resource name="users" list={<p>The users page</p>} />
                 <Resource

--- a/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/layout/ResourceMenuItem.tsx
@@ -13,13 +13,19 @@ import { MenuItemLink } from './MenuItemLink';
 
 export const ResourceMenuItem = ({ name }: { name: string }) => {
     const resources = useResourceDefinitions();
-    const { canAccess, isPending } = useCanAccess({
+    const { canAccess, error, isPending } = useCanAccess({
         action: 'list',
         resource: name,
     });
     const getResourceLabel = useGetResourceLabel();
     const createPath = useCreatePath();
-    if (!resources || !resources[name] || isPending || canAccess === false)
+    if (
+        !resources ||
+        !resources[name] ||
+        isPending ||
+        canAccess === false ||
+        error != null
+    )
         return null;
     return (
         <MenuItemLink


### PR DESCRIPTION
## Problem

When using the `basename` prop on `<Admin>`, access control redirects don't work.
Also, `ResourceMenuItem` should not render in case of access control error

Fixes #10380

## Solution

- Use the `basename` in those redirects.
- Fix `ResourceMenuItem` should not render in case of access control error

## How To Test

- Unit tests
- http://localhost:9010/iframe.html?args=&id=react-admin-admin--access-control-in-sub-path

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

