### PR TITLE
[Doc] Fix dialogs `title` doc

### DIFF
--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -210,35 +210,32 @@ Unlike the `<Create>` components, with Dialog components the title will be displ
 Here is an example:
 
 ```tsx
-import React from 'react';
 import {
     List,
+    ListActions,
     Datagrid,
     SimpleForm,
     TextInput,
     DateInput,
+    DateField,
     required,
 } from 'react-admin';
-import {
-    CreateDialog,
-} from '@react-admin/ra-form-layout';
+import { CreateDialog } from '@react-admin/ra-form-layout';
 
 const CustomerList = () => (
     <>
-        <List hasCreate>
+        <List actions={<ListActions hasCreate />}>
             <Datagrid>
                 ...
-                <ShowButton />
             </Datagrid>
         </List>
-        <ShowDialog title={<CustomerShowTitle />}>
-            <SimpleShowLayout>
-                <TextField source="id" />
-                <TextField source="first_name" />
-                <TextField source="last_name" />
-                <DateField source="date_of_birth" label="born" />
-            </SimpleShowLayout>
-        </ShowDialog>
+        <CreateDialog title="Create a new customer">
+            <SimpleForm>
+                <TextInput source="first_name" validate={required()} />
+                <TextInput source="last_name" validate={required()} />
+                <DateInput source="date_of_birth" />
+            </SimpleForm>
+        </CreateDialog>
     </>
 );
 ```

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -217,7 +217,6 @@ import {
     SimpleForm,
     TextInput,
     DateInput,
-    DateField,
     required,
 } from 'react-admin';
 import { CreateDialog } from '@react-admin/ra-form-layout';

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -236,8 +236,9 @@ const MyEditDialog = () => (
 
 ## `title`
 
-Unlike the `<Create>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
-If you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
+Unlike the `<Edit>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+If you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component.
+That means you can display non-editable details of the current `record` in the title component.
 Here is an example:
 
 ```tsx

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -302,7 +302,8 @@ const EditButton = () => (
 ## `title`
 
 Unlike the `<Edit>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
-Still, for `<EditInDialogButton>`, if you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
+If you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component.
+That means you can display non-editable details of the current `record` in the title component.
 Here is an example:
 
 ```tsx

--- a/docs/ShowInDialogButton.md
+++ b/docs/ShowInDialogButton.md
@@ -314,8 +314,8 @@ const ShowButton = () => (
 
 ## `title`
 
-Unlike the `<Create>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
-Still, for `<ShowInDialogButton>`, if you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
+Unlike the `<Show>` components, with Dialog components the title will be displayed in the `<Dialog>`, not in the `<AppBar>`.
+If you pass a custom title component, it will render in the same `RecordContext` as the dialog's child component. That means you can display non-editable details of the current `record` in the title component.
 Here is an example:
 
 ```tsx


### PR DESCRIPTION
## Problem

We have some typos in dialog `title`'s sections

## Solution

Fix those typos

