### PR TITLE
Update TranslationLocales.md (Portuguese pt-pt)

### DIFF
--- a/docs/TranslationLocales.md
+++ b/docs/TranslationLocales.md
@@ -37,7 +37,7 @@ You can find translation packages for the following languages:
 - Malay (`ms`): [kayuapi/ra-language-malay](https://github.com/kayuapi/ra-language-malay.git)
 - Norwegian (`no`): [jon-harald/ra-language-norwegian](https://github.com/jon-harald/ra-language-norwegian)
 - Polish (`pl`): [tymek/ra-language-polish](https://github.com/tymek/ra-language-polish)
-- Portuguese (`pt`): [henriko202/ra-language-portuguese](https://github.com/henriko202/ra-language-portuguese)
+- Portuguese (`pt`): [PauloCoelhoP5/ra-language-portuguese](https://github.com/PauloCoelhoP5/ra-language-portuguese)
 - Romanian (`ro`): [gyhaLabs/ra-language-romanian](https://github.com/gyhaLabs/ra-language-romanian)
 - Russian (`ru`): [klucherev/ra-language-russian](https://github.com/klucherev/ra-language-russian)
 - Slovak (`sk`): [zavadpe/ra-language-slovak](https://github.com/zavadpe/ra-language-slovak)


### PR DESCRIPTION
## Problem

The current Portuguese (pt-pt) translation could benefit from improvements and updates.  

## Solution

This PR updates the Portuguese (pt-pt) translation with:
- Refined and merged content from:
  - [@henriko202](https://github.com/henriko202)'s ra-language-portuguese
  - [@gucarletto](https://github.com/gucarletto)'s ra-language-pt-br
- Additional internal improvements used in production at our company
- Published as an NPM package here: [`@acmp5/ra-language-portuguese-pt`](https://www.npmjs.com/package/@acmp5/ra-language-portuguese-pt)

## How To Test

1. Replace the current pt-pt translation with this version.
2. Run the admin interface with Portuguese (pt-pt) as the selected locale.
3. Navigate through common pages (list, show, edit, create, etc.) to verify translation quality and consistency.

## Additional Checks

- [x] The PR targets `next` since this is a new language feature
- [ ] The PR includes unit tests (N/A for static translation files)
- [ ] The PR includes one or several stories (not applicable here)
- [x] The documentation is up to date (included a reference to the new translation package, if required)

