### PR TITLE
[Doc] Update `<MarkdownInput>` doc to address vulnerability in `dompurify`

### DIFF
--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -55,7 +55,9 @@ const PostEdit = () => (
 
 **CVE-2025-26791 ADVISORY**
 
-The version of `dompurify` used by `@toastui/editor` is vulnerable to a cross-site scripting (XSS) attack (see Github security advisory [GHSA-vhxf-7vqr-mrjg](https://github.com/advisories/GHSA-vhxf-7vqr-mrjg)). This vulnerability has been fixed in `dompurify` version 3.2.4. To address this vulnerability, you should use npm's `override` or yarn's `resolutions` feature to force the installation of a fixed version of `dompurify` in your project.
+`<MarkdownInput>` relies on `@toastui/editor`, which depends on a package called `dompurify` that is vulnerable to a cross-site scripting (XSS) attack (see Github security advisory [GHSA-vhxf-7vqr-mrjg](https://github.com/advisories/GHSA-vhxf-7vqr-mrjg)). This vulnerability has been fixed in `dompurify` version 3.2.4, but the `@toastui/editor` package still uses an older version of `dompurify` that is vulnerable. 
+
+To address this vulnerability, you should use npm's `override` or yarn's `resolutions` feature to force the installation of a fixed version of `dompurify` in your project.
 
 Example for npm:
 
@@ -76,6 +78,8 @@ Example for yarn:
     }
 }
 ```
+
+The react-admin team is working on a solution to this issue and will release a new version of `@react-admin/ra-markdown` as soon as possible.
 
 ## Props
 

--- a/docs/MarkdownInput.md
+++ b/docs/MarkdownInput.md
@@ -53,6 +53,30 @@ const PostEdit = () => (
 );
 ```
 
+**CVE-2025-26791 ADVISORY**
+
+The version of `dompurify` used by `@toastui/editor` is vulnerable to a cross-site scripting (XSS) attack (see Github security advisory [GHSA-vhxf-7vqr-mrjg](https://github.com/advisories/GHSA-vhxf-7vqr-mrjg)). This vulnerability has been fixed in `dompurify` version 3.2.4. To address this vulnerability, you should use npm's `override` or yarn's `resolutions` feature to force the installation of a fixed version of `dompurify` in your project.
+
+Example for npm:
+
+```json
+{
+    "overrides": {
+        "dompurify": "^3.2.4"
+    }
+}
+```
+
+Example for yarn:
+
+```json
+{
+    "resolutions": {
+        "dompurify": "^3.2.4"
+    }
+}
+```
+
 ## Props
 
 `<MarkdownInput>` accepts the following props:


### PR DESCRIPTION
## Problem

The version of `dompurify` used by `@toastui/editor` is vulnerable to a cross-site scripting (XSS) attack (see Github security advisory [GHSA-vhxf-7vqr-mrjg](https://github.com/advisories/GHSA-vhxf-7vqr-mrjg)). This vulnerability has been fixed in `dompurify` version 3.2.4. But `@toastui/editor` is not up to date.

## Solution

Document how to address this vulnerability, by using npm's `override` or yarn's `resolutions` feature to force the installation of a fixed version of `dompurify`.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date
