### PR TITLE
[chore] Automatically update create-react-admin templates when releasing a new minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "build-storybook": "storybook build -c .storybook -o public --quiet",
         "update-changelog": "tsx scripts/update-changelog.ts",
         "update-milestones": "tsx scripts/update-milestones.ts",
-        "create-github-release": "tsx scripts/create-github-release.ts"
+        "create-github-release": "tsx scripts/create-github-release.ts",
+        "update-create-react-admin-deps": "tsx scripts/update-create-react-admin-deps.ts"
     },
     "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,11 +48,6 @@ echo "Test the 3 demos (simple, e-commerce, crm): check console & UI"
 echo "Press Enter when this is done"
 read
 
-step "manual task: Update the create-react-admin dependencies"
-echo "[Minor version only] Update the dependencies to RA packages in the create-react-admin templates && commit"
-echo "Press Enter when this is done"
-read
-
 step "manual task: Update the OldVersion.md file"
 echo "[Minor version only] Update the ./docs/OldVersions.md file to add the new minor version and update the previous one && commit"
 echo "Press Enter when this is done"
@@ -76,6 +71,16 @@ if [ ! -z "$RELEASE_DRY_RUN" ]; then
     # In dry-run mode, reset the last commit to avoid accidental push
     echo "dry mode -- Resetting the workspace to the last commit"
     git reset --soft HEAD~1
+fi
+
+if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
+    echo "New minor version - Updating the dependencies to RA packages in the create-react-admin templates"
+    yarn run update-create-react-admin-deps ${npm_current_package_version}
+    if [ -z "$RELEASE_DRY_RUN" ]; then
+        echo "Committing the create-react-admin templates dependencies update"
+        git add .
+        git commit -m "Update create-react-admin templates dependencies for version ${npm_current_package_version}"
+    fi
 fi
 
 step "update-changelog"
@@ -127,7 +132,7 @@ if [ -d $RA_DOC_PATH ]; then
     # Set the latest version in the versions.yml file
     echo "Update the latest version in the versions.yml file"
     sed -i "/^\(- latest\).*/s//\1 \($npm_current_package_version\)/" $RA_DOC_PATH/_data/versions.yml
-    if [ "${npm_previous_package_version%.*}" == "${npm_current_package_version%.*}" ]; then
+    if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
         echo "Add the previous minor version to the list of versions in the versions.yml file"
         # Add the previous minor version to the list of versions in the versions.yml file
         sed -i "/^\(- latest.*\)/s//\1 \n- \"${npm_current_package_version%.*}\"/" $RA_DOC_PATH/_data/versions.yml

--- a/scripts/update-create-react-admin-deps.ts
+++ b/scripts/update-create-react-admin-deps.ts
@@ -1,0 +1,80 @@
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dependencyTypes = ['dependencies', 'devDependencies', 'peerDependencies'];
+
+const main = async () => {
+    if (process.env.RELEASE_DRY_RUN) {
+        console.log('Dry run mode is enabled');
+    }
+
+    const version = process.argv[2];
+    if (!version || !version.match(/^\d{1,2}\.\d{1,2}\.\d{1,2}$/)) {
+        console.error(`Invalid version provided: ${version}`);
+        console.error(
+            'Usage: yarn run update-create-react-admin-deps <version>'
+        );
+        process.exit(1);
+    }
+
+    const templates = fs.readdirSync(
+        path.join(__dirname, '../packages/create-react-admin/templates')
+    );
+    const raPackages = fs.readdirSync(path.join(__dirname, '../packages'));
+
+    for (const template of templates) {
+        const packageJsonPath = path.join(
+            __dirname,
+            '../packages/create-react-admin/templates',
+            template,
+            'package.json'
+        );
+        if (fs.existsSync(packageJsonPath)) {
+            const packageJson = JSON.parse(
+                fs.readFileSync(packageJsonPath, 'utf-8')
+            );
+            let updatedDependencies = [];
+            for (const raPackage of raPackages) {
+                for (const dependencyType of dependencyTypes) {
+                    if (packageJson[dependencyType]?.[raPackage]) {
+                        updatedDependencies.push([
+                            raPackage,
+                            packageJson[dependencyType][raPackage],
+                            version,
+                        ]);
+                        packageJson[dependencyType][raPackage] = `^${version}`;
+                    }
+                }
+            }
+
+            if (updatedDependencies.length > 0) {
+                if (process.env.RELEASE_DRY_RUN) {
+                    console.group(
+                        `\nUpdated template "${template}" dependencies:`
+                    );
+                    for (const [
+                        packageName,
+                        oldVersion,
+                        newVersion,
+                    ] of updatedDependencies) {
+                        console.log(
+                            `- ${packageName}: ${oldVersion} -> ${newVersion}`
+                        );
+                    }
+                    console.groupEnd();
+                } else {
+                    fs.writeFileSync(
+                        packageJsonPath,
+                        `${JSON.stringify(packageJson, null, 4)}\n`,
+                        {
+                            encoding: 'utf-8',
+                        }
+                    );
+                }
+            }
+        }
+    }
+};
+
+main();


### PR DESCRIPTION
## Problem

When we release a new minor version, we have to manually update `create-react-admin` templates dependencies.

## Solution

- Automatically update create-react-admin templates when releasing a new minor version

## How To Test

These scripts support a `RELEASE_DRY_RUN` env variable allowing to skip all mutations to git, GitHub or npm, except 1 git commit (but not pushed!) from lerna.

First, create a `.env` file from the `.env.template` file and fill it in with your Github token.

Then run:

```
RELEASE_DRY_RUN=true make release
```

Select the new minor version when Lerna asks for it.

When this is done, don't forget to revert the commit created by lerna to update the versions:

```
git reset --hard HEAD~1
```

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature