### PR TITLE
Fix `<RichTextField>` should render `emptyText` when value is an empty string

### DIFF
--- a/packages/ra-ui-materialui/src/field/RichTextField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/RichTextField.spec.tsx
@@ -110,7 +110,7 @@ describe('<RichTextField />', () => {
         expect(container.children[0].classList.contains('foo')).toBe(true);
     });
 
-    it.each([null, undefined])(
+    it.each([null, undefined, ''])(
         'should render the emptyText when value is %s and stripTags is set to false',
         body => {
             const { queryByText } = render(
@@ -124,7 +124,7 @@ describe('<RichTextField />', () => {
         }
     );
 
-    it.each([null, undefined])(
+    it.each([null, undefined, ''])(
         'should render the emptyText when value is %s and stripTags is set to true',
         body => {
             const { queryByText } = render(

--- a/packages/ra-ui-materialui/src/field/RichTextField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/RichTextField.stories.tsx
@@ -133,3 +133,23 @@ It is regarded as one of Tolstoy's finest literary achievements and remains a cl
         <RichTextField source="body" purifyOptions={{ ADD_ATTR: ['target'] }} />
     </RecordContextProvider>
 );
+
+export const Empty = ({ emptyText, body }) => (
+    <RecordContextProvider value={{ id: 1, body }}>
+        <RichTextField source="body" emptyText={emptyText} />
+    </RecordContextProvider>
+);
+Empty.args = {
+    emptyText: 'empty',
+    body: '',
+};
+Empty.argTypes = {
+    emptyText: {
+        options: [undefined, 'empty'],
+        control: { type: 'inline-radio' },
+    },
+    body: {
+        options: [undefined, null, '', 'foo'],
+        control: { type: 'inline-radio' },
+    },
+};

--- a/packages/ra-ui-materialui/src/field/RichTextField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/RichTextField.stories.tsx
@@ -149,7 +149,13 @@ Empty.argTypes = {
         control: { type: 'inline-radio' },
     },
     body: {
-        options: [undefined, null, '', 'foo'],
+        options: [undefined, null, 'empty string', 'foo'],
+        mapping: {
+            undefined: undefined,
+            null: null,
+            'empty string': '',
+            'foo': 'foo',
+        },
         control: { type: 'inline-radio' },
     },
 };

--- a/packages/ra-ui-materialui/src/field/RichTextField.tsx
+++ b/packages/ra-ui-materialui/src/field/RichTextField.tsx
@@ -44,7 +44,7 @@ const RichTextFieldImpl = <
             component="span"
             {...sanitizeFieldRestProps(rest)}
         >
-            {value == null && emptyText ? (
+            {(value == null || value === '') && emptyText ? (
                 translate(emptyText, { _: emptyText })
             ) : stripTags ? (
                 removeTags(value)


### PR DESCRIPTION
## Problem

`<RichTextField>` does not render `emptyText` when the value is equal to `''`.

## Solution

Fix `<RichTextField>` to render `emptyText` when the value is an empty string.

## How To Test

Unit test + new Story

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
