### PR TITLE
[chore] Fix incorrect description for build-crm in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run-graphql-demo: ## run the ecommerce example with a graphql backend
 run-crm: ## run the crm example
 	@yarn run-crm
 
-build-crm: ## run the crm example
+build-crm: ## build the crm example
 	@yarn build-crm
 
 build-ra-core:


### PR DESCRIPTION
- Updated the description for `build-crm` in Makefile.
- Previously labeled as "run the crm example", but it actually builds the example.
- Now correctly labeled as "build the crm example".