### PR TITLE
Fix invalid code example in Fields-docs

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -520,7 +520,7 @@ const TextField = (props) => {
 -    const record = useRecordContext();
 +   const value = useFieldValue(props);
 -   return record ? <span>{record[props.source]}</span> : null;
-+   return <span>{value}</span> : null;
++   return value ? <span>{value}</span> : null;
 }
 
 export default TextField;


### PR DESCRIPTION
## Problem

The code example in the documentation is not valid code.

## Solution

Corrected example to valid code.

## How To Test

\-

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] ~The PR includes **unit tests** (if not possible, describe why)~ (docs change)
- [ ] ~The PR includes one or several **stories** (if not possible, describe why)~ (docs change)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
