### PR TITLE
Fix release script add wrong minor in documentation versions list

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -135,7 +135,7 @@ if [ -d $RA_DOC_PATH ]; then
     if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
         echo "Add the previous minor version to the list of versions in the versions.yml file"
         # Add the previous minor version to the list of versions in the versions.yml file
-        sed -i "/^\(- latest.*\)/s//\1 \n- \"${npm_current_package_version%.*}\"/" $RA_DOC_PATH/_data/versions.yml
+        sed -i "/^\(- latest.*\)/s//\1 \n- \"${npm_previous_package_version%.*}\"/" $RA_DOC_PATH/_data/versions.yml
     fi
     if [ -z "$RELEASE_DRY_RUN" ]; then
         ( cd $RA_DOC_PATH && git add . && git commit -m "Update the documentation for version $npm_current_package_version" && git push )


### PR DESCRIPTION
## Problem

The script adds the latest minor version in the list of previous minor versions

## Solution

Add the previous minor in the list of previous minor versions

## How To Test


These scripts support a `RELEASE_DRY_RUN` env variable allowing to skip all mutations to git, GitHub or npm, except 1 git commit (but not pushed!) from lerna.

First, create a `.env` file from the `.env.template` file and fill it in with your Github token.

Then run:

```
RELEASE_DRY_RUN=true make release
```

Select the new minor version when Lerna asks for it.

When this is done, don't forget to revert the commit created by lerna to update the versions:

```
git reset --hard HEAD~1
```

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature