### PR TITLE
[Doc] Fix `useNotify` custom notification with close example

### DIFF
--- a/docs/useNotify.md
+++ b/docs/useNotify.md
@@ -240,8 +240,8 @@ export const CheckForApplicationUpdate = () => {
     const notify = useNotify();
 
     const onNewVersionAvailable = () => {
-        // autoHideDuration is set to 0 to disable the auto hide feature
-        notify(<ApplicationUpdateNotification />, { autoHideDuration: 0 });
+        // autoHideDuration is set to null to disable the auto hide feature
+        notify(<ApplicationUpdateNotification />, { autoHideDuration: null });
     };
 
     useCheckForApplicationUpdate({ onNewVersionAvailable, ...rest });


### PR DESCRIPTION
## Problem

The `autohideDuration: 0` is wrong, it should be `autohideDuration: null`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date
