### PR TITLE
[chore] Fix lerna doesn't update yarn.lock on publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
     "lerna": "2.5.1",
     "packages": ["examples/data-generator", "examples/simple", "packages/*"],
-    "version": "5.5.3"
+    "version": "5.5.3",
+    "npmClient": "yarn"
 }


### PR DESCRIPTION
## Problem

Lerna doesn't update `yarn.lock` on publish, which leads to having the commit on which the version tag is put fail the CI.

This prevents steps like greenframe and codesandbox update from running.

## Solution

Fix the lerna configuration.

## How To Test

You can run the following command locally to simulate what lerna does when publishing a new version, without actually publishing it to npm neither pushing the commits to git:

```
./node_modules/.bin/lerna version --force-publish --no-push --no-git-tag-version
```

You will see that with the fixed configuration, the `yarn.lock` is also updated.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature

