### PR TITLE
[chore] Fix release script does not include the changelog in the tag

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,7 @@ echo "Press Enter when this is done"
 read
 
 step "lerna version"
-./node_modules/.bin/lerna version --force-publish --no-push
+./node_modules/.bin/lerna version --force-publish --no-push --no-git-tag-version
 
 # Get the version from package.json
 npm_package_version=$(jq -r '.version' ./packages/react-admin/package.json)
@@ -54,6 +54,14 @@ if [ -z "$RELEASE_DRY_RUN" ]; then
     echo "Committing the changelog"
     git add CHANGELOG.md
     git commit -m "Update changelog for version ${npm_package_version}"
+fi
+
+step "git tag"
+if [ -z "$RELEASE_DRY_RUN" ]; then
+    echo "Creating git tag v${npm_package_version}"
+    git tag "v${npm_package_version}"
+else
+    echo "dry mode -- skipping git tag"
 fi
 
 step "git push"


### PR DESCRIPTION
## Problem

Release script introduced by https://github.com/marmelab/react-admin/pull/10516 let lerna create the git tag for the version, but the changelog was updated afterwards so it was not included in the tag.

## Solution

Delete the tag created by lerna, and recreate it ourselves after the changelog was updated.

## How To Test

Cannot really be tested without doing a real release.
However individual commands can be tested manually.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
