### PR TITLE
Fix the `<ReferenceManyToManyInput mutationOption={{onError}}>` doc

### DIFF
--- a/docs/ReferenceManyToManyInput.md
+++ b/docs/ReferenceManyToManyInput.md
@@ -210,21 +210,6 @@ You can for instance use it to pass [a custom meta](./Actions.md#meta-parameter)
 
 {% endraw %}
 
-## `perPage`
-
-By default, react-admin displays at most 25 entries from the associative table (e.g. 25 `performances`). You can change the limit by setting the `perPage` prop:
-
-```tsx
-<ReferenceManyToManyInput
-    reference="venues"
-    through="performances"
-    using="band_id,venue_id"
-    perPage={10}
->
-    {/* ... */}
-</ReferenceManyToManyInput>
-```
-
 You can also use it to pass an `onError` function as follows:
 
 {% raw %}
@@ -243,6 +228,21 @@ You can also use it to pass an `onError` function as follows:
 ```
 
 {% endraw %}
+
+## `perPage`
+
+By default, react-admin displays at most 25 entries from the associative table (e.g. 25 `performances`). You can change the limit by setting the `perPage` prop:
+
+```tsx
+<ReferenceManyToManyInput
+    reference="venues"
+    through="performances"
+    using="band_id,venue_id"
+    perPage={10}
+>
+    {/* ... */}
+</ReferenceManyToManyInput>
+```
 
 ## `perPageChoices`
 


### PR DESCRIPTION
## From
![image](https://github.com/user-attachments/assets/f597b8de-4303-4667-bb63-ff9fe479ca56)

## To
![image](https://github.com/user-attachments/assets/8de34c34-1ea1-4c17-8bd8-37fdc869e2bc)
