### PR TITLE
Fix outlined inputs when label is false

### DIFF
--- a/packages/ra-ui-materialui/src/form/SimpleForm.stories.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.stories.tsx
@@ -6,7 +6,13 @@ import {
     testDataProvider,
     TestMemoryRouter,
 } from 'ra-core';
-import { Stack, ThemeProvider, createTheme } from '@mui/material';
+import {
+    Stack,
+    Grid,
+    ThemeProvider,
+    createTheme,
+    Typography,
+} from '@mui/material';
 
 import { AdminContext } from '../AdminContext';
 import { Edit } from '../detail';
@@ -76,6 +82,37 @@ export const StackProps = () => (
             <TextInput source="title" />
             <TextInput source="author" />
             <NumberInput source="year" />
+        </SimpleForm>
+    </Wrapper>
+);
+
+const LabelAndInput = ({ label, input }) => (
+    <Grid container columnSpacing={2}>
+        <Grid item xs={3} textAlign={'right'} alignContent="space-around">
+            <Typography variant="body2" color="text.secondary">
+                {label}
+            </Typography>
+        </Grid>
+        <Grid item xs={9}>
+            {React.cloneElement(input, {
+                label: '',
+                helperText: false,
+                margin: 'none',
+                variant: 'outlined',
+            })}
+        </Grid>
+    </Grid>
+);
+
+export const SideLabel = () => (
+    <Wrapper>
+        <SimpleForm alignItems="center" gap={1}>
+            <LabelAndInput label="Title" input={<TextInput source="title" />} />
+            <LabelAndInput
+                label="Author"
+                input={<TextInput source="author" />}
+            />
+            <LabelAndInput label="Year" input={<NumberInput source="year" />} />
         </SimpleForm>
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -632,12 +632,14 @@ If you provided a React element for the optionText prop, you must also provide t
                         <TextField
                             name={field.name}
                             label={
-                                <FieldTitle
-                                    label={label}
-                                    source={source}
-                                    resource={resourceProp}
-                                    isRequired={isRequired}
-                                />
+                                label !== '' && label !== false ? (
+                                    <FieldTitle
+                                        label={label}
+                                        source={source}
+                                        resource={resourceProp}
+                                        isRequired={isRequired}
+                                    />
+                                ) : null
                             }
                             error={!!fetchError || invalid}
                             helperText={

--- a/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.stories.tsx
@@ -103,6 +103,12 @@ export const Parse = ({ simpleFormProps }) => (
     </Wrapper>
 );
 
+export const OutlinedNoLabel = () => (
+    <Wrapper>
+        <DateInput source="publishedAt" label={false} variant="outlined" />
+    </Wrapper>
+);
+
 export const ExternalChanges = ({
     dateInputProps = {},
     simpleFormProps = {

--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -205,12 +205,14 @@ export const DateInput = ({
                 ) : null
             }
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label !== '' && label !== false ? (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                ) : null
             }
             InputLabelProps={defaultInputLabelProps}
             {...sanitizeInputRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.stories.tsx
@@ -48,6 +48,12 @@ export const ReadOnly = () => (
     </Wrapper>
 );
 
+export const OutlinedNoLabel = () => (
+    <Wrapper>
+        <DateTimeInput source="published" label={false} variant="outlined" />
+    </Wrapper>
+);
+
 export const ExternalChanges = ({
     simpleFormProps = {
         defaultValues: { published: '2021-09-11 20:00:00' },

--- a/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateTimeInput.tsx
@@ -164,12 +164,14 @@ export const DateTimeInput = ({
                 ) : null
             }
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label !== '' && label !== false ? (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                ) : null
             }
             InputLabelProps={defaultInputLabelProps}
             {...sanitizeInputRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.stories.tsx
@@ -30,6 +30,16 @@ export const ReadOnly = () => (
     </Wrapper>
 );
 
+export const outlinedNoLabel = () => (
+    <Wrapper>
+        <NullableBooleanInput
+            source="published"
+            label={false}
+            variant="outlined"
+        />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({ children }) => (

--- a/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NullableBooleanInput.tsx
@@ -74,12 +74,14 @@ export const NullableBooleanInput = (inProps: NullableBooleanInputProps) => {
             readOnly={readOnly}
             margin={margin}
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label !== '' && label !== false ? (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                ) : null
             }
             error={invalid}
             helperText={

--- a/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.stories.tsx
@@ -202,6 +202,12 @@ export const Sx = () => (
     </Wrapper>
 );
 
+export const OutlinedNoLabel = () => (
+    <Wrapper>
+        <NumberInput source="views" label={false} variant="outlined" />
+    </Wrapper>
+);
+
 const FormStateInspector = () => {
     const { touchedFields, isDirty, dirtyFields, isValid, errors } =
         useFormState();

--- a/packages/ra-ui-materialui/src/input/NumberInput.tsx
+++ b/packages/ra-ui-materialui/src/input/NumberInput.tsx
@@ -149,12 +149,14 @@ export const NumberInput = ({
                 ) : null
             }
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label !== '' && label !== false ? (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                ) : null
             }
             margin={margin}
             inputProps={{ ...inputProps, readOnly }}

--- a/packages/ra-ui-materialui/src/input/TimeInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/TimeInput.stories.tsx
@@ -35,6 +35,12 @@ export const ReadOnly = () => (
     </Wrapper>
 );
 
+export const OutlinedNoLabel = () => (
+    <Wrapper>
+        <TimeInput source="published" label={false} variant="outlined" />
+    </Wrapper>
+);
+
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 
 const Wrapper = ({ children }) => (

--- a/packages/ra-ui-materialui/src/input/TimeInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TimeInput.tsx
@@ -100,12 +100,14 @@ export const TimeInput = ({
                 ) : null
             }
             label={
-                <FieldTitle
-                    label={label}
-                    source={source}
-                    resource={resource}
-                    isRequired={isRequired}
-                />
+                label !== '' && label !== false ? (
+                    <FieldTitle
+                        label={label}
+                        source={source}
+                        resource={resource}
+                        isRequired={isRequired}
+                    />
+                ) : null
             }
             InputLabelProps={defaultInputLabelProps}
             {...sanitizeInputRestProps(rest)}

--- a/packages/ra-ui-materialui/src/input/inputs.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/inputs.stories.tsx
@@ -17,6 +17,8 @@ import {
     radiantLightTheme,
     houseDarkTheme,
     houseLightTheme,
+    bwDarkTheme,
+    bwLightTheme,
     useTheme,
 } from '../theme';
 import {
@@ -47,6 +49,7 @@ export default {
 
 const themes = [
     { name: 'default', light: defaultLightTheme, dark: defaultDarkTheme },
+    { name: 'bw', light: bwLightTheme, dark: bwDarkTheme },
     { name: 'nano', light: nanoLightTheme, dark: nanoDarkTheme },
     { name: 'radiant', light: radiantLightTheme, dark: radiantDarkTheme },
     { name: 'house', light: houseLightTheme, dark: houseDarkTheme },


### PR DESCRIPTION
## Problem

Outlined inputs with no label show a gap in the outline. This prevents form layouts where the label is on the side. 

<img width="595" alt="image" src="https://github.com/user-attachments/assets/555bded0-2f39-4062-8783-b99e63be109a" />


## Solution

Apply the same fix to other inputs than TextInput. And now we can have side labels:

<img width="603" alt="image" src="https://github.com/user-attachments/assets/7c9837f2-2990-40e5-82a9-84fe1d14b60e" />


## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~~[ ] The PR includes **unit tests**~~ (UI only)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

