### PR TITLE
[Doc] Impove `scrollToTop` in buttons doc and document `_scrollToTop` in `useRedirect` 

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -598,6 +598,14 @@ const PostList = () => (
 
 It also supports [all the other `<Button>` props](#button).
 
+### `scrollToTop`
+
+By default, react-admin scrolls to top on each redirection. You can disable it as follows:
+
+```jsx
+const CloneButtonWithoutScrollToTop = () => <CloneButton scrollToTop={false} />
+```
+
 ### Access Control
 
 If you want to control whether this button should be displayed based on users permissions, use the `<CloneButton>` exported by the `@react-admin/ra-rbac` Enterprise package.
@@ -688,6 +696,14 @@ It also supports [all the other `<Button>` props](#button).
 **Tip**: If you want to link to the Create view manually, use the `/{resource}/create` location.
 
 **Tip:** To allow users to create a record without leaving the current view, use the [`<CreateInDialogButton>`](./CreateInDialogButton.md) component.
+
+### `scrollToTop`
+
+By default, react-admin scrolls to top on each redirection. You can disable it as follows:
+
+```jsx
+const CreateButtonWithoutScrollToTop = () => <CreateButton scrollToTop={false} />
+```
 
 ### `sx`: CSS API
 
@@ -962,6 +978,14 @@ It also supports [all the other `<Button>` props](#button).
 
 **Tip:** To allow users to edit a record without leaving the current view, use the [`<EditInDialogButton>`](./EditInDialogButton.md) component.
 
+### `scrollToTop`
+
+By default, react-admin scrolls to top on each redirection. You can disable it as follows:
+
+```jsx
+const EditButtonWithoutScrollToTop = () => <EditButton scrollToTop={false} />
+```
+
 ### Access Control
 
 If your `authProvider` implements [Access Control](./Permissions.md#access-control), `<EditButton>` will only render if the user has the "edit" access to the related resource.
@@ -1190,6 +1214,14 @@ It also supports [all the other `<Button>` props](#button).
 **Tip**: You can use it as `<Datagrid>` child with no props too. However, you should use the `<Datagrid rowClick="show">` prop instead to avoid using one column for the Edit button.
 
 **Tip**: If you want to link to the Show view manually, use the `/{resource}/{record.id}/show` location.
+
+### `scrollToTop`
+
+By default, react-admin scrolls to top on each redirection. You can disable it as follows:
+
+```jsx
+const ShowButtonWithoutScrollToTop = () => <ShowButton scrollToTop={false} />
+```
 
 ### Access Control
 

--- a/docs/useRedirect.md
+++ b/docs/useRedirect.md
@@ -47,6 +47,14 @@ redirect(false);
 
 Note that `useRedirect` allows redirection to an absolute URL outside the current React app.
 
+**Tip:** By default, react-admin scrolls to top on each redirection. You can disable it as follows:
+
+```jsx
+redirect(`/deals/${deal.id}/show`, undefined, undefined, undefined, {
+    _scrollToTop: false,
+});
+```
+
 **Tip:** For even more specific navigation, you can use the [`useNavigate`](https://reactrouter.com/en/main/hooks/use-navigate) hook from `react-router-dom` as follows:
 
 ```jsx

--- a/docs/useRedirect.md
+++ b/docs/useRedirect.md
@@ -7,6 +7,8 @@ title: "useRedirect"
 
 This hook returns a function that redirects the user to another page.
 
+## Usage
+
 ```jsx
 import { useRedirect } from 'react-admin';
 
@@ -20,13 +22,14 @@ const DashboardButton = () => {
 ```
 
 The callback takes 5 arguments:
- - The page to redirect the user to ('list', 'create', 'edit', 'show', a function or a custom path)
- - The current `resource`
- - The `id` of the record to redirect to (if any)
- - A record-like object to be passed to the first argument, when the first argument is a function
- - A `state` to be set to the location
 
-Here are more examples of `useRedirect` calls: 
+- The page to redirect the user to ('list', 'create', 'edit', 'show', a function or a custom path)
+- The current `resource`
+- The `id` of the record to redirect to (if any)
+- A record-like object to be passed to the first argument, when the first argument is a function
+- A `state` to be set to the location
+
+Here are more examples of `useRedirect` calls:
 
 ```jsx
 // redirect to the post list page
@@ -35,25 +38,11 @@ redirect('list', 'posts');
 redirect('edit', 'posts', 1);
 // redirect to the post creation page:
 redirect('create', 'posts');
-// redirect to the result of a function
-redirect((resource, id, data) => { 
-    return data.hasComments ? '/comments' : '/posts';
-}, 'posts', 1, { hasComments: true });
 // redirect to edit view with state data
 redirect('edit', 'posts', 1, {}, { record: { post_id: record.id } });
-// do not redirect (resets the record form)
-redirect(false);
 ```
 
 Note that `useRedirect` allows redirection to an absolute URL outside the current React app.
-
-**Tip:** By default, react-admin scrolls to top on each redirection. You can disable it as follows:
-
-```jsx
-redirect(`/deals/${deal.id}/show`, undefined, undefined, undefined, {
-    _scrollToTop: false,
-});
-```
 
 **Tip:** For even more specific navigation, you can use the [`useNavigate`](https://reactrouter.com/en/main/hooks/use-navigate) hook from `react-router-dom` as follows:
 
@@ -76,4 +65,33 @@ const MyPageButton = () => {
     }
     return <button onClick={handleClick}>My page</button>;
 };
+```
+
+## Redirect function
+
+`useRedirect` allows you to redirect to the result of a function as follows:
+
+```jsx
+redirect((resource, id, data) => { 
+    return data.hasComments ? '/comments' : '/posts';
+}, 'posts', 1, { hasComments: true });
+```
+
+## `_scrollToTop`
+
+**Tip:** By default, react-admin scrolls to top on each redirection. You can disable it as follows:
+
+```jsx
+redirect(`/deals/${deal.id}/show`, undefined, undefined, undefined, {
+    _scrollToTop: false,
+});
+```
+
+## Reset the record form
+
+`useRedirect` resets the record form, so you can use the `redirect` function to reset it without redirecting as follows:
+
+```jsx
+// do not redirect (resets the record form)
+redirect(false);
 ```


### PR DESCRIPTION
## Problem

- We can't find `scrollToTop` with the Algolia search
- domument `_scrollToTop` in `useRedirect`'s doc

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date
