### PR TITLE
[Doc] Remove bad indication for "yarn create react-admin@latest"

### DIFF
--- a/docs/CreateReactAdmin.md
+++ b/docs/CreateReactAdmin.md
@@ -32,7 +32,7 @@ npx create-react-admin@latest your-admin-name
 # Using npm
 npm create react-admin@latest your-admin-name
 # Using yarn
-yarn create react-admin@latest your-admin-name
+yarn create react-admin your-admin-name
 # Using bun
 bun create react-admin@latest your-admin-name
 ```

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -28,7 +28,7 @@ React-admin is built on React. To start, we'll use [create-react-admin](./Create
 ```sh
 npm create react-admin@latest test-admin
 # or
-yarn create react-admin@latest test-admin
+yarn create react-admin test-admin
 ```
 
 When prompted, choose **JSON Server** as the data provider, then **None** as the auth provider. Do not add any resources for now and press **Enter**. Next, choose either `npm` or `yarn` and press **Enter**. Once everything is installed, run the following commands:

--- a/packages/create-react-admin/README.md
+++ b/packages/create-react-admin/README.md
@@ -9,7 +9,7 @@ npm create react-admin@latest my-app
 # or
 npx create react-admin@latest my-app
 # or
-yarn create react-admin@latest my-app
+yarn create react-admin my-app
 # or
 bun create react-admin@latest my-app
 ```

--- a/packages/create-react-admin/src/cli.tsx
+++ b/packages/create-react-admin/src/cli.tsx
@@ -88,8 +88,8 @@ const cli = meow(
     Examples
 	  $ npx create-react-admin@latest my-admin
 	  $ npx create-react-admin@latest my-admin --data-provider json-server --auth-provider local-auth-provider --resource posts --resource comments --install npm
-	  $ yarn create react-admin@latest my-admin
-	  $ yarn create react-admin@latest my-admin --data-provider json-server --auth-provider local-auth-provider --resource posts --resource comments --install npm
+	  $ yarn create react-admin my-admin
+	  $ yarn create react-admin my-admin --data-provider json-server --auth-provider local-auth-provider --resource posts --resource comments --install npm
 	  $ bun create react-admin@latest my-admin
 	  $ bun create react-admin@latest my-admin --data-provider json-server --auth-provider local-auth-provider --resource posts --resource comments --install npm
 `,


### PR DESCRIPTION
## Problem

`yarn create react-admin@latest` doesn't work but we document it

## Solution

document `yarn create react-admin@latest` instead

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date