### PR TITLE
Introduce `<AuthLayout>`

### DIFF
--- a/packages/ra-ui-materialui/src/auth/AuthLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/auth/AuthLayout.stories.tsx
@@ -6,7 +6,7 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import { TextInput } from '../input';
 import { AdminContext } from '../AdminContext';
-import { AuthLayout, AuthLayoutClasses } from './AuthLayout';
+import { AuthLayout } from './AuthLayout';
 import { Stack } from '@mui/system';
 
 export default { title: 'ra-ui-materialui/auth/AuthLayout' };
@@ -51,41 +51,36 @@ export const Sx = () => (
     <AdminContext i18nProvider={i18nProvider}>
         <AuthLayout
             sx={{
-                [`& .${AuthLayoutClasses.card}`]: {
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                },
+                backgroundImage:
+                    'radial-gradient(circle at 50% 14em, #bb44f0 0%, #9614d0 60%, #660094 100%)',
             }}
         >
-            <Avatar
-                sx={{
-                    margin: '1em',
-                }}
-            >
-                <LockIcon color="inherit" />
-            </Avatar>
             <CardContent>
-                <Typography gutterBottom>
-                    Please enter your username to reset your password
-                </Typography>
-                <Form>
-                    <TextInput
-                        autoFocus
-                        source="username"
-                        label="ra.auth.username"
-                        autoComplete="username"
-                        validate={required()}
-                    />
-                    <Button
-                        variant="contained"
-                        type="submit"
-                        color="primary"
-                        fullWidth
-                    >
-                        Reset my password
-                    </Button>
-                </Form>
+                <Stack alignItems="center" gap={2}>
+                    <Avatar>
+                        <LockIcon color="inherit" />
+                    </Avatar>
+                    <Typography>
+                        Please enter your username to reset your password
+                    </Typography>
+                    <Form>
+                        <TextInput
+                            autoFocus
+                            source="username"
+                            label="ra.auth.username"
+                            autoComplete="username"
+                            validate={required()}
+                        />
+                        <Button
+                            variant="contained"
+                            type="submit"
+                            color="primary"
+                            fullWidth
+                        >
+                            Reset my password
+                        </Button>
+                    </Form>
+                </Stack>
             </CardContent>
         </AuthLayout>
     </AdminContext>

--- a/packages/ra-ui-materialui/src/auth/AuthLayout.stories.tsx
+++ b/packages/ra-ui-materialui/src/auth/AuthLayout.stories.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { Avatar, Button, CardContent, Typography } from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import { Form, required } from 'ra-core';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
+import { TextInput } from '../input';
+import { AdminContext } from '../AdminContext';
+import { AuthLayout, AuthLayoutClasses } from './AuthLayout';
+import { Stack } from '@mui/system';
+
+export default { title: 'ra-ui-materialui/auth/AuthLayout' };
+
+const i18nProvider = polyglotI18nProvider(() => englishMessages);
+
+export const Basic = () => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <AuthLayout>
+            <CardContent>
+                <Stack alignItems="center" gap={2}>
+                    <Avatar>
+                        <LockIcon color="inherit" />
+                    </Avatar>
+                    <Typography>
+                        Please enter your username to reset your password
+                    </Typography>
+                    <Form>
+                        <TextInput
+                            autoFocus
+                            source="username"
+                            label="ra.auth.username"
+                            autoComplete="username"
+                            validate={required()}
+                        />
+                        <Button
+                            variant="contained"
+                            type="submit"
+                            color="primary"
+                            fullWidth
+                        >
+                            Reset my password
+                        </Button>
+                    </Form>
+                </Stack>
+            </CardContent>
+        </AuthLayout>
+    </AdminContext>
+);
+
+export const Sx = () => (
+    <AdminContext i18nProvider={i18nProvider}>
+        <AuthLayout
+            sx={{
+                [`& .${AuthLayoutClasses.card}`]: {
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                },
+            }}
+        >
+            <Avatar
+                sx={{
+                    margin: '1em',
+                }}
+            >
+                <LockIcon color="inherit" />
+            </Avatar>
+            <CardContent>
+                <Typography gutterBottom>
+                    Please enter your username to reset your password
+                </Typography>
+                <Form>
+                    <TextInput
+                        autoFocus
+                        source="username"
+                        label="ra.auth.username"
+                        autoComplete="username"
+                        validate={required()}
+                    />
+                    <Button
+                        variant="contained"
+                        type="submit"
+                        color="primary"
+                        fullWidth
+                    >
+                        Reset my password
+                    </Button>
+                </Form>
+            </CardContent>
+        </AuthLayout>
+    </AdminContext>
+);

--- a/packages/ra-ui-materialui/src/auth/AuthLayout.tsx
+++ b/packages/ra-ui-materialui/src/auth/AuthLayout.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Card, styled, Theme } from '@mui/material';
+import { MUIStyledCommonProps } from '@mui/system';
+import clsx from 'clsx';
+
+export const AuthLayout = ({
+    children,
+    className,
+    ...props
+}: AuthLayoutProps) => (
+    <Root className={clsx(AuthLayoutClasses.root, className)} {...props}>
+        <Card className={AuthLayoutClasses.card}>{children}</Card>
+    </Root>
+);
+
+export interface AuthLayoutProps
+    extends MUIStyledCommonProps<Theme>,
+        React.DetailedHTMLProps<
+            React.HTMLAttributes<HTMLDivElement>,
+            HTMLDivElement
+        > {}
+
+const PREFIX = 'RaAuthLayout';
+export const AuthLayoutClasses = {
+    root: `${PREFIX}-root`,
+    card: `${PREFIX}-card`,
+};
+
+const Root = styled('div', {
+    name: PREFIX,
+    overridesResolver: (props, styles) => styles.root,
+})(() => ({
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
+    height: '1px',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    backgroundImage:
+        'radial-gradient(circle at 50% 14em, #313264 0%, #00023b 60%, #00023b 100%)',
+
+    [`& .${AuthLayoutClasses.card}`]: {
+        minWidth: 300,
+        marginTop: '6em',
+    },
+}));

--- a/packages/ra-ui-materialui/src/auth/index.ts
+++ b/packages/ra-ui-materialui/src/auth/index.ts
@@ -1,5 +1,6 @@
 export * from './AuthCallback';
 export * from './AuthError';
+export * from './AuthLayout';
 export * from './Login';
 export * from './LoginWithEmail';
 export * from './LoginForm';


### PR DESCRIPTION
## Problem

When building several pages linked to authentication, we have to repeat Several elemens between pages.

## Solution

- [x] Extract and rename the Root component from Login to AuthLayout and export it. Do not embark the avatar, the auth check, or the background.
## How To Test

- https://react-admin-storybook-hczd4x6ow-marmelab.vercel.app/?path=/story/ra-ui-materialui-auth-authlayout--basic

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes one or several **stories** (if not possible, describe why)