### PR TITLE
Add a `--basic` flag to the `create-react-admin` package to skip interactive steps

### DIFF
--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -16,12 +16,12 @@ const cli = meow(
 	  --auth-provider  Set the auth provider to use ("local-auth-provider" or "none")
 	  --resource       Add a resource that will be initialized with guessers (can be used multiple times). Set to "skip" to bypass the interactive resource step.
 	  --install        Set the package manager to use for installing dependencies ("yarn", "npm" or "skip" to bypass the interactive install step)
-      --basic          Skip all the interactive steps and create a basic app with no data provider, no auth provider, no resources and no install step
+	  --basic          Skip all the interactive steps and create a basic app with no data provider, no auth provider, no resources and no install step
 
     Examples
 	  $ create-admin-app my-admin
 	  $ create-admin-app my-admin --data-provider ra-data-json-server --auth-provider local-auth-provider --resource posts --resource comments --install npm
-      $ create-admin-app my-admin --basic
+	  $ create-admin-app my-admin --basic
 `,
     {
         flags: {

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -60,8 +60,7 @@ if (cli.flags.h) {
     const install = cli.flags.basic ? 'skip' : cli.flags.install;
     const resources =
         cli.flags.basic ||
-        cli.flags.resource.includes('skip') ||
-        cli.flags.resource.length === 0
+        cli.flags.resource.includes('skip')
             ? []
             : cli.flags.resource;
 

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -54,30 +54,24 @@ const cli = meow(
 
 if (cli.flags.h) {
     cli.showHelp();
-} else if (cli.flags.basic) {
-    render(
-        <App
-            name={cli.input.length > 0 ? cli.input[0] : undefined}
-            dataProvider="none"
-            authProvider="none"
-            resources={[]}
-            install="skip"
-        />
-    );
 } else {
+    const dataProvider = cli.flags.basic ? 'none' : cli.flags.dataProvider;
+    const authProvider = cli.flags.basic ? 'none' : cli.flags.authProvider;
+    const install = cli.flags.basic ? 'skip' : cli.flags.install;
+    const resources =
+        cli.flags.basic ||
+        cli.flags.resource.includes('skip') ||
+        cli.flags.resource.length === 0
+            ? []
+            : cli.flags.resource;
+
     render(
         <App
             name={cli.input.length > 0 ? cli.input[0] : undefined}
-            dataProvider={cli.flags.dataProvider}
-            authProvider={cli.flags.authProvider}
-            resources={
-                cli.flags.resource.includes('skip')
-                    ? []
-                    : cli.flags.resource.length > 0
-                      ? cli.flags.resource
-                      : undefined
-            }
-            install={cli.flags.install}
+            dataProvider={dataProvider}
+            authProvider={authProvider}
+            resources={resources}
+            install={install}
         />
     );
 }

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -59,8 +59,7 @@ if (cli.flags.h) {
     const authProvider = cli.flags.basic ? 'none' : cli.flags.authProvider;
     const install = cli.flags.basic ? 'skip' : cli.flags.install;
     const resources =
-        cli.flags.basic ||
-        cli.flags.resource.includes('skip')
+        cli.flags.basic || cli.flags.resource.includes('skip')
             ? []
             : cli.flags.resource;
 

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -16,16 +16,21 @@ const cli = meow(
 	  --auth-provider  Set the auth provider to use ("local-auth-provider" or "none")
 	  --resource       Add a resource that will be initialized with guessers (can be used multiple times). Set to "skip" to bypass the interactive resource step.
 	  --install        Set the package manager to use for installing dependencies ("yarn", "npm" or "skip" to bypass the interactive install step)
+      --basic          Skip all the interactive steps and create a basic app with no data provider, no auth provider, no resources and no install step
 
     Examples
 	  $ create-admin-app my-admin
 	  $ create-admin-app my-admin --data-provider ra-data-json-server --auth-provider local-auth-provider --resource posts --resource comments --install npm
+      $ create-admin-app my-admin --basic
 `,
     {
         flags: {
             help: {
                 type: 'boolean',
                 alias: 'h',
+            },
+            basic: {
+                type: 'boolean',
             },
             dataProvider: {
                 type: 'string',
@@ -49,6 +54,16 @@ const cli = meow(
 
 if (cli.flags.h) {
     cli.showHelp();
+} else if (cli.flags.basic) {
+    render(
+        <App
+            name={cli.input.length > 0 ? cli.input[0] : undefined}
+            dataProvider="none"
+            authProvider="none"
+            resources={[]}
+            install="skip"
+        />
+    );
 } else {
     render(
         <App


### PR DESCRIPTION
## Problem

To get a non-interactive \`create-react-admin\`, one must pass all options:

```
npx create-react-admin my-admin -- \
  --data-provider none
  --auth-provider none
  --resource skip
  --install skip
```

This is super verbose, especially in documentation.

## Solution

Add a `--basic` option that replaces all the others

```
npm init react-admin test-admin1 -- --basic
```

## How To Test

On the `xx` branch, build the cli:
```
make build-create-react-admin
```
Create a new project with npx:
```
npx create-react-admin test-admin-npx -- \
  --data-provider none
  --auth-provider none
  --resource skip
  --install skip
```
Create another one with the local version of the cli:
```
./node_modules/.bin/create-react-admin test-admin-local --basic
```
Compare folders:
```
diff test-admin-npx test-admin-local
```

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [x] The **documentation** is up to date (cli doc with `help` flag)
- ~[ ] The **documentation** is up to date~
