### PR TITLE
Add a check for videos format in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,15 @@ jobs:
     - name: Type check simple example
       run: cd examples/simple && yarn type-check
 
+  doc-videos-format-check:
+    runs-on: ubuntu-latest
+    if: github.ref_type != 'tag'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Videos format check
+        run: make check-documentation-videos-format
+
   doc-check:
     runs-on: ubuntu-latest
     if: github.ref_type != 'tag'

--- a/Makefile
+++ b/Makefile
@@ -175,3 +175,6 @@ build-storybook: ## Build the storybook
 
 update-sandbox: ## Push the local version of the simple example to the sandbox repository
 	./scripts/update-sandbox.sh
+
+check-documentation-videos-format: ## Check the documentation format
+	./scripts/check-documentation-videos-format.sh

--- a/scripts/check-documentation-videos-format.sh
+++ b/scripts/check-documentation-videos-format.sh
@@ -1,12 +1,10 @@
-for file in ./docs/img/*; do
+for file in ./docs/img/**; do
   codec=$(mediainfo --Inform="Video;%CodecID%" "$file")
   if [ "$codec" = "hvc1" ]; then
-    # Construct the output file name
-    output_file="${file%.*}_avc1.${file##*.}"
-    # Convert the file to avc1 (H.264)
-    ffmpeg -i "$file" -c:v libx264 -c:a copy "$output_file"
-    rm $file
-    mv $output_file $file
-    echo "Fixed codec for $file"
+    echo "Invalid codec for $file"
+    echo "Convert it to avc1 with:"
+    echo "ffmpeg -i $file -c:v libx264 -c:a copy ${file%.*}_avc1.${file##*.}"
+    echo "rm $file"
+    echo "mv $output_file $file"
   fi
 done

--- a/scripts/check-documentation-videos-format.sh
+++ b/scripts/check-documentation-videos-format.sh
@@ -1,9 +1,11 @@
 for file in ./docs/img/**; do
   codec=$(mediainfo --Inform="Video;%CodecID%" "$file")
   if [ "$codec" = "hvc1" ]; then
+    # Construct the output file name
+    output_file="${file%.*}_avc1.${file##*.}"
     echo "Invalid codec for $file"
     echo "Convert it to avc1 with:"
-    echo "ffmpeg -i $file -c:v libx264 -c:a copy ${file%.*}_avc1.${file##*.}"
+    echo "ffmpeg -i $file -c:v libx264 -c:a copy ${output_file}"
     echo "rm $file"
     echo "mv $output_file $file"
     exit 1;

--- a/scripts/check-documentation-videos-format.sh
+++ b/scripts/check-documentation-videos-format.sh
@@ -6,5 +6,6 @@ for file in ./docs/img/**; do
     echo "ffmpeg -i $file -c:v libx264 -c:a copy ${file%.*}_avc1.${file##*.}"
     echo "rm $file"
     echo "mv $output_file $file"
+    exit 1;
   fi
 done

--- a/scripts/check-documentation-videos-format.sh
+++ b/scripts/check-documentation-videos-format.sh
@@ -1,0 +1,12 @@
+for file in ./docs/img/*; do
+  codec=$(mediainfo --Inform="Video;%CodecID%" "$file")
+  if [ "$codec" = "hvc1" ]; then
+    # Construct the output file name
+    output_file="${file%.*}_avc1.${file##*.}"
+    # Convert the file to avc1 (H.264)
+    ffmpeg -i "$file" -c:v libx264 -c:a copy "$output_file"
+    rm $file
+    mv $output_file $file
+    echo "Fixed codec for $file"
+  fi
+done


### PR DESCRIPTION
## Problem

We had many issues in the past with incompatible video formats or codecs on video assets used in the documentation (e.g. not readable on Firefox or Ubuntu+Chrome)

We risk doing the same error in the future, as our screen capture tools seem to produce erroneous videos by default

## Solution

Add a CI step to check the video asset files

## How To Test

- Create a video with a wrong format (use something like https://convertio.co/ to convert a video into HEVC format)
- run the script: `make check-documentation-videos-format`
- It should print a warning:

```
Invalid codec for ./docs/img/test/test.mp4
Convert it to avc1 with:
ffmpeg -i ./docs/img/test/test.mp4 -c:v libx264 -c:a copy ./docs/img/test/test_avc1.mp4
rm ./docs/img/test/test.mp4
mv ./docs/img/test/test_avc1.mp4 ./docs/img/test/test.mp4
make: *** [Makefile:180: check-documentation-videos-format] Error 1
```

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
