### PR TITLE
Add support for `optimistic` and `undoable` `mutationMode` in `useCreate`

### DIFF
--- a/packages/ra-core/src/controller/create/CreateBase.spec.tsx
+++ b/packages/ra-core/src/controller/create/CreateBase.spec.tsx
@@ -53,7 +53,7 @@ describe('CreateBase', () => {
                     test: 'test',
                 },
                 { data: { test: 'test' }, resource: 'posts' },
-                undefined
+                { snapshot: [] }
             );
         });
     });
@@ -85,7 +85,7 @@ describe('CreateBase', () => {
                     test: 'test',
                 },
                 { data: { test: 'test' }, resource: 'posts' },
-                undefined
+                { snapshot: [] }
             );
         });
         expect(onSuccess).not.toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe('CreateBase', () => {
             expect(onError).toHaveBeenCalledWith(
                 { message: 'test' },
                 { data: { test: 'test' }, resource: 'posts' },
-                undefined
+                { snapshot: [] }
             );
         });
     });
@@ -139,7 +139,7 @@ describe('CreateBase', () => {
             expect(onErrorOverride).toHaveBeenCalledWith(
                 { message: 'test' },
                 { data: { test: 'test' }, resource: 'posts' },
-                undefined
+                { snapshot: [] }
             );
         });
         expect(onError).not.toHaveBeenCalled();

--- a/packages/ra-core/src/controller/create/useCreateController.spec.tsx
+++ b/packages/ra-core/src/controller/create/useCreateController.spec.tsx
@@ -105,6 +105,7 @@ describe('useCreateController', () => {
                         smart_count: 1,
                         _: 'ra.notification.created',
                     },
+                    undoable: false,
                 },
             },
         ]);

--- a/packages/ra-core/src/core/CoreAdmin.tsx
+++ b/packages/ra-core/src/core/CoreAdmin.tsx
@@ -99,6 +99,7 @@ export const CoreAdmin = (props: CoreAdminProps) => {
         loading,
         loginPage,
         queryClient,
+        QueryClientProvider,
         ready,
         requireAuth,
         store,
@@ -111,6 +112,7 @@ export const CoreAdmin = (props: CoreAdminProps) => {
             dataProvider={dataProvider}
             i18nProvider={i18nProvider}
             queryClient={queryClient}
+            QueryClientProvider={QueryClientProvider}
             store={store}
         >
             <CoreAdminUI

--- a/packages/ra-core/src/core/CoreAdminContext.tsx
+++ b/packages/ra-core/src/core/CoreAdminContext.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { useMemo } from 'react';
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import {
+    QueryClientProvider as DefaultQueryClientProvider,
+    QueryClient,
+} from '@tanstack/react-query';
 
 import { AdminRouter } from '../routing';
 import { AuthContext, convertLegacyAuthProvider } from '../auth';
@@ -140,6 +143,7 @@ export interface CoreAdminContextProps {
      * );
      */
     queryClient?: QueryClient;
+    QueryClientProvider?: React.ComponentType;
 
     /**
      * The internationalization provider for translations
@@ -175,6 +179,7 @@ export const CoreAdminContext = (props: CoreAdminContextProps) => {
         store = defaultStore,
         children,
         queryClient,
+        QueryClientProvider = DefaultQueryClientProvider,
     } = props;
 
     if (!dataProvider) {

--- a/packages/ra-core/src/dataProvider/useCreate.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.optimistic.stories.tsx
@@ -1,0 +1,405 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useCreate } from './useCreate';
+import { useGetOne } from './useGetOne';
+
+export default { title: 'ra-core/dataProvider/useCreate/optimistic' };
+
+export const SuccessCase = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, error, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate();
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: { id: 2, title: 'Hello World' },
+            },
+            {
+                mutationMode: 'optimistic',
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+    };
+    return (
+        <>
+            {error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const ErrorCase = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <ErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const ErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, error: getOneError, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate();
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: {
+                    id: 2,
+                    title: 'Hello World',
+                },
+            },
+            {
+                mutationMode: 'optimistic',
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+    };
+    return (
+        <>
+            {getOneError ? (
+                <p>{getOneError.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {error && <div>{error.message}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const WithMiddlewaresSuccess = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <WithMiddlewaresSuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const WithMiddlewaresSuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, error, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {
+            data: {
+                id: 2,
+                title: 'Hello World',
+            },
+        },
+        {
+            mutationMode: 'optimistic',
+            // @ts-ignore
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: {
+                        ...params.data,
+                        title: `${params.data.title} from middleware`,
+                    },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: {
+                    id: 2,
+                    title: 'Hello World',
+                },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+    };
+    return (
+        <>
+            {error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const WithMiddlewaresError = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <WithMiddlewaresErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const WithMiddlewaresErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, error: getOneError, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {
+            data: {
+                id: 2,
+                title: 'Hello World',
+            },
+        },
+        {
+            mutationMode: 'optimistic',
+            // @ts-ignore
+            mutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: {
+                        ...params.data,
+                        title: `${params.data.title} from middleware`,
+                    },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        setError(undefined);
+        create(
+            'posts',
+            {
+                data: {
+                    id: 2,
+                    title: 'Hello World',
+                },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+    };
+    return (
+        <>
+            {getOneError ? (
+                <p>{getOneError.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {error && <div>{error.message}</div>}
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useCreate.pessimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.pessimistic.stories.tsx
@@ -6,7 +6,7 @@ import { CoreAdminContext } from '../core';
 import { useCreate } from './useCreate';
 import { useGetOne } from './useGetOne';
 
-export default { title: 'ra-core/dataProvider/useCreate' };
+export default { title: 'ra-core/dataProvider/useCreate/pessimistic' };
 
 export const SuccessCase = ({ timeout = 1000 }) => {
     const posts: { id: number; title: string; author: string }[] = [];

--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, act } from '@testing-library/react';
 import expect from 'expect';
 
 import { RaRecord } from '../types';
@@ -8,9 +8,23 @@ import { useCreate } from './useCreate';
 import { useGetList } from './useGetList';
 import { CoreAdminContext } from '../core';
 import {
-    WithMiddlewaresError,
-    WithMiddlewaresSuccess,
-} from './useCreate.stories';
+    ErrorCase as ErrorCasePessimistic,
+    SuccessCase as SuccessCasePessimistic,
+    WithMiddlewaresSuccess as WithMiddlewaresSuccessPessimistic,
+    WithMiddlewaresError as WithMiddlewaresErrorPessimistic,
+} from './useCreate.pessimistic.stories';
+import {
+    ErrorCase as ErrorCaseOptimistic,
+    SuccessCase as SuccessCaseOptimistic,
+    WithMiddlewaresSuccess as WithMiddlewaresSuccessOptimistic,
+    WithMiddlewaresError as WithMiddlewaresErrorOptimistic,
+} from './useCreate.optimistic.stories';
+import {
+    ErrorCase as ErrorCaseUndoable,
+    SuccessCase as SuccessCaseUndoable,
+    WithMiddlewaresSuccess as WithMiddlewaresSuccessUndoable,
+    WithMiddlewaresError as WithMiddlewaresErrorUndoable,
+} from './useCreate.undoable.stories';
 
 describe('useCreate', () => {
     it('returns a callback that can be used with create arguments', async () => {
@@ -186,9 +200,148 @@ describe('useCreate', () => {
         });
     });
 
+    describe('mutationMode', () => {
+        it('when pessimistic, displays result and success side effects when dataProvider promise resolves', async () => {
+            render(<SuccessCasePessimistic timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(screen.queryByText('Hello World')).toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+        it('when pessimistic, displays error and error side effects when dataProvider promise rejects', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<ErrorCasePessimistic timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(screen.queryByText('something went wrong')).toBeNull();
+                expect(screen.queryByText('Hello World')).toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(
+                    screen.queryByText('something went wrong')
+                ).not.toBeNull();
+                expect(screen.queryByText('not found')).toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+        it('when optimistic, displays result and success side effects right away', async () => {
+            render(<SuccessCaseOptimistic timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+        it('when optimistic, displays error and error side effects when dataProvider promise rejects', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<ErrorCaseOptimistic timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(
+                    screen.queryByText('something went wrong')
+                ).not.toBeNull();
+                expect(screen.queryByText('Hello World')).toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            await screen.findByText('not found');
+        });
+        it('when undoable, displays result and success side effects right away and fetched on confirm', async () => {
+            render(<SuccessCaseUndoable timeout={10} />);
+            act(() => {
+                screen.getByText('Create post').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            act(() => {
+                screen.getByText('Confirm').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(
+                () => {
+                    expect(screen.queryByText('mutating')).toBeNull();
+                },
+                { timeout: 4000 }
+            );
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello World')).not.toBeNull();
+        });
+        it('when undoable, displays result and success side effects right away and reverts on cancel', async () => {
+            render(<SuccessCaseUndoable timeout={10} />);
+            await screen.findByText('not found');
+            act(() => {
+                screen.getByText('Create post').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            act(() => {
+                screen.getByText('Cancel').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('Hello World')).toBeNull();
+            });
+            expect(screen.queryByText('mutating')).toBeNull();
+            await screen.findByText('not found');
+        });
+        it('when undoable, displays result and success side effects right away and reverts on error', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<ErrorCaseUndoable />);
+            await screen.findByText('not found', undefined, { timeout: 5000 });
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            screen.getByText('Confirm').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await screen.findByText('not found', undefined, { timeout: 4000 });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(screen.queryByText('Hello World')).toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+    });
+
     describe('middlewares', () => {
-        it('it accepts middlewares and displays result and success side effects when dataProvider promise resolves', async () => {
-            render(<WithMiddlewaresSuccess timeout={10} />);
+        it('when pessimistic, it accepts middlewares and displays result and success side effects when dataProvider promise resolves', async () => {
+            render(<WithMiddlewaresSuccessPessimistic timeout={10} />);
             screen.getByText('Create post').click();
             await waitFor(() => {
                 expect(screen.queryByText('success')).toBeNull();
@@ -206,9 +359,9 @@ describe('useCreate', () => {
             });
         });
 
-        it('it accepts middlewares and displays error and error side effects when dataProvider promise rejects', async () => {
+        it('when pessimistic, it accepts middlewares and displays error and error side effects when dataProvider promise rejects', async () => {
             jest.spyOn(console, 'error').mockImplementation(() => {});
-            render(<WithMiddlewaresError timeout={10} />);
+            render(<WithMiddlewaresErrorPessimistic timeout={10} />);
             screen.getByText('Create post').click();
             await waitFor(() => {
                 expect(screen.queryByText('success')).toBeNull();
@@ -229,5 +382,123 @@ describe('useCreate', () => {
                 expect(screen.queryByText('mutating')).toBeNull();
             });
         });
+
+        it('when optimistic, it accepts middlewares and displays result and success side effects right away', async () => {
+            render(<WithMiddlewaresSuccessOptimistic timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+        });
+        it('when optimistic, it accepts middlewares and displays error and error side effects when dataProvider promise rejects', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<WithMiddlewaresErrorOptimistic timeout={10} />);
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).toBeNull();
+                expect(
+                    screen.queryByText('something went wrong')
+                ).not.toBeNull();
+                expect(
+                    screen.queryByText('Hello World from middleware')
+                ).toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            await screen.findByText('not found');
+        });
+
+        it('when undoable, it accepts middlewares and displays result and success side effects right away and fetched on confirm', async () => {
+            render(<WithMiddlewaresSuccessUndoable timeout={10} />);
+            act(() => {
+                screen.getByText('Create post').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            act(() => {
+                screen.getByText('Confirm').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await waitFor(
+                () => {
+                    expect(screen.queryByText('mutating')).toBeNull();
+                },
+                { timeout: 4000 }
+            );
+            expect(screen.queryByText('success')).not.toBeNull();
+            await screen.findByText('Hello World from middleware');
+        });
+        it('when undoable, it accepts middlewares and displays result and success side effects right away and reverts on cancel', async () => {
+            render(<WithMiddlewaresSuccessUndoable timeout={10} />);
+            await screen.findByText('not found');
+            act(() => {
+                screen.getByText('Create post').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            act(() => {
+                screen.getByText('Cancel').click();
+            });
+            await waitFor(() => {
+                expect(screen.queryByText('Hello World')).toBeNull();
+            });
+            expect(screen.queryByText('mutating')).toBeNull();
+            await screen.findByText('not found');
+        });
+        it('when undoable, it accepts middlewares and displays result and success side effects right away and reverts on error', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<WithMiddlewaresErrorUndoable />);
+            await screen.findByText('not found', undefined, { timeout: 5000 });
+            screen.getByText('Create post').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).toBeNull();
+            });
+            screen.getByText('Confirm').click();
+            await waitFor(() => {
+                expect(screen.queryByText('success')).not.toBeNull();
+                expect(screen.queryByText('Hello World')).not.toBeNull();
+                expect(screen.queryByText('mutating')).not.toBeNull();
+            });
+            await screen.findByText('Hello World', undefined, {
+                timeout: 4000,
+            });
+            await waitFor(
+                () => {
+                    expect(screen.queryByText('success')).toBeNull();
+                },
+                { timeout: 5000 }
+            );
+
+            expect(
+                screen.queryByText('Hello World from middleware')
+            ).toBeNull();
+            expect(screen.queryByText('mutating')).toBeNull();
+        }, 6000);
     });
 });

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -5,11 +5,23 @@ import {
     UseMutationResult,
     useQueryClient,
     MutateOptions,
+    QueryKey,
+    UseInfiniteQueryResult,
+    InfiniteData,
 } from '@tanstack/react-query';
 
 import { useDataProvider } from './useDataProvider';
-import { RaRecord, CreateParams, Identifier, DataProvider } from '../types';
+import {
+    RaRecord,
+    CreateParams,
+    GetListResult as OriginalGetListResult,
+    GetInfiniteListResult,
+    Identifier,
+    DataProvider,
+    MutationMode,
+} from '../types';
 import { useEvent } from '../util';
+import { useAddUndoableMutation } from './undo';
 
 /**
  * Get a callback to call the dataProvider.create() method, the result and the loading state.
@@ -80,12 +92,111 @@ export const useCreate = <
 ): UseCreateResult<RecordType, boolean, MutationError, ResultRecordType> => {
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
+    const addUndoableMutation = useAddUndoableMutation();
+    const { data, meta } = params;
+
+    const {
+        mutationMode = 'pessimistic',
+        getMutateWithMiddlewares,
+        ...mutationOptions
+    } = options;
+    const mode = useRef<MutationMode>(mutationMode);
     const paramsRef =
         useRef<Partial<CreateParams<Partial<RecordType>>>>(params);
-    const hasCallTimeOnError = useRef(false);
+    const snapshot = useRef<Snapshot>([]);
+
+    // Ref that stores the mutation with middlewares to avoid losing them if the calling component is unmounted
+    const mutateWithMiddlewares = useRef(dataProvider.create);
+
+    // We need to store the call-time onError and onSettled in refs to be able to call them in the useMutation hook even
+    // when the calling component is unmounted
+    const callTimeOnError =
+        useRef<
+            UseCreateOptions<
+                RecordType,
+                MutationError,
+                ResultRecordType
+            >['onError']
+        >();
+    const callTimeOnSettled =
+        useRef<
+            UseCreateOptions<
+                RecordType,
+                MutationError,
+                ResultRecordType
+            >['onSettled']
+        >();
+
+    // We don't need to keep a ref on the onSuccess callback as we call it ourselves for optimistic and
+    // undoable mutations. There is a limitation though: if one of the side effects applied by the onSuccess callback
+    // unmounts the component that called the useUpdate hook (redirect for instance), it must be the last one applied,
+    // otherwise the other side effects may not applied.
     const hasCallTimeOnSuccess = useRef(false);
-    const hasCallTimeOnSettled = useRef(false);
-    const { getMutateWithMiddlewares, ...mutationOptions } = options;
+
+    const updateCache = ({ resource, id, data, meta }) => {
+        // hack: only way to tell react-query not to fetch this query for the next 5 seconds
+        // because setQueryData doesn't accept a stale time option
+        const now = Date.now();
+        const updatedAt = mode.current === 'undoable' ? now + 5 * 1000 : now;
+        // Stringify and parse the data to remove undefined values.
+        // If we don't do this, an update with { id: undefined } as payload
+        // would remove the id from the record, which no real data provider does.
+        const clonedData = JSON.parse(JSON.stringify(data));
+
+        const updateColl = (old: RecordType[]) => {
+            if (!old) return old;
+            return [data, ...old];
+        };
+
+        type GetListResult = Omit<OriginalGetListResult, 'data'> & {
+            data?: RecordType[];
+        };
+
+        queryClient.setQueryData(
+            [resource, 'getOne', { id: String(id), meta }],
+            (record: RecordType) => ({ ...record, ...clonedData }),
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            { queryKey: [resource, 'getList'] },
+            (res: GetListResult) =>
+                res && res.data ? { ...res, data: updateColl(res.data) } : res,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            { queryKey: [resource, 'getInfiniteList'] },
+            (
+                res: UseInfiniteQueryResult<
+                    InfiniteData<GetInfiniteListResult>
+                >['data']
+            ) =>
+                res && res.pages
+                    ? {
+                          ...res,
+                          pages: res.pages.map(page => ({
+                              ...page,
+                              data: updateColl(page.data),
+                          })),
+                      }
+                    : res,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            { queryKey: [resource, 'getMany'] },
+            (coll: RecordType[]) =>
+                coll && coll.length > 0 ? updateColl(coll) : coll,
+            { updatedAt }
+        );
+        queryClient.setQueriesData(
+            { queryKey: [resource, 'getManyReference'] },
+            (res: GetListResult) =>
+                res && res.data
+                    ? { data: updateColl(res.data), total: res.total }
+                    : res,
+            { updatedAt }
+        );
+    };
+
     const mutation = useMutation<
         ResultRecordType,
         MutationError,
@@ -106,63 +217,111 @@ export const useCreate = <
                     'useCreate mutation requires a non-empty data object'
                 );
             }
-            if (getMutateWithMiddlewares) {
-                const createWithMiddlewares = getMutateWithMiddlewares(
-                    dataProvider.create.bind(dataProvider)
-                );
-                return createWithMiddlewares(callTimeResource, {
-                    data: callTimeData,
-                    meta: callTimeMeta,
-                }).then(({ data }) => data);
-            }
-            return dataProvider
-                .create<RecordType, ResultRecordType>(callTimeResource, {
+
+            return mutateWithMiddlewares
+                .current(callTimeResource, {
                     data: callTimeData,
                     meta: callTimeMeta,
                 })
                 .then(({ data }) => data);
         },
         ...mutationOptions,
-        onError: (error, variables, context) => {
-            if (options.onError && !hasCallTimeOnError.current) {
-                return options.onError(error, variables, context);
+        onMutate: async (
+            variables: Partial<UseCreateMutateParams<RecordType>>
+        ) => {
+            if (mutationOptions.onMutate) {
+                const userContext =
+                    (await mutationOptions.onMutate(variables)) || {};
+                return {
+                    snapshot: snapshot.current,
+                    // @ts-ignore
+                    ...userContext,
+                };
+            } else {
+                // Return a context object with the snapshot value
+                return { snapshot: snapshot.current };
             }
+        },
+        onError: (error, variables, context: { snapshot: Snapshot }) => {
+            if (mode.current === 'optimistic' || mode.current === 'undoable') {
+                // If the mutation fails, use the context returned from onMutate to rollback
+                context.snapshot.forEach(([key, value]) => {
+                    queryClient.setQueryData(key, value);
+                });
+            }
+            if (callTimeOnError.current) {
+                return callTimeOnError.current(error, variables, context);
+            }
+            if (mutationOptions.onError) {
+                return mutationOptions.onError(error, variables, context);
+            }
+            // call-time error callback is executed by react-query
         },
         onSuccess: (
             data: ResultRecordType,
             variables: Partial<UseCreateMutateParams<RecordType>> = {},
             context: unknown
         ) => {
-            const { resource: callTimeResource = resource } = variables;
-            queryClient.setQueryData(
-                [callTimeResource, 'getOne', { id: String(data.id) }],
-                data
-            );
-            queryClient.invalidateQueries({
-                queryKey: [callTimeResource, 'getList'],
-            });
-            queryClient.invalidateQueries({
-                queryKey: [callTimeResource, 'getInfiniteList'],
-            });
-            queryClient.invalidateQueries({
-                queryKey: [callTimeResource, 'getMany'],
-            });
-            queryClient.invalidateQueries({
-                queryKey: [callTimeResource, 'getManyReference'],
-            });
+            if (mode.current === 'pessimistic') {
+                const { resource: callTimeResource = resource } = variables;
+                queryClient.setQueryData(
+                    [callTimeResource, 'getOne', { id: String(data.id) }],
+                    data
+                );
+                queryClient.invalidateQueries({
+                    queryKey: [callTimeResource, 'getList'],
+                });
+                queryClient.invalidateQueries({
+                    queryKey: [callTimeResource, 'getInfiniteList'],
+                });
+                queryClient.invalidateQueries({
+                    queryKey: [callTimeResource, 'getMany'],
+                });
+                queryClient.invalidateQueries({
+                    queryKey: [callTimeResource, 'getManyReference'],
+                });
 
-            if (options.onSuccess && !hasCallTimeOnSuccess.current) {
-                options.onSuccess(data, variables, context);
+                if (
+                    mutationOptions.onSuccess &&
+                    !hasCallTimeOnSuccess.current
+                ) {
+                    mutationOptions.onSuccess(data, variables, context);
+                }
             }
         },
-        onSettled: (data, error, variables, context) => {
-            if (options.onSettled && !hasCallTimeOnSettled.current) {
-                return options.onSettled(data, error, variables, context);
+        onSettled: (
+            data,
+            error,
+            variables,
+            context: { snapshot: Snapshot }
+        ) => {
+            if (mode.current === 'optimistic' || mode.current === 'undoable') {
+                // Always refetch after error or success:
+                context.snapshot.forEach(([queryKey]) => {
+                    queryClient.invalidateQueries({ queryKey });
+                });
+            }
+
+            if (callTimeOnSettled.current) {
+                return callTimeOnSettled.current(
+                    data,
+                    error,
+                    variables,
+                    context
+                );
+            }
+            if (mutationOptions.onSettled) {
+                return mutationOptions.onSettled(
+                    data,
+                    error,
+                    variables,
+                    context
+                );
             }
         },
     });
 
-    const create = (
+    const create = async (
         callTimeResource: string | undefined = resource,
         callTimeParams: Partial<CreateParams<Partial<RecordType>>> = {},
         callTimeOptions: MutateOptions<
@@ -170,27 +329,175 @@ export const useCreate = <
             MutationError,
             Partial<UseCreateMutateParams<RecordType>>,
             unknown
-        > & { returnPromise?: boolean } = {}
+        > & { mutationMode?: MutationMode; returnPromise?: boolean } = {}
     ) => {
         const {
-            returnPromise = options.returnPromise,
+            mutationMode,
+            returnPromise = mutationOptions.returnPromise,
+            onError,
+            onSettled,
+            onSuccess,
             ...otherCallTimeOptions
         } = callTimeOptions;
 
-        hasCallTimeOnError.current = !!otherCallTimeOptions.onError;
-        hasCallTimeOnSuccess.current = !!otherCallTimeOptions.onSuccess;
-        hasCallTimeOnSettled.current = !!otherCallTimeOptions.onSettled;
+        // Store the mutation with middlewares to avoid losing them if the calling component is unmounted
+        if (getMutateWithMiddlewares) {
+            mutateWithMiddlewares.current = getMutateWithMiddlewares(
+                dataProvider.create.bind(dataProvider)
+            );
+        } else {
+            mutateWithMiddlewares.current = dataProvider.create;
+        }
 
-        if (returnPromise) {
-            return mutation.mutateAsync(
-                { resource: callTimeResource, ...callTimeParams },
-                otherCallTimeOptions
+        // We need to keep the onSuccess callback here and not in the useMutation for undoable mutations
+        hasCallTimeOnSuccess.current = !!onSuccess;
+        // We need to store the onError and onSettled callbacks here to be able to call them in the useMutation hook
+        // so that they are called even when the calling component is unmounted
+        callTimeOnError.current = onError;
+        callTimeOnSettled.current = onSettled;
+
+        // store the hook time params *at the moment of the call*
+        // because they may change afterwards, which would break the undoable mode
+        // as the previousData would be overwritten by the optimistic update
+        paramsRef.current = params;
+
+        if (mutationMode) {
+            mode.current = mutationMode;
+        }
+
+        if (returnPromise && mode.current !== 'pessimistic') {
+            console.warn(
+                'The returnPromise parameter can only be used if the mutationMode is set to pessimistic'
             );
         }
-        return mutation.mutate(
-            { resource: callTimeResource, ...callTimeParams },
-            otherCallTimeOptions
+
+        if (mode.current === 'pessimistic') {
+            if (returnPromise) {
+                return mutation.mutateAsync(
+                    { resource: callTimeResource, ...callTimeParams },
+                    // We don't pass onError and onSettled here as we will call them in the useMutation hook side effects
+                    { onSuccess, ...otherCallTimeOptions }
+                );
+            }
+            return mutation.mutate(
+                { resource: callTimeResource, ...callTimeParams },
+                // We don't pass onError and onSettled here as we will call them in the useMutation hook side effects
+                { onSuccess, ...otherCallTimeOptions }
+            );
+        }
+
+        const { data: callTimeData = data, meta: callTimeMeta = meta } =
+            callTimeParams;
+        const callTimeId = callTimeData?.id;
+        if (callTimeId == null) {
+            console.warn(
+                'useCreate() data parameter must contain an id key when used with the optimistic or undoable modes'
+            );
+        }
+        // optimistic create as documented in https://react-query-v3.tanstack.com/guides/optimistic-updates
+        // except we do it in a mutate wrapper instead of the onMutate callback
+        // to have access to success side effects
+
+        const queryKeys = [
+            [
+                callTimeResource,
+                'getOne',
+                { id: String(callTimeId), meta: callTimeMeta },
+            ],
+            [callTimeResource, 'getList'],
+            [callTimeResource, 'getInfiniteList'],
+            [callTimeResource, 'getMany'],
+            [callTimeResource, 'getManyReference'],
+        ];
+
+        /**
+         * Snapshot the previous values via queryClient.getQueriesData()
+         *
+         * The snapshotData ref will contain an array of tuples [query key, associated data]
+         *
+         * @example
+         * [
+         *   [['posts', 'getOne', { id: '1' }], { id: 1, title: 'Hello' }],
+         *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+         *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+         * ]
+         *
+         * @see https://react-query-v3.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+         */
+        snapshot.current = queryKeys.reduce(
+            (prev, queryKey) =>
+                prev.concat(queryClient.getQueriesData({ queryKey })),
+            [] as Snapshot
         );
+
+        // Cancel any outgoing re-fetches (so they don't overwrite our optimistic update)
+        await Promise.all(
+            snapshot.current.map(([queryKey]) =>
+                queryClient.cancelQueries({ queryKey })
+            )
+        );
+
+        // Optimistically update to the new value
+        updateCache({
+            resource: callTimeResource,
+            id: callTimeId,
+            data: callTimeData,
+            meta: callTimeMeta,
+        });
+
+        // run the success callbacks during the next tick
+        setTimeout(() => {
+            if (onSuccess) {
+                onSuccess(
+                    callTimeData as unknown as ResultRecordType,
+                    { resource: callTimeResource, ...callTimeParams },
+                    { snapshot: snapshot.current }
+                );
+            } else if (
+                mutationOptions.onSuccess &&
+                !hasCallTimeOnSuccess.current
+            ) {
+                mutationOptions.onSuccess(
+                    callTimeData as unknown as ResultRecordType,
+                    { resource: callTimeResource, ...callTimeParams },
+                    { snapshot: snapshot.current }
+                );
+            }
+        }, 0);
+
+        if (mode.current === 'optimistic') {
+            // call the mutate method without success side effects
+            return mutation.mutate({
+                resource: callTimeResource,
+                // We don't pass onError and onSettled here as we will call them in the useMutation hook side effects
+                ...callTimeParams,
+            });
+        } else {
+            // Undoable mutation: add the mutation to the undoable queue.
+            // The Notification component will dequeue it when the user confirms or cancels the message.
+            addUndoableMutation(({ isUndo }) => {
+                if (isUndo) {
+                    // rollback
+                    queryClient.removeQueries({
+                        queryKey: [
+                            callTimeResource,
+                            'getOne',
+                            { id: String(callTimeId), meta },
+                        ],
+                        exact: true,
+                    });
+                    snapshot.current.forEach(([key, value]) => {
+                        queryClient.setQueryData(key, value);
+                    });
+                } else {
+                    // call the mutate method without success side effects
+                    mutation.mutate({
+                        resource: callTimeResource,
+                        ...callTimeParams,
+                    });
+                }
+            });
+        }
     };
 
     const mutationResult = useMemo(
@@ -203,6 +510,8 @@ export const useCreate = <
 
     return [useEvent(create), mutationResult];
 };
+
+type Snapshot = [key: QueryKey, value: any][];
 
 export interface UseCreateMutateParams<
     RecordType extends Omit<RaRecord, 'id'> = any,
@@ -224,6 +533,7 @@ export type UseCreateOptions<
     >,
     'mutationFn'
 > & {
+    mutationMode?: MutationMode;
     returnPromise?: boolean;
     getMutateWithMiddlewares?: <
         CreateFunctionType extends
@@ -248,8 +558,8 @@ export type CreateMutationFunction<
         MutationError,
         Partial<UseCreateMutateParams<RecordType>>,
         unknown
-    > & { returnPromise?: TReturnPromise }
-) => TReturnPromise extends true ? Promise<ResultRecordType> : void;
+    > & { mutationMode?: MutationMode; returnPromise?: TReturnPromise }
+) => Promise<TReturnPromise extends true ? ResultRecordType : void>;
 
 export type UseCreateResult<
     RecordType extends Omit<RaRecord, 'id'> = any,

--- a/packages/ra-core/src/dataProvider/useCreate.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.undoable.stories.tsx
@@ -1,0 +1,507 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useTakeUndoableMutation } from './undo';
+import { useCreate } from './useCreate';
+import { useGetOne } from './useGetOne';
+
+export default { title: 'ra-core/dataProvider/useCreate/undoable' };
+
+export const SuccessCase = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const takeMutation = useTakeUndoableMutation();
+    const { data, error, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate();
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: { id: 2, title: 'Hello World' },
+            },
+            {
+                mutationMode: 'undoable',
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+        setNotification(true);
+    };
+
+    return (
+        <>
+            {error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isPending}>
+                        Create post
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const ErrorCase = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <ErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const ErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const takeMutation = useTakeUndoableMutation();
+    const { data, error: getOneError, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate();
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: { id: 2, title: 'Hello World' },
+            },
+            {
+                mutationMode: 'undoable',
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+        setNotification(true);
+    };
+    return (
+        <>
+            {getOneError ? (
+                <p>{getOneError.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isPending}>
+                        Create post
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {error && <div>{error.message}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const WithMiddlewaresSuccess = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <WithMiddlewaresCore />
+        </CoreAdminContext>
+    );
+};
+
+const WithMiddlewaresCore = () => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const takeMutation = useTakeUndoableMutation();
+    const { data, error, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {
+            data: { id: 2, title: 'Hello World' },
+        },
+        {
+            mutationMode: 'undoable',
+            // @ts-ignore
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: {
+                        ...params.data,
+                        title: `${params.data.title} from middleware`,
+                    },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: { id: 2, title: 'Hello World' },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+        setNotification(true);
+    };
+    return (
+        <>
+            {error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isPending}>
+                        Create post
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const WithMiddlewaresError = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('not found'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <WithMiddlewaresErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const WithMiddlewaresErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const takeMutation = useTakeUndoableMutation();
+    const { data, error: getOneError, refetch } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {
+            data: { id: 2, title: 'Hello World' },
+        },
+        {
+            mutationMode: 'undoable',
+            // @ts-ignore
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: {
+                        ...params.data,
+                        title: `${params.data.title} from middleware`,
+                    },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        create(
+            'posts',
+            {
+                data: { id: 2, title: 'Hello World' },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+        setNotification(true);
+    };
+    return (
+        <>
+            {getOneError ? (
+                <p>{getOneError.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isPending}>
+                        Create post
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {error && <div>{error.message}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-ui-materialui/src/button/CreateButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.stories.tsx
@@ -50,6 +50,7 @@ const AccessControlAdmin = ({ queryClient }: { queryClient: QueryClient }) => {
     const [resourcesAccesses, setResourcesAccesses] = React.useState({
         'books.list': true,
         'books.create': false,
+        'books.delete': false,
     });
 
     const authProvider: AuthProvider = {

--- a/packages/ra-ui-materialui/src/detail/Create.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.tsx
@@ -66,6 +66,7 @@ export const Create = <
         record,
         redirect,
         transform,
+        mutationMode,
         mutationOptions,
         disableAuthentication,
         hasEdit,
@@ -79,6 +80,7 @@ export const Create = <
             record={record}
             redirect={redirect}
             transform={transform}
+            mutationMode={mutationMode}
             mutationOptions={mutationOptions}
             disableAuthentication={disableAuthentication}
             hasEdit={hasEdit}

--- a/packages/react-admin/src/Admin.tsx
+++ b/packages/react-admin/src/Admin.tsx
@@ -115,6 +115,7 @@ export const Admin = (props: AdminProps) => {
         loginPage,
         notification,
         queryClient,
+        QueryClientProvider,
         ready,
         requireAuth,
         store = defaultStore,
@@ -138,6 +139,7 @@ export const Admin = (props: AdminProps) => {
             i18nProvider={i18nProvider}
             lightTheme={lightTheme}
             queryClient={queryClient}
+            QueryClientProvider={QueryClientProvider}
             store={store}
             theme={theme}
         >


### PR DESCRIPTION
## Problem

We currently don't support `optimistic` and `undoable` `mutationMode` in `useCreate`, which prevent us from supporting offline first applications.

## Solution

Given that the new record identifier is generated client side, we can support  `optimistic` and `undoable` `mutationMode`.

## How To Test

- https://react-admin-storybook-kdp07s42y-marmelab.vercel.app/?path=/story/ra-core-dataprovider-usecreate-optimistic--success-case
- https://react-admin-storybook-kdp07s42y-marmelab.vercel.app/?path=/story/ra-core-dataprovider-usecreate-pessimistic--success-case
- https://react-admin-storybook-kdp07s42y-marmelab.vercel.app/?path=/story/ra-core-dataprovider-usecreate-undoable--success-case

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
