### PR TITLE
Fix SimpleFormIterator does not display some components correctly

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -287,7 +287,9 @@ const Root = styled('div', {
         marginTop: theme.spacing(1),
         [theme.breakpoints.down('md')]: { display: 'none' },
     },
-    [`& .${SimpleFormIteratorClasses.form}`]: {},
+    [`& .${SimpleFormIteratorClasses.form}`]: {
+        minWidth: 0,
+    },
     [`&.fullwidth > ul > li > .${SimpleFormIteratorClasses.form}`]: {
         flex: 2,
     },


### PR DESCRIPTION
## Problem

When you add some inputs such as the `MarkdownInput` from `ra-enterprise`, they may overflow horizontally.

## Solution

Add a `min-width: 0` to the inputs containers to ensure they adapt to their children size. 
See https://www.bigbinary.com/blog/understanding-the-automatic-minimum-size-of-flex-items#the-solutions

## How To Test

I can't reproduce this issue with any other inputs than `MarkdownInput` but I tested this solution in the enterprise storybook. It does not have any other side effects.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
