### PR TITLE
Fix ArrayInput makes the form dirty in strict mode

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -62,7 +62,6 @@ const BookEdit = () => {
             }}
         >
             <SimpleForm>
-                <FormInspector />
                 <TextInput source="title" />
                 <ArrayInput source="authors">
                     <SimpleFormIterator>
@@ -70,6 +69,7 @@ const BookEdit = () => {
                         <TextInput source="role" />
                     </SimpleFormIterator>
                 </ArrayInput>
+                <FormInspector />
             </SimpleForm>
         </Edit>
     );
@@ -89,6 +89,7 @@ const FormInspector = () => {
         </div>
     );
 };
+
 export const Basic = () => (
     <React.StrictMode>
         <TestMemoryRouter initialEntries={['/books/1']}>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Admin } from 'react-admin';
 import {
+    minLength,
     required,
     Resource,
     testI18nProvider,
@@ -19,6 +20,7 @@ import { AutocompleteInput } from '../AutocompleteInput';
 import { TranslatableInputs } from '../TranslatableInputs';
 import { ReferenceField, TextField, TranslatableFields } from '../../field';
 import { Labeled } from '../../Labeled';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 export default { title: 'ra-ui-materialui/input/ArrayInput' };
 
@@ -60,6 +62,7 @@ const BookEdit = () => {
             }}
         >
             <SimpleForm>
+                <FormInspector />
                 <TextInput source="title" />
                 <ArrayInput source="authors">
                     <SimpleFormIterator>
@@ -72,12 +75,28 @@ const BookEdit = () => {
     );
 };
 
+const FormInspector = () => {
+    const {
+        formState: { defaultValues, isDirty, dirtyFields },
+    } = useFormContext();
+    const values = useWatch();
+    return (
+        <div>
+            <div>isDirty: {isDirty.toString()}</div>
+            <div>dirtyFields: {JSON.stringify(dirtyFields, null, 2)}</div>
+            <div>defaultValues: {JSON.stringify(defaultValues, null, 2)}</div>
+            <div>values: {JSON.stringify(values, null, 2)}</div>
+        </div>
+    );
+};
 export const Basic = () => (
-    <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin dataProvider={dataProvider}>
-            <Resource name="books" edit={BookEdit} />
-        </Admin>
-    </TestMemoryRouter>
+    <React.StrictMode>
+        <TestMemoryRouter initialEntries={['/books/1']}>
+            <Admin dataProvider={dataProvider}>
+                <Resource name="books" edit={BookEdit} />
+            </Admin>
+        </TestMemoryRouter>
+    </React.StrictMode>
 );
 
 export const Disabled = () => (
@@ -669,24 +688,44 @@ export const ActionsLeft = () => (
     </TestMemoryRouter>
 );
 
-const globalValidator = values => {
-    const errors: any = {};
-    if (!values.authors || !values.authors.length) {
-        errors.authors = 'ra.validation.required';
-    } else {
-        errors.authors = values.authors.map(author => {
-            const authorErrors: any = {};
-            if (!author?.name) {
-                authorErrors.name = 'A name is required';
-            }
-            if (!author?.role) {
-                authorErrors.role = 'ra.validation.required';
-            }
-            return authorErrors;
-        });
-    }
-    return errors;
+const BookEditValidation = () => {
+    return (
+        <Edit
+            mutationMode="pessimistic"
+            mutationOptions={{
+                onSuccess: data => {
+                    console.log(data);
+                },
+            }}
+        >
+            <SimpleForm>
+                <ArrayInput
+                    source="authors"
+                    fullWidth
+                    validate={[
+                        required(),
+                        minLength(2, 'You need two authors at minimum'),
+                    ]}
+                    helperText="At least two authors"
+                >
+                    <SimpleFormIterator>
+                        <TextInput source="name" validate={required()} />
+                        <TextInput source="role" validate={required()} />
+                    </SimpleFormIterator>
+                </ArrayInput>
+            </SimpleForm>
+        </Edit>
+    );
 };
+
+export const Validation = () => (
+    <TestMemoryRouter initialEntries={['/books/1']}>
+        <Admin dataProvider={dataProvider}>
+            <Resource name="books" edit={BookEditValidation} />
+        </Admin>
+    </TestMemoryRouter>
+);
+
 const BookEditGlobalValidation = () => {
     return (
         <Edit
@@ -712,6 +751,26 @@ const BookEditGlobalValidation = () => {
         </Edit>
     );
 };
+
+const globalValidator = values => {
+    const errors: any = {};
+    if (!values.authors || !values.authors.length) {
+        errors.authors = 'ra.validation.required';
+    } else {
+        errors.authors = values.authors.map(author => {
+            const authorErrors: any = {};
+            if (!author?.name) {
+                authorErrors.name = 'A name is required';
+            }
+            if (!author?.role) {
+                authorErrors.role = 'ra.validation.required';
+            }
+            return authorErrors;
+        });
+    }
+    return errors;
+};
+
 export const GlobalValidation = () => (
     <TestMemoryRouter initialEntries={['/books/1']}>
         <Admin dataProvider={dataProvider}>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -101,8 +101,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
         : validate;
     const getValidationErrorMessage = useGetValidationErrorMessage();
 
-    const { getFieldState, formState, getValues, register, unregister } =
-        useFormContext();
+    const { getFieldState, formState, getValues } = useFormContext();
 
     const fieldProps = useFieldArray({
         name: finalSource,
@@ -121,25 +120,17 @@ export const ArrayInput = (props: ArrayInputProps) => {
         },
     });
 
-    // We need to register the array itself as a field to enable validation at its level
     useEffect(() => {
-        register(finalSource);
-        formGroups &&
-            formGroupName != null &&
+        if (formGroups && formGroupName != null) {
             formGroups.registerField(finalSource, formGroupName);
+        }
 
         return () => {
-            unregister(finalSource, {
-                keepValue: true,
-                keepError: true,
-                keepDirty: true,
-                keepTouched: true,
-            });
-            formGroups &&
-                formGroupName != null &&
+            if (formGroups && formGroupName != null) {
                 formGroups.unregisterField(finalSource, formGroupName);
+            }
         };
-    }, [register, unregister, finalSource, formGroups, formGroupName]);
+    }, [finalSource, formGroups, formGroupName]);
 
     useApplyInputDefaultValues({
         inputProps: props,


### PR DESCRIPTION
## Problem

Fixes #9661

## Solution

We had a workaround for adding validation on the ArrayInput itself (like min/max number of items) that triggered a register/unregister of the input in react-hook-form inside a `useEffect`. This effect is run twice in StrictMode. 
It appears the workaround isn't needed anymore to have validation on the ArrayInput.

## How To Test

- https://react-admin-storybook-61vioyrs6-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-input-arrayinput--basic To check the `isDirty`. Run the story locally for React.StrictMode
- https://react-admin-storybook-61vioyrs6-marmelab.vercel.app/?path=%2Fstory%2Fra-ui-materialui-input-arrayinput--validation To check validation is still working

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
