### PR TITLE
Fix `<FileInput>` triggers `onChange` twice with latest version of `react-dropzone`

### DIFF
--- a/packages/ra-ui-materialui/src/input/FileInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.stories.tsx
@@ -114,6 +114,24 @@ export const CustomRemoveIcon = () => (
     </Wrapper>
 );
 
+export const OnChange = ({ onChange = console.log }) => (
+    <Wrapper>
+        <FileInput source="attachment" onChange={onChange}>
+            <FileField source="src" title="title" />
+        </FileInput>
+        <FormInspector name="attachment" />
+    </Wrapper>
+);
+
+export const OnChangeMultiple = ({ onChange = console.log }) => (
+    <Wrapper>
+        <FileInput source="attachment" onChange={onChange} multiple>
+            <FileField source="src" title="title" />
+        </FileInput>
+        <FormInspector name="attachment" />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({ children }) => (

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -40,6 +40,7 @@ export const FileInput = (props: FileInputProps) => {
         labelMultiple = 'ra.input.file.upload_several',
         labelSingle = 'ra.input.file.upload_single',
         options = {},
+        onChange: onChangeProp,
         onRemove: onRemoveProp,
         parse,
         placeholder,
@@ -95,6 +96,7 @@ export const FileInput = (props: FileInputProps) => {
         validate,
         disabled,
         readOnly,
+        onChange: onChangeProp,
         ...rest,
     });
     const { error, invalid } = fieldState;


### PR DESCRIPTION
## Problem

Fix https://github.com/marmelab/react-admin/issues/10401

### Analysis

The issue only happens after upgrading `react-dropzone` to the latest version (14.3.5 at the time of writing). Version 14.2.3 does not show the issue.

At first I thought it seemed like a regression from the `react-dropzone` lib, but on second thought, I think we should not forward the `onChange` prop to the wrapping `<Labeled>` anyways. We should only call `onChange` ourselves, to make sure it's always fed with a `File` object or array.

## Solution

Exclude the `onChange` prop from the `...rest` parameters.

## How To Test

Locally update the `react-dropzone` version: `yarn up react-dropzone`.
Then, run one of the following stories, and make sure they only trigger `onChange` once, with either a `File` object or array.
- http://localhost:9010/?path=/story/ra-ui-materialui-input-fileinput--on-change
- http://localhost:9010/?path=/story/ra-ui-materialui-input-fileinput--on-change-multiple

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> not possible, current unit tests about setting a file are disabled because jsdom doesn't support the drop event
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
