### PR TITLE
Fix `<AutocompleteInput>` can flicker when used in a `<FormDataConsumer>`

### DIFF
--- a/packages/ra-ui-materialui/src/form/FormDataConsumer.stories.tsx
+++ b/packages/ra-ui-materialui/src/form/FormDataConsumer.stories.tsx
@@ -1,10 +1,25 @@
 import * as React from 'react';
-import { FormDataConsumer, required, ResourceContextProvider } from 'ra-core';
+import {
+    FilterLiveForm,
+    FormDataConsumer,
+    required,
+    ResourceContextProvider,
+    useListContext,
+} from 'ra-core';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { AdminContext } from '../AdminContext';
-import { AutocompleteInput, ReferenceInput, TextInput } from '../input';
+import {
+    ArrayInput,
+    AutocompleteInput,
+    ReferenceInput,
+    SelectInput,
+    SimpleFormIterator,
+    TextInput,
+} from '../input';
 import { SimpleForm } from './SimpleForm';
 import { Create } from '../detail';
+import { Datagrid, List } from '../list';
+import { TextField } from '../field';
 
 // We keep this test in ra-ui-materialui because we need heavy components to reproduce the issue https://github.com/marmelab/react-admin/issues/10415
 export default { title: 'ra-core/form/FormDataConsumer' };
@@ -45,6 +60,85 @@ export const Basic = () => (
                     <TextInput source="body" multiline rows={5} />
                 </SimpleForm>
             </Create>
+        </ResourceContextProvider>
+    </AdminContext>
+);
+
+const config = {
+    name: {
+        operators: [
+            { id: 'eq', name: 'Equals' },
+            { id: 'ne', name: 'Not equals' },
+        ],
+    },
+    id: {
+        operators: [
+            { id: 'eq', name: 'Equals' },
+            { id: 'ne', name: 'Not equals' },
+        ],
+    },
+};
+
+const StackedFiltersForm = () => (
+    <FilterLiveForm>
+        <ArrayInput source="filters">
+            <SimpleFormIterator inline disableReordering disableClear>
+                <AutocompleteInput
+                    source="source"
+                    choices={[
+                        { id: 'name', name: 'Name' },
+                        { id: 'id', name: 'Id' },
+                    ]}
+                />
+                <FormDataConsumer>
+                    {({ scopedFormData }) => {
+                        if (!scopedFormData) return null;
+                        const source = scopedFormData.source;
+                        const operators = config[source]?.operators ?? [];
+                        return (
+                            <SelectInput
+                                source="operator"
+                                choices={operators}
+                                disabled={!operators.length}
+                            />
+                        );
+                    }}
+                </FormDataConsumer>
+                <FormDataConsumer>
+                    {({ scopedFormData }) => {
+                        if (!scopedFormData) return null;
+                        const source = scopedFormData.source;
+                        const operators = config[source]?.operators ?? [];
+                        return (
+                            <TextInput
+                                helperText={false}
+                                source="value"
+                                disabled={!operators.length}
+                            />
+                        );
+                    }}
+                </FormDataConsumer>
+            </SimpleFormIterator>
+        </ArrayInput>
+    </FilterLiveForm>
+);
+
+const FiltersDebugger = () => {
+    const { filterValues } = useListContext();
+    return <pre>{JSON.stringify(filterValues, null, 2)}</pre>;
+};
+
+export const StackedFilters = () => (
+    <AdminContext dataProvider={dataProvider}>
+        <ResourceContextProvider value="users">
+            <List>
+                <StackedFiltersForm />
+                <FiltersDebugger />
+                <Datagrid>
+                    <TextField source="id" />
+                    <TextField source="name" />
+                </Datagrid>
+            </List>
         </ResourceContextProvider>
     </AdminContext>
 );

--- a/packages/ra-ui-materialui/src/form/FormDataConsumer.stories.tsx
+++ b/packages/ra-ui-materialui/src/form/FormDataConsumer.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
     FilterLiveForm,
     FormDataConsumer,
+    ListBase,
     required,
     ResourceContextProvider,
     useListContext,
@@ -18,8 +19,7 @@ import {
 } from '../input';
 import { SimpleForm } from './SimpleForm';
 import { Create } from '../detail';
-import { Datagrid, List } from '../list';
-import { TextField } from '../field';
+import { Paper } from '@mui/material';
 
 // We keep this test in ra-ui-materialui because we need heavy components to reproduce the issue https://github.com/marmelab/react-admin/issues/10415
 export default { title: 'ra-core/form/FormDataConsumer' };
@@ -131,14 +131,12 @@ const FiltersDebugger = () => {
 export const StackedFilters = () => (
     <AdminContext dataProvider={dataProvider}>
         <ResourceContextProvider value="users">
-            <List>
-                <StackedFiltersForm />
-                <FiltersDebugger />
-                <Datagrid>
-                    <TextField source="id" />
-                    <TextField source="name" />
-                </Datagrid>
-            </List>
+            <ListBase>
+                <Paper sx={{ p: 2 }}>
+                    <StackedFiltersForm />
+                    <FiltersDebugger />
+                </Paper>
+            </ListBase>
         </ResourceContextProvider>
     </AdminContext>
 );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -35,6 +35,7 @@ import {
     warning,
     useGetRecordRepresentation,
     useEvent,
+    OptionTextFunc,
 } from 'ra-core';
 import {
     SupportCreateSuggestionOptions,
@@ -163,7 +164,7 @@ export const AutocompleteInput = <
         onChange,
         onCreate,
         openText = 'ra.action.open',
-        optionText,
+        optionText: optionTextProp,
         optionValue,
         parse,
         resource: resourceProp,
@@ -227,6 +228,11 @@ export const AutocompleteInput = <
         readOnly,
         ...rest,
     });
+
+    // Memoize optionText
+    const optionTextEvent = useEvent(optionTextProp as OptionTextFunc);
+    const optionText =
+        typeof optionTextProp === 'function' ? optionTextEvent : optionTextProp;
 
     const finalChoices = useMemo(
         () =>


### PR DESCRIPTION
## Problem

Fixes https://github.com/marmelab/react-admin/issues/10415

Supersedes https://github.com/marmelab/react-admin/pull/10417 (which was reverted in https://github.com/marmelab/react-admin/commit/3f6a312a7e035a89c715a4dd402ef775b25c9d9c as it caused other issues notably with StackedFilters).

## Solution

The flicker actually comes from a missing memoization of the `optionText` prop in the `<AutocompleteInput>` component.

## How To Test

- Story without the fix: https://react-admin-storybook.vercel.app/?path=/story/ra-core-form-formdataconsumer--basic
- Story with the fix: http://localhost:9010/?path=/story/ra-core-form-formdataconsumer--basic

For both: Enter a title then select a user. Notice the flicker each time you change the user value. You might have to set a CPU throttle in your devtool to notice it.

---

FTR: Also added a story allowing to reproduce the issue the first fix attempt created in the `StackedFilters` component.
To reproduce the bug:
1. Open story: http://localhost:9010/?path=/story/ra-core-form-formdataconsumer--stacked-filters
2. Add a new filter, leave every input blank
3. Remove the newly added filter
4. Add a new filter again
5. This should trigger an error: `Cannot read properties of null (reading 'focus')`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why): not possible
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
