### PR TITLE
Update ArrayInput to throw an error when using outdated disabled prop

### DIFF
--- a/docs/ArrayInput.md
+++ b/docs/ArrayInput.md
@@ -84,7 +84,7 @@ Check [the `<SimpleFormIterator>` documentation](./SimpleFormIterator.md) for de
 
 ## Props
 
-`<ArrayInput>` accepts the [common input props](./Inputs.md#common-input-props) (except `format` and `parse`).
+`<ArrayInput>` accepts the [common input props](./Inputs.md#common-input-props) (except `disabled`, `readOnly`, `format` and `parse`).
 
 ## Global validation
 
@@ -109,3 +109,27 @@ You need to return an errors object shaped like this:
 ```
 
 **Tip:** You can find a sample `validate` function that handles arrays in the [Form Validation documentation](./Validation.md#global-validation).
+
+## Disabling The Input
+
+`<ArrayInput>` does not support the `disabled` and `readOnly` props.
+
+If you need to disable the input, set the `<SimpleFormIterator disabled>` prop, and make the child inputs `readOnly`:
+
+```jsx
+const OrderEdit = () => (
+    <Edit>
+        <SimpleForm>
+            <TextInput source="customer" />
+            <DateInput source="date" />
+            <ArrayInput source="items">
+                <SimpleFormIterator inline disabled>
+                    <TextInput source="name" readOnly/>
+                    <NumberInput source="price" readOnly />
+                    <NumberInput source="quantity" readOnly />
+                </SimpleFormIterator>
+            </ArrayInput>
+        </SimpleForm>
+    </Edit>
+);
+```

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -117,11 +117,11 @@ export const Disabled = () => (
                         >
                             <SimpleForm>
                                 <TextInput source="title" />
-                                <ArrayInput source="authors" disabled>
-                                    <SimpleFormIterator>
-                                        <TextInput source="name" />
-                                        <TextInput source="role" />
-                                        <TextInput source="surname" />
+                                <ArrayInput source="authors">
+                                    <SimpleFormIterator disabled>
+                                        <TextInput source="name" disabled />
+                                        <TextInput source="role" disabled />
+                                        <TextInput source="surname" disabled />
                                     </SimpleFormIterator>
                                 </ArrayInput>
                             </SimpleForm>
@@ -150,11 +150,11 @@ export const ReadOnly = () => (
                         >
                             <SimpleForm>
                                 <TextInput source="title" />
-                                <ArrayInput source="authors" readOnly>
-                                    <SimpleFormIterator>
-                                        <TextInput source="name" />
-                                        <TextInput source="role" />
-                                        <TextInput source="surname" />
+                                <ArrayInput source="authors">
+                                    <SimpleFormIterator disabled>
+                                        <TextInput source="name" readOnly />
+                                        <TextInput source="role" readOnly />
+                                        <TextInput source="surname" readOnly />
                                     </SimpleFormIterator>
                                 </ArrayInput>
                             </SimpleForm>

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -91,6 +91,17 @@ export const ArrayInput = (props: ArrayInputProps) => {
         ...rest
     } = props;
 
+    if (disabled) {
+        throw new Error(
+            '<ArrayInput> does not accept a disabled prop. Set the disabled prop on the SimpleFormIterator and its child inputs instead.'
+        );
+    }
+    if (readOnly) {
+        throw new Error(
+            '<ArrayInput> does not accept a readOnly prop. Set the disabled prop on the SimpleFormIterator and make its children inputs readOnly instead.'
+        );
+    }
+
     const formGroupName = useFormGroupContext();
     const formGroups = useFormGroups();
     const parentSourceContext = useSourceContext();
@@ -250,7 +261,14 @@ export interface ArrayInputProps
         Omit<FormControlProps, 'defaultValue' | 'onBlur' | 'onChange'> {
     className?: string;
     children: ReactElement;
+    /**
+     * @deprecated Set the disabled prop on the SimpleFormIterator and its child inputs instead
+     */
     disabled?: boolean;
+    /**
+     * @deprecated Set the disabled prop on the SimpleFormIterator and its child inputs instead
+     */
+    readOnly?: boolean;
     isFetching?: boolean;
     isLoading?: boolean;
     isPending?: boolean;

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -85,22 +85,9 @@ export const ArrayInput = (props: ArrayInputProps) => {
         source: arraySource,
         validate,
         variant,
-        disabled,
-        readOnly,
         margin = 'dense',
         ...rest
     } = props;
-
-    if (disabled) {
-        throw new Error(
-            '<ArrayInput> does not accept a disabled prop. Set the disabled prop on the SimpleFormIterator and its child inputs instead.'
-        );
-    }
-    if (readOnly) {
-        throw new Error(
-            '<ArrayInput> does not accept a readOnly prop. Set the disabled prop on the SimpleFormIterator and make its children inputs readOnly instead.'
-        );
-    }
 
     const formGroupName = useFormGroupContext();
     const formGroups = useFormGroups();
@@ -257,18 +244,13 @@ export const getArrayInputError = error => {
 };
 
 export interface ArrayInputProps
-    extends CommonInputProps,
-        Omit<FormControlProps, 'defaultValue' | 'onBlur' | 'onChange'> {
+    extends Omit<CommonInputProps, 'disabled' | 'readOnly'>,
+        Omit<
+            FormControlProps,
+            'defaultValue' | 'disabled' | 'readOnly' | 'onBlur' | 'onChange'
+        > {
     className?: string;
     children: ReactElement;
-    /**
-     * @deprecated Set the disabled prop on the SimpleFormIterator and its child inputs instead
-     */
-    disabled?: boolean;
-    /**
-     * @deprecated Set the disabled prop on the SimpleFormIterator and its child inputs instead
-     */
-    readOnly?: boolean;
     isFetching?: boolean;
     isLoading?: boolean;
     isPending?: boolean;


### PR DESCRIPTION
## Problem

`<ArrayInput disabled>` isn't supported since v5 (see https://marmelab.com/react-admin/Upgrade.html#simpleformiterator-no-longer-clones-its-children). 

Yet the component prop type still supports it, and the documentation says nothing about it. 

This leads to developers wondering why this prop does nothing. 

## Solution

- Update the type to fail compilation when readOnly or disabled are used
- Update the doc to explain how to disable an ArrayInput
- Fix remaining stories

