### PR TITLE
Fix demo has multiple conflicting MUI packages

### DIFF
--- a/examples/demo/vite.config.ts
+++ b/examples/demo/vite.config.ts
@@ -68,6 +68,21 @@ export default defineConfig(async () => {
                 //     find: 'scheduler/tracing',
                 //     replacement: 'scheduler/tracing-profiling',
                 // },
+                // The 2 next aliases are needed to avoid having multiple MUI instances
+                {
+                    find: '@mui/material',
+                    replacement: path.resolve(
+                        __dirname,
+                        'node_modules/@mui/material'
+                    ),
+                },
+                {
+                    find: '@mui/icons-material',
+                    replacement: path.resolve(
+                        __dirname,
+                        'node_modules/@mui/icons-material'
+                    ),
+                },
                 // we need to manually follow the symlinks for local packages to allow deep HMR
                 ...Object.keys(aliases).map(packageName => ({
                     find: packageName,


### PR DESCRIPTION
## Problem

Following release 5.5, the demo shows larger padding than usual. This is because multiple conflicting versions of MUI packages are loaded. This only happens in the monorepo though.

## Solution

Use Vite aliases to force the resolution of MUI packages to the ones installed in the demo project.

## How To Test

- Run the demo
- Notice the padding is back to normal

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
