### PR TITLE
fix(rowClick): adjusting execution order

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -124,23 +124,25 @@ const DatagridRow: React.ForwardRefExoticComponent<
     const handleClick = useCallback(
         async event => {
             event.persist();
-            const path = await getPathForRecord({
-                record,
-                resource,
-                link:
-                    typeof rowClick === 'function'
-                        ? (record, resource) =>
-                              rowClick(record.id, resource, record)
-                        : rowClick,
-            });
-            if (rowClick === 'expand') {
+            const rowClickValue =
+                typeof rowClick === 'function'
+                    ? (record, resource) =>
+                          rowClick(record.id, resource, record)
+                    : rowClick;
+
+            if (rowClickValue === 'expand') {
                 handleToggleExpand(event);
                 return;
             }
-            if (rowClick === 'toggleSelection') {
+            if (rowClickValue === 'toggleSelection') {
                 handleToggleSelection(event);
                 return;
             }
+            const path = await getPathForRecord({
+                record,
+                resource,
+                link: rowClickValue,
+            });
             if (path === false || path == null) {
                 return;
             }


### PR DESCRIPTION
## Problem

This PR addresses an issue in the React Admin DataGrid where the rowClick function does not properly interpret key strings such as 'expand' or 'toggleSelection'. Instead, the function's return value was always treated as a path, causing the expected behavior (like expanding a row) to not work as intended.

## Solution

Rearrange the conditions to consider the return of the rowClick function

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
