### PR TITLE
[Doc] Document how to have sourcemaps in production

### DIFF
--- a/docs/Vite.md
+++ b/docs/Vite.md
@@ -184,6 +184,31 @@ export default defineConfig({
 });
 ```
 
+## Sourcemaps in production
+
+By default, Vite won't include the TypeScript sourcemaps in production builds. This means you'll only have the react-admin ESM builds for debugging.
+Should you prefer to have the TypeScript sources, you'll have to configure some Vite aliases:
+
+```tsx
+// in vite.config.ts
+import { defineConfig } from "vite";
+import path from "path";
+import react from "@vitejs/plugin-react";
+
+const alias = [
+  { find: 'react-admin', replacement: path.resolve(__dirname, './node_modules/react-admin/src') },
+  { find: 'ra-core', replacement: path.resolve(__dirname, './node_modules/ra-core/src') },
+  { find: 'ra-ui-materialui', replacement: path.resolve(__dirname, './node_modules/ra-ui-materialui/src') },
+  // add any other react-admin packages you have
+]
+
+export default defineConfig({
+  plugins: [react()],
+  build: { sourcemap: true },
+  resolve: { alias },
+});
+```
+
 ## Troubleshooting
 
 ### Error about `global` Being `undefined`

--- a/packages/create-react-admin/templates/common/vite.config.ts
+++ b/packages/create-react-admin/templates/common/vite.config.ts
@@ -1,11 +1,45 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+const alias = [
+  { find: "react-admin", replacement: "./node_modules/react-admin/src" },
+  { find: "ra-core", replacement: "./node_modules/ra-core/src" },
+  {
+    find: "ra-ui-materialui",
+    replacement: "./node_modules/ra-ui-materialui/src",
+  },
+  {
+    find: "ra-i18n-polyglot",
+    replacement: "./node_modules/ra-i18n-polyglot/src",
+  },
+  {
+    find: "ra-language-english",
+    replacement: "./node_modules/ra-language-english/src",
+  },
+  {
+    find: "ra-data-json-server",
+    replacement: "./node_modules/ra-data-json-server/src",
+  },
+  {
+    find: "ra-data-simple-rest",
+    replacement: "./node_modules/ra-data-simple-rest/src",
+  },
+  {
+    find: "ra-data-fakerest",
+    replacement: "./node_modules/ra-data-fakerest/src",
+  },
+  // add any other react-admin packages you have
+];
 
 // https://vitejs.dev/config/
-export default defineConfig({
-    plugins: [react()],
-    server: {
-        host: true,
-    },
-    base: './',
-});
+export default defineConfig(({ mode }) => ({
+  plugins: [react()],
+  server: {
+    host: true,
+  },
+  build: {
+    sourcemap: mode === "developement",
+  },
+  resolve: { alias },
+  base: "./",
+}));

--- a/packages/create-react-admin/templates/ra-data-fakerest/vite.config.ts
+++ b/packages/create-react-admin/templates/ra-data-fakerest/vite.config.ts
@@ -39,6 +39,9 @@ export default defineConfig({
         host: true,
     },
     base: './',
+    build: {
+        sourcemap: mode === "developement",
+    },
     resolve: { alias },
     test: {
         globals: true,

--- a/packages/create-react-admin/templates/ra-data-fakerest/vite.config.ts
+++ b/packages/create-react-admin/templates/ra-data-fakerest/vite.config.ts
@@ -2,6 +2,36 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const alias = [
+  { find: "react-admin", replacement: "./node_modules/react-admin/src" },
+  { find: "ra-core", replacement: "./node_modules/ra-core/src" },
+  {
+    find: "ra-ui-materialui",
+    replacement: "./node_modules/ra-ui-materialui/src",
+  },
+  {
+    find: "ra-i18n-polyglot",
+    replacement: "./node_modules/ra-i18n-polyglot/src",
+  },
+  {
+    find: "ra-language-english",
+    replacement: "./node_modules/ra-language-english/src",
+  },
+  {
+    find: "ra-data-json-server",
+    replacement: "./node_modules/ra-data-json-server/src",
+  },
+  {
+    find: "ra-data-simple-rest",
+    replacement: "./node_modules/ra-data-simple-rest/src",
+  },
+  {
+    find: "ra-data-fakerest",
+    replacement: "./node_modules/ra-data-fakerest/src",
+  },
+  // add any other react-admin packages you have
+];
+
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
@@ -9,6 +39,7 @@ export default defineConfig({
         host: true,
     },
     base: './',
+    resolve: { alias },
     test: {
         globals: true,
         environment: 'jsdom'


### PR DESCRIPTION
## Problem

In production, even with sourcemaps enabled, only the ESM sources are loaded in the devtool.

## Solution

- Document how to enable sourcemaps with TS source files
- Do it automatically in new create-react-admin apps

## How To Test

- `make build-create-react-admin`
- `./node_modules/.bin/create-react-admin myadmin --data-provider ra-data-fakerest --auth-provider local-auth-provider --install npm`
- `cd myadmin`
- `npm run dev`: verify that debugging react-admin files still happen in TS files
- `npm run build && npm run serve`: verify that debugging react-admin files still happen in TS files

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
