### PR TITLE
fix: Typo in disabled choices example

### DIFF
--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -107,7 +107,7 @@ You can render some options as disabled by setting the `disabled` field in some 
 const choices = [
     { id: 'tech', name: 'Tech' },
     { id: 'lifestyle', name: 'Lifestyle' },
-    { id: 'people', name: 'People', disable: true },
+    { id: 'people', name: 'People', disabled: true },
 ];
 <SelectInput source="author_id" choices={choices} />
 ```


### PR DESCRIPTION
## Problem

The documentation has a typo.

## Solution

Correct the typo.

## How To Test

Check the documentation with the code.