### PR TITLE
Improve `<DeleteButton>` and `<UpdateButton>` confirmation wording using record representation

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -246,7 +246,11 @@ const DeleteButton = () => {
                 loading={isPending}
                 title="ra.message.delete_title"
                 content="ra.message.delete_content"
-                translateOptions={{
+                titleTranslateOptions={{
+                    name: resource,
+                    id: record.id,
+                }}
+                contentTranslateOptions={{
                     name: resource,
                     id: record.id,
                 }}

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -925,7 +925,8 @@ const EditToolbar = () => {
         <DeleteWithConfirmButton
             confirmContent="You will not be able to recover this record. Are you sure?"
             confirmColor="warning"
-            translateOptions={{ name: record.name }}
+            contentTranslateOptions={{ name: record.name }}
+            titleTranslateOptions={{ name: record.name }}
         />
     </Toolbar>
 };

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -904,12 +904,12 @@ Delete the current record after a confirm dialog has been accepted. To be used i
 | `confirmTitle`            | Optional | `ReactNode`                                      | 'ra.message.delete_title'   | Title of the confirm dialog                                             |
 | `confirmContent`          | Optional | `ReactNode`                                      | 'ra.message.delete_content' | Message or React component to be used as the body of the confirm dialog |
 | `confirmColor`            | Optional | <code>'primary' &#124; 'warning'</code>          | 'primary'                   | The color of the confirm dialog's "Confirm" button                      |
-| `contentTranslateOptions` | Optional | `Object`                                         | {}                          | Custom id, name and record representation to be used in the confirm dialog's title |
+| `contentTranslateOptions` | Optional | `Object`                                         | {}                          | Custom id, name and record representation to be used in the confirm dialog's content |
 | `icon`                    | Optional | `ReactElement`                                   | `<DeleteIcon>`              | iconElement, e.g. `<CommentIcon />`                                     |
 | `label`                   | Optional | `string`                                         | 'ra.action.delete'          | label or translation message to use                                     |
 | `mutationOptions`         | Optional |                                                  | null                        | options for react-query `useMutation` hook                              |
 | `redirect`                | Optional | <code>string &#124; false &#124; Function</code> | 'list'                      | Custom redirection after success side effect                            |
-| `titleTranslateOptions`   | Optional | `Object`                                         | {}                          | Custom id, name and record representation to be used in the confirm dialog's content |
+| `titleTranslateOptions`   | Optional | `Object`                                         | {}                          | Custom id, name and record representation to be used in the confirm dialog's title |
 | `successMessage`          | Optional | `string`                                         | 'ra.notification.deleted'   | Lets you customize the success notification message.                    |
 
 {% raw %}
@@ -1368,10 +1368,10 @@ export const PostEdit = () => (
 | `data`                    | Required | `Object`    |                                  | The data used to update the record                       |
 | `confirmTitle`            | Optional | `ReactNode` | `ra.message.bulk_update_title`   | The title of the confirmation dialog when `mutationMode` is not `undoable` |
 | `confirmContent`          | Optional | `ReactNode` | `ra.message.bulk_update_content` | The content of the confirmation dialog when `mutationMode` is not `undoable` |
-| `contentTranslateOptions` | Optional | `Object`    | {}                               | Custom id, name and record representation to be used in the confirm dialog's title   |
+| `contentTranslateOptions` | Optional | `Object`    | {}                               | Custom id, name and record representation to be used in the confirm dialog's content   |
 | `mutationMode`            | Optional | `string`    | `undoable`                       | Mutation mode (`'undoable'`, `'pessimistic'` or `'optimistic'`) |
 | `mutationOptions`         | Optional | `Object`    |                                  | The react-query mutation options |
-| `titleTranslateOptions`   | Optional | `Object`    | {}                               | Custom id, name and record representation to be used in the confirm dialog's content |
+| `titleTranslateOptions`   | Optional | `Object`    | {}                               | Custom id, name and record representation to be used in the confirm dialog's title |
 
 `<UpdateButton>` also accepts the [Button props](./Buttons.md#button).
 

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -898,18 +898,19 @@ If your `authProvider` implements [Access Control](./Permissions.md#access-contr
 
 Delete the current record after a confirm dialog has been accepted. To be used inside a `<Toolbar/>` component.
 
-| Prop               | Required | Type                                             | Default                     | Description                                                             |
-|------------------- |----------|--------------------------------------------------|-----------------------------|-------------------------------------------------------------------------|
-| `className`        | Optional | `string`                                         | -                           | Class name to customize the look and feel of the button element itself  |
-| `label`            | Optional | `string`                                         | 'ra.action.delete'          | label or translation message to use                                     |
-| `icon`             | Optional | `ReactElement`                                   | `<DeleteIcon>`              | iconElement, e.g. `<CommentIcon />`                                     |
-| `confirmTitle`     | Optional | `ReactNode`                                      | 'ra.message.delete_title'   | Title of the confirm dialog                                             |
-| `confirmContent`   | Optional | `ReactNode`                                      | 'ra.message.delete_content' | Message or React component to be used as the body of the confirm dialog |
-| `confirmColor`     | Optional | <code>'primary' &#124; 'warning'</code>          | 'primary'                   | The color of the confirm dialog's "Confirm" button                      |
-| `redirect`         | Optional | <code>string &#124; false &#124; Function</code> | 'list'                      | Custom redirection after success side effect                            |
-| `translateOptions` | Optional | `{ id?: string, name?: string }`                 | {}                          | Custom id and name to be used in the confirm dialog's title             |
-| `mutationOptions`  | Optional |                                                  | null                        | options for react-query `useMutation` hook                              |
-| `successMessage`   | Optional | `string`                                         | 'ra.notification.deleted'   | Lets you customize the success notification message.                                                                                 |
+| Prop                      | Required | Type                                             | Default                     | Description                                                             |
+|-------------------------- |----------|--------------------------------------------------|-----------------------------|-------------------------------------------------------------------------|
+| `className`               | Optional | `string`                                         | -                           | Class name to customize the look and feel of the button element itself  |
+| `confirmTitle`            | Optional | `ReactNode`                                      | 'ra.message.delete_title'   | Title of the confirm dialog                                             |
+| `confirmContent`          | Optional | `ReactNode`                                      | 'ra.message.delete_content' | Message or React component to be used as the body of the confirm dialog |
+| `confirmColor`            | Optional | <code>'primary' &#124; 'warning'</code>          | 'primary'                   | The color of the confirm dialog's "Confirm" button                      |
+| `contentTranslateOptions` | Optional | `Object`                                         | {}                          | Custom id, name and record representation to be used in the confirm dialog's title |
+| `icon`                    | Optional | `ReactElement`                                   | `<DeleteIcon>`              | iconElement, e.g. `<CommentIcon />`                                     |
+| `label`                   | Optional | `string`                                         | 'ra.action.delete'          | label or translation message to use                                     |
+| `mutationOptions`         | Optional |                                                  | null                        | options for react-query `useMutation` hook                              |
+| `redirect`                | Optional | <code>string &#124; false &#124; Function</code> | 'list'                      | Custom redirection after success side effect                            |
+| `titleTranslateOptions`   | Optional | `Object`                                         | {}                          | Custom id, name and record representation to be used in the confirm dialog's content |
+| `successMessage`          | Optional | `string`                                         | 'ra.notification.deleted'   | Lets you customize the success notification message.                    |
 
 {% raw %}
 ```jsx
@@ -1361,13 +1362,15 @@ export const PostEdit = () => (
 
 `<UpdateButton>` accepts the following props:
 
-| Prop             | Required | Type        | Default    | Description                                              |
-| ---------------- | -------- | ----------- | ---------- | -------------------------------------------------------- |
-| `data`           | Required | `object`    |            | The data used to update the record                       |
-| `mutationMode`   | Optional | `string`    | `undoable` | Mutation mode (`'undoable'`, `'pessimistic'` or `'optimistic'`) |
-| `confirmTitle`   | Optional | `ReactNode` | `ra.message.bulk_update_title` | The title of the confirmation dialog when `mutationMode` is not `undoable` |
-| `confirmContent` | Optional | `ReactNode` | `ra.message.bulk_update_content` | The content of the confirmation dialog when `mutationMode` is not `undoable` |
-| `mutationOptions` | Optional | `Object`  |        | The react-query mutation options |
+| Prop                      | Required | Type        | Default                          | Description                                              |
+| ------------------------- | -------- | ----------- | -------------------------------- | -------------------------------------------------------- |
+| `data`                    | Required | `Object`    |                                  | The data used to update the record                       |
+| `confirmTitle`            | Optional | `ReactNode` | `ra.message.bulk_update_title`   | The title of the confirmation dialog when `mutationMode` is not `undoable` |
+| `confirmContent`          | Optional | `ReactNode` | `ra.message.bulk_update_content` | The content of the confirmation dialog when `mutationMode` is not `undoable` |
+| `contentTranslateOptions` | Optional | `Object`    | {}                               | Custom id, name and record representation to be used in the confirm dialog's title   |
+| `mutationMode`            | Optional | `string`    | `undoable`                       | Mutation mode (`'undoable'`, `'pessimistic'` or `'optimistic'`) |
+| `mutationOptions`         | Optional | `Object`    |                                  | The react-query mutation options |
+| `titleTranslateOptions`   | Optional | `Object`    | {}                               | Custom id, name and record representation to be used in the confirm dialog's content |
 
 `<UpdateButton>` also accepts the [Button props](./Buttons.md#button).
 

--- a/docs/Confirm.md
+++ b/docs/Confirm.md
@@ -72,7 +72,7 @@ const BulkResetViewsButton = () => {
 | `ConfirmIcon`      | Optional | `Component`                      | `CheckCircleIcon`      | Icon component of the confirm button                                 |
 | `CancelIcon`       | Optional | `Component`                      | `ErrorOutlineIcon`     | Icon component of the cancel button                                  |
 | `title Translate Options` | Optional | `{ id?: string, name?: string }` | {}                    | Custom id and name to be used in the dialog title                  |
-| `content Translate Options` | Optional | `{ id?: string, name?: string }` | {}                    | Custom id and name to be used in the dialog title                  |
+| `content Translate Options` | Optional | `{ id?: string, name?: string }` | {}                    | Custom id and name to be used in the dialog content                  |
 | `sx`               | Optional | `SxProps`                        | ''                    | Material UI shortcut for defining custom styles with access to the theme   |
 
 Text props such as `title`, `content`, `cancel` and `confirm` are translatable. You can pass translation keys in these props. Note: `content` is only translatable when value is `string`, otherwise it renders the content as a `ReactNode`.

--- a/docs/Confirm.md
+++ b/docs/Confirm.md
@@ -71,10 +71,11 @@ const BulkResetViewsButton = () => {
 | `confirmColor`     | Optional | `string`                         | 'primary'             | Color of the confirm button                                        |
 | `ConfirmIcon`      | Optional | `Component`                      | `CheckCircleIcon`      | Icon component of the confirm button                                 |
 | `CancelIcon`       | Optional | `Component`                      | `ErrorOutlineIcon`     | Icon component of the cancel button                                  |
-| `translate Options` | Optional | `{ id?: string, name?: string }` | {}                    | Custom id and name to be used in the dialog title                  |
+| `title Translate Options` | Optional | `{ id?: string, name?: string }` | {}                    | Custom id and name to be used in the dialog title                  |
+| `content Translate Options` | Optional | `{ id?: string, name?: string }` | {}                    | Custom id and name to be used in the dialog title                  |
 | `sx`               | Optional | `SxProps`                        | ''                    | Material UI shortcut for defining custom styles with access to the theme   |
 
-Text props such as `title`, `content`, `cancel`, `confirm` and `translateOptions` are translatable. You can pass translation keys in these props. Note: `content` is only translatable when value is `string`, otherwise it renders the content as a `ReactNode`.
+Text props such as `title`, `content`, `cancel` and `confirm` are translatable. You can pass translation keys in these props. Note: `content` is only translatable when value is `string`, otherwise it renders the content as a `ReactNode`.
 
 ## `sx`: CSS API
 

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -53,7 +53,11 @@ import { useTranslate } from '../../i18n';
  *                 loading={isPending}
  *                 title="ra.message.delete_title"
  *                 content="ra.message.delete_content"
- *                 translateOptions={{
+ *                 titleTranslateOptions={{
+ *                     name: resource,
+ *                     id: record.id,
+ *                 }}
+ *                 contentTranslateOptions={{
  *                     name: resource,
  *                     id: record.id,
  *                 }}

--- a/packages/ra-core/src/core/useGetRecordRepresentation.ts
+++ b/packages/ra-core/src/core/useGetRecordRepresentation.ts
@@ -5,7 +5,7 @@ import get from 'lodash/get';
 import { useResourceDefinition } from './useResourceDefinition';
 
 /**
- * Get default string representation of a record
+ * Get the default representation of a record (either a string or a React node)
  *
  * @example // No customization
  * const getRecordRepresentation = useGetRecordRepresentation('posts');

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -102,13 +102,15 @@ const englishMessages: TranslationMessages = {
             bulk_update_content:
                 'Are you sure you want to update this %{name}? |||| Are you sure you want to update these %{smart_count} items?',
             bulk_update_content_record_representation:
-                'Are you sure you want to update %{name}? |||| Are you sure you want to update these %{smart_count} items?',
+                'Are you sure you want to update %{resource} %{name}? |||| Are you sure you want to update these %{smart_count} items?',
             bulk_update_title:
                 'Update %{name} |||| Update %{smart_count} %{name}',
+            bulk_update_title_record_representation:
+                'Update %{resource} %{name} |||| Update %{smart_count} %{name}',
             clear_array_input: 'Are you sure you want to clear the whole list?',
             delete_content: 'Are you sure you want to delete this item?',
             delete_title: 'Delete %{name} #%{id}',
-            delete_title_record_representation: 'Delete %{name}',
+            delete_title_record_representation: 'Delete %{resource} %{name}',
             details: 'Details',
             error: "A client error occurred and your request couldn't be completed.",
             invalid_form: 'The form is not valid. Please check for errors',

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -101,11 +101,14 @@ const englishMessages: TranslationMessages = {
                 'Delete %{name} |||| Delete %{smart_count} %{name}',
             bulk_update_content:
                 'Are you sure you want to update this %{name}? |||| Are you sure you want to update these %{smart_count} items?',
+            bulk_update_content_record_representation:
+                'Are you sure you want to update %{name}? |||| Are you sure you want to update these %{smart_count} items?',
             bulk_update_title:
                 'Update %{name} |||| Update %{smart_count} %{name}',
             clear_array_input: 'Are you sure you want to clear the whole list?',
             delete_content: 'Are you sure you want to delete this item?',
             delete_title: 'Delete %{name} #%{id}',
+            delete_title_record_representation: 'Delete %{name}',
             details: 'Details',
             error: "A client error occurred and your request couldn't be completed.",
             invalid_form: 'The form is not valid. Please check for errors',

--- a/packages/ra-language-english/src/index.ts
+++ b/packages/ra-language-english/src/index.ts
@@ -100,17 +100,12 @@ const englishMessages: TranslationMessages = {
             bulk_delete_title:
                 'Delete %{name} |||| Delete %{smart_count} %{name}',
             bulk_update_content:
-                'Are you sure you want to update this %{name}? |||| Are you sure you want to update these %{smart_count} items?',
-            bulk_update_content_record_representation:
-                'Are you sure you want to update %{resource} %{name}? |||| Are you sure you want to update these %{smart_count} items?',
+                'Are you sure you want to update %{name} %{recordRepresentation}? |||| Are you sure you want to update these %{smart_count} items?',
             bulk_update_title:
-                'Update %{name} |||| Update %{smart_count} %{name}',
-            bulk_update_title_record_representation:
-                'Update %{resource} %{name} |||| Update %{smart_count} %{name}',
+                'Update %{name} %{recordRepresentation} |||| Update %{smart_count} %{name}',
             clear_array_input: 'Are you sure you want to clear the whole list?',
-            delete_content: 'Are you sure you want to delete this item?',
-            delete_title: 'Delete %{name} #%{id}',
-            delete_title_record_representation: 'Delete %{resource} %{name}',
+            delete_content: 'Are you sure you want to delete this %{name}?',
+            delete_title: 'Delete %{name} %{recordRepresentation}',
             details: 'Details',
             error: "A client error occurred and your request couldn't be completed.",
             invalid_form: 'The form is not valid. Please check for errors',

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -102,6 +102,8 @@ const frenchMessages: TranslationMessages = {
                 'Supprimer %{name} |||| Supprimer %{smart_count} %{name}',
             bulk_update_content:
                 'Êtes-vous sûr(e) de vouloir modifier cet élément ? |||| Êtes-vous sûr(e) de vouloir modifier ces %{smart_count} éléments ?',
+            bulk_update_content_record_representation:
+                'Êtes-vous sûr(e) de vouloir modifier cet élément ? |||| Êtes-vous sûr(e) de vouloir modifier ces %{smart_count} éléments ?',
             bulk_update_title:
                 'Modifier %{name} |||| Modifier %{smart_count} %{name}',
             clear_array_input:
@@ -109,6 +111,7 @@ const frenchMessages: TranslationMessages = {
             delete_content:
                 'Êtes-vous sûr(e) de vouloir supprimer cet élément ?',
             delete_title: 'Supprimer %{name} #%{id}',
+            delete_title_record_representation: 'Supprimer %{name}',
             details: 'Détails',
             error: "En raison d'une erreur côté navigateur, votre requête n'a pas pu aboutir.",
             invalid_form: "Le formulaire n'est pas valide.",

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -103,13 +103,12 @@ const frenchMessages: TranslationMessages = {
             bulk_update_content:
                 'Êtes-vous sûr(e) de vouloir modifier cet élément ? |||| Êtes-vous sûr(e) de vouloir modifier ces %{smart_count} éléments ?',
             bulk_update_title:
-                'Modifier %{name} |||| Modifier %{smart_count} %{name}',
+                'Modifier %{name} %{recordRepresentation} |||| Modifier %{smart_count} %{name}',
             clear_array_input:
                 'Êtes-vous sûr(e) de vouloir supprimer tous les éléments de la liste ?',
             delete_content:
                 'Êtes-vous sûr(e) de vouloir supprimer cet élément ?',
             delete_title: 'Supprimer %{name} %{recordRepresentation}',
-            delete_title_record_representation: 'Supprimer %{name}',
             details: 'Détails',
             error: "En raison d'une erreur côté navigateur, votre requête n'a pas pu aboutir.",
             invalid_form: "Le formulaire n'est pas valide.",

--- a/packages/ra-language-french/src/index.ts
+++ b/packages/ra-language-french/src/index.ts
@@ -102,15 +102,13 @@ const frenchMessages: TranslationMessages = {
                 'Supprimer %{name} |||| Supprimer %{smart_count} %{name}',
             bulk_update_content:
                 'Êtes-vous sûr(e) de vouloir modifier cet élément ? |||| Êtes-vous sûr(e) de vouloir modifier ces %{smart_count} éléments ?',
-            bulk_update_content_record_representation:
-                'Êtes-vous sûr(e) de vouloir modifier cet élément ? |||| Êtes-vous sûr(e) de vouloir modifier ces %{smart_count} éléments ?',
             bulk_update_title:
                 'Modifier %{name} |||| Modifier %{smart_count} %{name}',
             clear_array_input:
                 'Êtes-vous sûr(e) de vouloir supprimer tous les éléments de la liste ?',
             delete_content:
                 'Êtes-vous sûr(e) de vouloir supprimer cet élément ?',
-            delete_title: 'Supprimer %{name} #%{id}',
+            delete_title: 'Supprimer %{name} %{recordRepresentation}',
             delete_title_record_representation: 'Supprimer %{name}',
             details: 'Détails',
             error: "En raison d'une erreur côté navigateur, votre requête n'a pas pu aboutir.",

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -130,7 +130,22 @@ export const BulkDeleteWithConfirmButton = (
                 title={confirmTitle}
                 content={confirmContent}
                 confirmColor={confirmColor}
-                translateOptions={{
+                titleTranslateOptions={{
+                    smart_count: selectedIds.length,
+                    name: translate(`resources.${resource}.forcedCaseName`, {
+                        smart_count: selectedIds.length,
+                        _: humanize(
+                            translate(`resources.${resource}.name`, {
+                                smart_count: selectedIds.length,
+                                _: resource
+                                    ? inflect(resource, selectedIds.length)
+                                    : undefined,
+                            }),
+                            true
+                        ),
+                    }),
+                }}
+                contentTranslateOptions={{
                     smart_count: selectedIds.length,
                     name: translate(`resources.${resource}.forcedCaseName`, {
                         smart_count: selectedIds.length,

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -127,7 +127,22 @@ export const BulkUpdateWithConfirmButton = (
                 loading={isPending}
                 title={confirmTitle}
                 content={confirmContent}
-                translateOptions={{
+                titleTranslateOptions={{
+                    smart_count: selectedIds.length,
+                    name: translate(`resources.${resource}.forcedCaseName`, {
+                        smart_count: selectedIds.length,
+                        _: humanize(
+                            translate(`resources.${resource}.name`, {
+                                smart_count: selectedIds.length,
+                                _: resource
+                                    ? inflect(resource, selectedIds.length)
+                                    : undefined,
+                            }),
+                            true
+                        ),
+                    }),
+                }}
+                contentTranslateOptions={{
                     smart_count: selectedIds.length,
                     name: translate(`resources.${resource}.forcedCaseName`, {
                         smart_count: selectedIds.length,

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
@@ -349,7 +349,7 @@ describe('<DeleteWithConfirmButton />', () => {
                 ) as HTMLElement
             ).getByText('Delete')
         );
-        await screen.findByText('Delete War and Peace');
+        await screen.findByText('Delete book War and Peace');
     });
 
     it('should use the default translation in the confirmation title when no record representation is available', async () => {
@@ -361,6 +361,6 @@ describe('<DeleteWithConfirmButton />', () => {
                 ) as HTMLElement
             ).getByText('Delete')
         );
-        await screen.findByText('Delete #1');
+        await screen.findByText('Delete author #1');
     });
 });

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
@@ -23,6 +23,7 @@ import { Notification } from '../layout';
 import {
     Basic,
     NoRecordRepresentation,
+    WithDefaultTranslation,
 } from './DeleteWithConfirmButton.stories';
 
 const theme = createTheme();
@@ -340,7 +341,7 @@ describe('<DeleteWithConfirmButton />', () => {
         });
     });
 
-    it('should use the record representation in the confirmation title', async () => {
+    it('should use the record representation in the confirmation title and content with a resource specific translation', async () => {
         render(<Basic />);
         fireEvent.click(
             within(
@@ -349,10 +350,26 @@ describe('<DeleteWithConfirmButton />', () => {
                 ) as HTMLElement
             ).getByText('Delete')
         );
-        await screen.findByText('Delete book War and Peace');
+        await screen.findByText('Delete the book "War and Peace"?');
+        await screen.findByText(
+            'Do you really want to delete the book "War and Peace"?'
+        );
     });
 
-    it('should use the default translation in the confirmation title when no record representation is available', async () => {
+    it('should use the record representation in the confirmation title and content without a resource specific translation', async () => {
+        render(<WithDefaultTranslation />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('War and Peace')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Delete')
+        );
+        await screen.findByText('Delete book War and Peace');
+        await screen.findByText('Are you sure you want to delete this book?');
+    });
+
+    it('should use the default record representation in the confirmation title and title when no record representation is available', async () => {
         render(<NoRecordRepresentation />);
         fireEvent.click(
             within(
@@ -362,5 +379,6 @@ describe('<DeleteWithConfirmButton />', () => {
             ).getByText('Delete')
         );
         await screen.findByText('Delete author #1');
+        await screen.findByText('Are you sure you want to delete this author?');
     });
 });

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+import {
+    screen,
+    render,
+    waitFor,
+    fireEvent,
+    within,
+} from '@testing-library/react';
 import expect from 'expect';
 import {
     CoreAdminContext,
@@ -14,6 +20,10 @@ import { Toolbar, SimpleForm } from '../form';
 import { Edit } from '../detail';
 import { TextInput } from '../input';
 import { Notification } from '../layout';
+import {
+    Basic,
+    NoRecordRepresentation,
+} from './DeleteWithConfirmButton.stories';
 
 const theme = createTheme();
 
@@ -328,5 +338,29 @@ describe('<DeleteWithConfirmButton />', () => {
                 },
             ]);
         });
+    });
+
+    it('should use the record representation in the confirmation title', async () => {
+        render(<Basic />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('War and Peace')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Delete')
+        );
+        await screen.findByText('Delete War and Peace');
+    });
+
+    it('should use the default translation in the confirmation title when no record representation is available', async () => {
+        render(<NoRecordRepresentation />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('Leo Tolstoy')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Delete')
+        );
+        await screen.findByText('Delete #1');
     });
 });

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.stories.tsx
@@ -28,11 +28,60 @@ const i18nProvider = polyglotI18nProvider(
                               author: 'Auteur',
                               year: 'Année',
                           },
+                          message: {
+                              delete_title:
+                                  'Supprimer le livre "%{recordRepresentation}" ?',
+                              delete_content:
+                                  'Souhaitez-vous vraiment supprimer le livre "%{recordRepresentation}" ?',
+                          },
+                      },
+                  },
+              }
+            : {
+                  ...englishMessages,
+                  resources: {
+                      books: {
+                          message: {
+                              delete_title:
+                                  'Delete the book "%{recordRepresentation}"?',
+                              delete_content:
+                                  'Do you really want to delete the book "%{recordRepresentation}"?',
+                          },
+                      },
+                  },
+              },
+    // Default locale
+    'en',
+    [
+        { locale: 'en', name: 'English' },
+        { locale: 'fr', name: 'Français' },
+    ]
+);
+
+const i18nProviderDefault = polyglotI18nProvider(
+    locale =>
+        locale === 'fr'
+            ? {
+                  ...frenchMessages,
+                  resources: {
+                      books: {
+                          name: 'Livre |||| Livres',
+                          fields: {
+                              id: 'Id',
+                              title: 'Titre',
+                              author: 'Auteur',
+                              year: 'Année',
+                          },
                       },
                   },
               }
             : englishMessages,
-    'en' // Default locale
+    // Default locale
+    'en',
+    [
+        { locale: 'en', name: 'English' },
+        { locale: 'fr', name: 'Français' },
+    ]
 );
 
 const dataProvider = fakeRestDataProvider({
@@ -148,6 +197,26 @@ const AuthorList = ({ children }) => {
 export const Basic = () => (
     <TestMemoryRouter initialEntries={['/books']}>
         <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+            <AdminUI>
+                <Resource
+                    name="books"
+                    list={
+                        <BookList>
+                            <DeleteWithConfirmButton />
+                        </BookList>
+                    }
+                />
+            </AdminUI>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+export const WithDefaultTranslation = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <AdminContext
+            dataProvider={dataProvider}
+            i18nProvider={i18nProviderDefault}
+        >
             <AdminUI>
                 <Resource
                     name="books"

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -25,7 +25,7 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
     const {
         className,
         confirmTitle: confirmTitleProp,
-        confirmContent = 'ra.message.delete_content',
+        confirmContent: confirmContentProp,
         confirmColor = 'primary',
         icon = defaultIcon,
         label = 'ra.action.delete',
@@ -33,6 +33,8 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
         onClick,
         redirect = 'list',
         translateOptions = {},
+        titleTranslateOptions = translateOptions,
+        contentTranslateOptions = translateOptions,
         mutationOptions,
         color = 'error',
         successMessage,
@@ -58,9 +60,9 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
         successMessage,
     });
     const getRecordRepresentation = useGetRecordRepresentation(resource);
-    const recordRepresentation = getRecordRepresentation(record);
-    let confirmNameParam = recordRepresentation;
-    let confirmTitle = 'ra.message.delete_title_record_representation';
+    let recordRepresentation = getRecordRepresentation(record);
+    let confirmTitle = `resources.${resource}.message.delete_title`;
+    let confirmContent = `resources.${resource}.message.delete_content`;
     const resourceName = translate(`resources.${resource}.forcedCaseName`, {
         smart_count: 1,
         _: humanize(
@@ -71,10 +73,9 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
             true
         ),
     });
-
+    // We don't support React elements for this
     if (isValidElement(recordRepresentation)) {
-        confirmTitle = 'ra.message.delete_title';
-        confirmNameParam = resourceName;
+        recordRepresentation = `#${record?.id}`;
     }
 
     return (
@@ -93,13 +94,29 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
                 isOpen={open}
                 loading={isPending}
                 title={confirmTitleProp ?? confirmTitle}
-                content={confirmContent}
+                content={confirmContentProp ?? confirmContent}
                 confirmColor={confirmColor}
-                translateOptions={{
-                    name: confirmNameParam,
-                    resource: resourceName,
+                titleTranslateOptions={{
+                    recordRepresentation,
+                    name: resourceName,
                     id: record?.id,
-                    ...translateOptions,
+                    _: translate('ra.message.delete_title', {
+                        recordRepresentation,
+                        name: resourceName,
+                        id: record?.id,
+                    }),
+                    ...titleTranslateOptions,
+                }}
+                contentTranslateOptions={{
+                    recordRepresentation,
+                    name: resourceName,
+                    id: record?.id,
+                    _: translate('ra.message.delete_content', {
+                        recordRepresentation,
+                        name: resourceName,
+                        id: record?.id,
+                    }),
+                    ...contentTranslateOptions,
                 }}
                 onConfirm={handleDelete}
                 onClose={handleDialogClose}
@@ -121,7 +138,12 @@ export interface DeleteWithConfirmButtonProps<
     mutationMode?: MutationMode;
     onClick?: ReactEventHandler<any>;
     // May be injected by Toolbar - sanitized in Button
+    /**
+     * @deprecated use `titleTranslateOptions` and `contentTranslateOptions` instead
+     */
     translateOptions?: object;
+    titleTranslateOptions?: object;
+    contentTranslateOptions?: object;
     mutationOptions?: UseMutationOptions<
         RecordType,
         MutationOptionsError,

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactEventHandler } from 'react';
+import React, { Fragment, isValidElement, ReactEventHandler } from 'react';
 import ActionDelete from '@mui/icons-material/Delete';
 import clsx from 'clsx';
 
@@ -12,6 +12,7 @@ import {
     useResourceContext,
     useTranslate,
     RedirectionSideEffect,
+    useGetRecordRepresentation,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
@@ -23,7 +24,7 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
 ) => {
     const {
         className,
-        confirmTitle = 'ra.message.delete_title',
+        confirmTitle: confirmTitleProp,
         confirmContent = 'ra.message.delete_content',
         confirmColor = 'primary',
         icon = defaultIcon,
@@ -56,6 +57,24 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
         resource,
         successMessage,
     });
+    const getRecordRepresentation = useGetRecordRepresentation(resource);
+    const recordRepresentation = getRecordRepresentation(record);
+    let confirmNameParam = recordRepresentation;
+    let confirmTitle = 'ra.message.delete_title_record_representation';
+
+    if (isValidElement(recordRepresentation)) {
+        confirmTitle = 'ra.message.delete_title';
+        confirmNameParam = translate(`resources.${resource}.forcedCaseName`, {
+            smart_count: 1,
+            _: humanize(
+                translate(`resources.${resource}.name`, {
+                    smart_count: 1,
+                    _: resource ? singularize(resource) : undefined,
+                }),
+                true
+            ),
+        });
+    }
 
     return (
         <Fragment>
@@ -72,20 +91,11 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
             <Confirm
                 isOpen={open}
                 loading={isPending}
-                title={confirmTitle}
+                title={confirmTitleProp ?? confirmTitle}
                 content={confirmContent}
                 confirmColor={confirmColor}
                 translateOptions={{
-                    name: translate(`resources.${resource}.forcedCaseName`, {
-                        smart_count: 1,
-                        _: humanize(
-                            translate(`resources.${resource}.name`, {
-                                smart_count: 1,
-                                _: resource ? singularize(resource) : undefined,
-                            }),
-                            true
-                        ),
-                    }),
+                    name: confirmNameParam,
                     id: record?.id,
                     ...translateOptions,
                 }}

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -61,19 +61,20 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
     const recordRepresentation = getRecordRepresentation(record);
     let confirmNameParam = recordRepresentation;
     let confirmTitle = 'ra.message.delete_title_record_representation';
+    const resourceName = translate(`resources.${resource}.forcedCaseName`, {
+        smart_count: 1,
+        _: humanize(
+            translate(`resources.${resource}.name`, {
+                smart_count: 1,
+                _: resource ? singularize(resource) : undefined,
+            }),
+            true
+        ),
+    });
 
     if (isValidElement(recordRepresentation)) {
         confirmTitle = 'ra.message.delete_title';
-        confirmNameParam = translate(`resources.${resource}.forcedCaseName`, {
-            smart_count: 1,
-            _: humanize(
-                translate(`resources.${resource}.name`, {
-                    smart_count: 1,
-                    _: resource ? singularize(resource) : undefined,
-                }),
-                true
-            ),
-        });
+        confirmNameParam = resourceName;
     }
 
     return (
@@ -96,6 +97,7 @@ export const DeleteWithConfirmButton = <RecordType extends RaRecord = any>(
                 confirmColor={confirmColor}
                 translateOptions={{
                     name: confirmNameParam,
+                    resource: resourceName,
                     id: record?.id,
                     ...translateOptions,
                 }}

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.spec.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+import {
+    screen,
+    render,
+    waitFor,
+    fireEvent,
+    within,
+} from '@testing-library/react';
 import expect from 'expect';
 import { CoreAdminContext, MutationMode, testDataProvider } from 'ra-core';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -10,6 +16,10 @@ import { Edit } from '../detail';
 import { TextInput } from '../input';
 import { Notification } from '../layout';
 import { MutationOptions } from './UpdateButton.stories';
+import {
+    Basic,
+    NoRecordRepresentation,
+} from './UpdateWithConfirmButton.stories';
 
 const theme = createTheme();
 
@@ -252,7 +262,7 @@ describe('<UpdateWithConfirmButton />', () => {
         fireEvent.click(await screen.findByText('Reset views'));
         await screen.findByRole('dialog');
         await screen.findByText(
-            'Are you sure you want to update this post?',
+            'Are you sure you want to update Lorem Ipsum?',
             undefined,
             { timeout: 4000 }
         );
@@ -263,7 +273,34 @@ describe('<UpdateWithConfirmButton />', () => {
         // wait until next tick, as the settled side effect is called after the success side effect
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 300)));
         expect(
-            screen.queryByText('Are you sure you want to update this post?')
+            screen.queryByText('Are you sure you want to update Lorem Ipsum?')
         ).toBeNull();
+    });
+
+    it('should use the record representation in the confirmation title and content', async () => {
+        render(<Basic />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('War and Peace')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Update')
+        );
+        await screen.findByText('Update War and Peace');
+        await screen.findByText(
+            'Are you sure you want to update War and Peace?'
+        );
+    });
+
+    it('should use the default translation in the confirmation title when no record representation is available', async () => {
+        render(<NoRecordRepresentation />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('Leo Tolstoy')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Update')
+        );
+        await screen.findByText('Update #1');
     });
 });

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.spec.tsx
@@ -262,7 +262,7 @@ describe('<UpdateWithConfirmButton />', () => {
         fireEvent.click(await screen.findByText('Reset views'));
         await screen.findByRole('dialog');
         await screen.findByText(
-            'Are you sure you want to update Lorem Ipsum?',
+            'Are you sure you want to update post Lorem Ipsum?',
             undefined,
             { timeout: 4000 }
         );
@@ -273,7 +273,9 @@ describe('<UpdateWithConfirmButton />', () => {
         // wait until next tick, as the settled side effect is called after the success side effect
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 300)));
         expect(
-            screen.queryByText('Are you sure you want to update Lorem Ipsum?')
+            screen.queryByText(
+                'Are you sure you want to update post Lorem Ipsum?'
+            )
         ).toBeNull();
     });
 
@@ -286,9 +288,9 @@ describe('<UpdateWithConfirmButton />', () => {
                 ) as HTMLElement
             ).getByText('Update')
         );
-        await screen.findByText('Update War and Peace');
+        await screen.findByText('Update book War and Peace');
         await screen.findByText(
-            'Are you sure you want to update War and Peace?'
+            'Are you sure you want to update book War and Peace?'
         );
     });
 
@@ -301,6 +303,6 @@ describe('<UpdateWithConfirmButton />', () => {
                 ) as HTMLElement
             ).getByText('Update')
         );
-        await screen.findByText('Update #1');
+        await screen.findByText('Update author #1');
     });
 });

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.spec.tsx
@@ -19,6 +19,7 @@ import { MutationOptions } from './UpdateButton.stories';
 import {
     Basic,
     NoRecordRepresentation,
+    WithDefaultTranslation,
 } from './UpdateWithConfirmButton.stories';
 
 const theme = createTheme();
@@ -279,8 +280,22 @@ describe('<UpdateWithConfirmButton />', () => {
         ).toBeNull();
     });
 
-    it('should use the record representation in the confirmation title and content', async () => {
+    it('should use the record representation in the confirmation title and content with a resource specific translation', async () => {
         render(<Basic />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('War and Peace')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Update')
+        );
+        await screen.findByText('Update the book "War and Peace"?');
+        await screen.findByText(
+            'Do you really want to update the book "War and Peace"?'
+        );
+    });
+    it('should use the record representation in the confirmation title and content without a resource specific translation', async () => {
+        render(<WithDefaultTranslation />);
         fireEvent.click(
             within(
                 (await screen.findByText('War and Peace')).closest(
@@ -291,6 +306,20 @@ describe('<UpdateWithConfirmButton />', () => {
         await screen.findByText('Update book War and Peace');
         await screen.findByText(
             'Are you sure you want to update book War and Peace?'
+        );
+    });
+    it('should use the record representation in the confirmation title and content', async () => {
+        render(<Basic />);
+        fireEvent.click(
+            within(
+                (await screen.findByText('War and Peace')).closest(
+                    'tr'
+                ) as HTMLElement
+            ).getByText('Update')
+        );
+        await screen.findByText('Update the book "War and Peace"?');
+        await screen.findByText(
+            'Do you really want to update the book "War and Peace"?'
         );
     });
 
@@ -304,5 +333,6 @@ describe('<UpdateWithConfirmButton />', () => {
             ).getByText('Update')
         );
         await screen.findByText('Update author #1');
+        await screen.findByText('Are you sure you want to update author #1?');
     });
 });

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.stories.tsx
@@ -6,13 +6,13 @@ import { Resource, TestMemoryRouter } from 'ra-core';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { Alert } from '@mui/material';
 
-import { DeleteWithConfirmButton } from './DeleteWithConfirmButton';
+import { UpdateWithConfirmButton } from './UpdateWithConfirmButton';
 import { AdminContext } from '../AdminContext';
 import { AdminUI } from '../AdminUI';
 import { List, Datagrid } from '../list';
 import { TextField } from '../field';
 
-export default { title: 'ra-ui-materialui/button/DeleteWithConfirmButton' };
+export default { title: 'ra-ui-materialui/button/UpdateWithConfirmButton' };
 
 const i18nProvider = polyglotI18nProvider(
     locale =>
@@ -153,7 +153,9 @@ export const Basic = () => (
                     name="books"
                     list={
                         <BookList>
-                            <DeleteWithConfirmButton />
+                            <UpdateWithConfirmButton
+                                data={{ title: 'modified' }}
+                            />
                         </BookList>
                     }
                 />
@@ -170,7 +172,9 @@ export const NoRecordRepresentation = () => (
                     name="authors"
                     list={
                         <AuthorList>
-                            <DeleteWithConfirmButton />
+                            <UpdateWithConfirmButton
+                                data={{ fullName: 'modified' }}
+                            />
                         </AuthorList>
                     }
                 />
@@ -187,19 +191,19 @@ export const WithCustomDialogContent = () => (
                     name="books"
                     list={
                         <BookList>
-                            <DeleteWithConfirmButton
+                            <UpdateWithConfirmButton
+                                data={{ title: 'modified' }}
                                 confirmTitle={
                                     <>
-                                        Delete <strong>Full Name</strong>
+                                        Set <strong>title</strong>
                                     </>
                                 }
                                 confirmContent={
                                     <Alert severity="warning">
-                                        Are you sure you want to delete this
-                                        user?
+                                        Are you sure you want to update this
+                                        book?
                                     </Alert>
                                 }
-                                confirmColor="warning"
                             />
                         </BookList>
                     }

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.stories.tsx
@@ -28,11 +28,60 @@ const i18nProvider = polyglotI18nProvider(
                               author: 'Auteur',
                               year: 'Année',
                           },
+                          message: {
+                              bulk_update_title:
+                                  'Mettre à jour le livre "%{recordRepresentation}" ?',
+                              bulk_update_content:
+                                  'Souhaitez-vous vraiment mettre à jour le livre "%{recordRepresentation}" ?',
+                          },
+                      },
+                  },
+              }
+            : {
+                  ...englishMessages,
+                  resources: {
+                      books: {
+                          message: {
+                              bulk_update_title:
+                                  'Update the book "%{recordRepresentation}"?',
+                              bulk_update_content:
+                                  'Do you really want to update the book "%{recordRepresentation}"?',
+                          },
+                      },
+                  },
+              },
+    // Default locale
+    'en',
+    [
+        { locale: 'en', name: 'English' },
+        { locale: 'fr', name: 'Français' },
+    ]
+);
+
+const i18nProviderDefault = polyglotI18nProvider(
+    locale =>
+        locale === 'fr'
+            ? {
+                  ...frenchMessages,
+                  resources: {
+                      books: {
+                          name: 'Livre |||| Livres',
+                          fields: {
+                              id: 'Id',
+                              title: 'Titre',
+                              author: 'Auteur',
+                              year: 'Année',
+                          },
                       },
                   },
               }
             : englishMessages,
-    'en' // Default locale
+    // Default locale
+    'en',
+    [
+        { locale: 'en', name: 'English' },
+        { locale: 'fr', name: 'Français' },
+    ]
 );
 
 const dataProvider = fakeRestDataProvider({
@@ -148,6 +197,28 @@ const AuthorList = ({ children }) => {
 export const Basic = () => (
     <TestMemoryRouter initialEntries={['/books']}>
         <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+            <AdminUI>
+                <Resource
+                    name="books"
+                    list={
+                        <BookList>
+                            <UpdateWithConfirmButton
+                                data={{ title: 'modified' }}
+                            />
+                        </BookList>
+                    }
+                />
+            </AdminUI>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+export const WithDefaultTranslation = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <AdminContext
+            dataProvider={dataProvider}
+            i18nProvider={i18nProviderDefault}
+        >
             <AdminUI>
                 <Resource
                     name="books"

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
@@ -12,6 +12,7 @@ import {
     useRecordContext,
     useUpdate,
     UpdateParams,
+    useGetRecordRepresentation,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
@@ -30,7 +31,7 @@ export const UpdateWithConfirmButton = (
 
     const {
         confirmTitle = 'ra.message.bulk_update_title',
-        confirmContent = 'ra.message.bulk_update_content',
+        confirmContent: confirmContentProp,
         data,
         icon = defaultIcon,
         label = 'ra.action.update',
@@ -109,6 +110,24 @@ export const UpdateWithConfirmButton = (
         }
     };
 
+    const getRecordRepresentation = useGetRecordRepresentation(resource);
+    const recordRepresentation = getRecordRepresentation(record);
+    let confirmNameParam = recordRepresentation;
+    let confirmContent = 'ra.message.bulk_update_content_record_representation';
+
+    if (React.isValidElement(recordRepresentation)) {
+        confirmNameParam = translate(`resources.${resource}.forcedCaseName`, {
+            smart_count: 1,
+            _: humanize(
+                translate(`resources.${resource}.name`, {
+                    smart_count: 1,
+                    _: resource ? inflect(resource, 1) : undefined,
+                }),
+                true
+            ),
+        });
+        confirmContent = 'ra.message.bulk_update_content';
+    }
     return (
         <Fragment>
             <StyledButton
@@ -122,19 +141,10 @@ export const UpdateWithConfirmButton = (
                 isOpen={isOpen}
                 loading={isPending}
                 title={confirmTitle}
-                content={confirmContent}
+                content={confirmContentProp ?? confirmContent}
                 translateOptions={{
                     smart_count: 1,
-                    name: translate(`resources.${resource}.forcedCaseName`, {
-                        smart_count: 1,
-                        _: humanize(
-                            translate(`resources.${resource}.name`, {
-                                smart_count: 1,
-                                _: resource ? inflect(resource, 1) : undefined,
-                            }),
-                            true
-                        ),
-                    }),
+                    name: confirmNameParam,
                 }}
                 onConfirm={handleUpdate}
                 onClose={handleDialogClose}

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
@@ -30,7 +30,7 @@ export const UpdateWithConfirmButton = (
     const record = useRecordContext(props);
 
     const {
-        confirmTitle = 'ra.message.bulk_update_title',
+        confirmTitle: confirmTitleProp,
         confirmContent: confirmContentProp,
         data,
         icon = defaultIcon,
@@ -114,18 +114,21 @@ export const UpdateWithConfirmButton = (
     const recordRepresentation = getRecordRepresentation(record);
     let confirmNameParam = recordRepresentation;
     let confirmContent = 'ra.message.bulk_update_content_record_representation';
+    let confirmTitle = 'ra.message.bulk_update_title_record_representation';
+    const resourceName = translate(`resources.${resource}.forcedCaseName`, {
+        smart_count: 1,
+        _: humanize(
+            translate(`resources.${resource}.name`, {
+                smart_count: 1,
+                _: resource ? inflect(resource, 1) : undefined,
+            }),
+            true
+        ),
+    });
 
     if (React.isValidElement(recordRepresentation)) {
-        confirmNameParam = translate(`resources.${resource}.forcedCaseName`, {
-            smart_count: 1,
-            _: humanize(
-                translate(`resources.${resource}.name`, {
-                    smart_count: 1,
-                    _: resource ? inflect(resource, 1) : undefined,
-                }),
-                true
-            ),
-        });
+        confirmNameParam = resourceName;
+        confirmTitle = 'ra.message.bulk_update_title';
         confirmContent = 'ra.message.bulk_update_content';
     }
     return (
@@ -140,11 +143,12 @@ export const UpdateWithConfirmButton = (
             <Confirm
                 isOpen={isOpen}
                 loading={isPending}
-                title={confirmTitle}
+                title={confirmTitleProp ?? confirmTitle}
                 content={confirmContentProp ?? confirmContent}
                 translateOptions={{
                     smart_count: 1,
                     name: confirmNameParam,
+                    resource: resourceName,
                 }}
                 onConfirm={handleUpdate}
                 onClose={handleDialogClose}

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
@@ -120,10 +120,9 @@ export const UpdateWithConfirmButton = (
     };
 
     const getRecordRepresentation = useGetRecordRepresentation(resource);
-    const recordRepresentation = getRecordRepresentation(record);
-    let confirmNameParam = recordRepresentation;
-    let confirmContent = 'ra.message.bulk_update_content_record_representation';
-    let confirmTitle = 'ra.message.bulk_update_title_record_representation';
+    let recordRepresentation = getRecordRepresentation(record);
+    let confirmContent = `resources.${resource}.message.bulk_update_content`;
+    let confirmTitle = `resources.${resource}.message.bulk_update_title`;
     const resourceName = translate(`resources.${resource}.forcedCaseName`, {
         smart_count: 1,
         _: humanize(
@@ -134,12 +133,11 @@ export const UpdateWithConfirmButton = (
             true
         ),
     });
-
+    // We don't support React elements for this
     if (React.isValidElement(recordRepresentation)) {
-        confirmNameParam = resourceName;
-        confirmTitle = 'ra.message.bulk_update_title';
-        confirmContent = 'ra.message.bulk_update_content';
+        recordRepresentation = `#${record?.id}`;
     }
+
     return (
         <Fragment>
             <StyledButton
@@ -154,10 +152,25 @@ export const UpdateWithConfirmButton = (
                 loading={isPending}
                 title={confirmTitleProp ?? confirmTitle}
                 content={confirmContentProp ?? confirmContent}
-                translateOptions={{
+                titleTranslateOptions={{
                     smart_count: 1,
-                    name: confirmNameParam,
-                    resource: resourceName,
+                    name: resourceName,
+                    recordRepresentation,
+                    _: translate('ra.message.bulk_update_title', {
+                        smart_count: 1,
+                        name: resourceName,
+                        recordRepresentation,
+                    }),
+                }}
+                contentTranslateOptions={{
+                    smart_count: 1,
+                    name: resourceName,
+                    recordRepresentation,
+                    _: translate('ra.message.bulk_update_content', {
+                        smart_count: 1,
+                        name: resourceName,
+                        recordRepresentation,
+                    }),
                 }}
                 onConfirm={handleUpdate}
                 onClose={handleDialogClose}

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -56,6 +56,8 @@ export const Confirm = (inProps: ConfirmProps) => {
         onClose,
         onConfirm,
         translateOptions = {},
+        titleTranslateOptions = translateOptions,
+        contentTranslateOptions = translateOptions,
         ...rest
     } = props;
 
@@ -84,7 +86,7 @@ export const Confirm = (inProps: ConfirmProps) => {
         >
             <DialogTitle id="alert-dialog-title">
                 {typeof title === 'string'
-                    ? translate(title, { _: title, ...translateOptions })
+                    ? translate(title, { _: title, ...titleTranslateOptions })
                     : title}
             </DialogTitle>
             <DialogContent>
@@ -92,7 +94,7 @@ export const Confirm = (inProps: ConfirmProps) => {
                     <DialogContentText>
                         {translate(content, {
                             _: content,
-                            ...translateOptions,
+                            ...contentTranslateOptions,
                         })}
                     </DialogContentText>
                 ) : (
@@ -140,7 +142,12 @@ export interface ConfirmProps
     onClose: MouseEventHandler;
     onConfirm: MouseEventHandler;
     title: React.ReactNode;
+    /**
+     * @deprecated use `titleTranslateOptions` and `contentTranslateOptions` instead
+     */
     translateOptions?: object;
+    titleTranslateOptions?: object;
+    contentTranslateOptions?: object;
 }
 
 const PREFIX = 'RaConfirm';


### PR DESCRIPTION
## Problem

`<DeleteButton>` and `<UpdateButton>` confirmation dialog titles show a very generic message but we can do better thanks to the record representation.

## Solution

- If a resource has a string record representation, use it.
- To avoid breaking changes, introduce new translation keys where needed

## How To Test

### `<DeleteButton>`

- https://react-admin-storybook-j5tx6l6fc-marmelab.vercel.app/?path=/story/ra-ui-materialui-button-deletewithconfirmbutton--basic
- https://react-admin-storybook-j5tx6l6fc-marmelab.vercel.app/?path=/story/ra-ui-materialui-button-deletewithconfirmbutton--no-record-representation
- https://react-admin-storybook-j5tx6l6fc-marmelab.vercel.app/?path=/story/ra-ui-materialui-button-deletewithconfirmbutton--with-custom-dialog-content

### `<UpdateButton>`

- https://react-admin-storybook-j5tx6l6fc-marmelab.vercel.app/?path=/story/ra-ui-materialui-button-updatewithconfirmbutton--basic
- https://react-admin-storybook-j5tx6l6fc-marmelab.vercel.app/?path=/story/ra-ui-materialui-button-updatewithconfirmbutton--no-record-representation
- https://react-admin-storybook-j5tx6l6fc-marmelab.vercel.app/?path=/story/ra-ui-materialui-button-updatewithconfirmbutton--with-custom-dialog-content

## Screenshots

### `<DeleteButton>`

**Before**
![image](https://github.com/user-attachments/assets/cedccb39-2d66-4a21-9995-5467b1b01ec6)
**After**
![image](https://github.com/user-attachments/assets/0a64cdfe-4f9f-4fea-90aa-0421e1d46f84)


### `<UpdateButton>`

**Before**
![image](https://github.com/user-attachments/assets/a63dc6dc-9d5e-42e7-91a5-82b85db62679)
**After**
![image](https://github.com/user-attachments/assets/214fc9fd-b5e2-4c53-8b79-36deb90ecc48)


## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
