### PR TITLE
Align queryOptions type in reference components and controller

### DIFF
--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -52,10 +52,9 @@ export interface UseReferenceFieldControllerOptions<
     ReferenceRecordType extends RaRecord = RaRecord,
 > {
     source: string;
-    queryOptions?: Partial<
-        UseQueryOptions<ReferenceRecordType[], Error> & {
-            meta?: any;
-        }
+    queryOptions?: Omit<
+        UseQueryOptions<ReferenceRecordType[], Error>,
+        'queryFn' | 'queryKey'
     >;
     reference: string;
     link?: LinkToType<ReferenceRecordType>;

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -126,7 +126,10 @@ export interface ReferenceArrayFieldProps<
     reference: string;
     sort?: SortPayload;
     sx?: SxProps;
-    queryOptions?: UseQueryOptions<ReferenceRecordType[], Error>;
+    queryOptions?: Omit<
+        UseQueryOptions<ReferenceRecordType[], Error>,
+        'queryFn' | 'queryKey'
+    >;
 }
 
 export interface ReferenceArrayFieldViewProps

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -83,10 +83,9 @@ export interface ReferenceFieldProps<
     ReferenceRecordType extends RaRecord = RaRecord,
 > extends FieldProps<RecordType> {
     children?: ReactNode;
-    queryOptions?: Partial<
-        UseQueryOptions<ReferenceRecordType[], Error> & {
-            meta?: any;
-        }
+    queryOptions?: Omit<
+        UseQueryOptions<ReferenceRecordType[], Error>,
+        'queryFn' | 'queryKey'
     >;
     reference: string;
     translateChoice?: Function | boolean;


### PR DESCRIPTION
Fixes #10379

## Problem

`ReferenceArrayField`'s `queryOptions` required `queryFn` and `queryKey` props even though these should be optional.

## Solution

Update types to omit the above two fields.
Also aligned the types between `ReferenceField`, `ReferenceArrayField` and `useReferenceFieldController`.

## How To Test

Create a `<ReferenceArrayField queryOptions={{}} />` and confirm no type errors occur on `queryOptions` stating that `queryFn` and `queryKey` are required.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
  - Didn't see an existing unit test yet, should a new one be added?
- [ ] The PR includes one or several **stories** (if not possible, describe why)
  - Unsure if story is required for this change. Please let me know if you have an idea.
- [x] The **documentation** is up to date
