### PR TITLE
Fix potential prototype-polluting assignment in `ra-data-local-storage`

### DIFF
--- a/packages/ra-data-local-forage/src/index.ts
+++ b/packages/ra-data-local-forage/src/index.ts
@@ -166,6 +166,7 @@ export default (params?: LocalForageDataProviderParams): DataProvider => {
             resource: string,
             params: UpdateParams<any>
         ) => {
+            checkResource(resource);
             await initialize();
             if (!data) {
                 throw new Error('The dataProvider is not initialized.');
@@ -185,6 +186,7 @@ export default (params?: LocalForageDataProviderParams): DataProvider => {
             return baseDataProvider.update<RecordType>(resource, params);
         },
         updateMany: async (resource: string, params: UpdateManyParams<any>) => {
+            checkResource(resource);
             await initialize();
             if (!baseDataProvider) {
                 throw new Error('The dataProvider is not initialized.');
@@ -209,6 +211,7 @@ export default (params?: LocalForageDataProviderParams): DataProvider => {
             resource: string,
             params: CreateParams<any>
         ) => {
+            checkResource(resource);
             await initialize();
             if (!baseDataProvider) {
                 throw new Error('The dataProvider is not initialized.');
@@ -232,6 +235,7 @@ export default (params?: LocalForageDataProviderParams): DataProvider => {
             resource: string,
             params: DeleteParams<RecordType>
         ) => {
+            checkResource(resource);
             await initialize();
             if (!baseDataProvider) {
                 throw new Error('The dataProvider is not initialized.');
@@ -247,6 +251,7 @@ export default (params?: LocalForageDataProviderParams): DataProvider => {
             return baseDataProvider.delete<RecordType>(resource, params);
         },
         deleteMany: async (resource: string, params: DeleteManyParams<any>) => {
+            checkResource(resource);
             await initialize();
             if (!baseDataProvider) {
                 throw new Error('The dataProvider is not initialized.');
@@ -267,6 +272,13 @@ export default (params?: LocalForageDataProviderParams): DataProvider => {
             return baseDataProvider.deleteMany(resource, params);
         },
     };
+};
+
+const checkResource = resource => {
+    if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
+        // protection against prototype pollution
+        throw new Error(`Invalid resource key: ${resource}`);
+    }
 };
 
 export interface LocalForageDataProviderParams {

--- a/packages/ra-data-local-storage/src/index.ts
+++ b/packages/ra-data-local-storage/src/index.ts
@@ -98,6 +98,7 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
 
         // update methods need to persist changes in localStorage
         update: <RecordType extends RaRecord = any>(resource, params) => {
+            checkResource(resource);
             updateLocalStorage(() => {
                 const index = data[resource]?.findIndex(
                     record => record.id == params.id
@@ -110,9 +111,7 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
             return baseDataProvider.update<RecordType>(resource, params);
         },
         updateMany: (resource, params) => {
-            if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
-                throw new Error(`Invalid resource key: ${resource}`);
-            }
+            checkResource(resource);
             updateLocalStorage(() => {
                 params.ids.forEach(id => {
                     const index = data[resource]?.findIndex(
@@ -130,6 +129,7 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
             resource,
             params
         ) => {
+            checkResource(resource);
             // we need to call the fakerest provider first to get the generated id
             return baseDataProvider
                 .create<RecordType>(resource, params)
@@ -144,9 +144,7 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
                 });
         },
         delete: <RecordType extends RaRecord = any>(resource, params) => {
-            if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
-                throw new Error(`Invalid resource key: ${resource}`);
-            }
+            checkResource(resource);
             updateLocalStorage(() => {
                 const index = data[resource]?.findIndex(
                     record => record.id == params.id
@@ -156,9 +154,7 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
             return baseDataProvider.delete<RecordType>(resource, params);
         },
         deleteMany: (resource, params) => {
-            if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
-                throw new Error(`Invalid resource key: ${resource}`);
-            }
+            checkResource(resource);
             updateLocalStorage(() => {
                 const indexes = params.ids.map(id =>
                     data[resource]?.findIndex(record => record.id == id)
@@ -168,6 +164,13 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
             return baseDataProvider.deleteMany(resource, params);
         },
     };
+};
+
+const checkResource = resource => {
+    if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
+        // protection against prototype pollution
+        throw new Error(`Invalid resource key: ${resource}`);
+    }
 };
 
 export interface LocalStorageDataProviderParams {

--- a/packages/ra-data-local-storage/src/index.ts
+++ b/packages/ra-data-local-storage/src/index.ts
@@ -110,6 +110,9 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
             return baseDataProvider.update<RecordType>(resource, params);
         },
         updateMany: (resource, params) => {
+            if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
+                throw new Error(`Invalid resource key: ${resource}`);
+            }
             updateLocalStorage(() => {
                 params.ids.forEach(id => {
                     const index = data[resource]?.findIndex(
@@ -141,6 +144,9 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
                 });
         },
         delete: <RecordType extends RaRecord = any>(resource, params) => {
+            if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
+                throw new Error(`Invalid resource key: ${resource}`);
+            }
             updateLocalStorage(() => {
                 const index = data[resource]?.findIndex(
                     record => record.id == params.id
@@ -150,6 +156,9 @@ export default (params?: LocalStorageDataProviderParams): DataProvider => {
             return baseDataProvider.delete<RecordType>(resource, params);
         },
         deleteMany: (resource, params) => {
+            if (['__proto__', 'constructor', 'prototype'].includes(resource)) {
+                throw new Error(`Invalid resource key: ${resource}`);
+            }
             updateLocalStorage(() => {
                 const indexes = params.ids.map(id =>
                     data[resource]?.findIndex(record => record.id == id)


### PR DESCRIPTION
Most JavaScript objects inherit the properties of the built-in Object.prototype object. Prototype pollution is a type of vulnerability in which an attacker is able to modify Object.prototype. Since most objects inherit from the compromised Object.prototype object, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting.


