### PR TITLE
create-react-admin: Upgrade to MUI v7

### DIFF
--- a/packages/create-react-admin/templates/common/package.json
+++ b/packages/create-react-admin/templates/common/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@mui/icons-material": "^6.4.0",
-        "@mui/material": "^6.4.0",
+        "@mui/icons-material": "^7.0.1",
+        "@mui/material": "^7.0.1",
         "react": "^19.0.0",
         "react-admin": "^5.7.0",
         "react-dom": "^19.0.0",

--- a/packages/create-react-admin/templates/resolutions/package.json
+++ b/packages/create-react-admin/templates/resolutions/package.json
@@ -2,8 +2,8 @@
     "resolutions": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@mui/icons-material": "^6.4.0",
-        "@mui/material": "^6.4.0",
+        "@mui/icons-material": "^7.0.1",
+        "@mui/material": "^7.0.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.3",


### PR DESCRIPTION
## Problem

#10639 brought support for MUI v7.
To help minimizing technical debt, all new react-admin apps should start using that version right away.
But create-react-admin still uses MUI v6 by default.

## Solution

Upgrade create-react-admin to generate projects that use MUI v7 by default.

## How To Test

**Testing with yarn**

It's the easiest way to test, since we force the version of MUI packages using yarn resolutions.

1. `make build-create-react-admin`
2. `./packages/create-react-admin/node_modules/.bin/create-react-admin my-admin -i`
3. select yarn as package manager
4. `cd my-admin`
5. `yarn run dev`
6. Make sure you are using MUI v7 (`yarn list @mui/material`) and that the app runs fine

**Testing with npm/pnpm/bun**

It's more complex to test, because react-admin 5.7.3 still requires MUI <= 6, and react-admin 5.8.0 has not been released yet.

So you'd need to build the react-admin packages, and then force using this local version when resolving the dependencies.

To me this test adds very little to the test with yarn (basically it comes down to testing the resolution algorithm of the selected package manager).

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
~~- [ ] The PR includes one or several **stories** (if not possible, describe why)~~
~~- [ ] The **documentation** is up to date~~

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
