### PR TITLE
[Doc] Add a new third-party component `huyanhvn/react-admin-clipboard-field`

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -615,10 +615,10 @@ const AuthorField = () => {
 
 You can find components for react-admin in third-party repositories.
 
-- [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): a quick and customizable copy-to-clipboard field.
 - [MrHertal/react-admin-json-view](https://github.com/MrHertal/react-admin-json-view): JSON field and input for react-admin.
 - [alexgschwend/react-admin-color-picker](https://github.com/alexgschwend/react-admin-color-picker): a color field.
 - [huyanhvn/react-admin-clipboard-field](https://github.com/huyanhvn/react-admin-clipboard-field): a wrapper to TextField that copies field content to clipboard.
+- [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): copy various formats of the same value to clipboard.
 
 ## TypeScript
 

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -617,7 +617,8 @@ You can find components for react-admin in third-party repositories.
 
 - [OoDeLally/react-admin-clipboard-list-field](https://github.com/OoDeLally/react-admin-clipboard-list-field): a quick and customizable copy-to-clipboard field.
 - [MrHertal/react-admin-json-view](https://github.com/MrHertal/react-admin-json-view): JSON field and input for react-admin.
-- [alexgschwend/react-admin-color-picker](https://github.com/alexgschwend/react-admin-color-picker): a color field
+- [alexgschwend/react-admin-color-picker](https://github.com/alexgschwend/react-admin-color-picker): a color field.
+- [huyanhvn/react-admin-clipboard-field](https://github.com/huyanhvn/react-admin-clipboard-field): a wrapper to TextField that copies field content to clipboard.
 
 ## TypeScript
 


### PR DESCRIPTION
Add a new third-party component huyanhvn/react-admin-clipboard-field.

## Problem

None. This is just a suggestion.

## Solution

Hello team, I've created this wrapper for TextField that copies the text into clipboard. I've been finding it quite useful. If you think it can be useful for others too, please accept this suggestion into the docs. Thank you.

## How To Test

Just copy `src/clipboard-field.tsx` to your source directory and use ClipboardField anywhere you would use a TextField.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why): No, because this is a doc update.
- [ ] The PR includes one or several **stories** (if not possible, describe why): No, because this is a suggestion.
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
