### PR TITLE
[TypeScript] Remove usage of JSX.Element

### DIFF
--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -34,7 +34,7 @@ const InfiniteListController = ({
     children,
     ...props
 }: {
-    children: (params: InfiniteListControllerResult) => JSX.Element;
+    children: (params: InfiniteListControllerResult) => React.ReactNode;
 } & InfiniteListControllerProps) => {
     const controllerProps = useInfiniteListController(props);
     return children(controllerProps);

--- a/packages/ra-core/src/controller/list/useInfiniteListController.stories.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.stories.tsx
@@ -4,7 +4,10 @@ import { QueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { CoreAdmin, CoreAdminContext, CoreAdminUI, Resource } from '../../core';
 import { AuthProvider, DataProvider } from '../../types';
-import { useInfiniteListController } from './useInfiniteListController';
+import {
+    InfiniteListControllerProps,
+    useInfiniteListController,
+} from './useInfiniteListController';
 import { Browser } from '../../storybook/FakeBrowser';
 import { TestMemoryRouter } from '../../routing';
 
@@ -59,7 +62,12 @@ const List = params => {
     );
 };
 
-const Posts = ({ children = List, ...props }) => {
+const Posts = ({
+    children = List,
+    ...props
+}: {
+    children?: (params: any) => React.ReactNode;
+} & Partial<InfiniteListControllerProps>) => {
     const params = useInfiniteListController({
         resource: 'posts',
         ...props,
@@ -140,7 +148,7 @@ export const Basic = ({
     children = ListWithCheckboxes,
 }: {
     dataProvider?: DataProvider;
-    children?: (props) => React.JSX.Element;
+    children?: (props) => React.ReactNode;
 }) => {
     return (
         <TestMemoryRouter>

--- a/packages/ra-core/src/controller/list/useListController.stories.tsx
+++ b/packages/ra-core/src/controller/list/useListController.stories.tsx
@@ -91,7 +91,7 @@ export const Basic = ({
     children = defaultRender,
 }: {
     dataProvider?: DataProvider;
-    children?: (params: ListControllerResult) => JSX.Element;
+    children?: (params: ListControllerResult) => React.ReactNode;
 }) => (
     <CoreAdminContext dataProvider={dataProvider}>
         <ListController resource="posts">{children}</ListController>

--- a/packages/ra-core/src/i18n/useTranslateLabel.ts
+++ b/packages/ra-core/src/i18n/useTranslateLabel.ts
@@ -1,4 +1,4 @@
-import { useCallback, ReactElement } from 'react';
+import { useCallback } from 'react';
 
 import { useTranslate } from './useTranslate';
 import { getFieldLabelTranslationArgs } from '../util';
@@ -16,7 +16,7 @@ export const useTranslateLabel = () => {
             resource,
         }: {
             source?: string;
-            label?: string | false | ReactElement;
+            label?: React.ReactNode;
             resource?: string;
         }) => {
             if (label === false || label === '') {

--- a/packages/ra-core/src/i18n/useTranslateLabel.ts
+++ b/packages/ra-core/src/i18n/useTranslateLabel.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, ReactNode } from 'react';
 
 import { useTranslate } from './useTranslate';
 import { getFieldLabelTranslationArgs } from '../util';
@@ -16,7 +16,7 @@ export const useTranslateLabel = () => {
             resource,
         }: {
             source?: string;
-            label?: React.ReactNode;
+            label?: ReactNode;
             resource?: string;
         }) => {
             if (label === false || label === '') {

--- a/packages/ra-core/src/util/FieldTitle.tsx
+++ b/packages/ra-core/src/util/FieldTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement, memo } from 'react';
+import { memo } from 'react';
 
 import { useTranslateLabel } from '../i18n';
 
@@ -7,7 +7,7 @@ export interface FieldTitleProps {
     isRequired?: boolean;
     resource?: string;
     source?: string;
-    label?: string | ReactElement | boolean;
+    label?: React.ReactNode;
 }
 
 export const FieldTitle = (props: FieldTitleProps) => {

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -115,7 +115,7 @@ export interface AppBarProps extends MuiAppBarProps {
     alwaysOn?: boolean;
     container?: React.ElementType<any>;
     toolbar?: React.ReactNode;
-    userMenu?: React.ReactNode | boolean;
+    userMenu?: React.ReactNode;
 }
 
 const PREFIX = 'RaAppBar';

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -114,8 +114,8 @@ export interface AppBarProps extends MuiAppBarProps {
      */
     alwaysOn?: boolean;
     container?: React.ElementType<any>;
-    toolbar?: JSX.Element;
-    userMenu?: JSX.Element | boolean;
+    toolbar?: React.ReactNode;
+    userMenu?: React.ReactNode | boolean;
 }
 
 const PREFIX = 'RaAppBar';

--- a/packages/ra-ui-materialui/src/layout/CardContentInner.tsx
+++ b/packages/ra-ui-materialui/src/layout/CardContentInner.tsx
@@ -10,7 +10,7 @@ import CardContent from '@mui/material/CardContent';
  * padding double the spacing between each CardContent, leading to too much
  * wasted space. Use this component as a CardContent alternative.
  */
-export const CardContentInner = (props: CardContentInnerProps): JSX.Element => {
+export const CardContentInner = (props: CardContentInnerProps) => {
     const { className, children } = props;
 
     return <Root className={className}>{children}</Root>;

--- a/packages/ra-ui-materialui/src/layout/DeviceTestWrapper.tsx
+++ b/packages/ra-ui-materialui/src/layout/DeviceTestWrapper.tsx
@@ -26,7 +26,7 @@ function createMatchMedia(width) {
 export const DeviceTestWrapper = ({
     width = 'md',
     children,
-}: DeviceTestWrapperProps): JSX.Element => {
+}: DeviceTestWrapperProps) => {
     const theme = createTheme();
     // Use https://github.com/ericf/css-mediaquery as polyfill.
     const ssrMatchMedia = createMatchMedia(theme.breakpoints.values[width]);
@@ -52,5 +52,5 @@ export const DeviceTestWrapper = ({
 
 export interface DeviceTestWrapperProps {
     width: 'md' | 'xs' | 'sm' | 'lg' | 'xl';
-    children: JSX.Element;
+    children: React.ReactNode;
 }

--- a/packages/ra-ui-materialui/src/layout/ThemeTestWrapper.tsx
+++ b/packages/ra-ui-materialui/src/layout/ThemeTestWrapper.tsx
@@ -15,7 +15,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 export const ThemeTestWrapper = ({
     mode = 'light',
     children,
-}: ThemeTestWrapperProps): JSX.Element => {
+}: ThemeTestWrapperProps) => {
     const theme = createTheme();
     const ssrMatchMedia = query => ({
         matches:
@@ -47,5 +47,5 @@ export const ThemeTestWrapper = ({
 
 export interface ThemeTestWrapperProps {
     mode: 'light' | 'dark';
-    children: JSX.Element;
+    children: React.ReactNode;
 }

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
@@ -12,7 +12,7 @@ import { ThemeProvider, createTheme } from '@mui/material';
 import { Datagrid } from './Datagrid';
 import { AccessControl, SelectAllButton } from './Datagrid.stories';
 
-const TitleField = (): JSX.Element => {
+const TitleField = () => {
     const record = useRecordContext();
     return <span>{record?.title}</span>;
 };

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridCell.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TableCell, { TableCellProps } from '@mui/material/TableCell';
 import clsx from 'clsx';
 import { RaRecord } from 'ra-core';
-import { DatagridField } from './types';
+import type { DatagridField } from './types';
 
 const DatagridCell = React.forwardRef<HTMLTableCellElement, DatagridCellProps>(
     ({ className, field, record, resource, ...rest }, ref) => (

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridCell.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import TableCell, { TableCellProps } from '@mui/material/TableCell';
 import clsx from 'clsx';
 import { RaRecord } from 'ra-core';
+import { DatagridField } from './types';
 
 const DatagridCell = React.forwardRef<HTMLTableCellElement, DatagridCellProps>(
     ({ className, field, record, resource, ...rest }, ref) => (
@@ -18,7 +19,7 @@ const DatagridCell = React.forwardRef<HTMLTableCellElement, DatagridCellProps>(
 
 export interface DatagridCellProps extends TableCellProps {
     className?: string;
-    field: JSX.Element;
+    field: DatagridField;
     record?: RaRecord;
     resource?: string;
 }

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -11,15 +11,14 @@ import {
     useTranslateLabel,
 } from 'ra-core';
 import type { SortPayload } from 'ra-core';
+import { DatagridField } from './types';
 
 const oppositeOrder: Record<SortPayload['order'], SortPayload['order']> = {
     ASC: 'DESC',
     DESC: 'ASC',
 };
 
-export const DatagridHeaderCell = (
-    props: DatagridHeaderCellProps
-): JSX.Element => {
+export const DatagridHeaderCell = (props: DatagridHeaderCellProps) => {
     const { className, field, sort, updateSort, isSorting, ...rest } = props;
     const resource = useResourceContext();
 
@@ -107,7 +106,7 @@ export const DatagridHeaderCell = (
 export interface DatagridHeaderCellProps
     extends Omit<TableCellProps, 'classes' | 'resource'> {
     className?: string;
-    field?: JSX.Element;
+    field?: DatagridField;
     isSorting?: boolean;
     sort?: SortPayload;
     updateSort?: (event: any) => void;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -11,7 +11,7 @@ import {
     useTranslateLabel,
 } from 'ra-core';
 import type { SortPayload } from 'ra-core';
-import { DatagridField } from './types';
+import type { DatagridField } from './types';
 
 const oppositeOrder: Record<SortPayload['order'], SortPayload['order']> = {
     ASC: 'DESC',

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.spec.tsx
@@ -17,7 +17,7 @@ import { AdminContext } from '../../AdminContext';
 import DatagridRow from './DatagridRow';
 import DatagridContextProvider from './DatagridContextProvider';
 
-const TitleField = (): JSX.Element => {
+const TitleField = () => {
     const record = useRecordContext();
     return <span>{record?.title}</span>;
 };

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -28,6 +28,7 @@ import ExpandRowButton from './ExpandRowButton';
 import { DatagridClasses } from './useDatagridStyles';
 import { useDatagridContext } from './useDatagridContext';
 import { RowClickFunction } from '../types';
+import { DatagridField } from './types';
 
 const computeNbColumns = (expand, children, hasBulkActions) =>
     expand
@@ -215,14 +216,17 @@ const DatagridRow: React.ForwardRefExoticComponent<
                     isValidElement(field) ? (
                         <DatagridCell
                             key={`${id}-${
-                                (field.props as any).source || index
+                                (field as DatagridField).props.source || index
                             }`}
                             className={clsx(
-                                `column-${(field.props as any).source}`,
+                                `column-${(field as DatagridField).props.source}`,
                                 DatagridClasses.rowCell
                             )}
                             record={record}
-                            {...{ field, resource }}
+                            {...{
+                                field: field as DatagridField,
+                                resource,
+                            }}
                         />
                     ) : null
                 )}

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -28,7 +28,7 @@ import ExpandRowButton from './ExpandRowButton';
 import { DatagridClasses } from './useDatagridStyles';
 import { useDatagridContext } from './useDatagridContext';
 import { RowClickFunction } from '../types';
-import { DatagridField } from './types';
+import type { DatagridField } from './types';
 
 const computeNbColumns = (expand, children, hasBulkActions) =>
     expand

--- a/packages/ra-ui-materialui/src/list/datagrid/index.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/index.ts
@@ -19,6 +19,7 @@ export * from './DatagridHeader';
 export * from './SelectColumnsButton';
 export * from './useDatagridContext';
 export * from './useDatagridStyles';
+export * from './types';
 
 export {
     DatagridLoading,

--- a/packages/ra-ui-materialui/src/list/datagrid/types.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/types.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { TableCellProps } from '@mui/material';
+
+export type DatagridField = React.ReactElement & {
+    type?: {
+        sortable?: boolean;
+        textAlign?: TableCellProps['align'];
+    };
+};

--- a/packages/ra-ui-materialui/src/list/datagrid/types.ts
+++ b/packages/ra-ui-materialui/src/list/datagrid/types.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { TableCellProps } from '@mui/material';
 
+/**
+ * This type is used to avoid relying on defaultProps which is deprecated.
+ */
 export type DatagridField = React.ReactElement & {
     type?: {
         sortable?: boolean;

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -81,7 +81,7 @@ export const FilterButton = (props: FilterButtonProps) => {
     }
 
     const allTogglableFilters = filters.filter(
-        (filterElement: JSX.Element) => !filterElement.props.alwaysOn
+        (filterElement: React.ReactElement) => !filterElement.props.alwaysOn
     );
 
     const handleClickButton = useCallback(
@@ -171,7 +171,7 @@ export const FilterButton = (props: FilterButtonProps) => {
                 onClose={handleRequestClose}
             >
                 {allTogglableFilters.map(
-                    (filterElement: JSX.Element, index) => (
+                    (filterElement: React.ReactElement, index) => (
                         <FilterButtonMenuItem
                             key={filterElement.props.source}
                             filter={filterElement}

--- a/packages/ra-ui-materialui/src/list/filter/FilterButtonMenuItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButtonMenuItem.tsx
@@ -54,7 +54,7 @@ export const FilterButtonMenuItem = forwardRef<any, FilterButtonMenuItemProps>(
 );
 
 export interface FilterButtonMenuItemProps {
-    filter: JSX.Element;
+    filter: React.ReactElement;
     displayed: boolean;
     onShow: (params: { source: string; defaultValue: any }) => void;
     onHide: (params: { source: string }) => void;

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -35,7 +35,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
 
     useEffect(() => {
         if (!filters) return;
-        filters.forEach((filter: JSX.Element) => {
+        filters.forEach((filter: React.ReactElement) => {
             if (filter.props.alwaysOn && filter.props.defaultValue) {
                 throw new Error(
                     'Cannot use alwaysOn and defaultValue on a filter input. Please set the filterDefaultValues props on the <List> element instead.'
@@ -47,7 +47,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
     const getShownFilters = () => {
         if (!filters) return [];
         const values = form.getValues();
-        return filters.filter((filterElement: JSX.Element) => {
+        return filters.filter((filterElement: React.ReactElement) => {
             const filterValue = get(values, filterElement.props.source);
             return (
                 filterElement.props.alwaysOn ||
@@ -64,7 +64,7 @@ export const FilterFormBase = (props: FilterFormBaseProps) => {
 
     return (
         <>
-            {getShownFilters().map((filterElement: JSX.Element) => (
+            {getShownFilters().map((filterElement: React.ReactElement) => (
                 <FilterFormInput
                     key={filterElement.key || filterElement.props.source}
                     filterElement={filterElement}


### PR DESCRIPTION
## Problem

`JSX.Element` is type JSX which is not tied to react (JSX can be used in other frameworks). We should use the correct types from React.

## Solution

- Replace usage of `JSX.Element` by their React equivalent.
- Use `ReactNode` instead of `ReactElement` where it makes sense.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
