### PR TITLE
Update rbac documentation

### DIFF
--- a/docs/AccordionForm.md
+++ b/docs/AccordionForm.md
@@ -84,10 +84,13 @@ Here are all the props you can set on the `<AccordionForm>` component:
 
 | Prop                      | Required | Type              | Default | Description                                                                  |
 | ------------------------- | -------- | ----------------- | ------- | ---------------------------------------------------------------------------- |
+| `authorizationError`      | Optional | `ReactNode`       | `null`  | The content to display when authorization checks fail                    |
 | `autoClose`               | Optional | `boolean`         | -       | Set to `true` to close the current accordion when opening another one.       |
 | `children`                | Required | `ReactNode`       | -       | A list of `<AccordionForm.Panel>` elements.                                  |
 | `defaultValues`           | Optional | `object|function` | -       | The default values of the record.                                            |
+| `enableAccessControl`     | Optional | `boolean`         | `false` | Enable checking authorization rights for each panel and input            |
 | `id`                      | Optional | `string`          | -       | The id of the underlying `<form>` tag.                                       |
+| `loading`                 | Optional | `ReactNode`       |         | The content to display when checking authorizations                      |
 | `noValidate`              | Optional | `boolean`         | -       | Set to `true` to disable the browser's default validation.                   |
 | `onSubmit`                | Optional | `function`        | `save`  | A callback to call when the form is submitted.                               |
 | `sanitize EmptyValues`    | Optional | `boolean`         | -       | Set to `true` to remove empty values from the form state.                    |
@@ -97,6 +100,48 @@ Here are all the props you can set on the `<AccordionForm>` component:
 | `sx`                      | Optional | `Object`          | -       | An object containing the MUI style overrides to apply to the root component. |
 
 Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/docs/useform).
+
+## `authorizationError`
+
+Content displayed when `enableAccessControl` is set to `true` and an error occurs while checking for users permissions. Defaults to `null`:
+
+{% raw %}
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionForm } from '@react-admin/ra-form-layout';
+import { Alert } from '@mui/material';
+
+const CustomerEdit = () => (
+    <Edit>
+        <AccordionForm
+            enableAccessControl
+            authorizationError={
+                <Alert
+                    severity="error"
+                    sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}
+                >
+                    An error occurred while loading your permissions
+                </Alert>
+            }
+        >
+            <AccordionForm.Panel id="identity" defaultExpanded>
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </AccordionForm.Panel>
+            <AccordionForm.Panel id="occupations">
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </AccordionForm.Panel>
+        </AccordionForm>
+    </Edit>
+);
+```
+{% endraw %}
 
 ## `autoClose`
 
@@ -165,6 +210,47 @@ export const PostCreate = () => (
 
 **Tip**: React-admin also allows to define default values at the input level. See the [Setting default Values](./Forms.md#default-values) section.
 
+## `enableAccessControl`
+
+When set to `true`, React-admin will call the `authProvider.canAccess` method for each panel with the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.panel.PANEL_ID_OR_LABEL`. For instance: `customers.panel.identity`
+- `record`: The current record
+
+For each panel, react-admin will also call the `authProvider.canAccess` method for each input with the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.INPUT_SOURCE`. For instance: `customers.first_name`
+- `record`: The current record
+
+**Tip**: `<AccordionForm.Panel>` direct children that don't have a `source` will always be displayed.
+
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionForm } from '@react-admin/ra-form-layout';
+
+const CustomerEdit = () => (
+    <Edit>
+        <AccordionForm enableAccessControl>
+            <AccordionForm.Panel id="identity" defaultExpanded>
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </AccordionForm.Panel>
+            <AccordionForm.Panel id="occupations">
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </AccordionForm.Panel>
+        </AccordionForm>
+    </Edit>
+);
+```
+
+**Tip**: If you only want access control for the panels but not for the inputs, set the `enableAccessControl` prop to `false` on the `<AccordionForm.Panel>`.
+
 ## `id`
 
 Normally, a submit button only works when placed inside a `<form>` tag. However, you can place a submit button outside the form if the submit button `form` matches the form `id`.
@@ -183,6 +269,43 @@ export const PostCreate = () => (
         </AccordionForm>
         <SaveButton form="post_create_form" />
     </Create>
+);
+```
+
+## `loading`
+
+Content displayed when `enableAccessControl` is set to `true` while checking for users permissions. Defaults to `Loading` from `react-admin`:
+
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionForm } from '@react-admin/ra-form-layout';
+import { Typography } from '@mui/material';
+
+const CustomerEdit = () => (
+    <Edit>
+        <AccordionForm
+            enableAccessControl
+            loading={
+                <Typography>
+                    Loading your permissions...
+                </Typography>
+            }
+        >
+            <AccordionForm.Panel id="identity" defaultExpanded>
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </AccordionForm.Panel>
+            <AccordionForm.Panel id="occupations">
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </AccordionForm.Panel>
+        </AccordionForm>
+    </Edit>
 );
 ```
 
@@ -377,11 +500,14 @@ Here are all the props you can set on the `<AccordionForm.Panel>` component:
 
 | Prop              | Required | Type                    | Default | Description                                                                                            |
 | ----------------- | -------- | ----------------------- | ------- | ------------------------------------------------------------------------------------------------       |
+| `authorizationError`  | Optional | `ReactNode`             | `null`  | The content to display when authorization checks fail                    |
 | `children`        | Required | `ReactNode`             | -       | A list of `<Input>` elements                                                                           |
 | `defaultExpanded` | Optional | `boolean`               | `false` | Set to true to have the accordion expanded by default (except if autoClose = true on the parent)       |
 | `disabled`        | Optional | `boolean`               | `false` | If true, the accordion will be displayed in a disabled state.                                          |
+| `enableAccessControl` | Optional | `boolean`               | `false` | Enable checking authorization rights for this panel's inputs            |
 | `id`              | Optional | `string`                | -       | An id for this Accordion to be used in the [`useFormGroup`](./Upgrade.md#useformgroup-hook-returned-state-has-changed) hook and for CSS classes. |
 | `label`           | Required | `string` or `ReactNode` | -       | The main label used as the accordion summary. Appears in red when the accordion has errors             |
+| `loading`             | Optional | `ReactNode`             |         | The content to display when checking authorizations                      |
 | `secondary`       | Optional | `string` or `ReactNode` | -       | The secondary label used as the accordion summary                                                      |
 | `square`          | Optional | `boolean`               | `false` | If true, rounded corners are disabled.                                                                 |
 | `sx`              | Optional | `Object`                | -       | An object containing the MUI style overrides to apply to the root component.                           |
@@ -433,6 +559,8 @@ Here are all the props you can set on the `<AccordionSection>` component:
 
 | Prop               | Required | Type                    | Default | Description                                                   |
 | ------------------ | -------- | ----------------------- | ------- | ------------------------------------------------------------- |
+| `accessDenied`  | Optional | `Component`             | -       | The component to use when users don't have the permissions required to access this section. |
+| `authorizationError`  | Optional | `Component`             | -       | The component to use when an error occurs while checking permissions. |
 | `Accordion`        | Optional | `Component`             | -       | The component to use as the accordion.                        |
 | `AccordionDetails` | Optional | `Component`             | -       | The component to use as the accordion details.                |
 | `AccordionSummary` | Optional | `Component`             | -       | The component to use as the accordion summary.                |
@@ -440,9 +568,11 @@ Here are all the props you can set on the `<AccordionSection>` component:
 | `className`        | Optional | `string`                | -       | A class name to style the underlying `<Accordion>`            |
 | `defaultExpanded`  | Optional | `boolean`               | `false` | Set to true to have the accordion expanded by default         |
 | `disabled`         | Optional | `boolean`               | `false` | If true, the accordion will be displayed in a disabled state. |
+| `enableAccessControl` | Optional | `boolean`               | -       | Enable access control to the section and its inputs                   |
 | `fullWidth`        | Optional | `boolean`               | `false` | If true, the Accordion takes the entire form width.           |
 | `id`               | Optional | `string`                | -       | An id for this Accordion to be used for CSS classes.          |
 | `label`            | Required | `string` or `ReactNode` | -       | The main label used as the accordion summary.                 |
+| `loading`             | Optional | `Component`             | -       | The component to use while checking permissions.                      |
 | `secondary`        | Optional | `string` or `ReactNode` | -       | The secondary label used as the accordion summary             |
 | `square`           | Optional | `boolean`               | `false` | If true, rounded corners are disabled.                        |
 
@@ -491,6 +621,173 @@ const CustomerEdit = () => (
 );
 ```
 
+### `accessDenied`
+
+Content displayed when `enableAccessControl` is set to `true` and users don't have access to the section. Defaults to `null`:
+
+{% raw %}
+```tsx
+import { ReactNode } from 'react';
+import { ArrayInput, BooleanInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionSection } from '@react-admin/ra-form-layout';
+import { Alert } from '@mui/material';
+
+const AccessDenied = ({ children }: { children: ReactNode }) => (
+    <Alert
+        severity="info"
+        sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}
+        action={
+            <Button color="inherit" size="small">
+                Upgrade to Premium
+            </Button>
+        }
+    >
+        {children}
+    </Alert>
+)
+
+const CustomerEdit = () => (
+    <Edit component="div">
+        <SimpleForm>
+            <TextInput source="first_name" validate={required()} />
+            <TextInput source="last_name" validate={required()} />
+            <AccordionSection
+                label="Preferences"
+                enableAccessControl
+                accessDenied={<AccessDenied>You don&apos;t have access to the preferences section</AccessDenied>}
+            >
+                <SelectInput
+                    source="language"
+                    choices={languageChoices}
+                    defaultValue="en"
+                />
+                <BooleanInput source="dark_theme" />
+                <BooleanInput source="accepts_emails_from_partners" />
+            </AccordionSection>
+        </SimpleForm>
+    </Edit>
+);
+```
+{% endraw %}
+
+
+### `authorizationError`
+
+Content displayed when `enableAccessControl` is set to `true` and an error occurs while checking for users permissions. Defaults to `null`:
+
+{% raw %}
+```tsx
+import { ArrayInput, BooleanInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionSection } from '@react-admin/ra-form-layout';
+import { Alert } from '@mui/material';
+
+const AuthorizationError = () => (
+    <Alert
+        severity="error"
+        sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}
+    >
+        An error occurred while loading your permissions
+    </Alert>
+);
+
+const CustomerEdit = () => (
+    <Edit component="div">
+        <SimpleForm>
+            <TextInput source="first_name" validate={required()} />
+            <TextInput source="last_name" validate={required()} />
+            <AccordionSection label="Preferences" enableAccessControl authorizationError={<AuthorizationError />}>
+                <SelectInput
+                    source="language"
+                    choices={languageChoices}
+                    defaultValue="en"
+                />
+                <BooleanInput source="dark_theme" />
+                <BooleanInput source="accepts_emails_from_partners" />
+            </AccordionSection>
+        </SimpleForm>
+    </Edit>
+);
+```
+{% endraw %}
+
+### `enableAccessControl`
+
+When set to `true`, React-admin will call the `authProvider.canAccess` method the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.section.PANEL_ID_OR_LABEL`. For instance: `customers.section.identity`
+- `record`: The current record
+
+React-admin will also call the `authProvider.canAccess` method for each input with the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.INPUT_SOURCE`. For instance: `customers.first_name`
+- `record`: The current record
+
+```tsx
+import { ArrayInput, BooleanInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionSection } from '@react-admin/ra-form-layout';
+
+const CustomerEdit = () => (
+    <Edit component="div">
+        <SimpleForm>
+            <TextField source="id" />
+            <TextInput source="first_name" validate={required()} />
+            <TextInput source="last_name" validate={required()} />
+            <DateInput source="dob" label="born" validate={required()} />
+            <SelectInput source="sex" choices={sexChoices} />
+            <AccordionSection label="Preferences" enableAccessControl>
+                <SelectInput
+                    source="language"
+                    choices={languageChoices}
+                    defaultValue="en"
+                />
+                <BooleanInput source="dark_theme" />
+                <BooleanInput source="accepts_emails_from_partners" />
+            </AccordionSection>
+        </SimpleForm>
+    </Edit>
+);
+```
+
+**Tip**: `<AccordionSection>` direct children that don't have a `source` will always be displayed.
+
+### `loading`
+
+Content displayed when `enableAccessControl` is set to `true` while checking for users permissions. Defaults to `Loading` from `react-admin`:
+
+```tsx
+import { ArrayInput, BooleanInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { AccordionSection } from '@react-admin/ra-form-layout';
+import { Typography } from '@mui/material';
+
+const AuthorizationLoading = () => (
+    <Typography>
+        Loading your permissions...
+    </Typography>
+);
+
+const CustomerEdit = () => (
+    <Edit component="div">
+        <SimpleForm>
+            <TextField source="id" />
+            <TextInput source="first_name" validate={required()} />
+            <TextInput source="last_name" validate={required()} />
+            <DateInput source="dob" label="born" validate={required()} />
+            <SelectInput source="sex" choices={sexChoices} />
+            <AccordionSection label="Preferences" enableAccessControl loading={<AuthorizationLoading />}>
+                <SelectInput
+                    source="language"
+                    choices={languageChoices}
+                    defaultValue="en"
+                />
+                <BooleanInput source="dark_theme" />
+                <BooleanInput source="accepts_emails_from_partners" />
+            </AccordionSection>
+        </SimpleForm>
+    </Edit>
+);
+```
+
+
 ## AutoSave
 
 In forms where users may spend a lot of time, it's a good idea to save the form automatically after a few seconds of inactivity. You turn on this feature by using [the `<AutoSave>` component](./AutoSave.md).
@@ -532,56 +829,3 @@ Note that you **must** set the `<AccordionForm resetOptions>` prop to `{ keepDir
 If you're using it in an `<Edit>` page, you must also use a `pessimistic` or `optimistic` [`mutationMode`](https://marmelab.com/react-admin/Edit.html#mutationmode) - `<AutoSave>` doesn't work with the default `mutationMode="undoable"`.
 
 Check [the `<AutoSave>` component](./AutoSave.md) documentation for more details.
-
-## Role-Based Access Control (RBAC)
-
-Fine-grained permissions control can be added by using the [`<AccordionForm>`](./AuthRBAC.md#accordionform), [`<AccordionFormPanel>`](./AuthRBAC.md#accordionform) and [`<AccordionSection>`](./AuthRBAC.md#accordionsection) components provided by the `@react-admin/ra-enterprise` package.
-
-{% raw %}
-```tsx
-import { AccordionForm } from '@react-admin/ra-enterprise';
-
-const authProvider = {
-    checkAuth: () => Promise.resolve(),
-    login: () => Promise.resolve(),
-    logout: () => Promise.resolve(),
-    checkError: () => Promise.resolve(),
-    getPermissions: () =>Promise.resolve([
-        // 'delete' is missing
-        { action: ['list', 'edit'], resource: 'products' },
-        { action: 'write', resource: 'products.reference' },
-        { action: 'write', resource: 'products.width' },
-        { action: 'write', resource: 'products.height' },
-        // 'products.description' is missing
-        { action: 'write', resource: 'products.thumbnail' },
-        // 'products.image' is missing
-        { action: 'write', resource: 'products.panel.description' },
-        { action: 'write', resource: 'products.panel.images' },
-        // 'products.panel.stock' is missing
-    ]),
-};
-
-const ProductEdit = () => (
-    <Edit>
-        <AccordionForm>
-            <AccordionForm.Panel name="description" label="Description">
-                <TextInput source="reference" />
-                <TextInput source="width" />
-                <TextInput source="height" />
-                <TextInput source="description" />
-            </AccordionForm.Panel>
-            <AccordionForm.Panel name="images" label="Images">
-                <TextInput source="image" />
-                <TextInput source="thumbnail" />
-            </AccordionForm.Panel>
-            <AccordionForm.Panel name="stock" label="Stock">
-                <TextInput source="stock" />
-            </AccordionForm.Panel>
-            { /* delete button not displayed */ }
-        </AccordionForm>
-    </Edit>
-);
-```
-{% endraw %}
-
-Check [the RBAC `<AccordionForm>` component](./AuthRBAC.md#accordionform) documentation for more details.

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -521,7 +521,6 @@ You can leverage [the `<CanAccess>` component](./CanAccess.md) to display inputs
 import { CanAccess, Create, SimpleForm, TextInput } from 'react-admin';
 
 export const UserCreate = () => {
-    const { permissions } = useGetPermissions();
     return (
         <Create redirect="show">
             <SimpleForm>
@@ -548,8 +547,10 @@ export const UserCreate = () => {
         <Create redirect="show">
             <SimpleForm>
                 <TextInput source="name" validate={[required()]} />
-                {permissions === 'admin' &&
-                    <TextInput source="role" validate={[required()]} />}
+                {permissions === 'admin'
+                    ? <TextInput source="role" validate={[required()]} />
+                    : null
+                }
             </SimpleForm>
         </Create>
     );

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -535,29 +535,6 @@ export const UserCreate = () => {
 ```
 {% endraw %}
 
-You can leverage [the `usePermissions` hook](./usePermissions.md) to display inputs if the user has the required permissions.
-
-{% raw %}
-```jsx
-import { usePermissions, Create, SimpleForm, TextInput } from 'react-admin';
-
-export const UserCreate = () => {
-    const { permissions } = useGetPermissions();
-    return (
-        <Create redirect="show">
-            <SimpleForm>
-                <TextInput source="name" validate={[required()]} />
-                {permissions === 'admin'
-                    ? <TextInput source="role" validate={[required()]} />
-                    : null
-                }
-            </SimpleForm>
-        </Create>
-    );
-}
-```
-{% endraw %}
-
 ## Configurable
 
 You can let end users customize the fields displayed in the `<SimpleForm>` by using the `<SimpleFormConfigurable>` component instead.

--- a/docs/SimpleForm.md
+++ b/docs/SimpleForm.md
@@ -514,6 +514,28 @@ const formState = useFormState(); // ❌ should deconstruct the formState
 
 ## Displaying Inputs Based On Permissions
 
+You can leverage [the `<CanAccess>` component](./CanAccess.md) to display inputs if the user has the required access rights.
+
+{% raw %}
+```jsx
+import { CanAccess, Create, SimpleForm, TextInput } from 'react-admin';
+
+export const UserCreate = () => {
+    const { permissions } = useGetPermissions();
+    return (
+        <Create redirect="show">
+            <SimpleForm>
+                <TextInput source="name" validate={[required()]} />
+                <CanAccess resource="user.role" action="write">
+                    <TextInput source="role" validate={[required()]} />
+                </CanAccess>
+            </SimpleForm>
+        </Create>
+    );
+}
+```
+{% endraw %}
+
 You can leverage [the `usePermissions` hook](./usePermissions.md) to display inputs if the user has the required permissions.
 
 {% raw %}
@@ -646,51 +668,6 @@ Note that you **must** set the `<SimpleForm resetOptions>` prop to `{ keepDirtyV
 If you're using it in an `<Edit>` page, you must also use a `pessimistic` or `optimistic` [`mutationMode`](https://marmelab.com/react-admin/Edit.html#mutationmode) - `<AutoSave>` doesn't work with the default `mutationMode="undoable"`.
 
 Check [the `<AutoSave>` component](./AutoSave.md) documentation for more details.
-
-## Role-Based Access Control (RBAC)
-
-Fine-grained permissions control can be added by using the [`<SimpleForm>`](./AuthRBAC.md#simpleform) component provided by the `@react-admin/ra-rbac` package. 
-
-{% raw %}
-```jsx
-import { Edit, TextInput } from 'react-admin';
-import { SimpleForm } from '@react-admin/ra-rbac';
-
-const authProvider= {
-    // ...
-    getPermissions: () => Promise.resolve({
-        permissions: [
-            // 'delete' is missing
-            { action: ['list', 'edit'], resource: 'products' },
-            { action: 'write', resource: 'products.reference' },
-            { action: 'write', resource: 'products.width' },
-            { action: 'write', resource: 'products.height' },
-            // 'products.description' is missing
-            { action: 'write', resource: 'products.thumbnail' },
-            // 'products.image' is missing
-        ]
-    }),
-};
-
-const ProductEdit = () => (
-    <Edit>
-        <SimpleForm>
-            <TextInput source="reference" />
-            <TextInput source="width" />
-            <TextInput source="height" />
-            {/* not displayed */}
-            <TextInput source="description" />
-            {/* not displayed */}
-            <TextInput source="image" />
-            <TextInput source="thumbnail" />
-            {/* no delete button */}
-        </SimpleForm>
-    </Edit>
-);
-```
-{% endraw %}
-
-Check [the RBAC `<SimpleForm>` component](./AuthRBAC.md#simpleform) documentation for more details.
 
 ## Versioning
 

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -796,6 +796,85 @@ Check [the `<AutoSave>` component](./AutoSave.md) documentation for more details
 
 ## Displaying a Tab Based On Permissions
 
+You can leverage [the `useCanAccess` hook](./useCanAccess.md) to display tabs if the user has the required access rights.
+
+{% raw %}
+```jsx
+import { Edit, FormTab, Loading, TabbedForm, TextInput, useCanAccess } from 'react-admin';
+import { Alert } from '@mui/material';
+
+export const UserCreate = () => {
+    const { canAccess, isPending, error } = useCanAccess({
+        resource: 'users.tabs.security',
+        action: 'write',
+    });
+    if (isPending) return <Loading />;
+    if (error) {
+        return (
+            <Alert severity="error" sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}>
+                An error occurred while checking your permissions
+            </Alert>
+        );
+    }
+
+    return (
+        <Edit>
+            <TabbedForm>
+                <TabbedForm.Tab label="Summary">
+                    ...
+                </TabbedForm.Tab>
+                {canAccess &&
+                    <TabbedForm.Tab label="Security">
+                        ...
+                    </TabbedForm.Tab>
+                }
+            </TabbedForm>
+        </Edit>
+    );
+}
+```
+{% endraw %}
+
+If you need to check access rights for multiple tabs, leverage [the `useCanAccessResources` hook](./useCanAccess.md#multiple-resources).
+
+{% raw %}
+```jsx
+import { Edit, FormTab, Loading, TabbedForm, TextInput, useCanAccessResources } from 'react-admin';
+import { Alert } from '@mui/material';
+
+export const UserCreate = () => {
+    const { canAccess, isPending, error } = useCanAccessResources({
+        resources: ['users.tabs.summary', 'users.tabs.security'],
+        action: 'write',
+    });
+    if (isPending) return <Loading />;
+    if (error) {
+        return (
+            <Alert severity="error" sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}>
+                An error occurred while checking your permissions
+            </Alert>
+        );
+    }
+
+    return (
+        <Edit>
+            <TabbedForm>
+                {canAccess['users.tabs.summary'] &&
+                <TabbedForm.Tab label="Summary">
+                    ...
+                </TabbedForm.Tab>}
+                {canAccess['users.tabs.security'] &&
+                    <TabbedForm.Tab label="Security">
+                        ...
+                    </TabbedForm.Tab>
+                }
+            </TabbedForm>
+        </Edit>
+    );
+}
+```
+{% endraw %}
+
 You can leverage [the `usePermissions` hook](./usePermissions.md) to display a tab only if the user has the required permissions.
 
 {% raw %}
@@ -821,61 +900,6 @@ const UserEdit = () => {
 };
 ```
 {% endraw %}
-
-## Role-Based Access Control (RBAC)
-
-You can show or hide tabs and inputs based on user permissions by using the [`<TabbedForm>`](./AuthRBAC.md#tabbedform) component from the `@react-admin/ra-rbac` package instead of the `react-admin` package.
-
-[`<TabbedForm>`](./AuthRBAC.md#tabbedform) shows only the tabs for which users have write permissions, using the `[resource].tab.[tabName]` string as resource identifier. It also renders the delete button only if the user has a permission for the `delete` action in the current resource. `<TabbedForm.Tab>` shows only the child inputs for which users have the write permissions, using the `[resource].[source]` string as resource identifier.
-
-{% raw %}
-```tsx
-import { Edit, TextInput } from 'react-admin';
-import { TabbedForm } from '@react-admin/ra-rbac';
-
-const authProvider = {
-    // ...
-    getPermissions: () => Promise.resolve([
-        // crud (the delete action is missing)
-        { action: ['list', 'edit'], resource: 'products' },
-        // tabs ('products.tab.stock' is missing)
-        { action: 'write', resource: 'products.tab.description' },
-        { action: 'write', resource: 'products.tab.images' },
-        // fields ('products.description' and 'products.image' are missing)
-        { action: 'write', resource: 'products.reference' },
-        { action: 'write', resource: 'products.width' },
-        { action: 'write', resource: 'products.height' },
-        { action: 'write', resource: 'products.thumbnail' },
-    ]),
-};
-
-const ProductEdit = () => (
-    <Edit>
-        <TabbedForm>
-            <TabbedForm.Tab label="Description" name="description">
-                <TextInput source="reference" />
-                <TextInput source="width" />
-                <TextInput source="height" />
-                {/* the description input is not displayed */}
-                <TextInput source="description" />
-            </TabbedForm.Tab>
-            {/* the stock tab is not displayed */}
-            <TabbedForm.Tab label="Stock" name="stock">
-                <TextInput source="stock" />
-            </TabbedForm.Tab>
-            <TabbedForm.Tab label="Images" name="images">
-                {/* the images input is not displayed */}
-                <TextInput source="image" />
-                <TextInput source="thumbnail" />
-            </TabbedForm.Tab>
-            {/* the delete button is not displayed */}
-        </TabbedForm>
-    </Edit>
-);
-```
-{% endraw %}
-
-Check [the RBAC `<TabbedForm>` component](./AuthRBAC.md#tabbedform) documentation for more details.
 
 ## Versioning
 

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -875,32 +875,6 @@ export const UserEdit = () => {
 ```
 {% endraw %}
 
-You can leverage [the `usePermissions` hook](./usePermissions.md) to display a tab only if the user has the required permissions.
-
-{% raw %}
-```jsx
-import { usePermissions, Edit, TabbedForm } from 'react-admin';
-
-const UserEdit = () => {
-    const { permissions } = usePermissions();
-    return (
-        <Edit>
-            <TabbedForm>
-                <TabbedForm.Tab label="summary">
-                    ...
-                </TabbedForm.Tab>
-                {permissions === 'admin' &&
-                    <TabbedForm.Tab label="Security">
-                        ...
-                    </TabbedForm.Tab>
-                }
-            </TabbedForm>
-        </Edit>
-    );
-};
-```
-{% endraw %}
-
 ## Displaying Inputs Based On Permissions
 
 You can leverage [the `<CanAccess>` component](./CanAccess.md) to display inputs if the user has the required access rights.
@@ -918,34 +892,6 @@ export const UserEdit = () => {
                     <CanAccess resource="user.role" action="write">
                         <TextInput source="role" validate={[required()]} />
                     </CanAccess>
-                </TabbedForm.Tab>}
-                    <TabbedForm.Tab label="Security">
-                        ...
-                    </TabbedForm.Tab>
-            </TabbedForm>
-        </Edit>
-    );
-}
-```
-{% endraw %}
-
-You can leverage [the `usePermissions` hook](./usePermissions.md) to display inputs if the user has the required permissions.
-
-{% raw %}
-```jsx
-import { usePermissions, Edit, TabbedForm, TextInput } from 'react-admin';
-
-export const UserEdit = () => {
-    const { permissions } = useGetPermissions();
-    return (
-        <Edit>
-            <TabbedForm>
-                <TabbedForm.Tab label="Summary">
-                    <TextInput source="name" validate={[required()]} />
-                    {permissions === 'admin'
-                        ? <TextInput source="role" validate={[required()]} />
-                        : null
-                    }
                 </TabbedForm.Tab>}
                     <TabbedForm.Tab label="Security">
                         ...

--- a/docs/TabbedForm.md
+++ b/docs/TabbedForm.md
@@ -839,10 +839,10 @@ If you need to check access rights for multiple tabs, leverage [the `useCanAcces
 
 {% raw %}
 ```jsx
-import { Edit, FormTab, Loading, TabbedForm, TextInput, useCanAccessResources } from 'react-admin';
+import { Edit, Loading, TabbedForm, TextInput, useCanAccessResources } from 'react-admin';
 import { Alert } from '@mui/material';
 
-export const UserCreate = () => {
+export const UserEdit = () => {
     const { canAccess, isPending, error } = useCanAccessResources({
         resources: ['users.tabs.summary', 'users.tabs.security'],
         action: 'write',
@@ -879,7 +879,7 @@ You can leverage [the `usePermissions` hook](./usePermissions.md) to display a t
 
 {% raw %}
 ```jsx
-import { usePermissions, Edit, TabbedForm, FormTab } from 'react-admin';
+import { usePermissions, Edit, TabbedForm } from 'react-admin';
 
 const UserEdit = () => {
     const { permissions } = usePermissions();
@@ -898,6 +898,62 @@ const UserEdit = () => {
         </Edit>
     );
 };
+```
+{% endraw %}
+
+## Displaying Inputs Based On Permissions
+
+You can leverage [the `<CanAccess>` component](./CanAccess.md) to display inputs if the user has the required access rights.
+
+{% raw %}
+```jsx
+import { CanAccess, Edit, TabbedForm, TextInput } from 'react-admin';
+
+export const UserEdit = () => {
+    return (
+        <Edit>
+            <TabbedForm>
+                <TabbedForm.Tab label="Summary">
+                    <TextInput source="name" validate={[required()]} />
+                    <CanAccess resource="user.role" action="write">
+                        <TextInput source="role" validate={[required()]} />
+                    </CanAccess>
+                </TabbedForm.Tab>}
+                    <TabbedForm.Tab label="Security">
+                        ...
+                    </TabbedForm.Tab>
+            </TabbedForm>
+        </Edit>
+    );
+}
+```
+{% endraw %}
+
+You can leverage [the `usePermissions` hook](./usePermissions.md) to display inputs if the user has the required permissions.
+
+{% raw %}
+```jsx
+import { usePermissions, Edit, TabbedForm, TextInput } from 'react-admin';
+
+export const UserEdit = () => {
+    const { permissions } = useGetPermissions();
+    return (
+        <Edit>
+            <TabbedForm>
+                <TabbedForm.Tab label="Summary">
+                    <TextInput source="name" validate={[required()]} />
+                    {permissions === 'admin'
+                        ? <TextInput source="role" validate={[required()]} />
+                        : null
+                    }
+                </TabbedForm.Tab>}
+                    <TabbedForm.Tab label="Security">
+                        ...
+                    </TabbedForm.Tab>
+            </TabbedForm>
+        </Edit>
+    );
+}
 ```
 {% endraw %}
 

--- a/docs/TabbedShowLayout.md
+++ b/docs/TabbedShowLayout.md
@@ -345,61 +345,6 @@ const StaticPostShow = () => (
 
 When passed a `record`, `<TabbedShowLayout>` creates a `RecordContext` with the given record.
 
-## Role-Based Access Control (RBAC)
-
-You can show or hide tabs and inputs based on user permissions by using the [`<TabbedShowLayout>`](./AuthRBAC.md#tabbedshowlayout) component from the `@react-admin/ra-rbac` package instead of the `react-admin` package.
-
-[`<TabbedShowLayout>`](./AuthRBAC.md#tabbedshowlayout) shows only the tabs for which users have read permissions, using the `[resource].tab.[tabName]` string as resource identifier. `<TabbedShowLayout.Tab>` shows only the child fields for which users have the read permissions, using the `[resource].[source]` string as resource identifier.
-
-{% raw %}
-```tsx
-import { Show, TextField } from 'react-admin';
-import { TabbedShowLayout } from '@react-admin/ra-rbac';
-
-const authProvider = {
-    // ...
-    getPermissions: () => Promise.resolve([
-        // crud
-        { action: ['list', 'show'], resource: 'products' },
-        // tabs ('products.tab.stock' is missing)
-        { action: 'read', resource: 'products.tab.description' },
-        { action: 'read', resource: 'products.tab.images' },
-        // fields ('products.description' and 'products.image' are missing)
-        { action: 'read', resource: 'products.reference' },
-        { action: 'read', resource: 'products.width' },
-        { action: 'read', resource: 'products.height' },
-        { action: 'read', resource: 'products.thumbnail' },
-    ]),
-};
-
-const ProductShow = () => (
-    <Show>
-        <TabbedShowLayout>
-            <TabbedShowLayout.Tab label="Description" name="description">
-                <TextField source="reference" />
-                <TextField source="width" />
-                <TextField source="height" />
-                {/* the description field is not displayed */}
-                <TextField source="description" />
-            </TabbedShowLayout.Tab>
-            {/* the stock tab is not displayed */}
-            <TabbedShowLayout.Tab label="Stock" name="stock">
-                <TextField source="stock" />
-            </TabbedShowLayout.Tab>
-            <TabbedShowLayout.Tab label="Images" name="images">
-                {/* the images field is not displayed */}
-                <TextField source="image" />
-                <TextField source="thumbnail" />
-            </TabbedShowLayout.Tab>
-        </TabbedShowLayout>
-    </Show>
-);
-```
-{% endraw %}
-
-Check [the RBAC `<TabbedShowLayout>` component](./AuthRBAC.md#tabbedshowlayout) documentation for more details.
-
-
 ## See Also
 
 * [Field components](./Fields.md)

--- a/docs/WizardForm.md
+++ b/docs/WizardForm.md
@@ -49,9 +49,12 @@ The `<WizardForm>` component accepts the following props:
 
 | Prop                     | Required | Type              | Default | Description                                                |
 | ------------------------ | -------- | ----------------- | ------- | ---------------------------------------------------------- |
+| `authorizationError`     | Optional | `ReactNode`       | `null`  | The content to display when authorization checks fail                    |
 | `children`               | Required | `ReactNode`       | -       | A list of `<WizardForm.Step>` elements.                   |
 | `defaultValues`          | Optional | `object|function` | -       | The default values of the record.                          |
+| `enableAccessControl`    | Optional | `boolean`         | `false` | Enable checking authorization rights for each panel and input            |
 | `id`                     | Optional | `string`          | -       | The id of the underlying `<form>` tag.                     |
+| `loading`                | Optional | `ReactNode`       |         | The content to display when checking authorizations                      |
 | `noValidate`             | Optional | `boolean`         | -       | Set to `true` to disable the browser's default validation. |
 | `onSubmit`               | Optional | `function`        | `save`  | A callback to call when the form is submitted.             |
 | `progress`               | Optional | `ReactElement`    | -       | A custom progress stepper element.                         |
@@ -62,6 +65,49 @@ The `<WizardForm>` component accepts the following props:
 
 
 Additional props are passed to `react-hook-form`'s [`useForm` hook](https://react-hook-form.com/docs/useform).
+
+## `authorizationError`
+
+Used when `enableAccessControl` is set to `true` and an error occurs while checking for users permissions. Defaults to `null`:
+
+
+{% raw %}
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { WizardForm } from '@react-admin/ra-form-layout';
+import { Alert } from '@mui/material';
+
+const CustomerEdit = () => (
+    <Edit>
+        <WizardForm
+            enableAccessControl
+            authorizationError={
+                <Alert
+                    severity="error"
+                    sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}
+                >
+                    An error occurred while loading your permissions
+                </Alert>
+            }
+        >
+            <WizardForm.Step id="identity">
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </WizardForm.Step>
+            <WizardForm.Step id="occupations">
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </WizardForm.Step>
+        </WizardForm>
+    </Edit>
+);
+```
+{% endraw %}
 
 ## `children`
 
@@ -110,6 +156,45 @@ export const PostCreate = () => (
 
 **Tip**: React-admin also allows to define default values at the input level. See the [Setting default Values](./forms.md#default-values) section.
 
+## `enableAccessControl`
+
+When set to `true`, React-admin will call the `authProvider.canAccess` method for each panel with the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.section.PANEL_ID_OR_LABEL`. For instance: `customers.section.identity`
+- `record`: The current record
+
+For each panel, react-admin will also call the `authProvider.canAccess` method for each input with the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.INPUT_SOURCE`. For instance: `customers.first_name`
+- `record`: The current record
+
+**Tip**: `<WizardForm.Step>` direct children that don't have a `source` will always be displayed.
+
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { WizardForm } from '@react-admin/ra-form-layout';
+
+const CustomerEdit = () => (
+    <Edit>
+        <WizardForm enableAccessControl>
+            <WizardForm.Step id="identity">
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </WizardForm.Step>
+            <WizardForm.Step id="occupations">
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </WizardForm.Step>
+        </WizardForm>
+    </Edit>
+);
+```
+
 ## `id`
 
 Normally, a submit button only works when placed inside a `<form>` tag. However, you can place a submit button outside the form if the submit button `form` matches the form `id`.
@@ -128,6 +213,43 @@ export const PostCreate = () => (
         </WizardForm>
         <SaveButton form="post_create_form" />
     </Create>
+);
+```
+
+## `loading`
+
+Used when `enableAccessControl` is set to `true` while checking for users permissions. Defaults to `Loading` from `react-admin`:
+
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { WizardForm } from '@react-admin/ra-form-layout';
+import { Typography } from '@mui/material';
+
+const CustomerEdit = () => (
+    <Edit>
+        <WizardForm
+            enableAccessControl
+            loading={
+                <Typography>
+                    Loading your permissions...
+                </Typography>
+            }
+        >
+            <WizardForm.Step id="identity">
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </WizardForm.Step>
+            <WizardForm.Step id="occupations">
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </WizardForm.Step>
+        </WizardForm>
+    </Edit>
 );
 ```
 
@@ -433,6 +555,132 @@ const PostCreate = () => (
 );
 ```
 
+The children of `<WizardForm>` must be `<WizardForm.Step>` elements.
+
+### Props
+
+
+| Prop                  | Required | Type        | Default | Description                                                                          |
+| --------------------- | -------- | ----------- | ------- | ------------------------------------------------------------------------------------ |
+| `authorizationError`  | Optional | `ReactNode` | -       | The content to display when authorization checks fail                                |
+| `enableAccessControl` | Optional | `ReactNode` | -       | Enable authorization checks                                                          |
+| `label`               | Required | `string`    | -       | The main label used as the step title. Appears in red when the section has errors    |
+| `loading`             | Optional | `ReactNode` | -       | The content to display while checking authorizations                                 |
+| `children`            | Required | `ReactNode` | -       | A list of `<Input>` elements                                                         |
+| `sx`                  | Optional | `object`    | -       | An object containing the MUI style overrides to apply to the root component          |
+
+### `authorizationError`
+
+Used when `enableAccessControl` is set to `true` and an error occurs while checking for users permissions. Defaults to `null`:
+
+{% raw %}
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { WizardForm } from '@react-admin/ra-form-layout';
+import { Alert } from '@mui/material';
+
+const CustomerEdit = () => (
+    <Edit>
+        <WizardForm enableAccessControl>
+            <WizardForm.Step id="identity">
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </WizardForm.Step>
+            <WizardForm.Step id="occupations" authorizationError={
+                <Alert
+                    severity="error"
+                    sx={{ px: 2.5, py: 1, mt: 1, width: '100%' }}
+                >
+                    An error occurred while loading your permissions
+                </Alert>
+            }>
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </WizardForm.Step>
+        </WizardForm>
+    </Edit>
+);
+```
+{% endraw %}
+
+
+### `enableAccessControl`
+
+When set to `true`, react-admin will also call the `authProvider.canAccess` method for each input with the following parameters:
+- `action`: `write`
+- `resource`: `RESOURCE_NAME.INPUT_SOURCE`. For instance: `customers.first_name`
+- `record`: The current record
+
+**Tip**: `<WizardForm.Step>` direct children that don't have a `source` will always be displayed.
+
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { WizardForm } from '@react-admin/ra-form-layout';
+
+const CustomerEdit = () => (
+    <Edit>
+        <WizardForm>
+            <WizardForm.Step id="identity">
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </WizardForm.Step>
+            <WizardForm.Step id="occupations" enableAccessControl>
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </WizardForm.Step>
+        </WizardForm>
+    </Edit>
+);
+```
+
+### `loading`
+
+Used when `enableAccessControl` is set to `true` while checking for users permissions. Defaults to `Loading` from `react-admin`:
+
+```tsx
+import { ArrayInput, Edit, DateInput, SimpleFormIterator, TextInput } from 'react-admin';
+import { WizardForm } from '@react-admin/ra-form-layout';
+import { Typography } from '@mui/material';
+
+const CustomerEdit = () => (
+    <Edit>
+        <WizardForm enableAccessControl>
+            <WizardForm.Step id="identity" loading={
+                <Typography>
+                    Loading your permissions...
+                </Typography>
+            }>
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+            </WizardForm.Step>
+            <WizardForm.Step id="occupations" loading={
+                <Typography>
+                    Loading your permissions...
+                </Typography>
+            }>
+                <ArrayInput source="occupations" label="">
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <DateInput source="from" validate={required()} />
+                        <DateInput source="to" />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </WizardForm.Step>
+        </WizardForm>
+    </Edit>
+);
+```
+
 ## Adding a Summary Final Step
 
 In order to add a final step with a summary of the form values before submit, you can leverage `react-hook-form` [`useWatch`](https://react-hook-form.com/docs/usewatch) hook:
@@ -471,58 +719,3 @@ const PostCreate = () => (
     </Create>
 );
 ```
-
-## Role-Based Access Control (RBAC)
-
-Fine-grained permissions control can be added by using the [`<WizardForm>`](./AuthRBAC.md#wizardform) and [`<WizardFormStep>`](./AuthRBAC.md#wizardform) components provided by the `@react-admin/ra-enterprise` package. 
-
-{% raw %}
-```tsx
-import { WizardForm } from '@react-admin/ra-enterprise';
-
-const authProvider = {
-    checkAuth: () => Promise.resolve(),
-    login: () => Promise.resolve(),
-    logout: () => Promise.resolve(),
-    checkError: () => Promise.resolve(),
-    getPermissions: () =>Promise.resolve([
-        // 'delete' is missing
-        { action: ['list', 'edit'], resource: 'products' },
-        { action: 'write', resource: 'products.reference' },
-        { action: 'write', resource: 'products.width' },
-        { action: 'write', resource: 'products.height' },
-        // 'products.description' is missing
-        { action: 'write', resource: 'products.thumbnail' },
-        // 'products.image' is missing
-        { action: 'write', resource: 'products.step.description' },
-        { action: 'write', resource: 'products.step.images' },
-        // 'products.step.stock' is missing
-    ]),
-};
-
-const ProductCreate = () => (
-    <Create>
-        <WizardForm>
-            <WizardForm.Step name="description" label="Description">
-                <TextInput source="reference" />
-                <TextInput source="width" />
-                <TextInput source="height" />
-                {/* Won't be displayed */}
-                <TextInput source="description" />
-            </WizardForm.Step>
-            <WizardForm.Step name="images" label="Images">
-                {/* Won't be displayed */}
-                <TextInput source="image" />
-                <TextInput source="thumbnail" />
-            </WizardForm.Step>
-            {/* Won't be displayed */}
-            <WizardForm.Step name="stock" label="Stock">
-                <TextInput source="stock" />
-            </WizardForm.Step>
-        </WizardForm>
-    </Create>
-);
-```
-{% endraw %}
-
-Check [the RBAC `<WizardForm>`](./AuthRBAC.md#wizardform) documentation for more details.


### PR DESCRIPTION
## Problem

As we migrated some enterprise packages to leverage the new access control features, the documentation is now out of date.

## Solution

Update and improve access control documentation:

- [x] AccordionForm
- [ ] AuthRBAC
- [ ] Buttons
- [ ] ReferenceField
- [ ] CloneButton
- [ ] Datagrid
- [ ] ExportButton
- [ ] LongForm
- [ ] Menu
- [ ] Permissions
- [x] SimpleForm
- [ ] SimpleShowLayout
- [x] TabbedForm
- [ ] TabbedShowLayout
- [x] WizardForm
