### PR TITLE
Make the CI fail on `console.error` in tests

### DIFF
--- a/test-setup.js
+++ b/test-setup.js
@@ -7,9 +7,14 @@ import '@testing-library/jest-dom/jest-globals';
 
 // Make the CI fail if console.error in tests
 let error = console.error;
-console.error = message => {
-    error.apply(message); // keep default behaviour
-    throw message;
+console.error = (...args) => {
+    error.call(console, args);
+    throw new Error(
+        JSON.stringify({
+            message: 'The tests failed due to `console.error` calls',
+            error: args,
+        })
+    );
 };
 
 // Ignore warnings about act()

--- a/test-setup.js
+++ b/test-setup.js
@@ -5,6 +5,13 @@
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/jest-globals';
 
+// Make the CI fail if console.error in tests
+let error = console.error;
+console.error = message => {
+    error.apply(message); // keep default behaviour
+    throw message;
+};
+
 // Ignore warnings about act()
 // See https://github.com/testing-library/react-testing-library/issues/281,
 // https://github.com/facebook/react/issues/14769


### PR DESCRIPTION
## How To Test

Add a `console.error('foo', 'bar')` in a test and run it.

## Screenshot

![image](https://github.com/user-attachments/assets/36d9ab4a-a269-43dc-a1a8-2cac38216999)
