### PR TITLE
[chore] Improve release script by  automating enterprise packages tests

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,2 @@
 GITHUB_ACCESS_TOKEN=your_github_access_token
+RA_ENTERPRISE_PATH=../ra-enterprise

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+source ./.env
 RA_ENTERPRISE_PATH="${RA_ENTERPRISE_PATH:-../ra-enterprise}"
 
 info() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,10 @@ info() {
     echo -e "\033[1;34m$1\033[0m"
 }
 
+warn() {
+    echo -e "\033[1;33m$1\033[0m"
+}
+
 step() {
     echo ""
     info "$1"
@@ -23,11 +27,18 @@ make install
 step "make build"
 make build
 
-step "manual tests: Run the EE tests"
-echo "Copy the the packages folder content inside the node_modules of ra-enterprise, then run a full build and run the tests"
-echo "Tip: You can use the 'copy-ra-oss-packages-to-ee.sh' script if you have it"
-echo "Press Enter when this is done"
-read
+step "Run the EE tests"
+if [ -d ../ra-enterprise ]; then
+    cp -r packages/* ../ra-enterprise/node_modules
+    # We must remove the @mui directory from the react-admin node_modules to avoid conflicts
+    ( cd ../ra-enterprise && rm -rf node_modules/react-admin/node_modules/@mui && make build && CI=true make test )
+else
+    warn "Cannot find the ra-enterprise folder in the repository parent directory"
+    echo "Copy the the packages folder content inside the node_modules of ra-enterprise, then run a full build and run the tests"
+    echo "Tip: You can use the 'copy-ra-oss-packages-to-ee.sh' script if you have it"
+    echo "Press Enter when this is done"
+    read
+fi
 
 step "manual tests: Run the demos"
 echo "Test the 3 demos (simple, e-commerce, crm): check console & UI"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+RA_ENTERPRISE_PATH="${RA_ENTERPRISE_PATH:-../ra-enterprise}"
 
 info() {
     echo -e "\033[1;34m$1\033[0m"
@@ -28,12 +29,12 @@ step "make build"
 make build
 
 step "Run the EE tests"
-if [ -d ../ra-enterprise ]; then
-    cp -r packages/* ../ra-enterprise/node_modules
+if [ -d $RA_ENTERPRISE_PATH ]; then
+    cp -r packages/* $RA_ENTERPRISE_PATH/node_modules
     # We must remove the @mui directory from the react-admin node_modules to avoid conflicts
-    ( cd ../ra-enterprise && rm -rf node_modules/react-admin/node_modules/@mui && make build && CI=true make test )
+    ( cd $RA_ENTERPRISE_PATH && rm -rf node_modules/react-admin/node_modules/@mui && make build && CI=true make test )
 else
-    warn "Cannot find the ra-enterprise folder in the repository parent directory"
+    warn "Cannot find the $RA_ENTERPRISE_PATH folder in the repository parent directory"
     echo "Copy the the packages folder content inside the node_modules of ra-enterprise, then run a full build and run the tests"
     echo "Tip: You can use the 'copy-ra-oss-packages-to-ee.sh' script if you have it"
     echo "Press Enter when this is done"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -116,4 +116,4 @@ echo "You can use the 'copy-ra-oss-docs.sh' script if you have it"
 echo "Press Enter when this is done"
 read
 
-step "The release is done! 🎉"
+step "The ${npm_package_version} release is done! 🎉"


### PR DESCRIPTION
## Problem

There are still too many manual steps when releasing a new react-admin version

## Solution

Automate one more step: building and testing enterprise packages automatically when possible.

You can override the enterprise directory path by setting the `RA_ENTERPRISE_PATH` environment variable.

## How To Test

These scripts support a `RELEASE_DRY_RUN` env variable allowing to skip all mutations to git, GitHub or npm, except 1 git commit (but not pushed!) from lerna.

First, create a `.env` file from the `.env.template` file and fill it in with your Github token.

Then run:

```
RELEASE_DRY_RUN=true make release
```

When this is done, don't forget to revert the commit created by lerna to update the versions:

```
git reset --hard HEAD~1
```

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
