### PR TITLE
Fix `<AutocompleteInput>` with `optionValue` and create raises a React warning

### DIFF
--- a/packages/ra-core/src/form/choices/useChoices.tsx
+++ b/packages/ra-core/src/form/choices/useChoices.tsx
@@ -83,7 +83,7 @@ export const useChoices = ({
     );
 
     const getChoiceValue = useCallback(
-        choice => get(choice, optionValue),
+        choice => get(choice, optionValue, get(choice, 'id')),
         [optionValue]
     );
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -1496,6 +1496,24 @@ describe('<AutocompleteInput />', () => {
             ).toEqual('true');
             expect(screen.queryByText(/Create/)).toBeNull();
         });
+
+        it('should allow the creation of a new choice when using optionValue', async () => {
+            render(<OnCreate optionValue="_id" />);
+            const input = (await screen.findByLabelText(
+                'Author'
+            )) as HTMLInputElement;
+            // Enter an unknown value and submit it with Enter
+            await userEvent.type(input, 'New Value{Enter}');
+            await screen.getByDisplayValue('New Value');
+            // Clear the input, otherwise the new value won't be shown in the dropdown as it is selected
+            fireEvent.change(input, {
+                target: { value: '' },
+            });
+            // Open the dropdown
+            fireEvent.mouseDown(input);
+            // Check the new value is in the dropdown
+            await screen.findByText('New Value');
+        });
     });
     describe('create', () => {
         it('should allow the creation of a new choice', async () => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -260,6 +260,7 @@ export const OptionTextElement = () => (
 
 const choicesForCreationSupport: Partial<{
     id: number;
+    _id: number;
     name: string;
     full_name: string;
     first_name: string;
@@ -267,6 +268,7 @@ const choicesForCreationSupport: Partial<{
 }>[] = [
     {
         id: 1,
+        _id: 1,
         name: 'Leo Tolstoy',
         full_name: 'Leo Tolstoy',
         first_name: 'Leo',
@@ -274,6 +276,7 @@ const choicesForCreationSupport: Partial<{
     },
     {
         id: 2,
+        _id: 2,
         name: 'Victor Hugo',
         full_name: 'Victor Hugo',
         first_name: 'Victor',
@@ -281,6 +284,7 @@ const choicesForCreationSupport: Partial<{
     },
     {
         id: 3,
+        _id: 3,
         name: 'William Shakespeare',
         full_name: 'William Shakespeare',
         first_name: 'William',
@@ -288,6 +292,7 @@ const choicesForCreationSupport: Partial<{
     },
     {
         id: 4,
+        _id: 4,
         name: 'Charles Baudelaire',
         full_name: 'Charles Baudelaire',
         first_name: 'Charles',
@@ -295,6 +300,7 @@ const choicesForCreationSupport: Partial<{
     },
     {
         id: 5,
+        _id: 5,
         name: 'Marcel Proust',
         full_name: 'Marcel Proust',
         first_name: 'Marcel',
@@ -302,7 +308,7 @@ const choicesForCreationSupport: Partial<{
     },
 ];
 
-const OnCreateInput = () => {
+const OnCreateInput = (props: Partial<AutocompleteInputProps>) => {
     const [choices, setChoices] = useState(choicesForCreationSupport);
     return (
         <AutocompleteInput
@@ -313,6 +319,7 @@ const OnCreateInput = () => {
 
                 const newOption = {
                     id: choices.length + 1,
+                    _id: choices.length + 1,
                     name: filter,
                 };
                 setChoices(options => [...options, newOption]);
@@ -323,15 +330,29 @@ const OnCreateInput = () => {
             TextFieldProps={{
                 placeholder: 'Start typing to create a new item',
             }}
+            {...props}
         />
     );
 };
 
-export const OnCreate = () => (
+export const OnCreate = (props: Partial<AutocompleteInputProps>) => (
     <Wrapper>
-        <OnCreateInput />
+        <OnCreateInput {...props} />
     </Wrapper>
 );
+OnCreate.args = {
+    optionValue: undefined,
+};
+OnCreate.argTypes = {
+    optionValue: {
+        options: ['default', '_id'],
+        mapping: {
+            default: undefined,
+            _id: '_id',
+        },
+        control: { type: 'inline-radio' },
+    },
+};
 
 const AutocompleteWithCreateInReferenceInput = () => {
     const [create] = useCreate();


### PR DESCRIPTION
## Problem

Fix https://github.com/marmelab/react-admin/issues/8402

Using `<AutocompleteInput>` with `optionValue` and either `create` or `onCreate` logs a React warning in the console when rendering the _create_ option:

```
Warning: Each child in a list should have a unique "key" prop.
```

## Solution

Fix the option items key to support both options with the `optionValue` (e.g. `'_id'`) as `key`, but also the _create_ option which always uses `'id'` as `key`.

## How To Test

1. Open http://localhost:9010/?path=/story/ra-ui-materialui-input-autocompleteinput--on-create&args=optionValue:_id
2. Type something to see the _create_ option
3. Make sure there are no errors in the console about 'Each child in a list should have a unique "key" prop.'

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
