### PR TITLE
[Doc] Fix `<ReferenceInput enableGetChoices>` example

### DIFF
--- a/docs/ReferenceInput.md
+++ b/docs/ReferenceInput.md
@@ -152,7 +152,7 @@ You can make the `getList()` call lazy by using the `enableGetChoices` prop. Thi
 <ReferenceInput
      source="company_id"
      reference="companies"
-     enableGetChoices={({ q }) => q && q.length >= 2}
+     enableGetChoices={({ q }) => !!(q && q.length >= 2)}
 />
 ```
 


### PR DESCRIPTION
## Problem

`<ReferenceInput enableGetChoices>` example returns `undefined` when `q` is `undefined`, which will still fire the query (because `enable: undefined`) does not disable the query in react-query. It has to return `false` instead.

## Solution

Fix the example to return a boolean all the time.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date
