### PR TITLE
Fix TabbedForm and TabbedShowLayout with react-router v7

### DIFF
--- a/packages/ra-core/src/routing/index.ts
+++ b/packages/ra-core/src/routing/index.ts
@@ -11,3 +11,4 @@ export * from './useScrollToTop';
 export * from './useRestoreScrollPosition';
 export * from './types';
 export * from './TestMemoryRouter';
+export * from './useSplatPathBase';

--- a/packages/ra-core/src/routing/useSplatPathBase.ts
+++ b/packages/ra-core/src/routing/useSplatPathBase.ts
@@ -1,0 +1,24 @@
+import { useLocation, useParams } from 'react-router-dom';
+
+/**
+ * Utility hook to get the base path of a splat path.
+ * Compatible both with react-router v6 and v7.
+ *
+ * Example:
+ * If a splat path is defined as `/posts/:id/show/*`,
+ * and the current location is `/posts/12/show/3`,
+ * this hook will return `/posts/12/show`.
+ *
+ * Solution inspired by
+ * https://github.com/remix-run/react-router/issues/11052#issuecomment-1828470203
+ */
+export const useSplatPathBase = () => {
+    const location = useLocation();
+    const params = useParams();
+    const splatPathRelativePart = params['*'];
+    const splatPathBase = location.pathname.replace(
+        new RegExp(`/${splatPathRelativePart}$`),
+        ''
+    );
+    return splatPathBase;
+};

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -8,7 +8,7 @@ import {
     styled,
 } from '@mui/material';
 import { ResponsiveStyleValue } from '@mui/system';
-import { useTranslate, RaRecord } from 'ra-core';
+import { useTranslate, RaRecord, useSplatPathBase } from 'ra-core';
 import clsx from 'clsx';
 
 import { Labeled } from '../Labeled';
@@ -76,9 +76,14 @@ export const Tab = ({
 }: TabProps) => {
     const translate = useTranslate();
     const location = useLocation();
+    const splatPathBase = useSplatPathBase();
+    const newPathName =
+        value == null || value === ''
+            ? splatPathBase
+            : `${splatPathBase}/${value}`;
     const propsForLink = {
         component: Link,
-        to: { ...location, pathname: value },
+        to: { ...location, pathname: newPathName },
     };
 
     const renderHeader = () => {

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.stories.tsx
@@ -1,19 +1,23 @@
 import * as React from 'react';
 import { Divider as MuiDivider } from '@mui/material';
 import {
-    RecordContextProvider,
-    ResourceContext,
     useRecordContext,
     WithRecord,
     TestMemoryRouter,
+    RaRecord,
+    testDataProvider,
+    ResourceContextProvider,
 } from 'ra-core';
 import { Labeled } from '../Labeled';
 import { TextField, NumberField } from '../field';
 import { TabbedShowLayout } from './TabbedShowLayout';
+import { AdminContext } from '../AdminContext';
+import { Route, Routes } from 'react-router';
+import { Show } from './Show';
 
 export default { title: 'ra-ui-materialui/detail/TabbedShowLayout' };
 
-const record = {
+const data = {
     id: 1,
     title: 'War and Peace',
     author: 'Leo Tolstoy',
@@ -22,47 +26,73 @@ const record = {
     year: 1869,
 };
 
-export const Basic = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout>
-                    <TabbedShowLayout.Tab label="First">
-                        <TextField source="id" />
-                        <TextField source="title" />
-                    </TabbedShowLayout.Tab>
-                    <TabbedShowLayout.Tab label="Second">
-                        <TextField source="author" />
-                        <TextField source="summary" />
-                        <NumberField source="year" />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
+const Wrapper = ({
+    children,
+    record = data,
+}: {
+    children: React.ReactNode;
+    record?: RaRecord;
+}) => (
+    <TestMemoryRouter
+        initialEntries={[`/books/${encodeURIComponent(record.id)}/show`]}
+    >
+        <AdminContext
+            i18nProvider={{
+                translate: (x, options) => options?._ ?? x,
+                changeLocale: () => Promise.resolve(),
+                getLocale: () => 'en',
+            }}
+            dataProvider={testDataProvider({
+                // @ts-ignore
+                getOne: () => Promise.resolve({ data: record }),
+            })}
+            defaultTheme="light"
+        >
+            <ResourceContextProvider value="books">
+                <Routes>
+                    <Route
+                        path="/books/:id/show/*"
+                        element={<Show sx={{ width: 600 }}>{children}</Show>}
+                    />
+                </Routes>
+            </ResourceContextProvider>
+        </AdminContext>
     </TestMemoryRouter>
 );
 
+export const Basic = () => (
+    <Wrapper>
+        <TabbedShowLayout>
+            <TabbedShowLayout.Tab label="First">
+                <TextField source="id" />
+                <TextField source="title" />
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="Second">
+                <TextField source="author" />
+                <TextField source="summary" />
+                <NumberField source="year" />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
+);
+
 export const Count = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout>
-                    <TabbedShowLayout.Tab label="Main">
-                        <TextField source="id" />
-                        <TextField source="title" />
-                    </TabbedShowLayout.Tab>
-                    <TabbedShowLayout.Tab label="Details">
-                        <TextField source="author" />
-                        <TextField source="summary" />
-                        <NumberField source="year" />
-                    </TabbedShowLayout.Tab>
-                    <TabbedShowLayout.Tab label="Reviews" count={27}>
-                        <TextField source="reviews" />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
-    </TestMemoryRouter>
+    <Wrapper>
+        <TabbedShowLayout>
+            <TabbedShowLayout.Tab label="Main">
+                <TextField source="id" />
+                <TextField source="title" />
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="Details">
+                <TextField source="author" />
+                <TextField source="summary" />
+                <NumberField source="year" />
+            </TabbedShowLayout.Tab>
+            <TabbedShowLayout.Tab label="Reviews" count={27}>
+                <TextField source="reviews" />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
 );
 
 const BookTitle = () => {
@@ -71,98 +101,76 @@ const BookTitle = () => {
 };
 
 export const CustomChild = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout>
-                    <TabbedShowLayout.Tab label="First">
-                        <BookTitle />
-                        <WithRecord
-                            render={record => <span>{record.author}</span>}
-                        />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
-    </TestMemoryRouter>
+    <Wrapper>
+        <TabbedShowLayout>
+            <TabbedShowLayout.Tab label="First">
+                <BookTitle />
+                <WithRecord render={record => <span>{record.author}</span>} />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
 );
 
 export const CustomLabel = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout>
-                    <TabbedShowLayout.Tab label="First">
-                        <TextField label="Identifier" source="id" />
-                        <TextField source="title" />
-                        <Labeled label="Author name">
-                            <TextField source="author" />
-                        </Labeled>
-                        <TextField label={false} source="summary" />
-                        <NumberField source="year" />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
-    </TestMemoryRouter>
+    <Wrapper>
+        <TabbedShowLayout>
+            <TabbedShowLayout.Tab label="First">
+                <TextField label="Identifier" source="id" />
+                <TextField source="title" />
+                <Labeled label="Author name">
+                    <TextField source="author" />
+                </Labeled>
+                <TextField label={false} source="summary" />
+                <NumberField source="year" />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
 );
 
 export const Spacing = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout spacing={3}>
-                    <TabbedShowLayout.Tab label="First">
-                        <TextField source="id" />
-                        <TextField source="title" />
-                        <TextField source="author" />
-                        <TextField source="summary" />
-                        <NumberField source="year" />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
-    </TestMemoryRouter>
+    <Wrapper>
+        <TabbedShowLayout spacing={3}>
+            <TabbedShowLayout.Tab label="First">
+                <TextField source="id" />
+                <TextField source="title" />
+                <TextField source="author" />
+                <TextField source="summary" />
+                <NumberField source="year" />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
 );
 
 export const Divider = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout divider={<MuiDivider />}>
-                    <TabbedShowLayout.Tab label="First">
-                        <TextField source="id" />
-                        <TextField source="title" />
-                        <TextField source="author" />
-                        <TextField source="summary" />
-                        <NumberField source="year" />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
-    </TestMemoryRouter>
+    <Wrapper>
+        <TabbedShowLayout divider={<MuiDivider />}>
+            <TabbedShowLayout.Tab label="First">
+                <TextField source="id" />
+                <TextField source="title" />
+                <TextField source="author" />
+                <TextField source="summary" />
+                <NumberField source="year" />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
 );
 
 export const SX = () => (
-    <TestMemoryRouter>
-        <ResourceContext.Provider value="books">
-            <RecordContextProvider value={record}>
-                <TabbedShowLayout
-                    sx={{
-                        margin: 2,
-                        padding: 2,
-                        bgcolor: 'text.disabled',
-                    }}
-                >
-                    <TabbedShowLayout.Tab label="First">
-                        <TextField source="id" />
-                        <TextField source="title" />
-                        <TextField source="author" />
-                        <TextField source="summary" />
-                        <NumberField source="year" />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
-            </RecordContextProvider>
-        </ResourceContext.Provider>
-    </TestMemoryRouter>
+    <Wrapper>
+        <TabbedShowLayout
+            sx={{
+                margin: 2,
+                padding: 2,
+                bgcolor: 'text.disabled',
+            }}
+        >
+            <TabbedShowLayout.Tab label="First">
+                <TextField source="id" />
+                <TextField source="title" />
+                <TextField source="author" />
+                <TextField source="summary" />
+                <NumberField source="year" />
+            </TabbedShowLayout.Tab>
+        </TabbedShowLayout>
+    </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/form/FormTabHeader.tsx
+++ b/packages/ra-ui-materialui/src/form/FormTabHeader.tsx
@@ -3,7 +3,7 @@ import { ReactElement, ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Tab as MuiTab, TabProps as MuiTabProps } from '@mui/material';
 import clsx from 'clsx';
-import { useTranslate, useFormGroup } from 'ra-core';
+import { useTranslate, useFormGroup, useSplatPathBase } from 'ra-core';
 
 import { TabbedFormClasses } from './TabbedFormView';
 
@@ -18,12 +18,16 @@ export const FormTabHeader = ({
     ...rest
 }: FormTabHeaderProps): ReactElement => {
     const translate = useTranslate();
-    const location = useLocation();
     const formGroup = useFormGroup(value.toString());
-
+    const location = useLocation();
+    const splatPathBase = useSplatPathBase();
+    const newPathName =
+        value == null || value === ''
+            ? splatPathBase
+            : `${splatPathBase}/${value}`;
     const propsForLink = {
         component: Link,
-        to: { ...location, pathname: value },
+        to: { ...location, pathname: newPathName },
     };
 
     let tabLabel =

--- a/packages/ra-ui-materialui/src/form/TabbedForm.spec.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.spec.tsx
@@ -46,7 +46,8 @@ describe('<TabbedForm />', () => {
 
         const tabs = await screen.findAllByRole('tab');
         expect(tabs.length).toEqual(2);
-        await screen.findByLabelText('Title');
+        const titleInput = await screen.findByLabelText('Title');
+        expect(titleInput).toBeVisible();
     });
 
     it('should set the style of an inactive Tab button with errors', async () => {

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -10,16 +10,10 @@ import {
     useState,
 } from 'react';
 import clsx from 'clsx';
-import {
-    Routes,
-    Route,
-    matchPath,
-    useResolvedPath,
-    useLocation,
-} from 'react-router-dom';
+import { Routes, Route, matchPath, useLocation } from 'react-router-dom';
 import { CardContent, Divider, SxProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { useResourceContext } from 'ra-core';
+import { useResourceContext, useSplatPathBase } from 'ra-core';
 import { Toolbar } from './Toolbar';
 import { TabbedFormTabs, getTabbedFormTabFullPath } from './TabbedFormTabs';
 
@@ -35,9 +29,9 @@ export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
         ...rest
     } = props;
     const location = useLocation();
-    const resolvedPath = useResolvedPath('');
     const resource = useResourceContext(props);
     const [tabValue, setTabValue] = useState(0);
+    const splatPathBase = useSplatPathBase();
 
     const handleTabChange = (event: ChangeEvent<{}>, value: any): void => {
         if (!syncWithLocation) {
@@ -82,7 +76,7 @@ export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
                     const tabPath = getTabbedFormTabFullPath(tab, index);
                     const hidden = syncWithLocation
                         ? !matchPath(
-                              `${resolvedPath.pathname}/${tabPath}`,
+                              `${splatPathBase}/${tabPath}`,
                               // The current location might have encoded segments (e.g. the record id) but resolvedPath.pathname doesn't
                               // and the match would fail.
                               getDecodedPathname(location.pathname)

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -74,11 +74,6 @@ export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
                         return null;
                     }
                     const tabPath = getTabbedFormTabFullPath(tab, index);
-                    console.log(
-                        'matchPath',
-                        `${splatPathBase}/${tabPath}`,
-                        location.pathname
-                    );
                     const hidden = syncWithLocation
                         ? !matchPath(
                               `${splatPathBase}/${tabPath}`,

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -74,12 +74,15 @@ export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
                         return null;
                     }
                     const tabPath = getTabbedFormTabFullPath(tab, index);
+                    console.log(
+                        'matchPath',
+                        `${splatPathBase}/${tabPath}`,
+                        location.pathname
+                    );
                     const hidden = syncWithLocation
                         ? !matchPath(
                               `${splatPathBase}/${tabPath}`,
-                              // The current location might have encoded segments (e.g. the record id) but resolvedPath.pathname doesn't
-                              // and the match would fail.
-                              getDecodedPathname(location.pathname)
+                              location.pathname
                           )
                         : tabValue !== index;
 
@@ -97,12 +100,6 @@ export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
         </Root>
     );
 };
-
-/**
- * Returns the pathname with each segment decoded
- */
-const getDecodedPathname = (pathname: string) =>
-    pathname.split('/').map(decodeURIComponent).join('/');
 
 const DefaultTabs = <TabbedFormTabs />;
 const DefaultComponent = ({ children }) => (

--- a/test-setup.js
+++ b/test-setup.js
@@ -3,6 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
 
 // Ignore warnings about act()
 // See https://github.com/testing-library/react-testing-library/issues/281,


### PR DESCRIPTION
## Problem

Fix #10458

React-router v7 reintroduced the change they introduced in 6.19.0, which was reverted in 6.20.1 due to it causing [issues](https://github.com/remix-run/react-router/issues/11052) in many apps, including react-admin.

## Solution

Introduce `useSplatPathBase` hook, which allows to compute the splat route's base path, allowing react-admin to create absolute paths for tabs (as opposed to relative paths previously), which will work both with react-router v6 and v7.

## How To Test

Wrap the `<Admin>` in the simple example with a `<HashRouter>`.
Then, you can set `<HashRouter future={{ v7_relativeSplatPath: true }}>` to test with the feature enabled (which is the default in v7), or set it to `false` to disable the feature.

Then, use `PostEdit` and `PostShow` to confirm the tabs are working OK.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> can't unit test in v7
- [ ] The PR includes one or several **stories** (if not possible, describe why) -> no need for more stories
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
