### PR TITLE
docs: update field component example to use modern React patterns

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -482,12 +482,10 @@ Here is a custom field displaying the full name:
 ```jsx
 import { useRecordContext } from 'react-admin';
 
-export const FullNameField = (props) => {
+export const FullNameField = ({ label = 'Name', ...props }) => {
     const record = useRecordContext(props);
     return record ? <span>{record.firstName} {record.lastName}</span> : null;
 }
-
-FullNameField.defaultProps = { label: 'Name' };
 ```
 
 **Tip**: Always check the `record` is defined before inspecting its properties, as react-admin may display the Show view *before* fetching the record from the data provider. So the first time it renders the show view for a resource, the `record` is `undefined`.


### PR DESCRIPTION
  ## Problem
     The documentation currently recommends using defaultProps for function components, which is being removed in React 19.

     ## Solution
     Update the example to use modern React patterns with parameter destructuring and default values.

     ## Additional Checks
     - [x] The PR targets `master` for a documentation fix
     - [x] The documentation is up to date