### PR TITLE
feat: handle empty `emptyText` for `<ChipField>`

### DIFF
--- a/packages/ra-ui-materialui/src/field/ChipField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.spec.tsx
@@ -27,12 +27,7 @@ const i18nProvider = polyglotI18nProvider(
 describe('<ChipField />', () => {
     it('should display the record value added as source', () => {
         const { getByText } = render(
-            <ChipField
-                className="className"
-                classes={{}}
-                source="name"
-                record={{ id: 123, name: 'foo' }}
-            />
+            <ChipField source="name" record={{ id: 123, name: 'foo' }} />
         );
         expect(getByText('foo')).not.toBeNull();
     });
@@ -40,7 +35,7 @@ describe('<ChipField />', () => {
     it('should use record from RecordContext', () => {
         const { getByText } = render(
             <RecordContextProvider value={{ id: 123, name: 'foo' }}>
-                <ChipField className="className" classes={{}} source="name" />
+                <ChipField source="name" />
             </RecordContextProvider>
         );
         expect(getByText('foo')).not.toBeNull();
@@ -49,8 +44,6 @@ describe('<ChipField />', () => {
     it('should not display any label added as props', () => {
         const { getByText } = render(
             <ChipField
-                className="className"
-                classes={{}}
                 source="name"
                 record={{ id: 123, name: 'foo' }}
                 label="bar"
@@ -64,8 +57,6 @@ describe('<ChipField />', () => {
         name => {
             const { getByText } = render(
                 <ChipField
-                    className="className"
-                    classes={{}}
                     source="name"
                     record={{ id: 123, name }}
                     emptyText="NA"
@@ -93,8 +84,6 @@ describe('<ChipField />', () => {
     it('should return null when value and emptyText are an empty string', () => {
         const { container } = render(
             <ChipField
-                className="className"
-                classes={{}}
                 source="name"
                 record={{ id: 123, name: '' }}
                 emptyText=""
@@ -106,8 +95,6 @@ describe('<ChipField />', () => {
     it('should display the emptyText when value is an empty string', () => {
         const { getByText } = render(
             <ChipField
-                className="className"
-                classes={{}}
                 source="name"
                 record={{ id: 123, name: '' }}
                 emptyText="NA"
@@ -118,12 +105,7 @@ describe('<ChipField />', () => {
 
     it('should return null when value is an empty string and emptyText is null', () => {
         const { container } = render(
-            <ChipField
-                className="className"
-                classes={{}}
-                source="name"
-                record={{ id: 123, name: '' }}
-            />
+            <ChipField source="name" record={{ id: 123, name: '' }} />
         );
         expect(container.firstChild).toBeNull();
     });

--- a/packages/ra-ui-materialui/src/field/ChipField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.spec.tsx
@@ -89,4 +89,42 @@ describe('<ChipField />', () => {
 
         expect(getByText('Not found')).not.toBeNull();
     });
+
+    it('should return null when value and emptyText are an empty string', () => {
+        const { container } = render(
+            <ChipField
+                className="className"
+                classes={{}}
+                source="name"
+                record={{ id: 123, name: '' }}
+                emptyText=""
+            />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('should display the emptyText when value is an empty string', () => {
+        const { getByText } = render(
+            <ChipField
+                className="className"
+                classes={{}}
+                source="name"
+                record={{ id: 123, name: '' }}
+                emptyText="NA"
+            />
+        );
+        expect(getByText('NA')).not.toBeNull();
+    });
+
+    it('should return null when value is an empty string and emptyText is null', () => {
+        const { container } = render(
+            <ChipField
+                className="className"
+                classes={{}}
+                source="name"
+                record={{ id: 123, name: '' }}
+            />
+        );
+        expect(container.firstChild).toBeNull();
+    });
 });

--- a/packages/ra-ui-materialui/src/field/ChipField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.stories.tsx
@@ -1,0 +1,54 @@
+import { Paper, Stack } from '@mui/material';
+import * as React from 'react';
+
+import { ChipField, ChipFieldProps } from './ChipField';
+import { AdminContext } from '../AdminContext';
+import { defaultDarkTheme, defaultLightTheme } from '../theme';
+
+export default { title: 'ra-ui-materialui/fields/ChipField' };
+
+export const Basic = ({
+    theme,
+    value,
+    ...props
+}: Partial<ChipFieldProps> & { theme?: string; value?: string }) => {
+    return (
+        <AdminContext
+            theme={theme === 'light' ? defaultLightTheme : defaultDarkTheme}
+        >
+            <Paper sx={{ p: 2 }}>
+                <Stack direction="row">
+                    <ChipField record={{ value }} source="value" {...props} />
+                </Stack>
+            </Paper>
+        </AdminContext>
+    );
+};
+
+Basic.argTypes = {
+    value: {
+        options: ['filled', 'empty', 'undefined'],
+        mapping: {
+            filled: 'Bazinga',
+            empty: '',
+            undefined: undefined,
+        },
+        control: { type: 'select' },
+    },
+    emptyText: {
+        options: ['default', 'empty', 'provided'],
+        mapping: {
+            default: undefined,
+            empty: '',
+            provided: 'Nothing here',
+        },
+        control: { type: 'select' },
+    },
+    theme: {
+        options: ['light', 'dark'],
+        control: { type: 'select' },
+    },
+};
+Basic.args = {
+    theme: 'light',
+};

--- a/packages/ra-ui-materialui/src/field/ChipField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.stories.tsx
@@ -51,4 +51,5 @@ Basic.argTypes = {
 };
 Basic.args = {
     theme: 'light',
+    value: 'filled',
 };

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -18,8 +18,8 @@ const ChipFieldImpl = <
     const value = useFieldValue(props);
     const translate = useTranslate();
 
-    if (value == null && emptyText) {
-        return (
+    if (!value) {
+        return emptyText && emptyText.length > 0 ? (
             <Typography
                 component="span"
                 variant="body2"
@@ -28,7 +28,7 @@ const ChipFieldImpl = <
             >
                 {emptyText && translate(emptyText, { _: emptyText })}
             </Typography>
-        );
+        ) : null;
     }
 
     return (

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -19,7 +19,10 @@ const ChipFieldImpl = <
     const translate = useTranslate();
 
     if (!value) {
-        return emptyText && emptyText.length > 0 ? (
+        if (!emptyText || emptyText.length === 0) {
+            return null;
+        }
+        return (
             <Typography
                 component="span"
                 variant="body2"
@@ -28,7 +31,7 @@ const ChipFieldImpl = <
             >
                 {emptyText && translate(emptyText, { _: emptyText })}
             </Typography>
-        ) : null;
+        );
     }
 
     return (


### PR DESCRIPTION
## Problem

When passing an empty value (undefined or null), a `<Chip>` is rendered with nothing in it.

## Solution

If the value is an empty string, render the emptyText instead (just like the DateField does).

If the emptyText is an empty string, the component should return null.

## How To Test

- Unit tests should be green.
- https://react-admin-storybook-7jlxn1ynw-marmelab.vercel.app/?path=/story/ra-ui-materialui-fields-chipfield--basic

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
