### PR TITLE
fix <Authenticated> - never render its children when checkAuth return…

### DIFF
--- a/packages/ra-core/src/auth/Authenticated.spec.tsx
+++ b/packages/ra-core/src/auth/Authenticated.spec.tsx
@@ -26,6 +26,34 @@ describe('<Authenticated>', () => {
         );
         await screen.findByText('Loading');
     });
+
+    it('should not render its child when checkAuth raises an error', async () => {
+        const NeverDisplayedComponent = jest.fn(() => (
+            <div>It should not be called</div>
+        ));
+
+        const authProvider = {
+            checkAuth: jest.fn().mockRejectedValue(undefined),
+            logout: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        render(
+            <CoreAdminContext authProvider={authProvider}>
+                <Authenticated>
+                    <NeverDisplayedComponent />
+                </Authenticated>
+            </CoreAdminContext>
+        );
+
+        // Ensure that the NeverDisplayedComponent is not called
+        await waitFor(() => {
+            // Ensure that checkAuth and logout were called as expected
+            expect(authProvider.checkAuth).toHaveBeenCalled();
+            expect(authProvider.logout).toHaveBeenCalled();
+            expect(NeverDisplayedComponent).toHaveBeenCalledTimes(0);
+        });
+    });
+
     it('should render its child when authenticated', async () => {
         const authProvider = {
             login: () => Promise.reject('bad method'),

--- a/packages/ra-core/src/auth/Authenticated.tsx
+++ b/packages/ra-core/src/auth/Authenticated.tsx
@@ -35,9 +35,9 @@ export const Authenticated = (props: AuthenticatedProps) => {
     const { authParams, loading = null, children } = props;
 
     // this hook will redirect to login if the user is not authenticated
-    const { isPending } = useAuthenticated({ params: authParams });
+    const { isPending, isError } = useAuthenticated({ params: authParams });
 
-    if (isPending) {
+    if (isPending || isError) {
         return loading;
     }
 


### PR DESCRIPTION
…s error

## Problem

Using <Authenticated>, we can witness a quick render with the children provided whereas it shouldn't. This happens because react-query returns an object with isPending=False but the callback for error has not been called yet.

## Solution

Checking for isError and isPending seems to be more reliable

## How To Test

I added a test to demonstrate the problem

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
