### PR TITLE
Fix TS error when using `EditGuesser` in module's default export

### DIFF
--- a/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditGuesser.tsx
@@ -44,7 +44,7 @@ export const EditGuesser = <RecordType extends RaRecord = any>(
     );
 };
 
-interface EditGuesserProps<RecordType extends RaRecord = any>
+export interface EditGuesserProps<RecordType extends RaRecord = any>
     extends Omit<EditProps<RecordType>, 'children'> {}
 
 const EditViewGuesser = <RecordType extends RaRecord = any>(


### PR DESCRIPTION
## Problem

When using `EditGuesser` in a module's default export we get the following TS error:

```
Default export of the module has or is using private name 'EditGuesserProps'.
```

## Solution

Export `EditGuesserProps`.

## How To Test

This can be reproduced in the simple demo, by replacing the content of the file `examples/simple/src/posts/index.tsx`:

```tsx
import BookIcon from '@mui/icons-material/Book';
import PostCreate from './PostCreate';
import PostEdit from './PostEdit';
import PostList from './PostList';
import PostShow from './PostShow';
import { EditGuesser } from 'react-admin';

export default {
    list: PostList,
    create: PostCreate,
    edit: EditGuesser,
    show: PostShow,
    icon: BookIcon,
    recordRepresentation: 'title',
};
```

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

