### PR TITLE
Fix create-react-admin should correctly generate data.json for fakerest

### DIFF
--- a/packages/create-react-admin/src/generateProject.ts
+++ b/packages/create-react-admin/src/generateProject.ts
@@ -43,13 +43,16 @@ export const generateProject = async (state: ProjectConfiguration) => {
     if (!hasTemplateAppFile(state.dataProvider)) {
         generateAppFile(projectDirectory, state);
     }
-    if (
-        state.dataProvider === 'ra-data-fakerest' &&
-        ['posts', 'comments'].every(resource =>
-            state.resources.includes(resource)
-        )
-    ) {
-        generateAppTestFile(projectDirectory, state);
+    if (state.dataProvider === 'ra-data-fakerest') {
+        if (
+            ['posts', 'comments'].every(resource =>
+                state.resources.includes(resource)
+            )
+        ) {
+            generateAppTestFile(projectDirectory, state);
+        } else {
+            generateDataForFakeRest(projectDirectory, state);
+        }
     }
 
     generatePackageJson(projectDirectory, state);
@@ -324,4 +327,18 @@ const getYarnVersion = () => {
     // want to use yarn to install the dependencies.
     const { stdout } = execa.sync('yarn', ['--version'], { stdio: 'pipe' });
     return stdout;
+};
+
+const generateDataForFakeRest = (
+    projectDirectory: string,
+    state: ProjectConfiguration
+) => {
+    const data = state.resources.reduce((acc, resource) => {
+        acc[resource] = [];
+        return acc;
+    }, {});
+    fs.writeFileSync(
+        path.join(projectDirectory, 'src', 'data.json'),
+        JSON.stringify(data, null, 2)
+    );
 };


### PR DESCRIPTION
## Problem

Fixes #10567

## Solution

Add a project generation step specific to fakerest that generate a `data.json` file for the provided resources.

## How To Test

- `make build-create-react-admin install`
- `./node_modules/.bin/create-react-admin myadmin --data-provider fakerest --resource posts --resource comments` should still generate a working app with tests
- `./node_modules/.bin/create-react-admin myadmin --data-provider fakerest --resource books --resource authors` should generate a working app with a `data.json` file containing entries for `books` and `authors` but no tests.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature