### PR TITLE
Add generic type in datagrid

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -117,9 +117,16 @@ const defaultBulkActionButtons = <BulkDeleteButton />;
  *     );
  * }
  */
-export const Datagrid: React.ForwardRefExoticComponent<
-    Omit<DatagridProps, 'ref'> & React.RefAttributes<HTMLTableElement>
-> = React.forwardRef<HTMLTableElement, DatagridProps>((props, ref) => {
+
+const fixedForwardRef = <T, P = {}>(
+    render: (props: P, ref: React.Ref<T>) => React.ReactNode
+): ((props: P & React.RefAttributes<T>) => React.ReactNode) =>
+    React.forwardRef(render) as any;
+
+const WDatagrid = <RecordType extends RaRecord = any>(
+    props: DatagridProps<RecordType>,
+    ref
+) => {
     const resourceFromContext = useResourceContext(props);
     const { canAccess: canDelete } = useCanAccess({
         resource: resourceFromContext,
@@ -299,7 +306,9 @@ export const Datagrid: React.ForwardRefExoticComponent<
             </OptionalResourceContextProvider>
         </DatagridContextProvider>
     );
-});
+};
+
+export const Datagrid = fixedForwardRef(WDatagrid);
 
 const createOrCloneElement = (element, props, children) =>
     isValidElement(element)
@@ -524,7 +533,7 @@ export interface DatagridProps<RecordType extends RaRecord = any>
      *     </List>
      * );
      */
-    rowClick?: string | RowClickFunction | false;
+    rowClick?: string | RowClickFunction<RecordType> | false;
 
     /**
      * A function that returns the sx prop to apply to a row.
@@ -599,6 +608,6 @@ const sanitizeRestProps = props =>
         )
         .reduce((acc, key) => ({ ...acc, [key]: props[key] }), {});
 
-Datagrid.displayName = 'Datagrid';
+WDatagrid.displayName = 'Datagrid';
 
 const DefaultEmpty = <ListNoResults />;

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridLoading.tsx
@@ -15,6 +15,7 @@ import { useTimeout, Identifier, RaRecord } from 'ra-core';
 
 import { DatagridClasses } from './useDatagridStyles';
 import { Placeholder } from '../Placeholder';
+import { DatagridProps } from './Datagrid';
 
 const times = (nbChildren, fn) =>
     Array.from({ length: nbChildren }, (_, key) => fn(key));
@@ -117,13 +118,7 @@ const DatagridLoading = ({
 
 export interface DatagridLoadingProps {
     className?: string;
-    expand?:
-        | ReactElement
-        | FC<{
-              id: Identifier;
-              record: RaRecord;
-              resource: string;
-          }>;
+    expand?: DatagridProps['expand'];
     hasBulkActions?: boolean;
     nbChildren: number;
     nbFakeLines?: number;

--- a/packages/ra-ui-materialui/src/list/types.ts
+++ b/packages/ra-ui-materialui/src/list/types.ts
@@ -1,6 +1,6 @@
 import { Identifier, RaRecord } from 'ra-core';
 
-export type RowClickFunction = <RecordType extends RaRecord = RaRecord>(
+export type RowClickFunction<RecordType extends RaRecord = RaRecord> = (
     id: Identifier,
     resource: string,
     record: RecordType


### PR DESCRIPTION
## Problem
Closes #10595

_Describe the problem this PR solves_

## Solution
Since the datagrid is a React.forwardRef type component, I can't create a generic one easily, so I need help to solve and bring the best solution to this challenge.

I used the article below as a basis to solve the problem
https://www.totaltypescript.com/forwardref-with-generic-components

Variable names are for illustration purposes only, they can be better planned if the solution is to your liking.
_Describe the solution this PR implements_

## How To Test

In the datagrid component itself, you can create a test component passing a generic and seeing if this generic is going to the rowClick

At first I focused only on rowClick, which is my main problem today, if you need other places we can add it

_Describe the steps required to test the changes_

![image](https://github.com/user-attachments/assets/73f96abb-bf15-44c7-a193-490c185c2fe8)
```tsx
const Test = () => {
    return (
        <Datagrid<{ id: string; name: string }>
            rowClick={(id, resource, record) =>
                console.log({ id, resource, record })
            }   
        >
            <div></div>
        </Datagrid>
    );
};
```

## Additional Checks

- [ ] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
