### PR TITLE
Introduce SimpleList rowClick

### DIFF
--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -104,6 +104,7 @@ export const PostList = () => (
 * `rowClick="edit"`: links to the edit page. This is the default behavior.
 * `rowClick="show"`: links to the show page.
 * `rowClick={false}`: does not link to anything.
+* `rowClick="/custom"`: links to a custom path.
 * `rowClick={(id, resource, record) => path}`: path can be any of the above values
 
 ## `primaryText`

--- a/docs/SimpleList.md
+++ b/docs/SimpleList.md
@@ -28,7 +28,7 @@ export const PostList = () => (
             primaryText={record => record.title}
             secondaryText={record => `${record.views} views`}
             tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
-            linkType={record => record.canEdit ? "edit" : "show"}
+            rowClick={(id, resource, record) => record.canEdit ? "edit" : "show"}
             rowSx={record => ({ backgroundColor: record.nb_views >= 500 ? '#efe' : 'white' })}
         />
     </List>
@@ -44,7 +44,7 @@ export const PostList = () => (
 | `primaryText` | Optional | mixed | record representation | The primary text to display. |
 | `secondaryText` | Optional | mixed | | The secondary text to display. |
 | `tertiaryText` | Optional | mixed | | The tertiary text to display. |
-| `linkType` | Optional |mixed | `"edit"` | The target of each item click. |
+| `rowClick` | Optional |mixed | `"edit"` | The action to trigger when the user clicks on a row. |
 | `leftAvatar` | Optional | function | | A function returning an `<Avatar>` component to display before the primary text. |
 | `leftIcon` | Optional | function | | A function returning an `<Icon>` component to display before the primary text. |
 | `rightAvatar` | Optional | function | | A function returning an `<Avatar>` component to display after the primary text. |
@@ -80,9 +80,9 @@ This prop should be a function returning an `<Avatar>` component. When present, 
 
 This prop should be a function returning an `<Icon>` component. When present, the `<ListItem>` renders a `<ListIcon>` before the `<ListItemText>`
 
-## `linkType`
+## `rowClick`
 
-The `<SimpleList>` items link to the edition page by default. You can also set the `linkType` prop to `show` directly to link to the `<Show>` page instead.
+The `<SimpleList>` items link to the edition page by default. You can also set the `rowClick` prop to `show` directly to link to the `<Show>` page instead. 
 
 ```jsx
 import { List, SimpleList } from 'react-admin';
@@ -93,17 +93,18 @@ export const PostList = () => (
             primaryText={record => record.title}
             secondaryText={record => `${record.views} views`}
             tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
-            linkType="show"
+            rowClick="show"
         />
     </List>
 );
 ```
 
-`linkType` accepts the following values:
+`rowClick` accepts the following values:
 
-* `linkType="edit"`: links to the edit page. This is the default behavior.
-* `linkType="show"`: links to the show page.
-* `linkType={false}`: does not create any link.
+* `rowClick="edit"`: links to the edit page. This is the default behavior.
+* `rowClick="show"`: links to the show page.
+* `rowClick={false}`: does not link to anything.
+* `rowClick={(id, resource, record) => path}`: path can be any of the above values
 
 ## `primaryText`
 
@@ -254,7 +255,7 @@ export const PostList = () => {
                     primaryText={record => record.title}
                     secondaryText={record => `${record.views} views`}
                     tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
-                    linkType={record => record.canEdit ? "edit" : "show"}   
+                    rowClick={(id, resource, record) => record.canEdit ? "edit" : "show"}   
                 />
             ) : (
                 <Datagrid>

--- a/packages/ra-core/src/routing/useGetPathForRecord.ts
+++ b/packages/ra-core/src/routing/useGetPathForRecord.ts
@@ -81,6 +81,11 @@ export const useGetPathForRecord = <RecordType extends RaRecord = RaRecord>(
     useEffect(() => {
         if (!record) return;
 
+        if (link === false) {
+            setPath(false);
+            return;
+        }
+
         // Handle the inferred link type case
         if (link == null) {
             // We must check whether the resource has an edit view because if there is no

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.spec.tsx
@@ -79,10 +79,17 @@ describe('<SimpleList />', () => {
     it.each([
         ['edit', 'edit', '/books/1'],
         ['show', 'show', '/books/1/show'],
-        ['custom', (record, id) => `/books/${id}/custom`, '/books/1/custom'],
+        [
+            'a function that returns a custom path',
+            (record, id) =>
+                `/books/${id}/${record.title.toLowerCase().replaceAll(' ', '-')}`,
+            '/books/1/war-and-peace',
+        ],
+        ['a function that returns edit', () => 'edit', '/books/1'],
+        ['a function that returns show', () => 'show', '/books/1/show'],
     ])(
-        'should render %s links for each item with linkType',
-        async (_, linkType, expectedUrls) => {
+        'Providing %s as linkType should render a link for each item',
+        async (_, linkType, expectedUrl) => {
             let location: Location;
             render(
                 <LinkType
@@ -94,7 +101,7 @@ describe('<SimpleList />', () => {
             );
             fireEvent.click(await screen.findByText('War and Peace'));
             await waitFor(() => {
-                expect(location?.pathname).toEqual(expectedUrls);
+                expect(location?.pathname).toEqual(expectedUrl);
             });
         }
     );
@@ -130,9 +137,28 @@ describe('<SimpleList />', () => {
     it.each([
         ['edit', 'edit', '/books/1'],
         ['show', 'show', '/books/1/show'],
-        ['custom', id => `/books/${id}/custom`, '/books/1/custom'],
+        [
+            'a function that returns a custom path',
+            (id, resource, record) =>
+                `/${resource}/${id}/${record.title.toLowerCase().replaceAll(' ', '-')}`,
+            '/books/1/war-and-peace',
+        ],
+        ['a function that returns edit', () => 'edit', '/books/1'],
+        ['a function that returns show', () => 'show', '/books/1/show'],
+        ['a function that resolves to edit', async () => 'edit', '/books/1'],
+        [
+            'a function that resolves to show',
+            async () => 'show',
+            '/books/1/show',
+        ],
+        [
+            'a function that resolves to a custom path',
+            async (id, resource, record) =>
+                `/${resource}/${id}/${record.title.toLowerCase().replaceAll(' ', '-')}`,
+            '/books/1/war-and-peace',
+        ],
     ])(
-        'should render %s links for each item with rowClick',
+        'Providing %s as rowClick should render a link for each item',
         async (_, rowClick, expectedUrls) => {
             let location: Location;
             render(

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -14,12 +14,13 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 import { Alert, Box, FormControlLabel, FormGroup, Switch } from '@mui/material';
 import { Location } from 'react-router';
 
-import { FunctionLinkType, SimpleList } from './SimpleList';
 import { AdminUI } from '../../AdminUI';
 import { AdminContext, AdminContextProps } from '../../AdminContext';
 import { EditGuesser } from '../../detail';
 import { List, ListProps } from '../List';
 import { RowClickFunction } from '../types';
+import { SimpleList } from './SimpleList';
+import { FunctionLinkType } from './SimpleListItem';
 
 export default { title: 'ra-ui-materialui/list/SimpleList' };
 
@@ -166,7 +167,8 @@ LinkType.argTypes = {
             show: 'show',
             edit: 'edit',
             'no-link': false,
-            function: (record, id) => alert(`Clicked on ${id}`),
+            function: (record, id) =>
+                alert(`Clicked on record ${record.title} (#${id})`),
         },
         control: { type: 'select' },
     },
@@ -217,7 +219,10 @@ RowClick.argTypes = {
             show: 'show',
             edit: 'edit',
             'no-link': false,
-            function: id => alert(`Clicked on ${id}`),
+            function: (id, resource, record) =>
+                alert(
+                    `Clicked on record ${record.title} (#${id}) of type ${resource}`
+                ),
         },
         control: { type: 'select' },
     },

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.stories.tsx
@@ -7,16 +7,19 @@ import {
     TestMemoryRouter,
     ResourceContextProvider,
     ResourceProps,
+    ResourceDefinitionContextProvider,
 } from 'ra-core';
 import defaultMessages from 'ra-language-english';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
-import { Box, FormControlLabel, FormGroup, Switch } from '@mui/material';
+import { Alert, Box, FormControlLabel, FormGroup, Switch } from '@mui/material';
+import { Location } from 'react-router';
 
-import { SimpleList } from './SimpleList';
+import { FunctionLinkType, SimpleList } from './SimpleList';
 import { AdminUI } from '../../AdminUI';
 import { AdminContext, AdminContextProps } from '../../AdminContext';
 import { EditGuesser } from '../../detail';
 import { List, ListProps } from '../List';
+import { RowClickFunction } from '../types';
 
 export default { title: 'ra-ui-materialui/list/SimpleList' };
 
@@ -105,16 +108,120 @@ const data = {
 
 export const Basic = () => (
     <TestMemoryRouter>
-        <ResourceContextProvider value="books">
-            <SimpleList
-                data={data.books}
-                primaryText={record => record.title}
-                secondaryText={record => record.author}
-                tertiaryText={record => record.year}
-            />
-        </ResourceContextProvider>
+        <AdminContext>
+            <ResourceContextProvider value="books">
+                <SimpleList
+                    data={data.books}
+                    primaryText={record => record.title}
+                    secondaryText={record => record.author}
+                    tertiaryText={record => record.year}
+                />
+            </ResourceContextProvider>
+        </AdminContext>
     </TestMemoryRouter>
 );
+
+export const LinkType = ({
+    linkType,
+    locationCallback,
+}: {
+    linkType: string | FunctionLinkType | false;
+    locationCallback?: (l: Location) => void;
+}) => (
+    <TestMemoryRouter locationCallback={locationCallback}>
+        <AdminContext>
+            <ResourceDefinitionContextProvider
+                definitions={{
+                    books: {
+                        name: 'books',
+                        hasList: true,
+                        hasEdit: true,
+                        hasShow: false,
+                    },
+                }}
+            >
+                <ResourceContextProvider value="books">
+                    <Alert color="info">Inferred should target edit</Alert>
+                    <SimpleList
+                        data={data.books}
+                        primaryText={record => record.title}
+                        secondaryText={record => record.author}
+                        tertiaryText={record => record.year}
+                        linkType={linkType}
+                    />
+                </ResourceContextProvider>
+            </ResourceDefinitionContextProvider>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+LinkType.args = {
+    linkType: 'edit',
+};
+LinkType.argTypes = {
+    linkType: {
+        options: ['inferred', 'edit', 'show', 'no-link', 'function'],
+        mapping: {
+            inferred: undefined,
+            show: 'show',
+            edit: 'edit',
+            'no-link': false,
+            function: (record, id) => alert(`Clicked on ${id}`),
+        },
+        control: { type: 'select' },
+    },
+};
+
+export const RowClick = ({
+    locationCallback,
+    rowClick,
+}: {
+    locationCallback?: (l: Location) => void;
+    rowClick: string | RowClickFunction | false;
+}) => (
+    <TestMemoryRouter locationCallback={locationCallback}>
+        <AdminContext>
+            <ResourceDefinitionContextProvider
+                definitions={{
+                    books: {
+                        name: 'books',
+                        hasList: true,
+                        hasEdit: true,
+                        hasShow: false,
+                    },
+                }}
+            >
+                <ResourceContextProvider value="books">
+                    <Alert color="info">Inferred should target edit</Alert>
+                    <SimpleList
+                        data={data.books}
+                        primaryText={record => record.title}
+                        secondaryText={record => record.author}
+                        tertiaryText={record => record.year}
+                        rowClick={rowClick}
+                    />
+                </ResourceContextProvider>
+            </ResourceDefinitionContextProvider>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+RowClick.args = {
+    rowClick: 'edit',
+};
+RowClick.argTypes = {
+    rowClick: {
+        options: ['inferred', 'edit', 'show', 'no-link', 'function'],
+        mapping: {
+            inferred: undefined,
+            show: 'show',
+            edit: 'edit',
+            'no-link': false,
+            function: id => alert(`Clicked on ${id}`),
+        },
+        control: { type: 'select' },
+    },
+};
 
 const myDataProvider = fakeRestDataProvider(data);
 
@@ -289,26 +396,32 @@ export const FullAppInError = () => (
 
 export const Standalone = () => (
     <TestMemoryRouter>
-        <SimpleList
-            data={data.books}
-            primaryText={record => record.title}
-            secondaryText={record => record.author}
-            tertiaryText={record => record.year}
-            linkType={false}
-        />
+        <AdminContext>
+            <ResourceContextProvider value="books">
+                <SimpleList
+                    data={data.books}
+                    primaryText={record => record.title}
+                    secondaryText={record => record.author}
+                    tertiaryText={record => record.year}
+                    linkType={false}
+                />
+            </ResourceContextProvider>
+        </AdminContext>
     </TestMemoryRouter>
 );
 
 export const StandaloneEmpty = () => (
     <TestMemoryRouter>
-        <ResourceContextProvider value="books">
-            <SimpleList<any>
-                data={[]}
-                primaryText={record => record.title}
-                secondaryText={record => record.author}
-                tertiaryText={record => record.year}
-                linkType={false}
-            />
-        </ResourceContextProvider>
+        <AdminContext>
+            <ResourceContextProvider value="books">
+                <SimpleList<any>
+                    data={[]}
+                    primaryText={record => record.title}
+                    secondaryText={record => record.author}
+                    tertiaryText={record => record.year}
+                    linkType={false}
+                />
+            </ResourceContextProvider>
+        </AdminContext>
     </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -44,7 +44,7 @@ import {
  * - leftIcon: same
  * - rightAvatar: same
  * - rightIcon: same
- * - linkType: deprecated 'edit' or 'show', or a function returning 'edit' or 'show' based on the record
+ * - linkType: deprecated - 'edit' or 'show', or a function returning 'edit' or 'show' based on the record
  * - rowClick: The action to trigger when the user clicks on a row.
  * - rowStyle: function returning a style object based on (record, index)
  * - rowSx: function returning a sx object based on (record, index)

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleListItem.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import { ReactElement, ReactNode } from 'react';
+import type { SxProps } from '@mui/material';
+import { ListItem, ListItemButton, ListItemProps } from '@mui/material';
+import {
+    Identifier,
+    LinkToType,
+    RaRecord,
+    useEvent,
+    useGetPathForRecord,
+    useGetPathForRecordCallback,
+    useRecordContext,
+    useResourceContext,
+} from 'ra-core';
+import { Link, useNavigate } from 'react-router-dom';
+import { RowClickFunction } from '../types';
+
+export const SimpleListItem = <RecordType extends RaRecord = any>(
+    props: SimpleListItemProps<RecordType>
+) => {
+    const { children, linkType, rowClick, rowIndex, rowSx, rowStyle } = props;
+    const resource = useResourceContext(props);
+    const record = useRecordContext<RecordType>(props);
+    const navigate = useNavigate();
+    // If we don't have a function to get the path, we can compute the path immediately and set the href
+    // on the Link correctly without onClick (better for accessibility)
+    const isFunctionLink =
+        typeof linkType === 'function' || typeof rowClick === 'function';
+    const pathForRecord = useGetPathForRecord({
+        link: isFunctionLink ? false : linkType ?? rowClick,
+    });
+    const getPathForRecord = useGetPathForRecordCallback();
+    const handleClick = useEvent(
+        async (event: React.MouseEvent<HTMLAnchorElement>) => {
+            // No need to handle non function linkType or rowClick
+            if (!isFunctionLink) return;
+            if (!record) return;
+            event.persist();
+
+            let link: LinkToType =
+                typeof linkType === 'function'
+                    ? linkType(record, record.id)
+                    : typeof rowClick === 'function'
+                      ? (record, resource) =>
+                            rowClick(record.id, resource, record)
+                      : false;
+
+            const path = await getPathForRecord({
+                record,
+                resource,
+                link,
+            });
+            if (path === false || path == null) {
+                return;
+            }
+            navigate(path);
+        }
+    );
+
+    if (!record) return null;
+
+    if (isFunctionLink) {
+        return (
+            <ListItem
+                disablePadding
+                sx={{
+                    '.MuiListItem-container': {
+                        width: '100%',
+                    },
+                }}
+            >
+                {/* @ts-ignore */}
+                <ListItemButton
+                    onClick={handleClick}
+                    style={rowStyle ? rowStyle(record, rowIndex) : undefined}
+                    sx={rowSx?.(record, rowIndex)}
+                >
+                    {children}
+                </ListItemButton>
+            </ListItem>
+        );
+    }
+
+    if (pathForRecord) {
+        return (
+            <ListItem
+                disablePadding
+                sx={{
+                    '.MuiListItem-container': {
+                        width: '100%',
+                    },
+                }}
+            >
+                <ListItemButton
+                    component={Link}
+                    to={pathForRecord}
+                    style={rowStyle ? rowStyle(record, rowIndex) : undefined}
+                    sx={rowSx?.(record, rowIndex)}
+                >
+                    {children}
+                </ListItemButton>
+            </ListItem>
+        );
+    }
+
+    return (
+        <ListItem
+            sx={{
+                '.MuiListItem-container': {
+                    width: '100%',
+                },
+            }}
+        >
+            {children}
+        </ListItem>
+    );
+};
+
+export type FunctionToElement<RecordType extends RaRecord = any> = (
+    record: RecordType,
+    id: Identifier
+) => ReactNode;
+
+export type FunctionLinkType = (record: RaRecord, id: Identifier) => string;
+
+export interface SimpleListBaseProps<RecordType extends RaRecord = any> {
+    leftAvatar?: FunctionToElement<RecordType>;
+    leftIcon?: FunctionToElement<RecordType>;
+    primaryText?: FunctionToElement<RecordType> | ReactElement | string;
+    /**
+     * @deprecated use rowClick instead
+     */
+    linkType?: string | FunctionLinkType | false;
+
+    /**
+     * The action to trigger when the user clicks on a row.
+     *
+     * @see https://marmelab.com/react-admin/Datagrid.html#rowclick
+     * @example
+     * import { List, Datagrid } from 'react-admin';
+     *
+     * export const PostList = () => (
+     *     <List>
+     *         <Datagrid rowClick="edit">
+     *             ...
+     *         </Datagrid>                    </ListItem>
+
+     *     </List>
+     * );
+     */
+    rowClick?: string | RowClickFunction | false;
+    rightAvatar?: FunctionToElement<RecordType>;
+    rightIcon?: FunctionToElement<RecordType>;
+    secondaryText?: FunctionToElement<RecordType> | ReactElement | string;
+    tertiaryText?: FunctionToElement<RecordType> | ReactElement | string;
+    rowSx?: (record: RecordType, index: number) => SxProps;
+    rowStyle?: (record: RecordType, index: number) => any;
+}
+
+export interface SimpleListItemProps<RecordType extends RaRecord = any>
+    extends SimpleListBaseProps<RecordType>,
+        Omit<ListItemProps, 'button' | 'component' | 'id'> {
+    rowIndex: number;
+}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleListItem.tsx
@@ -30,32 +30,28 @@ export const SimpleListItem = <RecordType extends RaRecord = any>(
         link: isFunctionLink ? false : linkType ?? rowClick,
     });
     const getPathForRecord = useGetPathForRecordCallback();
-    const handleClick = useEvent(
-        async (event: React.MouseEvent<HTMLAnchorElement>) => {
-            // No need to handle non function linkType or rowClick
-            if (!isFunctionLink) return;
-            if (!record) return;
-            event.persist();
+    const handleClick = useEvent(async () => {
+        // No need to handle non function linkType or rowClick
+        if (!isFunctionLink) return;
+        if (!record) return;
 
-            let link: LinkToType =
-                typeof linkType === 'function'
-                    ? linkType(record, record.id)
-                    : typeof rowClick === 'function'
-                      ? (record, resource) =>
-                            rowClick(record.id, resource, record)
-                      : false;
+        let link: LinkToType =
+            typeof linkType === 'function'
+                ? linkType(record, record.id)
+                : typeof rowClick === 'function'
+                  ? (record, resource) => rowClick(record.id, resource, record)
+                  : false;
 
-            const path = await getPathForRecord({
-                record,
-                resource,
-                link,
-            });
-            if (path === false || path == null) {
-                return;
-            }
-            navigate(path);
+        const path = await getPathForRecord({
+            record,
+            resource,
+            link,
+        });
+        if (path === false || path == null) {
+            return;
         }
-    );
+        navigate(path);
+    });
 
     if (!record) return null;
 

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -29,7 +29,7 @@ import difference from 'lodash/difference';
 import { DatagridHeader } from './DatagridHeader';
 import DatagridLoading from './DatagridLoading';
 import DatagridBody, { PureDatagridBody } from './DatagridBody';
-import { RowClickFunction } from './DatagridRow';
+import { RowClickFunction } from '../types';
 import DatagridContextProvider from './DatagridContextProvider';
 import { DatagridClasses, DatagridRoot } from './useDatagridStyles';
 import { BulkActionsToolbar } from '../BulkActionsToolbar';

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridBody.tsx
@@ -4,8 +4,9 @@ import { SxProps, TableBody, TableBodyProps } from '@mui/material';
 import clsx from 'clsx';
 import { Identifier, RaRecord, RecordContextProvider } from 'ra-core';
 
+import { RowClickFunction } from '../types';
 import { DatagridClasses } from './useDatagridStyles';
-import DatagridRow, { PureDatagridRow, RowClickFunction } from './DatagridRow';
+import DatagridRow, { PureDatagridRow } from './DatagridRow';
 
 const DatagridBody: React.ForwardRefExoticComponent<
     Omit<DatagridBodyProps, 'ref'> &

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -27,6 +27,7 @@ import DatagridCell from './DatagridCell';
 import ExpandRowButton from './ExpandRowButton';
 import { DatagridClasses } from './useDatagridStyles';
 import { useDatagridContext } from './useDatagridContext';
+import { RowClickFunction } from '../types';
 
 const computeNbColumns = (expand, children, hasBulkActions) =>
     expand
@@ -264,12 +265,6 @@ export interface DatagridRowProps
     style?: any;
     selectable?: boolean;
 }
-
-export type RowClickFunction = (
-    id: Identifier,
-    resource: string,
-    record: RaRecord
-) => string | false | Promise<string | false>;
 
 const areEqual = (prevProps, nextProps) => {
     const { children: _1, expand: _2, ...prevPropsWithoutChildren } = prevProps;

--- a/packages/ra-ui-materialui/src/list/datagrid/index.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/index.ts
@@ -8,11 +8,7 @@ import DatagridHeaderCell, {
     DatagridHeaderCellProps,
 } from './DatagridHeaderCell';
 import DatagridLoading, { DatagridLoadingProps } from './DatagridLoading';
-import DatagridRow, {
-    DatagridRowProps,
-    PureDatagridRow,
-    RowClickFunction,
-} from './DatagridRow';
+import DatagridRow, { DatagridRowProps, PureDatagridRow } from './DatagridRow';
 import ExpandRowButton, { ExpandRowButtonProps } from './ExpandRowButton';
 
 export * from './Datagrid';
@@ -43,5 +39,4 @@ export type {
     DatagridLoadingProps,
     DatagridRowProps,
     ExpandRowButtonProps,
-    RowClickFunction,
 };

--- a/packages/ra-ui-materialui/src/list/index.ts
+++ b/packages/ra-ui-materialui/src/list/index.ts
@@ -16,3 +16,4 @@ export * from './pagination';
 export * from './Placeholder';
 export * from './SimpleList';
 export * from './SingleFieldList';
+export * from './types';

--- a/packages/ra-ui-materialui/src/list/types.ts
+++ b/packages/ra-ui-materialui/src/list/types.ts
@@ -1,0 +1,7 @@
+import { Identifier, RaRecord } from 'ra-core';
+
+export type RowClickFunction = <RecordType extends RaRecord = RaRecord>(
+    id: Identifier,
+    resource: string,
+    record: RecordType
+) => string | false | Promise<string | false>;


### PR DESCRIPTION
## Problem

Supersedes #10349

> The linkType for SimpleList provides less functionality than the rowClick for DataGrid. And also the inconsistency makes it harder to use.

## Solution

> Implement rowClick prop as it works for Datagrid.
Keep the linkType prop working as previously, but show it as deprecated. If both are set, linkType takes precedence (because it will be simpler to remove from the code later that way).

It also fixes an issue introduced by #10343 that produced nested `li` which is invalid HTML.

## How To Test

- `linkType`: https://react-admin-storybook-2x9vrs84o-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-list-simplelist--link-type
- `rowClick`: https://react-admin-storybook-2x9vrs84o-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-list-simplelist--row-click
- Fix for invalid html: https://react-admin-storybook-2x9vrs84o-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-list-simplelist--icons-avatars-and-link-type. Open the devtool and highlight an item: it should not have nested `li`. Besides, [this error](https://github.com/marmelab/react-admin/actions/runs/11839487973/job/32991563043#step:5:96) should not appear anymore in the tests output.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date