### PR TITLE
Fix `<SaveButton>` is not enabled when the form is prefilled (from `<CloneButton>` for instance)

### DIFF
--- a/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.spec.tsx
@@ -20,6 +20,11 @@ import {
     NumberInput,
 } from '../input';
 import { AdminContext } from '../AdminContext';
+import {
+    AlwaysEnable,
+    Basic,
+    EnabledWhenFormIsPrefilled,
+} from './SaveButton.stories';
 
 const invalidButtonDomProps = {
     disabled: true,
@@ -64,13 +69,7 @@ describe('<SaveButton />', () => {
     });
 
     it('should render as submit type by default', async () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <Form>
-                    <SaveButton />
-                </Form>
-            </AdminContext>
-        );
+        render(<Basic />);
         await waitFor(() =>
             expect(
                 screen.getByLabelText('ra.action.save').getAttribute('type')
@@ -388,13 +387,16 @@ describe('<SaveButton />', () => {
     });
 
     it('should render enabled if alwaysEnable is true', async () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <Form>
-                    <SaveButton alwaysEnable={true} />
-                </Form>
-            </AdminContext>
+        render(<AlwaysEnable />);
+        await waitFor(() =>
+            expect(screen.getByLabelText('ra.action.save')['disabled']).toEqual(
+                false
+            )
         );
+    });
+
+    it('should render enabled if the form is prefilled', async () => {
+        render(<EnabledWhenFormIsPrefilled />);
         await waitFor(() =>
             expect(screen.getByLabelText('ra.action.save')['disabled']).toEqual(
                 false

--- a/packages/ra-ui-materialui/src/button/SaveButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form } from 'ra-core';
+import { Form, TestMemoryRouter } from 'ra-core';
 import { Paper } from '@mui/material';
 
 import { SaveButton } from './SaveButton';
@@ -29,33 +29,55 @@ const MakeFormChange = () => {
 };
 
 export const Dirty = () => (
-    <AdminContext>
-        <Paper>
-            <Form>
-                <MakeFormChange />
-                <SaveButton />
-            </Form>
-        </Paper>
-    </AdminContext>
+    <TestMemoryRouter>
+        <AdminContext>
+            <Paper>
+                <Form>
+                    <MakeFormChange />
+                    <SaveButton />
+                </Form>
+            </Paper>
+        </AdminContext>
+    </TestMemoryRouter>
+);
+
+export const EnabledWhenFormIsPrefilled = () => (
+    <TestMemoryRouter
+        initialEntries={[
+            `/posts/create?source=${JSON.stringify({ title: 'foo' })}`,
+        ]}
+    >
+        <AdminContext>
+            <Paper>
+                <Form>
+                    <SaveButton />
+                </Form>
+            </Paper>
+        </AdminContext>
+    </TestMemoryRouter>
 );
 
 export const AlwaysEnable = () => (
-    <AdminContext>
-        <Paper>
-            <Form>
-                <SaveButton alwaysEnable />
-            </Form>
-        </Paper>
-    </AdminContext>
+    <TestMemoryRouter>
+        <AdminContext>
+            <Paper>
+                <Form>
+                    <SaveButton alwaysEnable />
+                </Form>
+            </Paper>
+        </AdminContext>
+    </TestMemoryRouter>
 );
 
 export const Submitting = () => (
-    <AdminContext>
-        <Paper>
-            <Form onSubmit={() => new Promise(() => {})}>
-                <MakeFormChange />
-                <SaveButton />
-            </Form>
-        </Paper>
-    </AdminContext>
+    <TestMemoryRouter>
+        <AdminContext>
+            <Paper>
+                <Form onSubmit={() => new Promise(() => {})}>
+                    <MakeFormChange />
+                    <SaveButton />
+                </Form>
+            </Paper>
+        </AdminContext>
+    </TestMemoryRouter>
 );

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -18,6 +18,7 @@ import {
     useTranslate,
     warning,
     setSubmissionErrors,
+    useRecordFromLocation,
 } from 'ra-core';
 
 /**
@@ -75,12 +76,14 @@ export const SaveButton = <RecordType extends RaRecord = any>(
     // useFormState().isDirty might differ from useFormState().dirtyFields (https://github.com/react-hook-form/react-hook-form/issues/4740)
     const isDirty = Object.keys(dirtyFields).length > 0;
     // Use form isDirty, isValidating and form context saving to enable or disable the save button
-    // if alwaysEnable is undefined
+    // if alwaysEnable is undefined and the form wasn't prefilled
+    const recordFromLocation = useRecordFromLocation();
     const disabled = valueOrDefault(
         alwaysEnable === false || alwaysEnable === undefined
             ? undefined
             : !alwaysEnable,
-        disabledProp || !isDirty || isValidating || isSubmitting
+        (disabledProp || !isDirty || isValidating || isSubmitting) &&
+            recordFromLocation == null
     );
 
     warning(


### PR DESCRIPTION
## Problem

When users navigate to a page with a form prefilled from the router location, e.g. they clicked a `<CloneButton>`, the `<SaveButton>` is disabled by default because the form isn't dirty yet.

Fixes #9217.

## Solution

As react-hook-form does not provide a way to set the form values from an object while setting the form dirty, we made the  `<SaveButton>` check for the presence of a record in the router location too.

## How To Test

- Run the simple example
- Click any post
- Click the *Clone* button
- Check that all save buttons are enabled

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
