### PR TITLE
feat: support Component and Element for List props

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -52,29 +52,29 @@ You can find more advanced examples of `<List>` usage in the [demos](./Demos.md)
 
 ## Props
 
-| Prop                      | Required | Type           | Default        | Description                                                                                  |
-|---------------------------|----------|----------------|----------------|----------------------------------------------------------------------------------------------|
-| `children`                | Required | `ReactNode`    | -              | The components rendering the list of records.                                          |
-| `actions`                 | Optional | `ReactElement` | -              | The actions to display in the toolbar.                                                       |
-| `aside`                   | Optional | `ReactElement` | -              | The component to display on the side of the list.                                            |
-| `component`               | Optional | `Component`    | `Card`         | The component to render as the root element.                                                 |
-| `debounce`                | Optional | `number`       | `500`          | The debounce delay in milliseconds to apply when users change the sort or filter parameters. |
-| `disable Authentication`  | Optional | `boolean`      | `false`        | Set to `true` to disable the authentication check.                                           |
-| `disable SyncWithLocation`| Optional | `boolean`      | `false`        | Set to `true` to disable the synchronization of the list parameters with the URL.            |
-| `empty`                   | Optional | `ReactElement` | -              | The component to display when the list is empty.                                             |
-| `empty WhileLoading`      | Optional | `boolean`      | `false`        | Set to `true` to return `null` while the list is loading.                                    |
-| `exporter`                | Optional | `function`     | -              | The function to call to export the list.                                                     |
-| `filters`                 | Optional | `ReactElement` | -              | The filters to display in the toolbar.                                                       |
-| `filter`                  | Optional | `object`       | -              | The permanent filter values.                                                                 |
-| `filter DefaultValues`    | Optional | `object`       | -              | The default filter values.                                                                   |
-| `pagination`              | Optional | `ReactElement` | `<Pagination>` | The pagination component to use.                                                             |
-| `perPage`                 | Optional | `number`       | `10`           | The number of records to fetch per page.                                                     |
-| `queryOptions`            | Optional | `object`       | -              | The options to pass to the `useQuery` hook.                                                  |
-| `resource`                | Optional | `string`       | -              | The resource name, e.g. `posts`.                                                             |
-| `sort`                    | Optional | `object`       | -              | The initial sort parameters.                                                                 |
-| `storeKey`                | Optional | `string | false` | -           | The key to use to store the current filter & sort. Pass `false` to disable store synchronization |
-| `title`                   | Optional | `string | ReactElement | false` | -              | The title to display in the App Bar.                                                         |
-| `sx`                      | Optional | `object`       | -              | The CSS styles to apply to the component.                                                    |
+| Prop                      | Required | Type                                   | Default        | Description                                                                                  |
+|---------------------------|----------|----------------------------------------|----------------|-------------------------------------------------------------------------------------------------|
+| `children`                | Required | `ReactNode`                                     | -              | The components rendering the list of records.                                          |
+| `actions`                 | Optional | `ReactElement | ComponentType | false`          | -              | The actions to display in the toolbar.                                                       |
+| `aside`                   | Optional | `ReactElement | ComponentType`                  | -              | The component to display on the side of the list.                                            |
+| `component`               | Optional | `Component`                                     | `Card`         | The component to render as the root element.                                                 |
+| `debounce`                | Optional | `number`                                        | `500`          | The debounce delay in milliseconds to apply when users change the sort or filter parameters. |
+| `disable Authentication`  | Optional | `boolean`                                       | `false`        | Set to `true` to disable the authentication check.                                           |
+| `disable SyncWithLocation`| Optional | `boolean`                                       | `false`        | Set to `true` to disable the synchronization of the list parameters with the URL.            |
+| `empty`                   | Optional | `ReactElement | ComponentType | false`          | -              | The component to display when the list is empty.                                             |
+| `empty WhileLoading`      | Optional | `boolean`                                       | `false`        | Set to `true` to return `null` while the list is loading.                                    |
+| `exporter`                | Optional | `function`                                      | -              | The function to call to export the list.                                                     |
+| `filters`                 | Optional | `ReactElement`                                  | -              | The filters to display in the toolbar.                                                       |
+| `filter`                  | Optional | `object`                                        | -              | The permanent filter values.                                                                 |
+| `filter DefaultValues`    | Optional | `object`                                        | -              | The default filter values.                                                                   |
+| `pagination`              | Optional | `ReactElement | ComponentType | false`          | `<Pagination>` | The pagination component to use.                                                             |
+| `perPage`                 | Optional | `number`                                        | `10`           | The number of records to fetch per page.                                                     |
+| `queryOptions`            | Optional | `object`                                        | -              | The options to pass to the `useQuery` hook.                                                  |
+| `resource`                | Optional | `string`                                        | -              | The resource name, e.g. `posts`.                                                             |
+| `sort`                    | Optional | `object`                                        | -              | The initial sort parameters.                                                                 |
+| `storeKey`                | Optional | `string | false`                                | -           | The key to use to store the current filter & sort. Pass `false` to disable store synchronization |
+| `title`                   | Optional | `string | ReactElement | ComponentType | false` | -              | The title to display in the App Bar.                                                         |
+| `sx`                      | Optional | `object`                                        | -              | The CSS styles to apply to the component.                                                    |
 
 Additional props are passed down to the root component (a MUI `<Card>` by default).
 
@@ -139,6 +139,7 @@ export const PostList = () => (
     </List>
 );
 ```
+You can use a `ReactElement` (e.g. `actions={<ListActions/>}`), a `ComponentType` (e.g. `actions={ListActions}`) or false to disable it.
 
 **Tip**: If you are looking for an `<ImportButton>`, check out this third-party package: [benwinding/react-admin-import-csv](https://github.com/benwinding/react-admin-import-csv).
 
@@ -175,7 +176,7 @@ The default `<List>` layout lets you render the component of your choice on the 
 
 ![List with aside](./img/list_aside.webp)
 
-Pass a React element as the `aside` prop for that purpose:
+Pass a React element or ComponentType as the `aside` prop for that purpose:
 
 {% raw %}
 ```jsx
@@ -483,7 +484,7 @@ When there is no result, and there is no active filter, and the resource has a c
 
 ![Empty invite](./img/list-empty.png)
 
-You can use the `empty` prop to replace that page by a custom component:
+You can use the `empty` prop to replace that page by a custom component, passing a ReactElement or ComponentType :
 
 {% raw %}
 ```jsx
@@ -783,7 +784,7 @@ By default, the `<List>` view displays a set of pagination controls at the botto
 
 ![Pagination](./img/list-pagination.webp)
 
-The `pagination` prop allows to replace the default pagination controls by your own.
+The `pagination` prop allows to replace the default pagination controls by your own, either with a ReactElement or a ComponentType.
 
 ```jsx
 // in src/MyPagination.js
@@ -990,7 +991,7 @@ export const PostList = () => (
 );
 ```
 
-The title can be a string, a React element, or `false` to disable the title.
+The title can be a string, a React element, a ComponentType or `false` to disable the title.
 
 ## `sx`: CSS API
 

--- a/packages/ra-ui-materialui/src/list/List.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/List.spec.tsx
@@ -22,6 +22,9 @@ import {
     PartialPagination,
     Default,
     SelectAllLimit,
+    TitleComponent,
+    ActionsElement,
+    ActionsComponent,
 } from './List.stories';
 
 const theme = createTheme(defaultTheme);
@@ -112,6 +115,25 @@ describe('<List />', () => {
         expect(screen.queryAllByText('Hello')).toHaveLength(1);
     });
 
+    it('should display aside component with ComponentType', () => {
+        const Dummy = () => <div />;
+        const Aside = () => <div id="aside">Hello</div>;
+        render(
+            <CoreAdminContext
+                dataProvider={testDataProvider({
+                    getList: () => Promise.resolve({ data: [], total: 0 }),
+                })}
+            >
+                <ThemeProvider theme={theme}>
+                    <List resource="posts" aside={Aside}>
+                        <Dummy />
+                    </List>
+                </ThemeProvider>
+            </CoreAdminContext>
+        );
+        expect(screen.queryAllByText('Hello')).toHaveLength(1);
+    });
+
     describe('empty', () => {
         it('should render an invite when the list is empty', async () => {
             const Dummy = () => {
@@ -186,6 +208,36 @@ describe('<List />', () => {
                 <CoreAdminContext dataProvider={dataProvider}>
                     <ThemeProvider theme={theme}>
                         <List resource="posts" empty={<CustomEmpty />}>
+                            <Dummy />
+                        </List>
+                    </ThemeProvider>
+                </CoreAdminContext>
+            );
+            await waitFor(() => {
+                expect(screen.queryByText('resources.posts.empty')).toBeNull();
+                screen.getByText('Custom Empty');
+            });
+        });
+
+        it('should render custom empty component when data is empty with ComponentType', async () => {
+            const Dummy = () => null;
+            const CustomEmpty = () => <div>Custom Empty</div>;
+
+            const dataProvider = {
+                getList: jest.fn(() =>
+                    Promise.resolve({
+                        data: [],
+                        pageInfo: {
+                            hasNextPage: false,
+                            hasPreviousPage: false,
+                        },
+                    })
+                ),
+            } as any;
+            render(
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <ThemeProvider theme={theme}>
+                        <List resource="posts" empty={CustomEmpty}>
                             <Dummy />
                         </List>
                     </ThemeProvider>
@@ -332,6 +384,12 @@ describe('<List />', () => {
 
         it('should render custom title element when defined', async () => {
             render(<TitleElement />);
+            await screen.findByText('War and Peace (1869)');
+            screen.getByText('Custom list title');
+        });
+
+        it('should render custom title component when defined', async () => {
+            render(<TitleComponent />);
             await screen.findByText('War and Peace (1869)');
             screen.getByText('Custom list title');
         });
@@ -484,6 +542,18 @@ describe('<List />', () => {
             await screen.findByText(
                 'There are too many elements to select them all. Only the first 11 elements were selected.'
             );
+        });
+    });
+    describe('Custom actions', () => {
+        it('should render custom actions with ReactElement', async () => {
+            render(<ActionsElement />);
+            await screen.findByText('War and Peace (1869)');
+            screen.getByText('Actions');
+        });
+        it('should render custom actions with ComponentType', async () => {
+            render(<ActionsComponent />);
+            await screen.findByText('War and Peace (1869)');
+            screen.getByText('Actions');
         });
     });
 });

--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -169,7 +169,7 @@ export const Basic = () => (
     </TestMemoryRouter>
 );
 
-export const Actions = () => (
+export const ActionsElement = () => (
     <TestMemoryRouter initialEntries={['/books']}>
         <Admin dataProvider={defaultDataProvider}>
             <Resource
@@ -182,6 +182,23 @@ export const Actions = () => (
                             </Box>
                         }
                     >
+                        <BookList />
+                    </List>
+                )}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
+const Actions = () => <Box sx={{ backgroundColor: 'info.main' }}>Actions</Box>;
+
+export const ActionsComponent = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <Admin dataProvider={defaultDataProvider}>
+            <Resource
+                name="books"
+                list={() => (
+                    <List actions={Actions}>
                         <BookList />
                     </List>
                 )}

--- a/packages/ra-ui-materialui/src/list/List.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/List.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Admin, AutocompleteInput } from 'react-admin';
+import { Admin, AutocompleteInput, Pagination } from 'react-admin';
 import {
     CustomRoutes,
     Resource,
@@ -10,6 +10,8 @@ import {
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { Box, Card, Typography, Button, Link as MuiLink } from '@mui/material';
 
+import { Empty as DefaultEmpty } from './Empty';
+import { Pagination as DefaultPagination } from './pagination';
 import { List } from './List';
 import { SimpleList } from './SimpleList';
 import { ListActions } from './ListActions';
@@ -284,6 +286,23 @@ export const TitleElement = () => (
     </TestMemoryRouter>
 );
 
+const TitleSpan = () => <span>Custom list title</span>;
+
+export const TitleComponent = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <Admin dataProvider={defaultDataProvider}>
+            <Resource
+                name="books"
+                list={() => (
+                    <List title={TitleSpan}>
+                        <BookList />
+                    </List>
+                )}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
 export const TitleFalse = () => (
     <TestMemoryRouter initialEntries={['/books']}>
         <Admin dataProvider={defaultDataProvider}>
@@ -314,15 +333,30 @@ export const HasCreate = () => (
     </TestMemoryRouter>
 );
 
-const AsideComponent = () => <Card sx={{ padding: 2 }}>Aside</Card>;
+const AsideBlock = () => <Card sx={{ padding: 2 }}>Aside</Card>;
 
-export const Aside = () => (
+export const AsideElement = () => (
     <TestMemoryRouter initialEntries={['/books']}>
         <Admin dataProvider={defaultDataProvider}>
             <Resource
                 name="books"
                 list={() => (
-                    <List aside={<AsideComponent />}>
+                    <List aside={<AsideBlock />}>
+                        <BookList />
+                    </List>
+                )}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
+export const AsideComponent = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <Admin dataProvider={defaultDataProvider}>
+            <Resource
+                name="books"
+                list={() => (
+                    <List aside={AsideBlock}>
                         <BookList />
                     </List>
                 )}
@@ -404,6 +438,22 @@ export const Empty = () => (
     </TestMemoryRouter>
 );
 
+export const EmptyComponent = () => (
+    <TestMemoryRouter initialEntries={['/authors']}>
+        <Admin dataProvider={defaultDataProvider}>
+            <Resource
+                name="authors"
+                list={() => (
+                    <List empty={DefaultEmpty}>
+                        <span />
+                    </List>
+                )}
+                create={() => <span />}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
 export const EmptyPartialPagination = () => (
     <TestMemoryRouter initialEntries={['/authors']}>
         <Admin
@@ -427,6 +477,21 @@ export const EmptyPartialPagination = () => (
                     </List>
                 )}
                 create={() => <span />}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
+export const PaginationComponent = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <Admin dataProvider={defaultDataProvider}>
+            <Resource
+                name="books"
+                list={() => (
+                    <List pagination={DefaultPagination}>
+                        <BookList />
+                    </List>
+                )}
             />
         </Admin>
     </TestMemoryRouter>

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -1,16 +1,23 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactElement, ReactNode, ElementType } from 'react';
-import { SxProps } from '@mui/system';
+import {
+    ComponentType,
+    ElementType,
+    ReactElement,
+    ReactNode,
+    isValidElement,
+} from 'react';
 import Card from '@mui/material/Card';
+import { styled } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
 import clsx from 'clsx';
-import { useListContext, RaRecord } from 'ra-core';
+import { RaRecord, useListContext } from 'ra-core';
 
 import { Title } from '../layout/Title';
+import { Empty } from './Empty';
+import { ListActions as DefaultActions } from './ListActions';
 import { ListToolbar } from './ListToolbar';
 import { Pagination as DefaultPagination } from './pagination';
-import { ListActions as DefaultActions } from './ListActions';
-import { Empty } from './Empty';
+import { isValidElementType } from 'react-is';
 
 const defaultActions = <DefaultActions />;
 const defaultPagination = <DefaultPagination />;
@@ -55,7 +62,7 @@ export const ListView = <RecordType extends RaRecord = any>(
                 <ListToolbar
                     className={ListClasses.actions}
                     filters={filters}
-                    actions={actions}
+                    actions={getElement(actions)}
                 />
             )}
             <Content className={ListClasses.content}>{children}</Content>
@@ -97,6 +104,25 @@ export const ListView = <RecordType extends RaRecord = any>(
     );
 };
 
+const getElement = (
+    ElementOrComponent: React.ComponentType<any> | ReactElement | false
+) => {
+    if (ElementOrComponent === false) {
+        return;
+    }
+
+    if (isValidElement(ElementOrComponent)) {
+        console.log(`We have an element`);
+        return ElementOrComponent;
+    }
+
+    if (isValidElementType(ElementOrComponent)) {
+        console.log(`We have a component`);
+        const Element = ElementOrComponent as ComponentType<any>;
+        return <Element />;
+    }
+};
+
 export interface ListViewProps {
     /**
      * The actions to display in the toolbar. defaults to Filter + Create + Export.
@@ -131,7 +157,7 @@ export interface ListViewProps {
      *     </List>
      * );
      */
-    actions?: ReactElement | false;
+    actions?: ReactElement | React.ComponentType | false;
 
     /**
      * The content to render as a sidebar.

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -62,16 +62,18 @@ export const ListView = <RecordType extends RaRecord = any>(
                 <ListToolbar
                     className={ListClasses.actions}
                     filters={filters}
-                    actions={getElement(actions)}
+                    actions={getActionsElement(actions)}
                 />
             )}
             <Content className={ListClasses.content}>{children}</Content>
-            {!error && pagination !== false && pagination}
+            {!error && pagination !== false && getElement(pagination)}
         </div>
     );
 
     const renderEmpty = () =>
-        empty !== false && <div className={ListClasses.noResults}>{empty}</div>;
+        empty !== false && (
+            <div className={ListClasses.noResults}>{getElement(empty)}</div>
+        );
 
     const shouldRenderEmptyPage =
         !error &&
@@ -93,34 +95,42 @@ export const ListView = <RecordType extends RaRecord = any>(
         <Root className={clsx('list-page', className)} {...rest}>
             {title !== false && (
                 <Title
-                    title={title}
+                    title={title ? getTitleElement(title) : undefined}
                     defaultTitle={defaultTitle}
                     preferenceKey={`${resource}.list.title`}
                 />
             )}
             {shouldRenderEmptyPage ? renderEmpty() : renderList()}
-            {aside}
+            {aside ? getElement(aside) : null}
         </Root>
     );
 };
 
-const getElement = (
-    ElementOrComponent: React.ComponentType<any> | ReactElement | false
-) => {
-    if (ElementOrComponent === false) {
+const getTitleElement = (title: ReactElement | ComponentType | string) => {
+    if (typeof title === 'string') {
+        return title;
+    }
+    return getElement(title);
+};
+
+const getActionsElement = (actions: ListViewProps['actions']) => {
+    if (!actions) {
         return;
     }
+    return getElement(actions);
+};
 
+const getElement = (ElementOrComponent: ComponentType | ReactElement) => {
     if (isValidElement(ElementOrComponent)) {
-        console.log(`We have an element`);
         return ElementOrComponent;
     }
-
     if (isValidElementType(ElementOrComponent)) {
-        console.log(`We have a component`);
-        const Element = ElementOrComponent as ComponentType<any>;
+        const Element = ElementOrComponent as ComponentType;
         return <Element />;
     }
+    throw new Error(
+        'the value prop should be a valid ReactElement or a valid React Component'
+    );
 };
 
 export interface ListViewProps {
@@ -157,7 +167,7 @@ export interface ListViewProps {
      *     </List>
      * );
      */
-    actions?: ReactElement | React.ComponentType | false;
+    actions?: ReactElement | ComponentType | false;
 
     /**
      * The content to render as a sidebar.
@@ -185,7 +195,7 @@ export interface ListViewProps {
      *     </List>
      * );
      */
-    aside?: ReactElement;
+    aside?: ReactElement | ComponentType;
 
     /**
      * A class name to apply to the root div element
@@ -256,7 +266,7 @@ export interface ListViewProps {
      *     </List>
      * );
      */
-    empty?: ReactElement | false;
+    empty?: ReactElement | ComponentType | false;
 
     /**
      * Set to true to return null while the list is loading.
@@ -309,7 +319,7 @@ export interface ListViewProps {
      *     </List>
      * );
      */
-    pagination?: ReactElement | false;
+    pagination?: ReactElement | ComponentType | false;
 
     /**
      * The page title (main title) to display above the data. Defaults to the humanized resource name.
@@ -324,7 +334,7 @@ export interface ListViewProps {
      *     </List>
      * );
      */
-    title?: string | ReactElement | false;
+    title?: string | ReactElement | ComponentType | false;
 
     /**
      * The CSS styles to apply to the component.


### PR DESCRIPTION
## Problem

In order to have a better developper experience we want to simplify the way we customise the `List` sub-component (eg: actions, filters, aside, pagination).

## Solution

Allow to use React.ComponentType in addition to ReactElement.

```tsx
  const Actions = () => <Box sx={{ backgroundColor: 'info.main' }}>Actions</Box>;
  <List actions={Actions}>
      <BookList />
  </List>
```
or 
```tsx
    <List
        actions={
            <Box sx={{ backgroundColor: 'info.main' }}>
                Actions
            </Box>
        }
    >
        <BookList />
    </List>
```

## How To Test

Create a List using a component (`actions={Actions}`)

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
