### PR TITLE
[Doc] Fix tips loading in production

### DIFF
--- a/docs/js/ra-doc-exec.js
+++ b/docs/js/ra-doc-exec.js
@@ -10,8 +10,8 @@ export const showTip = async () => {
     if (!tipElement) return;
 
     const [tips, features] = await Promise.all([
-        getContents('/assets/tips.md'),
-        getContents('/assets/features.md'),
+        getContents('./assets/tips.md'),
+        getContents('./assets/features.md'),
     ]);
     const all = tips.concat(features);
 

--- a/docs/js/ra-navigation.js
+++ b/docs/js/ra-navigation.js
@@ -153,9 +153,6 @@ document.addEventListener('DOMContentLoaded', () => {
         'beginner-mode-trigger'
     );
 
-    if (window.location.pathname === '/documentation.html') {
-    }
-
     if (beginnerModeTrigger) {
         beginnerModeTrigger.addEventListener('click', () => {
             beginnerMode = !beginnerMode;
@@ -230,7 +227,7 @@ window.addEventListener('popstate', () => {
         return;
     }
 
-    if (window.location.pathname === '/documentation.html') {
+    if (window.location.pathname.includes('/documentation.html')) {
         fetch(window.location.pathname)
             .then(res => res.text())
             .then(replaceContent)
@@ -268,7 +265,7 @@ window.addEventListener('DOMContentLoaded', () => {
     navigationFitScroll();
     loadNewsletterScript();
 
-    if (window.location.pathname === '/documentation.html') {
+    if (window.location.pathname.includes('/documentation.html')) {
         import('./ra-doc-exec.js').then(docExecModule => {
             document.querySelector('.DocSearch-content').innerHTML = '';
             toggleDockBlocks(true);


### PR DESCRIPTION
## Problem

The tips don't load in production due to absolute paths.

## Solution

Fix the paths

## How To Test

- `make doc`: tips should still load
- check in production :scream: 

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature