### PR TITLE
Simplify ra-data-local-forage setup

### DIFF
--- a/packages/ra-data-localforage/README.md
+++ b/packages/ra-data-localforage/README.md
@@ -19,24 +19,9 @@ import { Admin, Resource } from 'react-admin';
 import localForageDataProvider from 'ra-data-local-forage';
 
 import { PostList } from './posts';
+const dataProvider = localForageDataProvider();
 
 const App = () => {
-  const [dataProvider, setDataProvider] = React.useState<DataProvider | null>(null);
-
-  React.useEffect(() => {
-    async function startDataProvider() {
-      const localForageProvider = await localForageDataProvider();
-      setDataProvider(localForageProvider);
-    }
-
-    if (dataProvider === null) {
-      startDataProvider();
-    }
-  }, [dataProvider]);
-
-  // hide the admin until the data provider is ready
-  if (!dataProvider) return <p>Loading...</p>;
-
   return (
     <Admin dataProvider={dataProvider}>
       <Resource name="posts" list={ListGuesser}/>
@@ -52,7 +37,7 @@ export default App;
 By default, the data provider starts with no resource. To set default data if the IndexedDB is empty, pass a JSON object as the `defaultData` argument:
 
 ```js
-const dataProvider = await localForageDataProvider({
+const dataProvider = localForageDataProvider({
     defaultData: {
         posts: [
             { id: 0, title: 'Hello, world!' },
@@ -75,7 +60,7 @@ Foreign keys are also supported: just name the field `{related_resource_name}_id
 As this data provider doesn't use the network, you can't debug it using the network tab of your browser developer tools. However, it can log all calls (input and output) in the console, provided you set the `loggingEnabled` parameter:
 
 ```js
-const dataProvider = await localForageDataProvider({
+const dataProvider = localForageDataProvider({
     loggingEnabled: true
 });
 ```

--- a/packages/ra-data-localforage/src/index.stories.tsx
+++ b/packages/ra-data-localforage/src/index.stories.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Admin, EditGuesser, ListGuesser, Resource } from 'react-admin';
+import { Resource } from 'ra-core';
+import {
+    AdminContext,
+    AdminUI,
+    EditGuesser,
+    ListGuesser,
+} from 'ra-ui-materialui';
 import localforageDataProvider from './index';
 
 export default {
@@ -18,8 +24,10 @@ export const Basic = () => {
     });
 
     return (
-        <Admin dataProvider={dataProvider}>
-            <Resource name="posts" list={ListGuesser} edit={EditGuesser} />
-        </Admin>
+        <AdminContext dataProvider={dataProvider}>
+            <AdminUI>
+                <Resource name="posts" list={ListGuesser} edit={EditGuesser} />
+            </AdminUI>
+        </AdminContext>
     );
 };

--- a/packages/ra-data-localforage/src/index.stories.tsx
+++ b/packages/ra-data-localforage/src/index.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Admin, EditGuesser, ListGuesser, Resource } from 'react-admin';
+import localforageDataProvider from './index';
+
+export default {
+    title: 'ra-data-local-forage',
+};
+
+export const Basic = () => {
+    const dataProvider = localforageDataProvider({
+        prefixLocalForageKey: 'story-app-',
+        defaultData: {
+            posts: [
+                { id: 1, title: 'Hello, world!' },
+                { id: 2, title: 'FooBar' },
+            ],
+        },
+    });
+
+    return (
+        <Admin dataProvider={dataProvider}>
+            <Resource name="posts" list={ListGuesser} edit={EditGuesser} />
+        </Admin>
+    );
+};


### PR DESCRIPTION
## Problem

Setting up the `ra-data-local-forage` dataProvider is cumbersome.
You have to manage a state and initialize it in a `useEffect`.

## Solution

Simplify the setup.

- [x] Implement the solution
- [x] Showcase it in a story

## How To Test

### In storybook

https://react-admin-storybook-git-ra-data-localforage-s-a105c6-marmelab.vercel.app/?path=/story/ra-data-local-forage--basic

### In a new app

- build the project
- create a new react-admin app using the fakerest dataprovider
- copy the `ra-data-local-forage` inside the new project `node_modules`
- Setup the dataProvider instead of fakerest

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
