### PR TITLE
Create a codemod to replace `Datagrid` by `DataTable `

### DIFF
--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.input.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.input.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, Datagrid, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="id" label="Post number" />
+            <TextField source="title" />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.output.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, DataTable } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <DataTable>
+            <DataTable.Col source="id" label="Post number" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.input.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.input.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import {
+    List,
+    Datagrid,
+    TextField,
+    EmailField,
+    NumberField,
+    EditButton,
+    ReferenceField,
+    UrlField,
+    DateField,
+} from 'react-admin';
+
+// @ts-ignore
+import { MyCustomField } from './MyCustomField';
+
+const PostList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="id" />
+            <EmailField source="email" />
+            <NumberField source="nb_vues" />
+            <TextField source="title" />
+            <ReferenceField source="userId" reference="users">
+                <TextField source="name" />
+            </ReferenceField>
+            <UrlField source="url" />
+            <DateField source="createdAt" />
+            <MyCustomField source="code" />
+            <EditButton />
+        </Datagrid>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.output.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import {
+    List,
+    DataTable,
+    TextField,
+    EmailField,
+    EditButton,
+    ReferenceField,
+    UrlField,
+    DateField,
+} from 'react-admin';
+
+// @ts-ignore
+import { MyCustomField } from './MyCustomField';
+
+const PostList = () => (
+    <List>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="email" field={EmailField} />
+            <DataTable.NumberCol source="nb_vues" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="userId">
+                <ReferenceField source="userId" reference="users">
+                    <TextField source="name" />
+                </ReferenceField>
+            </DataTable.Col>
+            <DataTable.Col source="url" field={UrlField} />
+            <DataTable.Col source="createdAt" field={DateField} />
+            <DataTable.Col source="code" field={MyCustomField} />
+            <EditButton />
+        </DataTable>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.input.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.input.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, Datagrid, TextField, useRecordContext } from 'react-admin';
+
+const CustomEmpty = () => <div>No posts found</div>;
+
+const PostPanel = () => {
+    const record = useRecordContext();
+    return <div dangerouslySetInnerHTML={{ __html: record.body }} />;
+};
+
+const postRowStyle = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+
+const PostList = () => (
+    <List>
+        <Datagrid
+            bulkActionButtons={false}
+            empty={<CustomEmpty />}
+            expand={<PostPanel />}
+            expandSingle
+            rowClick={false}
+            optimized
+            rowStyle={postRowStyle}
+            sx={{
+                '& .RaDatagrid-row': {
+                    backgroundColor: 'white',
+                },
+                '& .RaDatagrid-row:hover': {
+                    backgroundColor: '#f5f5f5',
+                },
+            }}
+        >
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.output.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, DataTable, useRecordContext } from 'react-admin';
+
+const CustomEmpty = () => <div>No posts found</div>;
+
+const PostPanel = () => {
+    const record = useRecordContext();
+    return <div dangerouslySetInnerHTML={{ __html: record.body }} />;
+};
+
+const postRowStyle = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+
+const PostList = () => (
+    <List>
+        <DataTable
+            bulkActionButtons={false}
+            empty={<CustomEmpty />}
+            expand={<PostPanel />}
+            expandSingle
+            rowClick={false}
+            rowSx={postRowStyle}
+            sx={{
+                '& .RaDataTable-row': {
+                    backgroundColor: 'white',
+                },
+                '& .RaDataTable-row:hover': {
+                    backgroundColor: '#f5f5f5',
+                },
+            }}
+        >
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__tests__/replace-Datagrid-DataTable.spec.ts
+++ b/packages/ra-core/codemods/__tests__/replace-Datagrid-DataTable.spec.ts
@@ -1,0 +1,25 @@
+import { defineTest } from 'jscodeshift/dist/testUtils';
+
+jest.autoMockOff();
+
+defineTest(
+    __dirname,
+    'replace-Datagrid-DataTable',
+    null,
+    'replace-Datagrid-DataTable-Basic',
+    { parser: 'tsx' }
+);
+defineTest(
+    __dirname,
+    'replace-Datagrid-DataTable',
+    null,
+    'replace-Datagrid-DataTable-ManyChildren',
+    { parser: 'tsx' }
+);
+defineTest(
+    __dirname,
+    'replace-Datagrid-DataTable',
+    null,
+    'replace-Datagrid-DataTable-Props',
+    { parser: 'tsx' }
+);

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -4,12 +4,20 @@ module.exports = (file, api: j.API) => {
     const j = api.jscodeshift;
     const root = j(file.source);
 
-    replaceImports(root, j);
+    const continueAfterImport = replaceImport(root, j);
+    if (!continueAfterImport) {
+        return root.toSource();
+    }
+
+    const continueAfterComponent = replaceComponent(root, j);
+    if (!continueAfterComponent) {
+        return root.toSource();
+    }
 
     return root.toSource({ quote: 'single', lineTerminator: '\n' });
 };
 
-const replaceImports = (root, j) => {
+const replaceImport = (root, j) => {
     // Check if there is an import from react-admin
     const reactAdminImport = root.find(j.ImportDeclaration, {
         source: {
@@ -17,7 +25,7 @@ const replaceImports = (root, j) => {
         },
     });
     if (!reactAdminImport.length) {
-        return root.toSource();
+        return false;
     }
 
     // Check if there is an import of DataGrid from react-admin
@@ -28,10 +36,8 @@ const replaceImports = (root, j) => {
                 specifier.imported.name === 'Datagrid'
         );
     });
-    console.log('toto - 4', datagridImport);
     if (!datagridImport.length) {
-        console.log('toto - 5 - OUT');
-        return root.toSource();
+        return false;
     }
 
     // Replace import of DataGrid with DataTable
@@ -49,4 +55,9 @@ const replaceImports = (root, j) => {
             node.source
         )
     );
+};
+
+const replaceComponent = (root, j) => {
+    // TODO
+    return true;
 };

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -1,0 +1,52 @@
+import j from 'jscodeshift';
+
+module.exports = (file, api: j.API) => {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    replaceImports(root, j);
+
+    return root.toSource({ quote: 'single', lineTerminator: '\n' });
+};
+
+const replaceImports = (root, j) => {
+    // Check if there is an import from react-admin
+    const reactAdminImport = root.find(j.ImportDeclaration, {
+        source: {
+            value: 'react-admin',
+        },
+    });
+    if (!reactAdminImport.length) {
+        return root.toSource();
+    }
+
+    // Check if there is an import of DataGrid from react-admin
+    const datagridImport = reactAdminImport.filter(path => {
+        return path.node.specifiers.some(
+            specifier =>
+                j.ImportSpecifier.check(specifier) &&
+                specifier.imported.name === 'Datagrid'
+        );
+    });
+    console.log('toto - 4', datagridImport);
+    if (!datagridImport.length) {
+        console.log('toto - 5 - OUT');
+        return root.toSource();
+    }
+
+    // Replace import of DataGrid with DataTable
+    reactAdminImport.replaceWith(({ node }) =>
+        j.importDeclaration(
+            node.specifiers.map(specifier => {
+                if (
+                    j.ImportSpecifier.check(specifier) &&
+                    specifier.imported.name === 'Datagrid'
+                ) {
+                    return j.importSpecifier(j.identifier('DataTable'));
+                }
+                return specifier;
+            }),
+            node.source
+        )
+    );
+};


### PR DESCRIPTION
## Problem

We have too much `Datagrid` that we want to transform to `DataTable` to do it manually

## Solution

Create a codemod to do it magically

## How To Test

1. Create a `test.tsx` and fill it with the example you want to transform. e.g.: the following one
```tsx
import * as React from 'react';
import { List, Datagrid, TextField } from 'react-admin';

const PostList = () => (
    <List>
        <Datagrid>
            <TextField source="id" label="Post number" />
            <TextField source="title" />
            <TextField source="body" />
        </Datagrid>
    </List>
);

export default PostList;
```
2. run the following command:
```txt
npx jscodeshift test.tsx \
    --extensions=ts,tsx \
    --parser=tsx \
    --transform=./packages/ra-core/codemods/replace-Datagrid-DataTable.ts
```

## To Do

- [ ] Write unit tests
- Create the codemod
    - [ ] replace imports
    - [ ] replace the `Datagrid` component
    - [ ] wrap the field with a `<DataTable.Col source="xxx">`
    - [ ] keep the `Datagrid` props
    - [ ] delete the `optimized` prop of the `Datagrid` component
    - [ ] replace the `rowStyle` prop of the `Datagrid` component by `rowSx`
    - [ ] replace the `& .RaDatagrid-xxxx` key of the `sx` prop of the `Datagrid` component by `& .RaDataTable-xxxx`
    - [ ] don't wrap a field if it is a `NumberField` **??? -> if yes, what do we want to do for the props of the initial field ?**

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The **documentation** is up to date