### PR TITLE
Improve release script old version doc

### DIFF
--- a/docs/OldVersions.md
+++ b/docs/OldVersions.md
@@ -14,7 +14,7 @@ You have two options to read them:
 
 ## v5
 
-- [v5.7](https://github.com/marmelab/react-admin/blob/next/docs/Admin.md)
+- [v5.7](https://github.com/marmelab/react-admin/blob/master/docs/Admin.md)
 - [v5.6](https://github.com/marmelab/react-admin/blob/v5.6.4/docs/Admin.md)
 - [v5.5](https://github.com/marmelab/react-admin/blob/v5.5.4/docs/Admin.md)
 - [v5.4](https://github.com/marmelab/react-admin/blob/v5.4.4/docs/Admin.md)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,11 +48,6 @@ echo "Test the 3 demos (simple, e-commerce, crm): check console & UI"
 echo "Press Enter when this is done"
 read
 
-step "manual task: Update the OldVersion.md file"
-echo "[Minor version only] Update the ./docs/OldVersions.md file to add the new minor version and update the previous one && commit"
-echo "Press Enter when this is done"
-read
-
 # Get the current version from package.json
 npm_previous_package_version=$(jq -r '.version' ./packages/react-admin/package.json)
 
@@ -74,6 +69,13 @@ if [ ! -z "$RELEASE_DRY_RUN" ]; then
 fi
 
 if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
+    echo "New minor version - Updating the OldVersion.md file"
+    npm_previous_package_minor_version=${npm_previous_package_version%.*}
+    npm_current_package_minor_version=${npm_current_package_version%.*}
+    echo $npm_previous_package_minor_version
+    echo $npm_current_package_minor_version
+    sed -i "s/^- \[v$npm_previous_package_minor_version\].*/- [v$npm_current_package_minor_version](https:\/\/github.com\/marmelab\/react-admin\/blob\/master\/docs\/Admin.md)\n- [v$npm_previous_package_minor_version](https:\/\/github\.com\/marmelab\/react\-admin\/blob\/$npm_previous_package_version\/docs\/Admin.md\)/" docs/OldVersions.md
+
     echo "New minor version - Updating the dependencies to RA packages in the create-react-admin templates"
     yarn run update-create-react-admin-deps ${npm_current_package_version}
     if [ -z "$RELEASE_DRY_RUN" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,6 +75,11 @@ if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}"
     echo $npm_previous_package_minor_version
     echo $npm_current_package_minor_version
     sed -i "s/^- \[v$npm_previous_package_minor_version\].*/- [v$npm_current_package_minor_version](https:\/\/github.com\/marmelab\/react-admin\/blob\/master\/docs\/Admin.md)\n- [v$npm_previous_package_minor_version](https:\/\/github\.com\/marmelab\/react\-admin\/blob\/$npm_previous_package_version\/docs\/Admin.md\)/" docs/OldVersions.md
+    if [ -z "$RELEASE_DRY_RUN" ]; then
+        echo "Committing the OldVersion.md file update"
+        git add .
+        git commit -m "Update docs/OldVersion.md for version ${npm_current_package_version}"
+    fi
 
     echo "New minor version - Updating the dependencies to RA packages in the create-react-admin templates"
     yarn run update-create-react-admin-deps ${npm_current_package_version}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -74,7 +74,7 @@ if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}"
     npm_current_package_minor_version=${npm_current_package_version%.*}
     echo $npm_previous_package_minor_version
     echo $npm_current_package_minor_version
-    sed -i "s/^- \[v$npm_previous_package_minor_version\].*/- [v$npm_current_package_minor_version](https:\/\/github.com\/marmelab\/react-admin\/blob\/master\/docs\/Admin.md)\n- [v$npm_previous_package_minor_version](https:\/\/github\.com\/marmelab\/react\-admin\/blob\/$npm_previous_package_version\/docs\/Admin.md\)/" docs/OldVersions.md
+    sed -i "s/^- \[v$npm_previous_package_minor_version\].*/- [v$npm_current_package_minor_version](https:\/\/github.com\/marmelab\/react-admin\/blob\/master\/docs\/Admin.md)\n- [v$npm_previous_package_minor_version](https:\/\/github\.com\/marmelab\/react\-admin\/blob\/v$npm_previous_package_version\/docs\/Admin.md\)/" docs/OldVersions.md
     if [ -z "$RELEASE_DRY_RUN" ]; then
         echo "Committing the OldVersion.md file update"
         git add .

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,7 +72,7 @@ if [ ! -z "$RELEASE_DRY_RUN" ]; then
     git reset --soft HEAD~1
 fi
 
-if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
+if [ "$npm_previous_package_minor_version" != "$npm_current_package_minor_version" ]; then
     echo "New minor version - Updating the OldVersion.md file"
     sed -i "s/^- \[v$npm_previous_package_minor_version\].*/- [v$npm_current_package_minor_version](https:\/\/github.com\/marmelab\/react-admin\/blob\/master\/docs\/Admin.md)\n- [v$npm_previous_package_minor_version](https:\/\/github\.com\/marmelab\/react\-admin\/blob\/v$npm_previous_package_version\/docs\/Admin.md\)/" docs/OldVersions.md
     if [ -z "$RELEASE_DRY_RUN" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -50,6 +50,8 @@ read
 
 # Get the current version from package.json
 npm_previous_package_version=$(jq -r '.version' ./packages/react-admin/package.json)
+# ${npm_previous_package_version%.*} extract the major.minor version
+npm_previous_package_minor_version=${npm_previous_package_version%.*}
 
 step "lerna version"
 # Running lerna version
@@ -58,6 +60,8 @@ step "lerna version"
 
 # Get the version from package.json
 npm_current_package_version=$(jq -r '.version' ./packages/react-admin/package.json)
+# ${npm_current_package_version%.*} extract the major.minor version
+npm_current_package_minor_version=${npm_current_package_version%.*}
 
 # Remove the tag created by lerna
 echo "Removing tag v${npm_current_package_version} created by lerna"
@@ -70,10 +74,6 @@ fi
 
 if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
     echo "New minor version - Updating the OldVersion.md file"
-    npm_previous_package_minor_version=${npm_previous_package_version%.*}
-    npm_current_package_minor_version=${npm_current_package_version%.*}
-    echo $npm_previous_package_minor_version
-    echo $npm_current_package_minor_version
     sed -i "s/^- \[v$npm_previous_package_minor_version\].*/- [v$npm_current_package_minor_version](https:\/\/github.com\/marmelab\/react-admin\/blob\/master\/docs\/Admin.md)\n- [v$npm_previous_package_minor_version](https:\/\/github\.com\/marmelab\/react\-admin\/blob\/v$npm_previous_package_version\/docs\/Admin.md\)/" docs/OldVersions.md
     if [ -z "$RELEASE_DRY_RUN" ]; then
         echo "Committing the OldVersion.md file update"
@@ -135,15 +135,14 @@ yarn run create-github-release ${npm_current_package_version}
 step "Update the documentation"
 if [ -d $RA_DOC_PATH ]; then
     ( cd $RA_DOC_PATH && git pull )
-    # ${npm_current_package_version%.*} extract the major.minor version
-    RA_DOC_PATH="$RA_DOC_PATH" VERSION="${npm_current_package_version%.*}" ./scripts/copy-ra-oss-docs.sh
+    RA_DOC_PATH="$RA_DOC_PATH" VERSION="$npm_current_package_minor_version" ./scripts/copy-ra-oss-docs.sh
     # Set the latest version in the versions.yml file
     echo "Update the latest version in the versions.yml file"
     sed -i "/^\(- latest\).*/s//\1 \($npm_current_package_version\)/" $RA_DOC_PATH/_data/versions.yml
-    if [ "${npm_previous_package_version%.*}" != "${npm_current_package_version%.*}" ]; then
+    if [ "$npm_previous_package_minor_version" != "$npm_current_package_minor_version" ]; then
         echo "Add the previous minor version to the list of versions in the versions.yml file"
         # Add the previous minor version to the list of versions in the versions.yml file
-        sed -i "/^\(- latest.*\)/s//\1 \n- \"${npm_previous_package_version%.*}\"/" $RA_DOC_PATH/_data/versions.yml
+        sed -i "/^\(- latest.*\)/s//\1 \n- \"$npm_previous_package_minor_version\"/" $RA_DOC_PATH/_data/versions.yml
     fi
     if [ -z "$RELEASE_DRY_RUN" ]; then
         ( cd $RA_DOC_PATH && git add . && git commit -m "Update the documentation for version $npm_current_package_version" && git push )


### PR DESCRIPTION
## Problem

This is an unnecessary manual step.

## Solution

Automate it

## How To Test

These scripts support a `RELEASE_DRY_RUN` env variable allowing to skip all mutations to git, GitHub or npm, except 1 git commit (but not pushed!) from lerna.

First, create a `.env` file from the `.env.template` file and fill it in with your Github token.

Then run:

```
RELEASE_DRY_RUN=true make release
```

Select the new minor version when Lerna asks for it.

When this is done, don't forget to revert the commit created by lerna to update the versions:

```
git reset --hard HEAD~1
```

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
