### PR TITLE
[Doc] Add `<FormFillerButton>` documentation

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -242,7 +242,7 @@ React-admin supports **one-to-many**, **many-to-one**, **one-to-one**, and **man
 - [`<ReferenceManyToManyInput>`](./ReferenceManyToManyInput.md)
 - [`<ReferenceOneInput>`](./ReferenceOneInput.md)
 
-Reference components are a tremendous development accelerator for complex frontend features. They also liberate the backend developers from the burden of implementing complex joins. 
+Reference components are a tremendous development accelerator for complex frontend features. They also liberate the backend developers from the burden of implementing complex joins.
 
 To learn more about relationships, check out this tutorial: [Handling Relationships in React Admin](https://marmelab.com/blog/2025/02/06/handling-relationships-in-react-admin.html).
 
@@ -830,6 +830,13 @@ You can also use the [`<SmartRichTextInput>`](./SmartRichTextInput.md) component
 
 <video controls playsinline muted loop poster="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.png" >
   <source src="https://react-admin-ee.marmelab.com/assets/SmartRichTextInput.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
+One last example is [`<FormFillerButton>`](./FormFillerButton.md), which lets user fill the current form based on an image.
+
+<video controls autoplay playsinline muted loop>
+  <source src="https://react-admin-ee.marmelab.com/assets/FormFillerButton.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 

--- a/docs/FormFillerButton.md
+++ b/docs/FormFillerButton.md
@@ -1,0 +1,150 @@
+---
+layout: default
+title: "FormFillerButton"
+---
+
+# `<FormFillerButton>`
+
+This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" src="./img/premium.svg" /> component allows users to fill a form using an image or a camera. The image is sent to the AI backend together with the names of the fields to fill. The AI backend will extract the text from the image and fill the form.
+
+<video controls autoplay playsinline muted loop>
+  <source src="https://react-admin-ee.marmelab.com/assets/FormFillerButton.mp4" type="video/mp4"/>
+  Your browser does not support the video tag.
+</video>
+
+## Usage
+
+Include that button inside a react-admin form to allow users to fill the form using an image or a camera.
+
+```tsx
+import { Edit, SimpleForm, TextInput } from 'react-admin';
+import { FormFillerButton } from '@react-admin/ra-ai';
+
+export const ContactEdit = () => (
+    <Edit>
+        <SimpleForm>
+            <FormFillerButton />
+            <TextInput source="firstName" />
+            <TextInput source="lastName" />
+            <TextInput source="company" />
+            <TextInput source="email" />
+        </SimpleForm>
+    </Edit>
+);
+```
+
+**Tip**: `<FormFillerButton>` requires a model with Vision capabilities to extract text from images. We recommend using OpenAI's `gpt-4o-mini` or `gpt-4o` models.
+
+## Props
+
+`<FormFillerButton>` accepts the following props:
+
+| Prop              | Required | Type     | Default   | Description                                                                                                             |
+| ----------------- | -------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `acceptedFileTypes` | Optional | string   | 'image/*' | The accepted file types for the 'image' filler. |
+| `allowOverride`    | Optional | boolean  | false     | Allow the button to override the filled values. |
+| `fields`          | Optional | Object |        | The description of the fields to fill. This helps the AI to understand the context of the form. |
+| `maxDimension`        | Optional | number   | 1000      | The maximum width and height of the image. The image will be resized to fit this  dimension. |
+| `meta`            | Optional | object   | -         | Additional parameters to pass to the completion API. |
+| `sources`    | Optional | `string[]` | `['image', 'camera']` | The sources to use. Can be 'image' and/or 'camera'. |
+| `ButtonGroupProps` | Optional | object   | -         | Props to pass to the ButtonGroup component. |
+| `DialogProps`    | Optional | object   | -         | Props to pass to the Dialog component. |
+
+## `acceptedFileTypes`
+
+The accepted file types for the 'image' filler. Defaults to 'image/*'.
+
+```tsx
+<FormFillerButton acceptedFileTypes="image/jpeg" />
+```
+
+## `allowOverride`
+
+Allow the button to override the filled values. Defaults to false.
+
+```tsx
+<FormFillerButton allowOverride />
+```
+
+## `fields`
+
+The description of the fields to fill. This helps the AI to understand the context of the form.
+
+{% raw %}
+```tsx
+<FormFillerButton
+    fields={{
+        company: 'The company name. Example: Acme Inc.',
+        email: 'User email. If more than one email is present, find the one @acme.com',
+    }}
+/>
+```
+{% endraw %}
+
+## `maxDimension`
+
+The maximum width and height of the image. The image will be resized to fit this dimension. Defaults to 1000.
+
+Larger dimensions improve the OCR quality but increase the processing time.
+
+```tsx
+<FormFillerButton maxDimension={1500} />
+```
+
+## `meta`
+
+Lets you pass additional parameters to the `getCompletion()` query.
+
+For instance, the OpenAI implementation uses the `meta` parameter as a way to adjust the completion settings:
+
+{% raw %}
+```tsx
+<FormFillerButton
+    meta={{
+        top_p: 1,
+        frequency_penalty: 0,
+        presence_penalty: 0,
+    }}
+/>
+```
+{% endraw %}
+
+## `sources`
+
+The sources to use. The value must be an array. Possible values are 'image' and 'camera'. Defaults to `['image', 'camera']`.
+
+If you set only one source, the button will be a simple button instead of a split button.
+
+{% raw %}
+```tsx
+<FormFillerButton sources={['image']} />
+```
+{% endraw %}
+
+If you set more than one source, the first item will be the default source.
+
+{% raw %}
+```tsx
+<FormFillerButton sources={['camera', 'image']} />
+```
+{% endraw %}
+
+## `ButtonGroupProps`
+
+Props to pass to the ButtonGroup component.
+
+{% raw %}
+```tsx
+<FormFillerButton ButtonGroupProps={{ variant: 'contained' }} />
+```
+{% endraw %}
+
+## `DialogProps`
+
+Props to pass to the Dialog component.
+
+{% raw %}
+```tsx
+<FormFillerButton DialogProps={{ maxWidth: 'md' }} />
+```
+{% endraw %}

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -90,6 +90,7 @@ title: "Index"
 * [`<FilterLiveSearch>`](./FilterLiveSearch.md)
 * [`<Form>`](./Form.md)
 * [`<FormDataConsumer>`](./Inputs.md#linking-two-inputs)
+* [`<FormFillerButton>`](./FormFillerButton.md)
 * [`<FormTab>`](./TabbedForm.md)
 * [`<FunctionField>`](./FunctionField.md)
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -90,7 +90,7 @@ title: "Index"
 * [`<FilterLiveSearch>`](./FilterLiveSearch.md)
 * [`<Form>`](./Form.md)
 * [`<FormDataConsumer>`](./Inputs.md#linking-two-inputs)
-* [`<FormFillerButton>`](./FormFillerButton.md)
+* [`<FormFillerButton>`](./FormFillerButton.md)<img class="icon" src="./img/premium.svg" />
 * [`<FormTab>`](./TabbedForm.md)
 * [`<FunctionField>`](./FunctionField.md)
 

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -133,6 +133,7 @@
     <li {% if page.path == 'Toolbar.md' %} class="active" {% endif %}><a class="nav-link" href="./Toolbar.html"><code>&lt;Toolbar&gt;</code></a></li>
     <li {% if page.path == 'SaveButton.md' %} class="active" {% endif %}><a class="nav-link" href="./SaveButton.html"><code>&lt;SaveButton&gt;</code></a></li>
     <li {% if page.path == 'AutoSave.md' %} class="active" {% endif %}><a class="nav-link" href="./AutoSave.html"><code>&lt;AutoSave&gt;</code><img class="premium" src="./img/premium.svg" /></a></li>
+    <li {% if page.path == 'FormFillerButton.md' %} class="active" {% endif %}><a class="nav-link" href="./FormFillerButton.html"><code>&lt;FormFillerButton&gt;</code><img class="premium" src="./img/premium.svg" /></a></li>
     <li {% if page.path == 'useCreateContext.md' %} class="active" {% endif %}><a class="nav-link" href="./useCreateContext.html"><code>useCreateContext</code></a></li>
     <li {% if page.path == 'useCreateController.md' %} class="active" {% endif %}><a class="nav-link" href="./useCreateController.html"><code>useCreateController</code></a></li>
     <li {% if page.path == 'useEditContext.md' %} class="active" {% endif %}><a class="nav-link" href="./useEditContext.html"><code>useEditContext</code></a></li>


### PR DESCRIPTION
## Problem

`ra-ai` introduced a new `<FormFillerButton>` component which is not yet documented in OSS.

## Solution

Add `<FormFillerButton>` documentation

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
