### PR TITLE
[Demo] Fix vite config in Simple and CRM demos

### DIFF
--- a/examples/crm/vite.config.ts
+++ b/examples/crm/vite.config.ts
@@ -11,14 +11,20 @@ export default defineConfig(async () => {
     const aliases: Record<string, string> = {};
     for (const dirName of packages) {
         if (dirName === 'create-react-admin') continue;
-        // eslint-disable-next-line prettier/prettier
-        const packageJson = await import(
-            path.resolve(__dirname, '../../packages', dirName, 'package.json'),
-            { with: { type: 'json' } }
+        const packageJson = JSON.parse(
+            fs.readFileSync(
+                path.resolve(
+                    __dirname,
+                    '../../packages',
+                    dirName,
+                    'package.json'
+                ),
+                'utf8'
+            )
         );
-        aliases[packageJson.default.name] = path.resolve(
+        aliases[packageJson.name] = path.resolve(
             __dirname,
-            `../../packages/${packageJson.default.name}/src`
+            `../../packages/${packageJson.name}/src`
         );
     }
     return {

--- a/examples/simple/vite.config.ts
+++ b/examples/simple/vite.config.ts
@@ -10,30 +10,28 @@ import { defineConfig } from 'vite';
 export default defineConfig(async () => {
     // In codesandbox, we won't have the packages folder
     // We ignore errors in this case
-    let aliases: any[] = [];
+    const aliases: Record<string, string> = {};
     try {
         const packages = fs.readdirSync(
             path.resolve(__dirname, '../../packages')
         );
         for (const dirName of packages) {
             if (dirName === 'create-react-admin') continue;
-            // eslint-disable-next-line prettier/prettier
-            const packageJson = await import(
-                path.resolve(
-                    __dirname,
-                    '../../packages',
-                    dirName,
-                    'package.json'
-                ),
-                { with: { type: 'json' } }
+            const packageJson = JSON.parse(
+                fs.readFileSync(
+                    path.resolve(
+                        __dirname,
+                        '../../packages',
+                        dirName,
+                        'package.json'
+                    ),
+                    'utf8'
+                )
             );
-            aliases.push({
-                find: new RegExp(`^${packageJson.default.name}$`),
-                replacement: path.resolve(
-                    __dirname,
-                    `../../packages/${packageJson.default.name}/src`
-                ),
-            });
+            aliases[packageJson.name] = path.resolve(
+                __dirname,
+                `../../packages/${packageJson.name}/src`
+            );
         }
     } catch {}
 
@@ -41,11 +39,14 @@ export default defineConfig(async () => {
         plugins: [react()],
         resolve: {
             alias: [
-                ...aliases,
                 {
                     find: /^@mui\/icons-material\/(.*)/,
                     replacement: '@mui/icons-material/esm/$1',
                 },
+                ...Object.keys(aliases).map(packageName => ({
+                    find: packageName,
+                    replacement: aliases[packageName],
+                })),
             ],
         },
         server: {


### PR DESCRIPTION
## Problem

The Simple and CRM demos have a Vite config that no longer works with Node 18

## Solution

Apply the same fix as https://github.com/marmelab/react-admin/commit/d095b8f4b4d53c068367b29f7abee51311507146

## How To Test

Run the demos locally
`make run`
`make run-crm`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
