### PR TITLE
Fix release script does not update documentation completely

### DIFF
--- a/scripts/copy-ra-oss-docs.sh
+++ b/scripts/copy-ra-oss-docs.sh
@@ -14,10 +14,9 @@ cp ./docs/*.html ${RA_DOC_PATH}
 cp ./docs/_layouts/*.html ${RA_DOC_PATH}/_layouts
 cp ./docs/*.md ${RA_DOC_PATH}
 cp ./docs/img/* -r ${RA_DOC_PATH}/img
-cp ./docs/css/docsearch.css ${RA_DOC_PATH}/css
-cp ./docs/css/prism.css ${RA_DOC_PATH}/css
-cp ./docs/css/style-*.css ${RA_DOC_PATH}/css
-cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOC_PATH}/js
+cp ./docs/assets/* -r ${RA_DOC_PATH}/assets
+cp ./docs/css/* ${RA_DOC_PATH}/css
+cp ./docs/js/* ${RA_DOC_PATH}/js
 
 echo "Copying to the doc/${VERSION} folder..."
 mkdir -p ${RA_DOC_PATH}/doc/${VERSION}
@@ -28,10 +27,8 @@ cp ./docs/*.html ${RA_DOC_PATH}/doc/${VERSION}
 cp ./docs/*.md ${RA_DOC_PATH}/doc/${VERSION}
 rm ${RA_DOC_PATH}/doc/${VERSION}/404.html
 cp -r ./docs/img/* ${RA_DOC_PATH}/doc/${VERSION}/img
-cp ./docs/css/docsearch.css ${RA_DOC_PATH}/doc/${VERSION}/css
-cp ./docs/css/prism.css ${RA_DOC_PATH}/doc/${VERSION}/css
-cp ./docs/css/style-*.css ${RA_DOC_PATH}/doc/${VERSION}/css
-cp ./docs/js/materialize.min.js ./docs/js/prism.js ./docs/js/ra-doc-exec.js ${RA_DOC_PATH}/doc/${VERSION}/js
+cp ./docs/css/* ${RA_DOC_PATH}/doc/${VERSION}/css
+cp ./docs/js/* ${RA_DOC_PATH}/doc/${VERSION}/js
 
 echo "Done"
 


### PR DESCRIPTION
## Problem

The release script does not copy all assets

## Solution

Make it copy all assets

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature