### PR TITLE
[doc] Backport `title={null}`'s doc on dialog components

### DIFF
--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -72,15 +72,16 @@ In the related `<Resource>`, you don't need to declare a `create` component as t
 
 `<CreateDialog>` accepts the following props:
 
-| Prop           | Required | Type              | Default | Description |
-| -------------- | -------- | ----------------- | ------- | ----------- |
-| `children`     | Required | `ReactNode`       |         | The content of the dialog. |
-| `fullWidth`    | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen. |
-| `maxWidth`     | Optional | `string`          | `sm`    | The max width of the dialog. |
-| `mutation Options` | Optional | `object`       |         | The options to pass to the `useMutation` hook. |
-| `resource`     | Optional | `string`          |         | The resource name, e.g. `posts`
-| `sx`           | Optional | `object`          |         | Override the styles applied to the dialog component. |
-| `transform`    | Optional | `function`        |         | Transform the form data before calling `dataProvider.create()`. |
+| Prop               | Required | Type        | Default | Description                                                     |
+| ------------------ | -------- | ----------- | ------- | --------------------------------------------------------------- |
+| `children`         | Required | `ReactNode` |         | The content of the dialog                                       |
+| `fullWidth`        | Optional | `boolean`   | `false` | If `true`, the dialog stretches to the full width of the screen |
+| `maxWidth`         | Optional | `string`    | `sm`    | The max width of the dialog                                     |
+| `mutation Options` | Optional | `object`    |         | The options to pass to the `useMutation` hook                   |
+| `resource`         | Optional | `string`    |         | The resource name, e.g. `posts`                                 |
+| `sx`               | Optional | `object`    |         | Override the styles applied to the dialog component             |
+| `title`            | Optional | `ReactNode` |         | The title of the dialog                                         |
+| `transform`        | Optional | `function`  |         | Transform the form data before calling `dataProvider.create()`  |
 
 ## `children`
 
@@ -192,6 +193,7 @@ const EditAuthorDialog = () => {
 Customize the styles applied to the Material UI `<Dialog>` component:
 
 {% raw %}
+
 ```jsx
 const MyCreateDialog = () => (
   <CreateDialog sx={{ backgroundColor: 'paper' }}>
@@ -199,7 +201,57 @@ const MyCreateDialog = () => (
   </CreateDialog>
 );
 ```
+
 {% endraw %}
+
+## `title`
+
+Unlike the `<Create>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+Here is an example:
+
+```tsx
+import React from 'react';
+import {
+    List,
+    Datagrid,
+    SimpleForm,
+    TextInput,
+    DateInput,
+    required,
+} from 'react-admin';
+import {
+    CreateDialog,
+} from '@react-admin/ra-form-layout';
+
+const CustomerList = () => (
+    <>
+        <List hasCreate>
+            <Datagrid>
+                ...
+                <ShowButton />
+            </Datagrid>
+        </List>
+        <ShowDialog title={<CustomerShowTitle />}>
+            <SimpleShowLayout>
+                <TextField source="id" />
+                <TextField source="first_name" />
+                <TextField source="last_name" />
+                <DateField source="date_of_birth" label="born" />
+            </SimpleShowLayout>
+        </ShowDialog>
+    </>
+);
+```
+
+You can also hide the title by passing `null`:
+
+```tsx
+<CreateDialog title={null}>
+    <SimpleForm>
+        ...
+    </SimpleForm>
+</CreateDialog>
+```
 
 ## `transform`
 

--- a/docs/CreateInDialogButton.md
+++ b/docs/CreateInDialogButton.md
@@ -76,19 +76,37 @@ In the above example, `<CreateInDialogButton>` is used to create a new employee 
 
 `<CreateInDialogButton>` accepts the following props:
 
-| Prop           | Required | Type              | Default | Description |
-| -------------- | -------- | ----------------- | ------- | ----------- |
-| `children`     | Required | `ReactNode`       |         | The content of the dialog. |
-| `ButtonProps`  | Optional | `object`          |         | Object containing props to pass to Material UI's `<Button>`. |
-| `fullWidth`    | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen. |
-| `icon`         | Optional | `ReactElement`    |         | Allows to override the default icon. |
-| `inline`       | Optional | `boolean`         |         | Set to true to display only a Material UI `<IconButton>` instead of the full `<Button>`. |
-| `label`        | Optional | `string`          |         | Allows to override the default button label. I18N is supported. |
-| `maxWidth`     | Optional | `string`          | `sm`    | The max width of the dialog. |
-| `mutation Options` | Optional | `object`       |         | The options to pass to the `useMutation` hook. |
-| `resource`     | Optional | `string`          |         | The resource name, e.g. `posts`
-| `sx`           | Optional | `object`          |         | Override the styles applied to the dialog component. |
+| Prop               | Required | Type           | Default | Description                                                                             |
+| ------------------ | -------- | -------------- | ------- | --------------------------------------------------------------------------------------- |
+| `ButtonProps`      | Optional | `object`       |         | Object containing props to pass to Material UI's `<Button>`                             |
+| `children`         | Required | `ReactNode`    |         | The content of the dialog                                                               |
+| `fullWidth`        | Optional | `boolean`      | `false` | If `true`, the dialog stretches to the full width of the screen                         |
+| `icon`             | Optional | `ReactElement` |         | Allows to override the default icon                                                     |
+| `inline`           | Optional | `boolean`      |         | Set to true to display only a Material UI `<IconButton>` instead of the full `<Button>` |
+| `label`            | Optional | `string`       |         | Allows to override the default button label. I18N is supported                          |
+| `maxWidth`         | Optional | `string`       | `sm`    | The max width of the dialog                                                             |
+| `mutation Options` | Optional | `object`       |         | The options to pass to the `useMutation` hook                                           |
+| `resource`         | Optional | `string`       |         | The resource name, e.g. `posts`                                                         |
+| `sx`               | Optional | `object`       |         | Override the styles applied to the dialog component                                     |
+| `title`            | Optional | `ReactNode`    |         | The title of the dialog                                                                 |
 
+## `ButtonProps`
+
+The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color and size of the button:
+
+{% raw %}
+
+```jsx
+const CreateButton = () => (
+  <CreateInDialogButton ButtonProps={{ color: 'primary', fullWidth: true }}>
+      <SimpleForm>
+          ...
+      </SimpleForm>
+  </CreateInDialogButton>
+);
+```
+
+{% endraw %}
 
 ## `children`
 
@@ -123,22 +141,6 @@ const CreateButton = () => (
     </CreateInDialogButton>
 );
 ```
-
-## `ButtonProps`
-
-The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color and size of the button:
-
-{% raw %}
-```jsx
-const CreateButton = () => (
-  <CreateInDialogButton ButtonProps={{ color: 'primary', fullWidth: true }}>
-      <SimpleForm>
-          ...
-      </SimpleForm>
-  </CreateInDialogButton>
-);
-```
-{% endraw %}
 
 ## `fullWidth`
 
@@ -263,6 +265,31 @@ const CreateButton = () => (
 ```
 
 {% endraw %}
+
+## `title`
+
+Unlike the `<Create>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+Here is an example:
+
+```tsx
+const CreateButton = () => (
+  <CreateInDialogButton title="Create a new customer">
+      <SimpleForm>
+          ...
+      </SimpleForm>
+  </CreateInDialogButton>
+);
+```
+
+You can also hide the title by passing `null`:
+
+```tsx
+<CreateInDialogButton title={null}>
+    <SimpleForm>
+        ...
+    </SimpleForm>
+</CreateInDialogButton>
+```
 
 ## Warn When There Are Unsaved Changes
 

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -67,17 +67,18 @@ In the related `<Resource>`, you don't need to declare an `edit` component as th
 
 `<EditDialog>` accepts the following props:
 
-| Prop           | Required | Type              | Default | Description |
-| -------------- | -------- | ----------------- | ------- | ----------- |
-| `children`     | Required | `ReactNode`       |         | The content of the dialog. |
-| `fullWidth`    | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen. |
-| `id`           | Optional | `string | number` |         | The record id. If not provided, it will be deduced from the record context. |
-| `maxWidth`     | Optional | `string`          | `sm`    | The max width of the dialog. |
-| `mutation Options` | Optional | `object`       |         | The options to pass to the `useMutation` hook. |
-| `queryOptions` | Optional | `object`          |         | The options to pass to the `useQuery` hook.
-| `resource`     | Optional | `string`          |         | The resource name, e.g. `posts`
-| `sx`           | Optional | `object`          |         | Override the styles applied to the dialog component. |
-| `transform`    | Optional | `function`        |         | Transform the form data before calling `dataProvider.update()`. |
+| Prop               | Required | Type              | Default | Description                                                                |
+| ------------------ | -------- | ----------------- | ------- | -------------------------------------------------------------------------- |
+| `children`         | Required | `ReactNode`       |         | The content of the dialog                                                  |
+| `fullWidth`        | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen            |
+| `id`               | Optional | `string | number` |         | The record id. If not provided, it will be deduced from the record context |
+| `maxWidth`         | Optional | `string`          | `sm`    | The max width of the dialog                                                |
+| `mutation Options` | Optional | `object`          |         | The options to pass to the `useMutation` hook                              |
+| `queryOptions`     | Optional | `object`          |         | The options to pass to the `useQuery` hook                                 |
+| `resource`         | Optional | `string`          |         | The resource name, e.g. `posts`                                            |
+| `sx`               | Optional | `object`          |         | Override the styles applied to the dialog component                        |
+| `transform`        | Optional | `function`        |         | Transform the form data before calling `dataProvider.update()`             |
+| `title`            | Optional | `ReactNode`       |         | The title of the dialog                                                    |
 
 ## `children`
 
@@ -222,6 +223,7 @@ const EditAuthorDialog = () => {
 Customize the styles applied to the Material UI `<Dialog>` component:
 
 {% raw %}
+
 ```jsx
 const MyEditDialog = () => (
   <EditDialog sx={{ backgroundColor: 'paper' }}>
@@ -229,7 +231,69 @@ const MyEditDialog = () => (
   </EditDialog>
 );
 ```
+
 {% endraw %}
+
+## `title`
+
+Unlike the `<Create>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+If you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
+Here is an example:
+
+```tsx
+import React from 'react';
+import {
+    List,
+    Datagrid,
+    SimpleForm,
+    TextInput,
+    DateInput,
+    required,
+    useRecordContext,
+} from 'react-admin';
+import { EditDialog } from '@react-admin/ra-form-layout';
+
+const CustomerEditTitle = () => {
+    const record = useRecordContext();
+    return record ? (
+        <span>
+            Edit {record?.last_name} {record?.first_name}
+        </span>
+    ) : null;
+};
+
+const CustomerList = () => (
+    <>
+        <List hasCreate>
+            <Datagrid rowClick="edit">
+                ...
+            </Datagrid>
+        </List>
+        <EditDialog title={<CustomerEditTitle />}>
+            <SimpleForm>
+                <TextField source="id" />
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+                <DateInput
+                    source="date_of_birth"
+                    label="born"
+                    validate={required()}
+                />
+            </SimpleForm>
+        </EditDialog>
+    </>
+);
+```
+
+You can also hide the title by passing `null`:
+
+```tsx
+<EditDialog title={null}>
+    <SimpleForm>
+        ...
+    </SimpleForm>
+</EditDialog>
+```
 
 ## `transform`
 

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -69,20 +69,21 @@ const CompanyShow = () => (
 
 `<EditInDialogButton>` accepts the following props:
 
-| Prop           | Required | Type              | Default | Description |
-| -------------- | -------- | ----------------- | ------- | ----------- |
-| `children`     | Required | `ReactNode`       |         | The content of the dialog. |
-| `ButtonProps`  | Optional | `object`          |         | Object containing props to pass to Material UI's `<Button>`. |
-| `fullWidth`    | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen. |
-| `icon`         | Optional | `ReactElement`    |         | Allows to override the default icon. |
-| `id`           | Optional | `string | number` |         | The record id. If not provided, it will be deduced from the record context. |
-| `inline`       | Optional | `boolean`         |         | Set to true to display only a Material UI `<IconButton>` instead of the full `<Button>`. |
-| `label`        | Optional | `string`          |         | Allows to override the default button label. I18N is supported. |
-| `maxWidth`     | Optional | `string`          | `sm`    | The max width of the dialog. |
-| `mutation Options` | Optional | `object`       |         | The options to pass to the `useMutation` hook. |
-| `queryOptions` | Optional | `object`          |         | The options to pass to the `useQuery` hook.
-| `resource`     | Optional | `string`          |         | The resource name, e.g. `posts`
-| `sx`           | Optional | `object`          |         | Override the styles applied to the dialog component. |
+| Prop               | Required | Type              | Default | Description                                                                             |
+| ------------------ | -------- | ----------------- | ------- | --------------------------------------------------------------------------------------- |
+| `children`         | Required | `ReactNode`       |         | The content of the dialog                                                               |
+| `ButtonProps`      | Optional | `object`          |         | Object containing props to pass to Material UI's `<Button>`                             |
+| `fullWidth`        | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen                         |
+| `icon`             | Optional | `ReactElement`    |         | Allows to override the default icon                                                     |
+| `id`               | Optional | `string | number` |         | The record id. If not provided, it will be deduced from the record context              |
+| `inline`           | Optional | `boolean`         |         | Set to true to display only a Material UI `<IconButton>` instead of the full `<Button>` |
+| `label`            | Optional | `string`          |         | Allows to override the default button label. I18N is supported                          |
+| `maxWidth`         | Optional | `string`          | `sm`    | The max width of the dialog                                                             |
+| `mutation Options` | Optional | `object`          |         | The options to pass to the `useMutation` hook                                           |
+| `queryOptions`     | Optional | `object`          |         | The options to pass to the `useQuery` hook                                              |
+| `resource`         | Optional | `string`          |         | The resource name, e.g. `posts`                                                         |
+| `sx`               | Optional | `object`          |         | Override the styles applied to the dialog component                                     |
+| `title`            | Optional | `ReactNode`       |         | The title of the dialog                                                                 |
 
 ## `children`
 
@@ -123,6 +124,7 @@ const EditButton = () => (
 The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color and size of the button:
 
 {% raw %}
+
 ```jsx
 const EditButton = () => (
   <EditInDialogButton ButtonProps={{ color: 'primary', fullWidth: true }}>
@@ -132,6 +134,7 @@ const EditButton = () => (
   </EditInDialogButton>
 );
 ```
+
 {% endraw %}
 
 ## `fullWidth`
@@ -234,6 +237,7 @@ The `mutationOptions` prop allows you to pass options to the `useMutation` hook.
 This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.update()` call.
 
 {% raw %}
+
 ```jsx
 const EditButton = () => (
   <EditInDialogButton mutationOptions={{ meta: { fetch: 'author' } }}>
@@ -241,6 +245,7 @@ const EditButton = () => (
   </EditInDialogButton>
 );
 ```
+
 {% endraw %}
 
 ## `queryOptions`
@@ -250,6 +255,7 @@ The `queryOptions` prop allows you to pass options to the `useQuery` hook.
 This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getOne()` call.
 
 {% raw %}
+
 ```jsx
 const EditButton = () => (
   <EditInDialogButton queryOptions={{ meta: { fetch: 'author' } }}>
@@ -257,6 +263,7 @@ const EditButton = () => (
   </EditInDialogButton>
 );
 ```
+
 {% endraw %}
 
 ## `resource`
@@ -281,6 +288,7 @@ const EditAuthorButton = () => {
 Customize the styles applied to the Material UI `<Dialog>` component:
 
 {% raw %}
+
 ```jsx
 const EditButton = () => (
   <EditInDialogButton sx={{ backgroundColor: 'paper' }}>
@@ -288,7 +296,46 @@ const EditButton = () => (
   </EditInDialogButton>
 );
 ```
+
 {% endraw %}
+
+## `title`
+
+Unlike the `<Edit>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+Still, for `<EditInDialogButton>`, if you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
+Here is an example:
+
+```tsx
+import { SimpleForm, useRecordContext } from 'react-admin';
+import { EditInDialogButton } from '@react-admin/ra-form-layout';
+
+const CustomerEditTitle = () => {
+    const record = useRecordContext();
+    return record ? (
+        <span>
+            Edit {record?.last_name} {record?.first_name}
+        </span>
+    ) : null;
+};
+
+const EditButton = () => (
+  <EditInDialogButton title={<CustomerEditTitle />}>
+      <SimpleForm>
+          ...
+      </SimpleForm>
+  </EditInDialogButton>
+);
+```
+
+You can also hide the title by passing `null`:
+
+```tsx
+<EditInDialogButton title={null}>
+    <SimpleForm>
+        ...
+    </SimpleForm>
+</EditInDialogButton>
+```
 
 ## Redirection After Deletion
 

--- a/docs/ShowInDialogButton.md
+++ b/docs/ShowInDialogButton.md
@@ -31,6 +31,7 @@ Then, use the `<ShowInDialogButton>` component inside a `RecordContext` (in a `<
 Below is an example of an `<Edit>` view, inside which is a nested `<Datagrid>`, offering the ability to show the detail of each row in a dialog:
 
 {% raw %}
+
 ```jsx
 import {
   Datagrid,
@@ -82,6 +83,7 @@ const EmployerEdit = () => (
   </Edit>
 );
 ```
+
 {% endraw %}
 
 ## Props
@@ -90,8 +92,8 @@ This component accepts the following props:
 
 | Prop           | Required | Type           | Default  | Description               |
 |----------------|----------|----------------|----------|---------------------------|
-| `children`     | Required | `ReactNode`    |          | The content of the dialog |
 | `ButtonProps`  | Optional | `object`       |          | Props to pass to the MUI `<Button>` component |
+| `children`     | Required | `ReactNode`    |          | The content of the dialog |
 | `empty WhileLoading` | Optional | `boolean` |         | Set to `true` to return `null` while the list is loading |
 | `fullWidth`    | Optional | `boolean`      | `false`  | Set to `true` to make the dialog full width |
 | `icon`         | Optional | `ReactElement` |          | The icon of the button |
@@ -102,6 +104,25 @@ This component accepts the following props:
 | `queryOptions` | Optional | `object`       |          | The options to pass to the `useQuery` hook |
 | `resource`     | Optional | `string`       |          | The resource name, e.g. `posts` |
 | `sx`           | Optional | `object`       |          | Override the styles applied to the dialog component |
+| `title`            | Optional | `ReactNode`       |         | The title of the dialog                                                                 |
+
+## `ButtonProps`
+
+The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color of the button, you can use the `color` prop:
+
+{% raw %}
+
+```jsx
+const ShowButton = () => (
+  <ShowInDialogButton ButtonProps={{ color: 'primary' }}>
+      <SimpleShowLayout>
+          ...
+      </SimpleShowLayout>
+  </ShowInDialogButton>
+);
+```
+
+{% endraw %}
 
 ## `children`
 
@@ -132,22 +153,6 @@ const ShowButton = () => (
 ```
 
 You can also pass a React element as child, to build a custom layout. Check [Building a custom Show Layout](./ShowTutorial.md#building-a-custom-layout) for more details.
-
-## `ButtonProps`
-
-The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color of the button, you can use the `color` prop:
-
-{% raw %}
-```jsx
-const ShowButton = () => (
-  <ShowInDialogButton ButtonProps={{ color: 'primary' }}>
-      <SimpleShowLayout>
-          ...
-      </SimpleShowLayout>
-  </ShowInDialogButton>
-);
-```
-{% endraw %}
 
 ## `emptyWhileLoading`
 
@@ -263,6 +268,7 @@ The `queryOptions` prop allows you to pass options to the [`useQuery`](./Actions
 This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.getOne()` call.
 
 {% raw %}
+
 ```jsx
 const ShowButton = () => (
   <ShowInDialogButton queryOptions={{ meta: { fetch: 'author' } }}>
@@ -270,6 +276,7 @@ const ShowButton = () => (
   </ShowInDialogButton>
 );
 ```
+
 {% endraw %}
 
 ## `resource`
@@ -294,6 +301,7 @@ const ShowAuthorButton = () => {
 Customize the styles applied to the Material UI `<Dialog>` component:
 
 {% raw %}
+
 ```jsx
 const ShowButton = () => (
   <ShowInDialogButton sx={{ backgroundColor: 'paper' }}>
@@ -301,4 +309,50 @@ const ShowButton = () => (
   </ShowInDialogButton>
 );
 ```
+
 {% endraw %}
+
+## `title`
+
+Unlike the `<Create>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+Still, for `<ShowInDialogButton>`, if you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
+Here is an example:
+
+```tsx
+import { SimpleForm, useRecordContext } from 'react-admin';
+import { ShowInDialogButton } from '@react-admin/ra-form-layout';
+
+const CustomerShowTitle = () => {
+    const record = useRecordContext();
+    return record ? (
+        <span>
+            Show {record?.last_name} {record?.first_name}
+        </span>
+    ) : null;
+};
+
+const ShowButton = () => (
+  <ShowInDialogButton title={<CustomerEditTitle />}>
+    <SimpleShowLayout>
+      ...
+    </SimpleShowLayout>
+  </ShowInDialogButton>
+);
+
+const CustomersDatagrid = () => (
+  <Datagrid>
+    ...
+    <ShowButton />
+  </Datagrid>
+);
+```
+
+You can also hide the title by passing `null`:
+
+```tsx
+<ShowInDialogButton title={null}>
+    <SimpleForm>
+        ...
+    </SimpleForm>
+</ShowInDialogButton>
+```


### PR DESCRIPTION
## Problem

EE doc was updated to document the support of `title={false}` in dialog components

## Solution

Backport `<XxxxDialog title={null} />`'s doc

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date