### PR TITLE
doc: add emptyWhileLoading prop doc

### DIFF
--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -120,6 +120,20 @@ const EditButton = () => (
 );
 ```
 
+## `emptyWhileLoading`
+
+By default, `<EditInDialogButton>` renders its child component even before the `dataProvider.getOne()` call returns. It can lead to a flash of empty content.
+
+To avoid this, set the `emptyWhileLoading` prop to `true`:
+
+```jsx
+const EditButton = () => (
+  <EditInDialogButton emptyWhileLoading>
+      ...
+  </EditInDialogButton>
+);
+```
+
 ## `ButtonProps`
 
 The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color and size of the button:

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -71,8 +71,9 @@ const CompanyShow = () => (
 
 | Prop               | Required | Type              | Default | Description                                                                             |
 | ------------------ | -------- | ----------------- | ------- | --------------------------------------------------------------------------------------- |
-| `children`         | Required | `ReactNode`       |         | The content of the dialog                                                               |
 | `ButtonProps`      | Optional | `object`          |         | Object containing props to pass to Material UI's `<Button>`                             |
+| `children`         | Required | `ReactNode`       |         | The content of the dialog                                                               |
+| `emptyWhileLoading`| Optional | `boolean`         | `false` | Set to `true` to return `null` while the list is loading                                |
 | `fullWidth`        | Optional | `boolean`         | `false` | If `true`, the dialog stretches to the full width of the screen                         |
 | `icon`             | Optional | `ReactElement`    |         | Allows to override the default icon                                                     |
 | `id`               | Optional | `string | number` |         | The record id. If not provided, it will be deduced from the record context              |
@@ -84,7 +85,25 @@ const CompanyShow = () => (
 | `resource`         | Optional | `string`          |         | The resource name, e.g. `posts`                                                         |
 | `sx`               | Optional | `object`          |         | Override the styles applied to the dialog component                                     |
 | `title`            | Optional | `ReactNode`       |         | The title of the dialog                                                                 |
-| `emptyWhileLoading`| Optional | `boolean`         | `false` | Set to `true` to return `null` while the list is loading                                |
+
+
+## `ButtonProps`
+
+The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color and size of the button:
+
+{% raw %}
+
+```jsx
+const EditButton = () => (
+  <EditInDialogButton ButtonProps={{ color: 'primary', fullWidth: true }}>
+      <SimpleForm>
+          ...
+      </SimpleForm>
+  </EditInDialogButton>
+);
+```
+
+{% endraw %}
 
 ## `children`
 
@@ -133,24 +152,6 @@ const EditButton = () => (
   </EditInDialogButton>
 );
 ```
-
-## `ButtonProps`
-
-The `ButtonProps` prop allows you to pass props to the MUI `<Button>` component. For instance, to change the color and size of the button:
-
-{% raw %}
-
-```jsx
-const EditButton = () => (
-  <EditInDialogButton ButtonProps={{ color: 'primary', fullWidth: true }}>
-      <SimpleForm>
-          ...
-      </SimpleForm>
-  </EditInDialogButton>
-);
-```
-
-{% endraw %}
 
 ## `fullWidth`
 

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -84,6 +84,7 @@ const CompanyShow = () => (
 | `resource`         | Optional | `string`          |         | The resource name, e.g. `posts`                                                         |
 | `sx`               | Optional | `object`          |         | Override the styles applied to the dialog component                                     |
 | `title`            | Optional | `ReactNode`       |         | The title of the dialog                                                                 |
+| `emptyWhileLoading`| Optional | `boolean`         | `false` | Set to `true` to return `null` while the list is loading                                |
 
 ## `children`
 

--- a/docs/ShowInDialogButton.md
+++ b/docs/ShowInDialogButton.md
@@ -94,7 +94,7 @@ This component accepts the following props:
 |----------------|----------|----------------|----------|---------------------------|
 | `ButtonProps`  | Optional | `object`       |          | Props to pass to the MUI `<Button>` component |
 | `children`     | Required | `ReactNode`    |          | The content of the dialog |
-| `empty WhileLoading` | Optional | `boolean` |         | Set to `true` to return `null` while the list is loading |
+| `emptyWhileLoading` | Optional | `boolean` |         | Set to `true` to return `null` while the list is loading |
 | `fullWidth`    | Optional | `boolean`      | `false`  | Set to `true` to make the dialog full width |
 | `icon`         | Optional | `ReactElement` |          | The icon of the button |
 | `id`           | Optional | `string | number` |       | The record id. If not provided, it will be deduced from the record context |


### PR DESCRIPTION
## Problem

Missing documentation for emptyWhileLoading prop for EditInDialogButton

## Solution

Add missing doc.

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
