### PR TITLE
Fix `<EditGuesser>` produces invalid code for arrays of references

### DIFF
--- a/packages/ra-ui-materialui/src/detail/editFieldTypes.tsx
+++ b/packages/ra-ui-materialui/src/detail/editFieldTypes.tsx
@@ -74,7 +74,7 @@ ${children.map(child => `            ${child.getRepresentation()}`).join('\n')}
     referenceArray: {
         component: ReferenceArrayInput,
         representation: (props: ReferenceArrayInputProps) =>
-            `<ReferenceArrayInput source="${props.source}" reference="${props.reference}"><TextInput source="id" /></ReferenceArrayInput>`,
+            `<ReferenceArrayInput source="${props.source}" reference="${props.reference}" />`,
     },
     referenceArrayChild: {
         component: (


### PR DESCRIPTION
## Problem

The current guesser adds a `TextInput` as child of `ReferenceArrayInput`. This is wrong.

## Solution

Don't even try to add a children as `ReferenceArrayInput` already has a default one.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
