### PR TITLE
[Doc] Fix `<DatagridAGClient>` access control's doc

### DIFF
--- a/docs/DatagridAG.md
+++ b/docs/DatagridAG.md
@@ -2851,7 +2851,7 @@ const CarList = () => {
 
 ### Access Control
 
-`<DatagridAG>` has built-in [access control](./Permissions.me#access-control). If the `authProvider` implements the `canAccess` method, users will only be allowed to edit rows of, say, resource `'cars'` if `canAccess({ action: 'edit', resource: 'cars' })` returns `true`.
+`<DatagridAGClient>` has built-in [access control](./Permissions.me#access-control). If the `authProvider` implements the `canAccess` method, users will only be allowed to edit rows of, say, resource `'cars'` if `canAccess({ action: 'edit', resource: 'cars' })` returns `true`.
 
 **Note:** the access control check can only be done at the resource level and not at the record level.
 


### PR DESCRIPTION
## Problem

In the `<DatagridAGClient>`'s doc, we speak about the `<DatagridAG>`'s behavior (with access control) instead of the `<DatagridAGClient>`'s behavior.

## Solution

Fix this typo