### PR TITLE
Fix demo build

### DIFF
--- a/examples/demo/vite.config.ts
+++ b/examples/demo/vite.config.ts
@@ -6,7 +6,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import preserveDirectives from 'rollup-preserve-directives';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => {
+export default defineConfig(async ({ mode }) => {
     const packages = fs.readdirSync(path.resolve(__dirname, '../../packages'));
     const aliases: Record<string, string> = {
         'data-generator-retail': path.resolve(
@@ -68,6 +68,21 @@ export default defineConfig(async () => {
                 //     find: 'scheduler/tracing',
                 //     replacement: 'scheduler/tracing-profiling',
                 // },
+                // The 2 next aliases are needed to avoid having multiple react-router instances
+                {
+                    find: 'react-router-dom',
+                    replacement: path.resolve(
+                        __dirname,
+                        `node_modules/react-router/dist/${mode === 'production' ? 'production' : 'development'}/index.mjs`
+                    ),
+                },
+                {
+                    find: 'react-router',
+                    replacement: path.resolve(
+                        __dirname,
+                        `node_modules/react-router/dist/${mode === 'production' ? 'production' : 'development'}/index.mjs`
+                    ),
+                },
                 // The 2 next aliases are needed to avoid having multiple MUI instances
                 {
                     find: '@mui/material',


### PR DESCRIPTION
## Problem

Although the demo seems to build fine, it actually doesn't work when you run `vite preview`. It seems it loads multiple versions of `react-router`. This is only an issue in our monorepo setup.

## Solution

Add aliases so that Vite correctly resolve the react-router versions we want in the demo (v7)

## How To Test

- `make run-demo` => check it runs fine in development
- `make build-demo` => check it still builds fine
- `cd examples/demo && yarn preview` => check the production build runs fine

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature