### PR TITLE
Fix create-react-admin generated package.json when using yarn

### DIFF
--- a/packages/create-react-admin/src/generateProject.ts
+++ b/packages/create-react-admin/src/generateProject.ts
@@ -89,18 +89,26 @@ const generatePackageJson = (
     projectDirectory: string,
     state: ProjectConfiguration
 ) => {
+    let yarnVersion: string;
     const basePackageJson = getTemplatePackageJson('common');
     const dataProviderPackageJson = getTemplatePackageJson(state.dataProvider);
     const authProviderPackageJson = getTemplatePackageJson(state.authProvider);
     const resolutionsPackageJson = getTemplatePackageJson('resolutions');
-    const needResolutions =
-        state.installer === 'yarn' && getYarnVersion().startsWith('1');
+    if (state.installer === 'yarn') {
+        yarnVersion = getYarnVersion();
+    }
+    const needResolutions = yarnVersion && yarnVersion.startsWith('1');
 
     const packageJson = merge(
         basePackageJson,
         dataProviderPackageJson,
         authProviderPackageJson,
         needResolutions ? resolutionsPackageJson : {},
+        yarnVersion
+            ? {
+                  packageManager: `yarn@${yarnVersion}`,
+              }
+            : {},
         {
             name: state.name,
         }
@@ -110,6 +118,13 @@ const generatePackageJson = (
         path.join(projectDirectory, 'package.json'),
         JSON.stringify(packageJson, null, 2)
     );
+
+    if (yarnVersion && !yarnVersion.startsWith('1')) {
+        copyDirectoryFiles(
+            path.join(__dirname, '../templates/yarn'),
+            projectDirectory
+        );
+    }
 };
 
 const generateGitIgnore = (projectDirectory: string) => {

--- a/packages/create-react-admin/templates/resolutions/package.json
+++ b/packages/create-react-admin/templates/resolutions/package.json
@@ -1,0 +1,12 @@
+{
+    "resolutions": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^6.4.0",
+        "@mui/material": "^6.4.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router": "^7.1.3",
+        "react-router-dom": "^7.1.3"
+    }
+}

--- a/packages/create-react-admin/templates/yarn/.yarnrc.yml
+++ b/packages/create-react-admin/templates/yarn/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
## Problem

For some reason, yarn v1 install multiple versions of the dependencies for which we support multiple major versions.
This leads to an error page as soon as you run the generated application.

## Solution

When the chosen installer is `yarn`, detect the installed version and if it is v1, add resolutions to the generated `package.json` file

## How To Test

- `make build-create-react-admin install`
- `cd ..` Required to avoid yarn errors when it runs in our monorepo
- `./react-admin/.bin/react-admin/node_modules/.bin/create-react-admin myadmin --install yarn`
- `cd myadmin`
- `cat package.json` check resolutions are present
- `yarn run dev` check the app runs

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature