### PR TITLE
Fix B&W theme buttons in dark mode

### DIFF
--- a/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
+++ b/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useState } from 'react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
@@ -27,9 +26,12 @@ import {
     useTheme,
 } from './';
 import {
+    Alert,
     Box,
     ButtonGroup,
-    Card,
+    Chip,
+    Paper,
+    Snackbar,
     Stack,
     type StackProps,
     Typography,
@@ -80,8 +82,7 @@ const themes: Theme[] = [
 
 const store = memoryStore();
 
-const Wrapper = ({ children }) => {
-    const [themeName, setThemeName] = useState('Default');
+const Wrapper = ({ children, themeName, themeType }) => {
     const lightTheme = themes.find(theme => theme.name === themeName)?.light;
     const darkTheme = themes.find(theme => theme.name === themeName)?.dark;
     return (
@@ -92,15 +93,13 @@ const Wrapper = ({ children }) => {
                 <TestMemoryRouter>
                     <StoreContextProvider value={store}>
                         <ThemesContext.Provider
-                            value={{ lightTheme, darkTheme }}
+                            value={{
+                                lightTheme,
+                                darkTheme,
+                                defaultTheme: themeType,
+                            }}
                         >
-                            <ThemeProvider>
-                                <ThemeSelector
-                                    themeName={themeName}
-                                    setThemeName={setThemeName}
-                                />
-                                {children}
-                            </ThemeProvider>
+                            <ThemeProvider>{children}</ThemeProvider>
                         </ThemesContext.Provider>
                     </StoreContextProvider>
                 </TestMemoryRouter>
@@ -109,10 +108,29 @@ const Wrapper = ({ children }) => {
     );
 };
 
-export const ThemeTester = () => (
-    <Wrapper>
-        <Card sx={{ m: 2, p: 2 }}>
+export const ThemeTester = ({ themeName, themeType }) => (
+    <Wrapper themeName={themeName} themeType={themeType}>
+        <Snackbar
+            open
+            anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+            }}
+        >
+            <Alert severity="info" variant="outlined">
+                Use the story controls to change the theme
+            </Alert>
+        </Snackbar>
+
+        <Paper sx={{ p: 2 }}>
             <Section title="Base Buttons">
+                <Typography>Variant</Typography>
+                <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                    <Button label="Default" />
+                    <Button label="Outlined" variant="outlined" />
+                    <Button label="Contained" variant="contained" />
+                    <Button label="Text" variant="text" />
+                </Stack>
                 <Typography>Color</Typography>
                 <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
                     <Button label="Default" />
@@ -121,20 +139,14 @@ export const ThemeTester = () => (
                     <Button label="Error" color="error" />
                     <Button label="Warning" color="warning" />
                     <Button label="Success" color="success" />
+                    <Button label="Info" color="info" />
                     <Button label="Disabled" disabled />
-                </Stack>
-                <Typography>Variant</Typography>
-                <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-                    <Button label="Default" />
-                    <Button label="Outlined" variant="outlined" />
-                    <Button label="Contained" variant="contained" />
-                    <Button label="Text" variant="text" />
                 </Stack>
                 <Typography>Size</Typography>
                 <Stack
                     direction="row"
                     spacing={2}
-                    sx={{ mb: 2, alignItems: 'flex-start' }}
+                    sx={{ alignItems: 'flex-start' }}
                 >
                     <Button label="Default" />
                     <Button label="Small" size="small" />
@@ -179,9 +191,49 @@ export const ThemeTester = () => (
                     <SearchInput source="search" />
                 </Form>
             </Section>
-        </Card>
+            <Section title="Chips">
+                <Typography>Color</Typography>
+                <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+                    <Chip label="Default" />
+                    <Chip label="Primary" color="primary" />
+                    <Chip label="Secondary" color="secondary" />
+                    <Chip label="Error" color="error" />
+                    <Chip label="Warning" color="warning" />
+                    <Chip label="Success" color="success" />
+                    <Chip label="Info" color="info" />
+                    <Chip label="Disabled" disabled />
+                </Stack>
+                <Typography>Variant</Typography>
+                <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+                    <Chip label="Default" />
+                    <Chip label="Filled" variant="filled" />
+                    <Chip label="Outlined" variant="outlined" />
+                </Stack>
+                <Typography>Size</Typography>
+                <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+                    <Chip label="Default" />
+                    <Chip label="Small" size="small" />
+                    <Chip label="Medium" size="medium" />
+                </Stack>
+            </Section>
+        </Paper>
     </Wrapper>
 );
+
+ThemeTester.args = {
+    themeName: 'Default',
+    themeType: 'light',
+};
+ThemeTester.argTypes = {
+    themeName: {
+        control: 'select',
+        options: themes.map(theme => theme.name),
+    },
+    themeType: {
+        control: 'select',
+        options: ['light', 'dark'],
+    },
+};
 
 const ThemeSelector = ({ themeName, setThemeName }) => {
     const handleChange = (_: React.MouseEvent<HTMLElement>, index: number) => {

--- a/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
+++ b/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
@@ -136,8 +136,9 @@ export const ThemeTester = () => (
                     spacing={2}
                     sx={{ mb: 2, alignItems: 'flex-start' }}
                 >
+                    <Button label="Default" />
                     <Button label="Small" size="small" />
-                    <Button label="Medium" />
+                    <Button label="Medium" size="medium" />
                     <Button label="Large" size="large" />
                 </Stack>
             </Section>

--- a/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
+++ b/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { useStore, StoreContextProvider, memoryStore } from 'ra-core';
+import { StoreContextProvider, memoryStore } from 'ra-core';
 import {
     defaultLightTheme,
     defaultDarkTheme,
@@ -12,16 +12,34 @@ import {
     houseLightTheme,
     bwLightTheme,
     bwDarkTheme,
+    RaThemeOptions,
     ThemeProvider,
     ThemesContext,
+    useTheme,
 } from './';
-import { Box, Card, Stack, Typography } from '@mui/material';
+import {
+    Box,
+    ButtonGroup,
+    Card,
+    Stack,
+    type StackProps,
+    Typography,
+} from '@mui/material';
+import {
+    ThemeProvider as MuiThemeProvider,
+    createTheme,
+} from '@mui/material/styles';
 import { Button } from '../button';
 
 export default {
     title: 'ra-ui-materialui/theme/ThemeTester',
 };
 
+interface Theme {
+    name: string;
+    light: RaThemeOptions;
+    dark?: RaThemeOptions;
+}
 const themes: Theme[] = [
     { name: 'Default', light: defaultLightTheme, dark: defaultDarkTheme },
     {
@@ -34,19 +52,15 @@ const themes: Theme[] = [
     { name: 'House', light: houseLightTheme, dark: houseDarkTheme },
 ];
 
+const store = memoryStore();
+
 export const ThemeTester = () => {
-    const [themeName, setThemeName] = useState('themeName', 'default');
-    const [themeType, setThemeType] = useState('themeType', 'light');
+    const [themeName, setThemeName] = useState('Default');
     const lightTheme = themes.find(theme => theme.name === themeName)?.light;
     const darkTheme = themes.find(theme => theme.name === themeName)?.dark;
     return (
-        <StoreContextProvider value={memoryStore()}>
-            <ThemesContext.Provider
-                value={{
-                    lightTheme,
-                    darkTheme,
-                }}
-            >
+        <StoreContextProvider value={store}>
+            <ThemesContext.Provider value={{ lightTheme, darkTheme }}>
                 <ThemeProvider>
                     <ThemeSelector
                         themeName={themeName}
@@ -54,7 +68,33 @@ export const ThemeTester = () => {
                     />
                     <Card sx={{ m: 2, p: 2 }}>
                         <Section title="Buttons">
-                            <Button label="Default" />
+                            <Typography>Color</Typography>
+                            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                                <Button label="Default" />
+                                <Button label="Primary" color="primary" />
+                                <Button label="Secondary" color="secondary" />
+                                <Button label="Error" color="error" />
+                                <Button label="Warning" color="warning" />
+                                <Button label="Success" color="success" />
+                                <Button label="Disabled" disabled />
+                            </Stack>
+                            <Typography>Variant</Typography>
+                            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                                <Button label="Default" />
+                                <Button label="Outlined" variant="outlined" />
+                                <Button label="Contained" variant="contained" />
+                                <Button label="Text" variant="text" />
+                            </Stack>
+                            <Typography>Size</Typography>
+                            <Stack
+                                direction="row"
+                                spacing={2}
+                                sx={{ mb: 2, alignItems: 'flex-start' }}
+                            >
+                                <Button label="Small" size="small" />
+                                <Button label="Medium" />
+                                <Button label="Large" size="large" />
+                            </Stack>
                         </Section>
                     </Card>
                 </ThemeProvider>
@@ -68,47 +108,63 @@ const ThemeSelector = ({ themeName, setThemeName }) => {
         const newTheme = themes[index];
         setThemeName(newTheme.name);
     };
-    const [theme, setter] = useStore('theme', 'light');
+    const [theme, setter] = useTheme();
 
     return (
-        <Stack sx={{ p: 2 }}>
-            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-                <Typography sx={{ width: 200 }}>Theme</Typography>
-                <Stack spacing={2}>
-                    <Stack direction="row" spacing={2}>
-                        {themes.map((theme, index) => (
-                            <Button
-                                key={theme.name}
-                                label={theme.name}
-                                variant={
-                                    theme.name === themeName
-                                        ? 'outlined'
-                                        : 'text'
-                                }
-                                onClick={event => handleChange(event, index)}
-                            />
-                        ))}
+        <MuiThemeProvider theme={createTheme()}>
+            <Stack sx={{ p: 2 }}>
+                <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                    <Typography sx={{ width: 200 }}>Theme</Typography>
+                    <Stack spacing={2}>
+                        <Stack direction="row" spacing={2}>
+                            <ButtonGroup>
+                                {themes.map((theme, index) => (
+                                    <Button
+                                        key={theme.name}
+                                        label={theme.name}
+                                        variant={
+                                            theme.name === themeName
+                                                ? 'contained'
+                                                : 'outlined'
+                                        }
+                                        onClick={event =>
+                                            handleChange(event, index)
+                                        }
+                                    />
+                                ))}
+                            </ButtonGroup>
+                        </Stack>
+                    </Stack>
+                </Stack>
+                <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                    <Typography sx={{ width: 200 }}>Type</Typography>
+                    <Stack spacing={2}>
+                        <Stack direction="row" spacing={2}>
+                            <ButtonGroup>
+                                <Button
+                                    label="Light"
+                                    variant={
+                                        theme === 'light'
+                                            ? 'contained'
+                                            : 'outlined'
+                                    }
+                                    onClick={() => setter('light')}
+                                />
+                                <Button
+                                    label="Dark"
+                                    variant={
+                                        theme === 'dark'
+                                            ? 'contained'
+                                            : 'outlined'
+                                    }
+                                    onClick={() => setter('dark')}
+                                />
+                            </ButtonGroup>
+                        </Stack>
                     </Stack>
                 </Stack>
             </Stack>
-            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-                <Typography sx={{ width: 200 }}>Type</Typography>
-                <Stack spacing={2}>
-                    <Stack direction="row" spacing={2}>
-                        <Button
-                            label="Light"
-                            variant={theme === 'light' ? 'outlined' : 'text'}
-                            onClick={() => setter('light')}
-                        />
-                        <Button
-                            label="Dark"
-                            variant={theme === 'dark' ? 'outlined' : 'text'}
-                            onClick={() => setter('dark')}
-                        />
-                    </Stack>
-                </Stack>
-            </Stack>
-        </Stack>
+        </MuiThemeProvider>
     );
 };
 

--- a/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
+++ b/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useStore, StoreContextProvider, memoryStore } from 'ra-core';
+import {
+    defaultLightTheme,
+    defaultDarkTheme,
+    nanoDarkTheme,
+    nanoLightTheme,
+    radiantDarkTheme,
+    radiantLightTheme,
+    houseDarkTheme,
+    houseLightTheme,
+    bwLightTheme,
+    bwDarkTheme,
+    ThemeProvider,
+    ThemesContext,
+} from './';
+import { Box, Card, Stack, Typography } from '@mui/material';
+import { Button } from '../button';
+
+export default {
+    title: 'ra-ui-materialui/theme/ThemeTester',
+};
+
+const themes: Theme[] = [
+    { name: 'Default', light: defaultLightTheme, dark: defaultDarkTheme },
+    {
+        name: 'B&W',
+        light: bwLightTheme,
+        dark: bwDarkTheme,
+    },
+    { name: 'Nano', light: nanoLightTheme, dark: nanoDarkTheme },
+    { name: 'Radiant', light: radiantLightTheme, dark: radiantDarkTheme },
+    { name: 'House', light: houseLightTheme, dark: houseDarkTheme },
+];
+
+export const ThemeTester = () => {
+    const [themeName, setThemeName] = useState('themeName', 'default');
+    const [themeType, setThemeType] = useState('themeType', 'light');
+    const lightTheme = themes.find(theme => theme.name === themeName)?.light;
+    const darkTheme = themes.find(theme => theme.name === themeName)?.dark;
+    return (
+        <StoreContextProvider value={memoryStore()}>
+            <ThemesContext.Provider
+                value={{
+                    lightTheme,
+                    darkTheme,
+                }}
+            >
+                <ThemeProvider>
+                    <ThemeSelector
+                        themeName={themeName}
+                        setThemeName={setThemeName}
+                    />
+                    <Card sx={{ m: 2, p: 2 }}>
+                        <Section title="Buttons">
+                            <Button label="Default" />
+                        </Section>
+                    </Card>
+                </ThemeProvider>
+            </ThemesContext.Provider>
+        </StoreContextProvider>
+    );
+};
+
+const ThemeSelector = ({ themeName, setThemeName }) => {
+    const handleChange = (_: React.MouseEvent<HTMLElement>, index: number) => {
+        const newTheme = themes[index];
+        setThemeName(newTheme.name);
+    };
+    const [theme, setter] = useStore('theme', 'light');
+
+    return (
+        <Stack sx={{ p: 2 }}>
+            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                <Typography sx={{ width: 200 }}>Theme</Typography>
+                <Stack spacing={2}>
+                    <Stack direction="row" spacing={2}>
+                        {themes.map((theme, index) => (
+                            <Button
+                                key={theme.name}
+                                label={theme.name}
+                                variant={
+                                    theme.name === themeName
+                                        ? 'outlined'
+                                        : 'text'
+                                }
+                                onClick={event => handleChange(event, index)}
+                            />
+                        ))}
+                    </Stack>
+                </Stack>
+            </Stack>
+            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                <Typography sx={{ width: 200 }}>Type</Typography>
+                <Stack spacing={2}>
+                    <Stack direction="row" spacing={2}>
+                        <Button
+                            label="Light"
+                            variant={theme === 'light' ? 'outlined' : 'text'}
+                            onClick={() => setter('light')}
+                        />
+                        <Button
+                            label="Dark"
+                            variant={theme === 'dark' ? 'outlined' : 'text'}
+                            onClick={() => setter('dark')}
+                        />
+                    </Stack>
+                </Stack>
+            </Stack>
+        </Stack>
+    );
+};
+
+const Separator = () => (
+    <Box
+        sx={{
+            marginX: -2,
+            marginTop: 1,
+            marginBottom: 1.5,
+            borderBottom: '1px solid',
+            borderBottomColor: 'divider',
+            '&:last-child': { borderBottom: 'none', margin: 0 },
+        }}
+    />
+);
+
+interface SectionProps extends Omit<StackProps, 'title'> {
+    title: React.ReactNode;
+    children: React.ReactNode;
+}
+export const Section = ({ title, children, ...rest }: SectionProps) => (
+    <>
+        <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+            <Typography sx={{ width: 200 }}>{title}</Typography>
+            <Stack {...rest} sx={{ p: 0, maxWidth: 1000 }}>
+                {children}
+            </Stack>
+        </Stack>
+        <Separator />
+    </>
+);

--- a/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
+++ b/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { StoreContextProvider, memoryStore } from 'ra-core';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
+import {
+    Form,
+    I18nContextProvider,
+    StoreContextProvider,
+    TestMemoryRouter,
+    memoryStore,
+} from 'ra-core';
 import {
     defaultLightTheme,
     defaultDarkTheme,
@@ -29,7 +38,24 @@ import {
     ThemeProvider as MuiThemeProvider,
     createTheme,
 } from '@mui/material/styles';
-import { Button } from '../button';
+import {
+    Button,
+    CreateButton,
+    DeleteButton,
+    EditButton,
+    ListButton,
+    ShowButton,
+} from '../button';
+import {
+    TextInput,
+    DateInput,
+    SelectInput,
+    RadioButtonGroupInput,
+    CheckboxGroupInput,
+    BooleanInput,
+    PasswordInput,
+    SearchInput,
+} from '../input';
 
 export default {
     title: 'ra-ui-materialui/theme/ThemeTester',
@@ -54,54 +80,107 @@ const themes: Theme[] = [
 
 const store = memoryStore();
 
-export const ThemeTester = () => {
+const Wrapper = ({ children }) => {
     const [themeName, setThemeName] = useState('Default');
     const lightTheme = themes.find(theme => theme.name === themeName)?.light;
     const darkTheme = themes.find(theme => theme.name === themeName)?.dark;
     return (
-        <StoreContextProvider value={store}>
-            <ThemesContext.Provider value={{ lightTheme, darkTheme }}>
-                <ThemeProvider>
-                    <ThemeSelector
-                        themeName={themeName}
-                        setThemeName={setThemeName}
-                    />
-                    <Card sx={{ m: 2, p: 2 }}>
-                        <Section title="Buttons">
-                            <Typography>Color</Typography>
-                            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-                                <Button label="Default" />
-                                <Button label="Primary" color="primary" />
-                                <Button label="Secondary" color="secondary" />
-                                <Button label="Error" color="error" />
-                                <Button label="Warning" color="warning" />
-                                <Button label="Success" color="success" />
-                                <Button label="Disabled" disabled />
-                            </Stack>
-                            <Typography>Variant</Typography>
-                            <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-                                <Button label="Default" />
-                                <Button label="Outlined" variant="outlined" />
-                                <Button label="Contained" variant="contained" />
-                                <Button label="Text" variant="text" />
-                            </Stack>
-                            <Typography>Size</Typography>
-                            <Stack
-                                direction="row"
-                                spacing={2}
-                                sx={{ mb: 2, alignItems: 'flex-start' }}
-                            >
-                                <Button label="Small" size="small" />
-                                <Button label="Medium" />
-                                <Button label="Large" size="large" />
-                            </Stack>
-                        </Section>
-                    </Card>
-                </ThemeProvider>
-            </ThemesContext.Provider>
-        </StoreContextProvider>
+        <I18nContextProvider
+            value={polyglotI18nProvider(() => englishMessages)}
+        >
+            <QueryClientProvider client={new QueryClient()}>
+                <TestMemoryRouter>
+                    <StoreContextProvider value={store}>
+                        <ThemesContext.Provider
+                            value={{ lightTheme, darkTheme }}
+                        >
+                            <ThemeProvider>
+                                <ThemeSelector
+                                    themeName={themeName}
+                                    setThemeName={setThemeName}
+                                />
+                                {children}
+                            </ThemeProvider>
+                        </ThemesContext.Provider>
+                    </StoreContextProvider>
+                </TestMemoryRouter>
+            </QueryClientProvider>
+        </I18nContextProvider>
     );
 };
+
+export const ThemeTester = () => (
+    <Wrapper>
+        <Card sx={{ m: 2, p: 2 }}>
+            <Section title="Base Buttons">
+                <Typography>Color</Typography>
+                <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                    <Button label="Default" />
+                    <Button label="Primary" color="primary" />
+                    <Button label="Secondary" color="secondary" />
+                    <Button label="Error" color="error" />
+                    <Button label="Warning" color="warning" />
+                    <Button label="Success" color="success" />
+                    <Button label="Disabled" disabled />
+                </Stack>
+                <Typography>Variant</Typography>
+                <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                    <Button label="Default" />
+                    <Button label="Outlined" variant="outlined" />
+                    <Button label="Contained" variant="contained" />
+                    <Button label="Text" variant="text" />
+                </Stack>
+                <Typography>Size</Typography>
+                <Stack
+                    direction="row"
+                    spacing={2}
+                    sx={{ mb: 2, alignItems: 'flex-start' }}
+                >
+                    <Button label="Small" size="small" />
+                    <Button label="Medium" />
+                    <Button label="Large" size="large" />
+                </Stack>
+            </Section>
+            <Section title="Navigation Buttons" direction="row" spacing={1}>
+                <ListButton resource="posts" />
+                <EditButton resource="posts" record={{ id: 1 }} />
+                <ShowButton resource="posts" record={{ id: 1 }} />
+                <CreateButton resource="posts" />
+                <DeleteButton resource="posts" record={{ id: 1 }} />
+            </Section>
+            <Section title="Form Inputs">
+                <Form>
+                    <TextInput source="text" />
+                    <DateInput source="date" />
+                    <SelectInput
+                        source="select"
+                        choices={[
+                            { id: 1, name: 'One' },
+                            { id: 2, name: 'Two' },
+                        ]}
+                    />
+                    <RadioButtonGroupInput
+                        source="radio"
+                        choices={[
+                            { id: 1, name: 'One' },
+                            { id: 2, name: 'Two' },
+                        ]}
+                    />
+                    <CheckboxGroupInput
+                        source="checkbox"
+                        choices={[
+                            { id: 1, name: 'One' },
+                            { id: 2, name: 'Two' },
+                        ]}
+                    />
+                    <BooleanInput source="boolean" />
+                    <PasswordInput source="password" />
+                    <SearchInput source="search" />
+                </Form>
+            </Section>
+        </Card>
+    </Wrapper>
+);
 
 const ThemeSelector = ({ themeName, setThemeName }) => {
     const handleChange = (_: React.MouseEvent<HTMLElement>, index: number) => {
@@ -185,7 +264,7 @@ interface SectionProps extends Omit<StackProps, 'title'> {
     title: React.ReactNode;
     children: React.ReactNode;
 }
-export const Section = ({ title, children, ...rest }: SectionProps) => (
+const Section = ({ title, children, ...rest }: SectionProps) => (
     <>
         <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
             <Typography sx={{ width: 200 }}>{title}</Typography>

--- a/packages/ra-ui-materialui/src/theme/bwTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/bwTheme.ts
@@ -1,6 +1,5 @@
 import {
     amber,
-    common,
     deepOrange,
     green,
     grey,
@@ -10,8 +9,8 @@ import {
 import { alpha } from '@mui/material/styles';
 import { RaThemeOptions } from './types';
 
-const background = common['black'];
-const bodyBackground = common['black'];
+const commonBlack = '#090909';
+const commonWhite = '#fafafa';
 
 const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
     const isDarkMode = mode === 'dark';
@@ -21,8 +20,8 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
         palette: {
             mode,
             primary: {
-                dark: isDarkMode ? grey['200'] : common['black'],
-                main: isDarkMode ? common['white'] : grey['900'],
+                dark: isDarkMode ? grey['200'] : commonBlack,
+                main: isDarkMode ? commonWhite : grey['900'],
                 light: isDarkMode ? grey['800'] : grey['100'],
             },
             secondary: {
@@ -35,15 +34,15 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                 main: isDarkMode ? deepOrange['600'] : red['900'],
             },
             info: {
-                main: isDarkMode ? lightBlue['500'] : lightBlue['900'],
+                main: isDarkMode ? lightBlue['300'] : lightBlue['900'],
             },
             warning: {
                 main: isDarkMode ? amber['500'] : amber['900'],
             },
             divider: GREY,
             background: {
-                default: isDarkMode ? background : grey[50],
-                paper: isDarkMode ? background : grey[50],
+                default: isDarkMode ? commonBlack : grey[50],
+                paper: isDarkMode ? commonBlack : grey[50],
             },
         },
         shape: {
@@ -137,9 +136,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                     },
                     body: {
                         minHeight: '100%',
-                        backgroundColor: isDarkMode
-                            ? bodyBackground
-                            : '#fbfbfb',
+                        backgroundColor: isDarkMode ? commonBlack : '#fbfbfb',
                         backgroundRepeat: 'no-repeat',
                         backgroundPosition: 'top right',
                         backgroundSize: '100%',
@@ -155,9 +152,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
             MuiInputBase: {
                 styleOverrides: {
                     root: {
-                        backgroundColor: isDarkMode
-                            ? common['black']
-                            : common['white'],
+                        backgroundColor: isDarkMode ? commonBlack : commonWhite,
                     },
                 },
             },
@@ -225,9 +220,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
             MuiDrawer: {
                 styleOverrides: {
                     paper: {
-                        backgroundColor: isDarkMode
-                            ? background
-                            : common['white'],
+                        backgroundColor: isDarkMode ? commonBlack : commonWhite,
                         border: `1px solid ${GREY}`,
                     },
                 },
@@ -243,9 +236,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                 styleOverrides: {
                     root: {
                         backgroundImage: 'none',
-                        backgroundColor: isDarkMode
-                            ? '#090909'
-                            : common['white'],
+                        backgroundColor: isDarkMode ? '#090909' : commonWhite,
                         border: `1px solid ${GREY}`,
                     },
                 },
@@ -297,7 +288,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                             marginRight: 4,
                         },
                         '&:hover': {
-                            color: isDarkMode ? common['white'] : grey['900'],
+                            color: isDarkMode ? commonWhite : grey['900'],
                         },
                     },
                 },
@@ -331,10 +322,8 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                 },
             },
             MuiChip: {
-                styleOverrides: {
-                    root: {
-                        borderRadius: 4,
-                    },
+                defaultProps: {
+                    variant: 'outlined' as const,
                 },
             },
             RaSimpleFormIterator: {
@@ -351,7 +340,9 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                 styleOverrides: {
                     root: {
                         '& .RaBulkActionsToolbar-toolbar': {
-                            backgroundColor: isDarkMode ? background : grey[50],
+                            backgroundColor: isDarkMode
+                                ? commonBlack
+                                : grey[50],
                             border: `1px solid ${GREY}`,
                             '&.RaBulkActionsToolbar-collapsed': {
                                 border: 'transparent',
@@ -367,7 +358,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                         paddingRight: 0,
                         paddingLeft: SPACING,
                         borderRadius: 5,
-                        color: isDarkMode ? grey['200'] : common['black'],
+                        color: isDarkMode ? grey['200'] : commonBlack,
                         '&.RaMenuItemLink-active': {
                             backgroundColor: GREY,
                         },

--- a/packages/ra-ui-materialui/src/theme/bwTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/bwTheme.ts
@@ -7,6 +7,7 @@ import {
     lightBlue,
     red,
 } from '@mui/material/colors';
+import { alpha } from '@mui/material/styles';
 import { RaThemeOptions } from './types';
 
 const background = common['black'];
@@ -28,7 +29,7 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                 main: isDarkMode ? grey['100'] : grey['800'],
             },
             success: {
-                main: isDarkMode ? green['500'] : green['900'],
+                main: isDarkMode ? green['500'] : green['800'],
             },
             error: {
                 main: isDarkMode ? deepOrange['600'] : red['900'],
@@ -179,16 +180,22 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
                                 '--variant-outlinedBorder': GREY,
                             },
                         },
-                        '&.MuiButton-outlinedError': {
-                            '--variant-outlinedBorder': isDarkMode
-                                ? deepOrange['600']
-                                : red['900'],
+                        '&.MuiButton-outlinedSuccess': {
+                            borderColor: isDarkMode
+                                ? alpha(green['500'], 0.7)
+                                : alpha(green['800'], 0.5),
                             '&:hover': {
-                                backgroundColor: isDarkMode
-                                    ? deepOrange['600']
-                                    : red['900'],
-                                color: common['white'],
-                                '--variant-outlinedBorder': isDarkMode
+                                borderColor: isDarkMode
+                                    ? green['500']
+                                    : green['800'],
+                            },
+                        },
+                        '&.MuiButton-outlinedError': {
+                            borderColor: isDarkMode
+                                ? alpha(deepOrange['600'], 0.7)
+                                : alpha(red['900'], 0.5),
+                            '&:hover': {
+                                borderColor: isDarkMode
                                     ? deepOrange['600']
                                     : red['900'],
                             },


### PR DESCRIPTION
## Problem

Buttons in B&W theme in dark mode aren't visible enough due to a too high transparency of the border.

![image](https://github.com/user-attachments/assets/f052d45a-86c3-4601-87ee-d6795b9524b6)


## Solution

Decrease the border transparency in dark mode. 

![image](https://github.com/user-attachments/assets/a2dd3afc-5cc6-46f5-a6cb-de83f991ee6f)


## How To Test

I added a ThemeTester story that allows to test various components in various themes. 

https://react-admin-storybook-git-themetester-marmelab.vercel.app/?path=/story/ra-ui-materialui-theme-themetester--theme-tester

![image](https://github.com/user-attachments/assets/368cd8f1-cc27-43fd-9a97-74168214e886)


## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- ~~[ ] The PR includes **unit tests** (if not possible, describe why)~~(only theming)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
