### PR TITLE
fix: update DateInput filter immediately on clear in PostList

### DIFF
--- a/examples/simple/src/posts/PostList.tsx
+++ b/examples/simple/src/posts/PostList.tsx
@@ -31,6 +31,8 @@ import {
     TopToolbar,
     useRecordContext,
     useTranslate,
+    DateInput,
+    useListContext,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 
 import ResetViewsButton from './ResetViewsButton';
@@ -47,6 +49,21 @@ const QuickFilter = ({
     return <Chip sx={{ marginBottom: 1 }} label={translate(label)} />;
 };
 
+const InstantDateInput = props => {
+    const { setFilters, filterValues } = useListContext();
+    return (
+        <DateInput
+            {...props}
+            onChange={event => {
+                setFilters({
+                    ...filterValues,
+                    [props.source]: event.target.value,
+                });
+            }}
+        />
+    );
+};
+
 const postFilter = [
     <SearchInput source="q" alwaysOn />,
     <TextInput source="title" defaultValue="Qui tempore rerum et voluptates" />,
@@ -55,6 +72,7 @@ const postFilter = [
         source="commentable"
         defaultValue
     />,
+    <InstantDateInput label="Published At" source="published_at" alwaysOn />,
 ];
 
 const exporter = posts => {


### PR DESCRIPTION
This PR addresses react-admin issue #10707
> When clearing a DateInput filter, the filter does not update if the input is still focused.

What was changed?
>Added a custom InstantDateInput component to examples/simple/src/posts/PostList.tsx.
>This component calls setFilters on every change, ensuring the filter updates immediately when the date is cleared or changed, even if the input is still focused.
>Updated the postFilter array to use InstantDateInput for the published_at filter.


Why?
The default DateInput only triggers filter updates on blur, not on every change. This fix ensures a better user experience by updating the filter as soon as the user clears or changes the date.

How to test?
Go to the Posts list.
Use the "Published At" filter.
Clear the date while the input is still focused.
The list should update immediately.