### PR TITLE
Added emptyText to SelectArrayInput component

### DIFF
--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -418,7 +418,7 @@ You can override that label with the `emptyText` prop.
 
 ```jsx
 
-<SelectInput  source="category"  choices={choices}  emptyText="No category selected" />
+<SelectArrayInput  source="category"  choices={choices}  emptyText="No category selected" />
 
 ```
 
@@ -426,7 +426,7 @@ The `emptyText` prop accepts either a string or a React Element.
 And if you want to hide that empty choice, make the input required.
 
 ```jsx
-<SelectInput  source="category"  choices={choices}  validate={required()} />
+<SelectArrayInput  source="category"  choices={choices}  validate={required()} />
 ```
 
 ## Fetching Choices

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -409,6 +409,26 @@ In that case, set the `translateChoice` prop to `false`.
 <SelectArrayInput source="roles" choices={choices} translateChoice={false}/>
 ```
 
+## `emptyText`
+
+If the input isn't required (using `validate={required()}`), users can select an empty choice with an empty text `''` as label, when clicking on the empty option, all selected values ​​will be deselected.
+
+You can override that label with the `emptyText` prop.
+ 
+
+```jsx
+
+<SelectInput  source="category"  choices={choices}  emptyText="No category selected" />
+
+```
+
+The `emptyText` prop accepts either a string or a React Element.
+And if you want to hide that empty choice, make the input required.
+
+```jsx
+<SelectInput  source="category"  choices={choices}  validate={required()} />
+```
+
 ## Fetching Choices
 
 If you want to populate the `choices` attribute with a list of related records, you should decorate `<SelectArrayInput>` with [`<ReferenceArrayInput>`](./ReferenceArrayInput.md), and leave the `choices` empty:

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -777,7 +777,7 @@ describe('<SelectArrayInput />', () => {
         });
     });
 
-    it('should render the emptyValue option correctly', () => {
+    it('should render the emptyText option correctly', () => {
         const choices = [
             { id: 'programming', name: 'Programming' },
             { id: 'lifestyle', name: 'Lifestyle' },

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -84,6 +84,18 @@ describe('<SelectArrayInput />', () => {
         expect(screen.queryByText('Photography')).not.toBeNull();
     });
 
+    it('should clear the options when clicking in emptyOption', () => {
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm onSubmit={jest.fn()}>
+                        <SelectArrayInput {...defaultProps} />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+    });
+
     it('should use optionValue as value identifier', () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
@@ -763,5 +775,68 @@ describe('<SelectArrayInput />', () => {
                 );
             });
         });
+    });
+
+    it('should render the emptyValue option correctly', () => {
+        const choices = [
+            { id: 'programming', name: 'Programming' },
+            { id: 'lifestyle', name: 'Lifestyle' },
+            { id: 'photography', name: 'Photography' },
+        ];
+
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm onSubmit={jest.fn()}>
+                        <SelectArrayInput
+                            {...defaultProps}
+                            choices={choices}
+                            emptyText="Test Option"
+                        />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+
+        fireEvent.mouseDown(
+            screen.getByLabelText('resources.posts.fields.categories')
+        );
+        expect(screen.getByText('Test Option')).toBeInTheDocument();
+    });
+
+    it('should clear the options when clicking on emptyOption', async () => {
+        const choices = [
+            { id: 'programming', name: 'Programming' },
+            { id: 'lifestyle', name: 'Lifestyle' },
+            { id: 'photography', name: 'Photography' },
+        ];
+
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm onSubmit={jest.fn()}>
+                        <SelectArrayInput
+                            {...defaultProps}
+                            choices={choices}
+                            emptyText="Clear selections"
+                        />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+
+        fireEvent.mouseDown(
+            screen.getByLabelText('resources.posts.fields.categories')
+        );
+        fireEvent.click(screen.getByText('Programming'));
+        fireEvent.click(screen.getByText('Lifestyle'));
+        expect(
+            screen.getByDisplayValue('programming,lifestyle')
+        ).toBeInTheDocument();
+        fireEvent.mouseDown(
+            screen.getByLabelText('resources.posts.fields.categories')
+        );
+        fireEvent.click(screen.getByText('Clear selections'));
+        expect(screen.queryByDisplayValue('programming,lifestyle')).toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -261,7 +261,7 @@ export const EmptyText = () => (
                 { id: 'u002', name: 'Moderator' },
                 { id: 'u003', name: 'Reviewer' },
             ]}
-            emptyText={'Clear'}
+            emptyText='Clear'
             sx={{ width: 300 }}
         />
     </Wrapper>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -251,6 +251,22 @@ export const DefaultValue = () => (
     </Wrapper>
 );
 
+export const EmptyText = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+            emptyText={'Clear'}
+            sx={{ width: 300 }}
+        />
+    </Wrapper>
+);
+
 export const InsideArrayInput = () => (
     <Wrapper>
         <ArrayInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -230,14 +230,6 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
             ? [...(allChoices || []), createItem]
             : allChoices || [];
 
-    const renderEmptyItemOption = useCallback(() => {
-        return typeof emptyText === 'string'
-            ? emptyText === ''
-                ? ' ' // em space, forces the display of an empty line of normal height
-                : translate(emptyText, { _: emptyText })
-            : emptyText;
-    }, [emptyText, translate]);
-
     const renderMenuItemOption = useCallback(
         choice =>
             !!createItem &&
@@ -374,14 +366,18 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                 >
                     {!isRequired && (
                         <MenuItem
-                            value=''
+                            value=""
                             key="null"
                             aria-label={translate(
                                 'ra.action.clear_input_value'
                             )}
                             title={translate('ra.action.clear_input_value')}
                         >
-                            {renderEmptyItemOption()}
+                            {typeof emptyText === 'string'
+                                ? emptyText === ''
+                                    ? ' ' // em space, forces the display of an empty line of normal height
+                                    : translate(emptyText, { _: emptyText })
+                                : emptyText}
                         </MenuItem>
                     )}
                     {finalChoices.map(renderMenuItem)}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -374,7 +374,7 @@ export const SelectArrayInput = (props: SelectArrayInputProps) => {
                 >
                     {!isRequired && (
                         <MenuItem
-                            value={''}
+                            value=''
                             key="null"
                             aria-label={translate(
                                 'ra.action.clear_input_value'


### PR DESCRIPTION
# Problem

Absence of the emptyText property in the SelectArrayInput component #10454 

## Solution

The empty Text property was added to the component, the emptyText option clears all fields that had been selected

## How To Test

It is possible to view the update in the storybook

## Additional Checks

- [ ✓ ] The PR targets `master` for a bugfix, or `next` for a feature
- [ ✓ ] The PR includes **unit tests** (if not possible, describe why)
- [ ✓ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ✓ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
