### PR TITLE
Fix Loading component timeout

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Loading.tsx
+++ b/packages/ra-ui-materialui/src/layout/Loading.tsx
@@ -18,9 +18,10 @@ export const Loading = (inProps: LoadingProps) => {
         className,
         loadingPrimary = 'ra.page.loading',
         loadingSecondary = 'ra.message.loading',
+        timeout = 1000,
         ...rest
     } = props;
-    const oneSecondHasPassed = useTimeout(1000);
+    const oneSecondHasPassed = useTimeout(timeout);
     const translate = useTranslate();
     return oneSecondHasPassed ? (
         <Root className={className} {...rest}>
@@ -41,6 +42,7 @@ export interface LoadingProps {
     className?: string;
     loadingPrimary?: string;
     loadingSecondary?: string;
+    timeout?: number;
     sx?: SxProps<Theme>;
 }
 


### PR DESCRIPTION
## Problem

`Loading` component is difficult to re-use because it has a hard-coded one second timeout inside of it.

Supersedes #10687

## Solution

Add a `timeout` prop default to one second to make it more flexible

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
