### PR TITLE
Fix `<FilterLiveForm>` compatibility with react-hook-form 7.55.0

### DIFF
--- a/packages/ra-core/src/form/FilterLiveForm.spec.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.spec.tsx
@@ -9,6 +9,7 @@ import {
     PerInputValidation,
 } from './FilterLiveForm.stories';
 import React from 'react';
+import { WithFilterListSection } from '../../../ra-ui-materialui/src/list/filter/FilterLiveForm.stories';
 
 describe('<FilterLiveForm />', () => {
     it('should allow to set a filter value', async () => {
@@ -138,6 +139,30 @@ describe('<FilterLiveForm />', () => {
         ).toBeNull();
     });
 
+    it('should not reapply old filter values when they change externally', async () => {
+        render(<WithFilterListSection />);
+        // Click on Yes
+        fireEvent.click(await screen.findByText('Yes'));
+        await screen.findByText('"has_newsletter": true', { exact: false });
+        await new Promise(resolve => setTimeout(resolve, 510));
+        await screen.findByText('"has_newsletter": true', { exact: false });
+        // Click on No
+        fireEvent.click(await screen.findByText('No'));
+        await screen.findByText('"has_newsletter": false', { exact: false });
+        await new Promise(resolve => setTimeout(resolve, 510));
+        await screen.findByText('"has_newsletter": false', { exact: false });
+        // Click on Yes
+        fireEvent.click(await screen.findByText('Yes'));
+        await screen.findByText('"has_newsletter": true', { exact: false });
+        await new Promise(resolve => setTimeout(resolve, 510));
+        await screen.findByText('"has_newsletter": true', { exact: false });
+        // Click on No
+        fireEvent.click(await screen.findByText('No'));
+        await screen.findByText('"has_newsletter": false', { exact: false });
+        await new Promise(resolve => setTimeout(resolve, 510));
+        await screen.findByText('"has_newsletter": false', { exact: false });
+    });
+
     describe('getFilterFormValues', () => {
         it('should correctly get the filter form values from the new filterValues', () => {
             const currentFormValues = {
@@ -154,6 +179,7 @@ describe('<FilterLiveForm />', () => {
                 nestedUpdated: { nestedValue: 'jkl2' },
                 nestedToSet: { nestedValue: 'mno2' },
                 published_at: '2022-01-01T03:00:00.000Z',
+                newIgnoredValue: 'pqr',
             };
 
             expect(

--- a/packages/ra-core/src/form/FilterLiveForm.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
+import merge from 'lodash/merge';
 import set from 'lodash/set';
 import { ReactNode, useEffect } from 'react';
 import { FormProvider, useForm, UseFormProps } from 'react-hook-form';
@@ -110,10 +111,7 @@ export const FilterLiveForm = (props: FilterLiveFormProps) => {
             return;
         }
         formChangesPending.current = true;
-        setFilters({
-            ...filterValues,
-            ...values,
-        });
+        setFilters(merge({}, filterValues, values));
     };
     const debouncedOnSubmit = useDebouncedEvent(onSubmit, debounce || 0);
 
@@ -183,13 +181,10 @@ export const getFilterFormValues = (
     formValues: Record<string, any>,
     filterValues: Record<string, any>
 ) => {
-    return Object.keys(formValues).reduce(
-        (acc, key) => {
-            acc[key] = getInputValue(formValues, key, filterValues);
-            return acc;
-        },
-        cloneDeep(filterValues) ?? {}
-    );
+    return Object.keys(formValues).reduce((acc, key) => {
+        acc[key] = getInputValue(formValues, key, filterValues);
+        return acc;
+    }, {});
 };
 
 const getInputValue = (


### PR DESCRIPTION
## Problem

New version react-hook-form 7.55.0 causes bugs in filter forms using `<FilterLiveForm>`, where a previous value could be reapplied after a change.

### Reproduction 1

Sandbox: https://stackblitz.com/edit/github-ruowu9px?file=src%2Fposts%2FPostList.tsx
In the Post List (desktop mode), try to apply the newsletter filter more than three times.
You'll see that sometimes the previous value reapplies shortly after it was changed.

### Reproduction 2

In a local clone of the repository:
1. Update RHF to its latest version: `yarn up react-hook-form` (should be 7.55.0)
2. Run the Storybook: `make storybook`
3. Go to story http://localhost:9010/?path=/story/ra-ui-materialui-list-filter-filterliveform--with-filter-list-section
4. Try to apply the newsletter filter more than three times. You'll see the same thing as Repro 1.

## Solution

`<FilterLiveForm>` has some custom code to reset the form whenever the filter values change externally. This is required to keep the form values in sync.
However this means the form is reset with values that do not necessarily match the fields registered into it.
Apparently with RHF 7.55.0 this causes the `watch` callback to be called more often than necessary, even on fields registered in the form but which have not changed. This, in turns, calls the `setFilters` callback too often.

The solution consists in only resetting fields which are actually registered in the form. Other filter values do not need to trigger a reset of the form. Hence we avoid calling `setFilters` when the form values did not change, avoiding the race condition with external changes.

## How To Test

To test the fix you need to use RHF v7.55.0: `yarn up react-hook-form`
Then, you can test:
- The unit test: `FilterLiveForm.spec.tsx`
- The story: http://localhost:9010/?path=/story/ra-ui-materialui-list-filter-filterliveform--with-filter-list-section

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
