### PR TITLE
Remove doc from published react-admin package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,7 @@ build-ra-language-french:
 
 build-react-admin:
 	@echo "Transpiling react-admin files...";
-	@rm -rf ./packages/react-admin/docs
 	@cd ./packages/react-admin && yarn build
-	@mkdir packages/react-admin/docs
-	@cp docs/*.md packages/react-admin/docs
 
 build-ra-data-fakerest:
 	@echo "Transpiling ra-data-fakerest files...";

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ build-ra-language-french:
 
 build-react-admin:
 	@echo "Transpiling react-admin files...";
+	@rm -rf ./packages/react-admin/docs
 	@cd ./packages/react-admin && yarn build
 
 build-ra-data-fakerest:

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -5,8 +5,7 @@
     "files": [
         "*.md",
         "dist",
-        "src",
-        "docs"
+        "src"
     ],
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",


### PR DESCRIPTION
## Problem

We currently include a copy of the `docs` directory in the published `react-admin` package. This makes it quite heavy and is probably useless.

## Solution

- remove the command that copy the `docs` directory when building the package.
- remove the `docs` directory from the included files of the `package.json` for `react-admin`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
