### PR TITLE
[DOC] Rewrite select array input create doc

### DIFF
--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -546,7 +546,7 @@ const CreateTag = () => {
                         },
                     }}
                 >
-                    <SimpleForm >
+                    <SimpleForm>
                         <TextInput source="name" helperText={false} autoFocus/>
                     </SimpleForm>
                 </CreateBase>

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -547,7 +547,7 @@ const CreateTag = () => {
                     }}
                 >
                     <SimpleForm >
-                        <TextInput source="tag" helperText={false} autoFocus/>
+                        <TextInput source="name" helperText={false} autoFocus/>
                     </SimpleForm>
                 </CreateBase>
              </DialogContent>

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -518,9 +518,9 @@ const PostCreate = () => {
 const CreateTag = () => {
     const { onCancel, onCreate } = useCreateSuggestionContext();
  
- const onTagCreate = (tag) => {
-    onCreate(tag);
- }
+    const onTagCreate = (tag) => {
+        onCreate(tag);
+    }
     return (
         <Dialog open onClose={onCancel}>
              <DialogTitle sx={{ m: 0, p: 2 }}>Create Tag</DialogTitle>

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -517,43 +517,40 @@ const PostCreate = () => {
 
 const CreateTag = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-    const [value, setValue] = React.useState(filter || '');
-    const [create] = useCreate();
-
-    const handleSubmit = event => {
-        event.preventDefault();
-        create(
-          'tags',
-          {
-              data: {
-                  title: value,
-              },
-          },
-          {
-              onSuccess: (data) => {
-                  setValue('');
-                  onCreate(data);
-              },
-          }
-        );
-    };
-
+ 
+ const onTagCreate = (tag) => {
+    onCreate(tag);
+ }
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <TextField
-                        label="New tag"
-                        value={value}
-                        onChange={event => setValue(event.target.value)}
-                        autoFocus
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+             <DialogTitle sx={{ m: 0, p: 2 }}>Create Tag</DialogTitle>
+             <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="tags"
+                    mutationOptions={{
+                        onSuccess: tag => {
+                            onTagCreate(tag);
+                        },
+                    }}
+                >
+                    <SimpleForm >
+                        <TextInput source="tag" helperText={false} autoFocus/>
+                    </SimpleForm>
+                </CreateBase>
+             </DialogContent>
         </Dialog>
     );
 };

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -516,7 +516,7 @@ const PostCreate = () => {
 }
 
 const CreateTag = () => {
-    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
+    const { onCancel, onCreate } = useCreateSuggestionContext();
  
  const onTagCreate = (tag) => {
     onCreate(tag);

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -742,11 +742,6 @@ const CreateAuthor = () => {
 };
 
 export const InsideReferenceArrayInputAndCreationSupport = () => {
-    const optionRenderer = choice => {
-        return choice.first_name && choice.last_name
-            ? `${choice.first_name} ${choice.last_name}`
-            : `${choice.name}`;
-    };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
             <AdminContext
@@ -780,7 +775,6 @@ export const InsideReferenceArrayInputAndCreationSupport = () => {
                                         <SelectArrayInput
                                             create={<CreateAuthor />}
                                             createLabel="Create a new Author"
-                                            optionText={optionRenderer}
                                         />
                                     </ReferenceArrayInput>
                                     <FormInspector name="authors" />

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -713,7 +713,7 @@ const CreateAuthor = () => {
                         },
                     }}
                 >
-                    <SimpleForm defaultValues={{ first_name: filter }}>
+                    <SimpleForm>
                         <TextInput
                             source="first_name"
                             helperText={false}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -1,28 +1,31 @@
-import * as React from 'react';
-import polyglotI18nProvider from 'ra-i18n-polyglot';
-import englishMessages from 'ra-language-english';
+import CloseIcon from '@mui/icons-material/Close';
 import {
+    Box,
     Button,
     Dialog,
     DialogActions,
     DialogContent,
+    DialogTitle,
+    IconButton,
     Stack,
-    Box,
     TextField,
 } from '@mui/material';
 import fakeRestProvider from 'ra-data-fakerest';
+import polyglotI18nProvider from 'ra-i18n-polyglot';
+import englishMessages from 'ra-language-english';
+import * as React from 'react';
 
+import { CreateBase, Resource, TestMemoryRouter } from 'ra-core';
+import { Admin } from 'react-admin';
 import { AdminContext } from '../AdminContext';
 import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
-import { SelectArrayInput } from './SelectArrayInput';
-import { ReferenceArrayInput } from './ReferenceArrayInput';
-import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
-import { TextInput } from './TextInput';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
-import { Resource, TestMemoryRouter } from 'ra-core';
-import { Admin } from 'react-admin';
 import { FormInspector } from './common';
+import { ReferenceArrayInput } from './ReferenceArrayInput';
+import { SelectArrayInput } from './SelectArrayInput';
+import { TextInput } from './TextInput';
+import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 
 export default { title: 'ra-ui-materialui/input/SelectArrayInput' };
 
@@ -677,3 +680,96 @@ export const InsideReferenceArrayInputWithError = () => (
         </Admin>
     </TestMemoryRouter>
 );
+
+const CreateAuthor = () => {
+    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
+
+    const onAuthorCreate = author => {
+        onCreate(author);
+    };
+
+    return (
+        <Dialog open onClose={onCancel}>
+            <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="authors"
+                    mutationOptions={{
+                        onSuccess: author => {
+                            onAuthorCreate(author);
+                        },
+                    }}
+                >
+                    <SimpleForm defaultValues={{ first_name: filter }}>
+                        <TextInput
+                            source="first_name"
+                            helperText={false}
+                            autoFocus
+                        />
+                        <TextInput source="last_name" helperText={false} />
+                    </SimpleForm>
+                </CreateBase>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export const InsideReferenceArrayInputAndCreationSupport = () => {
+    const optionRenderer = choice => {
+        return choice.first_name && choice.last_name
+            ? `${choice.first_name} ${choice.last_name}`
+            : `${choice.name}`;
+    };
+    return (
+        <TestMemoryRouter initialEntries={['/books/1']}>
+            <Admin dataProvider={dataProviderWithAuthors}>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name}`
+                    }
+                />
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{
+                                onSuccess: data => {
+                                    console.log(data);
+                                },
+                            }}
+                        >
+                            <SimpleForm>
+                                <ReferenceArrayInput
+                                    reference="authors"
+                                    source="authors"
+                                >
+                                    <SelectArrayInput
+                                        create={<CreateAuthor />}
+                                        createLabel="Create a new Author"
+                                        optionText={optionRenderer}
+                                    />
+                                </ReferenceArrayInput>
+                                <FormInspector name="authors" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </Admin>
+        </TestMemoryRouter>
+    );
+};

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -682,7 +682,7 @@ export const InsideReferenceArrayInputWithError = () => (
 );
 
 const CreateAuthor = () => {
-    const { filter, onCancel, onCreate } = useCreateSuggestionContext();
+    const { onCancel, onCreate } = useCreateSuggestionContext();
 
     const onAuthorCreate = author => {
         onCreate(author);

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -16,8 +16,8 @@ import englishMessages from 'ra-language-english';
 import * as React from 'react';
 
 import { CreateBase, Resource, TestMemoryRouter } from 'ra-core';
-import { Admin } from 'react-admin';
 import { AdminContext } from '../AdminContext';
+import { AdminUI } from '../AdminUI.tsx';
 import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
@@ -552,37 +552,43 @@ const dataProviderWithAuthors = {
 
 export const InsideReferenceArrayInput = () => (
     <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin dataProvider={dataProviderWithAuthors}>
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
-            <Resource
-                name="books"
-                edit={() => (
-                    <Edit
-                        mutationMode="pessimistic"
-                        mutationOptions={{
-                            onSuccess: data => {
-                                console.log(data);
-                            },
-                        }}
-                    >
-                        <SimpleForm>
-                            <ReferenceArrayInput
-                                reference="authors"
-                                source="authors"
-                            >
-                                <SelectArrayInput />
-                            </ReferenceArrayInput>
-                            <FormInspector name="authors" />
-                        </SimpleForm>
-                    </Edit>
-                )}
-            />
-        </Admin>
+        <AdminContext
+            dataProvider={dataProviderWithAuthors}
+            i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
+            defaultTheme="light"
+        >
+            <AdminUI>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name}`
+                    }
+                />
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{
+                                onSuccess: data => {
+                                    console.log(data);
+                                },
+                            }}
+                        >
+                            <SimpleForm>
+                                <ReferenceArrayInput
+                                    reference="authors"
+                                    source="authors"
+                                >
+                                    <SelectArrayInput />
+                                </ReferenceArrayInput>
+                                <FormInspector name="authors" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
     </TestMemoryRouter>
 );
 
@@ -590,7 +596,7 @@ export const InsideReferenceArrayInputDefaultValue = ({
     onSuccess = console.log,
 }) => (
     <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin
+        <AdminContext
             dataProvider={{
                 ...dataProviderWithAuthors,
                 getOne: () =>
@@ -606,40 +612,44 @@ export const InsideReferenceArrayInputDefaultValue = ({
                         },
                     }),
             }}
+            i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
+            defaultTheme="light"
         >
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
-            <Resource
-                name="books"
-                edit={() => (
-                    <Edit
-                        mutationMode="pessimistic"
-                        mutationOptions={{ onSuccess }}
-                    >
-                        <SimpleForm>
-                            <TextInput source="title" />
-                            <ReferenceArrayInput
-                                reference="authors"
-                                source="authors"
-                            >
-                                <SelectArrayInput />
-                            </ReferenceArrayInput>
-                            <FormInspector name="authors" />
-                        </SimpleForm>
-                    </Edit>
-                )}
-            />
-        </Admin>
+            <AdminUI>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name}`
+                    }
+                />
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{ onSuccess }}
+                        >
+                            <SimpleForm>
+                                <TextInput source="title" />
+                                <ReferenceArrayInput
+                                    reference="authors"
+                                    source="authors"
+                                >
+                                    <SelectArrayInput />
+                                </ReferenceArrayInput>
+                                <FormInspector name="authors" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
     </TestMemoryRouter>
 );
 
 export const InsideReferenceArrayInputWithError = () => (
     <TestMemoryRouter initialEntries={['/books/1']}>
-        <Admin
+        <AdminContext
             dataProvider={{
                 ...dataProviderWithAuthors,
                 getList: () =>
@@ -647,37 +657,41 @@ export const InsideReferenceArrayInputWithError = () => (
                         new Error('Error while fetching the authors')
                     ),
             }}
+            i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
+            defaultTheme="light"
         >
-            <Resource
-                name="authors"
-                recordRepresentation={record =>
-                    `${record.first_name} ${record.last_name}`
-                }
-            />
-            <Resource
-                name="books"
-                edit={() => (
-                    <Edit
-                        mutationMode="pessimistic"
-                        mutationOptions={{
-                            onSuccess: data => {
-                                console.log(data);
-                            },
-                        }}
-                    >
-                        <SimpleForm>
-                            <ReferenceArrayInput
-                                reference="authors"
-                                source="authors"
-                            >
-                                <SelectArrayInput />
-                            </ReferenceArrayInput>
-                            <FormInspector name="authors" />
-                        </SimpleForm>
-                    </Edit>
-                )}
-            />
-        </Admin>
+            <AdminUI>
+                <Resource
+                    name="authors"
+                    recordRepresentation={record =>
+                        `${record.first_name} ${record.last_name}`
+                    }
+                />
+                <Resource
+                    name="books"
+                    edit={() => (
+                        <Edit
+                            mutationMode="pessimistic"
+                            mutationOptions={{
+                                onSuccess: data => {
+                                    console.log(data);
+                                },
+                            }}
+                        >
+                            <SimpleForm>
+                                <ReferenceArrayInput
+                                    reference="authors"
+                                    source="authors"
+                                >
+                                    <SelectArrayInput />
+                                </ReferenceArrayInput>
+                                <FormInspector name="authors" />
+                            </SimpleForm>
+                        </Edit>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
     </TestMemoryRouter>
 );
 
@@ -735,41 +749,47 @@ export const InsideReferenceArrayInputAndCreationSupport = () => {
     };
     return (
         <TestMemoryRouter initialEntries={['/books/1']}>
-            <Admin dataProvider={dataProviderWithAuthors}>
-                <Resource
-                    name="authors"
-                    recordRepresentation={record =>
-                        `${record.first_name} ${record.last_name}`
-                    }
-                />
-                <Resource
-                    name="books"
-                    edit={() => (
-                        <Edit
-                            mutationMode="pessimistic"
-                            mutationOptions={{
-                                onSuccess: data => {
-                                    console.log(data);
-                                },
-                            }}
-                        >
-                            <SimpleForm>
-                                <ReferenceArrayInput
-                                    reference="authors"
-                                    source="authors"
-                                >
-                                    <SelectArrayInput
-                                        create={<CreateAuthor />}
-                                        createLabel="Create a new Author"
-                                        optionText={optionRenderer}
-                                    />
-                                </ReferenceArrayInput>
-                                <FormInspector name="authors" />
-                            </SimpleForm>
-                        </Edit>
-                    )}
-                />
-            </Admin>
+            <AdminContext
+                dataProvider={dataProviderWithAuthors}
+                i18nProvider={polyglotI18nProvider(() => englishMessages, 'en')}
+                defaultTheme="light"
+            >
+                <AdminUI>
+                    <Resource
+                        name="authors"
+                        recordRepresentation={record =>
+                            `${record.first_name} ${record.last_name}`
+                        }
+                    />
+                    <Resource
+                        name="books"
+                        edit={() => (
+                            <Edit
+                                mutationMode="pessimistic"
+                                mutationOptions={{
+                                    onSuccess: data => {
+                                        console.log(data);
+                                    },
+                                }}
+                            >
+                                <SimpleForm>
+                                    <ReferenceArrayInput
+                                        reference="authors"
+                                        source="authors"
+                                    >
+                                        <SelectArrayInput
+                                            create={<CreateAuthor />}
+                                            createLabel="Create a new Author"
+                                            optionText={optionRenderer}
+                                        />
+                                    </ReferenceArrayInput>
+                                    <FormInspector name="authors" />
+                                </SimpleForm>
+                            </Edit>
+                        )}
+                    />
+                </AdminUI>
+            </AdminContext>
         </TestMemoryRouter>
     );
 };


### PR DESCRIPTION
## Problem

Current examples of <SelectArrayInput create> in the docs leverage useCreate, and require calling create manually with data coming from self-managed controlled inputs. https://marmelab.com/react-admin/SelectInput.html#create

## Solution

It’s actually simpler to leverage <CreateBase>, which removes the need to call create directly, and opens the ability to use <Form> along with RA Input components.

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-selectarrayinput--inside-reference-array-input-and-creation-support

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

