### PR TITLE
Fix `useGetOne` returns a never resolving Promise when `id` is `null`

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetOne.ts
+++ b/packages/ra-core/src/dataProvider/useGetOne.ts
@@ -71,7 +71,7 @@ export const useGetOne = <RecordType extends RaRecord = any, ErrorType = Error>(
         queryKey: [resource, 'getOne', { id: String(id), meta }],
         queryFn: queryParams =>
             id == null
-                ? new Promise(() => {})
+                ? Promise.reject('useGetOne: id cannot be null')
                 : dataProvider
                       .getOne<RecordType>(resource, {
                           id,


### PR DESCRIPTION
## Problem

Using `useGetOne` with a `null` (or `undefined`) `id`, and providing the `enabled` option (e.g. setting it to `false` to manually trigger the query with `refresh()`) will return a never resolving `Promise`, hence keeping the global query status loading forever.

## Solution

This `Promise` was added to solve a TS complaint when adding strict null checks ([original PR](https://github.com/marmelab/react-admin/pull/9971)). But as stated this Promise will never resolve.

Instead, we can replace this by a Promise that will reject instantly, saying `useGetOne` requires `id` to be defined.

## How To Test

```ts
const { refetch } = useGetOne("url", { id: null }, { enabled: false });
refetch();
```

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
