### PR TITLE
[TypeScript] Allow providing error type in dataProvider and controllers hooks

### DIFF
--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -64,8 +64,11 @@ import { useTranslate } from '../../i18n';
  *     );
  * };
  */
-const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
-    props: UseDeleteWithConfirmControllerParams<RecordType>
+const useDeleteWithConfirmController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: UseDeleteWithConfirmControllerParams<RecordType, ErrorType>
 ): UseDeleteWithConfirmControllerReturn => {
     const {
         record,
@@ -83,7 +86,7 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
     const redirect = useRedirect();
     const translate = useTranslate();
 
-    const [deleteOne, { isPending }] = useDelete<RecordType>(
+    const [deleteOne, { isPending }] = useDelete<RecordType, ErrorType>(
         resource,
         undefined,
         {
@@ -106,21 +109,22 @@ const useDeleteWithConfirmController = <RecordType extends RaRecord = any>(
                 record && unselect([record.id]);
                 redirect(redirectTo, resource);
             },
-            onError: (error: Error) => {
+            onError: error => {
                 setOpen(false);
 
                 notify(
                     typeof error === 'string'
                         ? error
-                        : error.message || 'ra.notification.http_error',
+                        : (error as Error)?.message ||
+                              'ra.notification.http_error',
                     {
                         type: 'error',
                         messageArgs: {
                             _:
                                 typeof error === 'string'
                                     ? error
-                                    : error && error.message
-                                      ? error.message
+                                    : (error as Error)?.message
+                                      ? (error as Error).message
                                       : undefined,
                         },
                     }

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -44,8 +44,11 @@ import { useTranslate } from '../../i18n';
  *     );
  * };
  */
-const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
-    props: UseDeleteWithUndoControllerParams<RecordType>
+const useDeleteWithUndoController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: UseDeleteWithUndoControllerParams<RecordType, ErrorType>
 ): UseDeleteWithUndoControllerReturn => {
     const {
         record,
@@ -60,7 +63,7 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
     const unselect = useUnselect(resource);
     const redirect = useRedirect();
     const translate = useTranslate();
-    const [deleteOne, { isPending }] = useDelete<RecordType>(
+    const [deleteOne, { isPending }] = useDelete<RecordType, ErrorType>(
         resource,
         undefined,
         {
@@ -82,19 +85,20 @@ const useDeleteWithUndoController = <RecordType extends RaRecord = any>(
                 record && unselect([record.id]);
                 redirect(redirectTo, resource);
             },
-            onError: (error: Error) => {
+            onError: error => {
                 notify(
                     typeof error === 'string'
                         ? error
-                        : error.message || 'ra.notification.http_error',
+                        : (error as Error)?.message ||
+                              'ra.notification.http_error',
                     {
                         type: 'error',
                         messageArgs: {
                             _:
                                 typeof error === 'string'
                                     ? error
-                                    : error && error.message
-                                      ? error.message
+                                    : (error as Error)?.message
+                                      ? (error as Error).message
                                       : undefined,
                         },
                     }

--- a/packages/ra-core/src/controller/create/CreateController.tsx
+++ b/packages/ra-core/src/controller/create/CreateController.tsx
@@ -4,6 +4,7 @@ import {
     CreateControllerProps,
     CreateControllerResult,
 } from './useCreateController';
+import { RaRecord } from '../../types';
 
 /**
  * Render prop version of the useCreateController hook
@@ -18,12 +19,18 @@ import {
  *     </CreateController>
  * );
  */
-export const CreateController = ({
+export const CreateController = <
+    RecordType extends Omit<RaRecord, 'id'> = any,
+    MutationOptionsError = Error,
+>({
     children,
     ...props
 }: {
-    children: (params: CreateControllerResult) => ReactNode;
-} & CreateControllerProps) => {
-    const controllerProps = useCreateController(props);
+    children: (params: CreateControllerResult<RecordType>) => ReactNode;
+} & CreateControllerProps<RecordType, MutationOptionsError>) => {
+    const controllerProps = useCreateController<
+        RecordType,
+        MutationOptionsError
+    >(props);
     return children(controllerProps);
 };

--- a/packages/ra-core/src/controller/edit/EditContextProvider.tsx
+++ b/packages/ra-core/src/controller/edit/EditContextProvider.tsx
@@ -34,7 +34,7 @@ export const EditContextProvider = ({
     value,
 }: {
     children: ReactNode;
-    value: EditControllerResult;
+    value: EditControllerResult<any, any>;
 }) => (
     <EditContext.Provider value={value}>
         <SaveContextProvider value={usePickSaveContext(value)}>

--- a/packages/ra-core/src/controller/edit/EditController.tsx
+++ b/packages/ra-core/src/controller/edit/EditController.tsx
@@ -4,6 +4,7 @@ import {
     EditControllerProps,
     EditControllerResult,
 } from './useEditController';
+import { RaRecord } from '../../types';
 
 /**
  * Render prop version of the useEditController hook
@@ -18,12 +19,17 @@ import {
  *     </EditController>
  * );
  */
-export const EditController = ({
+export const EditController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>({
     children,
     ...props
 }: {
-    children: (params: EditControllerResult) => ReactNode;
-} & EditControllerProps) => {
-    const controllerProps = useEditController(props);
+    children: (
+        params: EditControllerResult<RecordType, ErrorType>
+    ) => ReactNode;
+} & EditControllerProps<RecordType, ErrorType>) => {
+    const controllerProps = useEditController<RecordType, ErrorType>(props);
     return children(controllerProps);
 };

--- a/packages/ra-core/src/controller/edit/useEditContext.tsx
+++ b/packages/ra-core/src/controller/edit/useEditContext.tsx
@@ -15,12 +15,13 @@ import { EditControllerResult } from './useEditController';
  */
 export const useEditContext = <
     RecordType extends RaRecord = any,
->(): EditControllerResult<RecordType> => {
+    ErrorType = Error,
+>(): EditControllerResult<RecordType, ErrorType> => {
     const context = useContext(EditContext);
     if (!context) {
         throw new Error(
             'useEditContext must be used inside an EditContextProvider'
         );
     }
-    return context;
+    return context as EditControllerResult<RecordType, ErrorType>;
 };

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -53,7 +53,7 @@ export const useEditController = <
     ErrorType = Error,
 >(
     props: EditControllerProps<RecordType, ErrorType> = {}
-): EditControllerResult<RecordType> => {
+): EditControllerResult<RecordType, ErrorType> => {
     const {
         disableAuthentication = false,
         id: propsId,
@@ -111,7 +111,7 @@ export const useEditController = <
         isFetching,
         isPending,
         refetch,
-    } = useGetOne<RecordType>(
+    } = useGetOne<RecordType, ErrorType>(
         resource,
         { id, meta: queryMeta },
         {
@@ -279,7 +279,7 @@ export const useEditController = <
         save,
         saving,
         unregisterMutationMiddleware,
-    } as EditControllerResult<RecordType>;
+    } as EditControllerResult<RecordType, ErrorType>;
 };
 
 const DefaultRedirect = 'list';
@@ -292,7 +292,7 @@ export interface EditControllerProps<
     id?: RecordType['id'];
     mutationMode?: MutationMode;
     mutationOptions?: UseUpdateOptions<RecordType, ErrorType>;
-    queryOptions?: UseGetOneOptions<RecordType>;
+    queryOptions?: UseGetOneOptions<RecordType, ErrorType>;
     redirect?: RedirectionSideEffect;
     resource?: string;
     transform?: TransformData;
@@ -339,8 +339,11 @@ export interface EditControllerSuccessResult<RecordType extends RaRecord = any>
     isPending: false;
 }
 
-export type EditControllerResult<RecordType extends RaRecord = any> =
+export type EditControllerResult<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> =
     | EditControllerLoadingResult<RecordType>
-    | EditControllerLoadingErrorResult<RecordType>
-    | EditControllerRefetchErrorResult<RecordType>
+    | EditControllerLoadingErrorResult<RecordType, ErrorType>
+    | EditControllerRefetchErrorResult<RecordType, ErrorType>
     | EditControllerSuccessResult<RecordType>;

--- a/packages/ra-core/src/controller/field/useReferenceFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceFieldController.ts
@@ -8,9 +8,10 @@ import { useFieldValue } from '../../util';
 
 export const useReferenceFieldController = <
     ReferenceRecordType extends RaRecord = RaRecord,
+    ErrorType = Error,
 >(
-    options: UseReferenceFieldControllerOptions<ReferenceRecordType>
-): UseReferenceFieldControllerResult<ReferenceRecordType> => {
+    options: UseReferenceFieldControllerOptions<ReferenceRecordType, ErrorType>
+): UseReferenceFieldControllerResult<ReferenceRecordType, ErrorType> => {
     const { link, reference, queryOptions } = options;
     if (!reference) {
         throw new Error(
@@ -18,7 +19,7 @@ export const useReferenceFieldController = <
         );
     }
     const id = useFieldValue(options);
-    const referenceRecordQuery = useReference<ReferenceRecordType>({
+    const referenceRecordQuery = useReference<ReferenceRecordType, ErrorType>({
         reference,
         id,
         options: {
@@ -50,10 +51,11 @@ export const useReferenceFieldController = <
 
 export interface UseReferenceFieldControllerOptions<
     ReferenceRecordType extends RaRecord = RaRecord,
+    ErrorType = Error,
 > {
     source: string;
     queryOptions?: Omit<
-        UseQueryOptions<ReferenceRecordType[], Error>,
+        UseQueryOptions<ReferenceRecordType[], ErrorType>,
         'queryFn' | 'queryKey'
     >;
     reference: string;
@@ -62,6 +64,7 @@ export interface UseReferenceFieldControllerOptions<
 
 export interface UseReferenceFieldControllerResult<
     ReferenceRecordType extends RaRecord = RaRecord,
-> extends UseReferenceResult<ReferenceRecordType> {
+    ErrorType = Error,
+> extends UseReferenceResult<ReferenceRecordType, ErrorType> {
     link?: string | false;
 }

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -64,7 +64,7 @@ export const useReferenceManyFieldController = <
         sort: initialSort = { field: 'id', order: 'DESC' },
         queryOptions = {} as UseQueryOptions<
             { data: ReferenceRecordType[]; total: number },
-            Error
+            ErrorType
         >,
     } = props;
     const notify = useNotify();
@@ -182,7 +182,6 @@ export const useReferenceManyFieldController = <
         },
         {
             enabled: get(record, source) != null,
-            // @ts-expect-error FIXME The error type is not correctly inferred
             placeholderData: previousData => previousData,
             onError: error =>
                 notify(

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
@@ -8,6 +8,7 @@ import { UseReferenceResult } from '../useReference';
 
 export interface UseReferenceOneFieldControllerParams<
     RecordType extends RaRecord = any,
+    ErrorType = Error,
 > {
     record?: RaRecord;
     reference: string;
@@ -16,10 +17,13 @@ export interface UseReferenceOneFieldControllerParams<
     sort?: SortPayload;
     filter?: any;
     queryOptions?: Omit<
-        UseQueryOptions<{
-            data: RecordType[];
-            total: number;
-        }>,
+        UseQueryOptions<
+            {
+                data: RecordType[];
+                total: number;
+            },
+            ErrorType
+        >,
         'queryFn' | 'queryKey'
     > & { meta?: any };
 }
@@ -49,9 +53,10 @@ export interface UseReferenceOneFieldControllerParams<
  */
 export const useReferenceOneFieldController = <
     RecordType extends RaRecord = any,
+    ErrorType = Error,
 >(
-    props: UseReferenceOneFieldControllerParams<RecordType>
-): UseReferenceResult<RecordType> => {
+    props: UseReferenceOneFieldControllerParams<RecordType, ErrorType>
+): UseReferenceResult<RecordType, ErrorType> => {
     const {
         reference,
         record,
@@ -65,7 +70,7 @@ export const useReferenceOneFieldController = <
     const { meta, ...otherQueryOptions } = queryOptions;
 
     const { data, error, isFetching, isLoading, isPending, refetch } =
-        useGetManyReference<RecordType>(
+        useGetManyReference<RecordType, ErrorType>(
             reference,
             {
                 target,
@@ -81,15 +86,16 @@ export const useReferenceOneFieldController = <
                     notify(
                         typeof error === 'string'
                             ? error
-                            : error.message || 'ra.notification.http_error',
+                            : (error as Error).message ||
+                                  'ra.notification.http_error',
                         {
                             type: 'error',
                             messageArgs: {
                                 _:
                                     typeof error === 'string'
                                         ? error
-                                        : error && error.message
-                                          ? error.message
+                                        : (error as Error)?.message
+                                          ? (error as Error).message
                                           : undefined,
                             },
                         }

--- a/packages/ra-core/src/controller/list/ListController.tsx
+++ b/packages/ra-core/src/controller/list/ListController.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { RaRecord } from '../../types';
 import {
     useListController,
@@ -27,7 +28,7 @@ export const ListController = <
 }: {
     children: (
         params: ListControllerResult<RecordType, ErrorType>
-    ) => JSX.Element;
+    ) => ReactNode;
 } & ListControllerProps<RecordType, ErrorType>) => {
     const controllerProps = useListController<RecordType, ErrorType>(props);
     return children(controllerProps);

--- a/packages/ra-core/src/controller/list/ListController.tsx
+++ b/packages/ra-core/src/controller/list/ListController.tsx
@@ -1,3 +1,4 @@
+import { RaRecord } from '../../types';
 import {
     useListController,
     ListControllerProps,
@@ -17,12 +18,17 @@ import {
  *     </ListController>
  * )
  */
-export const ListController = ({
+export const ListController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>({
     children,
     ...props
 }: {
-    children: (params: ListControllerResult) => JSX.Element;
-} & ListControllerProps) => {
-    const controllerProps = useListController(props);
+    children: (
+        params: ListControllerResult<RecordType, ErrorType>
+    ) => JSX.Element;
+} & ListControllerProps<RecordType, ErrorType>) => {
+    const controllerProps = useListController<RecordType, ErrorType>(props);
     return children(controllerProps);
 };

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -40,9 +40,12 @@ import type {
  *     return <ListView {...controllerProps} {...props} />;
  * }
  */
-export const useInfiniteListController = <RecordType extends RaRecord = any>(
-    props: InfiniteListControllerProps<RecordType> = {}
-): InfiniteListControllerResult<RecordType> => {
+export const useInfiniteListController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: InfiniteListControllerProps<RecordType, ErrorType> = {}
+): InfiniteListControllerResult<RecordType, ErrorType> => {
     const {
         debounce = 500,
         disableAuthentication = false,
@@ -109,7 +112,7 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
         fetchPreviousPage,
         isFetchingPreviousPage,
         refetch,
-    } = useInfiniteGetList<RecordType>(
+    } = useInfiniteGetList<RecordType, ErrorType>(
         resource,
         {
             pagination: {
@@ -127,12 +130,15 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
             placeholderData: previousData => previousData,
             retry: false,
             onError: error =>
-                notify(error?.message || 'ra.notification.http_error', {
-                    type: 'error',
-                    messageArgs: {
-                        _: error?.message,
-                    },
-                }),
+                notify(
+                    (error as Error)?.message || 'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _: (error as Error)?.message,
+                        },
+                    }
+                ),
             ...otherQueryOptions,
         }
     );
@@ -218,11 +224,12 @@ export const useInfiniteListController = <RecordType extends RaRecord = any>(
         isFetchingNextPage,
         fetchPreviousPage,
         isFetchingPreviousPage,
-    } as InfiniteListControllerResult<RecordType>;
+    } as InfiniteListControllerResult<RecordType, ErrorType>;
 };
 
 export interface InfiniteListControllerProps<
     RecordType extends RaRecord = any,
+    ErrorType = Error,
 > {
     debounce?: number;
     disableAuthentication?: boolean;
@@ -234,24 +241,30 @@ export interface InfiniteListControllerProps<
     filter?: FilterPayload;
     filterDefaultValues?: object;
     perPage?: number;
-    queryOptions?: UseInfiniteGetListOptions<RecordType>;
+    queryOptions?: UseInfiniteGetListOptions<RecordType, ErrorType>;
     resource?: string;
     sort?: SortPayload;
     storeKey?: string | false;
 }
 
-export type InfiniteListControllerResult<RecordType extends RaRecord = any> =
-    ListControllerResult<RecordType> & {
-        fetchNextPage: InfiniteQueryObserverBaseResult<
-            InfiniteData<GetInfiniteListResult<RecordType>>
-        >['fetchNextPage'];
-        fetchPreviousPage: InfiniteQueryObserverBaseResult<
-            InfiniteData<GetInfiniteListResult<RecordType>>
-        >['fetchPreviousPage'];
-        isFetchingNextPage: InfiniteQueryObserverBaseResult<
-            InfiniteData<GetInfiniteListResult<RecordType>>
-        >['isFetchingNextPage'];
-        isFetchingPreviousPage: InfiniteQueryObserverBaseResult<
-            InfiniteData<GetInfiniteListResult<RecordType>>
-        >['isFetchingPreviousPage'];
-    };
+export type InfiniteListControllerResult<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = ListControllerResult<RecordType> & {
+    fetchNextPage: InfiniteQueryObserverBaseResult<
+        InfiniteData<GetInfiniteListResult<RecordType>>,
+        ErrorType
+    >['fetchNextPage'];
+    fetchPreviousPage: InfiniteQueryObserverBaseResult<
+        InfiniteData<GetInfiniteListResult<RecordType>>,
+        ErrorType
+    >['fetchPreviousPage'];
+    isFetchingNextPage: InfiniteQueryObserverBaseResult<
+        InfiniteData<GetInfiniteListResult<RecordType>>,
+        ErrorType
+    >['isFetchingNextPage'];
+    isFetchingPreviousPage: InfiniteQueryObserverBaseResult<
+        InfiniteData<GetInfiniteListResult<RecordType>>,
+        ErrorType
+    >['isFetchingPreviousPage'];
+};

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -52,9 +52,9 @@ const refetch = () => {
  * @param {SortPayload} props.sort: Optional. The initial sort (field and order)
  * @param {filterCallback} prop.filterCallback Optional. A function that allows you to make a custom filter
  */
-export const useList = <RecordType extends RaRecord = any>(
-    props: UseListOptions<RecordType>
-): UseListValue<RecordType> => {
+export const useList = <RecordType extends RaRecord = any, ErrorType = Error>(
+    props: UseListOptions<RecordType, ErrorType>
+): UseListValue<RecordType, ErrorType> => {
     const {
         data,
         error,
@@ -304,12 +304,15 @@ export const useList = <RecordType extends RaRecord = any>(
         setSort,
         showFilter,
         total: finalItems?.total,
-    } as UseListValue<RecordType>;
+    } as UseListValue<RecordType, ErrorType>;
 };
 
-export interface UseListOptions<RecordType extends RaRecord = any> {
+export interface UseListOptions<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> {
     data?: RecordType[];
-    error?: any;
+    error?: ErrorType | null;
     filter?: FilterPayload;
     isFetching?: boolean;
     isLoading?: boolean;
@@ -321,7 +324,9 @@ export interface UseListOptions<RecordType extends RaRecord = any> {
     filterCallback?: (record: RecordType) => boolean;
 }
 
-export type UseListValue<RecordType extends RaRecord = any> =
-    ListControllerResult<RecordType>;
+export type UseListValue<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = ListControllerResult<RecordType, ErrorType>;
 
 const defaultFilter = {};

--- a/packages/ra-core/src/controller/list/useListContext.ts
+++ b/packages/ra-core/src/controller/list/useListContext.ts
@@ -62,12 +62,13 @@ import { RaRecord } from '../../types';
  */
 export const useListContext = <
     RecordType extends RaRecord = any,
->(): ListControllerResult<RecordType> => {
+    ErrorType = Error,
+>(): ListControllerResult<RecordType, ErrorType> => {
     const context = useContext(ListContext);
     if (!context) {
         throw new Error(
             'useListContext must be used inside a ListContextProvider'
         );
     }
-    return context;
+    return context as ListControllerResult<RecordType, ErrorType>;
 };

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -42,9 +42,12 @@ import type {
  *     return <ListView {...controllerProps} {...props} />;
  * }
  */
-export const useListController = <RecordType extends RaRecord = any>(
-    props: ListControllerProps<RecordType> = {}
-): ListControllerResult<RecordType> => {
+export const useListController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: ListControllerProps<RecordType, ErrorType> = {}
+): ListControllerResult<RecordType, ErrorType> => {
     const {
         debounce = 500,
         disableAuthentication = false,
@@ -114,7 +117,7 @@ export const useListController = <RecordType extends RaRecord = any>(
         isFetching,
         isPending,
         refetch,
-    } = useGetList<RecordType>(
+    } = useGetList<RecordType, ErrorType>(
         resource,
         {
             pagination: {
@@ -132,12 +135,15 @@ export const useListController = <RecordType extends RaRecord = any>(
             placeholderData: previousData => previousData,
             retry: false,
             onError: error =>
-                notify(error?.message || 'ra.notification.http_error', {
-                    type: 'error',
-                    messageArgs: {
-                        _: error?.message,
-                    },
-                }),
+                notify(
+                    (error as Error)?.message || 'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _: (error as Error)?.message,
+                        },
+                    }
+                ),
             ...otherQueryOptions,
         }
     );
@@ -219,10 +225,13 @@ export const useListController = <RecordType extends RaRecord = any>(
               ? query.page * query.perPage < total
               : undefined,
         hasPreviousPage: pageInfo ? pageInfo.hasPreviousPage : query.page > 1,
-    } as ListControllerResult<RecordType>;
+    } as ListControllerResult<RecordType, ErrorType>;
 };
 
-export interface ListControllerProps<RecordType extends RaRecord = any> {
+export interface ListControllerProps<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> {
     /**
      * The debounce delay for filter queries in milliseconds. Defaults to 500ms.
      *
@@ -380,7 +389,7 @@ export interface ListControllerProps<RecordType extends RaRecord = any> {
      *     );
      * }
      */
-    queryOptions?: UseGetListOptions<RecordType>;
+    queryOptions?: UseGetListOptions<RecordType, ErrorType>;
 
     /**
      * The resource name. Defaults to the resource from ResourceContext.
@@ -559,8 +568,11 @@ export interface ListControllerSuccessResult<RecordType extends RaRecord = any>
     isPending: false;
 }
 
-export type ListControllerResult<RecordType extends RaRecord = any> =
+export type ListControllerResult<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> =
     | ListControllerLoadingResult<RecordType>
-    | ListControllerErrorResult<RecordType>
-    | ListControllerRefetchErrorResult<RecordType>
+    | ListControllerErrorResult<RecordType, ErrorType>
+    | ListControllerRefetchErrorResult<RecordType, ErrorType>
     | ListControllerSuccessResult<RecordType>;

--- a/packages/ra-core/src/controller/show/ShowController.tsx
+++ b/packages/ra-core/src/controller/show/ShowController.tsx
@@ -1,3 +1,4 @@
+import { RaRecord } from '../../types';
 import {
     useShowController,
     ShowControllerProps,
@@ -17,12 +18,17 @@ import {
  *     </ShowController>
  * );
  */
-export const ShowController = ({
+export const ShowController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>({
     children,
     ...props
 }: {
-    children: (params: ShowControllerResult) => JSX.Element;
-} & ShowControllerProps) => {
-    const controllerProps = useShowController(props);
+    children: (
+        params: ShowControllerResult<RecordType, ErrorType>
+    ) => JSX.Element;
+} & ShowControllerProps<RecordType, ErrorType>) => {
+    const controllerProps = useShowController<RecordType, ErrorType>(props);
     return children(controllerProps);
 };

--- a/packages/ra-core/src/controller/show/ShowController.tsx
+++ b/packages/ra-core/src/controller/show/ShowController.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { RaRecord } from '../../types';
 import {
     useShowController,
@@ -27,7 +28,7 @@ export const ShowController = <
 }: {
     children: (
         params: ShowControllerResult<RecordType, ErrorType>
-    ) => JSX.Element;
+    ) => ReactNode;
 } & ShowControllerProps<RecordType, ErrorType>) => {
     const controllerProps = useShowController<RecordType, ErrorType>(props);
     return children(controllerProps);

--- a/packages/ra-core/src/controller/show/useShowContext.tsx
+++ b/packages/ra-core/src/controller/show/useShowContext.tsx
@@ -15,7 +15,8 @@ import { ShowControllerResult } from './useShowController';
  */
 export const useShowContext = <
     RecordType extends RaRecord = any,
->(): ShowControllerResult<RecordType> => {
+    ErrorType = Error,
+>(): ShowControllerResult<RecordType, ErrorType> => {
     const context = useContext(ShowContext);
     // Props take precedence over the context
     if (!context) {
@@ -23,5 +24,5 @@ export const useShowContext = <
             'useShowContext must be used inside a ShowContextProvider'
         );
     }
-    return context;
+    return context as ShowControllerResult<RecordType, ErrorType>;
 };

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -49,9 +49,12 @@ import {
  *     return <ShowView {...controllerProps} />;
  * };
  */
-export const useShowController = <RecordType extends RaRecord = any>(
-    props: ShowControllerProps<RecordType> = {}
-): ShowControllerResult<RecordType> => {
+export const useShowController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: ShowControllerProps<RecordType, ErrorType> = {}
+): ShowControllerResult<RecordType, ErrorType> => {
     const {
         disableAuthentication = false,
         id: propsId,
@@ -96,7 +99,7 @@ export const useShowController = <RecordType extends RaRecord = any>(
         isFetching,
         isPending,
         refetch,
-    } = useGetOne<RecordType>(
+    } = useGetOne<RecordType, ErrorType>(
         resource,
         { id, meta },
         {
@@ -143,13 +146,16 @@ export const useShowController = <RecordType extends RaRecord = any>(
         record,
         refetch,
         resource,
-    } as ShowControllerResult<RecordType>;
+    } as ShowControllerResult<RecordType, ErrorType>;
 };
 
-export interface ShowControllerProps<RecordType extends RaRecord = any> {
+export interface ShowControllerProps<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> {
     disableAuthentication?: boolean;
     id?: RecordType['id'];
-    queryOptions?: UseGetOneOptions<RecordType>;
+    queryOptions?: UseGetOneOptions<RecordType, ErrorType>;
     resource?: string;
 }
 
@@ -191,8 +197,11 @@ export interface ShowControllerSuccessResult<RecordType extends RaRecord = any>
     isPending: false;
 }
 
-export type ShowControllerResult<RecordType extends RaRecord = any> =
+export type ShowControllerResult<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> =
     | ShowControllerLoadingResult<RecordType>
-    | ShowControllerLoadingErrorResult<RecordType>
-    | ShowControllerRefetchErrorResult<RecordType>
+    | ShowControllerLoadingErrorResult<RecordType, ErrorType>
+    | ShowControllerRefetchErrorResult<RecordType, ErrorType>
     | ShowControllerSuccessResult<RecordType>;

--- a/packages/ra-core/src/controller/useReference.ts
+++ b/packages/ra-core/src/controller/useReference.ts
@@ -2,21 +2,30 @@ import { RaRecord, Identifier } from '../types';
 import { UseGetManyHookValue, useGetManyAggregate } from '../dataProvider';
 import { UseQueryOptions } from '@tanstack/react-query';
 
-interface UseReferenceProps<RecordType extends RaRecord = any> {
+interface UseReferenceProps<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> {
     id: Identifier;
     reference: string;
-    options?: Omit<UseQueryOptions<RecordType[]>, 'queryFn' | 'queryKey'> & {
+    options?: Omit<
+        UseQueryOptions<RecordType[], ErrorType>,
+        'queryFn' | 'queryKey'
+    > & {
         meta?: any;
     };
 }
 
-export interface UseReferenceResult<RecordType extends RaRecord = any> {
+export interface UseReferenceResult<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> {
     isLoading: boolean;
     isPending: boolean;
     isFetching: boolean;
     referenceRecord?: RecordType;
-    error?: any;
-    refetch: UseGetManyHookValue<RecordType>['refetch'];
+    error?: ErrorType | null;
+    refetch: UseGetManyHookValue<RecordType, ErrorType>['refetch'];
 }
 
 /**
@@ -47,14 +56,20 @@ export interface UseReferenceResult<RecordType extends RaRecord = any> {
  *
  * @returns {UseReferenceResult} The reference record
  */
-export const useReference = <RecordType extends RaRecord = RaRecord>({
+export const useReference = <
+    RecordType extends RaRecord = RaRecord,
+    ErrorType = Error,
+>({
     reference,
     id,
     options = {},
-}: UseReferenceProps<RecordType>): UseReferenceResult<RecordType> => {
+}: UseReferenceProps<RecordType, ErrorType>): UseReferenceResult<
+    RecordType,
+    ErrorType
+> => {
     const { meta, ...otherQueryOptions } = options;
     const { data, error, isLoading, isFetching, isPending, refetch } =
-        useGetManyAggregate<RecordType>(
+        useGetManyAggregate<RecordType, ErrorType>(
             reference,
             { ids: [id], meta },
             otherQueryOptions

--- a/packages/ra-core/src/dataProvider/useGetList.ts
+++ b/packages/ra-core/src/dataProvider/useGetList.ts
@@ -54,10 +54,13 @@ const MAX_DATA_LENGTH_TO_CACHE = 100;
  *     )}</ul>;
  * };
  */
-export const useGetList = <RecordType extends RaRecord = any>(
+export const useGetList = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
     resource: string,
     params: Partial<GetListParams> = {},
-    options: UseGetListOptions<RecordType> = {}
+    options: UseGetListOptions<RecordType, ErrorType> = {}
 ): UseGetListHookValue<RecordType> => {
     const {
         pagination = { page: 1, perPage: 25 },
@@ -79,7 +82,7 @@ export const useGetList = <RecordType extends RaRecord = any>(
 
     const result = useQuery<
         GetListResult<RecordType>,
-        Error,
+        ErrorType,
         GetListResult<RecordType>
     >({
         queryKey: [resource, 'getList', { pagination, sort, filter, meta }],
@@ -185,15 +188,18 @@ export const useGetList = <RecordType extends RaRecord = any>(
 
 const noop = () => undefined;
 
-export type UseGetListOptions<RecordType extends RaRecord = any> = Omit<
-    UseQueryOptions<GetListResult<RecordType>, Error>,
+export type UseGetListOptions<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = Omit<
+    UseQueryOptions<GetListResult<RecordType>, ErrorType>,
     'queryKey' | 'queryFn'
 > & {
     onSuccess?: (value: GetListResult<RecordType>) => void;
-    onError?: (error: Error) => void;
+    onError?: (error: ErrorType) => void;
     onSettled?: (
         data?: GetListResult<RecordType>,
-        error?: Error | null
+        error?: ErrorType | null
     ) => void;
 };
 

--- a/packages/ra-core/src/dataProvider/useGetMany.ts
+++ b/packages/ra-core/src/dataProvider/useGetMany.ts
@@ -50,11 +50,14 @@ import { useEvent } from '../util';
  *     )}</ul>;
  * };
  */
-export const useGetMany = <RecordType extends RaRecord = any>(
+export const useGetMany = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
     resource: string,
     params: Partial<GetManyParams<RecordType>>,
-    options: UseGetManyOptions<RecordType> = {}
-): UseGetManyHookValue<RecordType> => {
+    options: UseGetManyOptions<RecordType, ErrorType> = {}
+): UseGetManyHookValue<RecordType, ErrorType> => {
     const { ids, meta } = params;
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
@@ -69,7 +72,7 @@ export const useGetMany = <RecordType extends RaRecord = any>(
     const onErrorEvent = useEvent(onError);
     const onSettledEvent = useEvent(onSettled);
 
-    const result = useQuery<RecordType[], Error, RecordType[]>({
+    const result = useQuery<RecordType[], ErrorType, RecordType[]>({
         queryKey: [
             resource,
             'getMany',
@@ -176,14 +179,16 @@ export const useGetMany = <RecordType extends RaRecord = any>(
 
 const noop = () => undefined;
 
-export type UseGetManyOptions<RecordType extends RaRecord = any> = Omit<
-    UseQueryOptions<RecordType[], Error>,
-    'queryKey' | 'queryFn'
-> & {
+export type UseGetManyOptions<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = Omit<UseQueryOptions<RecordType[], ErrorType>, 'queryKey' | 'queryFn'> & {
     onSuccess?: (data: RecordType[]) => void;
-    onError?: (error: Error) => void;
-    onSettled?: (data?: RecordType[], error?: Error | null) => void;
+    onError?: (error: ErrorType) => void;
+    onSettled?: (data?: RecordType[], error?: ErrorType | null) => void;
 };
 
-export type UseGetManyHookValue<RecordType extends RaRecord = any> =
-    UseQueryResult<RecordType[], Error>;
+export type UseGetManyHookValue<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = UseQueryResult<RecordType[], ErrorType>;

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -65,11 +65,14 @@ import { useEvent } from '../util';
  *      );
  * };
  */
-export const useGetManyAggregate = <RecordType extends RaRecord = any>(
+export const useGetManyAggregate = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
     resource: string,
     params: Partial<GetManyParams<RecordType>>,
-    options: UseGetManyAggregateOptions<RecordType> = {}
-): UseGetManyHookValue<RecordType> => {
+    options: UseGetManyAggregateOptions<RecordType, ErrorType> = {}
+): UseGetManyHookValue<RecordType, ErrorType> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
     const {
@@ -99,7 +102,7 @@ export const useGetManyAggregate = <RecordType extends RaRecord = any>(
         }
     }, [ids, queryClient, resource, meta]);
 
-    const result = useQuery<RecordType[], Error, RecordType[]>({
+    const result = useQuery<RecordType[], ErrorType, RecordType[]>({
         queryKey: [
             resource,
             'getMany',
@@ -373,11 +376,11 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
 
 const noop = () => undefined;
 
-export type UseGetManyAggregateOptions<RecordType extends RaRecord> = Omit<
-    UseQueryOptions<RecordType[]>,
-    'queryKey' | 'queryFn'
-> & {
+export type UseGetManyAggregateOptions<
+    RecordType extends RaRecord,
+    ErrorType = Error,
+> = Omit<UseQueryOptions<RecordType[], ErrorType>, 'queryKey' | 'queryFn'> & {
     onSuccess?: (data: RecordType[]) => void;
-    onError?: (error: Error) => void;
-    onSettled?: (data?: RecordType[], error?: Error | null) => void;
+    onError?: (error: ErrorType) => void;
+    onSettled?: (data?: RecordType[], error?: ErrorType | null) => void;
 };

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -88,11 +88,7 @@ export const useGetManyReference = <
     const onErrorEvent = useEvent(onError);
     const onSettledEvent = useEvent(onSettled);
 
-    const result = useQuery<
-        GetManyReferenceResult<RecordType>,
-        ErrorType,
-        GetManyReferenceResult<RecordType>
-    >({
+    const result = useQuery<GetManyReferenceResult<RecordType>, ErrorType>({
         queryKey: [
             resource,
             'getManyReference',

--- a/packages/ra-core/src/dataProvider/useGetManyReference.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyReference.ts
@@ -60,11 +60,14 @@ import { useEvent } from '../util';
  *     )}</ul>;
  * };
  */
-export const useGetManyReference = <RecordType extends RaRecord = any>(
+export const useGetManyReference = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
     resource: string,
     params: Partial<GetManyReferenceParams> = {},
-    options: UseGetManyReferenceHookOptions<RecordType> = {}
-): UseGetManyReferenceHookValue<RecordType> => {
+    options: UseGetManyReferenceHookOptions<RecordType, ErrorType> = {}
+): UseGetManyReferenceHookValue<RecordType, ErrorType> => {
     const {
         target,
         id,
@@ -87,7 +90,7 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
 
     const result = useQuery<
         GetManyReferenceResult<RecordType>,
-        Error,
+        ErrorType,
         GetManyReferenceResult<RecordType>
     >({
         queryKey: [
@@ -156,7 +159,7 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
                   }
                 : result,
         [result]
-    ) as UseQueryResult<RecordType[], Error> & {
+    ) as UseQueryResult<RecordType[], ErrorType> & {
         total?: number;
         pageInfo?: {
             hasNextPage?: boolean;
@@ -166,27 +169,31 @@ export const useGetManyReference = <RecordType extends RaRecord = any>(
     };
 };
 
-export type UseGetManyReferenceHookOptions<RecordType extends RaRecord = any> =
-    Omit<
-        UseQueryOptions<GetManyReferenceResult<RecordType>>,
-        'queryKey' | 'queryFn'
-    > & {
-        onSuccess?: (data: GetManyReferenceResult<RecordType>) => void;
-        onError?: (error: Error) => void;
-        onSettled?: (
-            data?: GetManyReferenceResult<RecordType>,
-            error?: Error | null
-        ) => void;
-    };
+export type UseGetManyReferenceHookOptions<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = Omit<
+    UseQueryOptions<GetManyReferenceResult<RecordType>, ErrorType>,
+    'queryKey' | 'queryFn'
+> & {
+    onSuccess?: (data: GetManyReferenceResult<RecordType>) => void;
+    onError?: (error: ErrorType) => void;
+    onSettled?: (
+        data?: GetManyReferenceResult<RecordType>,
+        error?: ErrorType | null
+    ) => void;
+};
 
-export type UseGetManyReferenceHookValue<RecordType extends RaRecord = any> =
-    UseQueryResult<RecordType[]> & {
-        total?: number;
-        pageInfo?: {
-            hasNextPage?: boolean;
-            hasPreviousPage?: boolean;
-        };
-        meta?: any;
+export type UseGetManyReferenceHookValue<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = UseQueryResult<RecordType[], ErrorType> & {
+    total?: number;
+    pageInfo?: {
+        hasNextPage?: boolean;
+        hasPreviousPage?: boolean;
     };
+    meta?: any;
+};
 
 const noop = () => undefined;

--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -47,11 +47,11 @@ import { useEvent } from '../util';
  *     return <div>User {data.username}</div>;
  * };
  */
-export const useGetOne = <RecordType extends RaRecord = any>(
+export const useGetOne = <RecordType extends RaRecord = any, ErrorType = Error>(
     resource: string,
     { id, meta }: Partial<GetOneParams<RecordType>>,
-    options: UseGetOneOptions<RecordType> = {}
-): UseGetOneHookValue<RecordType> => {
+    options: UseGetOneOptions<RecordType, ErrorType> = {}
+): UseGetOneHookValue<RecordType, ErrorType> => {
     const dataProvider = useDataProvider();
     const {
         onError = noop,
@@ -64,7 +64,7 @@ export const useGetOne = <RecordType extends RaRecord = any>(
     const onErrorEvent = useEvent(onError);
     const onSettledEvent = useEvent(onSettled);
 
-    const result = useQuery<RecordType>({
+    const result = useQuery<RecordType, ErrorType>({
         // Sometimes the id comes as a string (e.g. when read from the URL in a Show view).
         // Sometimes the id comes as a number (e.g. when read from a Record in useGetList response).
         // As the react-query cache is type-sensitive, we always stringify the identifier to get a match
@@ -117,17 +117,22 @@ export const useGetOne = <RecordType extends RaRecord = any>(
 
 const noop = () => undefined;
 
-export type UseGetOneOptions<RecordType extends RaRecord = any> = Omit<
-    UseQueryOptions<GetOneResult<RecordType>['data']>,
+export type UseGetOneOptions<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = Omit<
+    UseQueryOptions<GetOneResult<RecordType>['data'], ErrorType>,
     'queryKey' | 'queryFn'
 > & {
     onSuccess?: (data: GetOneResult<RecordType>['data']) => void;
-    onError?: (error: Error) => void;
+    onError?: (error: ErrorType) => void;
     onSettled?: (
         data?: GetOneResult<RecordType>['data'],
-        error?: Error | null
+        error?: ErrorType | null
     ) => void;
 };
 
-export type UseGetOneHookValue<RecordType extends RaRecord = any> =
-    UseQueryResult<GetOneResult<RecordType>['data']>;
+export type UseGetOneHookValue<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = UseQueryResult<GetOneResult<RecordType>['data'], ErrorType>;

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.ts
@@ -66,11 +66,14 @@ const MAX_DATA_LENGTH_TO_CACHE = 100;
  * };
  */
 
-export const useInfiniteGetList = <RecordType extends RaRecord = any>(
+export const useInfiniteGetList = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
     resource: string,
     params: Partial<GetListParams> = {},
-    options: UseInfiniteGetListOptions<RecordType> = {}
-): UseInfiniteGetListHookValue<RecordType> => {
+    options: UseInfiniteGetListOptions<RecordType, ErrorType> = {}
+): UseInfiniteGetListHookValue<RecordType, ErrorType> => {
     const {
         pagination = { page: 1, perPage: 25 },
         sort = { field: 'id', order: 'DESC' },
@@ -91,7 +94,7 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
 
     const result = useInfiniteQuery<
         GetInfiniteListResult<RecordType>,
-        Error,
+        ErrorType,
         InfiniteData<GetInfiniteListResult<RecordType>>,
         QueryKey,
         number
@@ -228,7 +231,7 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
             : result
     ) as UseInfiniteQueryResult<
         InfiniteData<GetInfiniteListResult<RecordType>>,
-        Error
+        ErrorType
     > & {
         total?: number;
         meta?: any;
@@ -237,10 +240,13 @@ export const useInfiniteGetList = <RecordType extends RaRecord = any>(
 
 const noop = () => undefined;
 
-export type UseInfiniteGetListOptions<RecordType extends RaRecord = any> = Omit<
+export type UseInfiniteGetListOptions<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = Omit<
     UseInfiniteQueryOptions<
         GetInfiniteListResult<RecordType>,
-        Error,
+        ErrorType,
         InfiniteData<GetInfiniteListResult<RecordType>>,
         GetInfiniteListResult<RecordType>,
         QueryKey,
@@ -253,15 +259,20 @@ export type UseInfiniteGetListOptions<RecordType extends RaRecord = any> = Omit<
     | 'initialPageParam'
 > & {
     onSuccess?: (data: InfiniteData<GetInfiniteListResult<RecordType>>) => void;
-    onError?: (error: Error) => void;
+    onError?: (error: ErrorType) => void;
     onSettled?: (
         data?: InfiniteData<GetInfiniteListResult<RecordType>>,
-        error?: Error | null
+        error?: ErrorType | null
     ) => void;
 };
 
-export type UseInfiniteGetListHookValue<RecordType extends RaRecord = any> =
-    UseInfiniteQueryResult<InfiniteData<GetInfiniteListResult<RecordType>>> & {
-        total?: number;
-        pageParam?: number;
-    };
+export type UseInfiniteGetListHookValue<
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+> = UseInfiniteQueryResult<
+    InfiniteData<GetInfiniteListResult<RecordType>>,
+    ErrorType
+> & {
+    total?: number;
+    pageParam?: number;
+};

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -481,7 +481,7 @@ describe('<ReferenceField />', () => {
             hidden: true,
         });
         expect(ErrorIcon).not.toBeNull();
-        expect(ErrorIcon?.getAttribute('aria-errormessage')).toBe('boo');
+        await screen.findByText('boo');
     });
 
     describe('link', () => {

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -19,6 +19,7 @@ import { LinearProgress } from '../layout';
 import { Link } from '../Link';
 import { FieldProps } from './types';
 import { genericMemo } from './genericMemo';
+import { visuallyHidden } from '@mui/utils';
 
 /**
  * Fetch reference record, and render its representation, or delegate rendering to child component.
@@ -111,13 +112,12 @@ export const ReferenceFieldView = <
 
     if (error) {
         return (
-            <ErrorIcon
-                aria-errormessage={
-                    typeof error === 'string' ? error : error?.message
-                }
-                color="error"
-                fontSize="small"
-            />
+            <div>
+                <ErrorIcon role="presentation" color="error" fontSize="small" />
+                <span style={visuallyHidden}>
+                    {typeof error === 'string' ? error : error?.message}
+                </span>
+            </div>
         );
     }
     // We explicitly check isLoading here as the record may not have an id for the reference,

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -111,14 +111,14 @@ export const ReferenceFieldView = <
 
     if (error) {
         return (
-            /* eslint-disable jsx-a11y/role-supports-aria-props */
             <ErrorIcon
-                aria-errormessage={error.message ? error.message : error}
+                aria-errormessage={
+                    typeof error === 'string' ? error : error?.message
+                }
                 role="presentation"
                 color="error"
                 fontSize="small"
             />
-            /* eslint-enable */
         );
     }
     // We explicitly check isLoading here as the record may not have an id for the reference,

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -115,7 +115,6 @@ export const ReferenceFieldView = <
                 aria-errormessage={
                     typeof error === 'string' ? error : error?.message
                 }
-                role="presentation"
                 color="error"
                 fontSize="small"
             />


### PR DESCRIPTION
## Problem

Many of our hooks do not allow to provide the `Error` type.

## Solution

Allow providing error type in dataProvider and controllers hooks

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
