### PR TITLE
[DateInput] Update docs to mention `format` prop for timezone adjustment

### DIFF
--- a/docs/DateInput.md
+++ b/docs/DateInput.md
@@ -37,7 +37,7 @@ The field value must be a string using the pattern `YYYY-MM-DD` (ISO 8601), e.g.
 
 In these cases, `<DateInput>` will automatically convert the value to the `YYYY-MM-DD` format, and will return a `string`, or `null` if the date is invalid.
 
-**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, use the [`format`](https://marmelab.com/react-admin/Inputs.html#format) prop to convert the date back to UTC and return the formatted string as `yyyy-MM-dd`.
+**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, use the [`format`](./Inputs.html#format) prop to convert the date to UTC and return the formatted string as `yyyy-MM-dd` to the input. In this scenario you likely want the outgoing value to stay consistent with UTC too, so provide your own [`parse`](./Inputs.md#parse) function to `<DateInput>` so that browser's timezone is stripped.
 
 ## Props
 

--- a/docs/DateInput.md
+++ b/docs/DateInput.md
@@ -37,7 +37,7 @@ The field value must be a string using the pattern `YYYY-MM-DD` (ISO 8601), e.g.
 
 In these cases, `<DateInput>` will automatically convert the value to the `YYYY-MM-DD` format, and will return a `string`, or `null` if the date is invalid.
 
-**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, pass your own `value` (perhaps a maipulation of the field from the context, to fix the offset) to `<DateInput>`.
+**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, use the [`format`](https://marmelab.com/react-admin/Inputs.html#format) prop to convert the date back to UTC and return the formatted string as `yyyy-MM-dd`.
 
 ## Props
 

--- a/docs/DateInput.md
+++ b/docs/DateInput.md
@@ -37,7 +37,7 @@ The field value must be a string using the pattern `YYYY-MM-DD` (ISO 8601), e.g.
 
 In these cases, `<DateInput>` will automatically convert the value to the `YYYY-MM-DD` format, and will return a `string`, or `null` if the date is invalid.
 
-**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, use the [`format`](./Inputs.html#format) prop to convert the date to UTC and return the formatted string as `yyyy-MM-dd` to the input. In this scenario you likely want the outgoing value to stay consistent with UTC too, so provide your own [`parse`](./Inputs.md#parse) function to `<DateInput>` so that browser's timezone is stripped.
+**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, use the [`format`](./Inputs.html#format) prop to convert the date to UTC and return the formatted string as `yyyy-MM-dd` to the input. In this scenario you likely want the outgoing value to stay consistent with UTC too, so provide your own [`parse`](./Inputs.md#parse) function to `<DateInput>` to transform it as needed.
 
 ## Props
 

--- a/docs/DateInput.md
+++ b/docs/DateInput.md
@@ -37,7 +37,7 @@ The field value must be a string using the pattern `YYYY-MM-DD` (ISO 8601), e.g.
 
 In these cases, `<DateInput>` will automatically convert the value to the `YYYY-MM-DD` format, and will return a `string`, or `null` if the date is invalid.
 
-**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, pass your own [`parse`](./Inputs.md#parse) function to `<DateInput>`.
+**Note**: This conversion may change the date because of timezones. For example, the date string `'2022-04-30T00:00:00.000Z'` in Europe may be displayed as `'2022-04-29'` in Honolulu. If this is not what you want, pass your own `value` (perhaps a maipulation of the field from the context, to fix the offset) to `<DateInput>`.
 
 ## Props
 

--- a/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
@@ -77,32 +77,6 @@ export const DefaultValue = () => (
         ))}
     </Wrapper>
 );
-
-export const DefaultValueVsFieldValue = () => (
-    <Wrapper
-        simpleFormProps={{
-            defaultValues: { publishedAt: '2021-09-11' },
-        }}
-    >
-        The defaultValue is not displayed, because there is a value from field
-        <DateInput
-            source={`publishedAt`}
-            defaultValue="2025-09-11T20:46:20.000Z"
-        />
-    </Wrapper>
-);
-
-export const ValueVsFieldValue = () => (
-    <Wrapper
-        simpleFormProps={{
-            defaultValues: { publishedAt: '2021-09-11' },
-        }}
-    >
-        The value prop is displayed, and wins over the field value
-        <DateInput source={`publishedAt`} value="2025" />
-    </Wrapper>
-);
-
 export const Disabled = () => (
     <Wrapper>
         <DateInput source="publishedAt" disabled />

--- a/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
@@ -77,6 +77,32 @@ export const DefaultValue = () => (
         ))}
     </Wrapper>
 );
+
+export const DefaultValueVsFieldValue = () => (
+    <Wrapper
+        simpleFormProps={{
+            defaultValues: { publishedAt: '2021-09-11' },
+        }}
+    >
+        The defaultValue is not displayed, because there is a value from field
+        <DateInput
+            source={`publishedAt`}
+            defaultValue="2025-09-11T20:46:20.000Z"
+        />
+    </Wrapper>
+);
+
+export const ValueVsFieldValue = () => (
+    <Wrapper
+        simpleFormProps={{
+            defaultValues: { publishedAt: '2021-09-11' },
+        }}
+    >
+        The value prop is displayed, and wins over the field value
+        <DateInput source={`publishedAt`} value="2025" />
+    </Wrapper>
+);
+
 export const Disabled = () => (
     <Wrapper>
         <DateInput source="publishedAt" disabled />

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -36,6 +36,11 @@ import { InputHelperText } from './InputHelperText';
  * // The input will display '2021-09-11' whatever the browser timezone.
  *
  * @example
+ * // If you want to manipulate the value from the field (data provider), use value prop
+ * <DateInput source="published_at" value={useRecordContext().published_at.getUTCFullYear()} />
+ * // The input will display the first of Jan, whatever the field value is.
+ *
+ * @example
  * // If you want the returned value to be a Date, you must pass a custom parse method
  * to convert the form value (which is always a date string) back to a Date object.
  * <DateInput source="published_at" parse={val => new Date(val)} />
@@ -43,34 +48,35 @@ import { InputHelperText } from './InputHelperText';
 export const DateInput = ({
     className,
     defaultValue,
+    disabled,
     format = defaultFormat,
-    label,
-    source,
-    resource,
     helperText,
+    label,
     margin,
     onChange,
     onFocus,
-    validate,
-    variant,
-    disabled,
     readOnly,
+    resource,
+    source,
+    validate,
+    value,
+    variant,
     ...rest
 }: DateInputProps) => {
     const { field, fieldState, id, isRequired } = useInput({
         defaultValue,
+        disabled,
+        format,
+        readOnly,
         resource,
         source,
         validate,
-        disabled,
-        readOnly,
-        format,
         ...rest,
     });
     const localInputRef = React.useRef<HTMLInputElement>();
     // DateInput is not a really controlled input to ensure users can start entering a date, go to another input and come back to complete it.
     // This ref stores the value that is passed to the input defaultValue prop to solve this issue.
-    const initialDefaultValueRef = React.useRef(field.value);
+    const initialDefaultValueRef = React.useRef(value ?? field.value);
     // As the defaultValue prop won't trigger a remount of the HTML input, we will force it by changing the key.
     const [inputKey, setInputKey] = React.useState(1);
     // This ref let us track that the last change of the form state value was made by the input itself
@@ -83,6 +89,13 @@ export const DateInput = ({
         if (wasLastChangedByInput.current) {
             // Resets the flag to ensure futures changes are handled
             wasLastChangedByInput.current = false;
+            return;
+        }
+
+        // The value has changed from outside the input,
+        // but a `value` prop has been provided to component,
+        // so that should win because that's what the developer wants to display
+        if (value) {
             return;
         }
 

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -27,18 +27,18 @@ import { InputHelperText } from './InputHelperText';
  * // If the initial value string contains more than a date (e.g. an hour, a timezone),
  * // these details are ignored.
  * <DateInput source="published_at" defaultValue="2021-09-11T20:46:20.000-04:00" />
- * // The input will display '2021-09-11' whatever the browser timezone.
+ * // The input will display '2021-09-11' regardless of the browser timezone.
  *
  * @example
  * // If the initial value is a Date object, DateInput converts it to a string
  * // and ignores the timezone.
  * <DateInput source="published_at" defaultValue={new Date("2021-09-11T20:46:20.000-04:00")} />
- * // The input will display '2021-09-11' whatever the browser timezone.
+ * // The input will display '2021-09-11' regardless of the browser timezone.
  *
  * @example
- * // If you want to manipulate the value from the field to adjust its timezone, use format prop
+ * // If you want to manipulate the value from the field to adjust its timezone, use the format prop
  * <DateInput source="published_at" format={value => new Date(value).toISOString().split("T")[0} />
- * // The input will display the UTC day whatever the browser timezone.
+ * // The input will display the UTC day regardless of the browser timezone.
  *
  * @example
  * // If you want the returned value to be a Date, you must pass a custom parse method

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -36,9 +36,9 @@ import { InputHelperText } from './InputHelperText';
  * // The input will display '2021-09-11' whatever the browser timezone.
  *
  * @example
- * // If you want to manipulate the value from the field (data provider), use value prop
- * <DateInput source="published_at" value={useRecordContext().published_at.getUTCFullYear()} />
- * // The input will display the first of Jan, whatever the field value is.
+ * // If you want to manipulate the value from the field to adjust its timezone, use format prop
+ * <DateInput source="published_at" format={value => new Date(value).toISOString().split("T")[0} />
+ * // The input will display the UTC day whatever the browser timezone.
  *
  * @example
  * // If you want the returned value to be a Date, you must pass a custom parse method
@@ -48,35 +48,34 @@ import { InputHelperText } from './InputHelperText';
 export const DateInput = ({
     className,
     defaultValue,
-    disabled,
     format = defaultFormat,
-    helperText,
     label,
+    source,
+    resource,
+    helperText,
     margin,
     onChange,
     onFocus,
-    readOnly,
-    resource,
-    source,
     validate,
-    value,
     variant,
+    disabled,
+    readOnly,
     ...rest
 }: DateInputProps) => {
     const { field, fieldState, id, isRequired } = useInput({
         defaultValue,
-        disabled,
-        format,
-        readOnly,
         resource,
         source,
         validate,
+        disabled,
+        readOnly,
+        format,
         ...rest,
     });
     const localInputRef = React.useRef<HTMLInputElement>();
     // DateInput is not a really controlled input to ensure users can start entering a date, go to another input and come back to complete it.
     // This ref stores the value that is passed to the input defaultValue prop to solve this issue.
-    const initialDefaultValueRef = React.useRef(value ?? field.value);
+    const initialDefaultValueRef = React.useRef(field.value);
     // As the defaultValue prop won't trigger a remount of the HTML input, we will force it by changing the key.
     const [inputKey, setInputKey] = React.useState(1);
     // This ref let us track that the last change of the form state value was made by the input itself
@@ -89,13 +88,6 @@ export const DateInput = ({
         if (wasLastChangedByInput.current) {
             // Resets the flag to ensure futures changes are handled
             wasLastChangedByInput.current = false;
-            return;
-        }
-
-        // The value has changed from outside the input,
-        // but a `value` prop has been provided to component,
-        // so that should win because that's what the developer wants to display
-        if (value) {
             return;
         }
 


### PR DESCRIPTION
## Problem

Problem is described [here](https://github.com/marmelab/react-admin/issues/10474), there is no way to manipulate the value coming from dataprovider because it will always win

## Solution

use `format` prop

## How To Test

Tested on storybook

## Additional Checks

- [x] The PR targets `master` for a bugfix
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
