### PR TITLE
[Doc] Fix remaining `<AutocompleteArrayInput>` and `<SelectArrayInput>` `create` examples

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -147,65 +147,68 @@ To allow users to add new options, pass a React element as the `create` prop. `<
 
 {% raw %}
 ```jsx
-import { CreateRole } from './CreateRole';
-
-const choices = [
-    { id: 'admin', name: 'Admin' },
-    { id: 'u001', name: 'Editor' },
-    { id: 'u002', name: 'Moderator' },
-    { id: 'u003', name: 'Reviewer' },
-];
+import {
+    AutocompleteArrayInput,
+    Create,
+    CreateBase,
+    ReferenceArrayInput,
+    SimpleForm,
+    TextInput,
+    useCreateSuggestionContext
+} from 'react-admin';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+} from '@mui/material';
 
 const UserCreate = () => (
     <Create>
         <SimpleForm>
-            <AutocompleteArrayInput
-                source="roles"
-                choices={choices}
-                create={<CreateRole />}
-            />
+            <ReferenceArrayInput source="roles" reference="roles">
+                <AutocompleteArrayInput create={<CreateRole />} />
+            </ReferenceArrayInput>
         </SimpleForm>
     </Create>
 );
 
-// in ./CreateRole.js
-import { useCreateSuggestionContext } from 'react-admin';
-import {
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    TextField,
-} from '@mui/material';
-
 const CreateRole = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-    const [value, setValue] = React.useState(filter || '');
-
-    const handleSubmit = event => {
-        event.preventDefault();
-        const newOption = { id: value, name: value };
-        choices.push(newOption);
-        setValue('');
-        onCreate(newOption);
-    };
 
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <TextField
-                        label="Role name"
-                        value={value}
-                        onChange={event => setValue(event.target.value)}
-                        autoFocus
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+            <DialogTitle sx={{ m: 0, p: 2 }}>Create Role</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="roles"
+                    mutationOptions={{
+                        onSuccess: onCreate,
+                    }}
+                >
+                    <SimpleForm defaultValues={{ name: filter }}>
+                        <TextInput
+                            source="name"
+                            helperText={false}
+                            autoFocus
+                        />
+                    </SimpleForm>
+                </CreateBase>
+            </DialogContent>
         </Dialog>
     );
 };
@@ -718,20 +721,14 @@ import {
     ReferenceArrayInput,
     SimpleForm,
     TextInput,
-    useCreate,
     useCreateSuggestionContext
 } from 'react-admin';
-
 import CloseIcon from '@mui/icons-material/Close';
 import {
-    Box,
-    BoxProps,
-    Button,
     Dialog,
     DialogContent,
     DialogTitle,
     IconButton,
-    TextField,
 } from '@mui/material';
 
 const PostCreate = () => {
@@ -749,10 +746,6 @@ const PostCreate = () => {
 
 const CreateTag = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-   
-    const onTagCreate = tag => {
-        onCreate(tag);
-    };
 
     return (
         <Dialog open onClose={onCancel}>
@@ -774,9 +767,7 @@ const CreateTag = () => {
                     redirect={false}
                     resource="tags"
                     mutationOptions={{
-                        onSuccess: tag => {
-                            onTagCreate(tag);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm defaultValues={{ name: filter }}>

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -151,7 +151,22 @@ To allow users to add new options, pass a React element as the `create` prop. `<
 
 {% raw %}
 ```jsx
-import { CreateAuthor } from './CreateAuthor';
+import { 
+    Create, 
+    CreateBase, 
+    SimpleForm, 
+    ReferenceInput, 
+    AutocompleteInput, 
+    TextInput, 
+    useCreateSuggestionContext 
+} from 'react-admin';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+} from '@mui/material';
 
 const BookCreate = () => (
     <Create>
@@ -165,24 +180,8 @@ const BookCreate = () => (
     </Create>
 );
 
-// in ./CreateAuthor.js
-import React from 'react';
-import { CreateBase, SimpleForm, TextInput, useCreateSuggestionContext } from 'react-admin';
-import CloseIcon from '@mui/icons-material/Close';
-import {
-    Button,
-    Dialog,
-    DialogContent,
-    DialogTitle,
-    IconButton,
-} from '@mui/material';
-
 const CreateAuthor = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-
-    const onAuthorCreate = author => {
-        onCreate(author);
-    };
 
     return (
         <Dialog open onClose={onCancel}>
@@ -204,9 +203,7 @@ const CreateAuthor = () => {
                     redirect={false}
                     resource="authors"
                     mutationOptions={{
-                        onSuccess: author => {
-                            onAuthorCreate(author);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm defaultValues={{ name: filter }}>
@@ -878,17 +875,13 @@ import {
     ReferenceInput,
     SimpleForm,
     TextInput,
-    useCreate,
     useCreateSuggestionContext,
 } from 'react-admin';
-
 import CloseIcon from '@mui/icons-material/Close';
 import {
-    Box,
-    BoxProps,
-    Button,
     Dialog,
     DialogContent,
+    DialogTitle,
     IconButton,
 } from '@mui/material';
 
@@ -907,11 +900,6 @@ const PostCreate = () => {
 
 const CreateCategory = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-   
-    const onCategoryCreate = category => {
-        onCreate(category);
-    };
-
 
     return (
         <Dialog open onClose={onCancel}>
@@ -933,9 +921,7 @@ const CreateCategory = () => {
                     redirect={false}
                     resource="categories"
                     mutationOptions={{
-                        onSuccess: category => {
-                            onCategoryCreate(category);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm defaultValues={{ title: filter }}>

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -155,65 +155,64 @@ In the create component, use the `useCreateSuggestionContext` hook to add a new 
 
 {% raw %}
 ```jsx
-import { CreateRole } from './CreateRole';
-
-const choices = [
-    { id: 'admin', name: 'Admin' },
-    { id: 'u001', name: 'Editor' },
-    { id: 'u002', name: 'Moderator' },
-    { id: 'u003', name: 'Reviewer' },
-];
+import {
+    Create,
+    CreateBase,
+    SelectArrayInput,
+    ReferenceArrayInput,
+    SimpleForm,
+    TextInput,
+    useCreateSuggestionContext
+} from 'react-admin';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+    Dialog,
+    DialogActions,
+    DialogContent,
+    IconButton,
+} from '@mui/material';
 
 const UserCreate = () => (
     <Create>
         <SimpleForm>
-            <SelectArrayInput
-                source="roles"
-                choices={choices}
-                create={<CreateRole />}
-            />
+            <ReferenceArrayInput source="roles" reference="roles">
+                <SelectArrayInput create={<CreateRole />} />
+            </ReferenceArrayInput>
         </SimpleForm>
     </Create>
 );
 
-// in ./CreateRole.js
-import { useCreateSuggestionContext } from 'react-admin';
-import {
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    TextField,
-} from '@mui/material';
-
 const CreateRole = () => {
     const { onCancel, onCreate } = useCreateSuggestionContext();
-    const [value, setValue] = React.useState('');
-
-    const handleSubmit = event => {
-        event.preventDefault();
-        const newOption = { id: value, name: value };
-        choices.push(newOption);
-        setValue('');
-        onCreate(newOption);
-    };
 
     return (
         <Dialog open onClose={onCancel}>
-            <form onSubmit={handleSubmit}>
-                <DialogContent>
-                    <TextField
-                        label="Role name"
-                        value={value}
-                        onChange={event => setValue(event.target.value)}
-                        autoFocus
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button type="submit">Save</Button>
-                    <Button onClick={onCancel}>Cancel</Button>
-                </DialogActions>
-            </form>
+             <DialogTitle sx={{ m: 0, p: 2 }}>Create Role</DialogTitle>
+             <IconButton
+                aria-label="close"
+                onClick={onCancel}
+                sx={theme => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent sx={{ p: 0 }}>
+                <CreateBase
+                    redirect={false}
+                    resource="roles"
+                    mutationOptions={{
+                        onSuccess: onCreate,
+                    }}
+                >
+                    <SimpleForm>
+                        <TextInput source="name" helperText={false} autoFocus/>
+                    </SimpleForm>
+                </CreateBase>
+             </DialogContent>
         </Dialog>
     );
 };
@@ -483,23 +482,20 @@ Use the `create` prop when you want a more polished or complex UI. For example a
 {% raw %}
 ```jsx
 import {
-    SelectArrayInput,
     Create,
+    CreateBase,
+    SelectArrayInput,
     ReferenceArrayInput,
     SimpleForm,
     TextInput,
-    useCreate,
     useCreateSuggestionContext
 } from 'react-admin';
-
+import CloseIcon from '@mui/icons-material/Close';
 import {
-    Box,
-    BoxProps,
-    Button,
     Dialog,
     DialogActions,
     DialogContent,
-    TextField,
+    IconButton,
 } from '@mui/material';
 
 const PostCreate = () => {
@@ -518,9 +514,6 @@ const PostCreate = () => {
 const CreateTag = () => {
     const { onCancel, onCreate } = useCreateSuggestionContext();
  
-    const onTagCreate = (tag) => {
-        onCreate(tag);
-    }
     return (
         <Dialog open onClose={onCancel}>
              <DialogTitle sx={{ m: 0, p: 2 }}>Create Tag</DialogTitle>
@@ -541,9 +534,7 @@ const CreateTag = () => {
                     redirect={false}
                     resource="tags"
                     mutationOptions={{
-                        onSuccess: tag => {
-                            onTagCreate(tag);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm>

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -158,7 +158,22 @@ To allow users to add new options, pass a React element as the `create` prop. `<
 
 {% raw %}
 ```jsx
-import { CreateAuthor } from './CreateAuthor';
+import { 
+    Create, 
+    CreateBase, 
+    SimpleForm, 
+    ReferenceInput,
+    SelectInput,
+    TextInput, 
+    useCreateSuggestionContext 
+} from 'react-admin';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+} from '@mui/material';
 
 const BookCreate = () => (
     <Create>
@@ -172,24 +187,8 @@ const BookCreate = () => (
     </Create>
 );
 
-// in ./CreateAuthor.js
-import React from 'react';
-import { CreateBase, SimpleForm, TextInput, useCreateSuggestionContext } from 'react-admin';
-import CloseIcon from '@mui/icons-material/Close';
-import {
-    Button,
-    Dialog,
-    DialogContent,
-    DialogTitle,
-    IconButton,
-} from '@mui/material';
-
 const CreateAuthor = () => {
     const { onCancel, onCreate } = useCreateSuggestionContext();
-
-    const onAuthorCreate = author => {
-        onCreate(author);
-    };
 
     return (
         <Dialog open onClose={onCancel}>
@@ -211,9 +210,7 @@ const CreateAuthor = () => {
                     redirect={false}
                     resource="authors"
                     mutationOptions={{
-                        onSuccess: author => {
-                            onAuthorCreate(author);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm>
@@ -665,23 +662,20 @@ Use the `create` prop when you want a more polished or complex UI. For example a
 {% raw %}
 ```jsx
 import {
-    SelectInput,
     Create,
-    ReferenceInput,
+    CreateBase, 
     SimpleForm,
+    ReferenceInput,
+    SelectInput,
     TextInput,
-    useCreate,
     useCreateSuggestionContext
 } from 'react-admin';
-
+import CloseIcon from '@mui/icons-material/Close';
 import {
-    Box,
-    BoxProps,
-    Button,
     Dialog,
-    DialogActions,
+    DialogTitle,
     DialogContent,
-    TextField,
+    IconButton,
 } from '@mui/material';
 
 const PostCreate = () => {
@@ -699,11 +693,6 @@ const PostCreate = () => {
 
 const CreateCategory = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
-   
-    const onCategoryCreate = category => {
-        onCreate(category);
-    };
-
 
     return (
         <Dialog open onClose={onCancel}>
@@ -725,9 +714,7 @@ const CreateCategory = () => {
                     redirect={false}
                     resource="categories"
                     mutationOptions={{
-                        onSuccess: category => {
-                            onCategoryCreate(category);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm>

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -692,10 +692,6 @@ export const InsideReferenceArrayInputOnChange = ({
 const CreateAuthor = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
 
-    const onAuthorCreate = author => {
-        onCreate(author);
-    };
-
     return (
         <Dialog open onClose={onCancel}>
             <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
@@ -716,9 +712,7 @@ const CreateAuthor = () => {
                     redirect={false}
                     resource="authors"
                     mutationOptions={{
-                        onSuccess: author => {
-                            onAuthorCreate(author);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm defaultValues={{ name: filter }}>

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -899,10 +899,6 @@ export const InsideReferenceInputWithError = () => (
 const CreateAuthor = () => {
     const { filter, onCancel, onCreate } = useCreateSuggestionContext();
 
-    const onAuthorCreate = author => {
-        onCreate(author);
-    };
-
     return (
         <Dialog open onClose={onCancel}>
             <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
@@ -923,9 +919,7 @@ const CreateAuthor = () => {
                     redirect={false}
                     resource="authors"
                     mutationOptions={{
-                        onSuccess: author => {
-                            onAuthorCreate(author);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm defaultValues={{ name: filter }}>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -17,7 +17,7 @@ import * as React from 'react';
 
 import { CreateBase, Resource, TestMemoryRouter } from 'ra-core';
 import { AdminContext } from '../AdminContext';
-import { AdminUI } from '../AdminUI.tsx';
+import { AdminUI } from '../AdminUI';
 import { Create, Edit } from '../detail';
 import { SimpleForm } from '../form';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
@@ -698,10 +698,6 @@ export const InsideReferenceArrayInputWithError = () => (
 const CreateAuthor = () => {
     const { onCancel, onCreate } = useCreateSuggestionContext();
 
-    const onAuthorCreate = author => {
-        onCreate(author);
-    };
-
     return (
         <Dialog open onClose={onCancel}>
             <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
@@ -722,9 +718,7 @@ const CreateAuthor = () => {
                     redirect={false}
                     resource="authors"
                     mutationOptions={{
-                        onSuccess: author => {
-                            onAuthorCreate(author);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm>

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -684,10 +684,6 @@ export const InsideReferenceInputWithError = () => (
 const CreateAuthor = () => {
     const { onCancel, onCreate } = useCreateSuggestionContext();
 
-    const onAuthorCreate = author => {
-        onCreate(author);
-    };
-
     return (
         <Dialog open onClose={onCancel}>
             <DialogTitle sx={{ m: 0, p: 2 }}>Create Author</DialogTitle>
@@ -708,9 +704,7 @@ const CreateAuthor = () => {
                     redirect={false}
                     resource="authors"
                     mutationOptions={{
-                        onSuccess: author => {
-                            onAuthorCreate(author);
-                        },
+                        onSuccess: onCreate,
                     }}
                 >
                     <SimpleForm>


### PR DESCRIPTION
## Problem

- `<AutocompleteArrayInput>` and `<SelectArrayInput>` _**Creating New Choices**_ sections were updated in https://github.com/marmelab/react-admin/pull/10711 and https://github.com/marmelab/react-admin/pull/10700, but the `create` sections were forgotten
- The code can be simplified by passing `onCreate` directly to `onSuccess`
- Some import statements were wrong

## Solution

All these issues were fixed in the docs and stories.

## How To Test

`make storybook` and test stories like `InsideReferenceInput...`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
