### PR TITLE
fix: use correct function name `convertRaTranslationsToI18next`

### DIFF
--- a/packages/ra-i18n-i18next/README.md
+++ b/packages/ra-i18n-i18next/README.md
@@ -21,14 +21,16 @@ npm install --save ra-i18n-i18next
 
 ```tsx
 import { Admin } from 'react-admin';
-import { useI18nextProvider, convertRaMessagesToI18next } from 'ra-i18n-i18next';
+import { useI18nextProvider, convertRaTranslationsToI18next } from 'ra-i18n-i18next';
 import englishMessages from 'ra-language-english';
 
 const App = () => {
     const i18nProvider = useI18nextProvider({
         options: {
             resources: {
-                translations: convertRaMessagesToI18next(englishMessages)
+                en: {
+                    translations: convertRaTranslationsToI18next(englishMessages)
+                }
             }
         }
     });
@@ -54,14 +56,16 @@ You can provide your own i18next instance but don't initialize it, the hook will
 
 ```tsx
 import { Admin } from 'react-admin';
-import { useI18nextProvider, convertRaMessagesToI18next } from 'ra-i18n-i18next';
+import { useI18nextProvider, convertRaTranslationsToI18next } from 'ra-i18n-i18next';
 import englishMessages from 'ra-language-english';
 
 const App = () => {
     const i18nProvider = useI18nextProvider({
         options: {
             resources: {
-                translations: convertRaMessagesToI18next(englishMessages)
+                en: {
+                    translations: convertRaTranslationsToI18next(englishMessages)
+                }
             }
         }
     });
@@ -190,7 +194,7 @@ const App = () => {
 };
 ```
 
-### `convertRaMessagesToI18next` function
+### `convertRaTranslationsToI18next` function
 
 A function that takes translations from a standard react-admin language package and converts them to i18next format.
 It transforms the following:
@@ -201,9 +205,9 @@ It transforms the following:
 
 ```ts
 import englishMessages from 'ra-language-english';
-import { convertRaMessagesToI18next } from 'ra-i18n-18next';
+import { convertRaTranslationsToI18next } from 'ra-i18n-18next';
 
-const messages = convertRaMessagesToI18next(englishMessages);
+const messages = convertRaTranslationsToI18next(englishMessages);
 ```
 
 #### Parameters
@@ -219,9 +223,9 @@ If you provided interpolation options to your i18next instance, you should provi
 
 ```ts
 import englishMessages from 'ra-language-english';
-import { convertRaMessagesToI18next } from 'ra-i18n-18next';
+import { convertRaTranslationsToI18next } from 'ra-i18n-18next';
 
-const messages = convertRaMessagesToI18next(englishMessages, {
+const messages = convertRaTranslationsToI18next(englishMessages, {
    prefix: '#{',
   suffix: '}#',
 });


### PR DESCRIPTION
## Problem

Documentation of ra-i18n-i18next talk about `convertRaMessagesToI18next`  instead of `convertRaTranslationsToI18next`, and the example has ts errors.

## Solution

change the name of the function, fix the example and check the ts error are gone.

## How To Test

Read the doc

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
