### PR TITLE
Make useHandleCallback compatible with StrictMode

### DIFF
--- a/packages/ra-core/src/auth/useHandleAuthCallback.spec.tsx
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.spec.tsx
@@ -160,4 +160,28 @@ describe('useHandleAuthCallback', () => {
             expect(abort).toHaveBeenCalled();
         });
     });
+
+    it('should only call handleCallback once when the component is rendered', async () => {
+        const handleCallback = jest.spyOn(authProvider, 'handleCallback');
+        render(
+            <React.StrictMode>
+                <TestMemoryRouter initialEntries={['/auth-callback']}>
+                    <AuthContext.Provider value={authProvider}>
+                        <QueryClientProvider client={new QueryClient()}>
+                            <Routes>
+                                <Route path="/" element={<div>Home</div>} />
+                                <Route
+                                    path="/auth-callback"
+                                    element={<TestComponent />}
+                                />
+                            </Routes>
+                        </QueryClientProvider>
+                    </AuthContext.Provider>
+                </TestMemoryRouter>
+            </React.StrictMode>
+        );
+
+        await screen.findByText('Home');
+        expect(handleCallback).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/ra-core/src/auth/useHandleAuthCallback.ts
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.ts
@@ -24,15 +24,38 @@ export const useHandleAuthCallback = (
     const nextSearch = locationState && locationState.nextSearch;
     const defaultRedirectUrl = nextPathName ? nextPathName + nextSearch : '/';
     const { onSuccess, onError, onSettled, ...queryOptions } = options ?? {};
+    let handleCallbackPromise: Promise<void> | null;
 
     const queryResult = useQuery({
         queryKey: ['auth', 'handleCallback'],
-        queryFn: ({ signal }) =>
-            authProvider && typeof authProvider.handleCallback === 'function'
-                ? authProvider
-                      .handleCallback({ signal })
-                      .then(result => result ?? null)
-                : Promise.resolve(),
+        queryFn: ({ signal }) => {
+            console.log('queryFn', handleCallbackPromise);
+            if (!handleCallbackPromise) {
+                handleCallbackPromise = new Promise(async (resolve, reject) => {
+                    if (authProvider) {
+                        if (typeof authProvider.handleCallback === 'function') {
+                            try {
+                                const result =
+                                    await authProvider.handleCallback({
+                                        signal,
+                                    });
+                                return resolve(result ?? null);
+                            } catch (error) {
+                                return reject({
+                                    redirectTo: false,
+                                    message: error.message,
+                                });
+                            }
+                        }
+                        return resolve();
+                    }
+                    return reject({
+                        message: 'Failed to handle login callback.',
+                    });
+                });
+            }
+            return handleCallbackPromise;
+        },
         retry: false,
         ...queryOptions,
     });

--- a/packages/ra-core/src/auth/useHandleAuthCallback.ts
+++ b/packages/ra-core/src/auth/useHandleAuthCallback.ts
@@ -29,30 +29,14 @@ export const useHandleAuthCallback = (
     const queryResult = useQuery({
         queryKey: ['auth', 'handleCallback'],
         queryFn: ({ signal }) => {
-            console.log('queryFn', handleCallbackPromise);
             if (!handleCallbackPromise) {
-                handleCallbackPromise = new Promise(async (resolve, reject) => {
-                    if (authProvider) {
-                        if (typeof authProvider.handleCallback === 'function') {
-                            try {
-                                const result =
-                                    await authProvider.handleCallback({
-                                        signal,
-                                    });
-                                return resolve(result ?? null);
-                            } catch (error) {
-                                return reject({
-                                    redirectTo: false,
-                                    message: error.message,
-                                });
-                            }
-                        }
-                        return resolve();
-                    }
-                    return reject({
-                        message: 'Failed to handle login callback.',
-                    });
-                });
+                handleCallbackPromise =
+                    authProvider &&
+                    typeof authProvider.handleCallback === 'function'
+                        ? authProvider
+                              .handleCallback({ signal })
+                              .then(result => result ?? null)
+                        : Promise.resolve();
             }
             return handleCallbackPromise;
         },


### PR DESCRIPTION
## Problem

Many authentication providers do not accept calling their methods for validating authentication callbacks multiple times. We had the case with `ra-auth-auth0` and `ra-keycloak` (maybe even `ra-supabase`).

Our solution until now was to implement the necessary logic in the `authProvider` implementation (storing ongoing promise in the `authProvider` closure). This is fine but it means custom implementations must do it themselves too and this is not trivial for many.

## Solution

Make the `useHandleCallback` resilient to `StrictMode`. Implement the logic that won’t call `authProvider.handleCallback` if another call is already ongoing.


## How To Test

Revert the fix in [useHandleAuthCallback.ts](https://github.com/marmelab/react-admin/compare/fix/useHandleCallback_compatible_StrictMode?expand=1#diff-4713b2324817c4e79d550875855dd6f867fc402601b37b894a2c0058fad91599) and run [the test *"should only call handleCallback once when the component is rendered"*  in `useHandleAuthCallback.spec.tsx`](https://github.com/marmelab/react-admin/compare/fix/useHandleCallback_compatible_StrictMode?expand=1#diff-391cad4dc18cad6095583daa4852a14f7c3153df8e328c149668f7c14bdb55ec).

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- ~[ ] The **documentation** is up to date~

## Screenshot

Test without the fix:

![image](https://github.com/user-attachments/assets/23a83848-751a-497d-a6c7-069ad2ed88a2)
