### PR TITLE
[DOC] selectInput create example + storie

### DIFF
--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -185,7 +185,7 @@ import {
 } from '@mui/material';
 
 const CreateAuthor = () => {
-    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
+    const { onCancel, onCreate } = useCreateSuggestionContext();
 
     const onAuthorCreate = author => {
         onCreate(author);

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -216,7 +216,7 @@ const CreateAuthor = () => {
                         },
                     }}
                 >
-                    <SimpleForm defaultValues={{ name: filter }}>
+                    <SimpleForm>
                         <TextInput source="name" helperText={false} />
                         <TextInput source="language" helperText={false} autoFocus />
                     </SimpleForm>
@@ -730,7 +730,7 @@ const CreateCategory = () => {
                         },
                     }}
                 >
-                    <SimpleForm defaultValues={{ title: filter }}>
+                    <SimpleForm>
                         <TextInput source="name" helperText={false} autoFocus/>
                     </SimpleForm>
                 </CreateBase>

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -158,66 +158,70 @@ To allow users to add new options, pass a React element as the `create` prop. `<
 
 {% raw %}
 ```jsx
-import { CreateCategory } from './CreateCategory';
+import { CreateAuthor } from './CreateAuthor';
 
-const PostCreate = () => (
+const BookCreate = () => (
     <Create>
         <SimpleForm>
-            <TextInput source="title" />
-            <ReferenceInput source="category_id" reference="categories">
-                <SelectInput create={<CreateCategory />} />
+            <ReferenceInput reference="authors" source="author">
+                <SelectInput
+                    create={<CreateAuthor />}
+                />
             </ReferenceInput>
         </SimpleForm>
     </Create>
 );
 
-// in ./CreateCategory.js
-import { useCreate, useCreateSuggestionContext } from 'react-admin';
+// in ./CreateAuthor.js
+import React from 'react';
+import { CreateBase, SimpleForm, TextInput, useCreateSuggestionContext } from 'react-admin';
+import CloseIcon from '@mui/icons-material/Close';
 import {
-    Box,
-    BoxProps,
     Button,
     Dialog,
-    DialogActions,
     DialogContent,
-    TextField,
+    DialogTitle,
+    IconButton,
 } from '@mui/material';
 
-const CreateCategory = () => {
+const CreateAuthor = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-    const [create] = useCreate();
-    const [value, setValue] = React.useState(filter || '');
 
-    const handleSubmit = event => {
-        event.preventDefault();
-        create(
-          'categories',
-          { data: { title: value } },
-          {
-              onSuccess: (data) => {
-                  setValue('');
-                  onCreate(data);
-              },
-          }
-        );
+    const onAuthorCreate = author => {
+        onCreate(author);
     };
 
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <TextField
-                        label="New category name"
-                        value={value}
-                        onChange={event => setValue(event.target.value)}
-                        autoFocus
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+            <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="authors"
+                    mutationOptions={{
+                        onSuccess: author => {
+                            onAuthorCreate(author);
+                        },
+                    }}
+                >
+                    <SimpleForm defaultValues={{ name: filter }}>
+                        <TextInput source="name" helperText={false} />
+                        <TextInput source="language" helperText={false} autoFocus />
+                    </SimpleForm>
+                </CreateBase>
+            </DialogContent>
         </Dialog>
     );
 };
@@ -695,43 +699,42 @@ const PostCreate = () => {
 
 const CreateCategory = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-    const [value, setValue] = React.useState(filter || '');
-    const [create] = useCreate();
-
-    const handleSubmit = event => {
-        event.preventDefault();
-        create(
-          'categories',
-          {
-              data: {
-                  title: value,
-              },
-          },
-          {
-              onSuccess: (data) => {
-                  setValue('');
-                  onCreate(data);
-              },
-          }
-        );
+   
+    const onCategoryCreate = category => {
+        onCreate(category);
     };
+
 
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <TextField
-                        label="New category name"
-                        value={value}
-                        onChange={event => setValue(event.target.value)}
-                        autoFocus
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+             <DialogTitle sx={{ m: 0, p: 2 }}>Create Category</DialogTitle>
+             <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="categories"
+                    mutationOptions={{
+                        onSuccess: category => {
+                            onCategoryCreate(category);
+                        },
+                    }}
+                >
+                    <SimpleForm defaultValues={{ title: filter }}>
+                        <TextInput source="name" helperText={false} autoFocus/>
+                    </SimpleForm>
+                </CreateBase>
+             </DialogContent>
         </Dialog>
     );
 };

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -651,7 +651,7 @@ export const InsideReferenceInputWithError = () => (
 );
 
 const CreateAuthor = () => {
-    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
+    const { onCancel, onCreate } = useCreateSuggestionContext();
 
     const onAuthorCreate = author => {
         onCreate(author);

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -16,10 +16,7 @@ import {
     useGetList,
 } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
-import {
-    default as defaultMessages,
-    default as englishMessages,
-} from 'ra-language-english';
+import englishMessages from 'ra-language-english';
 import * as React from 'react';
 
 import { AdminContext } from '../AdminContext';
@@ -505,7 +502,7 @@ export const FetchChoices = () => {
         <TestMemoryRouter initialEntries={['/books/1']}>
             <AdminContext
                 dataProvider={dataProviderWithAuthors}
-                i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+                i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
                 defaultTheme="light"
             >
                 <AdminUI>
@@ -543,7 +540,7 @@ export const InsideReferenceInput = () => (
     <TestMemoryRouter initialEntries={['/books/1']}>
         <AdminContext
             dataProvider={dataProviderWithAuthors}
-            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+            i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
             defaultTheme="light"
         >
             <AdminUI>
@@ -601,7 +598,7 @@ export const InsideReferenceInputDefaultValue = ({
                         },
                     }),
             }}
-            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+            i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
             defaultTheme="light"
         >
             <AdminUI>
@@ -646,7 +643,7 @@ export const InsideReferenceInputWithError = () => (
                         new Error('Error while fetching the authors')
                     ),
             }}
-            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+            i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
             defaultTheme="light"
         >
             <AdminUI>
@@ -740,7 +737,7 @@ export const InsideReferenceInputWithCreationSupport = () => {
         <TestMemoryRouter initialEntries={['/books/1']}>
             <AdminContext
                 dataProvider={dataProviderWithAuthors}
-                i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+                i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
                 defaultTheme="light"
             >
                 <AdminUI>

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -708,7 +708,7 @@ export const InsideReferenceInputWithCreationSupport = () => {
                 <Resource
                     name="authors"
                     recordRepresentation={record =>
-                        `${record.first_name} ${record.last_name} toto`
+                        `${record.first_name} ${record.last_name}`
                     }
                 />
                 <Resource

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -1,24 +1,27 @@
-import * as React from 'react';
-import { Admin, AdminContext } from 'react-admin';
-import { Resource, required, useGetList, TestMemoryRouter } from 'ra-core';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    TextField,
+} from '@mui/material';
+import { Resource, TestMemoryRouter, required, useGetList } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import {
-    Dialog,
-    DialogContent,
-    DialogActions,
-    TextField,
-    Button,
-} from '@mui/material';
+import * as React from 'react';
+import { Admin, AdminContext, CreateBase } from 'react-admin';
 
-import { Create as RaCreate, Edit } from '../detail';
-import { SimpleForm } from '../form';
-import { SelectInput, SelectInputProps } from './SelectInput';
-import { TextInput } from './TextInput';
-import { ReferenceInput } from './ReferenceInput';
 import { SaveButton } from '../button/SaveButton';
+import { Edit, Create as RaCreate } from '../detail';
+import { SimpleForm } from '../form';
 import { Toolbar } from '../form/Toolbar';
 import { FormInspector } from './common';
+import { ReferenceInput } from './ReferenceInput';
+import { SelectInput, SelectInputProps } from './SelectInput';
+import { TextInput } from './TextInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 export default { title: 'ra-ui-materialui/input/SelectInput' };
@@ -640,6 +643,100 @@ export const InsideReferenceInputWithError = () => (
         </Admin>
     </TestMemoryRouter>
 );
+
+const CreateAuthor = () => {
+    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
+
+    const onAuthorCreate = author => {
+        onCreate(author);
+    };
+
+    return (
+        <Dialog open onClose={onCancel}>
+            <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="authors"
+                    mutationOptions={{
+                        onSuccess: author => {
+                            onAuthorCreate(author);
+                        },
+                    }}
+                >
+                    <SimpleForm defaultValues={{ name: filter }}>
+                        <TextInput source="name" helperText={false} />
+                        <TextInput
+                            source="language"
+                            helperText={false}
+                            autoFocus
+                        />
+                    </SimpleForm>
+                </CreateBase>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export const InsideReferenceInputWithCreationSupport = () => {
+    const optionRenderer = choice => {
+        console.log(choice);
+        return choice.first_name && choice.last_name
+            ? `${choice.first_name} ${choice.last_name}`
+            : `${choice.name}`;
+    };
+    return (
+        <TestMemoryRouter initialEntries={['/books/1']}>
+            <Admin dataProvider={dataProviderWithAuthors}>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name} toto`
+                    }
+                />
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{
+                                onSuccess: data => {
+                                    console.log(data);
+                                },
+                            }}
+                        >
+                            <SimpleForm>
+                                <ReferenceInput
+                                    reference="authors"
+                                    source="author"
+                                >
+                                    <SelectInput
+                                        create={<CreateAuthor />}
+                                        createLabel="Create a new Author"
+                                        optionText={optionRenderer}
+                                    />
+                                </ReferenceInput>
+                                <FormInspector name="author" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </Admin>
+        </TestMemoryRouter>
+    );
+};
 
 export const TranslateChoice = () => {
     const i18nProvider = polyglotI18nProvider(() => ({

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -8,11 +8,17 @@ import {
     IconButton,
     TextField,
 } from '@mui/material';
-import { Resource, TestMemoryRouter, required, useGetList } from 'ra-core';
+import {
+    CreateBase,
+    Resource,
+    TestMemoryRouter,
+    required,
+    useGetList,
+} from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import * as React from 'react';
-import { Admin, AdminContext, CreateBase } from 'react-admin';
+import { Admin, AdminContext } from 'react-admin';
 
 import { SaveButton } from '../button/SaveButton';
 import { Edit, Create as RaCreate } from '../detail';

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -682,7 +682,7 @@ const CreateAuthor = () => {
                         },
                     }}
                 >
-                    <SimpleForm defaultValues={{ first_name: filter }}>
+                    <SimpleForm>
                         <TextInput
                             source="first_name"
                             helperText={false}

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -728,11 +728,6 @@ const CreateAuthor = () => {
 };
 
 export const InsideReferenceInputWithCreationSupport = () => {
-    const optionRenderer = choice => {
-        return choice.first_name && choice.last_name
-            ? `${choice.first_name} ${choice.last_name}`
-            : `${choice.name}`;
-    };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
             <AdminContext
@@ -765,8 +760,6 @@ export const InsideReferenceInputWithCreationSupport = () => {
                                     >
                                         <SelectInput
                                             create={<CreateAuthor />}
-                                            createLabel="Create a new Author"
-                                            optionText={optionRenderer}
                                         />
                                     </ReferenceInput>
                                     <FormInspector name="author" />

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -682,13 +682,13 @@ const CreateAuthor = () => {
                         },
                     }}
                 >
-                    <SimpleForm defaultValues={{ name: filter }}>
-                        <TextInput source="name" helperText={false} />
+                    <SimpleForm defaultValues={{ first_name: filter }}>
                         <TextInput
-                            source="language"
+                            source="first_name"
                             helperText={false}
                             autoFocus
                         />
+                        <TextInput source="last_name" helperText={false} />
                     </SimpleForm>
                 </CreateBase>
             </DialogContent>

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -698,7 +698,6 @@ const CreateAuthor = () => {
 
 export const InsideReferenceInputWithCreationSupport = () => {
     const optionRenderer = choice => {
-        console.log(choice);
         return choice.first_name && choice.last_name
             ? `${choice.first_name} ${choice.last_name}`
             : `${choice.name}`;

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -18,8 +18,10 @@ import {
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import * as React from 'react';
-import { Admin, AdminContext } from 'react-admin';
 
+import { AdminContext } from '../AdminContext';
+
+import { AdminUI } from '../AdminUI';
 import { SaveButton } from '../button/SaveButton';
 import { Edit, Create as RaCreate } from '../detail';
 import { SimpleForm } from '../form';
@@ -498,7 +500,142 @@ export const FetchChoices = () => {
     };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
-            <Admin dataProvider={dataProviderWithAuthors}>
+            <AdminContext dataProvider={dataProviderWithAuthors}>
+                <AdminUI>
+                    {' '}
+                    <Resource
+                        name="authors"
+                        recordRepresentation={record =>
+                            `${record.first_name} ${record.last_name}`
+                        }
+                    />
+                    <Resource
+                        name="books"
+                        edit={() => (
+                            <Edit
+                                mutationMode="pessimistic"
+                                mutationOptions={{
+                                    onSuccess: data => {
+                                        console.log(data);
+                                    },
+                                }}
+                            >
+                                <SimpleForm>
+                                    <BookAuthorsInput />
+                                    <FormInspector name="author" />
+                                </SimpleForm>
+                            </Edit>
+                        )}
+                    />
+                </AdminUI>
+            </AdminContext>
+        </TestMemoryRouter>
+    );
+};
+
+export const InsideReferenceInput = () => (
+    <TestMemoryRouter initialEntries={['/books/1']}>
+        <AdminContext dataProvider={dataProviderWithAuthors}>
+            <Resource
+                name="authors"
+                recordRepresentation={record =>
+                    `${record.first_name} ${record.last_name}`
+                }
+            />
+            <AdminUI>
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{
+                                onSuccess: data => {
+                                    console.log(data);
+                                },
+                            }}
+                        >
+                            <SimpleForm>
+                                <ReferenceInput
+                                    reference="authors"
+                                    source="author"
+                                >
+                                    <SelectInput />
+                                </ReferenceInput>
+                                <FormInspector name="author" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+export const InsideReferenceInputDefaultValue = ({
+    onSuccess = console.log,
+}) => (
+    <TestMemoryRouter initialEntries={['/books/1']}>
+        <AdminContext
+            dataProvider={{
+                ...dataProviderWithAuthors,
+                getOne: () =>
+                    Promise.resolve({
+                        data: {
+                            id: 1,
+                            title: 'War and Peace',
+                            // trigger default value
+                            author: undefined,
+                            summary:
+                                "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
+                            year: 1869,
+                        },
+                    }),
+            }}
+        >
+            <AdminUI>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name}`
+                    }
+                />
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{ onSuccess }}
+                        >
+                            <SimpleForm>
+                                <TextInput source="title" />
+                                <ReferenceInput
+                                    reference="authors"
+                                    source="author"
+                                >
+                                    <SelectInput />
+                                </ReferenceInput>
+                                <FormInspector name="author" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+export const InsideReferenceInputWithError = () => (
+    <TestMemoryRouter initialEntries={['/books/1']}>
+        <AdminContext
+            dataProvider={{
+                ...dataProviderWithAuthors,
+                getList: () =>
+                    Promise.reject(
+                        new Error('Error while fetching the authors')
+                    ),
+            }}
+        >
+            <AdminUI>
                 <Resource
                     name="authors"
                     recordRepresentation={record =>
@@ -517,136 +654,19 @@ export const FetchChoices = () => {
                             }}
                         >
                             <SimpleForm>
-                                <BookAuthorsInput />
+                                <ReferenceInput
+                                    reference="authors"
+                                    source="author"
+                                >
+                                    <SelectInput />
+                                </ReferenceInput>
                                 <FormInspector name="author" />
                             </SimpleForm>
                         </Edit>
                     )}
                 />
-            </Admin>
-        </TestMemoryRouter>
-    );
-};
-
-export const InsideReferenceInput = () => (
-    <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin dataProvider={dataProviderWithAuthors}>
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
-            <Resource
-                name="books"
-                edit={() => (
-                    <Edit
-                        mutationMode="pessimistic"
-                        mutationOptions={{
-                            onSuccess: data => {
-                                console.log(data);
-                            },
-                        }}
-                    >
-                        <SimpleForm>
-                            <ReferenceInput reference="authors" source="author">
-                                <SelectInput />
-                            </ReferenceInput>
-                            <FormInspector name="author" />
-                        </SimpleForm>
-                    </Edit>
-                )}
-            />
-        </Admin>
-    </TestMemoryRouter>
-);
-
-export const InsideReferenceInputDefaultValue = ({
-    onSuccess = console.log,
-}) => (
-    <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin
-            dataProvider={{
-                ...dataProviderWithAuthors,
-                getOne: () =>
-                    Promise.resolve({
-                        data: {
-                            id: 1,
-                            title: 'War and Peace',
-                            // trigger default value
-                            author: undefined,
-                            summary:
-                                "War and Peace broadly focuses on Napoleon's invasion of Russia, and the impact it had on Tsarist society. The book explores themes such as revolution, revolution and empire, the growth and decline of various states and the impact it had on their economies, culture, and society.",
-                            year: 1869,
-                        },
-                    }),
-            }}
-        >
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
-            <Resource
-                name="books"
-                edit={() => (
-                    <Edit
-                        mutationMode="pessimistic"
-                        mutationOptions={{ onSuccess }}
-                    >
-                        <SimpleForm>
-                            <TextInput source="title" />
-                            <ReferenceInput reference="authors" source="author">
-                                <SelectInput />
-                            </ReferenceInput>
-                            <FormInspector name="author" />
-                        </SimpleForm>
-                    </Edit>
-                )}
-            />
-        </Admin>
-    </TestMemoryRouter>
-);
-
-export const InsideReferenceInputWithError = () => (
-    <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin
-            dataProvider={{
-                ...dataProviderWithAuthors,
-                getList: () =>
-                    Promise.reject(
-                        new Error('Error while fetching the authors')
-                    ),
-            }}
-        >
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
-            <Resource
-                name="books"
-                edit={() => (
-                    <Edit
-                        mutationMode="pessimistic"
-                        mutationOptions={{
-                            onSuccess: data => {
-                                console.log(data);
-                            },
-                        }}
-                    >
-                        <SimpleForm>
-                            <ReferenceInput reference="authors" source="author">
-                                <SelectInput />
-                            </ReferenceInput>
-                            <FormInspector name="author" />
-                        </SimpleForm>
-                    </Edit>
-                )}
-            />
-        </Admin>
+            </AdminUI>
+        </AdminContext>
     </TestMemoryRouter>
 );
 
@@ -704,41 +724,43 @@ export const InsideReferenceInputWithCreationSupport = () => {
     };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
-            <Admin dataProvider={dataProviderWithAuthors}>
-                <Resource
-                    name="authors"
-                    recordRepresentation={record =>
-                        `${record.first_name} ${record.last_name}`
-                    }
-                />
-                <Resource
-                    name="books"
-                    edit={() => (
-                        <Edit
-                            mutationMode="pessimistic"
-                            mutationOptions={{
-                                onSuccess: data => {
-                                    console.log(data);
-                                },
-                            }}
-                        >
-                            <SimpleForm>
-                                <ReferenceInput
-                                    reference="authors"
-                                    source="author"
-                                >
-                                    <SelectInput
-                                        create={<CreateAuthor />}
-                                        createLabel="Create a new Author"
-                                        optionText={optionRenderer}
-                                    />
-                                </ReferenceInput>
-                                <FormInspector name="author" />
-                            </SimpleForm>
-                        </Edit>
-                    )}
-                />
-            </Admin>
+            <AdminContext dataProvider={dataProviderWithAuthors}>
+                <AdminUI>
+                    <Resource
+                        name="authors"
+                        recordRepresentation={record =>
+                            `${record.first_name} ${record.last_name}`
+                        }
+                    />
+                    <Resource
+                        name="books"
+                        edit={() => (
+                            <Edit
+                                mutationMode="pessimistic"
+                                mutationOptions={{
+                                    onSuccess: data => {
+                                        console.log(data);
+                                    },
+                                }}
+                            >
+                                <SimpleForm>
+                                    <ReferenceInput
+                                        reference="authors"
+                                        source="author"
+                                    >
+                                        <SelectInput
+                                            create={<CreateAuthor />}
+                                            createLabel="Create a new Author"
+                                            optionText={optionRenderer}
+                                        />
+                                    </ReferenceInput>
+                                    <FormInspector name="author" />
+                                </SimpleForm>
+                            </Edit>
+                        )}
+                    />
+                </AdminUI>
+            </AdminContext>
         </TestMemoryRouter>
     );
 };

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -16,7 +16,10 @@ import {
     useGetList,
 } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
-import englishMessages from 'ra-language-english';
+import {
+    default as defaultMessages,
+    default as englishMessages,
+} from 'ra-language-english';
 import * as React from 'react';
 
 import { AdminContext } from '../AdminContext';
@@ -500,9 +503,12 @@ export const FetchChoices = () => {
     };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
-            <AdminContext dataProvider={dataProviderWithAuthors}>
+            <AdminContext
+                dataProvider={dataProviderWithAuthors}
+                i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+                defaultTheme="light"
+            >
                 <AdminUI>
-                    {' '}
                     <Resource
                         name="authors"
                         recordRepresentation={record =>
@@ -535,14 +541,18 @@ export const FetchChoices = () => {
 
 export const InsideReferenceInput = () => (
     <TestMemoryRouter initialEntries={['/books/1']}>
-        <AdminContext dataProvider={dataProviderWithAuthors}>
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
+        <AdminContext
+            dataProvider={dataProviderWithAuthors}
+            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+            defaultTheme="light"
+        >
             <AdminUI>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name}`
+                    }
+                />
                 <Resource
                     name="books"
                     edit={() => (
@@ -591,6 +601,8 @@ export const InsideReferenceInputDefaultValue = ({
                         },
                     }),
             }}
+            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+            defaultTheme="light"
         >
             <AdminUI>
                 <Resource
@@ -634,6 +646,8 @@ export const InsideReferenceInputWithError = () => (
                         new Error('Error while fetching the authors')
                     ),
             }}
+            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+            defaultTheme="light"
         >
             <AdminUI>
                 <Resource
@@ -724,7 +738,11 @@ export const InsideReferenceInputWithCreationSupport = () => {
     };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
-            <AdminContext dataProvider={dataProviderWithAuthors}>
+            <AdminContext
+                dataProvider={dataProviderWithAuthors}
+                i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+                defaultTheme="light"
+            >
                 <AdminUI>
                     <Resource
                         name="authors"


### PR DESCRIPTION
## Problem

Current examples of <SelectInput create> in the docs leverage useCreate, and require calling create manually with data coming from self-managed controlled inputs. 
https://marmelab.com/react-admin/SelectInput.html#create

## Solution

It’s actually simpler to leverage <CreateBase>, which removes the need to call create directly, and opens the ability to use <Form> along with RA Input components.

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-selectinput--inside-reference-input-with-creation-support

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

