### PR TITLE
`useUpdate`: allow to disable cache update from `meta`

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -51,7 +51,11 @@ export const useCreateController = <
         MutationOptionsError,
         ResultRecordType
     > = {}
-): CreateControllerResult<RecordType> => {
+): CreateControllerResult<
+    RecordType,
+    MutationOptionsError,
+    ResultRecordType
+> => {
     const {
         disableAuthentication,
         record,
@@ -157,7 +161,10 @@ export const useCreateController = <
                 transform: transformFromSave,
                 meta: metaFromSave,
                 ...callTimeOptions
-            } = {} as SaveHandlerCallbacks
+            } = {} as SaveHandlerCallbacks<
+                ResultRecordType,
+                MutationOptionsError
+            >
         ) =>
             Promise.resolve(
                 transformFromSave
@@ -228,7 +235,14 @@ export interface CreateControllerProps<
 
 export interface CreateControllerResult<
     RecordType extends Omit<RaRecord, 'id'> = any,
-> extends SaveContextValue {
+    MutationOptionsError = any,
+    ResultRecordType extends RaRecord = RecordType & { id: Identifier },
+> extends SaveContextValue<
+        RecordType,
+        (...args: any[]) => any,
+        MutationOptionsError,
+        ResultRecordType
+    > {
     defaultTitle?: string;
     isFetching: boolean;
     isPending: boolean;

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -222,7 +222,8 @@ export const useEditController = <
                 onError: onErrorFromSave,
                 transform: transformFromSave,
                 meta: metaFromSave,
-            } = {} as SaveHandlerCallbacks
+                ...otherSaveMutationOptions
+            } = {} as SaveHandlerCallbacks<RecordType, ErrorType>
         ) =>
             Promise.resolve(
                 transformFromSave
@@ -246,6 +247,7 @@ export const useEditController = <
                         {
                             onError: onErrorFromSave,
                             onSuccess: onSuccessFromSave,
+                            ...otherSaveMutationOptions,
                         }
                     );
                 } catch (error) {

--- a/packages/ra-core/src/controller/saveContext/SaveContext.ts
+++ b/packages/ra-core/src/controller/saveContext/SaveContext.ts
@@ -1,19 +1,15 @@
 import { createContext } from 'react';
-import {
-    RaRecord,
-    OnError,
-    OnSuccess,
-    TransformData,
-    MutationMode,
-} from '../../types';
+import { OnError, OnSuccess, TransformData, MutationMode } from '../../types';
 import { Middleware } from './useMutationMiddlewares';
 import { UseMutationOptions } from '@tanstack/react-query';
 
 export interface SaveContextValue<
-    RecordType extends RaRecord = any,
+    RecordType = any,
     MutateFunc extends (...args: any[]) => any = (...args: any[]) => any,
+    ErrorType = Error,
+    ResultRecordType = RecordType,
 > {
-    save?: SaveHandler<RecordType>;
+    save?: SaveHandler<RecordType, ErrorType, ResultRecordType>;
     /**
      * @deprecated. Rely on the form isSubmitting value instead
      */
@@ -23,17 +19,21 @@ export interface SaveContextValue<
     unregisterMutationMiddleware?: (callback: Middleware<MutateFunc>) => void;
 }
 
-export type SaveHandler<RecordType, ErrorType = Error> = (
+export type SaveHandler<
+    RecordType,
+    ErrorType = Error,
+    ResultRecordType = RecordType,
+> = (
     record: Partial<RecordType>,
-    callbacks?: SaveHandlerCallbacks<RecordType, ErrorType>
+    callbacks?: SaveHandlerCallbacks<ResultRecordType, ErrorType>
 ) => Promise<void | RecordType> | Record<string, string>;
 
 export type SaveHandlerCallbacks<
-    RecordType = any,
+    ResultRecordType = any,
     ErrorType = Error,
     TVariables = any,
 > = Omit<
-    UseMutationOptions<RecordType, ErrorType, TVariables>,
+    UseMutationOptions<ResultRecordType, ErrorType, TVariables>,
     'mutationFn'
 > & {
     onSuccess?: OnSuccess;

--- a/packages/ra-core/src/controller/saveContext/SaveContext.ts
+++ b/packages/ra-core/src/controller/saveContext/SaveContext.ts
@@ -7,6 +7,7 @@ import {
     MutationMode,
 } from '../../types';
 import { Middleware } from './useMutationMiddlewares';
+import { UseMutationOptions } from '@tanstack/react-query';
 
 export interface SaveContextValue<
     RecordType extends RaRecord = any,
@@ -22,15 +23,23 @@ export interface SaveContextValue<
     unregisterMutationMiddleware?: (callback: Middleware<MutateFunc>) => void;
 }
 
-export type SaveHandler<RecordType> = (
+export type SaveHandler<RecordType, ErrorType = Error> = (
     record: Partial<RecordType>,
-    callbacks?: SaveHandlerCallbacks
+    callbacks?: SaveHandlerCallbacks<RecordType, ErrorType>
 ) => Promise<void | RecordType> | Record<string, string>;
 
-export type SaveHandlerCallbacks = {
+export type SaveHandlerCallbacks<
+    RecordType = any,
+    ErrorType = Error,
+    TVariables = any,
+> = Omit<
+    UseMutationOptions<RecordType, ErrorType, TVariables>,
+    'mutationFn'
+> & {
     onSuccess?: OnSuccess;
     onError?: OnError;
     transform?: TransformData;
     meta?: any;
+    disableCacheUpdate?: boolean;
 };
 export const SaveContext = createContext<SaveContextValue>({});

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -510,6 +510,619 @@ describe('useUpdate', () => {
                 });
             });
         });
+
+        describe('pessimistic mutation mode', () => {
+            it('updates getOne query cache when dataProvider promise resolves', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate();
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: undefined },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+            });
+
+            it('updates getOne query cache when dataProvider promise resolves with meta', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate();
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                    meta: { key: 'value' },
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+            });
+
+            it('updates getOne query cache when dataProvider promise resolves with meta at hook time', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate();
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+            });
+
+            it('does not update getOne query cache if disableCacheUpdate is true', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    [
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate();
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                    meta: { disableCacheUpdate: true },
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { disableCacheUpdate: true },
+                    });
+                });
+                // Wait some time after the update
+                await new Promise(resolve => setTimeout(resolve, 50));
+                expect(
+                    queryClient.getQueryData([
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ])
+                ).toEqual({
+                    id: 1,
+                    bar: 'bar',
+                });
+            });
+
+            it('does not update getOne query cache if disableCacheUpdate is true at hook time', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    [
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { disableCacheUpdate: true },
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate();
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { disableCacheUpdate: true },
+                    });
+                });
+                // Wait some time after the update
+                await new Promise(resolve => setTimeout(resolve, 50));
+                expect(
+                    queryClient.getQueryData([
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ])
+                ).toEqual({
+                    id: 1,
+                    bar: 'bar',
+                });
+            });
+        });
+
+        describe('optimistic mutation mode', () => {
+            it('updates getOne query cache immediately and invalidates query when dataProvider promise resolves', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(undefined, undefined, {
+                        mutationMode: 'optimistic',
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: undefined },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(queryClientSpy).toHaveBeenCalledWith({
+                        queryKey: [
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: undefined },
+                        ],
+                    });
+                });
+            });
+
+            it('updates getOne query cache immediately and invalidates query when dataProvider promise resolves with meta', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(undefined, undefined, {
+                        mutationMode: 'optimistic',
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                    meta: { key: 'value' },
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(queryClientSpy).toHaveBeenCalledWith({
+                        queryKey: [
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ],
+                    });
+                });
+            });
+
+            it('updates getOne query cache immediately and invalidates query when dataProvider promise resolves with meta at hook time', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(
+                        'foo',
+                        {
+                            id: 1,
+                            data: { bar: 'baz' },
+                            previousData: { id: 1, bar: 'bar' },
+                            meta: { key: 'value' },
+                        },
+                        {
+                            mutationMode: 'optimistic',
+                        }
+                    );
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate();
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(queryClientSpy).toHaveBeenCalledWith({
+                        queryKey: [
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ],
+                    });
+                });
+            });
+
+            it('does not update getOne query cache nor invalidates query if disableCacheUpdate is true', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    [
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(undefined, undefined, {
+                        mutationMode: 'optimistic',
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                    meta: { disableCacheUpdate: true },
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { disableCacheUpdate: true },
+                    });
+                });
+                // Wait some time after the update
+                await new Promise(resolve => setTimeout(resolve, 50));
+                expect(
+                    queryClient.getQueryData([
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ])
+                ).toEqual({
+                    id: 1,
+                    bar: 'bar',
+                });
+                expect(queryClientSpy).not.toHaveBeenCalled();
+            });
+
+            it('does not update getOne query cache nor invalidates query if disableCacheUpdate is true at hook time', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    [
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(
+                        'foo',
+                        {
+                            id: 1,
+                            data: { bar: 'baz' },
+                            previousData: { id: 1, bar: 'bar' },
+                            meta: { disableCacheUpdate: true },
+                        },
+                        {
+                            mutationMode: 'optimistic',
+                        }
+                    );
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate();
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { disableCacheUpdate: true },
+                    });
+                });
+                // Wait some time after the update
+                await new Promise(resolve => setTimeout(resolve, 50));
+                expect(
+                    queryClient.getQueryData([
+                        'foo',
+                        'getOne',
+                        { id: '1', meta: { disableCacheUpdate: true } },
+                    ])
+                ).toEqual({
+                    id: 1,
+                    bar: 'bar',
+                });
+                expect(queryClientSpy).not.toHaveBeenCalled();
+            });
+        });
     });
     describe('middlewares', () => {
         it('when pessimistic, it accepts middlewares and displays result and success side effects when dataProvider promise resolves', async () => {

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -672,11 +672,7 @@ describe('useUpdate', () => {
             it('does not update getOne query cache if disableCacheUpdate is true', async () => {
                 const queryClient = new QueryClient();
                 queryClient.setQueryData(
-                    [
-                        'foo',
-                        'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
-                    ],
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
                     { id: 1, bar: 'bar' }
                 );
                 const dataProvider = {
@@ -698,27 +694,29 @@ describe('useUpdate', () => {
                         <Dummy />
                     </CoreAdminContext>
                 );
-                localUpdate('foo', {
-                    id: 1,
-                    data: { bar: 'baz' },
-                    previousData: { id: 1, bar: 'bar' },
-                    meta: { disableCacheUpdate: true },
-                });
+                localUpdate(
+                    'foo',
+                    {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                    },
+                    { disableCacheUpdate: true }
+                );
                 await waitFor(() => {
                     expect(dataProvider.update).toHaveBeenCalledWith('foo', {
                         id: 1,
                         data: { bar: 'baz' },
                         previousData: { id: 1, bar: 'bar' },
-                        meta: { disableCacheUpdate: true },
                     });
                 });
                 // Wait some time after the update
-                await new Promise(resolve => setTimeout(resolve, 50));
+                await new Promise(resolve => setTimeout(resolve, 100));
                 expect(
                     queryClient.getQueryData([
                         'foo',
                         'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
+                        { id: '1', meta: undefined },
                     ])
                 ).toEqual({
                     id: 1,
@@ -729,11 +727,7 @@ describe('useUpdate', () => {
             it('does not update getOne query cache if disableCacheUpdate is true at hook time', async () => {
                 const queryClient = new QueryClient();
                 queryClient.setQueryData(
-                    [
-                        'foo',
-                        'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
-                    ],
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
                     { id: 1, bar: 'bar' }
                 );
                 const dataProvider = {
@@ -743,12 +737,15 @@ describe('useUpdate', () => {
                 } as any;
                 let localUpdate;
                 const Dummy = () => {
-                    const [update] = useUpdate('foo', {
-                        id: 1,
-                        data: { bar: 'baz' },
-                        previousData: { id: 1, bar: 'bar' },
-                        meta: { disableCacheUpdate: true },
-                    });
+                    const [update] = useUpdate(
+                        'foo',
+                        {
+                            id: 1,
+                            data: { bar: 'baz' },
+                            previousData: { id: 1, bar: 'bar' },
+                        },
+                        { disableCacheUpdate: true }
+                    );
                     localUpdate = update;
                     return <span />;
                 };
@@ -766,16 +763,15 @@ describe('useUpdate', () => {
                         id: 1,
                         data: { bar: 'baz' },
                         previousData: { id: 1, bar: 'bar' },
-                        meta: { disableCacheUpdate: true },
                     });
                 });
                 // Wait some time after the update
-                await new Promise(resolve => setTimeout(resolve, 50));
+                await new Promise(resolve => setTimeout(resolve, 100));
                 expect(
                     queryClient.getQueryData([
                         'foo',
                         'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
+                        { id: '1', meta: undefined },
                     ])
                 ).toEqual({
                     id: 1,
@@ -994,11 +990,7 @@ describe('useUpdate', () => {
             it('does not update getOne query cache nor invalidates query if disableCacheUpdate is true', async () => {
                 const queryClient = new QueryClient();
                 queryClient.setQueryData(
-                    [
-                        'foo',
-                        'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
-                    ],
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
                     { id: 1, bar: 'bar' }
                 );
                 const dataProvider = {
@@ -1026,27 +1018,29 @@ describe('useUpdate', () => {
                         <Dummy />
                     </CoreAdminContext>
                 );
-                localUpdate('foo', {
-                    id: 1,
-                    data: { bar: 'baz' },
-                    previousData: { id: 1, bar: 'bar' },
-                    meta: { disableCacheUpdate: true },
-                });
+                localUpdate(
+                    'foo',
+                    {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                    },
+                    { disableCacheUpdate: true }
+                );
                 await waitFor(() => {
                     expect(dataProvider.update).toHaveBeenCalledWith('foo', {
                         id: 1,
                         data: { bar: 'baz' },
                         previousData: { id: 1, bar: 'bar' },
-                        meta: { disableCacheUpdate: true },
                     });
                 });
                 // Wait some time after the update
-                await new Promise(resolve => setTimeout(resolve, 50));
+                await new Promise(resolve => setTimeout(resolve, 100));
                 expect(
                     queryClient.getQueryData([
                         'foo',
                         'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
+                        { id: '1', meta: undefined },
                     ])
                 ).toEqual({
                     id: 1,
@@ -1058,11 +1052,7 @@ describe('useUpdate', () => {
             it('does not update getOne query cache nor invalidates query if disableCacheUpdate is true at hook time', async () => {
                 const queryClient = new QueryClient();
                 queryClient.setQueryData(
-                    [
-                        'foo',
-                        'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
-                    ],
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
                     { id: 1, bar: 'bar' }
                 );
                 const dataProvider = {
@@ -1082,10 +1072,10 @@ describe('useUpdate', () => {
                             id: 1,
                             data: { bar: 'baz' },
                             previousData: { id: 1, bar: 'bar' },
-                            meta: { disableCacheUpdate: true },
                         },
                         {
                             mutationMode: 'optimistic',
+                            disableCacheUpdate: true,
                         }
                     );
                     localUpdate = update;
@@ -1105,16 +1095,15 @@ describe('useUpdate', () => {
                         id: 1,
                         data: { bar: 'baz' },
                         previousData: { id: 1, bar: 'bar' },
-                        meta: { disableCacheUpdate: true },
                     });
                 });
                 // Wait some time after the update
-                await new Promise(resolve => setTimeout(resolve, 50));
+                await new Promise(resolve => setTimeout(resolve, 100));
                 expect(
                     queryClient.getQueryData([
                         'foo',
                         'getOne',
-                        { id: '1', meta: { disableCacheUpdate: true } },
+                        { id: '1', meta: undefined },
                     ])
                 ).toEqual({
                     id: 1,
@@ -1124,6 +1113,7 @@ describe('useUpdate', () => {
             });
         });
     });
+
     describe('middlewares', () => {
         it('when pessimistic, it accepts middlewares and displays result and success side effects when dataProvider promise resolves', async () => {
             render(<WithMiddlewaresSuccessPessimistic timeout={10} />);


### PR DESCRIPTION
## Problem

After updating a record with `useUpdate`, regardless of the mutation mode or the mutation options, the cached data for the loaded queries (`getOne`, `getList`, ...) will be updated. This can cause unwanted refreshes of the UI, and can be a problem for instance in the context of a form, where we want to be able to save the current values without resetting the form (and losing newer changes) once the dataProvider resolves.

## Solution

Provide a way to disable the cache update.

This PR adds support for a `meta` prop named `disableCacheUpdate` allowing to do just that.

```tsx
const update = useUpdate();
update('foo', {
    id: 1,
    data: { bar: 'baz' },
    previousData: { id: 1, bar: 'bar' },
    meta: { disableCacheUpdate: true }, // cache won't be updated
});
```

## Additional fix

Also, this PR fixes a bug where the `meta` param was not used to construct the query keys when updating the cache, if the `meta` param was passed at call time, and the mutation mode was set to pessimistic.

## How To Test

Run the unit tests.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
