### PR TITLE
Fix create-react-admin does not ignore auth-provider when specified and using supabase

### DIFF
--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -45,6 +45,7 @@ const getAuthProvider = (flags: typeof cli.flags) => {
         console.warn(
             'Providing an auth-provider when using ra-supabase is not supported. It will be ignored.'
         );
+        return 'none';
     }
     if (flags.authProvider) return getAuthProviderName(flags.authProvider);
     if (getDataProviderName(flags.dataProvider) === 'ra-supabase')


### PR DESCRIPTION
## Problem

When specifying `supabase` as the `--data-provider` option and `local` as the `--auth-provider` option, `create-react-admin` says it will ignore the `--auth-provider` but actually doesn't.

## How To Test

- `make build-create-react-admin install`
- `/node_modules/.bin/create-react-admin myadmin --data-provider supabase --auth-provider local`
- check that the CLI does not mention anything about how to use the local auth provider
- check that the generated app does not include a custom auth provider

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
