### PR TITLE
Add a story when `TextInput` trigger a server error

### DIFF
--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { required } from 'ra-core';
+import { required, Resource, useNotify } from 'ra-core';
 import { useFormState, useFormContext } from 'react-hook-form';
 
 import { TextInput } from './TextInput';
@@ -9,6 +9,8 @@ import { Edit } from '../detail';
 import { SimpleForm, Toolbar } from '../form';
 import { SaveButton } from '../button';
 import { FormInspector } from './common';
+import { Admin } from 'react-admin';
+import { MemoryRouter } from 'react-router';
 
 export default { title: 'ra-ui-materialui/input/TextInput' };
 
@@ -174,6 +176,43 @@ export const Error = () => (
             </SimpleForm>
         </Create>
     </AdminContext>
+);
+
+const ServerErrorCreate = () => {
+    const notify = useNotify();
+    const onSuccess = () => notify('Created with success', { type: 'success' });
+    const onError = () =>
+        notify('Error during item creation', { type: 'error' });
+    return (
+        <Create
+            resource="posts"
+            record={{ id: 123, title: 'Lorem ipsum' }}
+            sx={{ width: 600 }}
+            mutationOptions={{ onSuccess, onError }}
+        >
+            <SimpleForm toolbar={AlwaysOnToolbar}>
+                <TextInput source="title" />
+                <FormInspector />
+            </SimpleForm>
+        </Create>
+    );
+};
+
+export const ServerError = () => (
+    <MemoryRouter initialEntries={['/posts/create']}>
+        <Admin
+            dataProvider={
+                {
+                    create: (resource, { data }) => {
+                        console.log(`reject create on ${resource}: `, data);
+                        return Promise.reject({ data });
+                    },
+                } as any
+            }
+        >
+            <Resource name="posts" create={ServerErrorCreate} />
+        </Admin>
+    </MemoryRouter>
 );
 
 export const Sx = () => (

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -178,26 +178,6 @@ export const Error = () => (
     </AdminContext>
 );
 
-const ServerErrorCreate = () => {
-    const notify = useNotify();
-    const onSuccess = () => notify('Created with success', { type: 'success' });
-    const onError = () =>
-        notify('Error during item creation', { type: 'error' });
-    return (
-        <Create
-            resource="posts"
-            record={{ id: 123, title: 'Lorem ipsum' }}
-            sx={{ width: 600 }}
-            mutationOptions={{ onSuccess, onError }}
-        >
-            <SimpleForm toolbar={AlwaysOnToolbar}>
-                <TextInput source="title" />
-                <FormInspector />
-            </SimpleForm>
-        </Create>
-    );
-};
-
 export const ServerError = () => (
     <MemoryRouter initialEntries={['/posts/create']}>
         <Admin
@@ -205,12 +185,68 @@ export const ServerError = () => (
                 {
                     create: (resource, { data }) => {
                         console.log(`reject create on ${resource}: `, data);
-                        return Promise.reject({ data });
+                        return Promise.reject({
+                            data,
+                            message:
+                                'An article with this title already exists. The title must be unique.',
+                        });
                     },
                 } as any
             }
         >
-            <Resource name="posts" create={ServerErrorCreate} />
+            <Resource
+                name="posts"
+                create={() => (
+                    <Create
+                        resource="posts"
+                        record={{ id: 123, title: 'Lorem ipsum' }}
+                        sx={{ width: 600 }}
+                    >
+                        <SimpleForm toolbar={AlwaysOnToolbar}>
+                            <TextInput source="title" />
+                            <FormInspector />
+                        </SimpleForm>
+                    </Create>
+                )}
+            />
+        </Admin>
+    </MemoryRouter>
+);
+
+export const ServerValidationError = () => (
+    <MemoryRouter initialEntries={['/posts/create']}>
+        <Admin
+            dataProvider={
+                {
+                    create: (resource, { data }) => {
+                        console.log(`reject create on ${resource}: `, data);
+                        return Promise.reject({
+                            data,
+                            body: {
+                                errors: {
+                                    title: 'An article with this title already exists. The title must be unique.',
+                                },
+                            },
+                        });
+                    },
+                } as any
+            }
+        >
+            <Resource
+                name="posts"
+                create={() => (
+                    <Create
+                        resource="posts"
+                        record={{ id: 123, title: 'Lorem ipsum' }}
+                        sx={{ width: 600 }}
+                    >
+                        <SimpleForm toolbar={AlwaysOnToolbar}>
+                            <TextInput source="title" />
+                            <FormInspector />
+                        </SimpleForm>
+                    </Create>
+                )}
+            />
         </Admin>
     </MemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -199,8 +199,7 @@ export const ServerError = () => (
                 create={() => (
                     <Create
                         resource="posts"
-                        record={{ id: 123, title: 'Lorem ipsum' }}
-                        sx={{ width: 600 }}
+                        record={{ title: 'Lorem ipsum' }}
                     >
                         <SimpleForm toolbar={AlwaysOnToolbar}>
                             <TextInput source="title" />
@@ -237,8 +236,7 @@ export const ServerValidationError = () => (
                 create={() => (
                     <Create
                         resource="posts"
-                        record={{ id: 123, title: 'Lorem ipsum' }}
-                        sx={{ width: 600 }}
+                        record={{ title: 'Lorem ipsum' }}
                     >
                         <SimpleForm toolbar={AlwaysOnToolbar}>
                             <TextInput source="title" />

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -197,10 +197,7 @@ export const ServerError = () => (
             <Resource
                 name="posts"
                 create={() => (
-                    <Create
-                        resource="posts"
-                        record={{ title: 'Lorem ipsum' }}
-                    >
+                    <Create resource="posts" record={{ title: 'Lorem ipsum' }}>
                         <SimpleForm toolbar={AlwaysOnToolbar}>
                             <TextInput source="title" />
                             <FormInspector />
@@ -234,10 +231,7 @@ export const ServerValidationError = () => (
             <Resource
                 name="posts"
                 create={() => (
-                    <Create
-                        resource="posts"
-                        record={{ title: 'Lorem ipsum' }}
-                    >
+                    <Create resource="posts" record={{ title: 'Lorem ipsum' }}>
                         <SimpleForm toolbar={AlwaysOnToolbar}>
                             <TextInput source="title" />
                             <FormInspector />

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { required, Resource, useNotify } from 'ra-core';
+import { required, Resource } from 'ra-core';
 import { useFormState, useFormContext } from 'react-hook-form';
 
 import { TextInput } from './TextInput';


### PR DESCRIPTION
## Problem

We don't show (in storybook) the behavior of `TextInput` when we trigger a server error

## Solution

Add a story

## How To Test

https://react-admin-storybook-fcemgnwhn-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-textinput--server-error
https://react-admin-storybook-fcemgnwhn-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-textinput--server-validation-error