### PR TITLE
Fix create react admin fakerest

### DIFF
--- a/packages/create-react-admin/src/app.tsx
+++ b/packages/create-react-admin/src/app.tsx
@@ -121,7 +121,7 @@ export default function App(props: Props) {
         resources: props.resources?.includes('skip')
             ? []
             : props.dataProvider === 'ra-data-fakerest' &&
-                props.resources == null
+                (props.resources == null || props.resources.length === 0)
               ? ['posts', 'comments']
               : props.resources,
         installer: props.install,

--- a/packages/create-react-admin/src/app.tsx
+++ b/packages/create-react-admin/src/app.tsx
@@ -58,10 +58,6 @@ const stepReducer = (
             const newState = {
                 ...state,
                 dataProvider: action.value,
-                resources:
-                    action.value === 'ra-data-fakerest'
-                        ? ['posts', 'comments']
-                        : state.resources,
             };
             return {
                 ...newState,
@@ -124,7 +120,8 @@ export default function App(props: Props) {
         authProvider: props.authProvider,
         resources: props.resources?.includes('skip')
             ? []
-            : props.dataProvider === 'ra-data-fakerest'
+            : props.dataProvider === 'ra-data-fakerest' &&
+                props.resources == null
               ? ['posts', 'comments']
               : props.resources,
         installer: props.install,

--- a/packages/create-react-admin/src/app.tsx
+++ b/packages/create-react-admin/src/app.tsx
@@ -58,6 +58,11 @@ const stepReducer = (
             const newState = {
                 ...state,
                 dataProvider: action.value,
+                resources:
+                    action.value === 'ra-data-fakerest' &&
+                    (state.resources == null || state.resources.length === 0)
+                        ? ['posts', 'comments']
+                        : state.resources,
             };
             return {
                 ...newState,

--- a/packages/create-react-admin/src/generateAppFile.ts
+++ b/packages/create-react-admin/src/generateAppFile.ts
@@ -24,24 +24,21 @@ ${
 export const App = () => (
     <Admin
         layout={Layout}
-        ${
-            state.dataProvider !== 'none'
-                ? `dataProvider={dataProvider}\n\t`
-                : ''
-        }${
+        ${state.dataProvider !== 'none' ? `dataProvider={dataProvider}` : ''}${
             state.authProvider !== 'none'
-                ? `\tauthProvider={authProvider}\n\t`
+                ? `\n\tauthProvider={authProvider}`
                 : ''
-        }>
+        }
+    >
         ${state.resources
             .map(
                 resource =>
                     `<Resource name="${resource}" list={ListGuesser} edit={EditGuesser} show={ShowGuesser} />`
             )
-            .join('\n\t\t')}
+            .join('\n\t')}
     </Admin>
 );
 
-    `
+`
     );
 };

--- a/packages/create-react-admin/src/generateAppFile.ts
+++ b/packages/create-react-admin/src/generateAppFile.ts
@@ -23,10 +23,9 @@ ${
 
 export const App = () => (
     <Admin
-        layout={Layout}
-        ${state.dataProvider !== 'none' ? `dataProvider={dataProvider}` : ''}${
+        layout={Layout}${state.dataProvider !== 'none' ? `\n\t\tdataProvider={dataProvider}` : ''}${
             state.authProvider !== 'none'
-                ? `\n\tauthProvider={authProvider}`
+                ? `\n\t\tauthProvider={authProvider}`
                 : ''
         }
     >
@@ -35,7 +34,7 @@ export const App = () => (
                 resource =>
                     `<Resource name="${resource}" list={ListGuesser} edit={EditGuesser} show={ShowGuesser} />`
             )
-            .join('\n\t')}
+            .join('\n\t\t')}
     </Admin>
 );
 

--- a/packages/create-react-admin/src/generateAppFile.ts
+++ b/packages/create-react-admin/src/generateAppFile.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { ProjectConfiguration } from './ProjectState.js';
 
+const tab = '    ';
 export const generateAppFile = (
     projectDirectory: string,
     state: ProjectConfiguration
@@ -23,9 +24,9 @@ ${
 
 export const App = () => (
     <Admin
-        layout={Layout}${state.dataProvider !== 'none' ? `\n\t\tdataProvider={dataProvider}` : ''}${
+        layout={Layout}${state.dataProvider !== 'none' ? `\n${tab}${tab}dataProvider={dataProvider}` : ''}${
             state.authProvider !== 'none'
-                ? `\n\t\tauthProvider={authProvider}`
+                ? `\n${tab}${tab}authProvider={authProvider}`
                 : ''
         }
     >
@@ -34,7 +35,7 @@ export const App = () => (
                 resource =>
                     `<Resource name="${resource}" list={ListGuesser} edit={EditGuesser} show={ShowGuesser} />`
             )
-            .join('\n\t\t')}
+            .join(`\n${tab}${tab}`)}
     </Admin>
 );
 


### PR DESCRIPTION
## Problem

Fixes #10493

- `create-react-admin` ignore custom resources when using `ra-data-fakerest`
- The generated `App.tsx` file is incorrectly formatted:
```tsx
import { Admin, Resource, ListGuesser, EditGuesser, ShowGuesser } from 'react-admin';
import { Layout } from './Layout';
import { dataProvider } from './dataProvider';


export const App = () => (
    <Admin
        layout={Layout}
        dataProvider={dataProvider}
        >
        <Resource name="books" list={ListGuesser} edit={EditGuesser} show={ShowGuesser} />
                <Resource name="authors" list={ListGuesser} edit={EditGuesser} show={ShowGuesser} />
    </Admin>
);

    
```

## Solution

- Allow to override resources by specifying them using the CLI `resource` option
- Fix formatting

## How To Test

1. `make build-create-react-admin install`

2. `./node_modules/.bin/create-react-admin myadmin --data-provider ra-data-fakerest --auth-provider local-auth-provider --resource books --resource authors --install skip`
- Check the generated `App.tsx` file contains only the `books` and `authors` resources.
- Check the generated app does not contain an `App.spec.tsx` file
- Check the generated `App.tsx` file is correctly formatted

3. delete the generated app and run `./node_modules/.bin/create-react-admin myadmin --data-provider ra-data-fakerest --auth-provider none --resource books --resource authors --install skip` (no auth)
- Check all the points in 2

4. delete the generated app and run `./node_modules/.bin/create-react-admin myadmin --data-provider ra-data-fakerest --auth-provider none --install skip` (no auth)
- Check the generated `App.tsx` file contains only the `posts` and `comments` resources.
- Check the generated app contains an `App.spec.tsx` file
- Check the generated `App.tsx` file is correctly formatted

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
