### PR TITLE
Fix `<AutocompleteInput>` has hole in the outline when no `label`

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -1329,3 +1329,14 @@ export const WithInputProps = () => (
         />
     </Wrapper>
 );
+
+export const OutlinedNoLabel = () => (
+    <Wrapper onSuccess={console.log}>
+        <AutocompleteInput
+            source="author"
+            choices={defaultChoices}
+            label={false}
+            variant="outlined"
+        />
+    </Wrapper>
+);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -643,7 +643,11 @@ If you provided a React element for the optionText prop, you must also provide t
                             }
                             margin={margin}
                             variant={variant}
-                            className={AutocompleteInputClasses.textField}
+                            className={clsx({
+                                [AutocompleteInputClasses.textField]: true,
+                                [AutocompleteInputClasses.emptyLabel]:
+                                    label === false || label === '',
+                            })}
                             {...params}
                             {...TextFieldProps}
                             InputProps={mergedTextFieldProps}
@@ -725,6 +729,7 @@ const PREFIX = 'RaAutocompleteInput';
 
 export const AutocompleteInputClasses = {
     textField: `${PREFIX}-textField`,
+    emptyLabel: `${PREFIX}-emptyLabel`,
 };
 
 const StyledAutocomplete = styled(Autocomplete, {
@@ -734,6 +739,10 @@ const StyledAutocomplete = styled(Autocomplete, {
     [`& .${AutocompleteInputClasses.textField}`]: {
         minWidth: theme.spacing(20),
     },
+    [`& .${AutocompleteInputClasses.emptyLabel} .MuiOutlinedInput-root legend`]:
+        {
+            width: 0,
+        },
 }));
 
 // @ts-ignore


### PR DESCRIPTION
## Problem

Closes https://github.com/marmelab/react-admin/issues/10645

## Solution

Apply styling workaround automatically (i.e. set width of `<legend>` to 0)

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-autocompleteinput--outlined-no-label

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why) -> not possible (UI only)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
