### PR TITLE
Fix `<AutcompleteInput>`, `<DateInput>` and `<DateTimeInput>` aren't focused when adding a new item in a `<ArrayInput>`

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -20,6 +20,7 @@ import {
     TextField,
     TextFieldProps,
     createFilterOptions,
+    useForkRef,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import {
@@ -325,7 +326,7 @@ If you provided a React element for the optionText prop, you must also provide t
 
     const [filterValue, setFilterValue] = useState('');
 
-    const handleChange = (newValue: any) => {
+    const handleChange = useEvent((newValue: any) => {
         if (multiple) {
             if (Array.isArray(newValue)) {
                 field.onChange(newValue.map(getChoiceValue), newValue);
@@ -338,7 +339,7 @@ If you provided a React element for the optionText prop, you must also provide t
         } else {
             field.onChange(getChoiceValue(newValue) ?? emptyValue, newValue);
         }
-    };
+    });
 
     // eslint-disable-next-line
     const debouncedSetFilter = useCallback(
@@ -478,7 +479,7 @@ If you provided a React element for the optionText prop, you must also provide t
         Multiple,
         DisableClearable,
         SupportCreate
-    >['onInputChange'] = (event, newInputValue, reason) => {
+    >['onInputChange'] = useEvent((event, newInputValue, reason) => {
         if (
             event?.type === 'change' ||
             !doesQueryMatchSelection(newInputValue)
@@ -497,7 +498,7 @@ If you provided a React element for the optionText prop, you must also provide t
             debouncedSetFilter('');
         }
         onInputChange?.(event, newInputValue, reason);
-    };
+    });
 
     const doesQueryMatchSelection = useCallback(
         (filter: string) => {
@@ -593,6 +594,7 @@ If you provided a React element for the optionText prop, you must also provide t
     };
     const renderHelperText = !!fetchError || helperText !== false || invalid;
 
+    const handleInputRef = useForkRef(field.ref, TextFieldProps?.inputRef);
     return (
         <>
             <StyledAutocomplete
@@ -641,6 +643,7 @@ If you provided a React element for the optionText prop, you must also provide t
                             {...TextFieldProps}
                             InputProps={mergedTextFieldProps}
                             size={size}
+                            inputRef={handleInputRef}
                         />
                     );
                 }}

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
-import { useInput, FieldTitle, mergeRefs, useEvent } from 'ra-core';
+import { useInput, FieldTitle, useEvent } from 'ra-core';
 
 import { CommonInputProps } from './CommonInputProps';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
+import { useForkRef } from '@mui/material';
 
 /**
  * Form input to edit a Date string value in the "YYYY-MM-DD" format (e.g. '2021-06-23').
@@ -91,12 +92,14 @@ export const DateInput = ({
             return;
         }
 
-        // The value has changed from outside the input, we update the input value
-        initialDefaultValueRef.current = field.value;
-        // Trigger a remount of the HTML input
-        setInputKey(r => r + 1);
-        // Resets the flag to ensure futures changes are handled
-        wasLastChangedByInput.current = false;
+        if (initialDefaultValueRef.current !== field.value) {
+            // The value has changed from outside the input, we update the input value
+            initialDefaultValueRef.current = field.value;
+            // Trigger a remount of the HTML input
+            setInputKey(r => r + 1);
+            // Resets the flag to ensure futures changes are handled
+            wasLastChangedByInput.current = false;
+        }
     }, [setInputKey, field.value]);
 
     const { onBlur: onBlurFromField } = field;
@@ -142,7 +145,7 @@ export const DateInput = ({
         }
     );
 
-    const handleBlur = () => {
+    const handleBlur = useEvent(() => {
         hasFocus.current = false;
 
         if (!localInputRef.current) {
@@ -164,12 +167,12 @@ export const DateInput = ({
         if (onBlurFromField) {
             onBlurFromField();
         }
-    };
+    });
     const { error, invalid } = fieldState;
     const renderHelperText = helperText !== false || invalid;
 
     const { ref, name } = field;
-    const inputRef = mergeRefs([ref, localInputRef]);
+    const inputRef = useForkRef(ref, localInputRef);
 
     return (
         <TextField

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
-import { useInput, FieldTitle, mergeRefs } from 'ra-core';
+import { useInput, FieldTitle } from 'ra-core';
 
 import { CommonInputProps } from './CommonInputProps';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
+import { useForkRef } from '@mui/material';
 
 /**
  * Input component for entering a date and a time with timezone, using the browser locale
@@ -58,12 +59,14 @@ export const DateTimeInput = ({
             return;
         }
 
-        // The value has changed from outside the input, we update the input value
-        initialDefaultValueRef.current = field.value;
-        // Trigger a remount of the HTML input
-        setInputKey(r => r + 1);
-        // Resets the flag to ensure futures changes are handled
-        wasLastChangedByInput.current = false;
+        if (initialDefaultValueRef.current !== field.value) {
+            // The value has changed from outside the input, we update the input value
+            initialDefaultValueRef.current = field.value;
+            // Trigger a remount of the HTML input
+            setInputKey(r => r + 1);
+            // Resets the flag to ensure futures changes are handled
+            wasLastChangedByInput.current = false;
+        }
     }, [setInputKey, field.value]);
 
     const { onBlur: onBlurFromField } = field;
@@ -128,7 +131,7 @@ export const DateTimeInput = ({
     const { error, invalid } = fieldState;
     const renderHelperText = helperText !== false || invalid;
     const { ref, name } = field;
-    const inputRef = mergeRefs([ref, localInputRef]);
+    const inputRef = useForkRef(ref, localInputRef);
 
     return (
         <TextField


### PR DESCRIPTION
## Problem

When adding a new item in a ArrayInput, the first input should be focused (react-hook-form handles this). This does not work if this first input is either an `AutcompleteInput`,. a `DateInput` or a `DateTimeInput`

Fixes #7643

## Solution

Correctly pass refs from react-hook-form and avoid rerendering the inputs when not necessary.

## How To Test

- Run the simple example
- Login as admin to see the users inputs
- Create a new post and add a backlink => the date input should be focused
- Edit a post and add an author => the autocomplete input should be focused

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
