### PR TITLE
Fix `create-react-admin --help` does not show help consistently

### DIFF
--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -123,7 +123,7 @@ const cli = meow(
     }
 );
 
-if (cli.flags.h) {
+if (cli.flags.h || cli.flags.help) {
     cli.showHelp();
 } else {
     const name = cli.input.length > 0 ? cli.input[0].trim() : undefined;


### PR DESCRIPTION
## Problem

If I run `npx create-react-admin --help`, the help view will be displayed.

If I run `npx create-react-admin my_project --help`, the help view won’t be displayed. We will directly create your new project

## Solution

Make `--help` override every options

## How To Test

- run `npx create-react-admin my_project --help` and see that the project is created
- run `make build-create-react-admin` and `./react-admin/node_modules/.bin/create-react-admin my-admin --help` and see that the project is **not** created but the help flag is now usefull

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> no tests in the `create-react-admin` package
- [ ] The PR includes one or several **stories** (if not possible, describe why) -> same
- ~~[ ] The **documentation** is up to date~~