### PR TITLE
[chore] Fix CI jobs that run on new tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,6 @@ jobs:
 
   e-commerce:
     runs-on: ubuntu-latest
-    if: github.ref_type != 'tag'
     needs: [typecheck]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

https://github.com/marmelab/react-admin/pull/10514 was not enough to run the CI jobs that are supposed to trigger on a new tag.

The issue is that those jobs depend on the `e-commerce` job, which does not trigger on a new tag.

## Solution

Also trigger the `e-commerce` job on a new tag.

## How To Test

We could probably test this  with a fake tag, but the change is so simple it can probably wait the next release to be tested.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
