### PR TITLE
Fix: allow booleanInput to be a controlled input

### DIFF
--- a/examples/crm/src/sales/SalesInputs.tsx
+++ b/examples/crm/src/sales/SalesInputs.tsx
@@ -37,6 +37,7 @@ export function SalesInputs() {
                 source="disabled"
                 readOnly={record?.id === identity?.id}
                 helperText={false}
+                value={true}
             />
         </Stack>
     );

--- a/packages/ra-ui-materialui/src/input/BooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/BooleanInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import clsx from 'clsx';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormHelperText from '@mui/material/FormHelperText';
@@ -31,6 +31,7 @@ export const BooleanInput = (props: BooleanInputProps) => {
         validate,
         options = defaultOptions,
         sx,
+        value: valueProp,
         ...rest
     } = props;
     const {
@@ -52,6 +53,12 @@ export const BooleanInput = (props: BooleanInputProps) => {
         readOnly,
         ...rest,
     });
+
+    useEffect(() => {
+        if (valueProp !== undefined && field.value !== valueProp) {
+            field.onChange(valueProp);
+        }
+    }, [valueProp, field]);
 
     const handleChange = useCallback(
         event => {
@@ -110,6 +117,7 @@ export type BooleanInputProps = CommonInputProps &
     Omit<SwitchProps, 'defaultValue'> &
     Omit<FormGroupProps, 'defaultValue' | 'onChange' | 'onBlur' | 'onFocus'> & {
         options?: SwitchProps;
+        value?: boolean;
     };
 
 const defaultOptions = {};


### PR DESCRIPTION
## Problem

Fixes issue #10629. The BooleanInput component did not properly support being controlled through the value prop, unlike other input components in React-Admin. This made it difficult to:

- Control filter inputs directly from props
- Handle mixed falsy values (null/false/'') in database records
- Create dynamic forms where BooleanInputs need to be programmatically controlled

## Solution

- Added support for the value prop in BooleanInput component
- Implemented an useEffect hook to synchronize the component's internal form state with the external value prop
- Added TypeScript type definition for the value prop
- Maintained backward compatibility with existing code
- The implementation is minimal and follows the same pattern used by other controlled components in React-Admin.

## How To Test

1. Run the CRM example with "make run-crm"
2.  Navigate to the Sales section(http://localhost:8000/#/sales) and edit any sales representative
3. Notice the "disabled" field is always checked regardless of the actual data value because it now has value={true}
4.  Try modifying the code:

-  Change value={true} to value={false} and verify the switch stays off
- Remove the value prop entirely and verify it behaves normally (reflecting the underlying data)

5. You can also test programmatically controlling the component by:

- Creating a state variable and connecting it to the value prop
- Toggling the state with a button outside the form

<img width="1139" alt="Screenshot 2025-04-02 at 06 43 55" src="https://github.com/user-attachments/assets/e4b2a102-037b-446d-8572-f924aafc791d" />

![Screenshot 2025-04-02 at 06 44 22](https://github.com/user-attachments/assets/d85a5d56-153e-4a8b-a2d6-7c061f09133a)


## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (the existing tests are sufficient)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
