### PR TITLE
Fix helperText has wrong height when passing an empty string

### DIFF
--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -18,7 +18,7 @@ export const InputHelperText = (props: InputHelperTextProps) => {
         return helperText;
     }
 
-    if (typeof helperText === 'string') {
+    if (typeof helperText === 'string' && helperText.length > 0) {
         return <>{translate(helperText, { _: helperText })}</>;
     }
 

--- a/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.stories.tsx
@@ -89,16 +89,32 @@ export const DefaultValue = () => (
     </Wrapper>
 );
 
-export const HelperText = () => (
+export const HelperText = ({
+    helperText = 'Number of times the post was read',
+}: {
+    helperText: any;
+}) => (
     <Wrapper>
         <TextInput source="title" />
         <TextInput source="title" helperText={false} />
-        <TextInput
-            source="title"
-            helperText="Number of times the post was read"
-        />
+        <TextInput source="title" helperText={helperText} />
     </Wrapper>
 );
+
+HelperText.argTypes = {
+    helperText: {
+        options: ['text', 'false', 'empty string'],
+        mapping: {
+            text: 'Number of times the post was read',
+            false: false,
+            'empty string': '',
+        },
+        control: { type: 'select' },
+    },
+};
+HelperText.args = {
+    helperText: 'text',
+};
 
 export const Label = () => (
     <Wrapper>


### PR DESCRIPTION
## Problem

Fixes #10562

## How To Test

Use the story control to check the last input behavior:
https://react-admin-storybook-6oudqo8iz-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-textinput--helper-text

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> design only
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
