### PR TITLE
Add `<Translate>` component

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -216,6 +216,7 @@ title: "Index"
 * [`<TourProvider>`](https://react-admin-ee.marmelab.com/documentation/ra-tour)<img class="icon" src="./img/premium.svg" alt="React Admin Enterprise Edition icon" />
 * [`<TranslatableFields>`](./TranslatableFields.md)
 * [`<TranslatableInputs>`](./TranslatableInputs.md)
+* [`<Translate>`](./Translate.md)
 * [`<Tree>`](./Tree.md)<img class="icon" src="./img/premium.svg" alt="React Admin Enterprise Edition icon" />
 * [`<TreeInput>`](./TreeInput.md)<img class="icon" src="./img/premium.svg" alt="React Admin Enterprise Edition icon" />
 * [`<TreeWithDetails>`](./TreeWithDetails.md)<img class="icon" src="./img/premium.svg" alt="React Admin Enterprise Edition icon" />

--- a/docs/Translate.md
+++ b/docs/Translate.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: "The Translate Component"
+---
+
+# `<Translate>`
+
+If you need to translate messages in your own components, React-admin provides the `<Translate>` component which displays your translated messages.
+
+# Usage
+
+```tsx
+const MyHelloButton = () => (
+    <Translate 
+        i18nKey="custom.hello_world"
+        component="button"
+    />
+);
+
+export default MyHelloButton;
+```
+
+**Tip:** You can directly use the translation function with [the `useTranslate` hook](./useTranslate.md).
+
+## Props
+
+| Prop        | Required | Type                    | Default            | Description                                             |
+| ----------- | -------- | ----------------------- | ------------------ | ------------------------------------------------------- |
+| `args`      | Optional | `Object`                | -                  | The arguments used for pluralization and interpolation. |
+| `children`  | Optional | `string`                | -                  | The default translation if the translation failed.      |
+| `component` | Optional | `ElementType`           | `div`              | The component to render as the root element.            |
+| `empty`     | Optional | `string` &#124; `false` | `"no translation"` | Message to be displayed if there is no translation.     |
+| `i18nKey`   | Required | `string`                | -                  | The translation key.                                    |
+
+Additional props are passed to the root element.
+
+## `args`: Pluralization and Interpolation
+
+Polyglot.js provides some nice features such as interpolation and pluralization, that you can use in react-admin.
+
+{%raw%}
+
+```tsx
+// in english.ts
+import englishMessages from 'ra-language-english';
+
+const messages = {
+    ...englishMessages,
+    custom: {
+        my_key: 'My Translated Key',
+        hello_world: 'Hello, %{my_world}!',
+        count_beer: 'Select one beer |||| Select %{smart_count} beers',
+    },
+};
+
+export default messages;
+```
+
+```tsx
+export const MyHelloButton = () => (
+    <Translate 
+        i18nKey="custom.hello_world"
+        component="button"
+        args={{ my_world: 'world' }}
+    />
+);
+
+export const SelectBeerButton = () => (
+    <Translate 
+        i18nKey="custom.count_beer"
+        component="button"
+        args={{ smart_count: 2 }}
+    />
+);
+```
+
+{%endraw%}
+
+## `children`
+
+You can provide a `children` to display if the translation function doesn't find a message with your `i18nKey`.
+
+```tsx
+const LoadingMessage = () => (
+    <Translate i18nKey="ra.page.loading" component="h3">
+        Loading
+    </Translate>
+);
+```
+
+## `component`
+
+The component to render as the root element.
+
+```tsx
+const LoadingMessage = () => <Translate i18nKey="ra.page.loading" component="h3" />;
+const MyHelloButton = () => <Translate i18nKey="custom.hello_world" component="button" />;
+const MarkedMessage = () => <Translate i18nKey="custom.myKey" component="mark" />;
+```
+
+## `empty`
+
+When your translation key doesn't fit with your dictionnary, react-admin displays an empty text.
+
+```tsx
+const MyMessage = () => <Translate i18nKey="custom.myKey" empty="translation failed" />;
+```
+
+**Tip:** You can set `empty` to false to don't render anything in this case.
+
+## `i18nKey`
+
+The key used to translate your message with your polyglot disctionnaries like `ra.action.unselect`, `custom.my_key`, etc.

--- a/docs/Translate.md
+++ b/docs/Translate.md
@@ -10,7 +10,7 @@ If you need to translate messages in your own components, React-admin provides t
 # Usage
 
 ```tsx
-const MyHelloButton = () => <Translate i18nKey="custom.hello_world" />;
+const MyHelloButton = () => <button><Translate i18nKey="custom.hello_world" /></button>;
 
 export default MyHelloButton;
 ```
@@ -22,15 +22,13 @@ export default MyHelloButton;
 | Prop        | Required | Type                    | Default            | Description                                             |
 | ----------- | -------- | ----------------------- | ------------------ | ------------------------------------------------------- |
 | `args`      | Optional | `Object`                | -                  | The arguments used for pluralization and interpolation. |
-| `children`  | Optional | `string`                | -                  | The default translation if the translation failed.      |
-| `empty`     | Optional | `string` &#124; `false` | `"no translation"` | Message to be displayed if there is no translation.     |
+| `children`  | Optional | `string`                | -                  | The default content to display if the translation is not found.      |
+| `empty`     | Optional | `string` &#124; `false` | `"no translation"` | Message to be displayed if the translation is not found and no children is provided.     |
 | `i18nKey`   | Required | `string`                | -                  | The translation key.                                    |
-
-Additional props are passed to the root element.
 
 ## `args`: Pluralization and Interpolation
 
-Polyglot.js provides some nice features such as interpolation and pluralization, that you can use in react-admin.
+If your i18n provider provides some nice features such as interpolation and pluralization (as [Polyglot.js](./Translation.md#ra-i18n-polyglot) and [i18next](./Translation.md#ra-i18n-i18next) did), that you can use in react-admin.
 
 {%raw%}
 
@@ -76,7 +74,7 @@ const LoadingMessage = () => <Translate i18nKey="ra.page.loading">Loading</Trans
 
 ## `empty`
 
-When your translation key doesn't fit with your dictionnary, react-admin displays an empty text.
+When your translation key doesn't fit with your dictionnary and no `children` is provided, react-admin displays an empty text.
 
 ```tsx
 const MyMessage = () => <Translate i18nKey="custom.myKey" empty="translation failed" />;

--- a/docs/Translate.md
+++ b/docs/Translate.md
@@ -19,11 +19,11 @@ export default MyHelloButton;
 
 ## Props
 
-| Prop       | Required | Type     | Default            | Description                                                     |
-| ---------- | -------- | -------- | ------------------ | --------------------------------------------------------------- |
-| `args`     | Optional | `Object` | -                  | The arguments used for pluralization and interpolation.         |
-| `children` | Optional | `string` | `"no translation"` | The default content to display if the translation is not found. |
-| `i18nKey`  | Required | `string` | -                  | The translation key.                                            |
+| Prop       | Required | Type     | Default | Description                                                     |
+| ---------- | -------- | -------- | ------- | --------------------------------------------------------------- |
+| `args`     | Optional | `Object` | -       | The arguments used for pluralization and interpolation.         |
+| `children` | Optional | `string` | -       | The default content to display if the translation is not found. |
+| `i18nKey`  | Required | `string` | -       | The translation key.                                            |
 
 ## `args`: Pluralization and Interpolation
 

--- a/docs/Translate.md
+++ b/docs/Translate.md
@@ -10,12 +10,7 @@ If you need to translate messages in your own components, React-admin provides t
 # Usage
 
 ```tsx
-const MyHelloButton = () => (
-    <Translate 
-        i18nKey="custom.hello_world"
-        component="button"
-    />
-);
+const MyHelloButton = () => <Translate i18nKey="custom.hello_world" />;
 
 export default MyHelloButton;
 ```
@@ -28,7 +23,6 @@ export default MyHelloButton;
 | ----------- | -------- | ----------------------- | ------------------ | ------------------------------------------------------- |
 | `args`      | Optional | `Object`                | -                  | The arguments used for pluralization and interpolation. |
 | `children`  | Optional | `string`                | -                  | The default translation if the translation failed.      |
-| `component` | Optional | `ElementType`           | `div`              | The component to render as the root element.            |
 | `empty`     | Optional | `string` &#124; `false` | `"no translation"` | Message to be displayed if there is no translation.     |
 | `i18nKey`   | Required | `string`                | -                  | The translation key.                                    |
 
@@ -58,19 +52,15 @@ export default messages;
 
 ```tsx
 export const MyHelloButton = () => (
-    <Translate 
-        i18nKey="custom.hello_world"
-        component="button"
-        args={{ my_world: 'world' }}
-    />
+    <button>
+        <Translate i18nKey="custom.hello_world" args={{ my_world: 'world' }} />
+    </button>
 );
 
 export const SelectBeerButton = () => (
-    <Translate 
-        i18nKey="custom.count_beer"
-        component="button"
-        args={{ smart_count: 2 }}
-    />
+    <button>
+        <Translate i18nKey="custom.count_beer" args={{ smart_count: 2 }} />
+    </button>
 );
 ```
 
@@ -81,21 +71,7 @@ export const SelectBeerButton = () => (
 You can provide a `children` to display if the translation function doesn't find a message with your `i18nKey`.
 
 ```tsx
-const LoadingMessage = () => (
-    <Translate i18nKey="ra.page.loading" component="h3">
-        Loading
-    </Translate>
-);
-```
-
-## `component`
-
-The component to render as the root element.
-
-```tsx
-const LoadingMessage = () => <Translate i18nKey="ra.page.loading" component="h3" />;
-const MyHelloButton = () => <Translate i18nKey="custom.hello_world" component="button" />;
-const MarkedMessage = () => <Translate i18nKey="custom.myKey" component="mark" />;
+const LoadingMessage = () => <Translate i18nKey="ra.page.loading">Loading</Translate>;
 ```
 
 ## `empty`

--- a/docs/Translate.md
+++ b/docs/Translate.md
@@ -19,11 +19,11 @@ export default MyHelloButton;
 
 ## Props
 
-| Prop       | Required | Type     | Default | Description                                                     |
-| ---------- | -------- | -------- | ------- | --------------------------------------------------------------- |
-| `args`     | Optional | `Object` | -       | The arguments used for pluralization and interpolation.         |
-| `children` | Optional | `string` | -       | The default content to display if the translation is not found. |
-| `i18nKey`  | Required | `string` | -       | The translation key.                                            |
+| Prop       | Required | Type        | Default | Description                                                     |
+| ---------- | -------- | ----------- | ------- | --------------------------------------------------------------- |
+| `args`     | Optional | `Object`    | -       | The arguments used for pluralization and interpolation.         |
+| `children` | Optional | `ReactNode` | -       | The default content to display if the translation is not found. |
+| `i18nKey`  | Required | `string`    | -       | The translation key.                                            |
 
 ## `args`: Pluralization and Interpolation
 

--- a/docs/Translate.md
+++ b/docs/Translate.md
@@ -19,12 +19,11 @@ export default MyHelloButton;
 
 ## Props
 
-| Prop        | Required | Type                    | Default            | Description                                             |
-| ----------- | -------- | ----------------------- | ------------------ | ------------------------------------------------------- |
-| `args`      | Optional | `Object`                | -                  | The arguments used for pluralization and interpolation. |
-| `children`  | Optional | `string`                | -                  | The default content to display if the translation is not found.      |
-| `empty`     | Optional | `string` &#124; `false` | `"no translation"` | Message to be displayed if the translation is not found and no children is provided.     |
-| `i18nKey`   | Required | `string`                | -                  | The translation key.                                    |
+| Prop       | Required | Type     | Default            | Description                                                     |
+| ---------- | -------- | -------- | ------------------ | --------------------------------------------------------------- |
+| `args`     | Optional | `Object` | -                  | The arguments used for pluralization and interpolation.         |
+| `children` | Optional | `string` | `"no translation"` | The default content to display if the translation is not found. |
+| `i18nKey`  | Required | `string` | -                  | The translation key.                                            |
 
 ## `args`: Pluralization and Interpolation
 
@@ -71,16 +70,6 @@ You can provide a `children` to display if the translation function doesn't find
 ```tsx
 const LoadingMessage = () => <Translate i18nKey="ra.page.loading">Loading</Translate>;
 ```
-
-## `empty`
-
-When your translation key doesn't fit with your dictionnary and no `children` is provided, react-admin displays an empty text.
-
-```tsx
-const MyMessage = () => <Translate i18nKey="custom.myKey" empty="translation failed" />;
-```
-
-**Tip:** You can set `empty` to false to don't render anything in this case.
 
 ## `i18nKey`
 

--- a/docs/navigation.html
+++ b/docs/navigation.html
@@ -248,6 +248,7 @@
     <li {% if page.path == 'TranslationLocales.md' %} class="active" {% endif %}><a class="nav-link" href="./TranslationLocales.html">Supported Locales</a></li>
     <li {% if page.path == 'TranslationTranslating.md' %} class="active" {% endif %}><a class="nav-link" href="./TranslationTranslating.html">Translating UI Components</a></li>
     <li {% if page.path == 'TranslationWriting.md' %} class="active" {% endif %}><a class="nav-link" href="./TranslationWriting.html">Writing an i18nProvider</a></li>
+    <li {% if page.path == 'Translate.md' %} class="active" {% endif %}><a class="nav-link" href="./Translate.html"><code>&lt;Translate&gt;</code></a></li>
     <li {% if page.path == 'useTranslate.md' %} class="active" {% endif %}><a class="nav-link" href="./useTranslate.html"><code>useTranslate</code></a></li>
     <li {% if page.path == 'useLocaleState.md' %} class="active" {% endif %}><a class="nav-link" href="./useLocaleState.html"><code>useLocaleState</code></a></li>
     <li {% if page.path == 'LocalesMenuButton.md' %} class="active" {% endif %}><a class="nav-link" href="./LocalesMenuButton.html"><code>&lt;LocalesMenuButton&gt;</code></a></li>

--- a/docs/useTranslate.md
+++ b/docs/useTranslate.md
@@ -14,6 +14,8 @@ const translate = useTranslate();
 const translatedMessage = translate(translationKey, options);
 ```
 
+**Tip:** Instead of working with a hook, you can directly use [the `<Translate>` component](./Translate.md).
+
 ## Usage
 
 ```jsx

--- a/docs/useTranslate.md
+++ b/docs/useTranslate.md
@@ -14,7 +14,7 @@ const translate = useTranslate();
 const translatedMessage = translate(translationKey, options);
 ```
 
-**Tip:** Instead of working with a hook, you can directly use [the `<Translate>` component](./Translate.md).
+**Tip:** Instead of a hook, you can use [the `<Translate>` component](./Translate.md).
 
 ## Usage
 

--- a/packages/ra-core/src/controller/input/referenceDataStatus.ts
+++ b/packages/ra-core/src/controller/input/referenceDataStatus.ts
@@ -1,4 +1,4 @@
-import { RaRecord, Translate } from '../../types';
+import { RaRecord, TranslateFunction } from '../../types';
 import { MatchingReferencesError } from './types';
 import { ControllerRenderProps } from 'react-hook-form';
 
@@ -6,7 +6,7 @@ interface GetStatusForInputParams<RecordType extends RaRecord = RaRecord> {
     field: Pick<ControllerRenderProps, 'value'>;
     matchingReferences: RecordType[] | MatchingReferencesError;
     referenceRecord: RecordType;
-    translate: Translate;
+    translate: TranslateFunction;
 }
 
 const isMatchingReferencesError = (
@@ -72,7 +72,7 @@ interface GetStatusForArrayInputParams<RecordType extends RaRecord = any> {
     field: ControllerRenderProps;
     matchingReferences: RecordType[] | MatchingReferencesError;
     referenceRecords: RecordType[];
-    translate: Translate;
+    translate: TranslateFunction;
 }
 
 export const getStatusForArrayInput = <RecordType extends RaRecord = any>({

--- a/packages/ra-core/src/i18n/TestTranslationProvider.tsx
+++ b/packages/ra-core/src/i18n/TestTranslationProvider.tsx
@@ -32,7 +32,7 @@ export const testI18nProvider = ({
                       ? typeof message === 'function'
                           ? message(options)
                           : message
-                      : options?._ || key;
+                      : options?._;
               }
             : translate || (key => key),
         changeLocale: () => Promise.resolve(),

--- a/packages/ra-core/src/i18n/Translate.spec.tsx
+++ b/packages/ra-core/src/i18n/Translate.spec.tsx
@@ -14,7 +14,7 @@ import { Translate } from './Translate';
 describe('<Translate />', () => {
     it('should render the translation', () => {
         const { container } = render(<Basic />);
-        expect(container.innerHTML).toBe('<span>My Translated Key</span>');
+        expect(container.innerHTML).toBe('My Translated Key');
     });
 
     it('should render the translation event if children is set', () => {
@@ -29,26 +29,26 @@ describe('<Translate />', () => {
                 <Translate i18nKey="custom.myKey" />
             </TestTranslationProvider>
         );
-        expect(container.innerHTML).toBe('<span>My Translated Key</span>');
+        expect(container.innerHTML).toBe('My Translated Key');
     });
 
     it('should render the empty prop if no translation available', () => {
         const { container } = render(<NoTranslation />);
-        expect(container.innerHTML).toBe('<span>no translation</span>');
+        expect(container.innerHTML).toBe('no translation');
     });
 
     it('should render the children if no translation available', () => {
         const { container } = render(<NoTranslationWithChildren />);
-        expect(container.innerHTML).toBe('<span>My Key</span>');
+        expect(container.innerHTML).toBe('My Key');
     });
 
     it('should render the empty prop if no translation available', () => {
         const { container } = render(<NoTranslationWithEmpty />);
-        expect(container.innerHTML).toBe('<span>translation failed</span>');
+        expect(container.innerHTML).toBe('translation failed');
     });
 
     it('should render the translation with args', () => {
         const { container } = render(<Args />);
-        expect(container.innerHTML).toBe('<span>It cost 6.00 $</span>');
+        expect(container.innerHTML).toBe('It cost 6.00 $');
     });
 });

--- a/packages/ra-core/src/i18n/Translate.spec.tsx
+++ b/packages/ra-core/src/i18n/Translate.spec.tsx
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 import {
     Args,
     Basic,
-    Component,
     NoTranslation,
     NoTranslationWithChildren,
     NoTranslationWithEmpty,
@@ -51,10 +50,5 @@ describe('<Translate />', () => {
     it('should render the translation with args', () => {
         const { container } = render(<Args />);
         expect(container.innerHTML).toBe('<span>It cost 6.00 $</span>');
-    });
-
-    it('should render the translation with a custom component', () => {
-        const { container } = render(<Component />);
-        expect(container.innerHTML).toBe('<mark>My Translated Key</mark>');
     });
 });

--- a/packages/ra-core/src/i18n/Translate.spec.tsx
+++ b/packages/ra-core/src/i18n/Translate.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import {
+    Args,
+    Basic,
+    Component,
+    NoTranslation,
+    NoTranslationWithChildren,
+    NoTranslationWithEmpty,
+} from './Translate.stories';
+import { TestTranslationProvider } from './TestTranslationProvider';
+import { Translate } from './Translate';
+
+describe('<Translate />', () => {
+    it('should render the translation', () => {
+        const { container } = render(<Basic />);
+        expect(container.innerHTML).toBe('<span>My Translated Key</span>');
+    });
+
+    it('should render the translation event if children is set', () => {
+        const { container } = render(
+            <TestTranslationProvider
+                messages={{
+                    custom: {
+                        myKey: 'My Translated Key',
+                    },
+                }}
+            >
+                <Translate i18nKey="custom.myKey" />
+            </TestTranslationProvider>
+        );
+        expect(container.innerHTML).toBe('<span>My Translated Key</span>');
+    });
+
+    it('should render the empty prop if no translation available', () => {
+        const { container } = render(<NoTranslation />);
+        expect(container.innerHTML).toBe('<span>no translation</span>');
+    });
+
+    it('should render the children if no translation available', () => {
+        const { container } = render(<NoTranslationWithChildren />);
+        expect(container.innerHTML).toBe('<span>My Key</span>');
+    });
+
+    it('should render the empty prop if no translation available', () => {
+        const { container } = render(<NoTranslationWithEmpty />);
+        expect(container.innerHTML).toBe('<span>translation failed</span>');
+    });
+
+    it('should render the translation with args', () => {
+        const { container } = render(<Args />);
+        expect(container.innerHTML).toBe('<span>It cost 6.00 $</span>');
+    });
+
+    it('should render the translation with a custom component', () => {
+        const { container } = render(<Component />);
+        expect(container.innerHTML).toBe('<mark>My Translated Key</mark>');
+    });
+});

--- a/packages/ra-core/src/i18n/Translate.spec.tsx
+++ b/packages/ra-core/src/i18n/Translate.spec.tsx
@@ -36,9 +36,18 @@ describe('<Translate />', () => {
         expect(container.innerHTML).toBe('');
     });
 
-    it('should render the children if no translation available', () => {
+    it('should render the children (string) if no translation available', () => {
         const { container } = render(<NoTranslationWithChildren />);
         expect(container.innerHTML).toBe('My Default Translation');
+    });
+
+    it('should render the children (ReactNode) if no translation available', () => {
+        const { container } = render(
+            <NoTranslationWithChildren isChildrenANode />
+        );
+        expect(container.innerHTML).toBe(
+            '<div style="color: red;"><i>My Default Translation</i></div>'
+        );
     });
 
     it('should render the translation with args', () => {

--- a/packages/ra-core/src/i18n/Translate.spec.tsx
+++ b/packages/ra-core/src/i18n/Translate.spec.tsx
@@ -25,15 +25,15 @@ describe('<Translate />', () => {
                     },
                 }}
             >
-                <Translate i18nKey="custom.myKey" />
+                <Translate i18nKey="custom.myKey">Lorem Ipsum</Translate>
             </TestTranslationProvider>
         );
         expect(container.innerHTML).toBe('My Translated Key');
     });
 
-    it('should render the empty prop if no translation available', () => {
+    it('should render anything if no translation available', () => {
         const { container } = render(<NoTranslation />);
-        expect(container.innerHTML).toBe('no translation');
+        expect(container.innerHTML).toBe('');
     });
 
     it('should render the children if no translation available', () => {

--- a/packages/ra-core/src/i18n/Translate.spec.tsx
+++ b/packages/ra-core/src/i18n/Translate.spec.tsx
@@ -6,7 +6,6 @@ import {
     Basic,
     NoTranslation,
     NoTranslationWithChildren,
-    NoTranslationWithEmpty,
 } from './Translate.stories';
 import { TestTranslationProvider } from './TestTranslationProvider';
 import { Translate } from './Translate';
@@ -39,12 +38,7 @@ describe('<Translate />', () => {
 
     it('should render the children if no translation available', () => {
         const { container } = render(<NoTranslationWithChildren />);
-        expect(container.innerHTML).toBe('My Key');
-    });
-
-    it('should render the empty prop if no translation available', () => {
-        const { container } = render(<NoTranslationWithEmpty />);
-        expect(container.innerHTML).toBe('translation failed');
+        expect(container.innerHTML).toBe('My Default Translation');
     });
 
     it('should render the translation with args', () => {

--- a/packages/ra-core/src/i18n/Translate.stories.tsx
+++ b/packages/ra-core/src/i18n/Translate.stories.tsx
@@ -26,19 +26,7 @@ export const NoTranslation = () => (
 
 export const NoTranslationWithChildren = () => (
     <TestTranslationProvider messages={{}}>
-        <Translate i18nKey="custom.myKey">My Key</Translate>
-    </TestTranslationProvider>
-);
-
-export const NoTranslationWithEmpty = () => (
-    <TestTranslationProvider messages={{}}>
-        <Translate i18nKey="custom.myKey" empty="translation failed" />
-    </TestTranslationProvider>
-);
-
-export const NoTranslationWithEmptyAsFalse = () => (
-    <TestTranslationProvider messages={{}}>
-        <Translate i18nKey="custom.myKey" empty={false} />
+        <Translate i18nKey="custom.myKey">My Default Translation</Translate>
     </TestTranslationProvider>
 );
 

--- a/packages/ra-core/src/i18n/Translate.stories.tsx
+++ b/packages/ra-core/src/i18n/Translate.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { TestTranslationProvider } from './TestTranslationProvider';
+import { Translate } from './Translate';
+
+export default {
+    title: 'ra-core/i18n/Translate',
+};
+
+export const Basic = () => (
+    <TestTranslationProvider
+        messages={{
+            custom: {
+                myKey: 'My Translated Key',
+            },
+        }}
+    >
+        <Translate i18nKey="custom.myKey" />
+    </TestTranslationProvider>
+);
+
+export const NoTranslation = () => (
+    <TestTranslationProvider messages={{}}>
+        <Translate i18nKey="custom.myKey" />
+    </TestTranslationProvider>
+);
+
+export const NoTranslationWithChildren = () => (
+    <TestTranslationProvider messages={{}}>
+        <Translate i18nKey="custom.myKey">My Key</Translate>
+    </TestTranslationProvider>
+);
+
+export const NoTranslationWithEmpty = () => (
+    <TestTranslationProvider messages={{}}>
+        <Translate i18nKey="custom.myKey" empty="translation failed" />
+    </TestTranslationProvider>
+);
+
+export const Args = () => (
+    <TestTranslationProvider
+        messages={{
+            custom: {
+                myKey: ({ price }) => `It cost ${price}.00 $`,
+            },
+        }}
+    >
+        <Translate i18nKey="custom.myKey" args={{ price: '6' }} />
+    </TestTranslationProvider>
+);
+
+export const Component = () => (
+    <TestTranslationProvider
+        messages={{
+            custom: {
+                myKey: 'My Translated Key',
+            },
+        }}
+    >
+        <Translate i18nKey="custom.myKey" component="mark" />
+    </TestTranslationProvider>
+);

--- a/packages/ra-core/src/i18n/Translate.stories.tsx
+++ b/packages/ra-core/src/i18n/Translate.stories.tsx
@@ -24,11 +24,28 @@ export const NoTranslation = () => (
     </TestTranslationProvider>
 );
 
-export const NoTranslationWithChildren = () => (
+export const NoTranslationWithChildren = ({
+    isChildrenANode = false,
+}: {
+    isChildrenANode?: boolean;
+}) => (
     <TestTranslationProvider messages={{}}>
-        <Translate i18nKey="custom.myKey">My Default Translation</Translate>
+        <Translate i18nKey="custom.myKey">
+            {isChildrenANode ? (
+                <div style={{ color: 'red' }}>
+                    <i>My Default Translation</i>
+                </div>
+            ) : (
+                'My Default Translation'
+            )}
+        </Translate>
     </TestTranslationProvider>
 );
+
+NoTranslationWithChildren.args = { isChildrenANode: false };
+NoTranslationWithChildren.argTypes = {
+    isChildrenANode: { control: 'boolean' },
+};
 
 export const Args = () => (
     <TestTranslationProvider

--- a/packages/ra-core/src/i18n/Translate.stories.tsx
+++ b/packages/ra-core/src/i18n/Translate.stories.tsx
@@ -36,6 +36,12 @@ export const NoTranslationWithEmpty = () => (
     </TestTranslationProvider>
 );
 
+export const NoTranslationWithEmptyAsFalse = () => (
+    <TestTranslationProvider messages={{}}>
+        <Translate i18nKey="custom.myKey" empty={false} />
+    </TestTranslationProvider>
+);
+
 export const Args = () => (
     <TestTranslationProvider
         messages={{

--- a/packages/ra-core/src/i18n/Translate.stories.tsx
+++ b/packages/ra-core/src/i18n/Translate.stories.tsx
@@ -53,15 +53,3 @@ export const Args = () => (
         <Translate i18nKey="custom.myKey" args={{ price: '6' }} />
     </TestTranslationProvider>
 );
-
-export const Component = () => (
-    <TestTranslationProvider
-        messages={{
-            custom: {
-                myKey: 'My Translated Key',
-            },
-        }}
-    >
-        <Translate i18nKey="custom.myKey" component="mark" />
-    </TestTranslationProvider>
-);

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -3,13 +3,10 @@ import { useTranslate } from './useTranslate';
 
 export const Translate = ({ i18nKey, args, children }: TranslateProps) => {
     const translate = useTranslate();
-    const translatedMessage = translate(i18nKey, args);
+    const translatedMessage = translate(i18nKey, { _: children, ...args });
 
     if (translatedMessage) {
         return <>{translatedMessage}</>;
-    }
-    if (children) {
-        return <>{children}</>;
     }
     return null;
 };

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -6,19 +6,18 @@ export const Translate = ({
     args,
     children,
     empty = 'no translation',
-    component = 'span',
 }: TranslateProps) => {
     const translate = useTranslate();
     const translatedMessage = translate(i18nKey, args);
 
     if (translatedMessage && translatedMessage !== i18nKey) {
-        return React.createElement(component, {}, translatedMessage);
+        return <>{translatedMessage}</>;
     }
     if (children) {
-        return React.createElement(component, {}, children);
+        return <>{children}</>;
     }
     if (empty) {
-        return React.createElement(component, {}, empty);
+        return <>{empty}</>;
     }
     return null;
 };
@@ -26,7 +25,6 @@ export const Translate = ({
 export interface TranslateProps {
     i18nKey: string;
     children?: string;
-    component?: React.ElementType;
     empty?: string | false;
     args?: Object;
 }

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { useTranslate } from './useTranslate';
 
-// story: test with i18next
-// story: test with polyglot
-
 export const Translate = ({
     i18nKey,
     args,
@@ -21,15 +18,15 @@ export const Translate = ({
         return React.createElement(component, {}, children);
     }
     if (empty) {
-        return <span>{empty}</span>;
+        return React.createElement(component, {}, empty);
     }
     return null;
 };
 
 export interface TranslateProps {
     i18nKey: string;
-    component?: React.ElementType;
     children?: string;
+    component?: React.ElementType;
     empty?: string | false;
-    args?: { [key: string]: string };
+    args?: Object;
 }

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -11,10 +11,7 @@ export const Translate = ({ i18nKey, args, children }: TranslateProps) => {
     if (translatedMessage) {
         return <>{translatedMessage}</>;
     }
-    if (children) {
-        return <>{children}</>;
-    }
-    return null;
+    return children;
 };
 
 export interface TranslateProps {

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -4,8 +4,7 @@ import { useTranslate } from './useTranslate';
 export const Translate = ({
     i18nKey,
     args,
-    children,
-    empty = 'no translation',
+    children = 'no translation',
 }: TranslateProps) => {
     const translate = useTranslate();
     const translatedMessage = translate(i18nKey, args);
@@ -13,18 +12,11 @@ export const Translate = ({
     if (translatedMessage && translatedMessage !== i18nKey) {
         return <>{translatedMessage}</>;
     }
-    if (children) {
-        return <>{children}</>;
-    }
-    if (empty) {
-        return <>{empty}</>;
-    }
-    return null;
+    return <>{children}</>;
 };
 
 export interface TranslateProps {
     i18nKey: string;
     children?: string;
-    empty?: string | false;
     args?: Object;
 }

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useTranslate } from './useTranslate';
+
+// story: test with i18next
+// story: test with polyglot
+
+export const Translate = ({
+    i18nKey,
+    args,
+    children,
+    empty = 'no translation',
+    component = 'span',
+}: TranslateProps) => {
+    const translate = useTranslate();
+    const translatedMessage = translate(i18nKey, args);
+
+    if (translatedMessage && translatedMessage !== i18nKey) {
+        return React.createElement(component, {}, translatedMessage);
+    }
+    if (children) {
+        return React.createElement(component, {}, children);
+    }
+    if (empty) {
+        return <span>{empty}</span>;
+    }
+    return null;
+};
+
+export interface TranslateProps {
+    i18nKey: string;
+    component?: React.ElementType;
+    children?: string;
+    empty?: string | false;
+    args?: { [key: string]: string };
+}

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -1,18 +1,24 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useTranslate } from './useTranslate';
 
 export const Translate = ({ i18nKey, args, children }: TranslateProps) => {
     const translate = useTranslate();
-    const translatedMessage = translate(i18nKey, { _: children, ...args });
+    const translatedMessage = translate(
+        i18nKey,
+        typeof children === 'string' ? { _: children, ...args } : args
+    );
 
     if (translatedMessage) {
         return <>{translatedMessage}</>;
+    }
+    if (children) {
+        return <>{children}</>;
     }
     return null;
 };
 
 export interface TranslateProps {
     i18nKey: string;
-    children?: string;
+    children?: ReactNode;
     args?: Object;
 }

--- a/packages/ra-core/src/i18n/Translate.tsx
+++ b/packages/ra-core/src/i18n/Translate.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { useTranslate } from './useTranslate';
 
-export const Translate = ({
-    i18nKey,
-    args,
-    children = 'no translation',
-}: TranslateProps) => {
+export const Translate = ({ i18nKey, args, children }: TranslateProps) => {
     const translate = useTranslate();
     const translatedMessage = translate(i18nKey, args);
 
-    if (translatedMessage && translatedMessage !== i18nKey) {
+    if (translatedMessage) {
         return <>{translatedMessage}</>;
     }
-    return <>{children}</>;
+    if (children) {
+        return <>{children}</>;
+    }
+    return null;
 };
 
 export interface TranslateProps {

--- a/packages/ra-core/src/i18n/index.ts
+++ b/packages/ra-core/src/i18n/index.ts
@@ -4,6 +4,7 @@ export * from './substituteTokens';
 export * from './TestTranslationProvider';
 export * from './I18nContext';
 export * from './I18nContextProvider';
+export * from './Translate';
 export * from './TranslationMessages';
 export * from './TranslatableContext';
 export * from './TranslatableContextProvider';

--- a/packages/ra-core/src/i18n/useTranslate.ts
+++ b/packages/ra-core/src/i18n/useTranslate.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { Translate } from '../types';
+import { TranslateFunction } from '../types';
 import { useI18nProvider } from './useI18nProvider';
 
 /**
@@ -22,7 +22,7 @@ import { useI18nProvider } from './useI18nProvider';
  *     return <MenuItem>{translate('settings')}</MenuItem>;
  * }
  */
-export const useTranslate = (): Translate => {
+export const useTranslate = (): TranslateFunction => {
     const i18nProvider = useI18nProvider();
     const translate = useCallback(
         (key: string, options?: any) =>

--- a/packages/ra-core/src/types.ts
+++ b/packages/ra-core/src/types.ts
@@ -33,7 +33,7 @@ export type ValidUntil = Date;
 export const I18N_TRANSLATE = 'I18N_TRANSLATE';
 export const I18N_CHANGE_LOCALE = 'I18N_CHANGE_LOCALE';
 
-export type Translate = (key: string, options?: any) => string;
+export type TranslateFunction = (key: string, options?: any) => string;
 
 export type Locale = {
     locale: string;
@@ -41,7 +41,7 @@ export type Locale = {
 };
 
 export type I18nProvider = {
-    translate: Translate;
+    translate: TranslateFunction;
     changeLocale: (locale: string, options?: any) => Promise<void>;
     getLocale: () => string;
     getLocales?: () => Locale[];

--- a/packages/ra-i18n-i18next/README.md
+++ b/packages/ra-i18n-i18next/README.md
@@ -3,13 +3,14 @@
 [i18next](https://www.i18next.com/) adapter for [react-admin](https://github.com/marmelab/react-admin), the frontend framework for building admin applications on top of REST/GraphQL services.
 
 You might prefer this package over `ra-i18n-polyglot` when:
+
 - you already use i18next services such as [locize](https://locize.com/)
 - you want more control on how you organize translations, leveraging [multiple files and namespaces](https://www.i18next.com/principles/namespaces)
 - you want more control on how you [load translations](https://www.i18next.com/how-to/add-or-load-translations)
 - you want to use features not available in Polyglot such as:
-    - [advanced formatting](https://www.i18next.com/translation-function/formatting);
-    - [nested translations](https://www.i18next.com/translation-function/nesting)
-    - [context](https://www.i18next.com/translation-function/context)
+  - [advanced formatting](https://www.i18next.com/translation-function/formatting);
+  - [nested translations](https://www.i18next.com/translation-function/nesting)
+  - [context](https://www.i18next.com/translation-function/context)
 
 ## Installation
 
@@ -21,14 +22,14 @@ npm install --save ra-i18n-i18next
 
 ```tsx
 import { Admin } from 'react-admin';
-import { useI18nextProvider, convertRaMessagesToI18next } from 'ra-i18n-i18next';
+import { useI18nextProvider, convertRaTranslationsToI18next } from 'ra-i18n-i18next';
 import englishMessages from 'ra-language-english';
 
 const App = () => {
     const i18nProvider = useI18nextProvider({
         options: {
             resources: {
-                translations: convertRaMessagesToI18next(englishMessages)
+                translation: convertRaTranslationsToI18next(englishMessages)
             }
         }
     });
@@ -54,14 +55,14 @@ You can provide your own i18next instance but don't initialize it, the hook will
 
 ```tsx
 import { Admin } from 'react-admin';
-import { useI18nextProvider, convertRaMessagesToI18next } from 'ra-i18n-i18next';
+import { useI18nextProvider, convertRaTranslationsToI18next } from 'ra-i18n-i18next';
 import englishMessages from 'ra-language-english';
 
 const App = () => {
     const i18nProvider = useI18nextProvider({
         options: {
             resources: {
-                translations: convertRaMessagesToI18next(englishMessages)
+                translation: convertRaTranslationsToI18next(englishMessages)
             }
         }
     });
@@ -190,10 +191,11 @@ const App = () => {
 };
 ```
 
-### `convertRaMessagesToI18next` function
+### `convertRaTranslationsToI18next` function
 
 A function that takes translations from a standard react-admin language package and converts them to i18next format.
 It transforms the following:
+
 - interpolations wrappers from `%{foo}` to `{{foo}}` unless a prefix and/or a suffix are provided
 - pluralization messages from a single key containing text like `"key": "foo |||| bar"` to multiple keys `"foo_one": "foo"` and `"foo_other": "bar"`
 
@@ -201,9 +203,9 @@ It transforms the following:
 
 ```ts
 import englishMessages from 'ra-language-english';
-import { convertRaMessagesToI18next } from 'ra-i18n-18next';
+import { convertRaTranslationsToI18next } from 'ra-i18n-18next';
 
-const messages = convertRaMessagesToI18next(englishMessages);
+const messages = convertRaTranslationsToI18next(englishMessages);
 ```
 
 #### Parameters
@@ -219,9 +221,9 @@ If you provided interpolation options to your i18next instance, you should provi
 
 ```ts
 import englishMessages from 'ra-language-english';
-import { convertRaMessagesToI18next } from 'ra-i18n-18next';
+import { convertRaTranslationsToI18next } from 'ra-i18n-18next';
 
-const messages = convertRaMessagesToI18next(englishMessages, {
+const messages = convertRaTranslationsToI18next(englishMessages, {
    prefix: '#{',
   suffix: '}#',
 });

--- a/packages/ra-i18n-i18next/src/index.spec.tsx
+++ b/packages/ra-i18n-i18next/src/index.spec.tsx
@@ -75,7 +75,7 @@ describe('i18next i18nProvider', () => {
         const { container } = render(<TranslateComponent />);
         await waitFor(() => {
             expect(container.innerHTML).toEqual(
-                '<span>My Translated Key</span><br /><span>It cost 6.00 $</span>'
+                '<span>My Translated Key</span><br><span>Dashboard</span><br><span>Hello, world!</span>'
             );
         });
     });

--- a/packages/ra-i18n-i18next/src/index.spec.tsx
+++ b/packages/ra-i18n-i18next/src/index.spec.tsx
@@ -75,7 +75,7 @@ describe('i18next i18nProvider', () => {
         const { container } = render(<TranslateComponent />);
         await waitFor(() => {
             expect(container.innerHTML).toEqual(
-                'My Translated Key<br>Dashboard<br>Hello, world!'
+                'My Translated Key<br>Dashboard<br>Hello, world!<br>2 beers'
             );
         });
     });

--- a/packages/ra-i18n-i18next/src/index.spec.tsx
+++ b/packages/ra-i18n-i18next/src/index.spec.tsx
@@ -75,7 +75,7 @@ describe('i18next i18nProvider', () => {
         const { container } = render(<TranslateComponent />);
         await waitFor(() => {
             expect(container.innerHTML).toEqual(
-                '<span>My Translated Key</span><br><span>Dashboard</span><br><span>Hello, world!</span>'
+                'My Translated Key<br>Dashboard<br>Hello, world!'
             );
         });
     });

--- a/packages/ra-i18n-i18next/src/index.spec.tsx
+++ b/packages/ra-i18n-i18next/src/index.spec.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
     Basic,
     WithCustomTranslations,
     WithCustomOptions,
     WithLazyLoadedLanguages,
+    TranslateComponent,
 } from './index.stories';
 
 describe('i18next i18nProvider', () => {
@@ -68,5 +69,14 @@ describe('i18next i18nProvider', () => {
         fireEvent.click(await screen.findByText('Lorem Ipsum'));
         // Check singularization
         await screen.findByText('Post Lorem Ipsum');
+    });
+
+    test('should be compatible with the <Translate> component', async () => {
+        const { container } = render(<TranslateComponent />);
+        await waitFor(() => {
+            expect(container.innerHTML).toEqual(
+                '<span>My Translated Key</span><br /><span>It cost 6.00 $</span>'
+            );
+        });
     });
 });

--- a/packages/ra-i18n-i18next/src/index.stories.tsx
+++ b/packages/ra-i18n-i18next/src/index.stories.tsx
@@ -11,7 +11,7 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import englishMessages from 'ra-language-english';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { Translate, I18nContextProvider } from 'ra-core';
-import { useI18nextProvider, convertRaTranslationsToI18next } from '..';
+import { useI18nextProvider, convertRaTranslationsToI18next } from './index';
 
 export default {
     title: 'ra-i18n-i18next',

--- a/packages/ra-i18n-i18next/src/index.stories.tsx
+++ b/packages/ra-i18n-i18next/src/index.stories.tsx
@@ -182,7 +182,8 @@ export const TranslateComponent = () => {
                         ...englishMessages,
                         custom: {
                             myKey: 'My Translated Key',
-                            myKeyWithArgs: 'Hello, %{myWorld}!',
+                            helloWorld: 'Hello, %{myWorld}!',
+                            countBeer: 'One beer |||| %{smart_count} beers',
                         },
                     }),
                 },
@@ -199,9 +200,11 @@ export const TranslateComponent = () => {
             <Translate i18nKey="ra.page.dashboard" />
             <br />
             <Translate
-                i18nKey="custom.myKeyWithArgs"
+                i18nKey="custom.helloWorld"
                 args={{ myWorld: 'world' }}
             />
+            <br />
+            <Translate i18nKey="custom.countBeer" args={{ smart_count: 2 }} />
         </I18nContextProvider>
     );
 };

--- a/packages/ra-i18n-i18next/src/index.stories.tsx
+++ b/packages/ra-i18n-i18next/src/index.stories.tsx
@@ -10,10 +10,7 @@ import i18n from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import englishMessages from 'ra-language-english';
 import fakeRestDataProvider from 'ra-data-fakerest';
-// TODO: fix this import
-import { Translate } from '../../ra-core/src/i18n/Translate';
-// import { Translate } from 'ra-core';
-import { I18nContextProvider } from 'ra-core';
+import { Translate, I18nContextProvider } from 'ra-core';
 import {
     useI18nextProvider,
     // convertRaMessagesToI18next,

--- a/packages/ra-i18n-i18next/src/index.stories.tsx
+++ b/packages/ra-i18n-i18next/src/index.stories.tsx
@@ -11,11 +11,7 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import englishMessages from 'ra-language-english';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { Translate, I18nContextProvider } from 'ra-core';
-import {
-    useI18nextProvider,
-    // convertRaMessagesToI18next,
-    convertRaTranslationsToI18next,
-} from '..';
+import { useI18nextProvider, convertRaTranslationsToI18next } from '..';
 
 export default {
     title: 'ra-i18n-i18next',
@@ -182,7 +178,7 @@ export const TranslateComponent = () => {
         options: {
             resources: {
                 en: {
-                    translations: convertRaTranslationsToI18next({
+                    translation: convertRaTranslationsToI18next({
                         ...englishMessages,
                         custom: {
                             myKey: 'My Translated Key',

--- a/packages/ra-i18n-i18next/src/index.stories.tsx
+++ b/packages/ra-i18n-i18next/src/index.stories.tsx
@@ -182,7 +182,7 @@ export const TranslateComponent = () => {
                         ...englishMessages,
                         custom: {
                             myKey: 'My Translated Key',
-                            myKeyWithArgs: 'It cost %{price}.00 $',
+                            myKeyWithArgs: 'Hello, %{myWorld}!',
                         },
                     }),
                 },
@@ -196,9 +196,12 @@ export const TranslateComponent = () => {
         <I18nContextProvider value={i18nProvider}>
             <Translate i18nKey="custom.myKey" />
             <br />
-            <Translate i18nKey="ra.action.add" />
+            <Translate i18nKey="ra.page.dashboard" />
             <br />
-            <Translate i18nKey="custom.myKeyWithArgs" args={{ price: '6' }} />
+            <Translate
+                i18nKey="custom.myKeyWithArgs"
+                args={{ myWorld: 'world' }}
+            />
         </I18nContextProvider>
     );
 };

--- a/packages/ra-i18n-i18next/src/index.stories.tsx
+++ b/packages/ra-i18n-i18next/src/index.stories.tsx
@@ -10,8 +10,15 @@ import i18n from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import englishMessages from 'ra-language-english';
 import fakeRestDataProvider from 'ra-data-fakerest';
-import { useI18nextProvider } from './index';
-import { convertRaTranslationsToI18next } from './convertRaTranslationsToI18next';
+// TODO: fix this import
+import { Translate } from '../../ra-core/src/i18n/Translate';
+// import { Translate } from 'ra-core';
+import { I18nContextProvider } from 'ra-core';
+import {
+    useI18nextProvider,
+    // convertRaMessagesToI18next,
+    convertRaTranslationsToI18next,
+} from '..';
 
 export default {
     title: 'ra-i18n-i18next',
@@ -170,6 +177,36 @@ export const WithCustomOptions = () => {
                 />
             </Admin>
         </TestMemoryRouter>
+    );
+};
+
+export const TranslateComponent = () => {
+    const i18nProvider = useI18nextProvider({
+        options: {
+            resources: {
+                en: {
+                    translations: convertRaTranslationsToI18next({
+                        ...englishMessages,
+                        custom: {
+                            myKey: 'My Translated Key',
+                            myKeyWithArgs: 'It cost %{price}.00 $',
+                        },
+                    }),
+                },
+            },
+        },
+    });
+
+    if (!i18nProvider) return null;
+
+    return (
+        <I18nContextProvider value={i18nProvider}>
+            <Translate i18nKey="custom.myKey" />
+            <br />
+            <Translate i18nKey="ra.action.add" />
+            <br />
+            <Translate i18nKey="custom.myKeyWithArgs" args={{ price: '6' }} />
+        </I18nContextProvider>
     );
 };
 

--- a/packages/ra-i18n-polyglot/src/index.spec.tsx
+++ b/packages/ra-i18n-polyglot/src/index.spec.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { TranslateComponent } from './index.stories';
+
+describe('i18next i18nProvider', () => {
+    test('should be compatible with the <Translate> component', async () => {
+        const { container } = render(<TranslateComponent />);
+        await waitFor(() => {
+            expect(container.innerHTML).toEqual(
+                '<span>My Translated Key</span><br><span>It cost 6.00 $</span>'
+            );
+        });
+    });
+});

--- a/packages/ra-i18n-polyglot/src/index.spec.tsx
+++ b/packages/ra-i18n-polyglot/src/index.spec.tsx
@@ -7,7 +7,7 @@ describe('i18next i18nProvider', () => {
         const { container } = render(<TranslateComponent />);
         await waitFor(() => {
             expect(container.innerHTML).toEqual(
-                '<span>My Translated Key</span><br><span>It cost 6.00 $</span>'
+                '<span>My Translated Key</span><br><span>Dashboard</span><br><span>Hello, world!</span>'
             );
         });
     });

--- a/packages/ra-i18n-polyglot/src/index.spec.tsx
+++ b/packages/ra-i18n-polyglot/src/index.spec.tsx
@@ -7,7 +7,7 @@ describe('i18next i18nProvider', () => {
         const { container } = render(<TranslateComponent />);
         await waitFor(() => {
             expect(container.innerHTML).toEqual(
-                '<span>My Translated Key</span><br><span>Dashboard</span><br><span>Hello, world!</span>'
+                '<span>My Translated Key</span><br><span>Dashboard</span><br><span>Hello, world!</span><br><span>2 beers</span>'
             );
         });
     });

--- a/packages/ra-i18n-polyglot/src/index.spec.tsx
+++ b/packages/ra-i18n-polyglot/src/index.spec.tsx
@@ -7,7 +7,7 @@ describe('i18next i18nProvider', () => {
         const { container } = render(<TranslateComponent />);
         await waitFor(() => {
             expect(container.innerHTML).toEqual(
-                '<span>My Translated Key</span><br><span>Dashboard</span><br><span>Hello, world!</span><br><span>2 beers</span>'
+                'My Translated Key<br>Dashboard<br>Hello, world!<br>2 beers'
             );
         });
     });

--- a/packages/ra-i18n-polyglot/src/index.stories.tsx
+++ b/packages/ra-i18n-polyglot/src/index.stories.tsx
@@ -56,6 +56,7 @@ export const TranslateComponent = () => {
         custom: {
             myKey: 'My Translated Key',
             myKeyWithArgs: 'Hello, %{myWorld}!',
+            countBeer: 'One beer |||| %{smart_count} beers',
         },
     };
     const messages = {
@@ -82,6 +83,8 @@ export const TranslateComponent = () => {
                 i18nKey="custom.myKeyWithArgs"
                 args={{ myWorld: 'world' }}
             />
+            <br />
+            <Translate i18nKey="custom.countBeer" args={{ smart_count: 2 }} />
         </I18nContextProvider>
     );
 };

--- a/packages/ra-i18n-polyglot/src/index.stories.tsx
+++ b/packages/ra-i18n-polyglot/src/index.stories.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import {
+    Admin,
+    EditGuesser,
+    ListGuesser,
+    Resource,
+    TestMemoryRouter,
+} from 'react-admin';
+import polyglotI18nProvider from '.';
+import englishMessages from 'ra-language-english';
+import frenchMessages from 'ra-language-french';
+import fakeRestDataProvider from 'ra-data-fakerest';
+// TODO: fix this import
+import { Translate } from '../../ra-core/src/i18n/Translate';
+// import { Translate } from 'ra-core';
+import { I18nContextProvider } from 'ra-core';
+
+export default {
+    title: 'ra-i18n-polyglot',
+};
+
+export const Basic = () => {
+    const messages = {
+        fr: frenchMessages,
+        en: englishMessages,
+    };
+
+    const i18nProvider = polyglotI18nProvider(
+        locale => messages[locale],
+        'en',
+        [
+            { locale: 'en', name: 'English' },
+            { locale: 'fr', name: 'Français' },
+        ]
+    );
+
+    return (
+        <TestMemoryRouter>
+            <Admin dataProvider={dataProvider} i18nProvider={i18nProvider}>
+                <Resource
+                    name="posts"
+                    list={<ListGuesser enableLog={false} />}
+                    edit={<EditGuesser enableLog={false} />}
+                />
+                <Resource
+                    name="comments"
+                    list={<ListGuesser enableLog={false} />}
+                    edit={<EditGuesser enableLog={false} />}
+                />
+            </Admin>
+        </TestMemoryRouter>
+    );
+};
+
+export const TranslateComponent = () => {
+    const customMessages = {
+        custom: {
+            myKey: 'My Translated Key',
+            myKeyWithArgs: 'It cost %{price}.00 $',
+        },
+    };
+    const messages = {
+        fr: { ...frenchMessages, ...customMessages },
+        en: { ...englishMessages, ...customMessages },
+    };
+
+    const i18nProvider = polyglotI18nProvider(
+        locale => messages[locale],
+        'en',
+        [
+            { locale: 'en', name: 'English' },
+            { locale: 'fr', name: 'Français' },
+        ]
+    );
+
+    return (
+        <I18nContextProvider value={i18nProvider}>
+            <Translate i18nKey="custom.myKey" />
+            <br />
+            <Translate i18nKey="custom.myKeyWithArgs" args={{ price: '6' }} />
+        </I18nContextProvider>
+    );
+};
+
+const dataProvider = fakeRestDataProvider({
+    posts: [{ id: 1, title: 'Lorem Ipsum' }],
+    comments: [{ id: 1, body: 'Sic dolor amet...' }],
+});

--- a/packages/ra-i18n-polyglot/src/index.stories.tsx
+++ b/packages/ra-i18n-polyglot/src/index.stories.tsx
@@ -55,7 +55,7 @@ export const TranslateComponent = () => {
     const customMessages = {
         custom: {
             myKey: 'My Translated Key',
-            myKeyWithArgs: 'Hello, %{myWorld}!',
+            helloWorld: 'Hello, %{myWorld}!',
             countBeer: 'One beer |||| %{smart_count} beers',
         },
     };
@@ -80,7 +80,7 @@ export const TranslateComponent = () => {
             <Translate i18nKey="ra.page.dashboard" />
             <br />
             <Translate
-                i18nKey="custom.myKeyWithArgs"
+                i18nKey="custom.helloWorld"
                 args={{ myWorld: 'world' }}
             />
             <br />

--- a/packages/ra-i18n-polyglot/src/index.stories.tsx
+++ b/packages/ra-i18n-polyglot/src/index.stories.tsx
@@ -53,7 +53,7 @@ export const TranslateComponent = () => {
     const customMessages = {
         custom: {
             myKey: 'My Translated Key',
-            myKeyWithArgs: 'It cost %{price}.00 $',
+            myKeyWithArgs: 'Hello, %{myWorld}!',
         },
     };
     const messages = {
@@ -74,7 +74,12 @@ export const TranslateComponent = () => {
         <I18nContextProvider value={i18nProvider}>
             <Translate i18nKey="custom.myKey" />
             <br />
-            <Translate i18nKey="custom.myKeyWithArgs" args={{ price: '6' }} />
+            <Translate i18nKey="ra.page.dashboard" />
+            <br />
+            <Translate
+                i18nKey="custom.myKeyWithArgs"
+                args={{ myWorld: 'world' }}
+            />
         </I18nContextProvider>
     );
 };

--- a/packages/ra-i18n-polyglot/src/index.stories.tsx
+++ b/packages/ra-i18n-polyglot/src/index.stories.tsx
@@ -10,10 +10,7 @@ import polyglotI18nProvider from '.';
 import englishMessages from 'ra-language-english';
 import frenchMessages from 'ra-language-french';
 import fakeRestDataProvider from 'ra-data-fakerest';
-// TODO: fix this import
-import { Translate } from '../../ra-core/src/i18n/Translate';
-// import { Translate } from 'ra-core';
-import { I18nContextProvider } from 'ra-core';
+import { Translate, I18nContextProvider } from 'ra-core';
 
 export default {
     title: 'ra-i18n-polyglot',


### PR DESCRIPTION
## BC

The `Translate` type exported by `ra-core` was renamed `TranslateFunction`

## Problem

To output text, developers must use the `useTranslate` hook. It can be cumbersome.

## To Be Defined

A. args:

1.  `<Translate i18nKey="my-key" smart_count="18" />`
2.  `<Translate i18nKey="my-key" args={{smart_count:"18"}} />`

B. New name, we already have a type named `Translate`

## Solution

A new `ra-core` component to translate text.
```
<Translate i18nKey="ra.action.delete">Delete</Translate>
```
The default value is the child. The component should also accept translation options.
Test with interpolation, with `i18next` and `polyglot`.

## How To Test

https://react-admin-storybook-a85l2rp3y-marmelab.vercel.app/?path=/story/ra-core-i18n-translate
https://react-admin-storybook-a85l2rp3y-marmelab.vercel.app/?path=/story/ra-i18n-polyglot--translate-component
https://react-admin-storybook-a85l2rp3y-marmelab.vercel.app/?path=/story/ra-i18n-i18next--translate-component

## Additional Checks

- [x] The PR targets `master` for a bugfix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date