### PR TITLE
Fix `canAccess` is called even when `disableAuthentication` is `true`

### DIFF
--- a/packages/ra-core/src/controller/create/useCreateController.security.stories.tsx
+++ b/packages/ra-core/src/controller/create/useCreateController.security.stories.tsx
@@ -13,6 +13,7 @@ import {
     CreateControllerProps,
     useCreateController,
 } from './useCreateController';
+import { useAuthState } from '../../auth';
 
 export default {
     title: 'ra-core/controller/useCreateController',
@@ -39,6 +40,16 @@ const defaultDataProvider = fakeDataProvider(
     process.env.NODE_ENV === 'development'
 );
 
+const PostList = () => {
+    useAuthState();
+    return (
+        <div style={styles.mainContainer}>
+            <div>List view</div>
+            <Link to="/posts/create">Create</Link>
+        </div>
+    );
+};
+
 const CreatePost = (props: Partial<CreateControllerProps>) => {
     const params = useCreateController({
         resource: 'posts',
@@ -47,6 +58,7 @@ const CreatePost = (props: Partial<CreateControllerProps>) => {
     return (
         <div style={styles.mainContainer}>
             {params.isPending ? <p>Loading...</p> : <div>Create view</div>}
+            <Link to="/posts">List</Link>
         </div>
     );
 };
@@ -93,15 +105,32 @@ export const DisableAuthentication = ({
                 dataProvider={dataProvider}
                 authProvider={authProvider}
             >
-                <CoreAdminUI>
+                <CoreAdminUI accessDenied={AccessDenied}>
                     <Resource
                         name="posts"
+                        list={<PostList />}
                         create={<CreatePost disableAuthentication />}
                     />
                 </CoreAdminUI>
             </CoreAdminContext>
         </TestMemoryRouter>
     );
+};
+DisableAuthentication.args = {
+    authProvider: undefined,
+};
+DisableAuthentication.argTypes = {
+    authProvider: {
+        options: ['default', 'canAccess'],
+        mapping: {
+            default: undefined,
+            canAccess: {
+                ...defaultAuthProvider,
+                canAccess: () => Promise.resolve(false),
+            },
+        },
+        control: { type: 'inline-radio' },
+    },
 };
 
 export const CanAccess = ({

--- a/packages/ra-core/src/controller/create/useCreateController.ts
+++ b/packages/ra-core/src/controller/create/useCreateController.ts
@@ -71,8 +71,7 @@ export const useCreateController = <
     const { isPending: isPendingCanAccess } = useRequireAccess<RecordType>({
         action: 'create',
         resource,
-        // If disableAuthentication is true then isPendingAuthenticated will always be true so this hook is disabled
-        enabled: !isPendingAuthenticated,
+        enabled: !disableAuthentication && !isPendingAuthenticated,
     });
     const { hasEdit, hasShow } = useResourceDefinition(props);
     const finalRedirectTo =

--- a/packages/ra-core/src/controller/edit/useEditController.security.stories.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.security.stories.tsx
@@ -10,6 +10,7 @@ import { Resource } from '../../core/Resource';
 import { AuthProvider, DataProvider } from '../../types';
 import { TestMemoryRouter } from '../../routing/TestMemoryRouter';
 import { EditControllerProps, useEditController } from './useEditController';
+import { useAuthState } from '../..';
 
 export default {
     title: 'ra-core/controller/useEditController',
@@ -36,6 +37,16 @@ const defaultDataProvider = fakeDataProvider(
     process.env.NODE_ENV === 'development'
 );
 
+const PostList = () => {
+    useAuthState();
+    return (
+        <div style={styles.mainContainer}>
+            <div>List view</div>
+            <Link to="/posts/1">Edit</Link>
+        </div>
+    );
+};
+
 const Post = (props: Partial<EditControllerProps>) => {
     const params = useEditController({
         id: 1,
@@ -51,6 +62,7 @@ const Post = (props: Partial<EditControllerProps>) => {
                     {params.record.title} - {params.record.votes} votes
                 </div>
             )}
+            <Link to="/posts">List</Link>
         </div>
     );
 };
@@ -97,15 +109,32 @@ export const DisableAuthentication = ({
                 dataProvider={dataProvider}
                 authProvider={authProvider}
             >
-                <CoreAdminUI>
+                <CoreAdminUI accessDenied={AccessDenied}>
                     <Resource
                         name="posts"
+                        list={<PostList />}
                         edit={<Post disableAuthentication />}
                     />
                 </CoreAdminUI>
             </CoreAdminContext>
         </TestMemoryRouter>
     );
+};
+DisableAuthentication.args = {
+    authProvider: undefined,
+};
+DisableAuthentication.argTypes = {
+    authProvider: {
+        options: ['default', 'canAccess'],
+        mapping: {
+            default: undefined,
+            canAccess: {
+                ...defaultAuthProvider,
+                canAccess: () => Promise.resolve(false),
+            },
+        },
+        control: { type: 'inline-radio' },
+    },
 };
 
 export const CanAccess = ({

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -1295,5 +1295,39 @@ describe('useEditController', () => {
             expect(dataProvider.getOne).toHaveBeenCalled();
             expect(authProvider.checkAuth).not.toHaveBeenCalled();
         });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            expect(authProvider.checkAuth).not.toHaveBeenCalled();
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true even if useAuthState was called before', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            fireEvent.click(await screen.findByText('List'));
+            await screen.findByText('List view');
+            fireEvent.click(await screen.findByText('Edit'));
+            await screen.findByText('Post #1 - 90 votes');
+            expect(authProvider.checkAuth).toHaveBeenCalledTimes(1);
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -76,8 +76,7 @@ export const useEditController = <
     const { isPending: isPendingCanAccess } = useRequireAccess<RecordType>({
         action: 'edit',
         resource,
-        // If disableAuthentication is true then isPendingAuthenticated will always be true so this hook is disabled
-        enabled: !isPendingAuthenticated,
+        enabled: !disableAuthentication && !isPendingAuthenticated,
     });
 
     const getRecordRepresentation = useGetRecordRepresentation(resource);

--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -701,8 +701,7 @@ describe('useInfiniteListController', () => {
             );
             await screen.findByText('A post - 0 votes');
             expect(dataProvider.getList).toHaveBeenCalled();
-            // Only called once by NavigationToFirstResource
-            expect(authProvider.checkAuth).toHaveBeenCalledTimes(1);
+            expect(authProvider.checkAuth).not.toHaveBeenCalled();
         });
 
         it('should not call checkAuth nor canAccess when disableAuthentication is true', async () => {

--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -704,5 +704,41 @@ describe('useInfiniteListController', () => {
             // Only called once by NavigationToFirstResource
             expect(authProvider.checkAuth).toHaveBeenCalledTimes(1);
         });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            expect(authProvider.checkAuth).not.toHaveBeenCalled();
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true even if useAuthState was called before', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            fireEvent.click(await screen.findByText('Dashboard'));
+            await screen.findByText('Dashboard view');
+            fireEvent.click(await screen.findByText('List'));
+            await screen.findByText('Post #1 - 90 votes');
+            // checkAuth is called twice: once by RA (with different params)
+            // and once by our custom Dashboard component
+            expect(authProvider.checkAuth).toHaveBeenCalledTimes(2);
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ra-core/src/controller/list/useInfiniteListController.stories.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from './useInfiniteListController';
 import { Browser } from '../../storybook/FakeBrowser';
 import { TestMemoryRouter } from '../../routing';
+import { useAuthState } from '../..';
 
 export default {
     title: 'ra-core/controller/list/useInfiniteListController',
@@ -58,6 +59,17 @@ const List = params => {
                     </ul>
                 </div>
             )}
+            <Link to="/">Dashboard</Link>
+        </div>
+    );
+};
+
+const Dashboard = () => {
+    useAuthState();
+    return (
+        <div style={styles.mainContainer}>
+            <div>Dashboard view</div>
+            <Link to="/posts">List</Link>
         </div>
     );
 };
@@ -177,7 +189,7 @@ export const Authenticated = ({
     dataProvider?: DataProvider;
 }) => {
     return (
-        <TestMemoryRouter>
+        <TestMemoryRouter initialEntries={['/posts']}>
             <CoreAdminContext
                 dataProvider={dataProvider}
                 authProvider={authProvider}
@@ -198,12 +210,13 @@ export const DisableAuthentication = ({
     dataProvider?: DataProvider;
 }) => {
     return (
-        <TestMemoryRouter>
+        <TestMemoryRouter initialEntries={['/posts']}>
             <CoreAdminContext
                 dataProvider={dataProvider}
                 authProvider={authProvider}
+                dashboard={Dashboard}
             >
-                <CoreAdminUI>
+                <CoreAdminUI dashboard={Dashboard} accessDenied={AccessDenied}>
                     <Resource
                         name="posts"
                         list={<Posts disableAuthentication />}
@@ -212,6 +225,22 @@ export const DisableAuthentication = ({
             </CoreAdminContext>
         </TestMemoryRouter>
     );
+};
+DisableAuthentication.args = {
+    authProvider: undefined,
+};
+DisableAuthentication.argTypes = {
+    authProvider: {
+        options: ['default', 'canAccess'],
+        mapping: {
+            default: undefined,
+            canAccess: {
+                ...defaultAuthProvider,
+                canAccess: () => Promise.resolve(false),
+            },
+        },
+        control: { type: 'inline-radio' },
+    },
 };
 
 export const CanAccess = ({

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -79,8 +79,7 @@ export const useInfiniteListController = <
     const { isPending: isPendingCanAccess } = useRequireAccess<RecordType>({
         action: 'list',
         resource,
-        // If disableAuthentication is true then isPendingAuthenticated will always be true so this hook is disabled
-        enabled: !isPendingAuthenticated,
+        enabled: !disableAuthentication && !isPendingAuthenticated,
     });
 
     const translate = useTranslate();

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -589,6 +589,42 @@ describe('useListController', () => {
             expect(dataProvider.getList).toHaveBeenCalled();
             expect(authProvider.checkAuth).not.toHaveBeenCalled();
         });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            expect(authProvider.checkAuth).not.toHaveBeenCalled();
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true even if useAuthState was called before', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            fireEvent.click(await screen.findByText('Dashboard'));
+            await screen.findByText('Dashboard view');
+            fireEvent.click(await screen.findByText('List'));
+            await screen.findByText('Post #1 - 90 votes');
+            // checkAuth is called twice: once by RA (with different params)
+            // and once by our custom Dashboard component
+            expect(authProvider.checkAuth).toHaveBeenCalledTimes(2);
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
     });
 
     describe('onSelectAll', () => {

--- a/packages/ra-core/src/controller/list/useListController.stories.tsx
+++ b/packages/ra-core/src/controller/list/useListController.stories.tsx
@@ -7,6 +7,7 @@ import { ListController } from './ListController';
 import type { DataProvider } from '../../types';
 import type { ListControllerResult } from './useListController';
 import { useNotificationContext } from '../../notification';
+import { TestMemoryRouter } from '../..';
 
 export default {
     title: 'ra-core/controller/list/useListController',
@@ -95,9 +96,11 @@ export const Basic = ({
     dataProvider?: DataProvider;
     children?: (params: ListControllerResult) => React.ReactNode;
 }) => (
-    <CoreAdminContext dataProvider={dataProvider}>
-        <ListController resource="posts">{children}</ListController>
-    </CoreAdminContext>
+    <TestMemoryRouter>
+        <CoreAdminContext dataProvider={dataProvider}>
+            <ListController resource="posts">{children}</ListController>
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );
 
 const OnlineManager = () => {
@@ -147,42 +150,44 @@ const Notifications = () => {
 };
 
 export const Offline = () => (
-    <CoreAdminContext dataProvider={defaultDataProvider}>
-        <OnlineManager />
-        <ListController resource="posts" perPage={3}>
-            {params => (
-                <div>
-                    <div
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '10px',
-                        }}
-                    >
-                        <button onClick={() => params.setPage(1)}>
-                            Page 1
-                        </button>
-                        <button onClick={() => params.setPage(2)}>
-                            Page 2
-                        </button>
-                        <button onClick={() => params.setPage(3)}>
-                            Page 3
-                        </button>
+    <TestMemoryRouter>
+        <CoreAdminContext dataProvider={defaultDataProvider}>
+            <OnlineManager />
+            <ListController resource="posts" perPage={3}>
+                {params => (
+                    <div>
+                        <div
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '10px',
+                            }}
+                        >
+                            <button onClick={() => params.setPage(1)}>
+                                Page 1
+                            </button>
+                            <button onClick={() => params.setPage(2)}>
+                                Page 2
+                            </button>
+                            <button onClick={() => params.setPage(3)}>
+                                Page 3
+                            </button>
+                        </div>
+                        <ul
+                            style={{
+                                listStyleType: 'none',
+                            }}
+                        >
+                            {params.data?.map(record => (
+                                <li key={record.id}>
+                                    {record.id} - {record.title}
+                                </li>
+                            ))}
+                        </ul>
                     </div>
-                    <ul
-                        style={{
-                            listStyleType: 'none',
-                        }}
-                    >
-                        {params.data?.map(record => (
-                            <li key={record.id}>
-                                {record.id} - {record.title}
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            )}
-        </ListController>
-        <Notifications />
-    </CoreAdminContext>
+                )}
+            </ListController>
+            <Notifications />
+        </CoreAdminContext>
+    </TestMemoryRouter>
 );

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -85,8 +85,7 @@ export const useListController = <
     const { isPending: isPendingCanAccess } = useRequireAccess<RecordType>({
         action: 'list',
         resource,
-        // If disableAuthentication is true then isPendingAuthenticated will always be true so this hook is disabled
-        enabled: !isPendingAuthenticated,
+        enabled: !disableAuthentication && !isPendingAuthenticated,
     });
 
     const translate = useTranslate();

--- a/packages/ra-core/src/controller/show/useShowController.security.stories.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.security.stories.tsx
@@ -10,6 +10,7 @@ import { Resource } from '../../core/Resource';
 import { AuthProvider, DataProvider } from '../../types';
 import { TestMemoryRouter } from '../../routing';
 import { ShowControllerProps, useShowController } from './useShowController';
+import { useAuthState } from '../..';
 
 export default {
     title: 'ra-core/controller/useShowController',
@@ -36,6 +37,16 @@ const defaultDataProvider = fakeDataProvider(
     process.env.NODE_ENV === 'development'
 );
 
+const PostList = () => {
+    useAuthState();
+    return (
+        <div style={styles.mainContainer}>
+            <div>List view</div>
+            <Link to="/posts/1/show">Show</Link>
+        </div>
+    );
+};
+
 const Post = (props: Partial<ShowControllerProps>) => {
     const params = useShowController({
         id: 1,
@@ -51,6 +62,7 @@ const Post = (props: Partial<ShowControllerProps>) => {
                     {params.record.title} - {params.record.votes} votes
                 </div>
             )}
+            <Link to="/posts">List</Link>
         </div>
     );
 };
@@ -97,15 +109,32 @@ export const DisableAuthentication = ({
                 dataProvider={dataProvider}
                 authProvider={authProvider}
             >
-                <CoreAdminUI>
+                <CoreAdminUI accessDenied={AccessDenied}>
                     <Resource
                         name="posts"
+                        list={<PostList />}
                         show={<Post disableAuthentication />}
                     />
                 </CoreAdminUI>
             </CoreAdminContext>
         </TestMemoryRouter>
     );
+};
+DisableAuthentication.args = {
+    authProvider: undefined,
+};
+DisableAuthentication.argTypes = {
+    authProvider: {
+        options: ['default', 'canAccess'],
+        mapping: {
+            default: undefined,
+            canAccess: {
+                ...defaultAuthProvider,
+                canAccess: () => Promise.resolve(false),
+            },
+        },
+        control: { type: 'inline-radio' },
+    },
 };
 
 export const CanAccess = ({

--- a/packages/ra-core/src/controller/show/useShowController.spec.tsx
+++ b/packages/ra-core/src/controller/show/useShowController.spec.tsx
@@ -254,5 +254,39 @@ describe('useShowController', () => {
             expect(dataProvider.getOne).toHaveBeenCalled();
             expect(authProvider.checkAuth).not.toHaveBeenCalled();
         });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            expect(authProvider.checkAuth).not.toHaveBeenCalled();
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
+
+        it('should not call checkAuth nor canAccess when disableAuthentication is true even if useAuthState was called before', async () => {
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn().mockResolvedValue(true),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+                canAccess: jest.fn().mockResolvedValue(false),
+            };
+            render(<DisableAuthentication authProvider={authProvider} />);
+            await screen.findByText('Post #1 - 90 votes');
+            fireEvent.click(await screen.findByText('List'));
+            await screen.findByText('List view');
+            fireEvent.click(await screen.findByText('Show'));
+            await screen.findByText('Post #1 - 90 votes');
+            expect(authProvider.checkAuth).toHaveBeenCalledTimes(1);
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -74,8 +74,7 @@ export const useShowController = <
     const { isPending: isPendingCanAccess } = useRequireAccess<RecordType>({
         action: 'show',
         resource,
-        // If disableAuthentication is true then isPendingAuthenticated will always be true so this hook is disabled
-        enabled: !isPendingAuthenticated,
+        enabled: !disableAuthentication && !isPendingAuthenticated,
     });
 
     const getRecordRepresentation = useGetRecordRepresentation(resource);


### PR DESCRIPTION
## Problem

Setting `disableAuthentication` to `true` should prevent all calls to the authProvider, i.e. calls to `checkAuth` but also `canAccess`.
However in some cases, if `checkAuth` was already called earlier and the result is already in the react-query cache, a call to `canAccess` might still be fired.

## Solution

Fix the condition under which `canAccess` is called from the controllers.

## How To Test

Unit tests and stories were added in this PR.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
