### PR TITLE
Fix `useUpdate` ignores `meta` when populating the query cache in pessimistic mode

### DIFF
--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -510,7 +510,374 @@ describe('useUpdate', () => {
                 });
             });
         });
+        describe('pessimistic mutation mode', () => {
+            it('updates getOne query cache when dataProvider promise resolves', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate();
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: undefined },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+            });
+
+            it('updates getOne query cache when dataProvider promise resolves with meta', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate();
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                    meta: { key: 'value' },
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+            });
+
+            it('updates getOne query cache when dataProvider promise resolves with meta at hook time', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate();
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+            });
+        });
+
+        describe('optimistic mutation mode', () => {
+            it('updates getOne query cache immediately and invalidates query when dataProvider promise resolves', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: undefined }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(undefined, undefined, {
+                        mutationMode: 'optimistic',
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: undefined },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(queryClientSpy).toHaveBeenCalledWith({
+                        queryKey: [
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: undefined },
+                        ],
+                    });
+                });
+            });
+
+            it('updates getOne query cache immediately and invalidates query when dataProvider promise resolves with meta', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(undefined, undefined, {
+                        mutationMode: 'optimistic',
+                    });
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                    meta: { key: 'value' },
+                });
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(queryClientSpy).toHaveBeenCalledWith({
+                        queryKey: [
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ],
+                    });
+                });
+            });
+
+            it('updates getOne query cache immediately and invalidates query when dataProvider promise resolves with meta at hook time', async () => {
+                const queryClient = new QueryClient();
+                queryClient.setQueryData(
+                    ['foo', 'getOne', { id: '1', meta: { key: 'value' } }],
+                    { id: 1, bar: 'bar' }
+                );
+                const dataProvider = {
+                    update: jest.fn(() =>
+                        Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                    ),
+                } as any;
+                const queryClientSpy = jest.spyOn(
+                    queryClient,
+                    'invalidateQueries'
+                );
+                let localUpdate;
+                const Dummy = () => {
+                    const [update] = useUpdate(
+                        'foo',
+                        {
+                            id: 1,
+                            data: { bar: 'baz' },
+                            previousData: { id: 1, bar: 'bar' },
+                            meta: { key: 'value' },
+                        },
+                        {
+                            mutationMode: 'optimistic',
+                        }
+                    );
+                    localUpdate = update;
+                    return <span />;
+                };
+                render(
+                    <CoreAdminContext
+                        dataProvider={dataProvider}
+                        queryClient={queryClient}
+                    >
+                        <Dummy />
+                    </CoreAdminContext>
+                );
+                localUpdate();
+                await waitFor(() => {
+                    expect(
+                        queryClient.getQueryData([
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ])
+                    ).toEqual({
+                        id: 1,
+                        bar: 'baz',
+                    });
+                });
+                await waitFor(() => {
+                    expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                        id: 1,
+                        data: { bar: 'baz' },
+                        previousData: { id: 1, bar: 'bar' },
+                        meta: { key: 'value' },
+                    });
+                });
+                await waitFor(() => {
+                    expect(queryClientSpy).toHaveBeenCalledWith({
+                        queryKey: [
+                            'foo',
+                            'getOne',
+                            { id: '1', meta: { key: 'value' } },
+                        ],
+                    });
+                });
+            });
+        });
     });
+
     describe('middlewares', () => {
         it('when pessimistic, it accepts middlewares and displays result and success side effects when dataProvider promise resolves', async () => {
             render(<WithMiddlewaresSuccessPessimistic timeout={10} />);

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -269,12 +269,13 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
                 const {
                     resource: callTimeResource = resource,
                     id: callTimeId = id,
+                    meta: callTimeMeta = meta,
                 } = variables;
                 updateCache({
                     resource: callTimeResource,
                     id: callTimeId,
                     data,
-                    meta: mutationOptions.meta ?? paramsRef.current.meta,
+                    meta: callTimeMeta,
                 });
 
                 if (


### PR DESCRIPTION
This PR fixes a bug where the `meta` param was not used to construct the query keys when updating the cache, if the `meta` param was passed at call time, and the mutation mode was set to pessimistic.

Supersedes https://github.com/marmelab/react-admin/pull/10418

## How To Test

run the unit tests

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
