### PR TITLE
fix: remove misspelled unused parameters from sanitizeRestProps in Se…

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -388,10 +388,6 @@ export type SelectArrayInputProps = ChoicesProps &
 const sanitizeRestProps = ({
     alwaysOn,
     choices,
-    classNamInputWithOptionsPropse,
-    componenInputWithOptionsPropst,
-    crudGetMInputWithOptionsPropsatching,
-    crudGetOInputWithOptionsPropsne,
     defaultValue,
     disableValue,
     emptyText,


### PR DESCRIPTION
This pull request removes several misspelled and unused parameters from the sanitizeRestProps function in SelectArrayInput.tsx.

Details:
The following parameters were removed:
classNamInputWithOptionsPropse
componenInputWithOptionsPropst
crudGetMInputWithOptionsPropsatching
crudGetOInputWithOptionsPropsne
These parameters do not correspond to any real props or variables and appear to be accidental copy-paste or auto-complete errors.
Cleaning these up improves code clarity and maintainability.

Checklist:
[x] Code compiles and tests pass
[x] Only unused/misspelled parameters were removed
[x] No breaking changes introduced