### PR TITLE
[DOC] Rewrite autocompletearray input create doc example

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -714,6 +714,7 @@ Use the `create` prop when you want a more polished or complex UI. For example a
 import {
     AutocompleteArrayInput,
     Create,
+    CreateBase,
     ReferenceArrayInput,
     SimpleForm,
     TextInput,
@@ -721,13 +722,15 @@ import {
     useCreateSuggestionContext
 } from 'react-admin';
 
+import CloseIcon from '@mui/icons-material/Close';
 import {
     Box,
     BoxProps,
     Button,
     Dialog,
-    DialogActions,
     DialogContent,
+    DialogTitle,
+    IconButton,
     TextField,
 } from '@mui/material';
 

--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -746,43 +746,45 @@ const PostCreate = () => {
 
 const CreateTag = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-    const [value, setValue] = React.useState(filter || '');
-    const [create] = useCreate();
-
-    const handleSubmit = event => {
-        event.preventDefault();
-        create(
-            'tags',
-            {
-                data: {
-                    title: value,
-                },                
-            },
-            {
-                onSuccess: (data) => {
-                    setValue('');
-                    onCreate(data);
-                },
-            }
-        );
+   
+    const onTagCreate = tag => {
+        onCreate(tag);
     };
 
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <TextField
-                        label="New tag"
-                        value={value}
-                        onChange={event => setValue(event.target.value)}
-                        autoFocus
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+            <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="tags"
+                    mutationOptions={{
+                        onSuccess: tag => {
+                            onTagCreate(tag);
+                        },
+                    }}
+                >
+                    <SimpleForm defaultValues={{ name: filter }}>
+                        <TextInput
+                            source="tag"
+                            helperText={false}
+                            autoFocus
+                        />
+                    </SimpleForm>
+                </CreateBase>
+            </DialogContent>
         </Dialog>
     );
 };

--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -781,7 +781,7 @@ const CreateTag = () => {
                 >
                     <SimpleForm defaultValues={{ name: filter }}>
                         <TextInput
-                            source="tag"
+                            source="name"
                             helperText={false}
                             autoFocus
                         />

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -1,36 +1,41 @@
 import * as React from 'react';
 import { Admin } from 'react-admin';
+
+import CloseIcon from '@mui/icons-material/Close';
 import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    TextField,
+} from '@mui/material';
+
+import {
+    CreateBase,
     Resource,
-    required,
-    useCreate,
-    useRecordContext,
     TestMemoryRouter,
+    required,
     testDataProvider,
+    useRecordContext,
 } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import {
-    Dialog,
-    DialogContent,
-    TextField,
-    DialogActions,
-    Button,
-    Stack,
-} from '@mui/material';
+
 import { useFormContext } from 'react-hook-form';
 
 import { AdminContext } from '../AdminContext';
 import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
+import { ArrayInput, SimpleFormIterator } from './ArrayInput';
 import {
     AutocompleteArrayInput,
     AutocompleteArrayInputProps,
 } from './AutocompleteArrayInput';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
-import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import { TextInput } from './TextInput';
-import { ArrayInput, SimpleFormIterator } from './ArrayInput';
+import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 export default { title: 'ra-ui-materialui/input/AutocompleteArrayInput' };
 
@@ -686,56 +691,46 @@ export const InsideReferenceArrayInputOnChange = ({
 
 const CreateAuthor = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-    const [name, setName] = React.useState(filter || '');
-    const [language, setLanguage] = React.useState('');
-    const [create] = useCreate();
 
-    const handleSubmit = event => {
-        event.preventDefault();
-        create(
-            'authors',
-            {
-                data: {
-                    name,
-                    language,
-                },
-            },
-            {
-                onSuccess: ({ data }) => {
-                    setName('');
-                    setLanguage('');
-                    onCreate(data);
-                },
-            }
-        );
+    const onAuthorCreate = author => {
+        onCreate(author);
     };
 
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <Stack gap={4}>
-                        <TextField
-                            name="name"
-                            label="The author name"
-                            value={name}
-                            onChange={event => setName(event.target.value)}
+            <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="authors"
+                    mutationOptions={{
+                        onSuccess: author => {
+                            onAuthorCreate(author);
+                        },
+                    }}
+                >
+                    <SimpleForm defaultValues={{ name: filter }}>
+                        <TextInput source="name" helperText={false} />
+                        <TextInput
+                            source="language"
+                            helperText={false}
                             autoFocus
                         />
-                        <TextField
-                            name="language"
-                            label="The author language"
-                            value={language}
-                            onChange={event => setLanguage(event.target.value)}
-                            autoFocus
-                        />
-                    </Stack>
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+                    </SimpleForm>
+                </CreateBase>
+            </DialogContent>
         </Dialog>
     );
 };
@@ -751,10 +746,7 @@ const BookEditWithReferenceAndCreationSupport = () => (
     >
         <SimpleForm>
             <ReferenceArrayInput reference="authors" source="author">
-                <AutocompleteArrayInput
-                    create={<CreateAuthor />}
-                    optionText="name"
-                />
+                <AutocompleteArrayInput create={<CreateAuthor />} />
             </ReferenceArrayInput>
         </SimpleForm>
     </Edit>


### PR DESCRIPTION
## Problem

Current examples of <AutocompleteArrayInput create> in the docs leverage useCreate, and require calling create manually with data coming from self-managed controlled inputs. 
https://marmelab.com/react-admin/AutocompleteArrayInput.html#creating-new-choices:~:text=OptionRenderer%20/%3E%3B-,Creating%20New%20Choices,-The%20%3CAutocompleteArrayInput%3E

## Solution

It’s actually simpler to leverage <CreateBase>, which removes the need to call create directly, and opens the ability to use <Form> along with RA Input components.

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-autocompletearrayinput--inside-reference-array-input-with-creation-support

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
