### PR TITLE
Fix useDelete does not invalidate cache in pessimistic mode

### DIFF
--- a/packages/ra-core/src/dataProvider/useDelete.pessimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.pessimistic.stories.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
+import fakeRestDataProvider from 'ra-data-fakerest';
 
 import { CoreAdminContext } from '../core';
+import { ListController } from '../controller/list';
 import { useDelete } from './useDelete';
 import { useGetList } from './useGetList';
 
@@ -73,6 +75,103 @@ const SuccessCore = () => {
             {success && <div>{success}</div>}
             {isMutating !== 0 && <div>mutating</div>}
         </>
+    );
+};
+
+const DeleteButton = ({ id, resource }) => {
+    const [deleteOne, { isPending }] = useDelete();
+    const handleClick = () => {
+        deleteOne(
+            resource,
+            {
+                id,
+                previousData: { id, title: 'Hello' },
+            },
+            {
+                mutationMode: 'pessimistic',
+            }
+        );
+    };
+    return (
+        <button onClick={handleClick} disabled={isPending}>
+            Delete
+        </button>
+    );
+};
+
+export const InList = () => {
+    const data = {
+        books: [
+            { id: 1, title: 'War and Peace' },
+            { id: 2, title: 'The Little Prince' },
+            { id: 3, title: "Swann's Way" },
+            { id: 4, title: 'A Tale of Two Cities' },
+            { id: 5, title: 'The Lord of the Rings' },
+            { id: 6, title: 'And Then There Were None' },
+            { id: 7, title: 'Dream of the Red Chamber' },
+            { id: 8, title: 'The Hobbit' },
+            { id: 9, title: 'She: A History of Adventure' },
+            { id: 10, title: 'The Lion, the Witch and the Wardrobe' },
+            { id: 11, title: 'The Chronicles of Narnia' },
+            { id: 12, title: 'Pride and Prejudice' },
+            { id: 13, title: 'Ulysses' },
+            { id: 14, title: 'The Catcher in the Rye' },
+            { id: 15, title: 'The Little Mermaid' },
+            { id: 16, title: 'The Secret Garden' },
+            { id: 17, title: 'The Wind in the Willows' },
+            { id: 18, title: 'The Wizard of Oz' },
+            { id: 19, title: 'Madam Bovary' },
+            { id: 20, title: 'The Little House' },
+            { id: 21, title: 'The Phantom of the Opera' },
+            { id: 22, title: 'The Adventures of Tom Sawyer' },
+            { id: 23, title: 'The Adventures of Huckleberry Finn' },
+            { id: 24, title: 'The Time Machine' },
+            { id: 25, title: 'The War of the Worlds' },
+        ],
+    };
+    const dataProvider = fakeRestDataProvider(
+        data,
+        process.env.NODE_ENV === 'development',
+        process.env.NODE_ENV === 'development' ? 500 : 0
+    );
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <ListController resource="books">
+                {({ data, total }) =>
+                    data && (
+                        <table>
+                            <tbody>
+                                {data.map((record: any) => (
+                                    <tr key={record.id}>
+                                        <td>{record.id}</td>
+                                        <td>{record.title}</td>
+                                        <td>
+                                            <DeleteButton
+                                                id={record.id}
+                                                resource="books"
+                                            />
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <td
+                                        colSpan={3}
+                                        style={{ textAlign: 'center' }}
+                                    >
+                                        Books 1-{data.length} on {total}
+                                    </td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    )
+                }
+            </ListController>
+        </CoreAdminContext>
     );
 };
 

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -448,10 +448,14 @@ describe('useDelete', () => {
             } as any;
             let localDeleteOne;
             const Dummy = () => {
-                const [deleteOne] = useDelete('foo', {
-                    id: 1,
-                    previousData: { id: 1, bar: 'bar' },
-                });
+                const [deleteOne] = useDelete(
+                    'foo',
+                    {
+                        id: 1,
+                        previousData: { id: 1, bar: 'bar' },
+                    },
+                    { mutationMode: 'optimistic' }
+                );
                 localDeleteOne = deleteOne;
                 return <span />;
             };
@@ -499,10 +503,14 @@ describe('useDelete', () => {
             } as any;
             let localDeleteOne;
             const Dummy = () => {
-                const [deleteOne] = useDelete('foo', {
-                    id: 1,
-                    previousData: { id: 1, bar: 'bar' },
-                });
+                const [deleteOne] = useDelete(
+                    'foo',
+                    {
+                        id: 1,
+                        previousData: { id: 1, bar: 'bar' },
+                    },
+                    { mutationMode: 'optimistic' }
+                );
                 localDeleteOne = deleteOne;
                 return <span />;
             };
@@ -555,10 +563,14 @@ describe('useDelete', () => {
             } as any;
             let localDeleteOne;
             const Dummy = () => {
-                const [deleteOne] = useDelete('foo', {
-                    id: 1,
-                    previousData: { id: 1, bar: 'bar' },
-                });
+                const [deleteOne] = useDelete(
+                    'foo',
+                    {
+                        id: 1,
+                        previousData: { id: 1, bar: 'bar' },
+                    },
+                    { mutationMode: 'optimistic' }
+                );
                 localDeleteOne = deleteOne;
                 return <span />;
             };

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -9,6 +9,7 @@ import { useDelete } from './useDelete';
 import {
     ErrorCase as ErrorCasePessimistic,
     SuccessCase as SuccessCasePessimistic,
+    InList,
 } from './useDelete.pessimistic.stories';
 import {
     ErrorCase as ErrorCaseOptimistic,
@@ -313,6 +314,25 @@ describe('useDelete', () => {
                 },
                 { timeout: 4000 }
             );
+        });
+        it('when pessimistic, forces a refresh of related queries', async () => {
+            render(<InList />);
+            await screen.findByText('Books 1-10 on 25');
+            // Element #2 is there
+            expect(screen.queryByText('The Little Prince')).not.toBeNull();
+            // Element #11 is not in this page
+            expect(screen.queryByText('The Chronicles of Narnia')).toBeNull();
+            // Delete element #2
+            const TheLittlePrinceDeleteButton =
+                screen.queryAllByText('Delete')[1];
+            TheLittlePrinceDeleteButton.click();
+            await screen.findByText('Books 1-10 on 24');
+            // Element #2 is not there anymore
+            expect(screen.queryByText('The Little Prince')).toBeNull();
+            // The list was refetched, so a new element appeared at the end
+            expect(
+                screen.queryByText('The Chronicles of Narnia')
+            ).not.toBeNull();
         });
         it('when optimistic, displays result and success side effects right away', async () => {
             jest.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -256,6 +256,16 @@ export const useDelete = <
             context: unknown
         ) => {
             if (mode.current === 'pessimistic') {
+                // update the getOne and getList query cache with the new result
+                const {
+                    resource: callTimeResource = resource,
+                    id: callTimeId = id,
+                } = variables;
+                updateCache({
+                    resource: callTimeResource,
+                    id: callTimeId,
+                });
+
                 if (
                     mutationOptions.onSuccess &&
                     !hasCallTimeOnSuccess.current

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -256,16 +256,6 @@ export const useDelete = <
             context: unknown
         ) => {
             if (mode.current === 'pessimistic') {
-                // update the getOne and getList query cache with the new result
-                const {
-                    resource: callTimeResource = resource,
-                    id: callTimeId = id,
-                } = variables;
-                updateCache({
-                    resource: callTimeResource,
-                    id: callTimeId,
-                });
-
                 if (
                     mutationOptions.onSuccess &&
                     !hasCallTimeOnSuccess.current
@@ -281,12 +271,10 @@ export const useDelete = <
             variables: Partial<UseDeleteMutateParams<RecordType>> = {},
             context: { snapshot: Snapshot }
         ) => {
-            if (mode.current === 'optimistic' || mode.current === 'undoable') {
-                // Always refetch after error or success:
-                context.snapshot.forEach(([queryKey]) => {
-                    queryClient.invalidateQueries({ queryKey });
-                });
-            }
+            // Always refetch after error or success:
+            context.snapshot.forEach(([queryKey]) => {
+                queryClient.invalidateQueries({ queryKey });
+            });
 
             if (mutationOptions.onSettled && !hasCallTimeOnSettled.current) {
                 return mutationOptions.onSettled(
@@ -330,13 +318,6 @@ export const useDelete = <
             mode.current = mutationMode;
         }
 
-        if (mode.current === 'pessimistic') {
-            return mutation.mutate(
-                { resource: callTimeResource, ...callTimeParams },
-                otherCallTimeOptions
-            );
-        }
-
         const {
             id: callTimeId = id,
             previousData: callTimePreviousData = previousData,
@@ -371,6 +352,13 @@ export const useDelete = <
                 prev.concat(queryClient.getQueriesData({ queryKey })),
             [] as Snapshot
         );
+
+        if (mode.current === 'pessimistic') {
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                otherCallTimeOptions
+            );
+        }
 
         // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
         await Promise.all(

--- a/packages/ra-ui-materialui/src/button/DeleteButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.stories.tsx
@@ -112,6 +112,78 @@ export const FullApp = () => {
     );
 };
 
+const data = {
+    books: [
+        {
+            id: 1,
+            title: 'War and Peace',
+            author: 'Leo Tolstoy',
+            year: 1869,
+        },
+        {
+            id: 2,
+            title: 'Pride and Predjudice',
+            author: 'Jane Austen',
+            year: 1813,
+        },
+        {
+            id: 3,
+            title: 'The Picture of Dorian Gray',
+            author: 'Oscar Wilde',
+            year: 1890,
+        },
+        {
+            id: 4,
+            title: 'Le Petit Prince',
+            author: 'Antoine de Saint-Exupéry',
+            year: 1943,
+        },
+        {
+            id: 5,
+            title: "Alice's Adventures in Wonderland",
+            author: 'Lewis Carroll',
+            year: 1865,
+        },
+        {
+            id: 6,
+            title: 'Madame Bovary',
+            author: 'Gustave Flaubert',
+            year: 1856,
+        },
+        {
+            id: 7,
+            title: 'The Lord of the Rings',
+            author: 'J. R. R. Tolkien',
+            year: 1954,
+        },
+        {
+            id: 8,
+            title: "Harry Potter and the Philosopher's Stone",
+            author: 'J. K. Rowling',
+            year: 1997,
+        },
+        {
+            id: 9,
+            title: 'The Alchemist',
+            author: 'Paulo Coelho',
+            year: 1988,
+        },
+        {
+            id: 10,
+            title: 'A Catcher in the Rye',
+            author: 'J. D. Salinger',
+            year: 1951,
+        },
+        {
+            id: 11,
+            title: 'Ulysses',
+            author: 'James Joyce',
+            year: 1922,
+        },
+    ],
+    authors: [],
+};
+
 const FullAppAdmin = ({ queryClient }: { queryClient: QueryClient }) => {
     const [resourcesAccesses, setResourcesAccesses] = React.useState({
         'books.list': true,
@@ -138,6 +210,10 @@ const FullAppAdmin = ({ queryClient }: { queryClient: QueryClient }) => {
             ),
         getPermissions: () => Promise.resolve(undefined),
     };
+    const dataProvider = fakeRestDataProvider(
+        data,
+        process.env.NODE_ENV === 'development'
+    );
 
     return (
         <AdminContext
@@ -161,18 +237,6 @@ const FullAppAdmin = ({ queryClient }: { queryClient: QueryClient }) => {
             >
                 <Resource name="books" list={BookList} />
             </AdminUI>
-        </AdminContext>
-    );
-};
-
-export const NotificationDefault = () => {
-    const dataProvider = {
-        delete: () => Promise.resolve({ data: { id: 1 } }),
-    } as any;
-    return (
-        <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
-            <DeleteButton record={{ id: 1 }} resource="books" />
-            <Notification />
         </AdminContext>
     );
 };
@@ -231,94 +295,57 @@ const AccessControlLayout = ({
     );
 };
 
-const BookList = () => {
+const BookList = ({ mutationMode = 'undoable' as const }) => (
+    <List>
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="author" />
+            <TextField source="year" />
+            <DeleteButton mutationMode={mutationMode} />
+        </Datagrid>
+    </List>
+);
+
+export const InList = ({ mutationMode }) => {
+    const dataProvider = fakeRestDataProvider(
+        data,
+        process.env.NODE_ENV === 'development',
+        process.env.NODE_ENV === 'development' ? 500 : 0
+    );
     return (
-        <List>
-            <Datagrid>
-                <TextField source="id" />
-                <TextField source="title" />
-                <TextField source="author" />
-                <TextField source="year" />
-                <DeleteButton />
-            </Datagrid>
-        </List>
+        <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+            <AdminUI>
+                <Resource
+                    name="books"
+                    list={() => <BookList mutationMode={mutationMode} />}
+                />
+            </AdminUI>
+        </AdminContext>
     );
 };
 
-const dataProvider = fakeRestDataProvider(
-    {
-        books: [
-            {
-                id: 1,
-                title: 'War and Peace',
-                author: 'Leo Tolstoy',
-                year: 1869,
-            },
-            {
-                id: 2,
-                title: 'Pride and Predjudice',
-                author: 'Jane Austen',
-                year: 1813,
-            },
-            {
-                id: 3,
-                title: 'The Picture of Dorian Gray',
-                author: 'Oscar Wilde',
-                year: 1890,
-            },
-            {
-                id: 4,
-                title: 'Le Petit Prince',
-                author: 'Antoine de Saint-Exupéry',
-                year: 1943,
-            },
-            {
-                id: 5,
-                title: "Alice's Adventures in Wonderland",
-                author: 'Lewis Carroll',
-                year: 1865,
-            },
-            {
-                id: 6,
-                title: 'Madame Bovary',
-                author: 'Gustave Flaubert',
-                year: 1856,
-            },
-            {
-                id: 7,
-                title: 'The Lord of the Rings',
-                author: 'J. R. R. Tolkien',
-                year: 1954,
-            },
-            {
-                id: 8,
-                title: "Harry Potter and the Philosopher's Stone",
-                author: 'J. K. Rowling',
-                year: 1997,
-            },
-            {
-                id: 9,
-                title: 'The Alchemist',
-                author: 'Paulo Coelho',
-                year: 1988,
-            },
-            {
-                id: 10,
-                title: 'A Catcher in the Rye',
-                author: 'J. D. Salinger',
-                year: 1951,
-            },
-            {
-                id: 11,
-                title: 'Ulysses',
-                author: 'James Joyce',
-                year: 1922,
-            },
-        ],
-        authors: [],
+InList.argTypes = {
+    mutationMode: {
+        options: ['undoable', 'optimistic', 'pessimistic'],
+        control: { type: 'select' },
     },
-    process.env.NODE_ENV === 'development'
-);
+};
+InList.args = {
+    mutationMode: 'undoable',
+};
+
+export const NotificationDefault = () => {
+    const dataProvider = {
+        delete: () => Promise.resolve({ data: { id: 1 } }),
+    } as any;
+    return (
+        <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+            <DeleteButton record={{ id: 1 }} resource="books" />
+            <Notification />
+        </AdminContext>
+    );
+};
 
 export const NotificationTranslated = () => {
     const dataProvider = {


### PR DESCRIPTION
## Problem

Whe using pessimistic mode, a call to the delete callback of `useDelete` does not invalidate active queries. 

As a consequence, lists aren't refreshed. This creates buggy behaior in some cases.

For instance, in a list where each row has a DeleteButton in pessimistic mode, clicking on a delete button properly removes the deleted row, but does not update the list, which therefore has less rows than the `perPage`.

https://github.com/user-attachments/assets/33c748ae-7b8c-4843-a1b8-7176e1997005

## Solution

Related queries (getList, getMany, etc) are only invalidated on success on optimistic and undoable mode. They should be invalidated in all modes. 

https://github.com/user-attachments/assets/73766a3a-e18b-4177-b138-1a789245b99a

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-button-deletebutton--in-list&args=mutationMode:pessimistic

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

