### PR TITLE
fix: add default options to NumberField for better decimal precision

### DIFF
--- a/docs/NumberField.md
+++ b/docs/NumberField.md
@@ -63,7 +63,7 @@ If Intl is not available, `<NumberField>` outputs numbers as is (and ignores the
 | Prop        | Required | Type               | Default | Description                                                                      |
 | ----------- | -------- | ------------------ | ------- | -------------------------------------------------------------------------------- |
 | `locales`   | Optional | string             | ''      | Locale to use for formatting. Passed as first argument to `Intl.NumberFormat()`. |
-| `options`   | Optional | Object             | -       | Number formatting options. Passed as second argument to `Intl.NumberFormat()`.   |
+| `options`   | Optional | Object             | `{ minimumFractionDigits: 0, maximumFractionDigits: 100 }` | Number formatting options. Passed as second argument to `Intl.NumberFormat()`.   |
 | `textAlign` | Optional | `'left' | 'right'` | `right` | Text alignment in a Datagrid                                                     |
 | `transform` | Optional | Function           | -       | A function to transform the value before display.                                |
 

--- a/packages/ra-ui-materialui/src/field/NumberField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/NumberField.spec.tsx
@@ -122,6 +122,14 @@ describe('<NumberField />', () => {
         expect(queryByText('2')).not.toBeNull();
     });
 
+    it('should display small decimal numbers correctly with default options', () => {
+        const { queryByText } = render(
+            <NumberField record={{ id: 123, value: 0.0001 }} source="value" />
+        );
+
+        expect(queryByText('0.0001')).not.toBeNull();
+    });
+
     describe('emptyText', () => {
         it.each([null, undefined])(
             'should render the emptyText when value is %s',

--- a/packages/ra-ui-materialui/src/field/NumberField.tsx
+++ b/packages/ra-ui-materialui/src/field/NumberField.tsx
@@ -44,7 +44,7 @@ const NumberFieldImpl = <
         emptyText,
         source,
         locales,
-        options,
+        options = { minimumFractionDigits: 0, maximumFractionDigits: 100 },
         textAlign,
         transform = defaultTransform,
         ...rest


### PR DESCRIPTION
## Description
Fixes the issue with small decimal numbers being displayed as 0 in the NumberField component.

## Changes
- Added default options to NumberField component to handle small decimal numbers correctly
- Updated documentation to reflect the new default options
- Added test case to verify the behavior with small decimal numbers

## Before
Small decimal numbers like 0.0001 would be displayed as 0 due to Intl.NumberFormat's default behavior.

## After
Small decimal numbers are now displayed correctly with their full precision by default.

## Related Issue
Fixes #10718 