### PR TITLE
Fix `<FilterLiveForm>` compatibility with react-hook-form 7.55.0, part 2

### DIFF
--- a/packages/ra-core/src/form/FilterLiveForm.spec.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.spec.tsx
@@ -1,12 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { getFilterFormValues } from './FilterLiveForm';
 import {
     Basic,
     GlobalValidation,
     MultipleFilterLiveForm,
+    MultipleFilterLiveFormOverlapping,
     MultipleInput,
     ParseFormat,
     PerInputValidation,
+    WithExternalChanges,
 } from './FilterLiveForm.stories';
 import React from 'react';
 import { WithFilterListSection } from '../../../ra-ui-materialui/src/list/filter/FilterLiveForm.stories';
@@ -161,6 +163,97 @@ describe('<FilterLiveForm />', () => {
         await screen.findByText('"has_newsletter": false', { exact: false });
         await new Promise(resolve => setTimeout(resolve, 510));
         await screen.findByText('"has_newsletter": false', { exact: false });
+    });
+
+    it('should not reapply old externally applied filters after clear', async () => {
+        render(<WithExternalChanges />);
+        // Set filter body: foo
+        fireEvent.change(await screen.findByLabelText('body'), {
+            target: { value: 'foo' },
+        });
+        fireEvent.click(await screen.findByText('Apply filter'));
+        await waitFor(() => {
+            expect(
+                JSON.parse(
+                    screen.queryByTestId('filter-values')?.textContent || ''
+                )
+            ).toEqual({
+                body: 'foo',
+            });
+        });
+        // Unmount
+        fireEvent.click(await screen.findByLabelText('Mount/unmount'));
+        await waitFor(() => {
+            expect(screen.queryByText('External list')).toBeNull();
+        });
+        // Mount
+        fireEvent.click(await screen.findByLabelText('Mount/unmount'));
+        await screen.findByText('External list');
+        expect(
+            JSON.parse(screen.queryByTestId('filter-values')?.textContent || '')
+        ).toEqual({
+            body: 'foo',
+        });
+        // Clear filters
+        fireEvent.click(await screen.findByText('Clear filters'));
+        await waitFor(() => {
+            expect(
+                JSON.parse(
+                    screen.queryByTestId('filter-values')?.textContent || ''
+                )
+            ).toEqual({});
+        });
+        // Wait for a bit
+        await new Promise(resolve => setTimeout(resolve, 510));
+        expect(
+            JSON.parse(screen.queryByTestId('filter-values')?.textContent || '')
+        ).toEqual({});
+    });
+
+    it('should not reapply old filter values when changing another FilterLiveForm', async () => {
+        render(<MultipleFilterLiveFormOverlapping />);
+        // Set first body input to foo
+        fireEvent.change((await screen.findAllByLabelText('body'))[0], {
+            target: { value: 'foo' },
+        });
+        await waitFor(() => {
+            expect(
+                JSON.parse(
+                    screen.queryByTestId('filter-values')?.textContent || ''
+                )
+            ).toEqual({
+                category: 'deals',
+                body: 'foo',
+            });
+        });
+        // Clear first body input
+        fireEvent.change((await screen.findAllByLabelText('body'))[0], {
+            target: { value: '' },
+        });
+        await waitFor(() => {
+            expect(
+                JSON.parse(
+                    screen.queryByTestId('filter-values')?.textContent || ''
+                )
+            ).toEqual({
+                category: 'deals',
+            });
+        });
+        // Change author input
+        fireEvent.change(await screen.findByLabelText('author'), {
+            target: { value: 'bar' },
+        });
+        await waitFor(() => {
+            expect(
+                JSON.parse(
+                    screen.queryByTestId('filter-values')?.textContent || ''
+                )
+            ).toEqual({
+                // body should not reappear
+                category: 'deals',
+                author: 'bar',
+            });
+        });
     });
 
     describe('getFilterFormValues', () => {

--- a/packages/ra-core/src/form/FilterLiveForm.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.tsx
@@ -76,27 +76,16 @@ export const FilterLiveForm = (props: FilterLiveFormProps) => {
 
     const formContext = useForm({
         mode: 'onChange',
-        defaultValues: filterValues,
         resolver: finalResolver,
         ...rest,
     });
     const { handleSubmit, getValues, reset, watch, formState } = formContext;
     const { isValid } = formState;
 
-    // Ref tracking if there are internal changes pending, i.e. changes that
-    // should not trigger a reset
-    const formChangesPending = React.useRef(false);
-
     // Reapply filterValues when they change externally
     useEffect(() => {
         const newValues = getFilterFormValues(getValues(), filterValues);
         const previousValues = getValues();
-        if (formChangesPending.current) {
-            // The effect was triggered by a form change (i.e. internal change),
-            // so we don't need to reset the form
-            formChangesPending.current = false;
-            return;
-        }
         if (!isEqual(newValues, previousValues)) {
             reset(newValues);
         }
@@ -110,7 +99,6 @@ export const FilterLiveForm = (props: FilterLiveFormProps) => {
         if (!isValid) {
             return;
         }
-        formChangesPending.current = true;
         setFilters(mergeObjNotArray(filterValues, values));
     };
     const debouncedOnSubmit = useDebouncedEvent(onSubmit, debounce || 0);

--- a/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterButton.spec.tsx
@@ -124,6 +124,63 @@ describe('<FilterButton />', () => {
             expect(checkboxes[2].getAttribute('aria-checked')).toBe('false');
         });
 
+        it('should remove the checked state of the menu item when removing its matching filter even when 2 filters were set', async () => {
+            render(<Basic />);
+
+            fireEvent.click(await screen.findByLabelText('Add filter'));
+            fireEvent.click(screen.getAllByRole('menuitemcheckbox')[0]);
+            await screen.findByRole('textbox', {
+                name: 'Title',
+            });
+
+            await screen.findByText('1-1 of 1');
+
+            fireEvent.click(await screen.findByLabelText('Add filter'));
+            fireEvent.click(screen.getAllByRole('menuitemcheckbox')[2]);
+            fireEvent.change(
+                await screen.findByRole('textbox', {
+                    name: 'Body',
+                }),
+                {
+                    target: { value: 'foo' },
+                }
+            );
+            await screen.findByText(
+                'No Posts found using the current filters.'
+            );
+
+            fireEvent.click(screen.getAllByTitle('Remove this filter')[1]);
+            await screen.findByText('1-1 of 1');
+
+            await waitFor(
+                () => {
+                    expect(
+                        screen.queryByRole('textbox', {
+                            name: 'Body',
+                        })
+                    ).toBeNull();
+                },
+                { timeout: 2000 }
+            );
+
+            // Wait for a bit
+            await new Promise(resolve => setTimeout(resolve, 510));
+
+            fireEvent.click(screen.getByTitle('Remove this filter'));
+            await screen.findByText('1-10 of 13');
+
+            await waitFor(
+                () => {
+                    expect(
+                        screen.queryByRole('textbox', {
+                            name: 'Title',
+                        })
+                    ).toBeNull();
+                },
+                { timeout: 2000 }
+            );
+        }, 10000);
+
         it('should display the filter button if all filters are shown and there is a filter value', () => {
             render(
                 <AdminContext theme={theme}>


### PR DESCRIPTION
## Problem

Despite https://github.com/marmelab/react-admin/pull/10657, 2 issues are still present when using RHF version >= 7.55.0:
- https://github.com/marmelab/react-admin/issues/10695
- A bug occurs when using enterprise component `DatagridAG`: Applying a filter from ag-grid, then leaving the page and coming back to it, then clearing all filters with the 'Remove all filters' button => brings back the filter added previously via ag-grid

Closes https://github.com/marmelab/react-admin/issues/10695

## Solution

It turns out the fix brought by https://github.com/marmelab/react-admin/pull/10657 was not enough.
In a nutshell, this fix made it so that the filter form is not reset if changed values only affect fields that are not part of the form. But the form was still initialized with `defaultValues` equal to the `filterValues`, so external values could still leak into the form state.
Part of the solution is then to remove the form `defaultValues`, and rely only on the `useEffect` to (selectively) apply them.

Other part of the solution was to remove the `formChangesPending` ref, as it turns out this workaround no longer works with RHF v7.55.0 onwards, because they tend to call the `useWatch` callback multiple times, even for fields whose value has not changed.
Instead, properly managing the form state and only resetting when values known to the form are modified (i.e. part 1 of the fix above) seems to be enough to avoid re-applying old values.

## How To Test

2 new stories were added:
- http://localhost:9010/?path=/story/ra-core-form-filterliveform--multiple-filter-live-form-overlapping
- http://localhost:9010/?path=/story/ra-core-form-filterliveform--with-external-changes

Also, https://github.com/marmelab/react-admin/issues/10695 can be reproduced in story http://localhost:9010/?path=/story/ra-ui-materialui-list-filter-filterbutton--basic

Unit tests were added to cover all known issues.

=> Hence, to test the fix, I recommend:
1. Playing around with the added stories (the unit tests are already run by the CI)
2. Then, update RHF to its latest version by running `yarn up react-hook-form`, and run the tests (`make test-unit`), then play with the added stories

**Note:** You will notice that some tests **not related to filters** are failing when using RHF v7.46.1, which is something we'll need to address in a future PR, but all tests related to filters should pass with this PR.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
