### PR TITLE
[Doc] Document how to setup Remix for production debugging

### DIFF
--- a/docs/Remix.md
+++ b/docs/Remix.md
@@ -245,3 +245,28 @@ export default function App() {
 That's it! Now Remix both renders the admin app and serves as a proxy to the Supabase API. You can test the app by visiting `http://localhost:5173/admin/`, and the API Proxy by visiting `http://localhost:5173/admin/api/posts`.
 
 Note that the Supabase credentials never leave the server. It's up to you to add your own authentication to the API proxy.
+
+## Sourcemaps in production
+
+By default, Vite won't include the TypeScript sourcemaps in production builds. This means you'll only have the react-admin ESM builds for debugging.
+Should you prefer to have the TypeScript sources, you'll have to configure some Vite aliases:
+
+```tsx
+// in vite.config.ts
+import { defineConfig } from "vite";
+import path from "path";
+import react from "@vitejs/plugin-react";
+
+const alias = [
+  { find: 'react-admin', replacement: path.resolve(__dirname, './node_modules/react-admin/src') },
+  { find: 'ra-core', replacement: path.resolve(__dirname, './node_modules/ra-core/src') },
+  { find: 'ra-ui-materialui', replacement: path.resolve(__dirname, './node_modules/ra-ui-materialui/src') },
+  // add any other react-admin packages you have
+]
+
+export default defineConfig({
+  plugins: [react()],
+  build: { sourcemap: true },
+  resolve: { alias },
+});
+```


### PR DESCRIPTION
## Problem

We document how to setup Vite for easier debugging in production. We should do the same for Remix

## Solution

Add a section similar to the one in Vite documentation

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
