### PR TITLE
[Doc] Document how to pass extra options to create-react-admin when using npm create

### DIFF
--- a/docs/CreateReactAdmin.md
+++ b/docs/CreateReactAdmin.md
@@ -24,7 +24,27 @@ cd your-admin-name
 npm run dev
 ```
 
-**Tip**: You can replace `npx` with `npm`, `yarn`, or `bun`.
+**Tip**: You can replace `npx` with `npm`, `yarn` or `bun`:
+
+```sh
+# Using npx
+npx create-react-admin@latest your-admin-name
+# Using npm
+npm create react-admin@latest your-admin-name
+# Using yarn
+yarn create react-admin@latest your-admin-name
+# Using bun
+bun create react-admin@latest your-admin-name
+```
+
+**Tip**: If you need to pass extra options, depending on the command you choose you may need to add `--` before the arguments:
+
+```sh
+# `npx` doesn't require the `--` before the arguments
+npx create-react-admin@latest your-admin-name --interactive
+# `npm create` does require the `--` before the arguments
+npm create react-admin@latest your-admin-name -- --interactive
+```
 
 ## Options
 


### PR DESCRIPTION
## Problem

Documentation says we can use either `npx` or `npm create` with create-react-admin. However newcomers may get confused when passing additional arguments to the CLI, as both commands have a different syntax.

## Solution

Document this gotcha and provide an example.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
