### PR TITLE
Fix create react admin detect package manager

### DIFF
--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -54,7 +54,7 @@ const getAuthProvider = (flags: typeof cli.flags) => {
 };
 
 const getDefaultInstaller = (userAgent: string) => {
-    if (!userAgent) return undefined;
+    if (!userAgent) return 'npm';
     const pkgSpec = userAgent.split(' ')[0];
     const pkgSpecArr = pkgSpec.split('/');
     return pkgSpecArr[0];

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -53,16 +53,17 @@ const getAuthProvider = (flags: typeof cli.flags) => {
     return 'none';
 };
 
-const getDefaultInstaller = (processExec: string) => {
-    if (processExec.includes('yarn')) return 'yarn';
-    if (processExec.includes('bun')) return 'bun';
-    return 'npm';
+const getDefaultInstaller = (userAgent: string) => {
+    if (!userAgent) return undefined;
+    const pkgSpec = userAgent.split(' ')[0];
+    const pkgSpecArr = pkgSpec.split('/');
+    return pkgSpecArr[0];
 };
 
-const getInstall = (flags: typeof cli.flags, processExec: string) => {
+const getInstall = (flags: typeof cli.flags, userAgent: string) => {
     if (flags.install) return flags.install;
     if (flags.interactive) return undefined;
-    return getDefaultInstaller(processExec);
+    return getDefaultInstaller(userAgent);
 };
 
 const getResources = (flags: typeof cli.flags) => {
@@ -133,7 +134,7 @@ if (cli.flags.h) {
     }
     const dataProvider = getDataProvider(cli.flags);
     const authProvider = getAuthProvider(cli.flags);
-    const install = getInstall(cli.flags, process.execPath);
+    const install = getInstall(cli.flags, process.env.npm_config_user_agent);
     const resources = getResources(cli.flags);
 
     render(


### PR DESCRIPTION
## Problem

`create-react-admin` does not detect the package manager used to run it correctly.

## Solution

Leverage the `process.env.npm_config_user_agent` environment variable to detect it, just like [`create-vite`](https://github.com/vitejs/vite/blob/main/packages/create-vite/src/index.ts#L315C36-L315C69)

## How To Test

Difficult to test without a release as you have to modify the global cache of the package manager.
- For bun it's in `$HOME/.bun/install/cache` and the package is unzipped into `create-react-admin@5.6.0@@@1`
- For yarn it's in `$HOME/.yarn/berry/cache` and the package is not unzipped but renamed to `create-react-admin-npm-5.6.0-941ece3bdb-10c0.zip`

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
