### PR TITLE
Fix FilerLiveForm does not allow to clear filters

### DIFF
--- a/packages/ra-core/src/form/FilterLiveForm.spec.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.spec.tsx
@@ -5,6 +5,7 @@ import {
     GlobalValidation,
     MultipleFilterLiveForm,
     MultipleInput,
+    ParseFormat,
     PerInputValidation,
 } from './FilterLiveForm.stories';
 import React from 'react';
@@ -24,6 +25,28 @@ describe('<FilterLiveForm />', () => {
         fireEvent.change(input, { target: { value: 'foo' } });
         await screen.findByText('{"category":"deals","title":"foo"}');
         fireEvent.change(input, { target: { value: '' } });
+        await screen.findByText('{"category":"deals"}');
+    });
+
+    it.only('should allow to clear a filter value with parse/format', async () => {
+        render(<ParseFormat />);
+        const input = await screen.findByLabelText('document');
+        fireEvent.change(input, { target: { value: '123123123123' } });
+        await screen.findByText(
+            '{"category":"deals","document":"123123123123"}'
+        );
+        fireEvent.change(input, { target: { value: '' } });
+        await screen.findByText('{"category":"deals"}');
+    });
+
+    it.only('should allow to clear a filter value through a clear button with parse/format', async () => {
+        render(<ParseFormat />);
+        const input = await screen.findByLabelText('document');
+        fireEvent.change(input, { target: { value: '123123123123' } });
+        await screen.findByText(
+            '{"category":"deals","document":"123123123123"}'
+        );
+        fireEvent.click(screen.getByText('Clear'));
         await screen.findByText('{"category":"deals"}');
     });
 

--- a/packages/ra-core/src/form/FilterLiveForm.spec.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.spec.tsx
@@ -28,7 +28,7 @@ describe('<FilterLiveForm />', () => {
         await screen.findByText('{"category":"deals"}');
     });
 
-    it.only('should allow to clear a filter value with parse/format', async () => {
+    it('should allow to clear a filter value with parse/format', async () => {
         render(<ParseFormat />);
         const input = await screen.findByLabelText('document');
         fireEvent.change(input, { target: { value: '123123123123' } });
@@ -39,7 +39,7 @@ describe('<FilterLiveForm />', () => {
         await screen.findByText('{"category":"deals"}');
     });
 
-    it.only('should allow to clear a filter value through a clear button with parse/format', async () => {
+    it('should allow to clear a filter value through a clear button with parse/format', async () => {
         render(<ParseFormat />);
         const input = await screen.findByLabelText('document');
         fireEvent.change(input, { target: { value: '123123123123' } });

--- a/packages/ra-core/src/form/FilterLiveForm.stories.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.stories.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
 
-import { FilterLiveForm, FilterLiveFormProps, useInput, required } from '.';
+import {
+    FilterLiveForm,
+    FilterLiveFormProps,
+    useInput,
+    required,
+    InputProps,
+} from '.';
 import { ListContextProvider } from '../controller/list/ListContextProvider';
 import { useList } from '../controller/list/useList';
 import { useListContext } from '../controller/list/useListContext';
 
 export default { title: 'ra-core/form/FilterLiveForm' };
 
-const TextInput = props => {
-    const { field, fieldState } = useInput(props);
+const TextInput = ({ defaultValue = '', ...props }: InputProps) => {
+    const { field, fieldState } = useInput({ defaultValue, ...props });
     const { error } = fieldState;
 
     return (
@@ -30,6 +36,7 @@ const TextInput = props => {
                     {error.message?.message || error.message}
                 </div>
             )}
+            <button onClick={() => field.onChange('')}>Clear</button>
         </div>
     );
 };
@@ -48,6 +55,42 @@ export const Basic = (props: Partial<FilterLiveFormProps>) => {
         <ListContextProvider value={listContext}>
             <FilterLiveForm {...props}>
                 <TextInput source="title" />
+            </FilterLiveForm>
+            <FilterValue />
+        </ListContextProvider>
+    );
+};
+
+const format = (value: string): string => {
+    if (!value) {
+        return value;
+    }
+    return value.length <= 11 ? value : `${value.slice(0, 11)}...`;
+};
+const parse = input => {
+    if (!input) {
+        return input;
+    }
+    return input.replace(/\D/g, '');
+};
+export const ParseFormat = (props: Partial<FilterLiveFormProps>) => {
+    const listContext = useList({
+        data: [
+            { id: 1, document: 'Hello', has_newsletter: true },
+            { id: 2, document: 'World', has_newsletter: false },
+        ],
+        filter: {
+            category: 'deals',
+        },
+    });
+    return (
+        <ListContextProvider value={listContext}>
+            <FilterLiveForm {...props}>
+                <p>
+                    Expect a number (larger than 13 characters to trigger
+                    format)
+                </p>
+                <TextInput source="document" parse={parse} format={format} />
             </FilterLiveForm>
             <FilterValue />
         </ListContextProvider>

--- a/packages/ra-core/src/form/FilterLiveForm.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
-import unset from 'lodash/unset';
+import set from 'lodash/set';
 import { ReactNode, useEffect } from 'react';
 import { FormProvider, useForm, UseFormProps } from 'react-hook-form';
 import {
@@ -125,7 +125,7 @@ export const FilterLiveForm = (props: FilterLiveFormProps) => {
             if (name) {
                 if (get(values, name) === '') {
                     const newValues = cloneDeep(values);
-                    unset(newValues, name);
+                    set(newValues, name, '');
                     debouncedOnSubmit(newValues);
                 } else {
                     debouncedOnSubmit(values);

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveForm.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveForm.stories.tsx
@@ -6,6 +6,7 @@ import TitleIcon from '@mui/icons-material/Title';
 import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
 import {
     FilterLiveForm,
+    FilterLiveFormProps,
     ListContextProvider,
     required,
     Resource,
@@ -511,3 +512,40 @@ export const AsListActions = () => (
         </AdminUI>
     </AdminContext>
 );
+
+const format = (value: string): string => {
+    if (!value) {
+        return value;
+    }
+    return value.length <= 11 ? value : `${value.slice(0, 11)}...`;
+};
+const parse = input => {
+    if (!input) {
+        return input;
+    }
+    return input.replace(/\D/g, '');
+};
+export const ParseFormat = (props: Partial<FilterLiveFormProps>) => {
+    const listContext = useList({
+        data: [
+            { id: 1, document: 'Hello', has_newsletter: true },
+            { id: 2, document: 'World', has_newsletter: false },
+        ],
+        filter: {
+            category: 'deals',
+        },
+    });
+    return (
+        <ListContextProvider value={listContext}>
+            <FilterLiveForm {...props}>
+                <TextInput
+                    source="document"
+                    parse={parse}
+                    format={format}
+                    resettable
+                />
+            </FilterLiveForm>
+            <FilterValue />
+        </ListContextProvider>
+    );
+};


### PR DESCRIPTION
## Problem

Fixes #10512. It seems that when calling `unset` which remove the property matching the filter input source from the filters, the value get re-added by react-hook-form.

## Solution

Set the filter value to an empty string which correctly removes it from the filter context.

## How To Test

In ra-core:
- https://react-admin-storybook-8h3fdlb89-marmelab.vercel.app/?path=/story/ra-core-form-filterliveform--parse-format
- Enter a number and removes it character by character until empty
- Enter a number then select the input value and remove it
- Enter a number then click the clear button

In ra-ui-materialui:
- https://react-admin-storybook-8h3fdlb89-marmelab.vercel.app/?path=/story/ra-ui-materialui-list-filter-filterliveform--parse-format
- Enter a number and removes it character by character until empty
- Enter a number then select the input value and remove it
- Enter a number then click the clear button

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
