### PR TITLE
[doc] Backport `<DatagridAG>` and `<DatagridAGClient>` access control's doc

### DIFF
--- a/docs/DatagridAG.md
+++ b/docs/DatagridAG.md
@@ -1341,6 +1341,12 @@ When using `DatagridAG` with dates, [the `ag-grid` documentation](https://www.ag
 > The default Value Parser and Value Formatter use the ISO string format 'yyyy-mm-dd'.
 > If you wish to use a different date format, then you can [Override the Pre-Defined Cell Data Type Definition](https://www.ag-grid.com/react-data-grid/cell-data-types/#overriding-the-pre-defined-cell-data-type-definitions).
 
+### Access Control
+
+`<DatagridAG>` has built-in [access control](./Permissions.md#access-control). If the `authProvider` implements the `canAccess` method, users will only be allowed to edit rows of, say, resource `'cars'` if `canAccess({ action: 'edit', resource: 'cars' })` returns `true`.
+
+**Note:** the access control check can only be done at the resource level and not at the record level.
+
 ### Enabling Full Row Edition
 
 By default, editing is enabled on cells, which means you can edit a cell by double-clicking on it, and it will trigger a call to the dataProvider's `update` function.
@@ -2842,6 +2848,12 @@ const CarList = () => {
 };
 ```
 {% endraw %}
+
+### Access Control
+
+`<DatagridAG>` has built-in [access control](./Permissions.me#access-control). If the `authProvider` implements the `canAccess` method, users will only be allowed to edit rows of, say, resource `'cars'` if `canAccess({ action: 'edit', resource: 'cars' })` returns `true`.
+
+**Note:** the access control check can only be done at the resource level and not at the record level.
 
 ### Enabling Full Row Edition
 


### PR DESCRIPTION
## Problem

EE doc was updated to document `<DatagridAG>` and `<DatagridAGClient>` access control

## Solution

Backport those doc

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date