### PR TITLE
Fix prefetched resources are not used by ReferenceField

### DIFF
--- a/packages/ra-core/src/dataProvider/populateQueryCache.ts
+++ b/packages/ra-core/src/dataProvider/populateQueryCache.ts
@@ -37,6 +37,11 @@ export const populateQueryCache = ({
                 record,
                 { updatedAt }
             );
+            queryClient.setQueryData(
+                [resource, 'getMany', { ids: [String(record.id)] }],
+                [record],
+                { updatedAt }
+            );
         });
         const recordIds = data[resource].map(record => String(record.id));
         queryClient.setQueryData(


### PR DESCRIPTION
## Problem

`<ReferenceField>` relies on `getManyAggregate` to call the data provider. Each instance will call a `getMany(resource, [id])`, that react-admin will not  pass to the data provider, -but aggregate into a single `getMany(resource, [id1, id2, id3])`.

The prefetch feature pre-populates the `getMany(resource, [id1, id2, id3])` cache, but this isn't enough to prevent the actual data provider query.

## Solution

Prefetched records should be used to populate the cache of *individual*  getMany queries.

