### PR TITLE
[chore] Fix create-react-admin pnpm template

### DIFF
--- a/packages/create-react-admin/templates/pnpm/vite.config.ts
+++ b/packages/create-react-admin/templates/pnpm/vite.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from "vite";
-import path from "path";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
## Problem

The `vite.config.ts` file for pnpm has an unnecessary import.

## Solution

Remove it.
