### PR TITLE
[Doc] Fix Dialog Forms examples regarding `hasCreate`

### DIFF
--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -468,6 +468,7 @@ Add the `warnWhenUnsavedChanges` prop to your Form like so:
 import React from 'react';
 import {
     List,
+    ListActions,
     Datagrid,
     SimpleForm,
 } from 'react-admin';
@@ -475,7 +476,7 @@ import { CreateDialog } from '@react-admin/ra-form-layout';
 
 const CustomerList = () => (
     <>
-        <List hasCreate>
+        <List actions={<ListActions hasCreate />}>
             <Datagrid rowClick="edit">
                 ...
             </Datagrid>

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -245,6 +245,7 @@ Here is an example:
 import React from 'react';
 import {
     List,
+    ListActions,
     Datagrid,
     SimpleForm,
     TextInput,
@@ -265,7 +266,7 @@ const CustomerEditTitle = () => {
 
 const CustomerList = () => (
     <>
-        <List hasCreate>
+        <List actions={<ListActions hasCreate />}>
             <Datagrid rowClick="edit">
                 ...
             </Datagrid>
@@ -510,6 +511,7 @@ Add the `warnWhenUnsavedChanges` prop to your Form like so:
 import React from 'react';
 import {
     List,
+    ListActions,
     Datagrid,
     SimpleForm,
 } from 'react-admin';
@@ -517,7 +519,7 @@ import { EditDialog } from '@react-admin/ra-form-layout';
 
 const CustomerList = () => (
     <>
-        <List hasCreate>
+        <List actions={<ListActions hasCreate />}>
             <Datagrid rowClick="edit">
                 ...
             </Datagrid>


### PR DESCRIPTION
## Problem

Dialog Forms examples still use the v4 syntax for the `hasCreate` prop.

## Solution

Use the v5 syntax

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
