### PR TITLE
Fix useRedirect might include two slashes in the final pathname

### DIFF
--- a/packages/ra-core/src/routing/useRedirect.spec.tsx
+++ b/packages/ra-core/src/routing/useRedirect.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 import expect from 'expect';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { CoreAdminContext } from '../core';
 
@@ -9,6 +9,7 @@ import { RedirectionSideEffect, useRedirect } from './useRedirect';
 import { testDataProvider } from '../dataProvider';
 import { Identifier, RaRecord } from '../types';
 import { TestMemoryRouter } from './TestMemoryRouter';
+import { UseRedirect } from './useRedirect.stories';
 
 const Redirect = ({
     redirectTo,
@@ -108,27 +109,18 @@ describe('useRedirect', () => {
         expect(window.location.href).toBe('https://google.com');
         window.location = oldLocation;
     });
-    it.each(['/foo', { pathname: '/foo' }])(
-        'should support functions that returns local absolute URLs with a leading /',
-        async redirect => {
-            render(
-                <TestMemoryRouter>
-                    <CoreAdminContext dataProvider={testDataProvider()}>
-                        <Routes>
-                            <Route
-                                path="/"
-                                element={
-                                    <Redirect redirectTo={() => redirect} />
-                                }
-                            />
-                            <Route path="foo" element={<Component />} />
-                        </Routes>
-                    </CoreAdminContext>
-                </TestMemoryRouter>
-            );
-            await waitFor(() => {
-                expect(screen.queryByDisplayValue('/foo')).not.toBeNull();
-            });
-        }
-    );
+    it('should support functions that returns local absolute URLs with a leading /', async () => {
+        render(
+            <TestMemoryRouter>
+                <UseRedirect />
+            </TestMemoryRouter>
+        );
+        fireEvent.click(await screen.findByText('Relative url'));
+        await screen.findByText('Admin dashboard');
+        fireEvent.click(await screen.findByText('Home'));
+        fireEvent.click(
+            await screen.findByText('Relative url from a function')
+        );
+        await screen.findByText('Admin dashboard');
+    });
 });

--- a/packages/ra-core/src/routing/useRedirect.spec.tsx
+++ b/packages/ra-core/src/routing/useRedirect.spec.tsx
@@ -108,4 +108,27 @@ describe('useRedirect', () => {
         expect(window.location.href).toBe('https://google.com');
         window.location = oldLocation;
     });
+    it.each(['/foo', { pathname: '/foo' }])(
+        'should support functions that returns local absolute URLs with a leading /',
+        async redirect => {
+            render(
+                <TestMemoryRouter>
+                    <CoreAdminContext dataProvider={testDataProvider()}>
+                        <Routes>
+                            <Route
+                                path="/"
+                                element={
+                                    <Redirect redirectTo={() => redirect} />
+                                }
+                            />
+                            <Route path="foo" element={<Component />} />
+                        </Routes>
+                    </CoreAdminContext>
+                </TestMemoryRouter>
+            );
+            await waitFor(() => {
+                expect(screen.queryByDisplayValue('/foo')).not.toBeNull();
+            });
+        }
+    );
 });

--- a/packages/ra-core/src/routing/useRedirect.stories.tsx
+++ b/packages/ra-core/src/routing/useRedirect.stories.tsx
@@ -28,6 +28,11 @@ const Home = () => {
                     </button>
                 </li>
                 <li>
+                    <button onClick={() => redirect(() => '/dashboard')}>
+                        Relative url from a function
+                    </button>
+                </li>
+                <li>
                     <button onClick={() => redirect('list', 'posts')}>
                         View name
                     </button>

--- a/packages/ra-core/src/routing/useRedirect.stories.tsx
+++ b/packages/ra-core/src/routing/useRedirect.stories.tsx
@@ -111,7 +111,7 @@ const SomePage = () => {
     );
 };
 
-export const useRedirect = () => (
+export const UseRedirect = () => (
     <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/dashboard" element={<Dashboard />} />

--- a/packages/ra-core/src/routing/useRedirect.ts
+++ b/packages/ra-core/src/routing/useRedirect.ts
@@ -50,9 +50,9 @@ export const useRedirect = () => {
                 const target: To = redirectTo(resource, id, data);
                 const absoluteTarget =
                     typeof target === 'string'
-                        ? `${basename}/${target}`
+                        ? `${basename}${target.startsWith('/') ? '' : '/'}${target}`
                         : {
-                              pathname: `${basename}/${target.pathname}`,
+                              pathname: `${basename}${target.pathname?.startsWith('/') ? '' : '/'}${target.pathname}`,
                               ...target,
                           };
                 navigate(absoluteTarget, {


### PR DESCRIPTION
## Problem

Fixes #10489

## Solution

- check for leading `/` and only add one when needed

## How To Test

- https://react-admin-storybook-dhj951475-marmelab.vercel.app/?path=/story/ra-core-routing--use-redirect

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
