### PR TITLE
Support `<ReferenceOneField emptyContent>`

### DIFF
--- a/docs/ReferenceOneField.md
+++ b/docs/ReferenceOneField.md
@@ -63,6 +63,7 @@ const BookShow = () => (
 | `link`         | Optional | `string | Function`                         | `edit`                           | Target of the link wrapping the rendered child. Set to `false` to disable the link. |
 | `queryOptions` | Optional | [`UseQueryOptions`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}` | `react-query` client options |
 | `sort`         | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'ASC' }`  | Used to order referenced records                                                    |
+| `emptyContent` | Optional | `ReactNode`                                 | -                                | Defines a content to be shown when a field has no value                                                      |
 
 `<ReferenceOneField>` also accepts the [common field props](./Fields.md#common-field-props).
 
@@ -74,6 +75,21 @@ For instance, if you want to render both the genre and the ISBN for a book:
 
 ```jsx
 <ReferenceOneField label="Details" reference="book_details" target="book_id">
+    <TextField source="genre" /> (<TextField source="ISBN" />)
+</ReferenceOneField>
+```
+
+## `emptyContent`
+
+Use `emptyContent` to display when the related record is empty.
+
+```jsx
+<ReferenceOneField
+    label="Details"
+    reference="book_details"
+    target="book_id"
+    emptyContent={<CreateButton to="/book_details/create" />}
+>
     <TextField source="genre" /> (<TextField source="ISBN" />)
 </ReferenceOneField>
 ```


### PR DESCRIPTION
Closes #10185

## Problem

We cannot pass a ReactNode to `ReferenceOneField` when we don't have any record, we can only pass text. 

## Solution

Support `<ReferenceOneField emptyContent>`

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date
