### PR TITLE
[Doc] Add a FAQ entry for duplicate react-hook-form versions

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,10 +6,11 @@ title: "FAQ"
 # FAQ
 
 - [Can I have custom identifiers/primary keys for my resources?](#can-i-have-custom-identifiersprimary-keys-for-my-resources)
-- [I get warning about unique key for child in array](#i-get-warning-about-unique-key-for-child-in-array)
+- [I get warning about unique key for child in array](#i-get-a-warning-about-unique-key-for-child-in-array)
 - [How can I customize forms depending on its inputs values?](#how-can-i-customize-forms-depending-on-its-inputs-values)
 - [UI in production build is empty or broken](#ui-in-production-build-is-empty-or-broken)
 - [My Resource is defined but not displayed on the Menu](#my-resource-is-defined-but-not-displayed-on-the-menu)
+- [I get an error about control being null](#i-get-an-error-about-control-being-null)
 
 ## Can I have custom identifiers/primary keys for my resources?
 
@@ -118,7 +119,7 @@ const dataProvider = {
 };
 ```
 
-## I get warning about unique key for child in array
+## I get a warning about unique key for child in array
 
 When displaying a `Datagrid` component, you get the following warning:
 
@@ -166,4 +167,28 @@ export const MyMenu = () => (
         <Menu.Item to="/reference/create" primaryText="New Reference" />
     </Menu>
 );
+```
+
+## I get an error about control being null
+
+In a view that contains a form, you may get the following error:
+
+> Cannot read properties of null (reading 'control')
+
+This is most probably because you have multiple versions of the `react-hook-form` package installed, one being a direct dependency in your project and the other brought by react-admin.
+
+First, you can run `npm list react-hook-form` to check if you have duplicate versions.
+
+To dedupe the package you can run `npm dedupe react-hook-form` or `yarn dedupe react-hook-form`.
+
+You may also edit the lockfile manually.
+
+Finally, you can use yarn’s [resolutions](https://yarnpkg.com/configuration/manifest#resolutions) or npm’s [overrides](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides) in your `package.json` file:
+
+```json
+{
+  "resolutions": {
+    "react-hook-form": "7.54.2"
+  }
+}
 ```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,6 +11,7 @@ title: "FAQ"
 - [UI in production build is empty or broken](#ui-in-production-build-is-empty-or-broken)
 - [My Resource is defined but not displayed on the Menu](#my-resource-is-defined-but-not-displayed-on-the-menu)
 - [I get an error about control being null](#i-get-an-error-about-control-being-null)
+- [I get an error about a hook that may be used only in the context of a Router component](#i-get-an-error-about-a-hook-that-may-be-used-only-in-the-context-of-a-router-component)
 
 ## Can I have custom identifiers/primary keys for my resources?
 
@@ -192,3 +193,44 @@ Finally, you can use yarn’s [resolutions](https://yarnpkg.com/configuration/ma
   }
 }
 ```
+
+## I get an error about a hook that may be used only in the context of a Router component
+
+When using custom routing configurations, you may encounter strange error messages like:
+
+> `useLocation()` may be used only in the context of a `<Router>` component
+
+or
+
+> `useNavigate()` may be used only in the context of a `<Router>` component
+
+or 
+
+> `useRoutes()` may be used only in the context of a `<Router>` component
+
+or 
+
+> `useHref()` may be used only in the context of a `<Router>` component.
+
+or
+
+> `<Route>` may be used only in the context of a `<Router>` component
+
+These errors can happen if you added `react-router` and/or `react-router-dom` to your dependencies, and didn't use the same version as react-admin. In that case, your application has two versions of react-router, and the calls you add can't see the react-admin routing context.
+
+You can use the `npm list react-router` and `npm list react-router-dom` commands to check which versions are installed.
+
+If there are duplicates, you need to make sure to use only the same version as react-admin. You can deduplicate them using yarn's [resolutions](https://yarnpkg.com/configuration/manifest#resolutions) or npm’s [overrides](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides).
+
+```js
+// in packages.json
+{
+    // ...
+  "resolutions": {
+    "react-router-dom": "6.7.0",
+    "react-router": "6.7.0"
+  }
+}
+```
+
+This may also happen inside a [Remix](https://remix.run/) application. See [Setting up react-admin for Remix](./Remix.md#setting-up-react-admin-in-remix) for instructions to overcome that problem.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ title: "FAQ"
 # FAQ
 
 - [Can I have custom identifiers/primary keys for my resources?](#can-i-have-custom-identifiersprimary-keys-for-my-resources)
-- [I get warning about unique key for child in array](#i-get-a-warning-about-unique-key-for-child-in-array)
+- [I get a warning about unique key for child in array](#i-get-a-warning-about-unique-key-for-child-in-array)
 - [How can I customize forms depending on its inputs values?](#how-can-i-customize-forms-depending-on-its-inputs-values)
 - [UI in production build is empty or broken](#ui-in-production-build-is-empty-or-broken)
 - [My Resource is defined but not displayed on the Menu](#my-resource-is-defined-but-not-displayed-on-the-menu)


### PR DESCRIPTION
## Problem

Users are still regularily getting errors because of duplicate version of react-hook-form or react-router.

Example: https://stackoverflow.com/q/79464423/3975522

## Solution

Create an entry in the [FAQ](https://marmelab.com/react-admin/FAQ.html) for these issues.

## How To Test

- `make doc`
- http://0.0.0.0:4000/FAQ.html#i-get-an-error-about-control-being-null

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

