### PR TITLE
[chore] Fix CI jobs that run on new tag, again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     name: GreenFrame
     needs: [e-commerce]
-    if: github.event_name == 'push' && github.ref_type == 'tag' && github.ref_name == 'refs/tags/v*' && !contains('beta', github.ref_name) && !contains('alpha', github.ref_name)
+    if: github.event_name == 'push' && github.ref_type == 'tag' && contains(github.ref, 'refs/tags/v') && !contains('beta', github.ref) && !contains('alpha', github.ref)
     steps:
       # To use this repository's private action,
       # you must check out the repository
@@ -225,7 +225,7 @@ jobs:
   update-sandbox-repository:
     runs-on: ubuntu-latest
     # Only run on new tags that target a release (not latest nor next) and avoid alpha and beta tags
-    if: github.event_name == 'push' && github.ref_type == 'tag' && github.ref_name == 'refs/tags/v*' && !contains('beta', github.ref_name) && !contains('alpha', github.ref_name)
+    if: github.event_name == 'push' && github.ref_type == 'tag' && contains(github.ref, 'refs/tags/v') && !contains('beta', github.ref) && !contains('alpha', github.ref)
     needs: [typecheck, simple-example-typecheck, unit-test, e2e-test]
     steps:
         - name: Checkout


### PR DESCRIPTION
## Problem

Follow up to https://github.com/marmelab/react-admin/pull/10525

It turns out the CI workflow configuration still contained errors

## Solution

Fix the remaining configuration mistakes

## How To Test

One way to test is by using https://github.com/nektos/act.

A 'tag pushed' event can be simulated like so:

1. Create a `push_tag_event.json` file:

```json
{
  "ref": "refs/tags/v1.0.0",
  "ref_type": "tag",
  "repository": {
    "full_name": "marmelab/react-admin"
  },
  "event_name": "push"
}
```

2. Edit the workflow jobs so that they don't do too much stuff (typically, only echo something for instance)

3. Run `act` with the event file:

```bash
act -e push_tag_event.json -W .github/workflows/test.yml
```

4. Make sure the `GreenFrame` and `update-sandbox-repository` jobs are triggered

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
