### PR TITLE
Add vitest tutorial

### DIFF
--- a/docs/Vite.md
+++ b/docs/Vite.md
@@ -147,6 +147,43 @@ const App = () => (
 export default App;
 ```
 
+## Unit Test Your App with Vitest
+
+Vitest is a fast and efficient unit testing framework designed specifically for the Vite ecosystem. 
+
+To enable it, start by adding the dependencies:
+
+```sh
+yarn add -D vitest @vitest/browser playwright
+```
+
+Then modify and use the following configs:
+
+```diff
+// in vite.config.ts
+
++/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
++ test: {
++   browser: {
++     enabled: true,
++     provider: "playwright",
++     instances: [
++       {
++         browser: "chromium",
++       },
++     ],
++   },
++   globals: true,
++ },
+});
+```
+
 ## Troubleshooting
 
 ### Error about `global` Being `undefined`


### PR DESCRIPTION
Replaces https://github.com/marmelab/react-admin/pull/9332 since we no longer have issues in !9332

In Vitest 3, the browser mode is finally added. We don't need to rely on jsdom and module resolution for server. Everything will be tested and run exactly the same in a browser. 

