### PR TITLE
[chore] Improve release script by automating documentation update

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,3 @@
 GITHUB_ACCESS_TOKEN=your_github_access_token
 RA_ENTERPRISE_PATH=../ra-enterprise
+RA_DOC_PATH=../react-admin-doc

--- a/scripts/copy-ra-oss-docs.sh
+++ b/scripts/copy-ra-oss-docs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+RA_DOCS_DIR=../react-admin-doc
+
+echo "Updating the documentation to version $VERSION"
+echo "Copying to the root folder..."
+cp ./docs/*.html ${RA_DOCS_DIR}
+cp ./docs/_layouts/*.html ${RA_DOCS_DIR}/_layouts
+cp ./docs/*.md ${RA_DOCS_DIR}
+cp ./docs/img/* -r ${RA_DOCS_DIR}/img
+cp ./docs/css/docsearch.css ${RA_DOCS_DIR}/css
+cp ./docs/css/prism.css ${RA_DOCS_DIR}/css
+cp ./docs/css/style-*.css ${RA_DOCS_DIR}/css
+cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOCS_DIR}/js
+
+echo "Copying to the doc/${VERSION} folder..."
+mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}
+mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}/img
+mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}/css
+mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}/js
+cp ./docs/*.html ${RA_DOCS_DIR}/doc/${VERSION}
+cp ./docs/*.md ${RA_DOCS_DIR}/doc/${VERSION}
+rm ${RA_DOCS_DIR}/doc/${VERSION}/404.html
+cp -r ./docs/img/* ${RA_DOCS_DIR}/doc/${VERSION}/img
+cp ./docs/css/docsearch.css ${RA_DOCS_DIR}/doc/${VERSION}/css
+cp ./docs/css/prism.css ${RA_DOCS_DIR}/doc/${VERSION}/css
+cp ./docs/css/style-*.css ${RA_DOCS_DIR}/doc/${VERSION}/css
+cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOCS_DIR}/doc/${VERSION}/js
+
+echo "Done"
+

--- a/scripts/copy-ra-oss-docs.sh
+++ b/scripts/copy-ra-oss-docs.sh
@@ -1,30 +1,28 @@
 #!/bin/bash
-RA_DOCS_DIR=../react-admin-doc
-
 echo "Updating the documentation to version $VERSION"
 echo "Copying to the root folder..."
-cp ./docs/*.html ${RA_DOCS_DIR}
-cp ./docs/_layouts/*.html ${RA_DOCS_DIR}/_layouts
-cp ./docs/*.md ${RA_DOCS_DIR}
-cp ./docs/img/* -r ${RA_DOCS_DIR}/img
-cp ./docs/css/docsearch.css ${RA_DOCS_DIR}/css
-cp ./docs/css/prism.css ${RA_DOCS_DIR}/css
-cp ./docs/css/style-*.css ${RA_DOCS_DIR}/css
-cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOCS_DIR}/js
+cp ./docs/*.html ${RA_DOC_PATH}
+cp ./docs/_layouts/*.html ${RA_DOC_PATH}/_layouts
+cp ./docs/*.md ${RA_DOC_PATH}
+cp ./docs/img/* -r ${RA_DOC_PATH}/img
+cp ./docs/css/docsearch.css ${RA_DOC_PATH}/css
+cp ./docs/css/prism.css ${RA_DOC_PATH}/css
+cp ./docs/css/style-*.css ${RA_DOC_PATH}/css
+cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOC_PATH}/js
 
 echo "Copying to the doc/${VERSION} folder..."
-mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}
-mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}/img
-mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}/css
-mkdir -p ${RA_DOCS_DIR}/doc/${VERSION}/js
-cp ./docs/*.html ${RA_DOCS_DIR}/doc/${VERSION}
-cp ./docs/*.md ${RA_DOCS_DIR}/doc/${VERSION}
-rm ${RA_DOCS_DIR}/doc/${VERSION}/404.html
-cp -r ./docs/img/* ${RA_DOCS_DIR}/doc/${VERSION}/img
-cp ./docs/css/docsearch.css ${RA_DOCS_DIR}/doc/${VERSION}/css
-cp ./docs/css/prism.css ${RA_DOCS_DIR}/doc/${VERSION}/css
-cp ./docs/css/style-*.css ${RA_DOCS_DIR}/doc/${VERSION}/css
-cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOCS_DIR}/doc/${VERSION}/js
+mkdir -p ${RA_DOC_PATH}/doc/${VERSION}
+mkdir -p ${RA_DOC_PATH}/doc/${VERSION}/img
+mkdir -p ${RA_DOC_PATH}/doc/${VERSION}/css
+mkdir -p ${RA_DOC_PATH}/doc/${VERSION}/js
+cp ./docs/*.html ${RA_DOC_PATH}/doc/${VERSION}
+cp ./docs/*.md ${RA_DOC_PATH}/doc/${VERSION}
+rm ${RA_DOC_PATH}/doc/${VERSION}/404.html
+cp -r ./docs/img/* ${RA_DOC_PATH}/doc/${VERSION}/img
+cp ./docs/css/docsearch.css ${RA_DOC_PATH}/doc/${VERSION}/css
+cp ./docs/css/prism.css ${RA_DOC_PATH}/doc/${VERSION}/css
+cp ./docs/css/style-*.css ${RA_DOC_PATH}/doc/${VERSION}/css
+cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOC_PATH}/doc/${VERSION}/js
 
 echo "Done"
 

--- a/scripts/copy-ra-oss-docs.sh
+++ b/scripts/copy-ra-oss-docs.sh
@@ -1,3 +1,12 @@
+if [ -z "$RA_DOC_PATH" ]; then
+    echo "RA_DOC_PATH environment variable is not set"
+    exit 1
+fi
+if [ -z "$VERSION" ]; then
+    echo "VERSION environment variable is not set"
+    exit 1
+fi
+
 #!/bin/bash
 echo "Updating the documentation to version $VERSION"
 echo "Copying to the root folder..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,7 @@
 set -e
 source ./.env
 RA_ENTERPRISE_PATH="${RA_ENTERPRISE_PATH:-../ra-enterprise}"
+RA_DOC_PATH="${RA_DOC_PATH:-../react-admin-doc}"
 
 info() {
     echo -e "\033[1;34m$1\033[0m"
@@ -114,18 +115,20 @@ yarn run update-milestones ${npm_package_version}
 step "create-github-release"
 yarn run create-github-release ${npm_package_version}
 
-if [ -d ../react-admin-doc ]; then
+if [ -d $RA_DOC_PATH ]; then
     step "Update the documentation"
     # ${npm_package_version%.*} extract the major.minor version
-    VERSION="${npm_package_version%.*}" ./scripts/copy-ra-oss-docs.sh
+    RA_DOC_PATH="$RA_DOC_PATH" VERSION="${npm_package_version%.*}" ./scripts/copy-ra-oss-docs.sh
     # Set the latest version in the versions.yml file
-    sed -i "/^\(- latest\).*/s//\1 \($npm_package_version\)/" ../react-admin-doc/_data/versions.yml
+    echo "Update the latest version in the versions.yml file"
+    sed -i "/^\(- latest\).*/s//\1 \($npm_package_version\)/" $RA_DOC_PATH/_data/versions.yml
     if [ "${npm_current_package_version%.*}" == "${npm_package_version%.*}" ]; then
+        echo "Add the previous minor version to the list of versions in the versions.yml file"
         # Add the previous minor version to the list of versions in the versions.yml file
-        sed -i "/^\(- latest.*\)/s//\1 \n- \"${npm_package_version%.*}\"/" ../react-admin-doc/_data/versions.yml
+        sed -i "/^\(- latest.*\)/s//\1 \n- \"${npm_package_version%.*}\"/" $RA_DOC_PATH/_data/versions.yml
     fi
 else
-    warn "Cannot find the react-admin-doc folder in the repository parent directory"
+    warn "Cannot find the $RA_DOC_PATH folder in the repository parent directory"
     step "manual step: Update the documentation"
     echo "You can use the 'copy-ra-oss-docs.sh' script if you have it"
     echo "Press Enter when this is done"


### PR DESCRIPTION
## Problem

There are still too many manual steps when releasing a new react-admin version.

## Solution

Follow #10574 

Automate one more step: updating the documentation automatically when possible:
- Copy the new doc to the `react-admin-doc` sibling directory if it exists
- Update the latest version in `react-admin-doc/_data/versions.yml`
- Add a new minor entry if necessary in `react-admin-doc/_data/versions.yml`

You can override the documentation directory path by setting the `RA_DOC_PATH` environment variable.

## How To Test

These scripts support a `RELEASE_DRY_RUN` env variable allowing to skip all mutations to git, GitHub or npm, except 1 git commit (but not pushed!) from lerna.

First, create a `.env` file from the `.env.template` file and fill it in with your Github token.

Then run:

```
RELEASE_DRY_RUN=true make release
```

When this is done, don't forget to revert the commit created by lerna to update the versions:

```
git reset --hard HEAD~1
```

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
