### PR TITLE
Improve theme dx

### DIFF
--- a/packages/ra-ui-materialui/src/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/Labeled.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
-import { ElementType, ReactElement } from 'react';
+import type { ElementType, ReactElement } from 'react';
 import {
     Stack,
-    StackProps,
-    Theme,
+    type StackProps,
+    type Theme,
     Typography,
-    TypographyProps,
+    type TypographyProps,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
-import { Property } from 'csstype';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
+import { type Property } from 'csstype';
 import clsx from 'clsx';
 
 import { FieldTitle } from 'ra-core';
-import { ResponsiveStyleValue } from '@mui/system';
+import { useThemeProps, type ResponsiveStyleValue } from '@mui/system';
 
 /**
  * Wrap a field or an input with a label if necessary.
@@ -26,57 +26,65 @@ import { ResponsiveStyleValue } from '@mui/system';
  *     <FooComponent source="title" />
  * </Labeled>
  */
-export const Labeled = ({
-    children,
-    className = '',
-    color,
-    component = 'span',
-    fullWidth,
-    isRequired,
-    label,
-    resource,
-    source,
-    TypographyProps,
-    ...rest
-}: LabeledProps) => (
-    <Root
-        // @ts-ignore https://github.com/mui/material-ui/issues/29875
-        component={component}
-        className={clsx(className, {
-            [LabeledClasses.fullWidth]: fullWidth,
-        })}
-        {...rest}
-    >
-        {label !== false &&
-        children.props.label !== false &&
-        typeof children.type !== 'string' &&
-        // @ts-ignore
-        children.type?.displayName !== 'Labeled' &&
-        // @ts-ignore
-        children.type?.displayName !== 'Labeled' ? (
-            <Typography
-                sx={
-                    color
-                        ? undefined
-                        : {
-                              color: theme => theme.palette.text.secondary,
-                          }
-                }
-                color={color}
-                className={LabeledClasses.label}
-                {...TypographyProps}
-            >
-                <FieldTitle
-                    label={label || children.props.label}
-                    source={source || children.props.source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
-            </Typography>
-        ) : null}
-        {children}
-    </Root>
-);
+export const Labeled = (inProps: LabeledProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const {
+        children,
+        className = '',
+        color,
+        component = 'span',
+        fullWidth,
+        isRequired,
+        label,
+        resource,
+        source,
+        TypographyProps,
+        ...rest
+    } = props;
+
+    return (
+        <Root
+            // @ts-ignore https://github.com/mui/material-ui/issues/29875
+            component={component}
+            className={clsx(className, {
+                [LabeledClasses.fullWidth]: fullWidth,
+            })}
+            {...rest}
+        >
+            {label !== false &&
+            children.props.label !== false &&
+            typeof children.type !== 'string' &&
+            // @ts-ignore
+            children.type?.displayName !== 'Labeled' &&
+            // @ts-ignore
+            children.type?.displayName !== 'Labeled' ? (
+                <Typography
+                    sx={
+                        color
+                            ? undefined
+                            : {
+                                  color: theme => theme.palette.text.secondary,
+                              }
+                    }
+                    color={color}
+                    className={LabeledClasses.label}
+                    {...TypographyProps}
+                >
+                    <FieldTitle
+                        label={label || children.props.label}
+                        source={source || children.props.source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                </Typography>
+            ) : null}
+            {children}
+        </Root>
+    );
+};
 
 Labeled.displayName = 'Labeled';
 
@@ -121,3 +129,22 @@ const Root = styled(Stack, {
         marginBottom: '0.2em',
     },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLabeled: 'root' | 'label' | 'fullWidth';
+    }
+
+    interface ComponentsPropsList {
+        RaLabeled: Partial<LabeledProps>;
+    }
+
+    interface Components {
+        RaLabeled?: {
+            defaultProps?: ComponentsPropsList['RaLabeled'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLabeled'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/Link.tsx
+++ b/packages/ra-ui-materialui/src/Link.tsx
@@ -1,13 +1,22 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { Link as RRLink, LinkProps as RRLinkProps } from 'react-router-dom';
+import {
+    Link as RRLink,
+    type LinkProps as RRLinkProps,
+} from 'react-router-dom';
 import {
     styled,
     Link as MuiLink,
-    LinkProps as MuiLinkProps,
+    type LinkProps as MuiLinkProps,
+    type ComponentsOverrides,
+    useThemeProps,
 } from '@mui/material';
 
-export const Link = (props: LinkProps) => {
+export const Link = (inProps: LinkProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { to, children, className, ...rest } = props;
 
     return (
@@ -28,10 +37,32 @@ export const LinkClasses = {
     link: `${PREFIX}-link`,
 };
 
-const StyledMuiLink = styled(MuiLink)({}) as typeof MuiLink; // @see https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop
+const StyledMuiLink = styled(MuiLink)({
+    name: PREFIX,
+    overridesResolver: (props, styles) => styles.root,
+}) as typeof MuiLink; // @see https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop
 
 // @see https://mui.com/material-ui/guides/composition/#with-typescript
 export interface LinkProps
     extends MuiLinkProps<React.ElementType<any>, RRLinkProps> {
     className?: string;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLink: 'root' | 'link';
+    }
+
+    interface ComponentsPropsList {
+        RaLink: Partial<LinkProps>;
+    }
+
+    interface Components {
+        RaLink?: {
+            defaultProps?: ComponentsPropsList['RaLink'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLink'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/auth/AuthError.tsx
+++ b/packages/ra-ui-materialui/src/auth/AuthError.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react';
-import { styled, SxProps } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
 import { useTranslate } from 'ra-core';
 import { Button } from '../button';
 import { Link } from 'react-router-dom';
 
-export const AuthError = (props: AuthErrorProps) => {
+export const AuthError = (inProps: AuthErrorProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         title = 'ra.page.error',
@@ -63,3 +72,22 @@ const Root = styled('div', {
         margin: '0 1em',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaAuthError: 'root' | 'message';
+    }
+
+    interface ComponentsPropsList {
+        RaAuthError: Partial<AuthErrorProps>;
+    }
+
+    interface Components {
+        RaAuthError?: {
+            defaultProps?: ComponentsPropsList['RaAuthError'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaAuthError'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/auth/AuthLayout.tsx
+++ b/packages/ra-ui-materialui/src/auth/AuthLayout.tsx
@@ -1,17 +1,25 @@
 import * as React from 'react';
-import { Card, styled, Theme } from '@mui/material';
-import { MUIStyledCommonProps } from '@mui/system';
+import {
+    Card,
+    type ComponentsOverrides,
+    styled,
+    type Theme,
+} from '@mui/material';
+import { useThemeProps, type MUIStyledCommonProps } from '@mui/system';
 import clsx from 'clsx';
 
-export const AuthLayout = ({
-    children,
-    className,
-    ...props
-}: AuthLayoutProps) => (
-    <Root className={clsx(AuthLayoutClasses.root, className)} {...props}>
-        <Card className={AuthLayoutClasses.card}>{children}</Card>
-    </Root>
-);
+export const AuthLayout = (inProps: AuthLayoutProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const { children, className, ...rest } = props;
+    return (
+        <Root className={clsx(AuthLayoutClasses.root, className)} {...rest}>
+            <Card className={AuthLayoutClasses.card}>{children}</Card>
+        </Root>
+    );
+};
 
 export interface AuthLayoutProps
     extends MUIStyledCommonProps<Theme>,
@@ -46,3 +54,22 @@ const Root = styled('div', {
         marginTop: '6em',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaAuthLayout: 'root' | 'card';
+    }
+
+    interface ComponentsPropsList {
+        RaAuthLayout: Partial<AuthLayoutProps>;
+    }
+
+    interface Components {
+        RaAuthLayout?: {
+            defaultProps?: ComponentsPropsList['RaAuthLayout'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaAuthLayout'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/auth/Login.tsx
+++ b/packages/ra-ui-materialui/src/auth/Login.tsx
@@ -1,7 +1,16 @@
 import * as React from 'react';
-import { HtmlHTMLAttributes, ReactNode, useRef, useEffect } from 'react';
-import { Card, Avatar, SxProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import {
+    type HtmlHTMLAttributes,
+    type ReactNode,
+    useRef,
+    useEffect,
+} from 'react';
+import { Card, Avatar, type SxProps } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import LockIcon from '@mui/icons-material/Lock';
 import { useNavigate } from 'react-router-dom';
 import { useCheckAuth } from 'ra-core';
@@ -26,7 +35,11 @@ import { LoginForm as DefaultLoginForm } from './LoginForm';
  *        </Admin>
  *     );
  */
-export const Login = (props: LoginProps) => {
+export const Login = (inProps: LoginProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children = defaultLoginForm,
         backgroundImage,
@@ -128,3 +141,22 @@ const Root = styled('div', {
         backgroundColor: theme.palette.secondary[500],
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLogin: 'root' | 'card' | 'avatar' | 'icon';
+    }
+
+    interface ComponentsPropsList {
+        RaLogin: Partial<LoginProps>;
+    }
+
+    interface Components {
+        RaLogin?: {
+            defaultProps?: ComponentsPropsList['RaLogin'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLogin'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/auth/LoginForm.tsx
+++ b/packages/ra-ui-materialui/src/auth/LoginForm.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
-import { styled, SxProps } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import { Button, CardContent, CircularProgress } from '@mui/material';
 import { Form, required, useTranslate, useLogin, useNotify } from 'ra-core';
 import { PasswordInput, TextInput } from '../input';
 
-export const LoginForm = (props: LoginFormProps) => {
+export const LoginForm = (inProps: LoginFormProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { redirectTo, className, sx, children } = props;
     const [loading, setLoading] = React.useState(false);
     const login = useLogin();
@@ -124,4 +133,23 @@ export interface LoginFormProps {
 interface FormData {
     username: string;
     password: string;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLoginForm: 'root' | 'content' | 'button' | 'icon';
+    }
+
+    interface ComponentsPropsList {
+        RaLoginForm: Partial<LoginFormProps>;
+    }
+
+    interface Components {
+        RaLoginForm?: {
+            defaultProps?: ComponentsPropsList['RaLoginForm'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLoginForm'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/auth/Logout.tsx
+++ b/packages/ra-ui-materialui/src/auth/Logout.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
-import { styled, Theme } from '@mui/material/styles';
-import { useCallback, ReactNode } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    type Theme,
+    useThemeProps,
+} from '@mui/material/styles';
+import { useCallback, type ReactNode } from 'react';
 import {
     ListItemIcon,
     ListItemText,
     MenuItem,
+    type MenuItemProps,
     useMediaQuery,
 } from '@mui/material';
-import { MenuItemProps } from '@mui/material/MenuItem';
 
 import ExitIcon from '@mui/icons-material/PowerSettingsNew';
 import clsx from 'clsx';
@@ -23,7 +28,11 @@ export const Logout: React.ForwardRefExoticComponent<
         React.RefAttributes<HTMLLIElement> &
         LogoutProps
 > = React.forwardRef<HTMLLIElement, LogoutProps & MenuItemProps<'li'>>(
-    function Logout(props, ref) {
+    function Logout(inProps, ref) {
+        const props = useThemeProps({
+            props: inProps,
+            name: PREFIX,
+        });
         const { className, redirectTo, icon, ...rest } = props;
 
         const { authenticated } = useAuthState();
@@ -76,4 +85,23 @@ export interface LogoutProps {
     className?: string;
     redirectTo?: string;
     icon?: ReactNode;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLogout: 'root' | 'icon';
+    }
+
+    interface ComponentsPropsList {
+        RaLogout: Partial<LogoutProps>;
+    }
+
+    interface Components {
+        RaLogout?: {
+            defaultProps?: ComponentsPropsList['RaLogout'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLogout'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -2,27 +2,36 @@ import * as React from 'react';
 import { Fragment, useState } from 'react';
 import ActionDelete from '@mui/icons-material/Delete';
 
-import { alpha, styled } from '@mui/material/styles';
 import {
-    MutationMode,
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import {
+    type MutationMode,
     useDeleteMany,
     useListContext,
     useNotify,
     useRefresh,
     useResourceContext,
     useTranslate,
-    RaRecord,
-    DeleteManyParams,
+    type RaRecord,
+    type DeleteManyParams,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
-import { Button, ButtonProps } from './Button';
-import { UseMutationOptions } from '@tanstack/react-query';
+import { Button, type ButtonProps } from './Button';
+import type { UseMutationOptions } from '@tanstack/react-query';
 import { humanize, inflect } from 'inflection';
 
 export const BulkDeleteWithConfirmButton = (
-    props: BulkDeleteWithConfirmButtonProps
+    inProps: BulkDeleteWithConfirmButtonProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         confirmTitle = 'ra.message.bulk_delete_title',
         confirmContent = 'ra.message.bulk_delete_content',
@@ -186,3 +195,22 @@ const StyledButton = styled(Button, {
 }));
 
 const defaultIcon = <ActionDelete />;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaBulkDeleteWithConfirmButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaBulkDeleteWithConfirmButton: Partial<BulkDeleteWithConfirmButtonProps>;
+    }
+
+    interface Components {
+        RaBulkDeleteWithConfirmButton?: {
+            defaultProps?: ComponentsPropsList['RaBulkDeleteWithConfirmButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaBulkDeleteWithConfirmButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -1,23 +1,32 @@
 import * as React from 'react';
 import ActionDelete from '@mui/icons-material/Delete';
-import { alpha, styled } from '@mui/material/styles';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     useDeleteMany,
     useRefresh,
     useNotify,
     useResourceContext,
     useListContext,
-    RaRecord,
-    DeleteManyParams,
+    type RaRecord,
+    type DeleteManyParams,
     useTranslate,
 } from 'ra-core';
 
-import { Button, ButtonProps } from './Button';
-import { UseMutationOptions } from '@tanstack/react-query';
+import { Button, type ButtonProps } from './Button';
+import type { UseMutationOptions } from '@tanstack/react-query';
 
 export const BulkDeleteWithUndoButton = (
-    props: BulkDeleteWithUndoButtonProps
+    inProps: BulkDeleteWithUndoButtonProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         label = 'ra.action.delete',
         icon = defaultIcon,
@@ -133,3 +142,22 @@ const StyledButton = styled(Button, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaBulkDeleteWithUndoButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaBulkDeleteWithUndoButton: Partial<BulkDeleteWithUndoButtonProps>;
+    }
+
+    interface Components {
+        RaBulkDeleteWithUndoButton?: {
+            defaultProps?: ComponentsPropsList['RaBulkDeleteWithUndoButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaBulkDeleteWithUndoButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { Fragment, useState } from 'react';
 import ActionUpdate from '@mui/icons-material/Update';
 
-import { alpha, styled } from '@mui/material/styles';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     useListContext,
     useTranslate,
@@ -10,19 +15,23 @@ import {
     useNotify,
     useUnselectAll,
     useResourceContext,
-    MutationMode,
-    RaRecord,
-    UpdateManyParams,
+    type MutationMode,
+    type RaRecord,
+    type UpdateManyParams,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
-import { Button, ButtonProps } from './Button';
-import { UseMutationOptions } from '@tanstack/react-query';
+import { Button, type ButtonProps } from './Button';
+import type { UseMutationOptions } from '@tanstack/react-query';
 import { humanize, inflect } from 'inflection';
 
 export const BulkUpdateWithConfirmButton = (
-    props: BulkUpdateWithConfirmButtonProps
+    inProps: BulkUpdateWithConfirmButtonProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const notify = useNotify();
     const translate = useTranslate();
     const resource = useResourceContext(props);
@@ -185,3 +194,22 @@ const StyledButton = styled(Button, {
 }));
 
 const defaultIcon = <ActionUpdate />;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaBulkUpdateWithConfirmButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaBulkUpdateWithConfirmButton: Partial<BulkUpdateWithConfirmButtonProps>;
+    }
+
+    interface Components {
+        RaBulkUpdateWithConfirmButton?: {
+            defaultProps?: ComponentsPropsList['RaBulkUpdateWithConfirmButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaBulkUpdateWithConfirmButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import ActionUpdate from '@mui/icons-material/Update';
-import { alpha, styled } from '@mui/material/styles';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     useUpdateMany,
     useRefresh,
@@ -8,17 +13,21 @@ import {
     useUnselectAll,
     useResourceContext,
     useListContext,
-    RaRecord,
-    UpdateManyParams,
+    type RaRecord,
+    type UpdateManyParams,
     useTranslate,
 } from 'ra-core';
-import { UseMutationOptions } from '@tanstack/react-query';
+import type { UseMutationOptions } from '@tanstack/react-query';
 
-import { Button, ButtonProps } from './Button';
+import { Button, type ButtonProps } from './Button';
 
 export const BulkUpdateWithUndoButton = (
-    props: BulkUpdateWithUndoButtonProps
+    inProps: BulkUpdateWithUndoButtonProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { selectedIds } = useListContext();
 
     const notify = useNotify();
@@ -143,3 +152,22 @@ const StyledButton = styled(Button, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaBulkUpdateWithUndoButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaBulkUpdateWithUndoButton: Partial<BulkUpdateWithUndoButtonProps>;
+    }
+
+    interface Components {
+        RaBulkUpdateWithUndoButton?: {
+            defaultProps?: ComponentsPropsList['RaBulkUpdateWithUndoButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaBulkUpdateWithUndoButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -7,7 +7,11 @@ import {
     useMediaQuery,
     Theme,
 } from '@mui/material';
-import { styled, useThemeProps } from '@mui/material/styles';
+import {
+    ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { useTranslate } from 'ra-core';
 import { Path, To } from 'react-router';
 
@@ -27,7 +31,7 @@ import { Path, To } from 'react-router';
 export const Button = <RootComponent extends React.ElementType = 'button'>(
     inProps: ButtonProps<RootComponent>
 ) => {
-    const props = useThemeProps({ props: inProps, name: 'RaButton' });
+    const props = useThemeProps({ props: inProps, name: PREFIX });
     const {
         alignIcon = 'left',
         children,
@@ -142,3 +146,22 @@ export type LocationDescriptor = Partial<Path> & {
     state?: any;
     replace?: boolean;
 };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaButton: Partial<ButtonProps>;
+    }
+
+    interface Components {
+        RaButton?: {
+            defaultProps?: ComponentsPropsList['RaButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import ContentAdd from '@mui/icons-material/Add';
-import { Fab, useMediaQuery, Theme } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { Fab, useMediaQuery, type Theme } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
@@ -11,9 +15,9 @@ import {
     useCreatePath,
     useCanAccess,
 } from 'ra-core';
-import { Link, To } from 'react-router-dom';
+import { Link, type To } from 'react-router-dom';
 
-import { Button, ButtonProps, LocationDescriptor } from './Button';
+import { Button, type ButtonProps, type LocationDescriptor } from './Button';
 
 /**
  * Opens the Create view of a given resource
@@ -28,7 +32,11 @@ import { Button, ButtonProps, LocationDescriptor } from './Button';
  *     <CreateButton label="Create comment" />
  * );
  */
-const CreateButton = (props: CreateButtonProps) => {
+const CreateButton = (inProps: CreateButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         icon = defaultIcon,
@@ -173,3 +181,22 @@ const getLinkParams = (locationDescriptor?: LocationDescriptor | string) => {
         state,
     };
 };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaCreateButton: 'root' | 'floating';
+    }
+
+    interface ComponentsPropsList {
+        RaCreateButton: Partial<CreateButtonProps>;
+    }
+
+    interface Components {
+        RaCreateButton?: {
+            defaultProps?: ComponentsPropsList['RaCreateButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaCreateButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/EditButton.tsx
+++ b/packages/ra-ui-materialui/src/button/EditButton.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import ContentCreate from '@mui/icons-material/Create';
 import { Link } from 'react-router-dom';
 import {
-    RaRecord,
+    type RaRecord,
     useResourceContext,
     useRecordContext,
     useCreatePath,
@@ -27,8 +31,12 @@ import { Button, ButtonProps } from './Button';
  * );
  */
 export const EditButton = <RecordType extends RaRecord = any>(
-    props: EditButtonProps<RecordType>
+    inProps: EditButtonProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         icon = defaultIcon,
         label = 'ra.action.edit',
@@ -97,3 +105,22 @@ const StyledButton = styled(Button, {
     name: PREFIX,
     overridesResolver: (_props, styles) => styles.root,
 })({});
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaEditButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaEditButton: Partial<EditButtonProps>;
+    }
+
+    interface Components {
+        RaEditButton?: {
+            defaultProps?: ComponentsPropsList['RaEditButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaEditButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/LocalesMenuButton.tsx
+++ b/packages/ra-ui-materialui/src/button/LocalesMenuButton.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
-import { MouseEvent, ReactNode, useState } from 'react';
+import { type MouseEvent, type ReactNode, useState } from 'react';
 import { useLocaleState, useLocales } from 'ra-core';
-import { Box, Button, Menu, MenuItem, styled } from '@mui/material';
+import {
+    Box,
+    Button,
+    type ComponentsOverrides,
+    Menu,
+    MenuItem,
+    styled,
+    useThemeProps,
+} from '@mui/material';
 import LanguageIcon from '@mui/icons-material/Translate';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
@@ -21,7 +29,11 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
  *     </AppBar>
  * );
  */
-export const LocalesMenuButton = (props: LocalesMenuButtonProps) => {
+export const LocalesMenuButton = (inProps: LocalesMenuButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { icon = DefaultIcon, languages: languagesProp } = props;
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const languages = useLocales({ locales: languagesProp });
@@ -93,4 +105,23 @@ const Root = styled('span', {
 export interface LocalesMenuButtonProps {
     icon?: ReactNode;
     languages?: { locale: string; name: string }[];
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLocalesMenuButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaLocalesMenuButton: Partial<LocalesMenuButtonProps>;
+    }
+
+    interface Components {
+        RaLocalesMenuButton?: {
+            defaultProps?: ComponentsPropsList['RaLocalesMenuButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLocalesMenuButton'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
+++ b/packages/ra-ui-materialui/src/button/PrevNextButtons.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-    RaRecord,
+    type RaRecord,
     useTranslate,
     usePrevNextController,
     UsePrevNextControllerProps,
@@ -14,8 +14,10 @@ import {
     Stack,
     Typography,
     IconButton,
-    SxProps,
+    type SxProps,
     styled,
+    type ComponentsOverrides,
+    useThemeProps,
 } from '@mui/material';
 import clsx from 'clsx';
 
@@ -97,8 +99,12 @@ import { LinearProgress } from '../layout/LinearProgress';
  */
 
 export const PrevNextButtons = <RecordType extends RaRecord = any>(
-    props: PrevNextButtonProps<RecordType>
+    inProps: PrevNextButtonProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { sx } = props;
 
     const {
@@ -208,3 +214,22 @@ const Root = styled(Stack, {
     alignItems: 'center',
     gap: '0.5em',
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaPrevNextButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaPrevNextButton: Partial<PrevNextButtonProps>;
+    }
+
+    interface Components {
+        RaPrevNextButton?: {
+            defaultProps?: ComponentsPropsList['RaPrevNextButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaPrevNextButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
-import { MouseEventHandler, useCallback } from 'react';
-import { UseMutationOptions } from '@tanstack/react-query';
-import { styled } from '@mui/material/styles';
-import { Button, ButtonProps, CircularProgress } from '@mui/material';
+import { type MouseEventHandler, useCallback } from 'react';
+import type { UseMutationOptions } from '@tanstack/react-query';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Button, type ButtonProps, CircularProgress } from '@mui/material';
 import ContentSave from '@mui/icons-material/Save';
 import { useFormContext, useFormState } from 'react-hook-form';
 import {
-    CreateParams,
-    RaRecord,
-    TransformData,
-    UpdateParams,
+    type CreateParams,
+    type RaRecord,
+    type TransformData,
+    type UpdateParams,
     useSaveContext,
     useTranslate,
     warning,
@@ -44,8 +48,12 @@ import {
  * }
  */
 export const SaveButton = <RecordType extends RaRecord = any>(
-    props: SaveButtonProps<RecordType>
+    inProps: SaveButtonProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         color = 'primary',
         icon = defaultIcon,
@@ -194,3 +202,22 @@ const StyledButton = styled(Button, {
 
 const valueOrDefault = (value, defaultValue) =>
     typeof value === 'undefined' ? defaultValue : value;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSaveButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSaveButton: Partial<SaveButtonProps>;
+    }
+
+    interface Components {
+        RaSaveButton?: {
+            defaultProps?: ComponentsPropsList['RaSaveButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSaveButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/SelectAllButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SelectAllButton.tsx
@@ -6,9 +6,14 @@ import {
     type UseReferenceArrayFieldControllerParams,
     type UseReferenceManyFieldControllerParams,
 } from 'ra-core';
-import { alpha, styled } from '@mui/material/styles';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 
-import { Button, ButtonProps } from './Button';
+import { Button, type ButtonProps } from './Button';
 
 /**
  * Select all items in the current List context.
@@ -47,7 +52,11 @@ import { Button, ButtonProps } from './Button';
  *     </List>
  * );
  */
-export const SelectAllButton = (props: SelectAllButtonProps) => {
+export const SelectAllButton = (inProps: SelectAllButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         label = 'ra.action.select_all_button',
         limit = 250,
@@ -108,3 +117,22 @@ const StyledButton = styled(Button, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSelectAllButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSelectAllButton: Partial<SelectAllButtonProps>;
+    }
+
+    interface Components {
+        RaSelectAllButton?: {
+            defaultProps?: ComponentsPropsList['RaSelectAllButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSelectAllButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/SkipNavigationButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SkipNavigationButton.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
-import { styled } from '@mui/material/styles';
-import { Button } from './Button';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Button, type ButtonProps } from './Button';
 
-export const SkipNavigationButton = () => {
+export const SkipNavigationButton = (inProps: ButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     return (
         <StyledButton
             onClick={skipToContent}
             className={'skip-nav-button'}
             label="ra.navigation.skip_nav"
             variant="contained"
+            {...props}
         />
     );
 };
@@ -62,3 +71,22 @@ const skipToContent = () => {
     element.blur();
     element.removeAttribute('tabIndex');
 };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSkipNavigationButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSkipNavigationButton: Partial<ButtonProps>;
+    }
+
+    interface Components {
+        RaSkipNavigationButton?: {
+            defaultProps?: ComponentsPropsList['RaSkipNavigationButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSkipNavigationButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/SortButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SortButton.tsx
@@ -8,10 +8,14 @@ import {
     Tooltip,
     IconButton,
     useMediaQuery,
-    Theme,
-    SxProps,
+    type Theme,
+    type SxProps,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import SortIcon from '@mui/icons-material/Sort';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import {
@@ -46,7 +50,11 @@ import {
  *     </TopToolbar>
  * );
  */
-const SortButton = (props: SortButtonProps) => {
+const SortButton = (inProps: SortButtonProps) => {
+    const props = useThemeProps({
+        name: PREFIX,
+        props: inProps,
+    });
     const {
         fields,
         label = 'ra.sort.sort_by',
@@ -197,3 +205,22 @@ const Root = styled('span', {
 });
 
 export default memo(SortButton, arePropsEqual);
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSortButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSortButton: Partial<SortButtonProps>;
+    }
+
+    interface Components {
+        RaSortButton?: {
+            defaultProps?: ComponentsPropsList['RaSortButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSortButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithConfirmButton.tsx
@@ -2,26 +2,35 @@ import * as React from 'react';
 import { Fragment, useState } from 'react';
 import ActionUpdate from '@mui/icons-material/Update';
 
-import { alpha, styled } from '@mui/material/styles';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     useTranslate,
     useNotify,
     useResourceContext,
-    MutationMode,
-    RaRecord,
+    type MutationMode,
+    type RaRecord,
     useRecordContext,
     useUpdate,
-    UpdateParams,
+    type UpdateParams,
 } from 'ra-core';
 
 import { Confirm } from '../layout';
-import { Button, ButtonProps } from './Button';
-import { UseMutationOptions } from '@tanstack/react-query';
+import { Button, type ButtonProps } from './Button';
+import type { UseMutationOptions } from '@tanstack/react-query';
 import { humanize, inflect } from 'inflection';
 
 export const UpdateWithConfirmButton = (
-    props: UpdateWithConfirmButtonProps
+    inProps: UpdateWithConfirmButtonProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const notify = useNotify();
     const translate = useTranslate();
     const resource = useResourceContext(props);
@@ -184,3 +193,22 @@ const StyledButton = styled(Button, {
 }));
 
 const defaultIcon = <ActionUpdate />;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaUpdateWithConfirmButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaUpdateWithConfirmButton: Partial<UpdateWithConfirmButtonProps>;
+    }
+
+    interface Components {
+        RaUpdateWithConfirmButton?: {
+            defaultProps?: ComponentsPropsList['RaUpdateWithConfirmButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaUpdateWithConfirmButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
@@ -1,21 +1,30 @@
 import * as React from 'react';
-import { alpha, styled } from '@mui/material/styles';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import ActionUpdate from '@mui/icons-material/Update';
 import {
     useRefresh,
     useNotify,
     useResourceContext,
-    RaRecord,
+    type RaRecord,
     useRecordContext,
     useUpdate,
-    UpdateParams,
+    type UpdateParams,
     useTranslate,
 } from 'ra-core';
-import { UseMutationOptions } from '@tanstack/react-query';
+import type { UseMutationOptions } from '@tanstack/react-query';
 
-import { Button, ButtonProps } from './Button';
+import { Button, type ButtonProps } from './Button';
 
-export const UpdateWithUndoButton = (props: UpdateWithUndoButtonProps) => {
+export const UpdateWithUndoButton = (inProps: UpdateWithUndoButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const record = useRecordContext(props);
     const notify = useNotify();
     const resource = useResourceContext(props);
@@ -136,3 +145,22 @@ const StyledButton = styled(Button, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaUpdateWithUndoButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaUpdateWithUndoButton: Partial<UpdateWithUndoButtonProps>;
+    }
+
+    interface Components {
+        RaUpdateWithUndoButton?: {
+            defaultProps?: ComponentsPropsList['RaUpdateWithUndoButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaUpdateWithUndoButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -1,12 +1,22 @@
 import * as React from 'react';
-import { ElementType, ReactElement } from 'react';
-import { Card, styled, SxProps } from '@mui/material';
+import type { ElementType, ReactElement } from 'react';
+import {
+    Card,
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material';
 import { useCreateContext } from 'ra-core';
 import clsx from 'clsx';
 
 import { Title } from '../layout';
 
-export const CreateView = (props: CreateViewProps) => {
+export const CreateView = (inProps: CreateViewProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         actions,
         aside,
@@ -76,3 +86,22 @@ const Root = styled('div', {
         flex: '1 1 auto',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaCreate: 'root' | 'main' | 'noActions' | 'card';
+    }
+
+    interface ComponentsPropsList {
+        RaCreate: Partial<CreateViewProps>;
+    }
+
+    interface Components {
+        RaCreate?: {
+            defaultProps?: ComponentsPropsList['RaCreate'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaCreate'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { ReactElement, ElementType } from 'react';
-import { Card, CardContent, styled, SxProps } from '@mui/material';
+import type { ReactElement, ElementType } from 'react';
+import {
+    Card,
+    CardContent,
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material';
 import clsx from 'clsx';
 import { useEditContext, useResourceDefinition } from 'ra-core';
 
@@ -9,7 +16,11 @@ import { Title } from '../layout';
 
 const defaultActions = <EditActions />;
 
-export const EditView = (props: EditViewProps) => {
+export const EditView = (inProps: EditViewProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         actions,
         aside,
@@ -87,3 +98,22 @@ const Root = styled('div', {
         flex: '1 1 auto',
     },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaEdit: 'root' | 'main' | 'noActions' | 'card';
+    }
+
+    interface ComponentsPropsList {
+        RaEdit: Partial<EditViewProps>;
+    }
+
+    interface Components {
+        RaEdit?: {
+            defaultProps?: ComponentsPropsList['RaEdit'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaEdit'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { ReactElement, ElementType } from 'react';
-import { Card, styled, SxProps } from '@mui/material';
+import type { ReactElement, ElementType } from 'react';
+import {
+    Card,
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material';
 import clsx from 'clsx';
 import { useShowContext, useResourceDefinition } from 'ra-core';
 import { ShowActions } from './ShowActions';
@@ -8,7 +14,11 @@ import { Title } from '../layout';
 
 const defaultActions = <ShowActions />;
 
-export const ShowView = (props: ShowViewProps) => {
+export const ShowView = (inProps: ShowViewProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         actions,
         aside,
@@ -83,3 +93,22 @@ const Root = styled('div', {
         flex: '1 1 auto',
     },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaShow: 'root' | 'main' | 'noActions' | 'card';
+    }
+
+    interface ComponentsPropsList {
+        RaShow: Partial<ShowViewProps>;
+    }
+
+    interface Components {
+        RaShow?: {
+            defaultProps?: ComponentsPropsList['RaShow'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaShow'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/SimpleShowLayout.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import { Children, isValidElement, ReactNode } from 'react';
-import { styled } from '@mui/material/styles';
-import { Stack, StackProps } from '@mui/material';
-import { SxProps } from '@mui/system';
+import { Children, isValidElement, type ReactNode } from 'react';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
+import {
+    Stack,
+    type StackProps,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material';
 import clsx from 'clsx';
 import {
-    RaRecord,
+    type RaRecord,
     useRecordContext,
     OptionalRecordContextProvider,
 } from 'ra-core';
@@ -51,7 +55,11 @@ import { Labeled } from '../Labeled';
  * @param {number} props.spacing The spacing to use between each field, passed to `<Stack>`. Defaults to 1.
  * @param {Object} props.sx Custom style object.
  */
-export const SimpleShowLayout = (props: SimpleShowLayoutProps) => {
+export const SimpleShowLayout = (inProps: SimpleShowLayoutProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className, children, spacing = 1, sx, ...rest } = props;
     const record = useRecordContext(props);
     if (!record) {
@@ -120,3 +128,22 @@ const sanitizeRestProps = ({
     translate,
     ...rest
 }: any) => rest;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSimpleShowLayout: 'root' | 'stack' | 'row';
+    }
+
+    interface ComponentsPropsList {
+        RaSimpleShowLayout: Partial<SimpleShowLayoutProps>;
+    }
+
+    interface Components {
+        RaSimpleShowLayout?: {
+            defaultProps?: ComponentsPropsList['RaSimpleShowLayout'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSimpleShowLayout'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { isValidElement, ReactElement, ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
+    ComponentsOverrides,
     Tab as MuiTab,
     TabProps as MuiTabProps,
     Stack,
     styled,
 } from '@mui/material';
-import { ResponsiveStyleValue } from '@mui/system';
+import { ResponsiveStyleValue, useThemeProps } from '@mui/system';
 import { useTranslate, RaRecord, useSplatPathBase } from 'ra-core';
 import clsx from 'clsx';
 
@@ -58,22 +59,27 @@ import { Labeled } from '../Labeled';
  *     );
  *     export default App;
  */
-export const Tab = ({
-    children,
-    contentClassName,
-    context,
-    count,
-    className,
-    divider,
-    icon,
-    iconPosition,
-    label,
-    record,
-    spacing = 1,
-    syncWithLocation = true,
-    value,
-    ...rest
-}: TabProps) => {
+export const Tab = (inProps: TabProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const {
+        children,
+        contentClassName,
+        context,
+        count,
+        className,
+        divider,
+        icon,
+        iconPosition,
+        label,
+        record,
+        spacing = 1,
+        syncWithLocation = true,
+        value,
+        ...rest
+    } = props;
     const translate = useTranslate();
     const location = useLocation();
     const splatPathBase = useSplatPathBase();
@@ -164,4 +170,23 @@ export interface TabProps extends Omit<MuiTabProps, 'children'> {
     spacing?: ResponsiveStyleValue<number | string>;
     syncWithLocation?: boolean;
     value?: string | number;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTab: 'root' | 'row';
+    }
+
+    interface ComponentsPropsList {
+        RaTab: Partial<TabProps>;
+    }
+
+    interface Components {
+        RaTab?: {
+            defaultProps?: ComponentsPropsList['RaTab'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTab'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
+++ b/packages/ra-ui-materialui/src/detail/TabbedShowLayout.tsx
@@ -1,19 +1,24 @@
 import * as React from 'react';
 import {
-    ChangeEvent,
+    type ChangeEvent,
     Children,
     cloneElement,
     isValidElement,
-    ReactElement,
-    ReactNode,
+    type ReactElement,
+    type ReactNode,
     useState,
 } from 'react';
-import { ResponsiveStyleValue, SxProps } from '@mui/system';
-import { styled } from '@mui/material/styles';
+import { ResponsiveStyleValue } from '@mui/system';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import { Divider } from '@mui/material';
 import { Outlet, Routes, Route } from 'react-router-dom';
 import {
-    RaRecord,
+    type RaRecord,
     useRecordContext,
     OptionalRecordContextProvider,
 } from 'ra-core';
@@ -74,7 +79,11 @@ import { Tab } from './Tab';
  * @param {boolean} props.syncWithLocation Whether to update the URL when the tab changes. Defaults to true.
  * @param {ElementType} props.tabs A custom component for rendering tabs.
  */
-export const TabbedShowLayout = (props: TabbedShowLayoutProps) => {
+export const TabbedShowLayout = (inProps: TabbedShowLayoutProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children,
         className,
@@ -222,3 +231,22 @@ const sanitizeRestProps = ({
     tabs,
     ...rest
 }: any) => rest;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTabbedShowLayout: 'root' | 'content';
+    }
+
+    interface ComponentsPropsList {
+        RaTabbedShowLayout: Partial<TabbedShowLayoutProps>;
+    }
+
+    interface Components {
+        RaTabbedShowLayout?: {
+            defaultProps?: ComponentsPropsList['RaTabbedShowLayout'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTabbedShowLayout'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/BooleanField.tsx
+++ b/packages/ra-ui-materialui/src/field/BooleanField.tsx
@@ -1,18 +1,31 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import DoneIcon from '@mui/icons-material/Done';
 import ClearIcon from '@mui/icons-material/Clear';
-import { Tooltip, Typography, TypographyProps, SvgIcon } from '@mui/material';
+import {
+    Tooltip,
+    Typography,
+    type TypographyProps,
+    SvgIcon,
+} from '@mui/material';
 import { useTranslate, useFieldValue } from 'ra-core';
 import { genericMemo } from './genericMemo';
-import { FieldProps } from './types';
+import type { FieldProps } from './types';
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
 
 const BooleanFieldImpl = <
     RecordType extends Record<string, any> = Record<string, any>,
 >(
-    props: BooleanFieldProps<RecordType>
+    inProps: BooleanFieldProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         emptyText,
@@ -108,3 +121,22 @@ const StyledTypography = styled(Typography, {
     [`& .${classes.trueIcon}`]: {},
     [`& .${classes.falseIcon}`]: {},
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaBooleanField: 'root' | 'trueIcon' | 'falseIcon';
+    }
+
+    interface ComponentsPropsList {
+        RaBooleanField: Partial<BooleanFieldProps>;
+    }
+
+    interface Components {
+        RaBooleanField?: {
+            defaultProps?: ComponentsPropsList['RaBooleanField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaBooleanField'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/ChipField.tsx
+++ b/packages/ra-ui-materialui/src/field/ChipField.tsx
@@ -1,19 +1,26 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import Chip, { ChipProps } from '@mui/material/Chip';
-import Typography from '@mui/material/Typography';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Chip, type ChipProps, Typography } from '@mui/material';
 import clsx from 'clsx';
 import { useFieldValue, useTranslate } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
-import { FieldProps } from './types';
+import type { FieldProps } from './types';
 import { genericMemo } from './genericMemo';
 
 const ChipFieldImpl = <
     RecordType extends Record<string, any> = Record<string, any>,
 >(
-    props: ChipFieldProps<RecordType>
+    inProps: ChipFieldProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className, emptyText, ...rest } = props;
     const value = useFieldValue(props);
     const translate = useTranslate();
@@ -68,3 +75,22 @@ const StyledChip = styled(Chip, {
 })({
     [`&.${ChipFieldClasses.chip}`]: { cursor: 'inherit' },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaChipField: 'root' | 'chip';
+    }
+
+    interface ComponentsPropsList {
+        RaChipField: Partial<ChipFieldProps>;
+    }
+
+    interface Components {
+        RaChipField?: {
+            defaultProps?: ComponentsPropsList['RaChipField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaChipField'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/FileField.tsx
+++ b/packages/ra-ui-materialui/src/field/FileField.tsx
@@ -1,17 +1,21 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import get from 'lodash/get';
 import Typography from '@mui/material/Typography';
 import {
-    ExtractRecordPaths,
-    HintedString,
+    type ExtractRecordPaths,
+    type HintedString,
     useFieldValue,
     useTranslate,
 } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
-import { FieldProps } from './types';
-import { SxProps } from '@mui/system';
+import type { FieldProps } from './types';
 import { Link } from '@mui/material';
 
 /**
@@ -30,8 +34,12 @@ import { Link } from '@mui/material';
 export const FileField = <
     RecordType extends Record<string, any> = Record<string, any>,
 >(
-    props: FileFieldProps<RecordType>
+    inProps: FileFieldProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         emptyText,
@@ -138,3 +146,22 @@ const Root = styled('div', {
 const StyledList = styled('ul')({
     display: 'inline-block',
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFileField: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaFileField: Partial<FileFieldProps>;
+    }
+
+    interface Components {
+        RaFileField?: {
+            defaultProps?: ComponentsPropsList['RaFileField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFileField'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/ImageField.tsx
+++ b/packages/ra-ui-materialui/src/field/ImageField.tsx
@@ -1,23 +1,31 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import { Box, Typography } from '@mui/material';
 import get from 'lodash/get';
 import {
-    ExtractRecordPaths,
-    HintedString,
+    type ExtractRecordPaths,
+    type HintedString,
     useFieldValue,
     useTranslate,
 } from 'ra-core';
 
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
-import { FieldProps } from './types';
-import { SxProps } from '@mui/system';
+import type { FieldProps } from './types';
 
 export const ImageField = <
     RecordType extends Record<string, any> = Record<string, any>,
 >(
-    props: ImageFieldProps<RecordType>
+    inProps: ImageFieldProps<RecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className, emptyText, src, title, ...rest } = props;
     const sourceValue = useFieldValue(props);
     const titleValue =
@@ -117,4 +125,23 @@ export interface ImageFieldProps<
     src?: string;
     title?: HintedString<ExtractRecordPaths<RecordType>>;
     sx?: SxProps;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaImageField: 'root' | 'list' | 'image';
+    }
+
+    interface ComponentsPropsList {
+        RaImageField: Partial<ImageFieldProps>;
+    }
+
+    interface Components {
+        RaImageField?: {
+            defaultProps?: ComponentsPropsList['RaImageField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaImageField'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.tsx
@@ -1,21 +1,25 @@
 import * as React from 'react';
-import { FC, memo, ReactElement, ReactNode } from 'react';
+import { memo, type ReactElement, type ReactNode } from 'react';
 import {
     ListContextProvider,
     useListContext,
-    ListControllerProps,
+    type ListControllerProps,
     useReferenceArrayFieldController,
-    SortPayload,
-    FilterPayload,
+    type SortPayload,
+    type FilterPayload,
     ResourceContextProvider,
     useRecordContext,
-    RaRecord,
+    type RaRecord,
 } from 'ra-core';
-import { styled } from '@mui/material/styles';
-import { SxProps } from '@mui/system';
-import { UseQueryOptions } from '@tanstack/react-query';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
-import { FieldProps } from './types';
+import type { FieldProps } from './types';
 import { LinearProgress } from '../layout';
 import { SingleFieldList } from '../list/SingleFieldList';
 
@@ -79,8 +83,12 @@ export const ReferenceArrayField = <
     RecordType extends RaRecord = RaRecord,
     ReferenceRecordType extends RaRecord = RaRecord,
 >(
-    props: ReferenceArrayFieldProps<RecordType, ReferenceRecordType>
+    inProps: ReferenceArrayFieldProps<RecordType, ReferenceRecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         filter,
         page = 1,
@@ -136,9 +144,9 @@ export interface ReferenceArrayFieldViewProps
     extends Omit<ReferenceArrayFieldProps, 'resource' | 'page' | 'perPage'>,
         Omit<ListControllerProps, 'queryOptions'> {}
 
-export const ReferenceArrayFieldView: FC<
-    ReferenceArrayFieldViewProps
-> = props => {
+export const ReferenceArrayFieldView = (
+    props: ReferenceArrayFieldViewProps
+) => {
     const { children, pagination, className, sx } = props;
     const { isPending, total } = useListContext();
 
@@ -175,3 +183,22 @@ const Root = styled('span', {
 }));
 
 const PureReferenceArrayFieldView = memo(ReferenceArrayFieldView);
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaReferenceArrayField: 'root' | 'progress';
+    }
+
+    interface ComponentsPropsList {
+        RaReferenceArrayField: Partial<ReferenceArrayFieldProps>;
+    }
+
+    interface Components {
+        RaReferenceArrayField?: {
+            defaultProps?: ComponentsPropsList['RaReferenceArrayField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaReferenceArrayField'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -1,23 +1,28 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
-import { Typography, SxProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import type { ReactNode } from 'react';
+import { Typography } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import ErrorIcon from '@mui/icons-material/Error';
 import {
-    LinkToType,
+    type LinkToType,
     useGetRecordRepresentation,
     useTranslate,
-    RaRecord,
+    type RaRecord,
     ReferenceFieldBase,
     useReferenceFieldContext,
     useFieldValue,
 } from 'ra-core';
-import { UseQueryOptions } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 import clsx from 'clsx';
 
 import { LinearProgress } from '../layout';
 import { Link } from '../Link';
-import { FieldProps } from './types';
+import type { FieldProps } from './types';
 import { genericMemo } from './genericMemo';
 import { visuallyHidden } from '@mui/utils';
 
@@ -56,8 +61,12 @@ export const ReferenceField = <
     RecordType extends Record<string, any> = Record<string, any>,
     ReferenceRecordType extends RaRecord = RaRecord,
 >(
-    props: ReferenceFieldProps<RecordType, ReferenceRecordType>
+    inProps: ReferenceFieldProps<RecordType, ReferenceRecordType>
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { emptyText } = props;
     const translate = useTranslate();
     const id = useFieldValue(props);
@@ -197,3 +206,22 @@ const Root = styled('span', {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaReferenceField: 'root' | 'link';
+    }
+
+    interface ComponentsPropsList {
+        RaReferenceField: Partial<ReferenceFieldProps>;
+    }
+
+    interface Components {
+        RaReferenceField?: {
+            defaultProps?: ComponentsPropsList['RaReferenceField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaReferenceField'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactElement, ReactNode } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import type { ReactElement, ReactNode } from 'react';
 import {
     TranslatableContextProvider,
     useTranslatable,
-    UseTranslatableOptions,
-    RaRecord,
+    type UseTranslatableOptions,
+    type RaRecord,
     useRecordContext,
     useResourceContext,
 } from 'ra-core';
@@ -66,9 +70,11 @@ import { TranslatableFieldsTabContent } from './TranslatableFieldsTabContent';
  * @param {string[]} props.locales An array of the possible locales in the form. For example [{ 'en', 'fr' }].
  * @param {ReactElement} props.selector The element responsible for selecting a locale. Defaults to Material UI tabs.
  */
-export const TranslatableFields = (
-    props: TranslatableFieldsProps
-): ReactElement => {
+export const TranslatableFields = (inProps: TranslatableFieldsProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         defaultLocale,
         locales,
@@ -131,3 +137,22 @@ const Root = styled('div', {
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(0.5),
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableFields: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableFields: Partial<TranslatableFieldsProps>;
+    }
+
+    interface Components {
+        RaTranslatableFields?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableFields'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableFields'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabContent.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
+import { Children, isValidElement, type ReactNode, useMemo } from 'react';
 import {
-    Children,
-    isValidElement,
-    ReactElement,
-    ReactNode,
-    useMemo,
-} from 'react';
-import { styled } from '@mui/material/styles';
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     useTranslatableContext,
-    RaRecord,
+    type RaRecord,
     RecordContextProvider,
     useOptionalSourceContext,
     SourceContextProvider,
@@ -23,8 +21,12 @@ import { Labeled } from '../Labeled';
  * @see TranslatableFields
  */
 export const TranslatableFieldsTabContent = (
-    props: TranslatableFieldsTabContentProps
-): ReactElement => {
+    inProps: TranslatableFieldsTabContentProps
+) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children,
         groupKey = '',
@@ -126,3 +128,22 @@ const Root = styled('div', {
     border: `1px solid ${theme.palette.divider}`,
     borderTop: 0,
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableFieldsTabContent: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableFieldsTabContent: Partial<TranslatableFieldsTabContentProps>;
+    }
+
+    interface Components {
+        RaTranslatableFieldsTabContent?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableFieldsTabContent'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableFieldsTabContent'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/field/TranslatableFieldsTabs.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFieldsTabs.tsx
@@ -1,19 +1,24 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactElement } from 'react';
-import AppBar from '@mui/material/AppBar';
-import Tabs, { TabsProps } from '@mui/material/Tabs';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { AppBar, type AppBarProps, Tabs, type TabsProps } from '@mui/material';
 import { useTranslatableContext } from 'ra-core';
 import { TranslatableFieldsTab } from './TranslatableFieldsTab';
-import { AppBarProps } from '../layout';
 
 /**
  * Default locale selector for the TranslatableFields component. Generates a tab for each specified locale.
  * @see TranslatableFields
  */
 export const TranslatableFieldsTabs = (
-    props: TranslatableFieldsTabsProps & AppBarProps
-): ReactElement => {
+    inProps: TranslatableFieldsTabsProps & AppBarProps
+) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { groupKey, TabsProps: tabsProps, className } = props;
     const { locales, selectLocale, selectedLocale } = useTranslatableContext();
 
@@ -60,3 +65,22 @@ const StyledAppBar = styled(AppBar, {
     borderTopRightRadius: theme.shape.borderRadius,
     border: `1px solid ${theme.palette.divider}`,
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableFieldsTabs: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableFieldsTabs: Partial<TranslatableFieldsTabsProps>;
+    }
+
+    interface Components {
+        RaTranslatableFieldsTabs?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableFieldsTabs'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableFieldsTabs'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
-import { ReactElement, ReactNode } from 'react';
-import { Form, FormProps } from 'ra-core';
-import { Stack, CardContent, SxProps, StackProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import type { ReactElement, ReactNode } from 'react';
+import { Form, type FormProps } from 'ra-core';
+import {
+    Stack,
+    CardContent,
+    type SxProps,
+    type StackProps,
+} from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 
 import { Toolbar } from './Toolbar';
 
@@ -36,7 +45,11 @@ import { Toolbar } from './Toolbar';
  *
  * @param {Props} props
  */
-export const SimpleForm = (props: SimpleFormProps) => {
+export const SimpleForm = (inProps: SimpleFormProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children,
         className,
@@ -106,3 +119,22 @@ const sanitizeRestProps = ({
     ...props
 }: SimpleFormProps) => props;
 /* eslint-enable @typescript-eslint/no-unused-vars */
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSimpleForm: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSimpleForm: Partial<SimpleFormProps>;
+    }
+
+    interface Components {
+        RaSimpleForm?: {
+            defaultProps?: ComponentsPropsList['RaSimpleForm'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSimpleForm'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedFormView.tsx
@@ -1,23 +1,32 @@
 import * as React from 'react';
 import {
-    ChangeEvent,
+    type ChangeEvent,
     Children,
-    ComponentType,
+    type ComponentType,
     cloneElement,
     isValidElement,
-    ReactElement,
-    ReactNode,
+    type ReactElement,
+    type ReactNode,
     useState,
 } from 'react';
 import clsx from 'clsx';
 import { Routes, Route, matchPath, useLocation } from 'react-router-dom';
-import { CardContent, Divider, SxProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { CardContent, Divider } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import { useResourceContext, useSplatPathBase } from 'ra-core';
 import { Toolbar } from './Toolbar';
 import { TabbedFormTabs, getTabbedFormTabFullPath } from './TabbedFormTabs';
 
-export const TabbedFormView = (props: TabbedFormViewProps): ReactElement => {
+export const TabbedFormView = (inProps: TabbedFormViewProps): ReactElement => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children,
         className,
@@ -133,3 +142,22 @@ const Root = styled('div', {
 }));
 
 const sanitizeRestProps = ({ record, resource, ...rest }: any) => rest;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTabbedForm: 'root' | 'errorTabButton';
+    }
+
+    interface ComponentsPropsList {
+        RaTabbedForm: Partial<TabbedFormViewProps>;
+    }
+
+    interface Components {
+        RaTabbedForm?: {
+            defaultProps?: ComponentsPropsList['RaTabbedForm'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTabbedForm'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/form/Toolbar.tsx
+++ b/packages/ra-ui-materialui/src/form/Toolbar.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { Children, ReactNode } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Children, type ReactNode } from 'react';
 import {
     Toolbar as MuiToolbar,
-    ToolbarProps as MuiToolbarProps,
+    type ToolbarProps as MuiToolbarProps,
     useMediaQuery,
     Theme,
 } from '@mui/material';
@@ -53,7 +57,11 @@ import { SaveButton, DeleteButton } from '../button';
  * @prop {ReactElement[]} children Customize the buttons you want to display in the <Toolbar>.
  *
  */
-export const Toolbar = (props: ToolbarProps) => {
+export const Toolbar = (inProps: ToolbarProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { children, className, resource, ...rest } = props;
 
     const isXs = useMediaQuery<Theme>(theme => theme.breakpoints.down('sm'));
@@ -125,3 +133,26 @@ const StyledToolbar = styled(MuiToolbar, {
         justifyContent: 'space-between',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaToolbar:
+            | 'root'
+            | 'desktopToolbar'
+            | 'mobileToolbar'
+            | 'defaultToolbar';
+    }
+
+    interface ComponentsPropsList {
+        RaToolbar: Partial<ToolbarProps>;
+    }
+
+    interface Components {
+        RaToolbar?: {
+            defaultProps?: ComponentsPropsList['RaToolbar'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaToolbar'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactElement, useEffect } from 'react';
+import { type ReactElement, useEffect } from 'react';
 import clsx from 'clsx';
 import {
     isRequired,
@@ -10,7 +10,7 @@ import {
     useFormGroupContext,
     useFormGroups,
     SourceContextProvider,
-    SourceContextValue,
+    type SourceContextValue,
     useSourceContext,
     OptionalResourceContextProvider,
 } from 'ra-core';
@@ -19,12 +19,14 @@ import {
     InputLabel,
     FormControl,
     FormHelperText,
-    FormControlProps,
+    type FormControlProps,
     styled,
+    type ComponentsOverrides,
+    useThemeProps,
 } from '@mui/material';
 
 import { LinearProgress } from '../../layout';
-import { CommonInputProps } from '../CommonInputProps';
+import type { CommonInputProps } from '../CommonInputProps';
 import { InputHelperText } from '../InputHelperText';
 import { sanitizeInputRestProps } from '../sanitizeInputRestProps';
 import { Labeled } from '../../Labeled';
@@ -71,7 +73,11 @@ import { ArrayInputContext } from './ArrayInputContext';
  *
  * @see {@link https://react-hook-form.com/docs/usefieldarray}
  */
-export const ArrayInput = (props: ArrayInputProps) => {
+export const ArrayInput = (inProps: ArrayInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         defaultValue,
@@ -278,3 +284,22 @@ const Root = styled(FormControl, {
         paddingLeft: theme.spacing(2),
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaArrayInput: 'root' | 'label';
+    }
+
+    interface ComponentsPropsList {
+        RaArrayInput: Partial<ArrayInputProps>;
+    }
+
+    interface Components {
+        RaArrayInput?: {
+            defaultProps?: ComponentsPropsList['RaArrayInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaArrayInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/SimpleFormIterator.tsx
@@ -1,29 +1,34 @@
 import * as React from 'react';
 import {
     Children,
-    ReactElement,
-    ReactNode,
+    type ReactElement,
+    type ReactNode,
     useCallback,
     useMemo,
     useRef,
     useState,
 } from 'react';
-import { styled, SxProps, useThemeProps } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material';
 import clsx from 'clsx';
 import get from 'lodash/get';
 import {
     FormDataConsumer,
-    RaRecord,
+    type RaRecord,
     useRecordContext,
     useTranslate,
     useWrappedSource,
 } from 'ra-core';
-import { UseFieldArrayReturn, useFormContext } from 'react-hook-form';
+import { type UseFieldArrayReturn, useFormContext } from 'react-hook-form';
 
 import { useArrayInput } from './useArrayInput';
 import {
     SimpleFormIteratorClasses,
-    SimpleFormIteratorPrefix,
+    SimpleFormIteratorPrefix as PREFIX,
 } from './useSimpleFormIteratorStyles';
 import { SimpleFormIteratorContext } from './SimpleFormIteratorContext';
 import {
@@ -37,7 +42,7 @@ import { Confirm } from '../../layout';
 export const SimpleFormIterator = (inProps: SimpleFormIteratorProps) => {
     const props = useThemeProps({
         props: inProps,
-        name: 'RaSimpleFormIterator',
+        name: PREFIX,
     });
     const {
         addButton = <DefaultAddItemButton />,
@@ -262,7 +267,7 @@ export interface SimpleFormIteratorProps extends Partial<UseFieldArrayReturn> {
 }
 
 const Root = styled('div', {
-    name: SimpleFormIteratorPrefix,
+    name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
     '& > ul': {
@@ -318,3 +323,32 @@ const Root = styled('div', {
             visibility: 'visible',
         },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSimpleFormIterator:
+            | 'root'
+            | 'action'
+            | 'add'
+            | 'clear'
+            | 'form'
+            | 'index'
+            | 'inline'
+            | 'line'
+            | 'list'
+            | 'buttons';
+    }
+
+    interface ComponentsPropsList {
+        RaSimpleFormIterator: Partial<SimpleFormIteratorProps>;
+    }
+
+    interface Components {
+        RaSimpleFormIterator?: {
+            defaultProps?: ComponentsPropsList['RaSimpleFormIterator'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSimpleFormIterator'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -6,7 +6,7 @@ import {
     useMemo,
     useRef,
     useState,
-    ReactNode,
+    type ReactNode,
 } from 'react';
 import debounce from 'lodash/debounce';
 import get from 'lodash/get';
@@ -14,23 +14,27 @@ import isEqual from 'lodash/isEqual';
 import clsx from 'clsx';
 import {
     Autocomplete,
-    AutocompleteChangeReason,
-    AutocompleteProps,
+    type AutocompleteChangeReason,
+    type AutocompleteProps,
     Chip,
     TextField,
-    TextFieldProps,
+    type TextFieldProps,
     createFilterOptions,
     useForkRef,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
 import {
-    ChoicesProps,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import {
+    type ChoicesProps,
     FieldTitle,
-    RaRecord,
+    type RaRecord,
     useChoicesContext,
     useInput,
     useSuggestions,
-    UseSuggestionsOptions,
+    type UseSuggestionsOptions,
     useTimeout,
     useTranslate,
     warning,
@@ -38,10 +42,10 @@ import {
     useEvent,
 } from 'ra-core';
 import {
-    SupportCreateSuggestionOptions,
+    type SupportCreateSuggestionOptions,
     useSupportCreateSuggestion,
 } from './useSupportCreateSuggestion';
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import { InputHelperText } from './InputHelperText';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 
@@ -120,13 +124,17 @@ export const AutocompleteInput = <
     DisableClearable extends boolean | undefined = boolean | undefined,
     SupportCreate extends boolean | undefined = false,
 >(
-    props: AutocompleteInputProps<
+    inProps: AutocompleteInputProps<
         OptionType,
         Multiple,
         DisableClearable,
         SupportCreate
     >
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         choices: choicesProp,
         className,
@@ -876,3 +884,22 @@ const areSelectedItemsEqual = (
 };
 
 const DefaultFilterToQuery = searchText => ({ q: searchText });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaAutocompleteInput: 'root' | 'textField';
+    }
+
+    interface ComponentsPropsList {
+        RaAutocompleteInput: Partial<AutocompleteInputProps>;
+    }
+
+    interface Components {
+        RaAutocompleteInput?: {
+            defaultProps?: ComponentsPropsList['RaAutocompleteInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaAutocompleteInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInput.tsx
@@ -1,22 +1,29 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
-import { useCallback, FunctionComponent } from 'react';
+import { useCallback } from 'react';
 import get from 'lodash/get';
-import FormLabel from '@mui/material/FormLabel';
-import FormControl, { FormControlProps } from '@mui/material/FormControl';
-import FormGroup from '@mui/material/FormGroup';
-import FormHelperText from '@mui/material/FormHelperText';
-import { CheckboxProps } from '@mui/material/Checkbox';
+import {
+    type CheckboxProps,
+    FormLabel,
+    FormControl,
+    type FormControlProps,
+    FormGroup,
+    FormHelperText,
+} from '@mui/material';
 import {
     FieldTitle,
     useInput,
-    ChoicesProps,
+    type ChoicesProps,
     useChoicesContext,
     useGetRecordRepresentation,
 } from 'ra-core';
 
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { CheckboxGroupInputItem } from './CheckboxGroupInputItem';
 import { InputHelperText } from './InputHelperText';
@@ -89,9 +96,11 @@ import { LinearProgress } from '../layout';
  *
  * The object passed as `options` props is passed to the Material UI <Checkbox> components
  */
-export const CheckboxGroupInput: FunctionComponent<
-    CheckboxGroupInputProps
-> = props => {
+export const CheckboxGroupInput = (inProps: CheckboxGroupInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         choices: choicesProp,
         className,
@@ -315,3 +324,22 @@ const StyledFormControl = styled(FormControl, {
         marginRight: 0,
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaCheckboxGroupInput: 'root' | 'label' | 'helperText';
+    }
+
+    interface ComponentsPropsList {
+        RaCheckboxGroupInput: Partial<CheckboxGroupInputProps>;
+    }
+
+    interface Components {
+        RaCheckboxGroupInput?: {
+            defaultProps?: ComponentsPropsList['RaCheckboxGroupInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaCheckboxGroupInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/CheckboxGroupInputItem.tsx
+++ b/packages/ra-ui-materialui/src/input/CheckboxGroupInputItem.tsx
@@ -1,10 +1,24 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
-import { useChoices } from 'ra-core';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import {
+    Checkbox,
+    type CheckboxProps,
+    FormControlLabel,
+    type FormControlLabelProps,
+} from '@mui/material';
+import { type ChoicesProps, useChoices } from 'ra-core';
 
-export const CheckboxGroupInputItem = props => {
+export const CheckboxGroupInputItem = (
+    inProps: CheckboxGroupInputItemProps
+) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         id,
         choice,
@@ -49,14 +63,23 @@ export const CheckboxGroupInputItem = props => {
                     }
                     value={String(getChoiceValue(choice))}
                     {...options}
-                    {...rest}
                 />
             }
             label={choiceName}
             labelPlacement={labelPlacement}
+            {...rest}
         />
     );
 };
+
+export interface CheckboxGroupInputItemProps
+    extends Omit<FormControlLabelProps, 'control' | 'label'>,
+        Pick<ChoicesProps, 'optionValue' | 'optionText' | 'translateChoice'> {
+    choice: any;
+    value: any;
+    fullWidth?: boolean;
+    options?: CheckboxProps;
+}
 
 const PREFIX = 'RaCheckboxGroupInputItem';
 
@@ -72,3 +95,22 @@ const StyledFormControlLabel = styled(FormControlLabel, {
         height: 32,
     },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaCheckboxGroupInputItem: 'root' | 'checkbox';
+    }
+
+    interface ComponentsPropsList {
+        RaCheckboxGroupInputItem: Partial<CheckboxGroupInputItemProps>;
+    }
+
+    interface Components {
+        RaCheckboxGroupInputItem?: {
+            defaultProps?: ComponentsPropsList['RaCheckboxGroupInputItem'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaCheckboxGroupInputItem'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/FileInput.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.tsx
@@ -1,14 +1,20 @@
 import React, {
     Children,
-    FC,
+    type ComponentType,
     isValidElement,
-    ReactElement,
-    ReactNode,
+    type ReactElement,
+    type ReactNode,
 } from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useTheme,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
-import { useDropzone, DropzoneOptions } from 'react-dropzone';
-import FormHelperText from '@mui/material/FormHelperText';
+import { useDropzone, type DropzoneOptions } from 'react-dropzone';
+import { FormHelperText, type SvgIconProps } from '@mui/material';
 import {
     useInput,
     useTranslate,
@@ -16,16 +22,17 @@ import {
     RecordContextProvider,
 } from 'ra-core';
 
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import { Labeled } from '../Labeled';
 import { FileInputPreview } from './FileInputPreview';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
-import { useTheme } from '@mui/material/styles';
-import { SxProps } from '@mui/system';
-import { SvgIconProps } from '@mui/material';
 
-export const FileInput = (props: FileInputProps) => {
+export const FileInput = (inProps: FileInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         accept,
         children,
@@ -275,8 +282,27 @@ export type FileInputProps = CommonInputProps & {
     options?: DropzoneOptions;
     onRemove?: Function;
     placeholder?: ReactNode;
-    removeIcon?: FC<SvgIconProps>;
+    removeIcon?: ComponentType<SvgIconProps>;
     inputProps?: any;
     validateFileRemoval?(file): boolean | Promise<boolean>;
     sx?: SxProps;
 };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFileInput: 'root' | 'dropZone' | 'removeButton';
+    }
+
+    interface ComponentsPropsList {
+        RaFileInput: Partial<FileInputProps>;
+    }
+
+    interface Components {
+        RaFileInput?: {
+            defaultProps?: ComponentsPropsList['RaFileInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFileInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInputPreview.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
-import { FC, ReactNode, useEffect } from 'react';
-import { styled } from '@mui/material/styles';
+import { type ReactNode, useEffect } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import RemoveCircle from '@mui/icons-material/RemoveCircle';
 import IconButton from '@mui/material/IconButton';
 import { useTranslate } from 'ra-core';
-import { SvgIconProps } from '@mui/material';
+import { type SvgIconProps } from '@mui/material';
 
-export const FileInputPreview = (props: FileInputPreviewProps) => {
+export const FileInputPreview = (inProps: FileInputPreviewProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children,
         className,
@@ -67,5 +75,24 @@ export interface FileInputPreviewProps {
     className?: string;
     onRemove: () => void;
     file: any;
-    removeIcon?: FC<SvgIconProps>;
+    removeIcon?: React.ComponentType<SvgIconProps>;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFileInputPreview: 'root' | 'removeButton' | 'removeIcon';
+    }
+
+    interface ComponentsPropsList {
+        RaFileInputPreview: Partial<FileInputPreviewProps>;
+    }
+
+    interface Components {
+        RaFileInputPreview?: {
+            defaultProps?: ComponentsPropsList['RaFileInputPreview'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFileInputPreview'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/input/ImageInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ImageInput.tsx
@@ -1,14 +1,24 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { FileInput, FileInputProps, FileInputClasses } from './FileInput';
 
-export const ImageInput = (props: ImageInputProps) => (
-    <StyledFileInput
-        labelMultiple="ra.input.image.upload_several"
-        labelSingle="ra.input.image.upload_single"
-        {...props}
-    />
-);
+export const ImageInput = (inProps: ImageInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    return (
+        <StyledFileInput
+            labelMultiple="ra.input.image.upload_several"
+            labelSingle="ra.input.image.upload_single"
+            {...props}
+        />
+    );
+};
 
 export type ImageInputProps = FileInputProps;
 
@@ -43,3 +53,22 @@ const StyledFileInput = styled(FileInput, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaImageInput: 'root' | 'dropZone' | 'removeButton';
+    }
+
+    interface ComponentsPropsList {
+        RaImageInput: Partial<ImageInputProps>;
+    }
+
+    interface Components {
+        RaImageInput?: {
+            defaultProps?: ComponentsPropsList['RaImageInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaImageInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { CircularProgress, InputAdornment } from '@mui/material';
-import { styled, SxProps } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import { useTimeout } from 'ra-core';
 
 import { ResettableTextField } from './ResettableTextField';
@@ -10,16 +15,21 @@ import { ResettableTextField } from './ResettableTextField';
  *
  * Avoids visual jumps when replaced by a form input
  */
-export const LoadingInput = ({
-    fullWidth,
-    label,
-    helperText,
-    margin,
-    size,
-    sx,
-    timeout = 1000,
-    variant,
-}: LoadingInputProps) => {
+export const LoadingInput = (inProps: LoadingInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const {
+        fullWidth,
+        label,
+        helperText,
+        margin,
+        size,
+        sx,
+        timeout = 1000,
+        variant,
+    } = props;
     const oneSecondHasPassed = useTimeout(timeout);
 
     return (
@@ -80,4 +90,23 @@ export interface LoadingInputProps {
     size?: 'medium' | 'small';
     timeout?: number;
     variant?: 'standard' | 'filled' | 'outlined';
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLoadingInput: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaLoadingInput: Partial<LoadingInputProps>;
+    }
+
+    interface Components {
+        RaLoadingInput?: {
+            defaultProps?: ComponentsPropsList['RaLoadingInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLoadingInput'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -1,15 +1,22 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import TextField, { TextFieldProps } from '@mui/material/TextField';
-import MenuItem from '@mui/material/MenuItem';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { MenuItem, TextField, type TextFieldProps } from '@mui/material';
 import clsx from 'clsx';
 import { useInput, useTranslate, FieldTitle } from 'ra-core';
 
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
 
-export const NullableBooleanInput = (props: NullableBooleanInputProps) => {
+export const NullableBooleanInput = (inProps: NullableBooleanInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         format = getStringFromBoolean,
@@ -129,3 +136,22 @@ export type NullableBooleanInputProps = CommonInputProps &
         falseLabel?: string;
         trueLabel?: string;
     };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaNullableBooleanInput: 'root' | 'input';
+    }
+
+    interface ComponentsPropsList {
+        RaNullableBooleanInput: Partial<NullableBooleanInputProps>;
+    }
+
+    interface Components {
+        RaNullableBooleanInput?: {
+            defaultProps?: ComponentsPropsList['RaNullableBooleanInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaNullableBooleanInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
+++ b/packages/ra-ui-materialui/src/input/RadioButtonGroupInput.tsx
@@ -1,24 +1,28 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
 import {
     FormControl,
+    type FormControlProps,
     FormHelperText,
     FormLabel,
     RadioGroup,
+    type RadioGroupProps,
 } from '@mui/material';
-import { RadioGroupProps } from '@mui/material/RadioGroup';
-import { FormControlProps } from '@mui/material/FormControl';
 import get from 'lodash/get';
 import {
     useInput,
     FieldTitle,
-    ChoicesProps,
+    type ChoicesProps,
     useChoicesContext,
     useGetRecordRepresentation,
 } from 'ra-core';
 
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import { InputHelperText } from './InputHelperText';
 import { RadioButtonGroupInputItem } from './RadioButtonGroupInputItem';
@@ -85,7 +89,11 @@ import { LinearProgress } from '../layout';
  *
  * The object passed as `options` props is passed to the Material UI <RadioButtonGroup> component
  */
-export const RadioButtonGroupInput = (props: RadioButtonGroupInputProps) => {
+export const RadioButtonGroupInput = (inProps: RadioButtonGroupInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         choices: choicesProp,
         className,
@@ -288,3 +296,22 @@ const StyledFormControl = styled(FormControl, {
 }));
 
 const defaultOptions = {};
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaRadioButtonGroupInput: 'root' | 'label';
+    }
+
+    interface ComponentsPropsList {
+        RaRadioButtonGroupInput: Partial<RadioButtonGroupInputProps>;
+    }
+
+    interface Components {
+        RaRadioButtonGroupInput?: {
+            defaultProps?: ComponentsPropsList['RaRadioButtonGroupInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaRadioButtonGroupInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import { forwardRef, useCallback } from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
 import {
     InputAdornment,
     IconButton,
     TextField as MuiTextField,
-    TextFieldProps,
+    type TextFieldProps,
 } from '@mui/material';
 import ClearIcon from '@mui/icons-material/Clear';
 import { useTranslate } from 'ra-core';
@@ -15,7 +19,11 @@ import { useTranslate } from 'ra-core';
  * An override of the default Material UI TextField which is resettable
  */
 export const ResettableTextField = forwardRef(
-    (props: ResettableTextFieldProps, ref) => {
+    (inProps: ResettableTextFieldProps, ref) => {
+        const props = useThemeProps({
+            props: inProps,
+            name: PREFIX,
+        });
         const {
             clearAlwaysVisible,
             InputProps,
@@ -214,3 +222,28 @@ const StyledTextField = styled(MuiTextField, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(ResettableTextFieldStyles);
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaResettableTextField:
+            | 'root'
+            | 'clearIcon'
+            | 'visibleClearIcon'
+            | 'clearButton'
+            | 'selectAdornment'
+            | 'inputAdornedEnd';
+    }
+
+    interface ComponentsPropsList {
+        RaResettableTextField: Partial<ResettableTextFieldProps>;
+    }
+
+    interface Components {
+        RaResettableTextField?: {
+            defaultProps?: ComponentsPropsList['RaResettableTextField'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaResettableTextField'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/SearchInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SearchInput.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import SearchIcon from '@mui/icons-material/Search';
 import { InputAdornment } from '@mui/material';
 import { useTranslate } from 'ra-core';
 
-import { CommonInputProps } from './CommonInputProps';
-import { TextInput, TextInputProps } from './TextInput';
+import type { CommonInputProps } from './CommonInputProps';
+import { TextInput, type TextInputProps } from './TextInput';
 
-export const SearchInput = (props: SearchInputProps) => {
+export const SearchInput = (inProps: SearchInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { label, ...rest } = props;
 
     const translate = useTranslate();
@@ -47,3 +55,22 @@ const StyledTextInput = styled(TextInput, {
 })({
     marginTop: 0,
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSearchInput: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSearchInput: Partial<SearchInputProps>;
+    }
+
+    interface Components {
+        RaSearchInput?: {
+            defaultProps?: ComponentsPropsList['RaSearchInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSearchInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -1,34 +1,38 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { useCallback, useRef, ChangeEvent } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { useCallback, useRef, type ChangeEvent } from 'react';
 import clsx from 'clsx';
 import {
     Select,
-    SelectProps,
+    type SelectProps,
     MenuItem,
     InputLabel,
     FormHelperText,
     FormControl,
+    type FormControlProps,
     Chip,
     OutlinedInput,
 } from '@mui/material';
 import {
-    ChoicesProps,
+    type ChoicesProps,
     FieldTitle,
     useInput,
     useChoicesContext,
     useChoices,
-    RaRecord,
+    type RaRecord,
     useGetRecordRepresentation,
 } from 'ra-core';
 import { InputHelperText } from './InputHelperText';
-import { FormControlProps } from '@mui/material/FormControl';
 
 import { LinearProgress } from '../layout';
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import { Labeled } from '../Labeled';
 import {
-    SupportCreateSuggestionOptions,
+    type SupportCreateSuggestionOptions,
     useSupportCreateSuggestion,
 } from './useSupportCreateSuggestion';
 
@@ -87,7 +91,11 @@ import {
  *    { id: 'photography', name: 'myroot.tags.photography' },
  * ];
  */
-export const SelectArrayInput = (props: SelectArrayInputProps) => {
+export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         choices: choicesProp,
         className,
@@ -446,3 +454,22 @@ const StyledFormControl = styled(FormControl, {
 }));
 
 const defaultOptions = {};
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSelectArrayInput: 'root' | 'chips' | 'chip';
+    }
+
+    interface ComponentsPropsList {
+        RaSelectArrayInput: Partial<SelectArrayInputProps>;
+    }
+
+    interface Components {
+        RaSelectArrayInput?: {
+            defaultProps?: ComponentsPropsList['RaSelectArrayInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSelectArrayInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -1,20 +1,29 @@
 import * as React from 'react';
-import { ReactElement, useCallback, useEffect, ChangeEvent } from 'react';
+import {
+    type ReactElement,
+    useCallback,
+    useEffect,
+    type ChangeEvent,
+} from 'react';
 import clsx from 'clsx';
-import { MenuItem, TextFieldProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { MenuItem, type TextFieldProps } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     useChoicesContext,
     useInput,
     FieldTitle,
     useTranslate,
-    ChoicesProps,
+    type ChoicesProps,
     useChoices,
-    RaRecord,
+    type RaRecord,
     useGetRecordRepresentation,
 } from 'ra-core';
 
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 import {
     ResettableTextField,
     ResettableTextFieldStyles,
@@ -23,7 +32,7 @@ import { InputHelperText } from './InputHelperText';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
 import {
     useSupportCreateSuggestion,
-    SupportCreateSuggestionOptions,
+    type SupportCreateSuggestionOptions,
 } from './useSupportCreateSuggestion';
 import { LoadingInput } from './LoadingInput';
 
@@ -102,7 +111,11 @@ import { LoadingInput } from './LoadingInput';
  * <SelectInput source="gender" choices={choices} disableValue="not_available" />
  *
  */
-export const SelectInput = (props: SelectInputProps) => {
+export const SelectInput = (inProps: SelectInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         choices: choicesProp,
         className,
@@ -408,3 +421,22 @@ export type SelectInputProps = Omit<CommonInputProps, 'source'> &
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
     };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSelectInput: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSelectInput: Partial<SelectInputProps>;
+    }
+
+    interface Components {
+        RaSelectInput?: {
+            defaultProps?: ComponentsPropsList['RaSelectInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSelectInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/TextArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextArrayInput.tsx
@@ -3,13 +3,17 @@ import clsx from 'clsx';
 import {
     Chip,
     Autocomplete,
-    AutocompleteProps,
+    type AutocompleteProps,
     TextField,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { useInput, FieldTitle } from 'ra-core';
 import { InputHelperText } from './InputHelperText';
-import { CommonInputProps } from './CommonInputProps';
+import type { CommonInputProps } from './CommonInputProps';
 
 export type TextArrayInputProps = CommonInputProps &
     Omit<
@@ -24,22 +28,27 @@ export type TextArrayInputProps = CommonInputProps &
         >
     >;
 
-export const TextArrayInput = ({
-    className,
-    disabled,
-    format,
-    helperText,
-    label,
-    margin,
-    parse,
-    readOnly,
-    size,
-    source,
-    sx,
-    validate,
-    variant,
-    ...props
-}: TextArrayInputProps) => {
+export const TextArrayInput = (inProps: TextArrayInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const {
+        className,
+        disabled,
+        format,
+        helperText,
+        label,
+        margin,
+        parse,
+        readOnly,
+        size,
+        source,
+        sx,
+        validate,
+        variant,
+        ...rest
+    } = props;
     const {
         field,
         fieldState: { error, invalid },
@@ -52,7 +61,7 @@ export const TextArrayInput = ({
         readOnly,
         source,
         validate,
-        ...props,
+        ...rest,
     });
 
     const renderHelperText = helperText !== false || invalid;
@@ -109,7 +118,7 @@ export const TextArrayInput = ({
             {...field}
             value={field.value || emptyArray} // Autocomplete does not accept null or undefined
             onChange={(e, newValue: string[]) => field.onChange(newValue)}
-            {...props}
+            {...rest}
             disabled={disabled || readOnly}
         />
     );
@@ -128,3 +137,22 @@ const StyledAutocomplete = styled(
 )(({ theme }) => ({
     minWidth: theme.spacing(20),
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTextArrayInput: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaTextArrayInput: Partial<TextArrayInputProps>;
+    }
+
+    interface Components {
+        RaTextArrayInput?: {
+            defaultProps?: ComponentsPropsList['RaTextArrayInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTextArrayInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SxProps, styled } from '@mui/material/styles';
+import { ComponentsOverrides, SxProps, styled } from '@mui/material/styles';
 import { StackProps, useThemeProps } from '@mui/material';
 import { ReactElement, ReactNode } from 'react';
 import {
@@ -139,3 +139,22 @@ const Root = styled('div', {
         width: '100%',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableInputs: 'root' | 'fullWidth';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableInputs: Partial<TranslatableInputsProps>;
+    }
+
+    interface Components {
+        RaTranslatableInputs?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableInputs'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableInputs'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/TranslatableInputsTab.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputsTab.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { styled } from '@mui/material/styles';
-import Tab, { TabProps } from '@mui/material/Tab';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Tab, type TabProps } from '@mui/material';
 import { useFormGroup, useTranslate } from 'ra-core';
 import { capitalize } from 'inflection';
 import clsx from 'clsx';
@@ -10,8 +14,12 @@ import clsx from 'clsx';
  * @see TranslatableInputs
  */
 export const TranslatableInputsTab = (
-    props: TranslatableInputsTabProps & TabProps
+    inProps: TranslatableInputsTabProps & TabProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { groupKey = '', locale, ...rest } = props;
     const { isValid } = useFormGroup(`${groupKey}${locale}`);
     const translate = useTranslate();
@@ -53,3 +61,22 @@ const StyledTab = styled(Tab, { name: PREFIX })(({ theme }) => ({
         color: theme.palette.error.main,
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableInputsTab: 'root' | 'error';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableInputsTab: Partial<TranslatableInputsTabProps>;
+    }
+
+    interface Components {
+        RaTranslatableInputsTab?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableInputsTab'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableInputsTab'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/TranslatableInputsTabContent.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputsTabContent.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import { ReactElement, ReactNode, useMemo } from 'react';
-import { styled } from '@mui/material/styles';
-import { Stack, StackProps } from '@mui/material';
+import { type ReactNode, useMemo } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Stack, type StackProps } from '@mui/material';
 import clsx from 'clsx';
 import {
     FormGroupContextProvider,
-    RaRecord,
+    type RaRecord,
     RecordContextProvider,
     SourceContextProvider,
     useRecordContext,
@@ -18,8 +22,12 @@ import {
  * @see TranslatableInputs
  */
 export const TranslatableInputsTabContent = (
-    props: TranslatableInputsTabContentProps
-): ReactElement => {
+    inProps: TranslatableInputsTabContentProps
+) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { children, groupKey = '', locale, ...other } = props;
     const { selectedLocale, getRecordForLocale } = useTranslatableContext();
     const parentSourceContext = useSourceContext();
@@ -112,3 +120,22 @@ const Root = styled(Stack, { name: PREFIX })(({ theme }) => ({
         display: 'none',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableInputsTabContent: 'root' | 'hidden';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableInputsTabContent: Partial<TranslatableInputsTabContentProps>;
+    }
+
+    interface Components {
+        RaTranslatableInputsTabContent?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableInputsTabContent'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableInputsTabContent'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/input/TranslatableInputsTabs.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputsTabs.tsx
@@ -1,18 +1,24 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactElement } from 'react';
-import { AppBar, Tabs, TabsProps } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { AppBar, type AppBarProps, Tabs, type TabsProps } from '@mui/material';
 import { useTranslatableContext } from 'ra-core';
 import { TranslatableInputsTab } from './TranslatableInputsTab';
-import { AppBarProps } from '../layout';
 
 /**
  * Default locale selector for the TranslatableInputs component. Generates a tab for each specified locale.
  * @see TranslatableInputs
  */
 export const TranslatableInputsTabs = (
-    props: TranslatableInputsTabsProps & AppBarProps
-): ReactElement => {
+    inProps: TranslatableInputsTabsProps & AppBarProps
+) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { groupKey, TabsProps: tabsProps } = props;
     const { locales, selectLocale, selectedLocale } = useTranslatableContext();
 
@@ -72,3 +78,22 @@ const StyledAppBar = styled(AppBar, { name: PREFIX })(({ theme }) => ({
         minHeight: theme.spacing(3),
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTranslatableInputsTabs: 'root' | 'tabs';
+    }
+
+    interface ComponentsPropsList {
+        RaTranslatableInputsTabs: Partial<TranslatableInputsTabsProps>;
+    }
+
+    interface Components {
+        RaTranslatableInputsTabs?: {
+            defaultProps?: ComponentsPropsList['RaTranslatableInputsTabs'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTranslatableInputsTabs'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/AccessDenied.tsx
+++ b/packages/ra-ui-materialui/src/layout/AccessDenied.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import LockIcon from '@mui/icons-material/Lock';
-import { Typography, SxProps } from '@mui/material';
+import { Typography } from '@mui/material';
 import clsx from 'clsx';
 import { useTranslate } from 'ra-core';
 
-export const AccessDenied = (props: AccessDeniedProps) => {
+export const AccessDenied = (inProps: AccessDeniedProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         icon = DEFAULT_ICON,
@@ -69,3 +78,22 @@ const Root = styled('div', {
 });
 
 const DEFAULT_ICON = <LockIcon className={AccessDeniedClasses.icon} />;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaAccessDenied: 'root' | 'icon' | 'message';
+    }
+
+    interface ComponentsPropsList {
+        RaAccessDenied: Partial<AccessDeniedProps>;
+    }
+
+    interface Components {
+        RaAccessDenied?: {
+            defaultProps?: ComponentsPropsList['RaAccessDenied'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaAccessDenied'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/AppBar.tsx
+++ b/packages/ra-ui-materialui/src/layout/AppBar.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
-import { FC } from 'react';
-import { styled } from '@mui/material/styles';
+import type { FC } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { Children, memo } from 'react';
 import {
     AppBar as MuiAppBar,
-    AppBarProps as MuiAppBarProps,
+    type AppBarProps as MuiAppBarProps,
     Toolbar,
     useMediaQuery,
     Theme,
@@ -42,7 +46,11 @@ import { ToggleThemeButton } from '../button/ToggleThemeButton';
  *
  * const MyAppBar = () => <AppBar userMenu={false} />;
  */
-export const AppBar: FC<AppBarProps> = memo(props => {
+export const AppBar: FC<AppBarProps> = memo(inProps => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         alwaysOn,
         children,
@@ -144,3 +152,29 @@ const StyledAppBar = styled(MuiAppBar, {
     },
     [`& .${AppBarClasses.title}`]: {},
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaAppBar:
+            | 'root'
+            | 'appBar'
+            | 'toolbar'
+            | 'menuButton'
+            | 'menuButtonIconClosed'
+            | 'menuButtonIconOpen'
+            | 'title';
+    }
+
+    interface ComponentsPropsList {
+        RaAppBar: Partial<AppBarProps>;
+    }
+
+    interface Components {
+        RaAppBar?: {
+            defaultProps?: ComponentsPropsList['RaAppBar'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaAppBar'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/AuthenticationError.tsx
+++ b/packages/ra-ui-materialui/src/layout/AuthenticationError.tsx
@@ -1,12 +1,21 @@
 import * as React from 'react';
-import { styled, SxProps } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import { Typography } from '@mui/material';
 import WarningAmber from '@mui/icons-material/WarningAmber';
 import clsx from 'clsx';
 import { useDefaultTitle, useTranslate } from 'ra-core';
 import { Title } from './Title';
 
-export const AuthenticationError = (props: AuthenticationErrorProps) => {
+export const AuthenticationError = (inProps: AuthenticationErrorProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         icon = DEFAULT_ICON,
@@ -78,3 +87,22 @@ const Root = styled('div', {
 const DEFAULT_ICON = (
     <WarningAmber className={AuthenticationErrorClasses.icon} />
 );
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaAuthenticationError: 'root' | 'icon' | 'message';
+    }
+
+    interface ComponentsPropsList {
+        RaAuthenticationError: Partial<AuthenticationErrorProps>;
+    }
+
+    interface Components {
+        RaAuthenticationError?: {
+            defaultProps?: ComponentsPropsList['RaAuthenticationError'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaAuthenticationError'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/CardContentInner.tsx
+++ b/packages/ra-ui-materialui/src/layout/CardContentInner.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactNode } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import type { ReactNode } from 'react';
 import CardContent from '@mui/material/CardContent';
 
 /**
@@ -10,7 +14,11 @@ import CardContent from '@mui/material/CardContent';
  * padding double the spacing between each CardContent, leading to too much
  * wasted space. Use this component as a CardContent alternative.
  */
-export const CardContentInner = (props: CardContentInnerProps) => {
+export const CardContentInner = (inProps: CardContentInnerProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className, children } = props;
 
     return <Root className={className}>{children}</Root>;
@@ -43,3 +51,22 @@ const Root = styled(CardContent, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaCardContentInner: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaCardContentInner: Partial<CardContentInnerProps>;
+    }
+
+    interface Components {
+        RaCardContentInner?: {
+            defaultProps?: ComponentsPropsList['RaCardContentInner'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaCardContentInner'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
-import { useCallback, MouseEventHandler, ComponentType } from 'react';
-import Dialog, { DialogProps } from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import Button from '@mui/material/Button';
-import { alpha, styled } from '@mui/material/styles';
+import { useCallback, type MouseEventHandler, type ComponentType } from 'react';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    type DialogProps,
+    DialogTitle,
+} from '@mui/material';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import ActionCheck from '@mui/icons-material/CheckCircle';
 import AlertError from '@mui/icons-material/ErrorOutline';
 import clsx from 'clsx';
@@ -29,7 +37,11 @@ import { useTranslate } from 'ra-core';
  *     onClose={() => { // do something }}
  * />
  */
-export const Confirm = (props: ConfirmProps) => {
+export const Confirm = (inProps: ConfirmProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         isOpen = false,
@@ -157,3 +169,22 @@ const StyledDialog = styled(Dialog, {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaConfirm: 'root' | 'confirmPrimary' | 'confirmWarning';
+    }
+
+    interface ComponentsPropsList {
+        RaConfirm: Partial<ConfirmProps>;
+    }
+
+    interface Components {
+        RaConfirm?: {
+            defaultProps?: ComponentsPropsList['RaConfirm'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaConfirm'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/Error.tsx
+++ b/packages/ra-ui-materialui/src/layout/Error.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
-import { ComponentType, ErrorInfo, Fragment, HtmlHTMLAttributes } from 'react';
-import { FallbackProps } from 'react-error-boundary';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentType,
+    type ErrorInfo,
+    Fragment,
+    type HtmlHTMLAttributes,
+} from 'react';
+import type { FallbackProps } from 'react-error-boundary';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     Button,
     Accordion,
     AccordionDetails,
     AccordionSummary,
     Typography,
-    SxProps,
+    type SxProps,
 } from '@mui/material';
 import ErrorIcon from '@mui/icons-material/Report';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -23,12 +32,16 @@ import type { TitleComponent } from 'ra-core';
 import { Title } from './Title';
 
 export const Error = (
-    props: InternalErrorProps & {
+    inProps: InternalErrorProps & {
         errorComponent?: ComponentType<ErrorProps>;
     } & {
         sx?: SxProps;
     }
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         error,
         errorComponent: ErrorComponent,
@@ -201,4 +214,31 @@ const Root = styled('div', {
 
 function goBack() {
     window.history.go(-1);
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaError:
+            | 'root'
+            | 'title'
+            | 'icon'
+            | 'panel'
+            | 'panelSumary'
+            | 'panelDetails'
+            | 'toolbar'
+            | 'advice';
+    }
+
+    interface ComponentsPropsList {
+        RaError: Partial<ErrorProps>;
+    }
+
+    interface Components {
+        RaError?: {
+            defaultProps?: ComponentsPropsList['RaError'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaError'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/layout/Layout.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.tsx
@@ -1,17 +1,31 @@
-import React, { ComponentType, ErrorInfo, Suspense, useState } from 'react';
+import React, {
+    type ComponentType,
+    type ErrorInfo,
+    Suspense,
+    useState,
+} from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import clsx from 'clsx';
-import { styled, SxProps } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 
-import { AppBar as DefaultAppBar, AppBarProps } from './AppBar';
-import { Sidebar as DefaultSidebar, SidebarProps } from './Sidebar';
-import { Menu as DefaultMenu, MenuProps } from './Menu';
-import { Error, ErrorProps } from './Error';
+import { AppBar as DefaultAppBar, type AppBarProps } from './AppBar';
+import { Sidebar as DefaultSidebar, type SidebarProps } from './Sidebar';
+import { Menu as DefaultMenu, type MenuProps } from './Menu';
+import { Error, type ErrorProps } from './Error';
 import { SkipNavigationButton } from '../button';
 import { Inspector } from '../preferences';
 import { Loading } from './Loading';
 
-export const Layout = (props: LayoutProps) => {
+export const Layout = (inProps: LayoutProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         appBar: AppBar = DefaultAppBar,
         appBarAlwaysOn,
@@ -133,3 +147,22 @@ const Core = styled('div', {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLayout: 'root' | 'appFrame' | 'contentWithSidebar' | 'content';
+    }
+
+    interface ComponentsPropsList {
+        RaLayout: Partial<LayoutProps>;
+    }
+
+    interface Components {
+        RaLayout?: {
+            defaultProps?: ComponentsPropsList['RaLayout'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLayout'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/LinearProgress.tsx
+++ b/packages/ra-ui-materialui/src/layout/LinearProgress.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import {
     Box,
     LinearProgress as MuiLinearProgress,
-    LinearProgressProps as ProgressProps,
+    type LinearProgressProps as ProgressProps,
 } from '@mui/material';
 import { useTimeout } from 'ra-core';
 
@@ -22,11 +26,12 @@ import { useTimeout } from 'ra-core';
  *
  * @param {Props} props
  */
-export const LinearProgress = ({
-    timeout = 1000,
-    ...props
-}: LinearProgressProps) => {
-    const { className, ...rest } = props;
+export const LinearProgress = (inProps: LinearProgressProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const { className, timeout = 1000, ...rest } = props;
 
     const oneSecondHasPassed = useTimeout(timeout);
 
@@ -53,3 +58,22 @@ const StyledProgress = styled(MuiLinearProgress, {
     margin: `${theme.spacing(1)} 0`,
     width: theme.spacing(20),
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLinearProgress: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaLinearProgress: Partial<LinearProgressProps>;
+    }
+
+    interface Components {
+        RaLinearProgress?: {
+            defaultProps?: ComponentsPropsList['RaLinearProgress'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLinearProgress'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/Loading.tsx
+++ b/packages/ra-ui-materialui/src/layout/Loading.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { Typography, SxProps } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Typography, type SxProps } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useTimeout, useTranslate } from 'ra-core';
 
-export const Loading = (props: LoadingProps) => {
+export const Loading = (inProps: LoadingProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         loadingPrimary = 'ra.page.loading',
@@ -64,3 +72,22 @@ const Root = styled('div', {
         height: '9em',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLoading: 'root' | 'icon' | 'message';
+    }
+
+    interface ComponentsPropsList {
+        RaLoading: Partial<LoadingProps>;
+    }
+
+    interface Components {
+        RaLoading?: {
+            defaultProps?: ComponentsPropsList['RaLoading'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLoading'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useTheme,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
-import { useTheme } from '@mui/material/styles';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useLoading } from 'ra-core';
 
-import { RefreshIconButton, RefreshIconButtonProps } from '../button';
-import { SxProps } from '@mui/system';
+import { RefreshIconButton, type RefreshIconButtonProps } from '../button';
 
-export const LoadingIndicator = (props: LoadingIndicatorProps) => {
+export const LoadingIndicator = (inProps: LoadingIndicatorProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className, onClick, sx, ...rest } = props;
     const loading = useLoading();
 
@@ -68,3 +76,22 @@ const Root = styled('div', {
         left: '30%',
     },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaLoadingIndicator: 'root' | 'loader' | 'loadedLoading' | 'loadedIcon';
+    }
+
+    interface ComponentsPropsList {
+        RaLoadingIndicator: Partial<LoadingIndicatorProps>;
+    }
+
+    interface Components {
+        RaLoadingIndicator?: {
+            defaultProps?: ComponentsPropsList['RaLoadingIndicator'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaLoadingIndicator'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/Menu.tsx
+++ b/packages/ra-ui-materialui/src/layout/Menu.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { MenuList } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import lodashGet from 'lodash/get';
 import clsx from 'clsx';
 
@@ -35,7 +39,11 @@ import { useHasDashboard } from 'ra-core';
  *     </Menu>
  * );
  */
-export const Menu = (props: MenuProps) => {
+export const Menu = (inProps: MenuProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { children, className, ...rest } = props;
     const hasDashboard = useHasDashboard();
     const [open] = useSidebarState();
@@ -101,3 +109,22 @@ const Root = styled(MenuList, {
         width: lodashGet(theme, 'sidebar.closedWidth', CLOSED_DRAWER_WIDTH),
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaMenu: 'root' | 'open' | 'closed';
+    }
+
+    interface ComponentsPropsList {
+        RaMenu: Partial<MenuProps>;
+    }
+
+    interface Components {
+        RaMenu?: {
+            defaultProps?: ComponentsPropsList['RaMenu'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaMenu'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -1,13 +1,22 @@
-import React, { forwardRef, useCallback, ReactElement, ReactNode } from 'react';
-import { styled } from '@mui/material/styles';
+import React, {
+    forwardRef,
+    useCallback,
+    type ReactElement,
+    type ReactNode,
+} from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
-import { Link, LinkProps, useMatch } from 'react-router-dom';
+import { Link, type LinkProps, useMatch } from 'react-router-dom';
 import {
     MenuItem,
-    MenuItemProps,
+    type MenuItemProps,
     ListItemIcon,
     Tooltip,
-    TooltipProps,
+    type TooltipProps,
     useMediaQuery,
     Theme,
 } from '@mui/material';
@@ -68,80 +77,88 @@ import { useTranslate, useBasename } from 'ra-core';
  *     </Admin>
  * );
  */
-export const MenuItemLink = forwardRef<any, MenuItemLinkProps>((props, ref) => {
-    const {
-        className,
-        primaryText,
-        leftIcon,
-        onClick,
-        sidebarIsOpen,
-        tooltipProps,
-        children,
-        ...rest
-    } = props;
+export const MenuItemLink = forwardRef<any, MenuItemLinkProps>(
+    (inProps, ref) => {
+        const props = useThemeProps({
+            props: inProps,
+            name: PREFIX,
+        });
+        const {
+            className,
+            primaryText,
+            leftIcon,
+            onClick,
+            sidebarIsOpen,
+            tooltipProps,
+            children,
+            ...rest
+        } = props;
 
-    const isSmall = useMediaQuery<Theme>(theme => theme.breakpoints.down('md'));
-    const translate = useTranslate();
-    const basename = useBasename();
-
-    const [open, setOpen] = useSidebarState();
-    const handleMenuTap = useCallback(
-        e => {
-            if (isSmall) {
-                setOpen(false);
-            }
-            onClick && onClick(e);
-        },
-        [setOpen, isSmall, onClick]
-    );
-
-    const to =
-        (typeof props.to === 'string' ? props.to : props.to.pathname) || '';
-    const match = useMatch({ path: to, end: to === `${basename}/` });
-
-    const renderMenuItem = () => {
-        return (
-            <StyledMenuItem
-                className={clsx(className, {
-                    [MenuItemLinkClasses.active]: !!match,
-                })}
-                // @ts-ignore
-                component={LinkRef}
-                ref={ref}
-                tabIndex={0}
-                {...rest}
-                onClick={handleMenuTap}
-            >
-                {leftIcon && (
-                    <ListItemIcon className={MenuItemLinkClasses.icon}>
-                        {leftIcon}
-                    </ListItemIcon>
-                )}
-                {children
-                    ? children
-                    : typeof primaryText === 'string'
-                      ? translate(primaryText, { _: primaryText })
-                      : primaryText}
-            </StyledMenuItem>
+        const isSmall = useMediaQuery<Theme>(theme =>
+            theme.breakpoints.down('md')
         );
-    };
+        const translate = useTranslate();
+        const basename = useBasename();
 
-    return open ? (
-        renderMenuItem()
-    ) : (
-        <Tooltip
-            title={
-                typeof primaryText === 'string'
-                    ? translate(primaryText, { _: primaryText })
-                    : primaryText
-            }
-            placement="right"
-            {...tooltipProps}
-        >
-            {renderMenuItem()}
-        </Tooltip>
-    );
-});
+        const [open, setOpen] = useSidebarState();
+        const handleMenuTap = useCallback(
+            e => {
+                if (isSmall) {
+                    setOpen(false);
+                }
+                onClick && onClick(e);
+            },
+            [setOpen, isSmall, onClick]
+        );
+
+        const to =
+            (typeof props.to === 'string' ? props.to : props.to.pathname) || '';
+        const match = useMatch({ path: to, end: to === `${basename}/` });
+
+        const renderMenuItem = () => {
+            return (
+                <StyledMenuItem
+                    className={clsx(className, {
+                        [MenuItemLinkClasses.active]: !!match,
+                    })}
+                    // @ts-ignore
+                    component={LinkRef}
+                    ref={ref}
+                    tabIndex={0}
+                    {...rest}
+                    onClick={handleMenuTap}
+                >
+                    {leftIcon && (
+                        <ListItemIcon className={MenuItemLinkClasses.icon}>
+                            {leftIcon}
+                        </ListItemIcon>
+                    )}
+                    {children
+                        ? children
+                        : typeof primaryText === 'string'
+                          ? translate(primaryText, { _: primaryText })
+                          : primaryText}
+                </StyledMenuItem>
+            );
+        };
+
+        return open ? (
+            renderMenuItem()
+        ) : (
+            <Tooltip
+                title={
+                    typeof primaryText === 'string'
+                        ? translate(primaryText, { _: primaryText })
+                        : primaryText
+                }
+                placement="right"
+                {...tooltipProps}
+            >
+                {renderMenuItem()}
+            </Tooltip>
+        );
+    }
+);
 
 export type MenuItemLinkProps = Omit<
     LinkProps & MenuItemProps<'li'>,
@@ -182,3 +199,22 @@ const StyledMenuItem = styled(MenuItem, {
 const LinkRef = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
     <Link ref={ref} {...props} />
 ));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaMenuItemLink: 'root' | 'active' | 'icon';
+    }
+
+    interface ComponentsPropsList {
+        RaMenuItemLink: Partial<MenuItemLinkProps>;
+    }
+
+    interface Components {
+        RaMenuItemLink?: {
+            defaultProps?: ComponentsPropsList['RaMenuItemLink'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaMenuItemLink'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/NotFound.tsx
+++ b/packages/ra-ui-materialui/src/layout/NotFound.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type Theme,
+    useThemeProps,
+} from '@mui/material/styles';
+import { type MUIStyledCommonProps } from '@mui/system';
 import Button from '@mui/material/Button';
 import HotTub from '@mui/icons-material/HotTub';
 import History from '@mui/icons-material/History';
@@ -8,16 +14,18 @@ import { useAuthenticated, useDefaultTitle, useTranslate } from 'ra-core';
 import { Title } from './Title';
 import { Loading } from './Loading';
 
-export const NotFound = props => {
-    const { className, ...rest } = props;
-
+export const NotFound = (inProps: NotFoundProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const translate = useTranslate();
     const { isPending } = useAuthenticated();
     const title = useDefaultTitle();
 
     if (isPending) return <Loading />;
     return (
-        <Root className={className} {...sanitizeRestProps(rest)}>
+        <Root {...sanitizeRestProps(props)}>
             <Title defaultTitle={title} />
             <div className={NotFoundClasses.message}>
                 <HotTub className={NotFoundClasses.icon} />
@@ -37,13 +45,20 @@ export const NotFound = props => {
     );
 };
 
+export interface NotFoundProps
+    extends React.DetailedHTMLProps<
+            React.HTMLAttributes<HTMLDivElement>,
+            HTMLDivElement
+        >,
+        MUIStyledCommonProps<Theme> {}
+
 const sanitizeRestProps = ({
     staticContext,
     history,
     location,
     match,
     ...rest
-}) => rest;
+}: any): NotFoundProps => rest;
 
 const PREFIX = 'RaNotFound';
 
@@ -88,4 +103,23 @@ const Root = styled('div', {
 
 function goBack() {
     window.history.go(-1);
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaNotFound: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaNotFound: Partial<NotFoundProps>;
+    }
+
+    interface Components {
+        RaNotFound?: {
+            defaultProps?: ComponentsPropsList['RaNotFound'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaNotFound'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -1,12 +1,22 @@
 import * as React from 'react';
-import { styled, Theme } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type Theme,
+    useThemeProps,
+} from '@mui/material/styles';
 import { useState, useEffect, useCallback } from 'react';
-import { Button, Snackbar, SnackbarProps, SnackbarOrigin } from '@mui/material';
+import {
+    Button,
+    Snackbar,
+    type SnackbarProps,
+    SnackbarOrigin,
+} from '@mui/material';
 import clsx from 'clsx';
 
 import {
     CloseNotificationContext,
-    NotificationPayload,
+    type NotificationPayload,
     undoableEventEmitter,
     useNotificationContext,
     useTakeUndoableMutation,
@@ -30,7 +40,11 @@ const defaultAnchorOrigin: SnackbarOrigin = {
  * @param {number} props.autoHideDuration Duration in milliseconds to wait until hiding a given notification. Defaults to 4000.
  * @param {boolean} props.multiLine Set it to `true` if the notification message should be shown in more than one line.
  */
-export const Notification = (props: NotificationProps) => {
+export const Notification = (inProps: NotificationProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         type = 'info',
@@ -219,4 +233,29 @@ export interface NotificationProps extends Omit<SnackbarProps, 'open'> {
     type?: string;
     autoHideDuration?: number;
     multiLine?: boolean;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaNotification:
+            | 'root'
+            | 'success'
+            | 'error'
+            | 'warning'
+            | 'undo'
+            | 'multiLine';
+    }
+
+    interface ComponentsPropsList {
+        RaNotification: Partial<NotificationProps>;
+    }
+
+    interface Components {
+        RaNotification?: {
+            defaultProps?: ComponentsPropsList['RaNotification'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaNotification'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/layout/Sidebar.tsx
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import {
     Drawer,
-    DrawerProps,
+    type DrawerProps,
     useMediaQuery,
-    Theme,
+    type Theme,
     useScrollTrigger,
 } from '@mui/material';
 import lodashGet from 'lodash/get';
@@ -14,7 +18,11 @@ import { useLocale } from 'ra-core';
 
 import { useSidebarState } from './useSidebarState';
 
-export const Sidebar = (props: SidebarProps) => {
+export const Sidebar = (inProps: SidebarProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { appBarAlwaysOn, children, closedSize, size, ...rest } = props;
     const isXSmall = useMediaQuery<Theme>(theme =>
         theme.breakpoints.down('sm')
@@ -157,3 +165,36 @@ const StyledDrawer = styled(Drawer, {
 
 export const DRAWER_WIDTH = 240;
 export const CLOSED_DRAWER_WIDTH = 55;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSidebar:
+            | 'root'
+            | 'docked'
+            | 'paper'
+            | 'paperAnchorLeft'
+            | 'paperAnchorRight'
+            | 'paperAnchorTop'
+            | 'paperAnchorBottom'
+            | 'paperAnchorDockedLeft'
+            | 'paperAnchorDockedTop'
+            | 'paperAnchorDockedRight'
+            | 'paperAnchorDockedBottom'
+            | 'modal'
+            | 'fixed'
+            | 'appBarCollapsed';
+    }
+
+    interface ComponentsPropsList {
+        RaSidebar: Partial<SidebarProps>;
+    }
+
+    interface Components {
+        RaSidebar?: {
+            defaultProps?: ComponentsPropsList['RaSidebar'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSidebar'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/SidebarToggleButton.tsx
+++ b/packages/ra-ui-materialui/src/layout/SidebarToggleButton.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { IconButton, Tooltip } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useTranslate } from 'ra-core';
@@ -11,7 +15,11 @@ import { useSidebarState } from './useSidebarState';
  * @param props The component props
  * @param {String} props.className An optional class name to apply to the button
  */
-export const SidebarToggleButton = (props: SidebarToggleButtonProps) => {
+export const SidebarToggleButton = (inProps: SidebarToggleButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const translate = useTranslate();
 
     const { className } = props;
@@ -70,3 +78,25 @@ const StyledIconButton = styled(IconButton, {
         transform: 'rotate(180deg)',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSidebarToggleButton:
+            | 'root'
+            | 'menuButtonIconClosed'
+            | 'menuButtonIconOpen';
+    }
+
+    interface ComponentsPropsList {
+        RaSidebarToggleButton: Partial<SidebarToggleButtonProps>;
+    }
+
+    interface Components {
+        RaSidebarToggleButton?: {
+            defaultProps?: ComponentsPropsList['RaSidebarToggleButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSidebarToggleButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/TopToolbar.tsx
+++ b/packages/ra-ui-materialui/src/layout/TopToolbar.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
-import { useMediaQuery, Theme } from '@mui/material';
-import { styled } from '@mui/material/styles';
-import Toolbar, { ToolbarProps } from '@mui/material/Toolbar';
+import { useMediaQuery, type Theme } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Toolbar, type ToolbarProps } from '@mui/material';
 
-export const TopToolbar = (props: ToolbarProps) => {
+export const TopToolbar = (inProps: ToolbarProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const isXSmall = useMediaQuery<Theme>(theme =>
         theme.breakpoints.down('sm')
     );
@@ -42,3 +50,22 @@ const StyledToolbar = styled(Toolbar, {
 }));
 
 const sanitizeToolbarRestProps = ({ hasCreate, ...props }: any) => props;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaTopToolbar: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaTopToolbar: Partial<ToolbarProps>;
+    }
+
+    interface Components {
+        RaTopToolbar?: {
+            defaultProps?: ComponentsPropsList['RaTopToolbar'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaTopToolbar'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/layout/UserMenu.tsx
+++ b/packages/ra-ui-materialui/src/layout/UserMenu.tsx
@@ -9,10 +9,14 @@ import {
     Tooltip,
     useMediaQuery,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { useAuthProvider, useGetIdentity, useTranslate } from 'ra-core';
 import * as React from 'react';
-import { ReactNode, useCallback, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { Logout } from '../auth/Logout';
 import { UserMenuContextProvider } from './UserMenuContextProvider';
 
@@ -57,7 +61,11 @@ import { UserMenuContextProvider } from './UserMenuContextProvider';
  * @param {Element} props.icon The icon of the UserMenu button.
  *
  */
-export const UserMenu = (props: UserMenuProps) => {
+export const UserMenu = (inProps: UserMenuProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const [anchorEl, setAnchorEl] = useState(null);
     const translate = useTranslate();
     const { isPending, identity } = useGetIdentity();
@@ -180,3 +188,22 @@ const TransformOrigin: PopoverOrigin = {
     vertical: 'top',
     horizontal: 'right',
 };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaUserMenu: 'root' | 'userButton' | 'avatar';
+    }
+
+    interface ComponentsPropsList {
+        RaUserMenu: Partial<UserMenuProps>;
+    }
+
+    interface Components {
+        RaUserMenu?: {
+            defaultProps?: ComponentsPropsList['RaUserMenu'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaUserMenu'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/BulkActionsToolbar.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
-import { isValidElement, ReactElement, ReactNode, useCallback } from 'react';
-import { alpha, styled } from '@mui/material/styles';
+import {
+    isValidElement,
+    type ReactElement,
+    type ReactNode,
+    useCallback,
+} from 'react';
+import {
+    alpha,
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import clsx from 'clsx';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
@@ -14,7 +24,11 @@ import { SelectAllButton } from '../button';
 
 const defaultSelectAllButton = <SelectAllButton />;
 
-export const BulkActionsToolbar = (props: BulkActionsToolbarProps) => {
+export const BulkActionsToolbar = (inProps: BulkActionsToolbarProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         label = 'ra.action.bulk_actions',
         children,
@@ -156,3 +170,29 @@ const Root = styled('div', {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaBulkActionsToolbar:
+            | 'root'
+            | 'toolbar'
+            | 'topToolbar'
+            | 'buttons'
+            | 'collapsed'
+            | 'title'
+            | 'icon';
+    }
+
+    interface ComponentsPropsList {
+        RaBulkActionsToolbar: Partial<BulkActionsToolbarProps>;
+    }
+
+    interface Components {
+        RaBulkActionsToolbar?: {
+            defaultProps?: ComponentsPropsList['RaBulkActionsToolbar'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaBulkActionsToolbar'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/Empty.tsx
+++ b/packages/ra-ui-materialui/src/list/Empty.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { Typography } from '@mui/material';
 import Inbox from '@mui/icons-material/Inbox';
 import {
@@ -11,7 +15,11 @@ import {
 
 import { CreateButton } from '../button';
 
-export const Empty = (props: EmptyProps) => {
+export const Empty = (inProps: EmptyProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className } = props;
     const { hasCreate } = useResourceDefinition(props);
     const resource = useResourceContext(props);
@@ -92,3 +100,22 @@ const Root = styled('span', {
         marginTop: '2em',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaEmpty: 'root' | 'message' | 'icon' | 'toolbar';
+    }
+
+    interface ComponentsPropsList {
+        RaEmpty: Partial<EmptyProps>;
+    }
+
+    interface Components {
+        RaEmpty?: {
+            defaultProps?: ComponentsPropsList['RaEmpty'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaEmpty'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/ListToolbar.tsx
+++ b/packages/ra-ui-materialui/src/list/ListToolbar.tsx
@@ -1,14 +1,21 @@
 import * as React from 'react';
-import { FC, memo } from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactElement } from 'react';
-import { ToolbarProps } from '@mui/material';
-import { Exporter } from 'ra-core';
+import { type FC, memo, type ReactElement } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import type { ToolbarProps } from '@mui/material';
+import type { Exporter } from 'ra-core';
 
 import { FilterForm } from './filter';
 import { FilterContext } from './FilterContext';
 
-export const ListToolbar: FC<ListToolbarProps> = memo(props => {
+export const ListToolbar: FC<ListToolbarProps> = memo(inProps => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { filters, actions, className, ...rest } = props;
 
     return Array.isArray(filters) ? (
@@ -65,3 +72,22 @@ const Root = styled('div', {
         flexDirection: 'column-reverse',
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaListToolbar: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaListToolbar: Partial<ListToolbarProps>;
+    }
+
+    interface Components {
+        RaListToolbar?: {
+            defaultProps?: ComponentsPropsList['RaListToolbar'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaListToolbar'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import { ReactElement, ReactNode, ElementType } from 'react';
-import { SxProps } from '@mui/system';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
+import type { ReactElement, ReactNode, ElementType } from 'react';
 import Card from '@mui/material/Card';
 import clsx from 'clsx';
-import { useListContext, RaRecord } from 'ra-core';
+import { useListContext, type RaRecord } from 'ra-core';
 
 import { Title } from '../layout/Title';
 import { ListToolbar } from './ListToolbar';
@@ -18,8 +22,12 @@ const defaultEmpty = <Empty />;
 const DefaultComponent = Card;
 
 export const ListView = <RecordType extends RaRecord = any>(
-    props: ListViewProps
+    inProps: ListViewProps
 ) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         actions = defaultActions,
         aside,
@@ -356,3 +364,22 @@ const Root = styled('div', {
         flex: 1,
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaList: 'root' | 'main' | 'content' | 'actions' | 'noResults';
+    }
+
+    interface ComponentsPropsList {
+        RaList: Partial<ListViewProps>;
+    }
+
+    interface Components {
+        RaList?: {
+            defaultProps?: ComponentsPropsList['RaList'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaList'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/Placeholder.tsx
+++ b/packages/ra-ui-materialui/src/list/Placeholder.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type Theme,
+    useThemeProps,
+} from '@mui/material/styles';
+import { MUIStyledCommonProps } from '@mui/system';
 
-interface PlaceholderProps {
+interface PlaceholderProps extends MUIStyledCommonProps<Theme> {
     className?: string;
 }
 
-export const Placeholder = (props: PlaceholderProps) => (
-    <Root className={props.className}>&nbsp;</Root>
-);
-
+export const Placeholder = (inProps: PlaceholderProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    return <Root {...props}>&nbsp;</Root>;
+};
 const PREFIX = 'RaPlaceholder';
 
 const Root = styled('span', {
@@ -18,3 +27,22 @@ const Root = styled('span', {
     backgroundColor: theme.palette.grey[300],
     display: 'flex',
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaPlaceholder: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaPlaceholder: Partial<PlaceholderProps>;
+    }
+
+    interface Components {
+        RaPlaceholder?: {
+            defaultProps?: ComponentsPropsList['RaPlaceholder'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaPlaceholder'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -7,9 +7,9 @@ import {
     ListItemText,
     ListProps,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
 import {
-    RaRecord,
+    type RaRecord,
     RecordContextProvider,
     sanitizeListRestProps,
     useGetRecordRepresentation,
@@ -19,15 +19,15 @@ import {
     useTranslate,
 } from 'ra-core';
 import * as React from 'react';
-import { isValidElement, ReactElement } from 'react';
+import { isValidElement, type ReactElement } from 'react';
 
 import { ListNoResults } from '../ListNoResults';
 import { SimpleListLoading } from './SimpleListLoading';
 import {
     FunctionToElement,
-    SimpleListBaseProps,
+    type SimpleListBaseProps,
     SimpleListItem,
-    SimpleListItemProps,
+    type SimpleListItemProps,
 } from './SimpleListItem';
 
 /**
@@ -276,3 +276,22 @@ const Root = styled(List, {
 });
 
 const DefaultEmpty = <ListNoResults />;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSimpleList: 'root' | 'tertiary';
+    }
+
+    interface ComponentsPropsList {
+        RaSimpleList: Partial<SimpleListProps>;
+    }
+
+    interface Components {
+        RaSimpleList?: {
+            defaultProps?: ComponentsPropsList['RaSimpleList'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSimpleList'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleListLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleListLoading.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import Avatar from '@mui/material/Avatar';
 import {
     List,
-    ListProps,
+    type ListProps,
     ListItem,
     ListItemAvatar,
     ListItemSecondaryAction,
@@ -13,7 +17,11 @@ import { useTimeout } from 'ra-core';
 
 import { Placeholder } from '../Placeholder';
 
-export const SimpleListLoading = (props: Props & ListProps) => {
+export const SimpleListLoading = (inProps: SimpleListLoadingProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         hasLeftAvatarOrIcon,
@@ -94,11 +102,30 @@ const StyledList = styled(List, {
 const times = (nbChildren, fn) =>
     Array.from({ length: nbChildren }, (_, key) => fn(key));
 
-interface Props {
+export interface SimpleListLoadingProps extends ListProps {
     className?: string;
     hasLeftAvatarOrIcon?: boolean;
     hasRightAvatarOrIcon?: boolean;
     hasSecondaryText?: boolean;
     hasTertiaryText?: boolean;
     nbFakeLines?: number;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSimpleListLoading: 'root' | 'primary' | 'tertiary';
+    }
+
+    interface ComponentsPropsList {
+        RaSimpleListLoading: Partial<SimpleListLoadingProps>;
+    }
+
+    interface Components {
+        RaSimpleListLoading?: {
+            defaultProps?: ComponentsPropsList['RaSimpleListLoading'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSimpleListLoading'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -1,10 +1,17 @@
 import * as React from 'react';
-import { Chip, Stack, StackProps, styled } from '@mui/material';
+import {
+    Chip,
+    type ComponentsOverrides,
+    Stack,
+    type StackProps,
+    styled,
+    useThemeProps,
+} from '@mui/material';
 import {
     sanitizeListRestProps,
     useListContextWithProps,
     useResourceContext,
-    RaRecord,
+    type RaRecord,
     RecordContextProvider,
     RecordRepresentation,
     useCreatePath,
@@ -47,7 +54,11 @@ import { Link } from '../Link';
  *     </SingleFieldList>
  * </ReferenceManyField>
  */
-export const SingleFieldList = (props: SingleFieldListProps) => {
+export const SingleFieldList = (inProps: SingleFieldListProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         className,
         children,
@@ -163,3 +174,22 @@ const DefaultChildComponent = ({ clickable }: { clickable?: boolean }) => (
         clickable={clickable}
     />
 );
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSingleFieldList: 'root' | 'link';
+    }
+
+    interface ComponentsPropsList {
+        RaSingleFieldList: Partial<SingleFieldListProps>;
+    }
+
+    interface Components {
+        RaSingleFieldList?: {
+            defaultProps?: ComponentsPropsList['RaSingleFieldList'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSingleFieldList'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeaderCell.tsx
@@ -1,16 +1,24 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { memo } from 'react';
 import clsx from 'clsx';
-import { TableCell, TableSortLabel, Tooltip } from '@mui/material';
-import { TableCellProps } from '@mui/material/TableCell';
+import {
+    TableCell,
+    type TableCellProps,
+    TableSortLabel,
+    Tooltip,
+} from '@mui/material';
 import {
     FieldTitle,
+    type SortPayload,
     useTranslate,
     useResourceContext,
     useTranslateLabel,
 } from 'ra-core';
-import type { SortPayload } from 'ra-core';
 import type { DatagridField } from './types';
 
 const oppositeOrder: Record<SortPayload['order'], SortPayload['order']> = {
@@ -18,7 +26,11 @@ const oppositeOrder: Record<SortPayload['order'], SortPayload['order']> = {
     DESC: 'ASC',
 };
 
-export const DatagridHeaderCell = (props: DatagridHeaderCellProps) => {
+export const DatagridHeaderCell = (inProps: DatagridHeaderCellProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { className, field, sort, updateSort, isSorting, ...rest } = props;
     const resource = useResourceContext();
 
@@ -139,3 +151,22 @@ const StyledTableCell = styled(TableCell, {
         display: 'inline',
     },
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDatagridHeaderCell: 'root' | 'icon';
+    }
+
+    interface ComponentsPropsList {
+        RaDatagridHeaderCell: Partial<DatagridHeaderCellProps>;
+    }
+
+    interface Components {
+        RaDatagridHeaderCell?: {
+            defaultProps?: ComponentsPropsList['RaDatagridHeaderCell'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDatagridHeaderCell'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.tsx
@@ -3,18 +3,22 @@ import { useStore, useTranslate, useResourceContext } from 'ra-core';
 import {
     Box,
     Button,
-    ButtonProps,
+    type ButtonProps,
     Popover,
     useMediaQuery,
     Theme,
     Tooltip,
     IconButton,
 } from '@mui/material';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import ViewWeekIcon from '@mui/icons-material/ViewWeek';
 
 import { FieldToggle } from '../../preferences';
 import { ConfigurableDatagridColumn } from './DatagridConfigurable';
-import { styled } from '@mui/material/styles';
 
 /**
  * Renders a button that lets users show / hide columns in a configurable datagrid
@@ -39,7 +43,11 @@ import { styled } from '@mui/material/styles';
  *   </List>
  * );
  */
-export const SelectColumnsButton = (props: SelectColumnsButtonProps) => {
+export const SelectColumnsButton = (inProps: SelectColumnsButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { preferenceKey } = props;
 
     const resource = useResourceContext(props);
@@ -170,9 +178,9 @@ export const SelectColumnsButton = (props: SelectColumnsButtonProps) => {
                     {availableColumns.map(column => (
                         <FieldToggle
                             key={column.index}
-                            source={column.source}
-                            label={column.label}
-                            index={column.index}
+                            source={column.source!}
+                            label={column.label!}
+                            index={column.index!}
                             selected={columns.includes(column.index)}
                             onToggle={handleToggle}
                             onMove={handleMove}
@@ -183,9 +191,10 @@ export const SelectColumnsButton = (props: SelectColumnsButtonProps) => {
         </>
     );
 };
+const PREFIX = 'RaSelectColumnsButton';
 
 const StyledButton = styled(Button, {
-    name: 'RaSelectColumnsButton',
+    name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })({
     '&.MuiButton-sizeSmall': {
@@ -203,4 +212,23 @@ const sanitizeRestProps = ({
 export interface SelectColumnsButtonProps extends ButtonProps {
     resource?: string;
     preferenceKey?: string;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSelectColumnsButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaSelectColumnsButton: Partial<SelectColumnsButtonProps>;
+    }
+
+    interface Components {
+        RaSelectColumnsButton?: {
+            defaultProps?: ComponentsPropsList['RaSelectColumnsButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSelectColumnsButton'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/useDatagridStyles.tsx
@@ -1,4 +1,5 @@
-import { styled } from '@mui/material';
+import { type ComponentsOverrides, styled } from '@mui/material';
+import type { DatagridProps } from './Datagrid';
 
 const PREFIX = 'RaDatagrid';
 
@@ -75,3 +76,41 @@ export const DatagridRoot = styled('div', {
     },
     [`& .${DatagridClasses.expandedPanel}`]: {},
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDatagrid:
+            | 'root'
+            | 'table'
+            | 'tableWrapper'
+            | 'thead'
+            | 'tbody'
+            | 'headerRow'
+            | 'headerCell'
+            | 'checkbox'
+            | 'row'
+            | 'clickableRow'
+            | 'rowEven'
+            | 'rowOdd'
+            | 'rowCell'
+            | 'selectable'
+            | 'expandHeader'
+            | 'expandIconCell'
+            | 'expandIcon'
+            | 'expandable'
+            | 'expandedPanel';
+    }
+
+    interface ComponentsPropsList {
+        RaDatagrid: Partial<DatagridProps>;
+    }
+
+    interface Components {
+        RaDatagrid?: {
+            defaultProps?: ComponentsPropsList['RaDatagrid'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDatagrid'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datatable/ColumnsButton.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/ColumnsButton.tsx
@@ -3,7 +3,7 @@ import { useTranslate, useResourceContext } from 'ra-core';
 import {
     Box,
     Button,
-    ButtonProps,
+    type ButtonProps,
     Menu,
     useMediaQuery,
     Theme,
@@ -11,7 +11,11 @@ import {
     IconButton,
 } from '@mui/material';
 import ViewWeekIcon from '@mui/icons-material/ViewWeek';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 
 /**
  * Renders a button that lets users show / hide columns in a DataTable
@@ -36,7 +40,11 @@ import { styled } from '@mui/material/styles';
  *   </List>
  * );
  */
-export const ColumnsButton = (props: ColumnsButtonProps) => {
+export const ColumnsButton = (inProps: ColumnsButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const resource = useResourceContext(props);
     const storeKey = props.storeKey || `${resource}.datatable`;
 
@@ -98,8 +106,9 @@ export const ColumnsButton = (props: ColumnsButtonProps) => {
     );
 };
 
+const PREFIX = 'RaColumnsButton';
 const Root = styled('span', {
-    name: 'RaColumnsButton',
+    name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })({
     '& .MuiButton-sizeSmall': {
@@ -117,4 +126,23 @@ const sanitizeRestProps = ({
 export interface ColumnsButtonProps extends ButtonProps {
     resource?: string;
     storeKey?: string;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaColumnsButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaColumnsButton: Partial<ColumnsButtonProps>;
+    }
+
+    interface Components {
+        RaColumnsButton?: {
+            defaultProps?: ComponentsPropsList['RaColumnsButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaColumnsButton'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/list/datatable/ColumnsSelectorItem.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/ColumnsSelectorItem.tsx
@@ -72,7 +72,7 @@ export const ColumnsSelectorItem = ({
     return (
         <FieldToggle
             key={columnRank}
-            source={source}
+            source={source!}
             label={fieldLabel}
             index={String(columnRank)}
             selected={!isColumnHidden}

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableBody.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableBody.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { type ComponentType } from 'react';
 import { RecordContextProvider, useDataTableDataContext } from 'ra-core';
 import { TableBody, useThemeProps, type TableBodyProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
 import clsx from 'clsx';
 
 import { DataTableClasses } from './DataTableRoot';
@@ -70,3 +70,22 @@ const TableBodyStyled = styled(TableBody, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(() => ({}));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        DataTableBody: 'root';
+    }
+
+    interface ComponentsPropsList {
+        DataTableBody: Partial<DataTableBodyProps>;
+    }
+
+    interface Components {
+        DataTableBody?: {
+            defaultProps?: ComponentsPropsList['DataTableBody'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['DataTableBody'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableCell.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useDataTableStoreContext, useRecordContext, useStore } from 'ra-core';
 import { TableCell, useThemeProps, type SxProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
 import get from 'lodash/get';
 import clsx from 'clsx';
 
@@ -78,3 +78,22 @@ const TableCellStyled = styled(TableCell, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(() => ({}));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDataTableCell: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaDataTableCell: Partial<DataTableColumnProps>;
+    }
+
+    interface Components {
+        RaDataTableCell?: {
+            defaultProps?: ComponentsPropsList['RaDataTableCell'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDataTableCell'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableHead.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableHead.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { memo } from 'react';
 import { TableCell, TableHead, TableRow } from '@mui/material';
-import { styled, type SxProps } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+    type SxProps,
+    type Theme,
+} from '@mui/material/styles';
 import clsx from 'clsx';
 import {
     useDataTableConfigContext,
@@ -18,7 +24,11 @@ import { DataTableClasses } from './DataTableRoot';
  *
  * Renders select all checkbox as well as column head buttons used for sorting.
  */
-export const DataTableHead = memo((props: DataTableHeadProps) => {
+export const DataTableHead = memo((inProps: DataTableHeadProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { children, className, sx } = props;
     const {
         expand,
@@ -77,7 +87,7 @@ export interface DataTableHeadProps {
     children?: React.ReactNode;
     className?: string;
     size?: 'medium' | 'small';
-    sx?: SxProps;
+    sx?: SxProps<Theme>;
 }
 
 DataTableHead.displayName = 'DataTableHead';
@@ -88,3 +98,22 @@ const TableHeadStyled = styled(TableHead, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(() => ({}));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDataTableHead: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaDataTableHead: Partial<DataTableHeadProps>;
+    }
+
+    interface Components {
+        RaDataTableHead?: {
+            defaultProps?: ComponentsPropsList['RaDataTableHead'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDataTableHead'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableHeadCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableHeadCell.tsx
@@ -16,10 +16,10 @@ import {
     Tooltip,
     useThemeProps,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
 import clsx from 'clsx';
 
-import { DataTableColumnProps } from './DataTableColumn';
+import type { DataTableColumnProps } from './DataTableColumn';
 import { DataTableClasses } from './DataTableRoot';
 
 const oppositeOrder: Record<SortPayload['order'], SortPayload['order']> = {
@@ -140,3 +140,22 @@ const TableCellStyled = styled(TableCell, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(() => ({}));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDataTableHeadCell: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaDataTableHeadCell: Partial<DataTableColumnProps>;
+    }
+
+    interface Components {
+        RaDataTableHeadCell?: {
+            defaultProps?: ComponentsPropsList['RaDataTableHeadCell'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDataTableHeadCell'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableRoot.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableRoot.tsx
@@ -1,4 +1,5 @@
-import { styled } from '@mui/material';
+import { type ComponentsOverrides, styled } from '@mui/material';
+import type { DataTableProps } from './DataTable';
 
 const PREFIX = 'RaDataTable';
 
@@ -79,3 +80,42 @@ export const DataTableRoot = styled('div', {
     },
     [`& .${DataTableClasses.expandRow}`]: {},
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDataTable:
+            | 'root'
+            | 'table'
+            | 'tableWrapper'
+            | 'thead'
+            | 'tbody'
+            | 'headerRow'
+            | 'headerCell'
+            | 'checkbox'
+            | 'row'
+            | 'clickableRow'
+            | 'rowEven'
+            | 'rowOdd'
+            | 'rowCell'
+            | 'selectable'
+            | 'expandHeader'
+            | 'expandIconCell'
+            | 'expandIcon'
+            | 'expandable'
+            | 'expanded'
+            | 'expandRow';
+    }
+
+    interface ComponentsPropsList {
+        RaDataTable: Partial<DataTableProps>;
+    }
+
+    interface Components {
+        RaDataTable?: {
+            defaultProps?: ComponentsPropsList['RaDataTable'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDataTable'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableRow.tsx
@@ -13,7 +13,7 @@ import {
     useThemeProps,
     type TableRowProps,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { type ComponentsOverrides, styled } from '@mui/material/styles';
 import {
     useDataTableCallbacksContext,
     useDataTableConfigContext,
@@ -241,3 +241,22 @@ const TableRowStyled = styled(TableRow, {
     name: PREFIX,
     overridesResolver: (props, styles) => styles.root,
 })(() => ({}));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaDataTableRow: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaDataTableRow: Partial<DataTableRowProps>;
+    }
+
+    interface Components {
+        RaDataTableRow?: {
+            defaultProps?: ComponentsPropsList['RaDataTableRow'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaDataTableRow'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.tsx
@@ -3,8 +3,8 @@ import {
     useState,
     useCallback,
     useRef,
-    ReactNode,
-    HtmlHTMLAttributes,
+    type ReactNode,
+    type HtmlHTMLAttributes,
     useContext,
 } from 'react';
 import {
@@ -13,8 +13,10 @@ import {
     ListItemIcon,
     ListItemText,
     styled,
-    ButtonProps as MuiButtonProps,
+    type ButtonProps as MuiButtonProps,
     Divider,
+    type ComponentsOverrides,
+    useThemeProps,
 } from '@mui/material';
 import ClearIcon from '@mui/icons-material/Clear';
 import BookmarkAddIcon from '@mui/icons-material/BookmarkAdd';
@@ -33,7 +35,11 @@ import { extractValidSavedQueries, useSavedQueries } from './useSavedQueries';
 import { AddSavedQueryDialog } from './AddSavedQueryDialog';
 import { RemoveSavedQueryDialog } from './RemoveSavedQueryDialog';
 
-export const FilterButton = (props: FilterButtonProps) => {
+export const FilterButton = (inProps: FilterButtonProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         filters: filtersProp,
         className,
@@ -313,3 +319,22 @@ const Root = styled('div', {
 })({
     display: 'inline-block',
 });
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFilterButton: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaFilterButton: Partial<FilterButtonProps>;
+    }
+
+    interface Components {
+        RaFilterButton?: {
+            defaultProps?: ComponentsPropsList['RaFilterButton'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFilterButton'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterForm.tsx
@@ -1,10 +1,14 @@
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import get from 'lodash/get';
 import { FilterLiveForm, useListContext, useResourceContext } from 'ra-core';
 import * as React from 'react';
 import {
-    HtmlHTMLAttributes,
-    ReactNode,
+    type HtmlHTMLAttributes,
+    type ReactNode,
     useCallback,
     useContext,
     useEffect,
@@ -14,7 +18,11 @@ import { useFormContext } from 'react-hook-form';
 import { FilterContext } from '../FilterContext';
 import { FilterFormInput } from './FilterFormInput';
 
-export const FilterForm = (props: FilterFormProps) => {
+export const FilterForm = (inProps: FilterFormProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { filters: filtersProps, ...rest } = props;
     const filters = useContext(FilterContext) || filtersProps;
 
@@ -139,3 +147,22 @@ const isEmptyValue = (filterValue: unknown) => {
 
     return false;
 };
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFilterForm: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaFilterForm: Partial<FilterFormProps>;
+    }
+
+    interface Components {
+        RaFilterForm?: {
+            defaultProps?: ComponentsPropsList['RaFilterForm'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFilterForm'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
 import { IconButton } from '@mui/material';
 import ActionHide from '@mui/icons-material/RemoveCircleOutline';
 import clsx from 'clsx';
 import { useResourceContext, useTranslate } from 'ra-core';
 
-export const FilterFormInput = props => {
+export const FilterFormInput = (inProps: FilterFormInputProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const { filterElement, handleHide, className } = props;
     const resource = useResourceContext(props);
     const translate = useTranslate();
@@ -43,6 +51,13 @@ export const FilterFormInput = props => {
     );
 };
 
+export interface FilterFormInputProps {
+    filterElement: React.ReactElement;
+    handleHide: (event: React.MouseEvent<HTMLElement>) => void;
+    className?: string;
+    resource?: string;
+}
+
 const PREFIX = 'RaFilterFormInput';
 
 export const FilterFormInputClasses = {
@@ -68,3 +83,22 @@ const Root = styled('div', {
 }));
 
 const emptyRecord = {};
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFilterFormInput: 'root' | 'spacer' | 'hideButton';
+    }
+
+    interface ComponentsPropsList {
+        RaFilterFormInput: Partial<FilterFormInputProps>;
+    }
+
+    interface Components {
+        RaFilterFormInput?: {
+            defaultProps?: ComponentsPropsList['RaFilterFormInput'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFilterFormInput'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { isElement } from 'react-is';
-import { styled } from '@mui/material/styles';
-import { memo, ReactElement } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { memo, type ReactElement } from 'react';
 import {
     IconButton,
     ListItem,
     ListItemButton,
     ListItemIcon,
-    ListItemProps,
+    type ListItemProps,
     ListItemText,
     ListItemSecondaryAction,
 } from '@mui/material';
@@ -147,7 +151,11 @@ const arePropsEqual = (prevProps, nextProps) =>
  *     </Card>
  * );
  */
-export const FilterListItem = memo((props: FilterListItemProps) => {
+export const FilterListItem = memo((inProps: FilterListItemProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         label,
         value,
@@ -259,4 +267,27 @@ export interface FilterListItemProps extends Omit<ListItemProps, 'value'> {
     icon?: ReactElement;
     toggleFilter?: (value: any, filters: any) => any;
     isSelected?: (value: any, filters: any) => boolean;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFilterListItem:
+            | 'root'
+            | 'listItemButton'
+            | 'listItemText'
+            | 'listItemIcon';
+    }
+
+    interface ComponentsPropsList {
+        RaFilterListItem: Partial<FilterListItemProps>;
+    }
+
+    interface Components {
+        RaFilterListItem?: {
+            defaultProps?: ComponentsPropsList['RaFilterListItem'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFilterListItem'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/list/filter/SavedQueriesList.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/SavedQueriesList.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
-import { styled, Tooltip } from '@mui/material';
+import type { ReactNode } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    Tooltip,
+    useThemeProps,
+} from '@mui/material';
 import BookmarkIcon from '@mui/icons-material/BookmarkBorder';
 import HelpIcon from '@mui/icons-material/HelpOutline';
 import { useListContext, useTranslate } from 'ra-core';
@@ -53,9 +58,12 @@ import { FilterList } from './FilterList';
  * );
  *
  */
-export const SavedQueriesList = ({
-    icon = defaultIcon,
-}: SavedQueriesListProps) => {
+export const SavedQueriesList = (inProps: SavedQueriesListProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
+    const { icon = defaultIcon } = props;
     const translate = useTranslate();
     const { resource, filterValues, displayedFilters, sort, perPage } =
         useListContext();
@@ -131,4 +139,28 @@ const defaultIcon = <BookmarkIcon />;
 
 export interface SavedQueriesListProps {
     icon?: ReactNode;
+}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSavedQueriesList:
+            | 'root'
+            | 'floatingIcon'
+            | 'floatingTooltip'
+            | 'titleContainer'
+            | 'titleIcon';
+    }
+
+    interface ComponentsPropsList {
+        RaSavedQueriesList: Partial<SavedQueriesListProps>;
+    }
+
+    interface Components {
+        RaSavedQueriesList?: {
+            defaultProps?: ComponentsPropsList['RaSavedQueriesList'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSavedQueriesList'];
+        };
+    }
 }

--- a/packages/ra-ui-materialui/src/list/filter/SavedQueryFilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/SavedQueryFilterListItem.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { ReactElement, memo } from 'react';
+import { type ReactElement, memo } from 'react';
 import {
     IconButton,
     ListItem,
     ListItemButton,
-    ListItemProps,
+    type ListItemProps,
     ListItemText,
     ListItemSecondaryAction,
     styled,
+    type ComponentsOverrides,
+    useThemeProps,
 } from '@mui/material';
 import CancelIcon from '@mui/icons-material/CancelOutlined';
 import isEqual from 'lodash/isEqual';
@@ -25,7 +27,11 @@ const arePropsEqual = (
     isEqual(prevProps.value, nextProps.value);
 
 export const SavedQueryFilterListItem = memo(
-    (props: SavedQueryFilterListItemProps): ReactElement => {
+    (inProps: SavedQueryFilterListItemProps): ReactElement => {
+        const props = useThemeProps({
+            props: inProps,
+            name: PREFIX,
+        });
         const { className, label, sx, value } = props;
         const { filterValues, sort, perPage, displayedFilters } =
             useListContext();
@@ -110,3 +116,22 @@ const StyledListItem = styled(ListItem, {
 export interface SavedQueryFilterListItemProps
     extends SavedQuery,
         Omit<ListItemProps, 'value'> {}
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaSavedQueryFilterListItem: 'root' | 'listItemButton' | 'listItemText';
+    }
+
+    interface ComponentsPropsList {
+        RaSavedQueryFilterListItem: Partial<SavedQueryFilterListItemProps>;
+    }
+
+    interface Components {
+        RaSavedQueryFilterListItem?: {
+            defaultProps?: ComponentsPropsList['RaSavedQueryFilterListItem'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaSavedQueryFilterListItem'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/list/pagination/PaginationActions.tsx
+++ b/packages/ra-ui-materialui/src/list/pagination/PaginationActions.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
-import { memo, FC } from 'react';
-import { styled } from '@mui/material/styles';
-import { Pagination, PaginationProps } from '@mui/material';
+import { memo, type FC } from 'react';
+import {
+    type ComponentsOverrides,
+    styled,
+    useThemeProps,
+} from '@mui/material/styles';
+import { Pagination, type PaginationProps } from '@mui/material';
 import { useTranslate } from 'ra-core';
 
-export const PaginationActions: FC<PaginationActionsProps> = memo(props => {
+export const PaginationActions: FC<PaginationActionsProps> = memo(inProps => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         page,
         rowsPerPage,
@@ -80,3 +88,22 @@ const sanitizeRestProps = ({
     slotProps,
     ...rest
 }: any) => rest;
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaPaginationActions: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaPaginationActions: Partial<PaginationActionsProps>;
+    }
+
+    interface Components {
+        RaPaginationActions?: {
+            defaultProps?: ComponentsPropsList['RaPaginationActions'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaPaginationActions'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/preferences/Configurable.tsx
+++ b/packages/ra-ui-materialui/src/preferences/Configurable.tsx
@@ -1,12 +1,23 @@
 import * as React from 'react';
-import { useRef, useEffect, useState, cloneElement, ReactElement } from 'react';
+import {
+    useRef,
+    useEffect,
+    useState,
+    cloneElement,
+    type ReactElement,
+} from 'react';
 import {
     usePreferencesEditor,
     PreferenceKeyContextProvider,
     useTranslate,
 } from 'ra-core';
 import { alpha, Popover } from '@mui/material';
-import { styled, SxProps } from '@mui/material/styles';
+import {
+    type ComponentsOverrides,
+    styled,
+    type SxProps,
+    useThemeProps,
+} from '@mui/material/styles';
 import SettingsIcon from '@mui/icons-material/Settings';
 import clsx from 'clsx';
 
@@ -26,7 +37,11 @@ import clsx from 'clsx';
  *     </Configurable>
  * );
  */
-export const Configurable = (props: ConfigurableProps) => {
+export const Configurable = (inProps: ConfigurableProps) => {
+    const props = useThemeProps({
+        props: inProps,
+        name: PREFIX,
+    });
     const {
         children,
         editor,
@@ -203,3 +218,22 @@ const Root = styled('span', {
             outline: `${theme.palette.warning.main} solid 2px`,
         },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaConfigurable: 'root' | 'editMode' | 'editorActive';
+    }
+
+    interface ComponentsPropsList {
+        RaConfigurable: Partial<ConfigurableProps>;
+    }
+
+    interface Components {
+        RaConfigurable?: {
+            defaultProps?: ComponentsPropsList['RaConfigurable'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaConfigurable'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
+++ b/packages/ra-ui-materialui/src/preferences/FieldToggle.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { FieldTitle, useResourceContext } from 'ra-core';
 import { Switch, Typography } from '@mui/material';
 import DragIcon from '@mui/icons-material/DragIndicator';
-import { styled } from '@mui/material/styles';
+import { ComponentsOverrides, styled } from '@mui/material/styles';
 
 /**
  * UI to enable/disable a field
  */
-export const FieldToggle = props => {
+export const FieldToggle = (props: FieldToggleProps) => {
     const { selected, label, onToggle, onMove, source, index } = props;
     const resource = useResourceContext();
     const dropIndex = React.useRef<number | null>(null);
@@ -85,7 +85,7 @@ export const FieldToggle = props => {
         }
 
         if (dropItem && list === dropItem.closest('ul')) {
-            onMove(selectedItem.dataset.index, dropIndex.current);
+            if (onMove) onMove(selectedItem.dataset.index!, dropIndex.current!);
         } else {
             event.preventDefault();
             event.stopPropagation();
@@ -113,7 +113,7 @@ export const FieldToggle = props => {
                 <Switch
                     checked={selected}
                     onChange={onToggle}
-                    name={index}
+                    name={`${index}`}
                     id={`switch_${index}`}
                     size="small"
                     sx={{ mr: 0.5, ml: -0.5 }}
@@ -137,8 +137,21 @@ export const FieldToggle = props => {
     );
 };
 
+export interface FieldToggleProps {
+    selected: boolean;
+    label: React.ReactNode;
+    onToggle?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onMove?: (
+        dragIndex: string | number,
+        dropIndex: string | number | null
+    ) => void;
+    source: string;
+    index: number | string;
+}
+
+const PREFIX = 'RaFieldToggle';
 const Root = styled('li', {
-    name: 'RaFieldToggle',
+    name: PREFIX,
     overridesResolver: (_props, styles) => styles.root,
 })(({ theme }) => ({
     display: 'flex',
@@ -156,3 +169,22 @@ const Root = styled('li', {
         },
     },
 }));
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaFieldToggle: 'root';
+    }
+
+    interface ComponentsPropsList {
+        RaFieldToggle: Partial<FieldToggleProps>;
+    }
+
+    interface Components {
+        RaFieldToggle?: {
+            defaultProps?: ComponentsPropsList['RaFieldToggle'];
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaFieldToggle'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/preferences/Inspector.tsx
+++ b/packages/ra-ui-materialui/src/preferences/Inspector.tsx
@@ -10,7 +10,7 @@ import {
 import { Paper, Typography, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/CancelOutlined';
 import DeleteIcon from '@mui/icons-material/DeleteOutline';
-import { useTheme, styled } from '@mui/material/styles';
+import { useTheme, styled, ComponentsOverrides } from '@mui/material/styles';
 
 import { InspectorRoot } from './InspectorRoot';
 
@@ -197,3 +197,17 @@ const StyledPaper = styled(Paper, {
 }));
 
 Inspector.displayName = 'Inspector';
+
+declare module '@mui/material/styles' {
+    interface ComponentNameToClassKey {
+        RaInspector: 'root' | 'modal' | 'title' | 'content';
+    }
+
+    interface Components {
+        RaInspector?: {
+            styleOverrides?: ComponentsOverrides<
+                Omit<Theme, 'components'>
+            >['RaInspector'];
+        };
+    }
+}

--- a/packages/ra-ui-materialui/src/theme/bwTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/bwTheme.ts
@@ -6,13 +6,12 @@ import {
     lightBlue,
     red,
 } from '@mui/material/colors';
-import { alpha } from '@mui/material/styles';
-import { RaThemeOptions } from './types';
+import { alpha, ThemeOptions } from '@mui/material/styles';
 
 const commonBlack = '#090909';
 const commonWhite = '#fafafa';
 
-const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
+const createBWTheme = (mode: 'light' | 'dark'): ThemeOptions => {
     const isDarkMode = mode === 'dark';
     const SPACING = 8;
     const GREY = isDarkMode ? grey[800] : grey[300];
@@ -332,10 +331,12 @@ const createBWTheme = (mode: 'light' | 'dark'): RaThemeOptions => {
             },
             MuiDialog: {
                 styleOverrides: {
-                    backdrop: {
-                        backgroundColor: isDarkMode
-                            ? 'rgb(0,0,0,0.8)'
-                            : 'rgb(0,0,0,0.5)',
+                    root: {
+                        '& .MuiBackdrop-root': {
+                            backgroundColor: isDarkMode
+                                ? 'rgb(0,0,0,0.8)'
+                                : 'rgb(0,0,0,0.5)',
+                        },
                     },
                 },
             },

--- a/packages/ra-ui-materialui/src/theme/defaultTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/defaultTheme.ts
@@ -1,7 +1,7 @@
-import { RaThemeOptions } from './types';
+import { ThemeOptions } from '@mui/material';
 import { deepmerge } from '@mui/utils';
 
-const defaultThemeInvariants = {
+const defaultThemeInvariants: ThemeOptions = {
     typography: {
         h6: {
             fontWeight: 400,
@@ -71,7 +71,7 @@ const defaultThemeInvariants = {
     },
 };
 
-export const defaultLightTheme: RaThemeOptions = deepmerge(
+export const defaultLightTheme: ThemeOptions = deepmerge(
     defaultThemeInvariants,
     {
         palette: {
@@ -100,7 +100,7 @@ export const defaultLightTheme: RaThemeOptions = deepmerge(
     }
 );
 
-export const defaultDarkTheme: RaThemeOptions = deepmerge(
+export const defaultDarkTheme: ThemeOptions = deepmerge(
     defaultThemeInvariants,
     {
         palette: {

--- a/packages/ra-ui-materialui/src/theme/houseTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/houseTheme.ts
@@ -4,8 +4,8 @@ import {
     darken,
     Theme,
     PaletteOptions,
+    ThemeOptions,
 } from '@mui/material';
-import { RaThemeOptions } from './types';
 
 /**
  * House: A young and joyful theme.
@@ -13,7 +13,7 @@ import { RaThemeOptions } from './types';
  * Uses rounded corners, blurry backdrop, large padding, and a bright color palette.
  */
 
-const componentsOverrides = (theme: Theme) => ({
+const componentsOverrides = (theme: Theme): ThemeOptions['components'] => ({
     MuiBackdrop: {
         styleOverrides: {
             root: {
@@ -189,7 +189,7 @@ const lightPalette: PaletteOptions = {
     mode: 'light' as 'light',
 };
 
-const createHouseTheme = (palette: RaThemeOptions['palette']) => {
+const createHouseTheme = (palette: PaletteOptions) => {
     const themeOptions = {
         palette,
         shape: { borderRadius: 20 },

--- a/packages/ra-ui-materialui/src/theme/nanoTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/nanoTheme.ts
@@ -1,5 +1,9 @@
-import { createTheme, PaletteOptions, Theme } from '@mui/material';
-import { RaThemeOptions } from './types';
+import {
+    createTheme,
+    PaletteOptions,
+    Theme,
+    ThemeOptions,
+} from '@mui/material';
 
 /**
  * Nano: A dense theme with minimal chrome, ideal for complex apps.
@@ -7,7 +11,7 @@ import { RaThemeOptions } from './types';
  * Uses a small font size, reduced spacing, text buttons, standard variant inputs, pale colors.
  */
 
-const componentsOverrides = (theme: Theme) => ({
+const componentsOverrides = (theme: Theme): ThemeOptions['components'] => ({
     MuiAlert: {
         defaultProps: {
             variant: 'outlined' as const,
@@ -348,7 +352,7 @@ const lightPalette: PaletteOptions = {
     ...alert,
 };
 
-const createNanoTheme = (palette: RaThemeOptions['palette']) => {
+const createNanoTheme = (palette: PaletteOptions) => {
     const themeOptions = {
         palette,
         shape: { borderRadius: 0 },

--- a/packages/ra-ui-materialui/src/theme/radiantTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/radiantTheme.ts
@@ -1,5 +1,10 @@
-import { alpha, createTheme, PaletteOptions, Theme } from '@mui/material';
-import { RaThemeOptions } from './types';
+import {
+    alpha,
+    createTheme,
+    PaletteOptions,
+    Theme,
+    ThemeOptions,
+} from '@mui/material';
 
 /**
  * Radiant: A theme emphasizing clarity and ease of use.
@@ -7,7 +12,7 @@ import { RaThemeOptions } from './types';
  * Uses generous margins, outlined inputs and buttons, no uppercase, and an acid color palette.
  */
 
-const componentsOverrides = (theme: Theme) => {
+const componentsOverrides = (theme: Theme): ThemeOptions['components'] => {
     const shadows = [
         alpha(theme.palette.primary.main, 0.2),
         alpha(theme.palette.primary.main, 0.1),
@@ -169,7 +174,7 @@ const lightPalette: PaletteOptions = {
     mode: 'light' as 'light',
 };
 
-const createRadiantTheme = (palette: RaThemeOptions['palette']) => {
+const createRadiantTheme = (palette: PaletteOptions) => {
     const themeOptions = {
         palette,
         shape: { borderRadius: 6 },

--- a/packages/ra-ui-materialui/src/theme/types.ts
+++ b/packages/ra-ui-materialui/src/theme/types.ts
@@ -4,6 +4,22 @@ export type ComponentsTheme = {
     [key: string]: any;
 };
 
+declare module '@mui/material/styles' {
+    interface Theme {
+        sidebar: {
+            width: number;
+            closedWidth: number;
+        };
+    }
+    // allow configuration using `createTheme()`
+    interface ThemeOptions {
+        sidebar?: {
+            width?: number;
+            closedWidth?: number;
+        };
+    }
+}
+
 export interface RaThemeOptions extends MuiThemeOptions {
     sidebar?: {
         width?: number;


### PR DESCRIPTION
## Problem

- Our components does not leverage MUI types for themes
- Our components don't support `defaultProps` override from themes

## Solution

- Ensure all components augment MUI Theme types
- Ensure all components support `defaultProps` override from themes

## How To Test

- Run the demos and compare them with production

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

