### PR TITLE
[typescript] Add SxProps to Error component

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -8,6 +8,7 @@ import {
     AccordionDetails,
     AccordionSummary,
     Typography,
+    SxProps,
 } from '@mui/material';
 import ErrorIcon from '@mui/icons-material/Report';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -24,6 +25,8 @@ import { Title } from './Title';
 export const Error = (
     props: InternalErrorProps & {
         errorComponent?: ComponentType<ErrorProps>;
+    } & {
+        sx?: SxProps;
     }
 ) => {
     const {


### PR DESCRIPTION
The styled component in error.tsx should accept sxprops to customize its styles