### PR TITLE
Fix collapsed menu in B&W theme

### DIFF
--- a/examples/demo/src/layout/Menu.tsx
+++ b/examples/demo/src/layout/Menu.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import LabelIcon from '@mui/icons-material/Label';
-
 import {
     useTranslate,
     DashboardMenuItem,
@@ -10,6 +9,7 @@ import {
     MenuProps,
     useSidebarState,
 } from 'react-admin';
+import clsx from 'clsx';
 
 import visitors from '../visitors';
 import orders from '../orders';
@@ -46,6 +46,10 @@ const Menu = ({ dense = false }: MenuProps) => {
                         duration: theme.transitions.duration.leavingScreen,
                     }),
             }}
+            className={clsx({
+                'RaMenu-open': open,
+                'RaMenu-closed': !open,
+            })}
         >
             <DashboardMenuItem />
             <SubMenu

--- a/examples/demo/src/layout/SubMenu.tsx
+++ b/examples/demo/src/layout/SubMenu.tsx
@@ -51,6 +51,7 @@ const SubMenu = (props: Props) => {
                     dense={dense}
                     component="div"
                     disablePadding
+                    className="SubMenu"
                     sx={{
                         '& .MuiMenuItem-root': {
                             transition:

--- a/examples/demo/src/themes/themes.tsx
+++ b/examples/demo/src/themes/themes.tsx
@@ -30,10 +30,39 @@ export interface Theme {
     dark?: RaThemeOptions;
 }
 
+const BW_SIDEBAR_OVERRIDE = {
+    styleOverrides: {
+        root: {
+            '& .SubMenu .MuiMenuItem-root': {
+                paddingLeft: 24,
+            },
+            '& .RaMenu-closed .SubMenu .MuiMenuItem-root': {
+                paddingLeft: 8,
+            },
+        },
+    },
+};
+
 export const themes: Theme[] = [
     { name: 'soft', light: softLightTheme, dark: softDarkTheme },
     { name: 'default', light: defaultLightTheme, dark: defaultDarkTheme },
-    { name: 'B&W', light: bwLightTheme, dark: bwDarkTheme },
+    {
+        name: 'B&W',
+        light: {
+            ...bwLightTheme,
+            components: {
+                ...bwLightTheme.components,
+                RaSidebar: BW_SIDEBAR_OVERRIDE,
+            },
+        },
+        dark: {
+            ...bwDarkTheme,
+            components: {
+                ...bwDarkTheme.components,
+                RaSidebar: BW_SIDEBAR_OVERRIDE,
+            },
+        },
+    },
     { name: 'nano', light: nanoLightTheme, dark: nanoDarkTheme },
     { name: 'radiant', light: radiantLightTheme, dark: radiantDarkTheme },
     { name: 'house', light: houseLightTheme, dark: houseDarkTheme },

--- a/packages/ra-ui-materialui/src/layout/Sidebar.tsx
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
+import clsx from 'clsx';
 import { ReactElement } from 'react';
 import {
     Drawer,
@@ -40,9 +41,12 @@ export const Sidebar = (props: SidebarProps) => {
             open={open}
             onClose={toggleSidebar}
             classes={SidebarClasses}
-            className={
-                trigger && !appBarAlwaysOn ? SidebarClasses.appBarCollapsed : ''
-            }
+            className={clsx(
+                trigger && !appBarAlwaysOn
+                    ? SidebarClasses.appBarCollapsed
+                    : '',
+                open ? OPEN_CLASS : CLOSED_CLASS
+            )}
             {...rest}
         >
             <div className={SidebarClasses.fixed}>{children}</div>
@@ -74,6 +78,9 @@ export const SidebarClasses = {
     fixed: `${PREFIX}-fixed`,
     appBarCollapsed: `${PREFIX}-appBarCollapsed`,
 };
+
+const OPEN_CLASS = `${PREFIX}-open`;
+const CLOSED_CLASS = `${PREFIX}-closed`;
 
 const StyledDrawer = styled(Drawer, {
     name: PREFIX,

--- a/packages/ra-ui-materialui/src/theme/bwTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/bwTheme.ts
@@ -343,6 +343,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                     root: {
                         margin: `0 ${SPACING}px`,
                         paddingRight: 0,
+                        paddingLeft: SPACING,
                         borderRadius: 5,
                         color: isDarkMode ? grey['200'] : common['black'],
                         '&.RaMenuItemLink-active': {
@@ -351,13 +352,16 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                         '& .RaMenuItemLink-icon': {
                             minWidth: 30,
                         },
+                        '.RaMenu-closed &': {
+                            margin: `0 0 0 ${SPACING}px`,
+                        },
                     },
                 },
             },
         },
         sidebar: {
             width: 195,
-            closedWidth: 50,
+            closedWidth: 45,
         },
     };
 };


### PR DESCRIPTION
## Problem

When using the B&W theme, the collapsed menu looks off

<img width="276" alt="Capture d’écran 2025-02-21 à 21 43 36" src="https://github.com/user-attachments/assets/32a76c7f-7f18-4fef-8a6d-d36724e68e82" />


## Solution

Fix the theme. 

<img width="272" alt="Capture d’écran 2025-02-21 à 21 43 59" src="https://github.com/user-attachments/assets/aa467f8c-602b-4deb-b2e4-da902fd8b497" />
