### PR TITLE
Fix `useLogin` should invalidate the `getPermissions` cache

### DIFF
--- a/packages/ra-core/src/auth/useLogin.spec.tsx
+++ b/packages/ra-core/src/auth/useLogin.spec.tsx
@@ -7,6 +7,7 @@ import { CoreAdminContext } from '../core/CoreAdminContext';
 import useLogin from './useLogin';
 
 import { TestMemoryRouter } from '../routing';
+import { PermissionsState } from './useLogin.stories';
 
 describe('useLogin', () => {
     describe('redirect after login', () => {
@@ -98,5 +99,15 @@ describe('useLogin', () => {
             expect(screen.queryByText('Home')).toBeNull();
             expect(screen.queryByText('Login')).not.toBeNull();
         });
+    });
+
+    it('should invalidate the getPermissions cache', async () => {
+        render(<PermissionsState />);
+        await screen.findByText('PERMISSIONS: guest');
+        fireEvent.click(screen.getByText('Login'));
+        await screen.findByText('PERMISSIONS: admin');
+        fireEvent.click(screen.getByText('Logout'));
+        await screen.findByText('LOADING');
+        await screen.findByText('PERMISSIONS: guest');
     });
 });

--- a/packages/ra-core/src/auth/useLogin.stories.tsx
+++ b/packages/ra-core/src/auth/useLogin.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import usePermissions, { UsePermissionsResult } from './usePermissions';
+import usePermissions from './usePermissions';
 import { CoreAdminContext, TestMemoryRouter, useLogin, useLogout } from '..';
 
 export default {
@@ -36,34 +36,26 @@ const LogoutButton = () => {
     return <button onClick={logout}>Logout</button>;
 };
 
-const UsePermissions = ({
-    children,
-}: {
-    children: (state: UsePermissionsResult<any, Error>) => React.ReactNode;
-}) => {
+const UsePermissions = () => {
     const permissionQueryParams = {
         retry: false,
     };
-    const res = usePermissions({}, permissionQueryParams);
-    return children(res);
+    const state = usePermissions({}, permissionQueryParams);
+    return (
+        <div>
+            {state.isPending ? <span>LOADING</span> : null}
+            {state.permissions ? (
+                <span>PERMISSIONS: {state.permissions}</span>
+            ) : null}
+            {state.error ? <span>ERROR</span> : null}
+        </div>
+    );
 };
-
-const inspectPermissionsState = (state: UsePermissionsResult<any, Error>) => (
-    <div>
-        {state.isPending ? <span>LOADING</span> : null}
-        {state.permissions ? (
-            <span>PERMISSIONS: {state.permissions}</span>
-        ) : null}
-        {state.error ? <span>ERROR</span> : null}
-    </div>
-);
 
 export const PermissionsState = () => (
     <TestMemoryRouter>
         <CoreAdminContext authProvider={getAuthProviderWithLoginAndLogout()}>
-            <UsePermissions>
-                {state => inspectPermissionsState(state)}
-            </UsePermissions>
+            <UsePermissions />
             <LoginButton />
             <LogoutButton />
         </CoreAdminContext>

--- a/packages/ra-core/src/auth/useLogin.stories.tsx
+++ b/packages/ra-core/src/auth/useLogin.stories.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import usePermissions, { UsePermissionsResult } from './usePermissions';
+import { CoreAdminContext, TestMemoryRouter, useLogin, useLogout } from '..';
+
+export default {
+    title: 'ra-core/auth/useLogin',
+};
+
+const getAuthProviderWithLoginAndLogout = () => {
+    let isLoggedIn = false;
+    return {
+        login: () => {
+            isLoggedIn = true;
+            return Promise.resolve();
+        },
+        logout: () => {
+            isLoggedIn = false;
+            return Promise.resolve();
+        },
+        checkAuth: () => (isLoggedIn ? Promise.resolve() : Promise.reject()),
+        checkError: () => Promise.reject('bad method'),
+        getPermissions: () =>
+            new Promise(resolve =>
+                setTimeout(resolve, 300, isLoggedIn ? 'admin' : 'guest')
+            ),
+    };
+};
+
+const LoginButton = () => {
+    const login = useLogin();
+    return <button onClick={login}>Login</button>;
+};
+
+const LogoutButton = () => {
+    const logout = useLogout();
+    return <button onClick={logout}>Logout</button>;
+};
+
+const UsePermissions = ({
+    children,
+}: {
+    children: (state: UsePermissionsResult<any, Error>) => React.ReactNode;
+}) => {
+    const permissionQueryParams = {
+        retry: false,
+    };
+    const res = usePermissions({}, permissionQueryParams);
+    return children(res);
+};
+
+const inspectPermissionsState = (state: UsePermissionsResult<any, Error>) => (
+    <div>
+        {state.isPending ? <span>LOADING</span> : null}
+        {state.permissions ? (
+            <span>PERMISSIONS: {state.permissions}</span>
+        ) : null}
+        {state.error ? <span>ERROR</span> : null}
+    </div>
+);
+
+export const PermissionsState = () => (
+    <TestMemoryRouter>
+        <CoreAdminContext authProvider={getAuthProviderWithLoginAndLogout()}>
+            <UsePermissions>
+                {state => inspectPermissionsState(state)}
+            </UsePermissions>
+            <LoginButton />
+            <LogoutButton />
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);

--- a/packages/ra-core/src/auth/useLogin.ts
+++ b/packages/ra-core/src/auth/useLogin.ts
@@ -5,6 +5,7 @@ import { useNotificationContext } from '../notification';
 import { useBasename } from '../routing';
 import useAuthProvider, { defaultAuthParams } from './useAuthProvider';
 import { removeDoubleSlashes } from '../routing/useCreatePath';
+import { useQueryClient } from '@tanstack/react-query';
 
 /**
  * Get a callback for calling the authProvider.login() method
@@ -31,6 +32,7 @@ import { removeDoubleSlashes } from '../routing/useCreatePath';
  */
 const useLogin = (): Login => {
     const authProvider = useAuthProvider();
+    const queryClient = useQueryClient();
     const location = useLocation();
     const locationState = location.state as any;
     const navigate = useNavigate();
@@ -47,6 +49,9 @@ const useLogin = (): Login => {
             if (authProvider) {
                 return authProvider.login(params).then(ret => {
                     resetNotifications();
+                    queryClient.invalidateQueries({
+                        queryKey: ['auth', 'getPermissions'],
+                    });
                     if (ret && ret.hasOwnProperty('redirectTo')) {
                         if (ret) {
                             navigate(ret.redirectTo);
@@ -67,6 +72,7 @@ const useLogin = (): Login => {
         },
         [
             authProvider,
+            queryClient,
             navigate,
             nextPathName,
             nextSearch,


### PR DESCRIPTION
## Problem

Consider an Admin that has some pages that allow anonymous access, and also a `authProvider.getPermissions()` implementation, that, say, returns `'user'` when the user is logged in, and `undefined` when the user is not logged in.

If the user first accesses the anonymous parts of the Admin, the cached permission will be `undefined`. But if he then logs in, without leaving the Admin, then the cache is not updated, and the permissions still return `undefined` instead of `'user'`.

## Solution

Invalidate the `getPermissions` cache after a successful login, to force a refetch of the permissions.

## How To Test

https://react-admin-storybook-31pnpeyju-marmelab.vercel.app/?path=/story/ra-core-auth-uselogin--permissions-state

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date -> no need, bugfix

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
