### PR TITLE
Make the `basic` flag use `npm`

### DIFF
--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -16,7 +16,7 @@ const cli = meow(
 	  --auth-provider  Set the auth provider to use ("local-auth-provider" or "none")
 	  --resource       Add a resource that will be initialized with guessers (can be used multiple times). Set to "skip" to bypass the interactive resource step.
 	  --install        Set the package manager to use for installing dependencies ("yarn", "npm" or "skip" to bypass the interactive install step)
-	  --basic          Skip all the interactive steps and create a basic app with no data provider, no auth provider, no resources and no install step
+	  --basic          Skip all the interactive steps and create a basic app with no data provider, no auth provider, no resources and install with npm
 
     Examples
 	  $ create-admin-app my-admin

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -57,7 +57,7 @@ if (cli.flags.h) {
 } else {
     const dataProvider = cli.flags.basic ? 'none' : cli.flags.dataProvider;
     const authProvider = cli.flags.basic ? 'none' : cli.flags.authProvider;
-    const install = cli.flags.basic ? 'skip' : cli.flags.install;
+    const install = cli.flags.basic ? 'npm' : cli.flags.install;
     const resources =
         cli.flags.basic || cli.flags.resource.includes('skip')
             ? []

--- a/packages/create-react-admin/src/generateAppFile.ts
+++ b/packages/create-react-admin/src/generateAppFile.ts
@@ -9,7 +9,11 @@ export const generateAppFile = (
     fs.writeFileSync(
         path.join(projectDirectory, 'src', 'App.tsx'),
         `
-import { Admin, Resource, ListGuesser, EditGuesser, ShowGuesser } from 'react-admin';
+${
+    state.resources.length > 0
+        ? `import { Admin, Resource, ListGuesser, EditGuesser, ShowGuesser } from 'react-admin';`
+        : `import { Admin } from 'react-admin';`
+}
 import { Layout } from './Layout';
 ${
     state.dataProvider !== 'none'


### PR DESCRIPTION
## Problem

We want that the `basic` flag of the `create-react-admin` downloads the `node_modules` with `npm`

## How To Test

![Capture d’écran du 2025-02-06 11-31-22](https://github.com/user-attachments/assets/eb07cf09-bad3-4c6d-81de-8db07b2e407e)

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [x] The **documentation** is up to date
