### PR TITLE
[Doc] Change our `Datagrid` examples to `DataTable`

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -156,17 +156,17 @@ See the [Success and Error Side Effects](#success-and-error-side-effects) below 
 
 {% raw %}
 ```jsx
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 
 const PostList = () => (
     <List
         queryOptions={{ onSettled: (data, error) => console.log(data, error) }}
     >
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
     </List>
 );
 ```
@@ -319,8 +319,8 @@ To execute some logic after a query or a mutation is complete, use the `onSucces
 - [`useNotify`](./useNotify.md): Return a function to display a notification.
 - [`useRedirect`](./useRedirect.md): Return a function to redirect the user to another page.
 - [`useRefresh`](./useRefresh.md): Return a function to force a rerender of the current view (equivalent to pressing the Refresh button).
-- [`useUnselect`](./useUnselect.md): Return a function to unselect lines in the current `Datagrid` based on the ids passed to it.
-- [`useUnselectAll`](./useUnselectAll.md): Return a function to unselect all lines in the current `Datagrid`.
+- [`useUnselect`](./useUnselect.md): Return a function to unselect lines in the current `DataTable` based on the ids passed to it.
+- [`useUnselectAll`](./useUnselectAll.md): Return a function to unselect all lines in the current `DataTable`.
 
 ### `onSuccess`
 

--- a/docs/AppTheme.md
+++ b/docs/AppTheme.md
@@ -273,7 +273,7 @@ const ThemeToggler = () => {
 
 In a custom theme, you can override the style of a component for the entire application using the `components` key.
 
-For instance, to create a custom theme that overrides the style of the `<Datagrid>` component:
+For instance, to create a custom theme that overrides the style of the `<DataTable>` component:
 
 ```jsx
 import { defaultTheme } from 'react-admin';
@@ -281,11 +281,11 @@ import { deepmerge } from '@mui/utils';
 
 const theme = deepmerge(defaultTheme, {
     components: {
-        RaDatagrid: {
+        RaDataTable: {
             styleOverrides: {
               root: {
                   backgroundColor: "Lavender",
-                  "& .RaDatagrid-headerCell": {
+                  "& .RaDataTable-headerCell": {
                       backgroundColor: "MistyRose",
                   },
               }
@@ -306,7 +306,7 @@ There are 2 important gotchas here:
 - Don't forget to merge your custom style overrides with the ones from react-admin's `defaultTheme`, otherwise the application will have the default Material UI theme (most notably, outlined text inputs)
 - Custom style overrides must live under a `root` key. Then, the style override syntax is the same as the one used for the [`sx`](./SX.md) prop.
 
-To guess the name of the subclass to use (like `.RaDatagrid-headerCell` above) for customizing a component, you can use the developer tools of your browser, or check the react-admin documentation for individual components (e.g. the [Datagrid CSS documentation](./Datagrid.md#sx-css-api)).
+To guess the name of the subclass to use (like `.RaDataTable-headerCell` above) for customizing a component, you can use the developer tools of your browser, or check the react-admin documentation for individual components (e.g. the [DataTable CSS documentation](./DataTable.md#sx-css-api)).
 
 **Tip**: As an alternative, you can also re-export styled components, and use them instead of the react-admin components. Check the [Reusable Components](./SX.md#reusable-components) documentation for an example.
 
@@ -499,11 +499,11 @@ import { defaultTheme } from 'react-admin';
 
 const theme = deepmerge(defaultTheme, {
     components: {
-        RaDatagrid: {
+        RaDataTable: {
             styleOverrides: {
               root: {
                   backgroundColor: "Lavender",
-                  "& .RaDatagrid-headerCell": {
+                  "& .RaDataTable-headerCell": {
                       backgroundColor: "MistyRose",
                   },
               }

--- a/docs/ArrayField.md
+++ b/docs/ArrayField.md
@@ -9,7 +9,7 @@ title: "The ArrayField Component"
 
 ![ArrayField](./img/array-field.webp)
 
-`<ArrayField>` creates a [`ListContext`](./useListContext.md) with the field value, and renders its children components - usually iterator components like [`<Datagrid>`](./Datagrid.md) or [`<SingleFieldList>`](./SingleFieldList.md).
+`<ArrayField>` creates a [`ListContext`](./useListContext.md) with the field value, and renders its children components - usually iterator components like [`<DataTable>`](./DataTable.md) or [`<SingleFieldList>`](./SingleFieldList.md).
 
 ## Usage
 
@@ -35,13 +35,13 @@ title: "The ArrayField Component"
 }
 ```
 
-Leverage `<ArrayField>` e.g. in a Show view, to display the `tags` as a `<SingleFieldList>` and the `backlinks` as a `<Datagrid>`:
+Leverage `<ArrayField>` e.g. in a Show view, to display the `tags` as a `<SingleFieldList>` and the `backlinks` as a `<DataTable>`:
 
 ```jsx
 import { 
     ArrayField,
     ChipField,
-    Datagrid,
+    DataTable,
     Show,
     SimpleShowLayout,
     SingleFieldList,
@@ -58,11 +58,11 @@ const PostShow = () => (
                 </SingleFieldList>
             </ArrayField>
             <ArrayField source="backlinks">
-                <Datagrid bulkActionButtons={false}>
-                    <TextField source="uuid" />
-                    <TextField source="date" />
-                    <TextField source="url" />
-                </Datagrid>
+                <DataTable bulkActionButtons={false}>
+                    <DataTable.Col source="uuid" />
+                    <DataTable.Col source="date" />
+                    <DataTable.Col source="url" />
+                </DataTable>
             </ArrayField>
         </SimpleShowLayout>
     </Show>
@@ -84,7 +84,7 @@ const PostShow = () => (
 
 ## `children`
 
-`<ArrayField>` renders its `children` component wrapped in a [`<ListContextProvider>`](./useListContext.md). Commonly used child components are [`<Datagrid>`](./Datagrid.md), [`<SingleFieldList>`](./SingleFieldList.md), and [`<SimpleList>`](./SimpleList.md).
+`<ArrayField>` renders its `children` component wrapped in a [`<ListContextProvider>`](./useListContext.md). Commonly used child components are [`<DataTable>`](./DataTable.md), [`<SingleFieldList>`](./SingleFieldList.md), and [`<SimpleList>`](./SimpleList.md).
 
 ```jsx
 {/* using SingleFieldList as child */}
@@ -94,13 +94,13 @@ const PostShow = () => (
     </SingleFieldList>
 </ArrayField>
 
-{/* using Datagrid as child */}
+{/* using DataTable as child */}
 <ArrayField source="backlinks">
-    <Datagrid>
-        <TextField source="uuid" />
-        <TextField source="date" />
-        <TextField source="url" />
-    </Datagrid>
+    <DataTable>
+        <DataTable.Col source="uuid" />
+        <DataTable.Col source="date" />
+        <DataTable.Col source="url" />
+    </DataTable>
 </ArrayField>
 
 {/* using SimpleList as child */}
@@ -159,11 +159,11 @@ You can use the `filter` prop to display only a subset of the items in the array
 {% raw %}
 ```jsx
 <ArrayField source="backlinks" filter={{ date: '2012-08-10T00:00:00.000Z' }}>
-    <Datagrid>
-        <TextField source="uuid" />
-        <TextField source="date" />
-        <TextField source="url" />
-    </Datagrid>
+    <DataTable>
+        <DataTable.Col source="uuid" />
+        <DataTable.Col source="date" />
+        <DataTable.Col source="url" />
+    </DataTable>
 </ArrayField>
 ```
 {% endraw %}
@@ -179,7 +179,7 @@ As `<ArrayField>` creates a [`ListContext`](./useListContext.md), you can use th
 ```jsx
 import { 
     ArrayField,
-    Datagrid,
+    DataTable,
     Pagination,
     Show,
     SimpleShowLayout,
@@ -191,11 +191,11 @@ const PostShow = () => (
         <SimpleShowLayout>
             <TextField source="title" />
             <ArrayField source="backlinks" perPage={5}>
-                <Datagrid>
-                    <TextField source="uuid" />
-                    <TextField source="date" />
-                    <TextField source="url" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="uuid" />
+                    <DataTable.Col source="date" />
+                    <DataTable.Col source="url" />
+                </DataTable>
                 <Pagination />
             </ArrayField>
         </SimpleShowLayout>

--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -742,7 +742,7 @@ Let's see how the components for the songs list and detail pages define their ap
 {% raw %}
 ```jsx
 // in src/songs/SongList.js
-import { useGetOne, List, SearchInput, Datagrid, TextField, DateField } from 'react-admin';
+import { useGetOne, List, SearchInput, DataTable, DateField } from 'react-admin';
 import { useDefineAppLocation } from '@react-admin/ra-navigation';
 import { useParams } from 'react-router-dom';
 
@@ -756,14 +756,16 @@ export const SongList = () => {
             filter={{ artist_id: id }}
             filters={[<SearchInput key="q" source="q" alwaysOn />]}
         >
-            <Datagrid>
-                <TextField source="title" />
-                <DateField source="released" />
-                <TextField source="writer" />
-                <TextField source="producer" />
-                <TextField source="recordCompany" label="Label" />
-                <EditSongButton />
-            </Datagrid>
+            <DataTable>
+                <DataTable.Col source="title" />
+                <DataTable.Col source="released" field={DateField} />
+                <DataTable.Col source="writer" />
+                <DataTable.Col source="producer" />
+                <DataTable.Col source="recordCompany" label="Label" />
+                <DataTable.Col>
+                    <EditSongButton />
+                </DataTable.Col>
+            </DataTable>
         </List>
     );
 };
@@ -857,16 +859,16 @@ To do so, override the [app location](#app-location) of the CRUD pages using the
 {% raw %}
 ```jsx
 // in src/songs/SongList.jsx
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 import { useDefineAppLocation } from '@react-admin/ra-navigation';
 
 export const SongList = () => {
     useDefineAppLocation('music.songs');
     return (
         <List>
-            <Datagrid>
-                <TextField source="title" />
-            </Datagrid>
+            <DataTable>
+                <DataTable.Col source="title" />
+            </DataTable>
         </List>
     );
 };

--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -36,7 +36,7 @@ React-Admin provides button components for all the common uses.
 
 ## `<BulkDeleteButton>`
 
-Deletes the selected rows. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons) (where it's enabled by default).
+Deletes the selected rows. To be used inside [the `<DataTable bulkActionButtons>` prop](./DataTable.md#bulkactionbuttons) (where it's enabled by default).
 
 ![Bulk Delete button](./img/bulk-delete-button.png)
 
@@ -47,7 +47,7 @@ Deletes the selected rows. To be used inside [the `<Datagrid bulkActionButtons>`
 ```jsx
 import * as React from 'react';
 import { Fragment } from 'react';
-import { BulkDeleteButton, BulkExportButton } from 'react-admin';
+import { BulkDeleteButton, BulkExportButton, DataTable } from 'react-admin';
 
 const PostBulkActionButtons = () => (
     <Fragment>
@@ -58,9 +58,9 @@ const PostBulkActionButtons = () => (
 
 export const PostList = () => (
     <List>
-        <Datagrid bulkActionButtons={<PostBulkActionButtons />}>
+        <DataTable bulkActionButtons={<PostBulkActionButtons />}>
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -114,7 +114,7 @@ Alternately, pass a `successMessage` prop:
 
 ## `<BulkExportButton>`
 
-Same as `<ExportButton>`, except it only exports the selected rows instead of the entire list. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
+Same as `<ExportButton>`, except it only exports the selected rows instead of the entire list. To be used inside [the `<DataTable bulkActionButtons>` prop](./DataTable.md#bulkactionbuttons).
 
 ![Bulk Export button](./img/bulk-export-button.png)
 
@@ -123,7 +123,7 @@ Same as `<ExportButton>`, except it only exports the selected rows instead of th
 ```jsx
 import * as React from 'react';
 import { Fragment } from 'react';
-import { BulkDeleteButton, BulkExportButton } from 'react-admin';
+import { BulkDeleteButton, BulkExportButton, DataTable, List } from 'react-admin';
 
 const PostBulkActionButtons = () => (
     <Fragment>
@@ -134,9 +134,9 @@ const PostBulkActionButtons = () => (
 
 export const PostList = () => (
     <List>
-        <Datagrid bulkActionButtons={<PostBulkActionButtons />}>
+        <DataTable bulkActionButtons={<PostBulkActionButtons />}>
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -152,7 +152,7 @@ export const PostList = () => (
 
 ## `<BulkUpdateButton>`
 
-Partially updates the selected rows. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
+Partially updates the selected rows. To be used inside [the `<DataTable bulkActionButtons>` prop](./DataTable.md#bulkactionbuttons).
 
 ![Bulk Update button](./img/bulk-update-button.png)
 
@@ -162,7 +162,7 @@ Partially updates the selected rows. To be used inside [the `<Datagrid bulkActio
 ```jsx
 import * as React from 'react';
 import { Fragment } from 'react';
-import { BulkDeleteButton, BulkExportButton, BulkUpdateButton } from 'react-admin';
+import { BulkDeleteButton, BulkExportButton, BulkUpdateButton, DataTable, List } from 'react-admin';
 
 const PostBulkActionButtons = () => (
     <Fragment>
@@ -174,9 +174,9 @@ const PostBulkActionButtons = () => (
 
 export const PostList = () => (
     <List>
-        <Datagrid bulkActionButtons={<PostBulkActionButtons />}>
+        <DataTable bulkActionButtons={<PostBulkActionButtons />}>
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -234,7 +234,7 @@ Alternately, pass a `successMessage` prop:
 
 ## `<BulkUpdateFormButton>`
 
-This component, part of the [enterprise edition](https://react-admin-ee.marmelab.com/documentation/ra-form-layout)<img class="icon" src="./img/premium.svg" alt="React Admin Enterprise Edition icon" />, lets users edit multiple records at once. To be used inside [the `<Datagrid bulkActionButtons>` prop](./Datagrid.md#bulkactionbuttons).
+This component, part of the [enterprise edition](https://react-admin-ee.marmelab.com/documentation/ra-form-layout)<img class="icon" src="./img/premium.svg" alt="React Admin Enterprise Edition icon" />, lets users edit multiple records at once. To be used inside [the `<DataTable bulkActionButtons>` prop](./DataTable.md#bulkactionbuttons).
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/BulkUpdateButton-SimpleForm.webm" type="video/webm"/>
@@ -246,7 +246,7 @@ The button opens a dialog containing the form passed as children. When the form 
 
 ### Usage
 
-`<BulkUpdateFormButton>` can be used inside `<Datagrid>`'s `bulkActionButtons`.
+`<BulkUpdateFormButton>` can be used inside `<DataTable>`'s `bulkActionButtons`.
 
 ```tsx
 import * as React from 'react';
@@ -254,13 +254,12 @@ import {
     Admin,
     BooleanField,
     BooleanInput,
-    Datagrid,
+    DataTable,
     DateField,
     DateInput,
     List,
     Resource,
     SimpleForm,
-    TextField,
 } from 'react-admin';
 import { BulkUpdateFormButton } from '@react-admin/ra-form-layout';
 
@@ -284,12 +283,12 @@ const PostBulkUpdateButton = () => (
 
 const PostList = () => (
     <List>
-        <Datagrid bulkActionButtons={<PostBulkUpdateButton />}>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="published_at" />
-            <BooleanField source="is_public" />
-        </Datagrid>
+        <DataTable bulkActionButtons={<PostBulkUpdateButton />}>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="published_at" field={DateField} />
+            <DataTable.Col source="is_public" field={BooleanField} />
+        </DataTable>
     </List>
 );
 ```
@@ -981,7 +980,7 @@ const CommentShow = () => (
 
 It also supports [all the other `<Button>` props](#button).
 
-**Tip**: You can use it as `<Datagrid>` child, too. However, you should use the `<Datagrid rowClick="edit">` prop instead to avoid using one column for the Edit button.
+**Tip**: You can use it as `<DataTable>` child, too. However, you should use the `<DataTable rowClick="edit">` prop instead to avoid using one column for the Edit button.
 
 **Tip**: If you want to link to the Edit view manually, use the `/{resource}/{record.id}` location.
 
@@ -1186,12 +1185,12 @@ The `<SelectAllButton>` component allows users to select all items from a resour
 
 ### Usage
 
-By default, react-admin's `<Datagrid>` displays a `<SelectAllButton>` in its `bulkActionsToolbar`. You can customize it by specifying your own `<BulkActionsToolbar selectAllButton>`:
+By default, react-admin's `<DataTable>` displays a `<SelectAllButton>` in its `bulkActionsToolbar`. You can customize it by specifying your own `<BulkActionsToolbar selectAllButton>`:
 
 {% raw %}
 
 ```jsx
-import { List, Datagrid, BulkActionsToolbar, SelectAllButton, BulkDeleteButton } from 'react-admin';
+import { List, DataTable, BulkActionsToolbar, SelectAllButton, BulkDeleteButton } from 'react-admin';
 
 const PostSelectAllButton = () => (
     <SelectAllButton 
@@ -1202,7 +1201,7 @@ const PostSelectAllButton = () => (
 
 export const PostList = () => (
     <List>
-        <Datagrid
+        <DataTable
             bulkActionsToolbar={
                 <BulkActionsToolbar selectAllButton={PostSelectAllButton}>
                     <BulkDeleteButton />
@@ -1210,7 +1209,7 @@ export const PostList = () => (
             }
         >
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -1302,7 +1301,7 @@ const CommentEdit = () => (
 
 It also supports [all the other `<Button>` props](#button).
 
-**Tip**: You can use it as `<Datagrid>` child with no props too. However, you should use the `<Datagrid rowClick="show">` prop instead to avoid using one column for the Edit button.
+**Tip**: You can use it as `<DataTable>` child with no props too. However, you should use the `<DataTable rowClick="show">` prop instead to avoid using one column for the Edit button.
 
 **Tip**: If you want to link to the Show view manually, use the `/{resource}/{record.id}/show` location.
 
@@ -1643,7 +1642,7 @@ See [The AppBar documentation](./AppBar.md#usermenu) for more details.
 
 ## Performance
 
-The ripple effect can cause [performance issues](https://github.com/marmelab/react-admin/issues/5587) when displaying a large number of buttons (e.g. in a large datagrid). It's possible to remove the ripple effect from within your Material UI theme. The [Material UI docs](https://mui.com/material-ui/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally) provide instructions on how to do this.
+The ripple effect can cause [performance issues](https://github.com/marmelab/react-admin/issues/5587) when displaying a large number of buttons (e.g. in a large datatable). It's possible to remove the ripple effect from within your Material UI theme. The [Material UI docs](https://mui.com/material-ui/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally) provide instructions on how to do this.
 
 It's worth noting that removing the ripple will cause accessibility issues, including a lack of focus states during tab navigating for components like `BooleanInput` and `CheckboxGroupInput`.
 

--- a/docs/CRUD.md
+++ b/docs/CRUD.md
@@ -36,20 +36,20 @@ Each component reads the parameters from the URL, fetches the data from the data
 For example, to display a list of posts, you would use the `<List>` component:
 
 ```jsx
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 
 const PostList = () => (
     <List resource="posts">
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
     </List>
 );
 ```
 
-Here, the `<List>` component will call `dataProvider.getList('posts')` to fetch the list of posts and create a `ListContext` to store the data. The `<Datagrid>` component will read the data from that `ListContext` and render a row for each post. That's why there is no need to explicitly pass the data to the `<Datagrid>` component.
+Here, the `<List>` component will call `dataProvider.getList('posts')` to fetch the list of posts and create a `ListContext` to store the data. The `<DataTable>` component will read the data from that `ListContext` and render a row for each post. That's why there is no need to explicitly pass the data to the `<DataTable>` component.
 
 ## Page Context
 
@@ -60,7 +60,7 @@ Here, the `<List>` component will call `dataProvider.getList('posts')` to fetch 
 - Filters
 - Record selection
 
-The [`ListContext`](./useListContext.md) exposes callbacks to update these settings, and `<List>`'s children components like `<Datagrid>` use these callbacks to update the data.
+The [`ListContext`](./useListContext.md) exposes callbacks to update these settings, and `<List>`'s children components like `<DataTable>` use these callbacks to update the data.
 
 ```jsx
 const listContext = useListContext();
@@ -135,16 +135,16 @@ This is the equivalent of the following react-router configuration:
 `<Resource>` defines a `ResourceContext` storing the current resource `name`. This context is used by the `<List>`, `<Edit>`, `<Create>`, and `<Show>` components to determine the resource they should fetch. So when declaring page components with `<Resource>`, you don't need to pass the `resource` prop to them.
 
 ```diff
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 
 const PostList = () => (
 -   <List resource="posts">
 +   <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
     </List>
 );
 ```
@@ -153,26 +153,26 @@ Check [the `<Resource>` documentation](./Resource.md) to learn more about routin
 
 ## The List Page
 
-To build list pages, developers primarily use the [`<List>`](./List.md) component. It fetches a list of records from the data provider and delegates the rendering to its child component (often a [`<Datagrid>`](./Datagrid.md), as in the example below).
+To build list pages, developers primarily use the [`<List>`](./List.md) component. It fetches a list of records from the data provider and delegates the rendering to its child component (often a [`<DataTable>`](./DataTable.md), as in the example below).
 
 ```jsx
-import { List, Datagrid, TextField, TextInput} from 'react-admin';
+import { List, DataTable, TextInput} from 'react-admin';
 
 const filters = [<TextInput label="Search" source="q" size="small" alwaysOn />];
 
 const BookList = () => (
     <List filters={filters}>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col source="year" />
+        </DataTable>
     </List>
 );
 ```
 
-`<List>` also lets you customize the UI for filters and pagination. As for `<Datagrid>`, it provides tons of customization options, like row expanders, bulk actions, and column chooser. You can learn more in the [List Tutorial](./ListTutorial.md).
+`<List>` also lets you customize the UI for filters and pagination. As for `<DataTable>`, it provides tons of customization options, like row expanders, bulk actions, and column chooser. You can learn more in the [List Tutorial](./ListTutorial.md).
 
 ### List Layouts
 
@@ -181,10 +181,11 @@ You can use any of the following components to build the list page:
 <table><tbody>
 <tr style="border:none">
     <td style="width:50%;border:none;text-align:center">
-        <a title="<Datagrid>" href="./Datagrid.html">
+        <a title="<DataTable>" href="./DataTable.html">
+            <!-- TODO: shoot a new screenshot of Datatable to replace the following one -->
             <img src="./img/Datagrid.jpg">
         </a>
-        <a href="./Datagrid.html" style="display: block;transform: translateY(-10px);"><code>&lt;Datagrid&gt;</code></a>
+        <a href="./DataTable.html" style="display: block;transform: translateY(-10px);"><code>&lt;DataTable&gt;</code></a>
     </td>
     <td style="width:50%;border:none;text-align:center">
          <a title="<DatagridAG>" href="./DatagridAG.html">
@@ -251,7 +252,7 @@ Inside these list layouts, you can use any of react-admin’s Field components t
 - [`<ExportButton>`](./Buttons.md#exportbutton): A button to export the list data
 - [`<CreateButton>`](./Buttons.md#createbutton): A button to create a new record
 - [`<SortButton>`](./SortButton.md): A button to sort the list
-- [`<SelectColumnsButton>`](./SelectColumnsButton.md): A button to select the columns to display in a Datagrid
+- [`<SelectColumnsButton>`](./SelectColumnsButton.md): A button to select the columns to display in a DataTable
 - [`<BulkUpdateButton>`](./Buttons.md#bulkupdatebutton): A button to update selected records
 - [`<BulkDeleteButton>`](./Buttons.md#bulkdeletebutton): A button to delete selected records
 - [`<ListActions>`](./List.md#actions): A toolbar with a create and an export button
@@ -427,7 +428,7 @@ Check the following components to learn more about guessers:
 
 ## Headless Variants
 
-`<List>` and other page components render their children (e.g., `<Datagrid>`) in a page layout. This layout contains a page title (e.g., "Posts"), toolbars for action buttons & filters, a footer for pagination, and a side column.
+`<List>` and other page components render their children (e.g., `<DataTable>`) in a page layout. This layout contains a page title (e.g., "Posts"), toolbars for action buttons & filters, a footer for pagination, and a side column.
 
 But sometimes, you want to use the list data in a different layout, without the page title and toolbar, or with a different UI kit. For these use cases, you can use the headless variants of the page components, which come in two flavors:
 
@@ -458,15 +459,15 @@ const MyList = () => {
 If you want to use react-admin components, prefer the Base components, which call the hooks internally and store the values in a context:
 
 ```jsx
-import { ListBase, Datagrid, TextField } from 'react-admin';
+import { ListBase, DataTable } from 'react-admin';
 
 const MyList = () => (
     <ListBase resource="posts">
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
     </ListBase>
 );
 ```

--- a/docs/Configurable.md
+++ b/docs/Configurable.md
@@ -13,7 +13,6 @@ This component makes another component configurable by the end user. When users 
   Your browser does not support the video tag.
 </video>
 
-
 Some react-admin components are already configurable - or rather they have a configurable counterpart:
 
 - [`<DatagridConfigurable>`](./Datagrid.md#configurable)

--- a/docs/Confirm.md
+++ b/docs/Confirm.md
@@ -95,30 +95,32 @@ React-admin's `<DeleteButton>` lets user delete the current record [in an optimi
 Alternately, you can force the user to confirm the deletion by using `<DeleteButton mutationMode="pessimistic">`. Under the hood, this leverages the `<Confirm>` component to ask for confirmation before deleting the record.
 
 ```jsx
-import { List, Datagrid, TextField, DeleteButton } from 'react-admin';
+import { List, DataTable, DeleteButton } from 'react-admin';
 
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DeleteButton mutationMode="pessimistic" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col>
+                <DeleteButton mutationMode="pessimistic" />
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
 
-The same goes for deleting multiple records in a [bulk action](./Datagrid.md#bulkactionbuttons): use `<BulkDeleteButton mutationMode="pessimistic">` to ask a confirmation before the deletion.
+The same goes for deleting multiple records in a [bulk action](./DataTable.md#bulkactionbuttons): use `<BulkDeleteButton mutationMode="pessimistic">` to ask a confirmation before the deletion.
 
 ```jsx
-import { List, Datagrid, TextField, BulkDeleteButton } from 'react-admin';
+import { List, DataTable, BulkDeleteButton } from 'react-admin';
 
 const PostList = () => (
     <List>
-        <Datagrid bulkActionButtons={<BulkDeleteButton mutationMode="pessimistic" />}>
-            <TextField source="id" />
-            <TextField source="title" />
-        </Datagrid>
+        <DataTable bulkActionButtons={<BulkDeleteButton mutationMode="pessimistic" />}>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+        </DataTable>
     </List>
 );
 ```

--- a/docs/Count.md
+++ b/docs/Count.md
@@ -144,38 +144,37 @@ If you need to count the number of records related to the current one via a one-
 ```jsx
 import { 
     ChipField,
-    Datagrid,
+    DataTable,
     DateField,
     List,
     NumberField,
     ReferenceArrayField,
     ReferenceManyCount,
     SingleFieldList,
-    TextField,
 } from 'react-admin';
 
 export const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="published_at" sortByOrder="DESC" />
-            <ReferenceManyCount
-                label="Comments"
-                reference="comments"
-                target="post_id"
-            />
-            <NumberField source="views" sortByOrder="DESC" />
-            <ReferenceArrayField
-                label="Tags"
-                reference="tags"
-                source="tags"
-            >
-                <SingleFieldList>
-                    <ChipField source="name.en" size="small" />
-                </SingleFieldList>
-            </ReferenceArrayField>
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="published_at">
+                <DateField source="published_at" sortByOrder="DESC" />
+            </DataTable.Col>
+            <DataTable.Col label="Comments">
+                <ReferenceManyCount reference="comments" target="post_id" />
+            </DataTable.Col>
+            <DataTable.Col source="views">
+                <NumberField source="views" sortByOrder="DESC" />
+            </DataTable.Col>
+            <DataTable.Col label="Tags">
+                <ReferenceArrayField reference="tags" source="tags">
+                    <SingleFieldList>
+                        <ChipField source="name.en" size="small" />
+                    </SingleFieldList>
+                </ReferenceArrayField>
+            </DataTable.Col>
+        </DataTable>
     </List>
 )
 ```

--- a/docs/Create.md
+++ b/docs/Create.md
@@ -489,7 +489,7 @@ That means that if you want to create a link to a creation form, presetting *som
 
 ```jsx
 import * as React from 'react';
-import { CreateButton, Datagrid, List, useRecordContext } from 'react-admin';
+import { CreateButton, DataTable, List, useRecordContext } from 'react-admin';
 
 const CreateRelatedCommentButton = () => {
     const record = useRecordContext();
@@ -503,10 +503,12 @@ const CreateRelatedCommentButton = () => {
 
 export default PostList = () => (
     <List>
-        <Datagrid>
+        <DataTable>
             ...
-            <CreateRelatedCommentButton />
-        </Datagrid>
+            <DataTable.Col>
+                <CreateRelatedCommentButton />
+            </DataTable.Col>
+        </DataTable>
     </List>
 )
 ```
@@ -540,7 +542,7 @@ Should you use the location `state` or the location `search`? The latter modifie
 
 And if you want to prefill the form with constant values, use the `defaultValues` prop on the Form tag.
 
-**Tip**: [The `<Clonebutton>` component](./Buttons.md#clonebutton) redirects to a Creation view prefilled with the same data as the current context. You can use it e.g. in a `<Datagrid>`, or in the `<Edit actions>` toolbar.
+**Tip**: [The `<Clonebutton>` component](./Buttons.md#clonebutton) redirects to a Creation view prefilled with the same data as the current context. You can use it e.g. in a `<DataTable>`, or in the `<Edit actions>` toolbar.
 
 ## Save And Add Another
 

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -31,7 +31,7 @@ Then, add the `<CreateDialog>` component as a sibling to a `<List>` component.
 import {
     List,
     ListActions,
-    Datagrid,
+    DataTable,
     SimpleForm,
     TextInput,
     DateInput,
@@ -43,9 +43,9 @@ import { CreateDialog } from '@react-admin/ra-form-layout';
 const CustomerList = () => (
     <>
         <List actions={<ListActions hasCreate />}>
-            <Datagrid>
+            <DataTable>
                 ...
-            </Datagrid>
+            </DataTable>
         </List>
         <CreateDialog>
             <SimpleForm>
@@ -213,7 +213,7 @@ Here is an example:
 import {
     List,
     ListActions,
-    Datagrid,
+    DataTable,
     SimpleForm,
     TextInput,
     DateInput,
@@ -224,9 +224,9 @@ import { CreateDialog } from '@react-admin/ra-form-layout';
 const CustomerList = () => (
     <>
         <List actions={<ListActions hasCreate />}>
-            <Datagrid>
+            <DataTable>
                 ...
-            </Datagrid>
+            </DataTable>
         </List>
         <CreateDialog title="Create a new customer">
             <SimpleForm>
@@ -305,7 +305,7 @@ Put `<CreateInDialogButton>` wherever you would put a `<CreateButton>`, and use 
 {% raw %}
 ```jsx
 import {
-  Datagrid,
+  DataTable,
   ReferenceManyField,
   Show,
   SimpleForm,
@@ -331,10 +331,10 @@ const CompanyShow = () => (
                         </SimpleForm>
                     </CreateInDialogButton>
                 )} />
-                <Datagrid>
-                    <TextField source="first_name" />
-                    <TextField source="last_name" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="first_name" />
+                    <DataTable.Col source="last_name" />
+                </DataTable>
             </ReferenceManyField>
         </SimpleShowLayout>
     </Show>
@@ -369,7 +369,7 @@ Below is an example of an `<Edit>` page, including a 'create a new customer' but
 import React, { useCallback, useState } from 'react';
 import {
     Button,
-    Datagrid,
+    DataTable,
     DateField,
     DateInput,
     Edit,
@@ -378,7 +378,6 @@ import {
     SelectField,
     SelectInput,
     SimpleForm,
-    TextField,
     TextInput,
     useRecordContext,
 } from 'react-admin';
@@ -437,13 +436,15 @@ const EmployerSimpleFormWithFullyControlledDialogs = () => {
                 reference="customers"
                 target="employer_id"
             >
-                <Datagrid>
-                    <TextField source="id" />
-                    <TextField source="first_name" />
-                    <TextField source="last_name" />
-                    <DateField source="dob" label="born" />
-                    <SelectField source="sex" choices={sexChoices} />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col source="first_name" />
+                    <DataTable.Col source="last_name" />
+                    <DataTable.Col source="dob" label="born" field={DateField} />
+                    <DataTable.Col source="sex">
+                        <SelectField source="sex" choices={sexChoices} />
+                    </DataTable.Col>
+                </DataTable>
             </ReferenceManyField>
         </SimpleForm>
     );
@@ -469,7 +470,7 @@ import React from 'react';
 import {
     List,
     ListActions,
-    Datagrid,
+    DataTable,
     SimpleForm,
 } from 'react-admin';
 import { CreateDialog } from '@react-admin/ra-form-layout';
@@ -477,9 +478,9 @@ import { CreateDialog } from '@react-admin/ra-form-layout';
 const CustomerList = () => (
     <>
         <List actions={<ListActions hasCreate />}>
-            <Datagrid rowClick="edit">
+            <DataTable rowClick="edit">
                 ...
-            </Datagrid>
+            </DataTable>
         </List>
         <CreateDialog>
             <SimpleForm warnWhenUnsavedChanges>

--- a/docs/CreateInDialogButton.md
+++ b/docs/CreateInDialogButton.md
@@ -12,7 +12,7 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
   Your browser does not support the video tag.
 </video>
 
-It can be useful in case you want the ability to create a record linked by a reference to the currently edited record, or if you have a nested `<Datagrid>` inside a `<Show>` or an `<Edit>` view. 
+It can be useful in case you want the ability to create a record linked by a reference to the currently edited record, or if you have a nested `<DataTable>` inside a `<Show>` or an `<Edit>` view.
 
 Note that this component doesn't use routing, so it doesn't change the URL. It's therefore not possible to bookmark the creation dialog, or to link to it from another page. If you need that functionality, use [`<CreateDialog>`](./CreateDialog.md) instead.
 
@@ -33,7 +33,7 @@ Then, put `<CreateInDialogButton>` wherever you would put a `<CreateButton>`, an
 {% raw %}
 ```jsx
 import {
-  Datagrid,
+  DataTable,
   ReferenceManyField,
   Show,
   SimpleForm,
@@ -59,10 +59,10 @@ const CompanyShow = () => (
                         </SimpleForm>
                     </CreateInDialogButton>
                 )} />
-                <Datagrid>
-                    <TextField source="first_name" />
-                    <TextField source="last_name" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="first_name" />
+                    <DataTable.Col source="last_name" />
+                </DataTable>
             </ReferenceManyField>
         </SimpleShowLayout>
     </Show>
@@ -317,13 +317,13 @@ const EmployerEditButton = () => (
 
 ## Combining With `<EditInDialogButton>`
 
-Below is an example of an `<Edit>` view, inside which is a nested `<Datagrid>`, offering the ability to **create**, **edit** and **show** the rows thanks to `<CreateInDialogButton>`, [`<EditInDialogButton>`](./EditInDialogButton.md) and [`<ShowInDialogButton>`](./ShowInDialogButton.md):
+Below is an example of an `<Edit>` view, inside which is a nested `<DataTable>`, offering the ability to **create**, **edit** and **show** the rows thanks to `<CreateInDialogButton>`, [`<EditInDialogButton>`](./EditInDialogButton.md) and [`<ShowInDialogButton>`](./ShowInDialogButton.md):
 
 {% raw %}
 ```jsx
 import React from "react";
 import {
-  Datagrid,
+  DataTable,
   DateField,
   DateInput,
   Edit,
@@ -367,10 +367,10 @@ const CustomerLayout = () => (
 );
 
 // helper component to add actions buttons in a column (children),
-// and also in the header (label) of a Datagrid
-const DatagridActionsColumn = ({ label, children }) => <>{children}</>;
+// and also in the header (label) of a DataTable
+const DataTableActionsColumn = ({ label, children }) => <DataTable.Col label={label}>{children}</DataTable.Col>;
 
-const NestedCustomersDatagrid = () => {
+const NestedCustomersDataTable = () => {
   const record = useRecordContext();
 
   const createButton = (
@@ -402,18 +402,20 @@ const NestedCustomersDatagrid = () => {
       reference="customers"
       target="employer_id"
     >
-      <Datagrid>
-        <TextField source="id" />
-        <TextField source="first_name" />
-        <TextField source="last_name" />
-        <DateField source="dob" label="born" />
-        <SelectField source="sex" choices={sexChoices} />
-        {/* Using a component as label is a trick to render it in the Datagrid header */}
-        <DatagridActionsColumn label={createButton}>
+      <DataTable>
+        <DataTable.Col source="id" />
+        <DataTable.Col source="first_name" />
+        <DataTable.Col source="last_name" />
+        <DataTable.Col source="dob" label="born" field={DateField} />
+        <DataTable.Col source="sex">
+          <SelectField source="sex" choices={sexChoices} />
+        </DataTable.Col>
+        {/* Using a component as label is a trick to render it in the DataTable header */}
+        <DataTableActionsColumn label={createButton}>
           {editButton}
           {showButton}
-        </DatagridActionsColumn>
-      </Datagrid>
+        </DataTableActionsColumn>
+      </DataTable>
     </ReferenceManyField>
   );
 };
@@ -424,7 +426,7 @@ const EmployerEdit = () => (
       <TextInput source="name" validate={required()} />
       <TextInput source="address" validate={required()} />
       <TextInput source="city" validate={required()} />
-      <NestedCustomersDatagrid />
+      <NestedCustomersDataTable />
     </SimpleForm>
   </Edit>
 );

--- a/docs/CustomRoutes.md
+++ b/docs/CustomRoutes.md
@@ -281,17 +281,17 @@ const App = () => (
 
 // in src/BookList.jss
 import { useParams } from 'react-router-dom';
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 
 const BookList = () => {
     const { authorId } = useParams();
     return (
         <List resource="books" filter={{ authorId }}>
-            <Datagrid>
-                <TextField source="id" />
-                <TextField source="title" />
-                <TextField source="year" />
-            </Datagrid>
+            <DataTable>
+                <DataTable.Col source="id" />
+                <DataTable.Col source="title" />
+                <DataTable.Col source="year" />
+            </DataTable>
         </List>
     );
 };

--- a/docs/DataProviders.md
+++ b/docs/DataProviders.md
@@ -364,13 +364,15 @@ For example, this allows you to display data from a related resource without mak
 const PostList = () => (
 -   <List>
 +   <List queryOptions={{ meta: { embed: ["author"] } }}>
-        <Datagrid>
-            <TextField source="title" />
--           <ReferenceField source="author_id" reference="authors>
--               <TextField source="name" />
--           </ReferenceField>
-+           <TextField source="author.name" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+-           <DataTable.Col source="author_id">
+-               <ReferenceField source="author_id" reference="authors>
+-                   <TextField source="name" />
+-               </ReferenceField>
+-           </DataTable.Col>
++           <DataTable.Col source="author.name" />
+        </DataTable>
     </List>
 );
 ```
@@ -415,11 +417,13 @@ For example, you can use prefetching to display the author's name in a post list
 ```jsx
 const PostList = () => (
     <List queryOptions={{ meta: { prefetch: ['author'] }}}>
-        <Datagrid>
-            <TextField source="title" />
-            {/** renders without an additional request */}
-            <ReferenceField source="author_id" reference="authors" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author_id">
+                {/** renders without an additional request */}
+                <ReferenceField source="author_id" reference="authors" />
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```

--- a/docs/DateField.md
+++ b/docs/DateField.md
@@ -14,16 +14,16 @@ Displays a date, datetime or time using the browser locale (thanks to `Date.toLo
 In a List or a Show view, use `<DateField>` as any other field component to render a date value:
 
 ```jsx
-import { List, Datagrid, TextField, DateField } from 'react-admin';
+import { List, DataTable, DateField } from 'react-admin';
 
 export const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="published_at" />
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="published_at" field={DateField} />
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 )
 ```

--- a/docs/DateRangeInput.md
+++ b/docs/DateRangeInput.md
@@ -160,7 +160,7 @@ Here is an example:
 
 ```tsx
 import { DateRangeInput } from '@react-admin/ra-form-layout/DateRangeInput';
-import { List, Datagrid, NumberField, TextField, DateField } from 'react-admin';
+import { List, DataTable, DateField } from 'react-admin';
 import { endOfDay } from 'date-fns';
 
 const dateRangeFilterParse = (dates: (Date | null)[]) => {
@@ -177,11 +177,11 @@ const eventsFilters = [
 
 export const EventsList = () => (
     <List filters={eventsFilters}>
-        <Datagrid>
-            <NumberField source="id" />
-            <TextField source="name" />
-            <DateField source="date" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.NumberCol source="id" />
+            <DataTable.Col source="name" />
+            <DataTable.Col source="date" field={DateField} />
+        </DataTable>
     </List>
 );
 ```

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -19,7 +19,7 @@ For instance, the following component will render an edition form for posts when
 
 ```jsx
 // in src/posts.js
-import { Edit, SimpleForm, TextInput, DateInput, ReferenceManyField, Datagrid, TextField, DateField, EditButton, required } from 'react-admin';
+import { Edit, SimpleForm, TextInput, DateInput, ReferenceManyField, DataTable, DateField, EditButton, required } from 'react-admin';
 import RichTextInput from 'ra-input-rich-text';
 
 export const PostEdit = () => (
@@ -31,11 +31,13 @@ export const PostEdit = () => (
             <RichTextInput source="body" validate={required()} />
             <DateInput label="Publication date" source="published_at" />
             <ReferenceManyField label="Comments" reference="comments" target="post_id">
-                <Datagrid>
-                    <TextField source="body" />
-                    <DateField source="created_at" />
-                    <EditButton />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="body" />
+                    <DataTable.Col source="created_at" field={DateField} />
+                    <DataTable.Col>
+                        <EditButton />
+                    </DataTable.Col>
+                </DataTable>
             </ReferenceManyField>
         </SimpleForm>
     </Edit>
@@ -798,7 +800,7 @@ That means that if you want to create a link to an edition view, modifying immed
 {% raw %}
 ```jsx
 import * as React from 'react';
-import { EditButton, Datagrid, List } from 'react-admin';
+import { EditButton, DataTable, List } from 'react-admin';
 
 const ApproveButton = () => {
     return (
@@ -810,10 +812,12 @@ const ApproveButton = () => {
 
 export default PostList = () => (
     <List>
-        <Datagrid>
+        <DataTable>
             ...
-            <ApproveButton />
-        </Datagrid>
+            <DataTable.Col>
+                <ApproveButton />
+            </DataTable.Col>
+        </DataTable>
     </List>
 )
 ```

--- a/docs/EditDialog.md
+++ b/docs/EditDialog.md
@@ -29,7 +29,7 @@ Then, add the `<EditDialog>` component as a sibling to a `<List>` component.
 ```jsx
 import {
     List,
-    Datagrid,
+    DataTable,
     SimpleForm,
     TextField,
     TextInput,
@@ -42,9 +42,9 @@ import { EditDialog } from '@react-admin/ra-form-layout';
 const CustomerList = () => (
     <>
         <List>
-            <Datagrid rowClick="edit">
+            <DataTable rowClick="edit">
                 ...
-            </Datagrid>
+            </DataTable>
         </List>
         <EditDialog>
             <SimpleForm>
@@ -246,7 +246,7 @@ import React from 'react';
 import {
     List,
     ListActions,
-    Datagrid,
+    DataTable,
     SimpleForm,
     TextInput,
     DateInput,
@@ -267,9 +267,9 @@ const CustomerEditTitle = () => {
 const CustomerList = () => (
     <>
         <List actions={<ListActions hasCreate />}>
-            <Datagrid rowClick="edit">
+            <DataTable rowClick="edit">
                 ...
-            </Datagrid>
+            </DataTable>
         </List>
         <EditDialog title={<CustomerEditTitle />}>
             <SimpleForm>
@@ -337,7 +337,7 @@ export const UserEdit = () => {
 
 ## Usage Without Routing
 
-By default, `<EditDialog>` creates a react-router `<Route>` for the edition path (e.g. `/posts/2`), and renders when users go to that location (either by clicking on a datagrid row, or by typing the URL in the browser). If you embed it in the `list` page as explained above, the dialog will always render on top of the list. 
+By default, `<EditDialog>` creates a react-router `<Route>` for the edition path (e.g. `/posts/2`), and renders when users go to that location (either by clicking on a datatable row, or by typing the URL in the browser). If you embed it in the `list` page as explained above, the dialog will always render on top of the list.
 
 This may not be what you want if you need to display the edit dialog in another page (e.g. to edit a related record).
 
@@ -352,7 +352,7 @@ Put `<EditInDialogButton>` wherever you would put an `<EditButton>`, and use the
 
 ```jsx
 import {
-  Datagrid,
+  DataTable,
   ReferenceManyField,
   Show,
   SimpleForm,
@@ -369,16 +369,18 @@ const CompanyShow = () => (
             <TextField source="address" />
             <TextField source="city" />
             <ReferenceManyField target="company_id" reference="employees">
-                <Datagrid>
-                    <TextField source="first_name" />
-                    <TextField source="last_name" />
-                    <EditInDialogButton>
-                        <SimpleForm>
-                            <TextInput source="first_name" />
-                            <TextInput source="last_name" />
-                        </SimpleForm>
-                    </EditInDialogButton>
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="first_name" />
+                    <DataTable.Col source="last_name" />
+                    <DataTable.Col>
+                        <EditInDialogButton>
+                            <SimpleForm>
+                                <TextInput source="first_name" />
+                                <TextInput source="last_name" />
+                            </SimpleForm>
+                        </EditInDialogButton>
+                    </DataTable.Col>
+                </DataTable>
             </ReferenceManyField>
         </SimpleShowLayout>
     </Show>
@@ -412,7 +414,7 @@ Below is an example of an `<Edit>` page, including a 'create a new customer' but
 import React, { useCallback, useState } from 'react';
 import {
     Button,
-    Datagrid,
+    DataTable,
     DateField,
     DateInput,
     Edit,
@@ -421,7 +423,6 @@ import {
     SelectField,
     SelectInput,
     SimpleForm,
-    TextField,
     TextInput,
     useRecordContext,
 } from 'react-admin';
@@ -462,20 +463,24 @@ const EmployerSimpleFormWithFullyControlledDialogs = () => {
                 reference="customers"
                 target="employer_id"
             >
-                <Datagrid>
-                    <TextField source="id" />
-                    <TextField source="first_name" />
-                    <TextField source="last_name" />
-                    <DateField source="dob" label="born" />
-                    <SelectField source="sex" choices={sexChoices} />
-                    <Button
-                        label="Edit customer"
-                        onClick={() => openEditDialog()}
-                        size="medium"
-                        variant="contained"
-                        sx={{ mb: 4 }}
-                    />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col source="first_name" />
+                    <DataTable.Col source="last_name" />
+                    <DataTable.Col source="dob" label="born" field={DateField} />
+                    <DataTable.Col source="sex">
+                        <SelectField source="sex" choices={sexChoices} />
+                    </DataTable.Col>
+                    <DataTable.Col>
+                        <Button
+                            label="Edit customer"
+                            onClick={() => openEditDialog()}
+                            size="medium"
+                            variant="contained"
+                            sx={{ mb: 4 }}
+                        />
+                    <DataTable.Col>
+                </DataTable>
             </ReferenceManyField>
             <EditDialog
                 fullWidth
@@ -512,7 +517,7 @@ import React from 'react';
 import {
     List,
     ListActions,
-    Datagrid,
+    DataTable,
     SimpleForm,
 } from 'react-admin';
 import { EditDialog } from '@react-admin/ra-form-layout';
@@ -520,9 +525,9 @@ import { EditDialog } from '@react-admin/ra-form-layout';
 const CustomerList = () => (
     <>
         <List actions={<ListActions hasCreate />}>
-            <Datagrid rowClick="edit">
+            <DataTable rowClick="edit">
                 ...
-            </Datagrid>
+            </DataTable>
         </List>
         <EditDialog>
             <SimpleForm warnWhenUnsavedChanges>

--- a/docs/EditInDialogButton.md
+++ b/docs/EditInDialogButton.md
@@ -12,7 +12,7 @@ This [Enterprise Edition](https://react-admin-ee.marmelab.com)<img class="icon" 
   Your browser does not support the video tag.
 </video>
 
-It can be useful in case you want the ability to edit a record linked by a reference to the currently edited record, or if you have a nested `<Datagrid>` inside a `<Show>` or an `<Edit>` view. 
+It can be useful in case you want the ability to edit a record linked by a reference to the currently edited record, or if you have a nested `<DataTable>` inside a `<Show>` or an `<Edit>` view. 
 
 Note that this component doesn't use routing, so it doesn't change the URL. It's therefore not possible to bookmark the edit dialog, or to link to it from another page. If you need that functionality, use [`<EditDialog>`](./EditDialog.md) instead.
 
@@ -32,7 +32,7 @@ Then, put `<EditInDialogButton>` wherever you would put an `<EditButton>`, and u
 
 ```jsx
 import {
-  Datagrid,
+  DataTable,
   ReferenceManyField,
   Show,
   SimpleForm,
@@ -49,16 +49,18 @@ const CompanyShow = () => (
             <TextField source="address" />
             <TextField source="city" />
             <ReferenceManyField target="company_id" reference="employees">
-                <Datagrid>
-                    <TextField source="first_name" />
-                    <TextField source="last_name" />
-                    <EditInDialogButton>
-                        <SimpleForm>
-                            <TextInput source="first_name" />
-                            <TextInput source="last_name" />
-                        </SimpleForm>
-                    </EditInDialogButton>
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="first_name" />
+                    <DataTable.Col source="last_name" />
+                    <DataTable.Col>
+                      <EditInDialogButton>
+                          <SimpleForm>
+                              <TextInput source="first_name" />
+                              <TextInput source="last_name" />
+                          </SimpleForm>
+                      </EditInDialogButton>
+                    </DataTable.Col>
+                </DataTable>
             </ReferenceManyField>
         </SimpleForm>
     </Show>
@@ -381,15 +383,17 @@ const EmployerEdit = () => (
         <SimpleForm>
             ...
             <ReferenceManyField target="employer_id" reference="customers">
-                <Datagrid>
+                <DataTable>
                     ...
-                    <EditInDialogButton fullWidth maxWidth="sm">
-                        <SimpleForm toolbar={<CustomToolbar />}>
-                            <TextInput source="first_name" />
-                            <TextInput source="last_name" />
-                        </SimpleForm>
-                    </EditInDialogButton>
-                </Datagrid>
+                    <DataTable.Col>
+                        <EditInDialogButton fullWidth maxWidth="sm">
+                            <SimpleForm toolbar={<CustomToolbar />}>
+                                <TextInput source="first_name" />
+                                <TextInput source="last_name" />
+                            </SimpleForm>
+                        </EditInDialogButton>
+                    </DataTable.Col>
+                </DataTable>
             </ReferenceManyField>
         </SimpleForm>
     </Edit>
@@ -424,13 +428,13 @@ const EmployerEditButton = () => (
 
 ## Combining With `<CreateInDialogButton>`
 
-Below is an example of an `<Edit>` view, inside which is a nested `<Datagrid>`, offering the ability to **create**, **edit** and **show** the rows thanks to [`<CreateInDialogButton>`](./CreateInDialogButton.md), `<EditInDialogButton>` and [`<ShowInDialogButton>`](./ShowInDialogButton.md):
+Below is an example of an `<Edit>` view, inside which is a nested `<DataTable>`, offering the ability to **create**, **edit** and **show** the rows thanks to [`<CreateInDialogButton>`](./CreateInDialogButton.md), `<EditInDialogButton>` and [`<ShowInDialogButton>`](./ShowInDialogButton.md):
 
 {% raw %}
 
 ```jsx
 import {
-  Datagrid,
+  DataTable,
   DateField,
   DateInput,
   Edit,
@@ -474,10 +478,10 @@ const CustomerLayout = () => (
 );
 
 // helper component to add actions buttons in a column (children),
-// and also in the header (label) of a Datagrid
-const DatagridActionsColumn = ({ label, children }) => <>{children}</>;
+// and also in the header (label) of a DataTable
+const DataTableActionsColumn = ({ label, children }) => <DataTable.Col label={label}>{children}</DataTable.Col>;
 
-const NestedCustomersDatagrid = () => {
+const NestedCustomersDataTable = () => {
   const record = useRecordContext();
 
   const createButton = (
@@ -509,18 +513,20 @@ const NestedCustomersDatagrid = () => {
       reference="customers"
       target="employer_id"
     >
-      <Datagrid>
-        <TextField source="id" />
-        <TextField source="first_name" />
-        <TextField source="last_name" />
-        <DateField source="dob" label="born" />
-        <SelectField source="sex" choices={sexChoices} />
-        {/* Using a component as label is a trick to render it in the Datagrid header */}
-        <DatagridActionsColumn label={createButton}>
+      <DataTable>
+        <DataTable.Col source="id" />
+        <DataTable.Col source="first_name" />
+        <DataTable.Col source="last_name" />
+        <DataTable.Col source="dob" label="born" field={DateField} />
+        <DataTable.Col source="sex">
+          <SelectField source="sex" choices={sexChoices} />
+        </DataTable.Col>
+        {/* Using a component as label is a trick to render it in the DataTable header */}
+        <DataTableActionsColumn label={createButton}>
           {editButton}
           {showButton}
-        </DatagridActionsColumn>
-      </Datagrid>
+        </DataTableActionsColumn>
+      </DataTable>
     </ReferenceManyField>
   );
 };
@@ -531,7 +537,7 @@ const EmployerEdit = () => (
       <TextInput source="name" validate={required()} />
       <TextInput source="address" validate={required()} />
       <TextInput source="city" validate={required()} />
-      <NestedCustomersDatagrid />
+      <NestedCustomersDataTable />
     </SimpleForm>
   </Edit>
 );

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -157,12 +157,14 @@ For instance, `<ReferenceField>` displays the name of a related record, like the
 ```jsx
 const BookList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <ReferenceField source="author_id" reference="authors" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author_id">
+                <ReferenceField source="author_id" reference="authors" />
+            </DataTable.Col>
+            <DataTable.Col source="year" />
+        </DataTable>
     </List>
 );
 ```
@@ -212,12 +214,14 @@ const BookList = () => (
     <List filters={[
         <ReferenceInput source="authorId" reference="authors" alwaysOn />,
     ]}>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <ReferenceField source="authorId" reference="authors" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="authorId">
+                <ReferenceField source="authorId" reference="authors" />
+            </DataTable.Col>
+            <DataTable.Col source="year" />
+        </DataTable>
     </List>
 );
 ```
@@ -515,7 +519,7 @@ Users often apply the same filters over and over again. Saved Queries **let user
 Here is an example `<FilterList>` sidebar with saved queries:
 
 ```jsx
-import { FilterList, FilterListItem, List, Datagrid } from 'react-admin';
+import { FilterList, FilterListItem, List, DataTable } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
 
 import { SavedQueriesList } from 'react-admin';
@@ -536,9 +540,9 @@ const SongFilterSidebar = () => (
 
 const SongList = () => (
     <List aside={<SongFilterSidebar />}>
-        <Datagrid>
+        <DataTable>
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -570,8 +574,7 @@ For instance, here is how to build a tabbed form for editing a blog post:
 import {
     TabbedForm,
     Edit,
-    Datagrid,
-    TextField,
+    DataTable,
     DateField,
     TextInput,
     ReferenceManyField,
@@ -601,11 +604,13 @@ export const PostEdit = () => (
             </TabbedForm.Tab>
             <TabbedForm.Tab label="comments">
                 <ReferenceManyField reference="comments" target="post_id" label={false}>
-                    <Datagrid>
-                        <TextField source="body" />
-                        <DateField source="created_at" />
-                        <EditButton />
-                    </Datagrid>
+                    <DataTable>
+                        <DataTable.Col source="body" />
+                        <DataTable.Col source="created_at" field={DateField} />
+                        <DataTable.Col>
+                            <EditButton />
+                        </DataTable.Col>
+                    </DataTable>
                 </ReferenceManyField>
             </TabbedForm.Tab>
         </TabbedForm>
@@ -1198,20 +1203,18 @@ For instance, include a `<ListLiveUpdate>` within a `<List>` to have a list refr
 ```diff
 import {
     List,
-    Datagrid,
-    TextField,
-    NumberField,
+    DataTable,
     Datefield,
 } from 'react-admin';
 +import { ListLiveUpdate } from '@react-admin/ra-realtime';
 
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <NumberField source="views" />
-            <DateField source="published_at" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.NumberCol source="views" />
+            <DataTable.Col source="published_at" field={DateField} />
+        </DataTable>
 +       <ListLiveUpdate />
     </List>
 );
@@ -1338,7 +1341,7 @@ For instance, the Saved Queries feature lets users **save a combination of filte
 Saved queries persist between sessions, so users can find their custom queries even after closing and reopening the admin. Saved queries are available both for the Filter Button/Form combo and for the `<FilterList>` Sidebar. It's enabled by default for the Filter Button/Form combo, but you have to add it yourself in the `<FilterList>` Sidebar.
 
 ```diff
-import { FilterList, FilterListItem, List, Datagrid } from 'react-admin';
+import { FilterList, FilterListItem, List, DataTable } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
 
 +import { SavedQueriesList } from 'react-admin';
@@ -1359,9 +1362,9 @@ const SongFilterSidebar = () => (
 
 const SongList = () => (
     <List aside={<SongFilterSidebar />}>
-        <Datagrid>
+        <DataTable>
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -1459,19 +1462,18 @@ Theming is so powerful that you can even use react-admin to build a [Music Playe
 
 ![Music Player](./img/navidrome.png)
 
-Use the `sx` prop on almost every react-admin component to override its default style - and the style of its descendants. For instance, here is how to change the width of Datagrid columns:
+Use the `sx` prop on almost every react-admin component to override its default style - and the style of its descendants. For instance, here is how to change the width of DataTable columns:
 
 {% raw %}
 
 ```jsx
 import {
     BooleanField,
-    Datagrid,
+    DataTable,
     DateField,
     EditButton,
     List,
     NumberField,
-    TextField,
     ShowButton,
 } from 'react-admin';
 import Icon from '@mui/icons-material/Person';
@@ -1480,22 +1482,28 @@ export const VisitorIcon = Icon;
 
 export const PostList = () => (
     <List>
-        <Datagrid
+        <DataTable
             sx={{
                 backgroundColor: "Lavender",
-                "& .RaDatagrid-headerCell": {
+                "& .RaDataTable-headerCell": {
                     backgroundColor: "MistyRose",
                 },
             }}
         >
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="published_at" sortByOrder="DESC" />
-            <BooleanField source="commentable" sortable={false} />
-            <NumberField source="views" sortByOrder="DESC" />
-            <EditButton />
-            <ShowButton />
-        </Datagrid>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col label="Published at">
+                <DateField source="published_at" sortByOrder="DESC" />
+            </DataTable.Col>
+            <DataTable.Col label="Commentable">
+                <BooleanField source="commentable" sortable={false} />
+            </DataTable.Col>
+            <DataTable.Col label="Views">
+                <NumberField source="views" sortByOrder="DESC" />
+            </DataTable.Col>
+            <DataTable.Col EditButton />
+            <DataTable.Col ShowButton />
+        </DataTable>
     </List>
 );
 ```
@@ -1535,11 +1543,11 @@ const theme = {
     ...defaultTheme,
     components: {
         ...defaultTheme.components,
-        RaDatagrid: {
+        RaDataTable: {
             styleOverrides: {
               root: {
                   backgroundColor: "Lavender",
-                  "& .RaDatagrid-headerCell": {
+                  "& .RaDataTable-headerCell": {
                       backgroundColor: "MistyRose",
                   },
               }
@@ -1678,12 +1686,12 @@ For a given component, the `sx` prop lets you customize its style based on the s
 
 {% endraw %}
 
-To make a component responsive, you can also render it conditionally based on the screen size. For instance, to render a `<SimpleList>` on desktop and a `<Datagrid>` on mobile:
+To make a component responsive, you can also render it conditionally based on the screen size. For instance, to render a `<SimpleList>` on desktop and a `<DataTable>` on mobile:
 
 ```jsx
 import * as React from 'react';
 import { useMediaQuery } from '@mui/material';
-import { List, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'react-admin';
+import { List, SimpleList, DataTable, TextField, ReferenceField, EditButton } from 'react-admin';
 
 export const PostList = () => {
     const isSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
@@ -1696,15 +1704,19 @@ export const PostList = () => {
                     tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
                 />
             ) : (
-                <Datagrid>
-                    <TextField source="id" />
-                    <ReferenceField label="User" source="userId" reference="users">
-                        <TextField source="name" />
-                    </ReferenceField>
-                    <TextField source="title" />
-                    <TextField source="body" />
-                    <EditButton />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col label="User">
+                        <ReferenceField source="userId" reference="users">
+                            <TextField source="name" />
+                        </ReferenceField>
+                    </DataTable.Col>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="body" />
+                    <DataTable.Col>
+                        <EditButton />
+                    </DataTable.Col>
+                </DataTable>
             )}
         </List>
     );

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -22,7 +22,7 @@ const PurpleTextField = ({ source }) => {
 ```
 {% endraw %}
 
-**Tip**: Every time it renders a record, react-admin creates a `RecordContext`. This includes datagrid rows, simple list items, reference fields, show, and edit pages. You can even create a `RecordContext` yourself and use react-admin Fields in custom pages.
+**Tip**: Every time it renders a record, react-admin creates a `RecordContext`. This includes datatable rows, simple list items, reference fields, show, and edit pages. You can even create a `RecordContext` yourself and use react-admin Fields in custom pages.
 
 React-admin Field components also accept a `record` prop. This allows you to use them outside a `RecordContext`, or to use another `record` than the one in the current context.
 
@@ -79,7 +79,7 @@ Will render
 </Typography>
 ```
 
-Field components are generally used in List and Show views, as children of `<Datagrid>`, `<SimpleShowLayout>`, and `<TabbedShowLayout>`. The parent component usually reads their `source` and/or `label` prop to add a title.
+Field components are generally used in List and Show views, as children of `<DataTable>`, `<SimpleShowLayout>`, and `<TabbedShowLayout>`. The parent component usually reads their `source` and/or `label` prop to add a title.
 
 ```jsx
 // in src/posts.js
@@ -122,7 +122,7 @@ All Field components accept the following props:
 | Prop                          | Required | Type                           | Default  | Description                                                                                                                                             |
 |-------------------------------| -------- |--------------------------------| -------- |---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [`source`](#source)           | Required | `string`                       | -        | Name of the property to display                                                                                                                         |
-| [`label`](#label)             | Optional | `string` &#124; `ReactElement` | `source` | Used as a Datagrid column header or in a Show layout                                                                                                    |
+| [`label`](#label)             | Optional | `string` &#124; `ReactElement` | `source` | Used as a DataTable column header or in a Show layout                                                                                                    |
 | [`record`](#record)           | Optional | `Object`                       | -        | Object containing the properties to display, to override the record from the current `RecordContext`                                                    |
 | [`sortable`](#sortable)       | Optional | `boolean`                      | `true`   | When used in a `List`, should the list be sortable using the `source` attribute? Setting it to `false` disables the click handler on the column header. |
 | [`sortBy`](#sortby)           | Optional | `string`                       | `source` | When used in a `List`, specifies the actual `source` to be used for sorting when the user clicks the column header                                      |
@@ -137,7 +137,7 @@ All Field components accept the following props:
 CSS class name passed to the root component. 
 
 ```jsx
-<TextField source="title" className="number" />
+<DataTable.Col source="title" className="number" />
 ```
 
 **Note**: To customize field styles, prefer [the `sx` prop](#sx).
@@ -149,27 +149,27 @@ By default, a Field renders an empty string when the record has no value for tha
 ```jsx
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <TextField source="author" emptyText="missing data" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" emptyText="missing data" />
+        </DataTable>
     </List>
 );
 ```
 
 ## `label`
 
-By default, a Field doesn't render any label - just the value. But when rendering several fields on the same screen, it's necessary to label them. That's why components like `<SimpleShowLayout>` and `<Datagrid>` read the field `source`, and use a humanized version as the label (e.g. `source="title"` gives the label `Title`). 
+By default, a Field doesn't render any label - just the value. But when rendering several fields on the same screen, it's necessary to label them. That's why components like `<SimpleShowLayout>` and `<DataTable>` read the field `source`, and use a humanized version as the label (e.g. `source="title"` gives the label `Title`). 
 
-You can customize this automated label by specifying a `label` prop. `<SimpleShowLayout>` and `<Datagrid>` will then use the `label` prop instead of the `source` prop to label the field.
+You can customize this automated label by specifying a `label` prop. `<SimpleShowLayout>` and `<DataTable>` will then use the `label` prop instead of the `source` prop to label the field.
 
 ```jsx
 // label can be a string
-<TextField source="author.name" label="Author" />
+<DataTable.Col source="author.name" label="Author" />
 // the label is automatically translated, so you can use translation identifiers
-<TextField source="author.name" label="ra.field.author" />
+<DataTable.Col source="author.name" label="ra.field.author" />
 // you can also use a React element
-<TextField source="author.name" label={<FieldTitle label="Author" />} />
+<DataTable.Col source="author.name" label={<FieldTitle label="Author" />} />
 ```
 
 **Tip**: If your admin has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./TranslationTranslating.md#translating-resource-and-field-names) for details.
@@ -181,7 +181,7 @@ You can customize this automated label by specifying a `label` prop. `<SimpleSho
 <TextField source="author.name" label={false} />
 ```
 
-**Note**: This prop has no effect when rendering a field outside a `<Datagrid>`, a `<SimpleShowLayout>`, a `<TabbedShowLayout>`, a `<SimpleForm>`, or a `<TabbedForm>`.
+**Note**: This prop has no effect when rendering a field outside a `<DataTable>`, a `<SimpleShowLayout>`, a `<TabbedShowLayout>`, a `<SimpleForm>`, or a `<TabbedForm>`.
 
 ## `record`
 
@@ -195,69 +195,75 @@ By default, fields use the `record` from the `RecordContext`. But you can overri
 
 ## `sortable`
 
-In a `<Datagrid>`, users can change the sort field and order by clicking on the column headers. You may want to disable this behavior for a given field (e.g. for reference or computed fields). In that case, pass the `sortable` prop to `<Field>` with a `false` value.
+In a `<DataTable>`, users can change the sort field and order by clicking on the column headers. You may want to disable this behavior for a given field (e.g. for reference or computed fields). In that case, pass the `sortable` prop to `<Field>` with a `false` value.
 
 ```jsx
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <ReferenceField source="author_id" sortable={false}>
-                <TextField source="name" />
-            </ReferenceField>
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col label="Author">
+                <ReferenceField source="author_id" sortable={false}>
+                    <TextField source="name" />
+                </ReferenceField>
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
 
-**Note**: This prop has no effect when rendering a field outside a `<Datagrid>`.
+**Note**: This prop has no effect when rendering a field outside a `<DataTable>`.
 
 ## `sortBy`
 
-In a `<Datagrid>`, users can change the sort field and order by clicking on the column headers. `<Datagrid>` uses the Field `source`to determine the sort field (e.g. clicking on the column header for the `<TextField source="title" />` field sorts the list according to the `title` field).
+In a `<DataTable>`, users can change the sort field and order by clicking on the column headers. `<DataTable>` uses the Field `source`to determine the sort field (e.g. clicking on the column header for the `<TextField source="title" />` field sorts the list according to the `title` field).
 
 You may want to use a different sort field than the `source`, e.g. for Reference fields. In that case, use the `sortBy` prop to specify the sort field.
 
 ```jsx
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <ReferenceField source="author_id" sortBy="author.name">
-                <TextField source="name" />
-            </ReferenceField>
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col label="Author">
+                <ReferenceField source="author_id" sortBy="author.name">
+                    <TextField source="name" />
+                </ReferenceField>
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
 
-**Note**: This prop has no effect when rendering a field outside a `<Datagrid>`.
+**Note**: This prop has no effect when rendering a field outside a `<DataTable>`.
 
 ## `sortByOrder`
 
-By default, when users click on a `<Datagrid>` column header, react-admin reorders the list using the field source, *with an ascending order*. For some fields, it brings unexpected results. For instance, when clicking on a "Last seen at" header, users probably expect to see the users seen more recently. 
+By default, when users click on a `<DataTable>` column header, react-admin reorders the list using the field source, *with an ascending order*. For some fields, it brings unexpected results. For instance, when clicking on a "Last seen at" header, users probably expect to see the users seen more recently. 
 
 You can change the default sort field order by using the `sortByOrder` prop.
 
 ```jsx
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <DateField source="updated_at" sortByOrder="DESC" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col label="Updated at">
+                <DateField source="updated_at" sortByOrder="DESC" />
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
 
-**Note**: This prop has no effect when rendering a field outside a `<Datagrid>`.
+**Note**: This prop has no effect when rendering a field outside a `<DataTable>`.
 
 ## `source`
 
 The name of the property to display. Can contain dots for accessing properties of nested objects. 
 
 ```jsx
-<TextField source="author.first_name" />
+<DataTable.Col source="author.first_name" />
 ```
 
 ## `sx`
@@ -266,15 +272,17 @@ Like all react-admin components, you can customize the style of Field components
 
 {% raw %}
 ```jsx
-import { List, Datagrid, WrapperField, TextField } from 'react-admin';
+import { List, DataTable, WrapperField } from 'react-admin';
 
 const UserList = () => (
     <List>
-        <Datagrid>
-            <ImageField source="avatar" sx={{ my: -2 }}/>
-            <TextField source="username" sx={{ color: 'lightgrey' }} />
-            <TextField source="email" sx={{ textOverflow: 'ellipsis' }} />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col label="Avatar">
+                <ImageField source="avatar" sx={{ my: -2 }}/>
+            </DataTable.Col>
+            <DataTable.Col source="username" sx={{ color: 'lightgrey' }} />
+            <DataTable.Col source="email" sx={{ textOverflow: 'ellipsis' }} />
+        </>
     </List>
 );
 ```
@@ -286,19 +294,21 @@ And see [the Material UI system documentation](https://mui.com/system/the-sx-pro
 
 ## `textAlign`
 
-This prop defines the text alignment of the field when rendered inside a `<Datagrid>` cell. By default, datagrid values are left-aligned ; for numeric values, it's often better to right-align them. Set `textAlign` to `right` for that.
+This prop defines the text alignment of the field when rendered inside a `<DataTable>` cell. By default, datatable values are left-aligned ; for numeric values, it's often better to right-align them. Set `textAlign` to `right` for that.
 
 ```jsx
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable, TextField } from 'react-admin';
 
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" textAlign="right" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col label="Year">
+                <TextField source="year" textAlign="right" />
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
@@ -335,16 +345,16 @@ const { data } = useGetOne('posts', { id: 123, meta: { embed: ['author'] } });
 
 <iframe src="https://www.youtube-nocookie.com/embed/fWc7c0URQMQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="aspect-ratio: 16 / 9;width:100%;margin-bottom:1em;"></iframe>
 
-React-admin Field layout components like [`<Datagrid>`](./Datagrid.md) and [`<SimpleShowLayout>`](./SimpleShowLayout.md) inspect their children and use their `label` prop to set the table headers or the field labels.
+React-admin Field layout components like [`<DataTable>`](./DataTable.md) and [`<SimpleShowLayout>`](./SimpleShowLayout.md) inspect their children and use their `label` prop to set the table headers or the field labels.
 
 So inside these components, you can provide a `label` prop to override the default label.
 
 ```jsx
 const BookList = () => (
    <List>
-       <Datagrid>
-            <TextField source="title" label="Post title" />
-      </Datagrid>
+       <DataTable>
+            <DataTable.Col source="title" label="Post title" />
+      </DataTable>
   </List>
 );
 ```
@@ -354,9 +364,9 @@ The label uses [the i18n layer](./Translation.md), so you can use a translation 
 ```jsx
 const BookList = () => (
    <List>
-       <Datagrid>
-            <TextField source="title" label="post.title" />
-      </Datagrid>
+       <DataTable>
+            <DataTable.Col source="title" label="post.title" />
+      </DataTable>
   </List>
 );
 ```
@@ -379,7 +389,7 @@ const BookEdit = () => (
 
 ## Hiding The Field Label
 
-React-admin Field layout components like [`<Datagrid>`](./Datagrid.md) and [`<SimpleShowLayout>`](./SimpleShowLayout.md) inspect their children and use their `source` prop to set the table headers or the field labels. To opt out of this behavior, pass `false` to the `label` prop.
+React-admin Field layout components like [`<DataTable>`](./DataTable.md) and [`<SimpleShowLayout>`](./SimpleShowLayout.md) inspect their children and use their `source` prop to set the table headers or the field labels. To opt out of this behavior, pass `false` to the `label` prop.
 
 ```jsx
 // No label will be added in SimpleShowLayout

--- a/docs/FieldsForRelationships.md
+++ b/docs/FieldsForRelationships.md
@@ -119,17 +119,17 @@ const AuthorShow = () => (
             <TextField source="last_name" />
             <DateField source="date_of_birth" />
             <ArrayField source="books">
-                <Datagrid>
-                    <TextField source="title" />
-                    <DateField source="published_at" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="published_at" field={DateField} />
+                </DataTable>
             </ArrayField>
         </SimpleShowLayout>
     </Show>
 );
 ```
 
-`<ArrayField>` creates a `ListContext` with the embedded records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+`<ArrayField>` creates a `ListContext` with the embedded records, so you can use any component relying on this context (`<DataTable>`, `<SimpleList>`, etc.).
 
 ## `<ReferenceField>`
 
@@ -176,16 +176,20 @@ This is fine, but what if you need to display the author details for a list of b
 ```jsx
 const BookList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <DateField source="published_at" />
-            <ReferenceField label="Author" source="author_id" reference="authors">
-                <FunctionField render={record => `${record.first_name} ${record.last_name}`} />
-            </ReferenceField>
-            <ReferenceField label="Author DOB" source="author_id" reference="authors">
-                <DateField source="date_of_birth" />
-            </ReferenceField>
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col source="published_at" field={DateField} />
+            <DataTable.Col label="Author">
+                <ReferenceField source="author_id" reference="authors">
+                    <FunctionField render={record => `${record.first_name} ${record.last_name}`} />
+                </ReferenceField>
+            </DataTable.Col>
+            <DataTable.Col label="Author DOB">
+                <ReferenceField source="author_id" reference="authors">
+                    <DateField source="date_of_birth" />
+                </ReferenceField>
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
@@ -219,10 +223,10 @@ const AuthorShow = () => (
             <TextField source="last_name" />
             <DateField source="date_of_birth" />
             <ReferenceManyField reference="books" target="author_id">
-                <Datagrid>
-                    <TextField source="title" />
-                    <DateField source="published_at" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="published_at" field={DateField} />
+                </DataTable>
             </ReferenceManyField>
         </SimpleShowLayout>
     </Show>
@@ -231,7 +235,7 @@ const AuthorShow = () => (
 
 `<ReferenceManyField>` uses the current `record` (an author in this example) to build a filter for the list of books on the foreign key field (`author_id`). Then, it uses `dataProvider.getManyReference('books', { target: 'author_id', id: book.id })` fetch the related books.
 
-`<ReferenceManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+`<ReferenceManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<DataTable>`, `<SimpleList>`, etc.).
 
 **Tip**: For many APIs, there is no difference between `dataProvider.getList()` and `dataProvider.getManyReference()`. The latter is a specialized version of the former, with a predefined `filter`. But some APIs expose related records as a sub-route, and therefore need a special method to fetch them. For instance, the books of an author can be exposed via the following endpoint: 
 
@@ -267,10 +271,10 @@ const AuthorShow = () => (
             <TextField source="last_name" />
             <DateField source="date_of_birth" />
             <ReferenceArrayField reference="books" source="book_ids">
-                <Datagrid>
-                    <TextField source="title" />
-                    <DateField source="published_at" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="published_at" field={DateField} />
+                </DataTable>
             </ReferenceArrayField>
         </SimpleShowLayout>
     </Show>
@@ -279,23 +283,25 @@ const AuthorShow = () => (
 
 `<ReferenceArrayField>` reads the list of `book_ids` in the current `record` (an author in this example). Then, it uses `dataProvider.getMany('books', { ids })` fetch the related books.
 
-`<ReferenceArrayField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+`<ReferenceArrayField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<DataTable>`, `<SimpleList>`, etc.).
 
 You can also use it in a List page:
 
 ```jsx
 const AuthorList = () => (
     <List>
-        <Datagrid>
-            <TextField source="first_name" />
-            <TextField source="last_name" />
-            <DateField source="date_of_birth" />
-            <ReferenceArrayField reference="books" source="book_ids">
-                <SingleFieldList>
-                    <TextField source="title" />
-                </SingleFieldList>
-            </ReferenceArrayField>
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="first_name" />
+            <DataTable.Col source="last_name" />
+            <DataTable.Col source="date_of_birth" field={DateField} />
+            <DataTable.Col label="Books">
+                <ReferenceArrayField reference="books" source="book_ids">
+                    <SingleFieldList>
+                        <TextField source="title" />
+                    </SingleFieldList>
+                </ReferenceArrayField>
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
@@ -331,10 +337,10 @@ const AuthorShow = () => (
                 through="book_authors"
                 using="author_id,book_id"
             >
-                <Datagrid>
-                    <TextField source="title" />
-                    <DateField source="published_at" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="published_at" field={DateField} />
+                </DataTable>
             </ReferenceManyToManyField>
             <EditButton />
         </SimpleShowLayout>
@@ -355,13 +361,14 @@ const BookShow = props => (
                 through="book_authors"
                 using="book_id,author_id"
             >
-                <Datagrid>
-                    <FunctionField 
-                        label="Author"
-                        render={record => `${record.first_name} ${record.last_name}`}
-                    />
-                    <DateField source="date_of_birth" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col label="Author">
+                        <FunctionField
+                            render={record => `${record.first_name} ${record.last_name}`}
+                        />
+                    </DataTable.Col>
+                    <DataTable.Col source="date_of_birth" field={DateField} />
+                </DataTable>
             </ReferenceManyToManyField>
             <EditButton />
         </SimpleShowLayout>
@@ -369,7 +376,7 @@ const BookShow = props => (
 );
 ```
 
-`<ReferenceManyToManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<Datagrid>`, `<SimpleList>`, etc.).
+`<ReferenceManyToManyField>` creates a `ListContext` with the related records, so you can use any component relying on this context (`<DataTable>`, `<SimpleList>`, etc.).
 
 ## `<ReferenceOneField>`
 

--- a/docs/FilterButton.md
+++ b/docs/FilterButton.md
@@ -23,12 +23,11 @@ It's an internal component that you should only need if you build a custom List 
 ```jsx
 import {
     CreateButton,
-    Datagrid,
+    DataTable,
     FilterButton,
     FilterForm,
     ListBase,
     Pagination,
-    TextField,
     TextInput,
     SearchInput
 } from 'react-admin';
@@ -52,11 +51,11 @@ const ListToolbar = () => (
 const PostList = () => (
     <ListBase>
         <ListToolbar />
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
         <Pagination />
     </ListBase>
 )

--- a/docs/FilterForm.md
+++ b/docs/FilterForm.md
@@ -23,12 +23,11 @@ It's an internal component that you should only need if you build a custom List 
 ```jsx
 import {
     CreateButton,
-    Datagrid,
+    DataTable,
     FilterButton,
     FilterForm,
     ListBase,
     Pagination,
-    TextField,
     TextInput,
     SearchInput
 } from 'react-admin';
@@ -52,11 +51,11 @@ const ListToolbar = () => (
 const PostList = () => (
     <ListBase>
         <ListToolbar />
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="body" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
         <Pagination />
     </ListBase>
 )

--- a/docs/FilterList.md
+++ b/docs/FilterList.md
@@ -153,7 +153,7 @@ const HasOrderedFilter = () => (
 
 ## Placing Filters In A Sidebar
 
-You can place these `<FilterList>` anywhere inside a `<List>`. The most common case is to put them in a sidebar that is on the left-hand side of the `Datagrid`. You can use the `aside` property for that:
+You can place these `<FilterList>` anywhere inside a `<List>`. The most common case is to put them in a sidebar that is on the left-hand side of the `DataTable`. You can use the `aside` property for that:
 
 {% raw %}
 ```jsx
@@ -315,7 +315,7 @@ import { Card, CardContent } from '@mui/material';
 import {
     AutocompleteInput,
     FilterLiveForm,
-    Datagrid,
+    DataTable,
     FilterList,
     FilterListItem,
     FilterListSection,
@@ -361,9 +361,9 @@ const BookListAside = () => (
 
 export const BookList = () => (
     <List aside={<BookListAside />}>
-        <Datagrid>
+        <DataTable>
             {/* ... */}
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```

--- a/docs/FilterLiveForm.md
+++ b/docs/FilterLiveForm.md
@@ -30,14 +30,13 @@ import { Card, CardContent } from '@mui/material';
 import {
     AutocompleteInput,
     FilterLiveForm,
-    Datagrid,
+    DataTable,
     FilterList,
     FilterListItem,
     FilterListSection,
     List,
     ReferenceField,
     ReferenceInput,
-    TextField,
     TextInput,
 } from 'react-admin';
 
@@ -76,11 +75,13 @@ const BookListAside = () => (
 
 export const BookList = () => (
     <List aside={<BookListAside />}>
-        <Datagrid>
-            <TextField source="title" />
-            <ReferenceField source="authorId" reference="authors" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col label="Autor">
+                <ReferenceField source="authorId" reference="authors" />
+            </DataTable.Col>
+            <DataTable.Col source="year" />
+        </DataTable>
     </List>
 );
 ```

--- a/docs/FilterLiveSearch.md
+++ b/docs/FilterLiveSearch.md
@@ -71,7 +71,7 @@ import { Card, CardContent } from '@mui/material';
 import {
     AutocompleteInput,
     FilterLiveForm,
-    Datagrid,
+    DataTable,
     FilterList,
     FilterListItem,
     FilterListSection,
@@ -117,9 +117,9 @@ const BookListAside = () => (
 
 export const BookList = () => (
     <List aside={<BookListAside />}>
-        <Datagrid>
+        <DataTable>
             {/* ... */}
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -227,11 +227,9 @@ Here is an example StackedFilters configuration:
 import {
     BooleanField,
     CreateButton,
-    Datagrid,
+    DataTable,
     List,
-    NumberField,
     ReferenceArrayField,
-    TextField,
     TopToolbar,
 } from 'react-admin';
 import {
@@ -259,12 +257,14 @@ const PostListToolbar = () => (
 
 const PostList = () => (
     <List actions={<PostListToolbar />}>
-        <Datagrid>
-            <TextField source="title" />
-            <NumberField source="views" />
-            <ReferenceArrayField tags="tags" source="tag_ids" />
-            <BooleanField source="published" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.NumberCol source="views" />
+            <DataTable.Col label="Tags">
+                <ReferenceArrayField tags="tags" source="tag_ids" />
+            </DataTable.Col>
+            <DataTable.Col source="published" field={BooleanField} />
+        </DataTable>
     </List>
 )
 ```
@@ -354,7 +354,7 @@ const LinkToRelatedProducts = () => {
 
 {% endraw %}
 
-You can use this button e.g. as a child of `<Datagrid>`. You can also create a custom Menu button with that technique to link to the unfiltered list by setting the filter value to `{}`.
+You can use this button e.g. as a child of `<DataTable.Col>`. You can also create a custom Menu button with that technique to link to the unfiltered list by setting the filter value to `{}`.
 
 ## Filter Operators
 
@@ -425,7 +425,7 @@ Saved Queries let users save a combination of filters and sort parameters into a
 `<SavedQueriesList>` is a complement to `<FilterList>` sections for the filter sidebar
 
 ```diff
-import { FilterList, FilterListItem, List, Datagrid } from 'react-admin';
+import { FilterList, FilterListItem, List, DataTable } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
 
 +import { SavedQueriesList } from 'react-admin';
@@ -446,9 +446,9 @@ const SongFilterSidebar = () => (
 
 const SongList = () => (
     <List aside={<SongFilterSidebar />}>
-        <Datagrid>
+        <DataTable>
             ...
-        </Datagrid>
+        </DataTable>
     </List>
 );
 ```
@@ -664,4 +664,4 @@ export const PostList = () => (
 
 **Tip**: No need to pass any `filters` to the list anymore, as the `<PostFilterForm>` component will display them.
 
-You can use a similar approach to offer alternative User Experiences for data filtering, e.g. to display the filters as a line in the datagrid headers.
+You can use a similar approach to offer alternative User Experiences for data filtering, e.g. to display the filters as a line in the datatable headers.

--- a/docs/InfiniteList.md
+++ b/docs/InfiniteList.md
@@ -12,7 +12,7 @@ The `<InfiniteList>` component is an alternative to [the `<List>` component](./L
   Your browser does not support the video tag.
 </video>
 
-`<InfiniteList>` fetches the list of records from the data provider, and renders the default list layout (title, buttons, filters). It delegates the rendering of the list of records to its child component. Usually, it's a [`<Datagrid>`](./Datagrid.md) or a [`<SimpleList>`](./SimpleList.md), responsible for displaying a table with one row for each record.
+`<InfiniteList>` fetches the list of records from the data provider, and renders the default list layout (title, buttons, filters). It delegates the rendering of the list of records to its child component. Usually, it's a [`<DataTable>`](./DataTable.md) or a [`<SimpleList>`](./SimpleList.md), responsible for displaying a table with one row for each record.
 
 ## Usage
 
@@ -20,15 +20,15 @@ Here is the minimal code necessary to display a list of books with infinite scro
 
 ```jsx
 // in src/books.js
-import { InfiniteList, Datagrid, TextField, DateField } from 'react-admin';
+import { InfiniteList, DataTable, DateField } from 'react-admin';
 
 export const BookList = () => (
     <InfiniteList>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="author" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" field={DateField} />
+        </DataTable>
     </InfiniteList>
 );
 
@@ -49,7 +49,7 @@ export default App;
 
 That's enough to display a basic post list, that users can sort and filter, and load additional records when they reach the bottom of the list.
 
-**Tip**: `<Datagrid>` has a sticky header by default, so the user can always see the column names when they scroll down.
+**Tip**: `<DataTable>` has a sticky header by default, so the user can always see the column names when they scroll down.
 
 ## Props
 
@@ -93,7 +93,7 @@ For example, here is a custom infinite pagination component displaying a "Load M
 
 {% raw %}
 ```jsx
-import { InfiniteList, useInfinitePaginationContext, Datagrid, TextField } from 'react-admin';
+import { InfiniteList, useInfinitePaginationContext, DataTable } from 'react-admin';
 import { Box, Button } from '@mui/material';
 
 const LoadMore = () => {
@@ -116,11 +116,11 @@ const LoadMore = () => {
 
 export const BookList = () => (
     <InfiniteList pagination={<LoadMore />}>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+        </DataTable>
     </InfiniteList>
 );
 ```
@@ -280,16 +280,16 @@ If your `authProvider` implements [Access Control](./Permissions.md#access-contr
 For instance, for the `<PostList>` page below:
 
 ```tsx
-import { InfiniteList, Datagrid, TextField } from 'react-admin';
+import { InfiniteList, DataTable } from 'react-admin';
 
 // Resource name is "posts"
 const PostList = () => (
     <InfiniteList>
-        <Datagrid>
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="published_at" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col source="published_at" />
+        </DataTable>
     </InfiniteList>
 );
 ```

--- a/docs/List.md
+++ b/docs/List.md
@@ -5,27 +5,27 @@ title: "The List Component"
 
 # `<List>`
 
-The `<List>` component is the root component for list pages. It fetches a list of records from the data provider, puts it in a [`ListContext`](./useListContext.md), renders the default list page layout (title, buttons, filters, pagination), and renders its children. Usual children of `<List>`, like [`<Datagrid>`](./Datagrid.md), are responsible for displaying the list of records.
+The `<List>` component is the root component for list pages. It fetches a list of records from the data provider, puts it in a [`ListContext`](./useListContext.md), renders the default list page layout (title, buttons, filters, pagination), and renders its children. Usual children of `<List>`, like [`<DataTable>`](./DataTable.md), are responsible for displaying the list of records.
 
 <iframe src="https://www.youtube-nocookie.com/embed/NNNPPmEMz6s" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="aspect-ratio: 16 / 9;width:100%;"></iframe>
 
 ## Usage
 
-Here is the minimal code necessary to display a list of posts using a [`<Datagrid>`](./Datagrid.md):
+Here is the minimal code necessary to display a list of posts using a [`<DataTable>`](./DataTable.md):
 
 ```jsx
 // in src/posts.jsx
-import { List, Datagrid, TextField, DateField, BooleanField } from 'react-admin';
+import { List, DataTable, DateField, BooleanField } from 'react-admin';
 
 export const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="published_at" />
-            <TextField source="category" />
-            <BooleanField source="commentable" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="published_at" field={DateField} />
+            <DataTable.Col source="category" />
+            <DataTable.Col source="commentable" field={BooleanField} />
+        </DataTable>
     </List>
 );
 
@@ -268,43 +268,45 @@ export const PostList = () => (
 
 ![List children](./img/list-children.webp)
 
-The most common List child is [`<Datagrid>`](./Datagrid.md):
+The most common List child is [`<DataTable>`](./DataTable.md):
 
 ```jsx
 export const BookList = () => (
     <List>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="published_at" />
-            <ReferenceManyCount label="Nb comments" reference="comments" target="post_id" link />
-            <BooleanField source="commentable" label="Com." />
-            <NumberField source="nb_views" label="Views" />
-            <>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="published_at" field={DateField} />
+            <DataTable.Col label="Nb comments">
+                <ReferenceManyCount reference="comments" target="post_id" link />
+            </DataTable.Col>
+            <DataTable.Col source="commentable" label="Com." field={BooleanField} />
+            <DataTable.Col source="nb_views" label="Views" />
+            <DataTable.Col>
                 <EditButton />
                 <ShowButton />
-            </>
-        </Datagrid>
+            </DataTable.Col>
+        </DataTable>
     </List>
 );
 ```
 
 React-admin provides several components that can read and display a list of records from a `ListContext`, each with a different layout:
 
-- [`<Datagrid>`](./Datagrid.md) displays records in a table
+- [`<DataTable>`](./DataTable.md) displays records in a table
 - [`<EditableDatagrid>`](./EditableDatagrid.md) displays records in a table AND lets users edit them inline
 - [`<SimpleList>`](./SimpleList.md) displays records in a list without many details - suitable for mobile devices
 - [`<Tree>`](./TreeWithDetails.md) displays records in a tree structure
 - [`<Calendar>`](./Calendar.md) displays event records in a calendar
 - [`<SingleFieldList>`](./SingleFieldList.md) displays records inline, showing one field per record
 
-So for instance, you can use a `<SimpleList>` instead of a `<Datagrid>` on mobile devices:
+So for instance, you can use a `<SimpleList>` instead of a `<DataTable>` on mobile devices:
 
 ```jsx
 // in src/posts.js
 import * as React from 'react';
 import { useMediaQuery } from '@mui/material';
-import { List, SimpleList, Datagrid, TextField, ReferenceField } from 'react-admin';
+import { List, SimpleList, DataTable, TextField, ReferenceField } from 'react-admin';
 
 export const PostList = () => {
     const isSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
@@ -317,14 +319,16 @@ export const PostList = () => {
                     tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
                 />
             ) : (
-                <Datagrid>
-                    <TextField source="id" />
-                    <ReferenceField label="User" source="userId" reference="users">
-                        <TextField source="name" />
-                    </ReferenceField>
-                    <TextField source="title" />
-                    <TextField source="body" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col label="User">
+                        <ReferenceField source="userId" reference="users">
+                            <TextField source="name" />
+                        </ReferenceField>
+                    </DataTable.Col>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="body" />
+                </DataTable>
             )}
         </List>
     );
@@ -358,7 +362,7 @@ Check [Building a custom List Iterator](./ListTutorial.md#building-a-custom-iter
 
 ## `component`
 
-By default, the List view renders the main content area inside a Material UI `<Card>` element. The actual layout of the list depends on the child component you're using (`<Datagrid>`, `<SimpleList>`, or a custom layout component).
+By default, the List view renders the main content area inside a Material UI `<Card>` element. The actual layout of the list depends on the child component you're using (`<DataTable>`, `<SimpleList>`, or a custom layout component).
 
 Some List layouts display each record in a `<Card>`, in which case the user ends up seeing a card inside a card, which is bad UI. To avoid that, you can override the main area container by passing a `component` prop:
 
@@ -527,7 +531,7 @@ const ProductList = () => (
 
 ## `emptyWhileLoading`
 
-Default layout components (`<Datagrid>` and `<SimpleList>`) return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
+Default layout components (`<DataTable>` and `<SimpleList>`) return null when the data is loading. If you use a custom layout component instead, you'll have to handle the case where the `data` is not yet defined.
 
 That means that the following will fail on load with a "ReferenceError: data is not defined" error:
 
@@ -667,7 +671,7 @@ const CommentList = () => (
 
 **Tip**: The `<ExportButton>` limits the main request to the `dataProvider` to 1,000 records. If you want to increase or decrease this limit, pass a `maxResults` prop to the `<ExportButton>` in a custom `<ListActions>` component.
 
-**Tip**: React-admin also provides a `<BulkExportButton>` component that depends on the `exporter`, and that you can use in the `bulkActionButtons` prop of the `<Datagrid>` component.
+**Tip**: React-admin also provides a `<BulkExportButton>` component that depends on the `exporter`, and that you can use in the `bulkActionButtons` prop of the `<DataTable>` component.
 
 **Tip**: For complex (or large) exports, fetching all the related records and assembling them client-side can be slow. In that case, create the CSV on the server side, and replace the `<ExportButton>` component by a custom one, fetching the CSV route.
 
@@ -921,8 +925,7 @@ import {
     CustomRoutes,
     Resource,
     List,
-    Datagrid,
-    TextField,
+    DataTable,
 } from 'react-admin';
 import { Route } from 'react-router-dom';
 
@@ -932,12 +935,12 @@ const NewerBooks = () => (
         storeKey="newerBooks"
         sort={{ field: 'year', order: 'DESC' }}
     >
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col source="year" />
+        </DataTable>
     </List>
 );
 
@@ -947,12 +950,12 @@ const OlderBooks = () => (
         storeKey="olderBooks"
         sort={{ field: 'year', order: 'ASC' }}
     >
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable source="id" />
+            <DataTable source="title" />
+            <DataTable source="author" />
+            <DataTable source="year" />
+        </DataTable>
     </List>
 );
 
@@ -1042,7 +1045,7 @@ const App = () => (
 );
 ```
 
-Just like `<List>`, `<ListGuesser>` fetches the data. It then analyzes the response, and guesses the fields it should use to display a basic `<Datagrid>` with the data. It also dumps the components it has guessed in the console, so you can copy it into your own code.
+Just like `<List>`, `<ListGuesser>` fetches the data. It then analyzes the response, and guesses the fields it should use to display a basic `<DataTable>` with the data. It also dumps the components it has guessed in the console, so you can copy it into your own code.
 
 ![Guessed List](./img/guessed-list.png)
 
@@ -1063,19 +1066,18 @@ To achieve infinite pagination, replace the `<List>` component with [the `<Infin
 import {
 -   List,
 +   InfiniteList,
-    Datagrid,
-    TextField,
+    DataTable,
     DateField
 } from 'react-admin';
 
 const BookList = () => (
 -   <List>
 +   <InfiniteList>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <DateField source="author" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" field={DateField} />
+        </DataTable>
 -   </List>
 +   </InfiniteList>
 );
@@ -1088,14 +1090,14 @@ const BookList = () => (
 If you want to subscribe to live updates on the list of records (topic: `resource/[resource]`), add [the `<ListLiveUpdate>` component](./ListLiveUpdate.md) in your `<List>` children.
 
 ```diff
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 +import { ListLiveUpdate } from '@react-admin/ra-realtime';
 
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+        </DataTable>
 +       <ListLiveUpdate />
     </List>
 );
@@ -1259,11 +1261,11 @@ const Dashboard = () => (
 - [`<ReferenceManyField>`](./ReferenceManyField.md),
 - [`<ReferenceManyToManyField>`](./ReferenceManyToManyField.md).
 
-If the `<List>` children allow to *modify* the list state (i.e. if they let users change the sort order, the filters, the selection, or the pagination), then you should also use the [`disableSyncWithLocation`](#disablesyncwithlocation) prop to prevent react-admin from changing the URL. This is the case e.g. if you use a `<Datagrid>`, which lets users sort the list by clicking on column headers.
+If the `<List>` children allow to *modify* the list state (i.e. if they let users change the sort order, the filters, the selection, or the pagination), then you should also use the [`disableSyncWithLocation`](#disablesyncwithlocation) prop to prevent react-admin from changing the URL. This is the case e.g. if you use a `<DataTable>`, which lets users sort the list by clicking on column headers.
 
 {% raw %}
 ```jsx
-import { List, Datagrid, TextField, NumberField, DateField } from 'react-admin';
+import { List, DataTable, DateField } from 'react-admin';
 import { Container, Typography } from '@mui/material';
 
 const Dashboard = () => (
@@ -1276,10 +1278,10 @@ const Dashboard = () => (
             perPage={10}
             disableSyncWithLocation
         >
-            <Datagrid bulkActionButtons={false}>
-                <TextField source="title" />
-                <NumberField source="views" />
-            </Datagrid>
+            <DataTable bulkActionButtons={false}>
+                <DataTable.Col source="title" />
+                <DataTable.NumberCol source="views" />
+            </DataTable>
         </List>
         <Typography>Latest comments</Typography>
         <List
@@ -1288,18 +1290,18 @@ const Dashboard = () => (
             perPage={10}
             disableSyncWithLocation
         >
-            <Datagrid bulkActionButtons={false}>
-                <TextField source="author.name" />
-                <TextField source="body" />
-                <DateField source="published_at" />
-            </Datagrid>
+            <DataTable bulkActionButtons={false}>
+                <DataTable.Col source="author.name" />
+                <DataTable.Col source="body" />
+                <DataTable.Col source="published_at" field={DateField} />
+            </DataTable>
         </List>
     </Container>
 )
 ```
 {% endraw %}
 
-**Note**: If you render more than one `<Datagrid>` for the same resource in the same page, they will share the selection state (i.e. the checked checkboxes). This is a design choice because if row selection is not tied to a resource, then when a user deletes a record it may remain selected without any ability to unselect it. You can get rid of the checkboxes by setting `<Datagrid bulkActionButtons={false}>`.
+**Note**: If you render more than one `<DataTable>` for the same resource in the same page, they will share the selection state (i.e. the checked checkboxes). This is a design choice because if row selection is not tied to a resource, then when a user deletes a record it may remain selected without any ability to unselect it. You can get rid of the checkboxes by setting `<DataTable bulkActionButtons={false}>`.
 
 ## Headless Version
 
@@ -1387,16 +1389,16 @@ If your `authProvider` implements [Access Control](./Permissions.md#access-contr
 For instance, to render the `<PostList>` page below:
 
 ```tsx
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, DataTable } from 'react-admin';
 
 // Resource name is "posts"
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="published_at" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col source="published_at" />
+        </DataTable>
     </List>
 );
 ```

--- a/docs/ListBase.md
+++ b/docs/ListBase.md
@@ -21,7 +21,7 @@ import {
     Title,
     ListToolbar,
     Pagination,
-    Datagrid,
+    DataTable,
 } from 'react-admin';
 import { Card } from '@mui/material';
 
@@ -41,9 +41,9 @@ const MyList = ({ children, actions, filters, title, ...props }) => (
 
 const PostList = () => (
     <MyList title="Post List">
-        <Datagrid>
+        <DataTable>
             ...
-        </Datagrid>
+        </DataTable>
     </MyList>
 );
 ```
@@ -78,16 +78,16 @@ If your `authProvider` implements [Access Control](./Permissions.md#access-contr
 For instance, for the `<PostList>` page below:
 
 ```tsx
-import { ListBase, Datagrid, TextField } from 'react-admin';
+import { ListBase, DataTable } from 'react-admin';
 
 // Resource name is "posts"
 const PostList = () => (
     <ListBase>
-        <Datagrid>
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="published_at" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col source="published_at" />
+        </DataTable>
     </ListBase>
 );
 ```

--- a/docs/ListGuesser.md
+++ b/docs/ListGuesser.md
@@ -9,7 +9,7 @@ Use `<ListGuesser>` to quickly bootstrap a List view on top of an existing API, 
 
 <iframe src="https://www.youtube-nocookie.com/embed/zImWX8HBr7A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="aspect-ratio: 16 / 9;width:100%;margin-bottom:1em;"></iframe>
 
-Just like [`<List>`](./List.md), `<ListGuesser>` fetches the data. It then analyzes the response, and guesses the fields it should use to display a basic `<Datagrid>` with the data. It also dumps the components it has guessed in the console, so you can copy it into your own code.
+Just like [`<List>`](./List.md), `<ListGuesser>` fetches the data. It then analyzes the response, and guesses the fields it should use to display a basic `<DataTable>` with the data. It also dumps the components it has guessed in the console, so you can copy it into your own code.
 
 ![Guessed List](./img/guessed-list.png)
 

--- a/docs/ListLiveUpdate.md
+++ b/docs/ListLiveUpdate.md
@@ -14,14 +14,14 @@ title: "ListLiveUpdate"
 Add the `<ListLiveUpdate>` in your `<List>` children:
 
 ```jsx
-import { Datagrid, List TextField } from 'react-admin';
+import { DataTable, List } from 'react-admin';
 import { ListLiveUpdate } from '@react-admin/ra-realtime';
 
 const PostList = () => (
     <List>
-        <Datagrid>
-            <TextField source="title" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="title" />
+        </DataTable>
         <ListLiveUpdate />
     </List>
 );
@@ -42,7 +42,7 @@ To trigger refreshes of `<ListLiveUpdate>`, the API has to publish events contai
 
 This also works with [`<ReferenceManyField>`](https://marmelab.com/react-admin/ReferenceManyField.html) or [`<ReferenceArrayField>`](https://marmelab.com/react-admin/ReferenceArrayField.html):
 ```tsx
-import { Show, SimpleShowLayout, ReferenceManyField, Datagrid, TextField, DateField } from 'react-admin';
+import { Show, SimpleShowLayout, ReferenceManyField, DataTable, TextField, DateField } from 'react-admin';
 import { ListLiveUpdate } from '@react-admin/ra-realtime';
 const AuthorShow = () => (
     <Show>
@@ -50,10 +50,10 @@ const AuthorShow = () => (
             <TextField source="first_name" />
             <TextField source="last_name" />
             <ReferenceManyField reference="books" target="author_id" label="Books">
-              <Datagrid>
-                <TextField source="title" />
-                <DateField source="published_at" />
-              </Datagrid>
+              <DataTable>
+                <DataTable.Col source="title" />
+                <DataTable.Col source="published_at" field={DateField} />
+              </DataTable>
               <ListLiveUpdate />
             </ReferenceManyField>
         </SimpleShowLayout>
@@ -66,7 +66,7 @@ const AuthorShow = () => (
 The `<ListLiveUpdate>` allows you to customize the side effects triggered when it receives a new event, by passing a function to the `onEventReceived` prop:
 
 ```jsx
-import { Datagrid, List, TextField, useNotify, useRefresh } from 'react-admin';
+import { DataTable, List, useNotify, useRefresh } from 'react-admin';
 import { ListLiveUpdate } from '@react-admin/ra-realtime';
 
 const PostList = () => {
@@ -81,9 +81,9 @@ const PostList = () => {
 
     return (
         <List>
-            <Datagrid>
-                <TextField source="title" />
-            </Datagrid>
+            <DataTable>
+                <DataTable.Col source="title" />
+            </DataTable>
             <ListLiveUpdate onEventReceived={handleEventReceived} />
         </List>
     );

--- a/docs/ListTutorial.md
+++ b/docs/ListTutorial.md
@@ -100,15 +100,15 @@ This example uses the `useGetList` hook instead of `fetch` because `useGetList` 
 
 This list is a bit rough in the edges (for instance, typing in the search input makes one call to the dataProvider per character), but it's good enough for the purpose of this chapter. 
 
-### `<Datagrid>` Displays Fields In A Table
+### `<DataTable>` Displays Fields In A Table
 
-Table layouts usually require a lot of code to define the table head, row, columns, etc. React-admin `<Datagrid>` component, together with Field components, can help remove that boilerplate:
+Table layouts usually require a lot of code to define the table head, row, columns, etc. React-admin `<DataTable>` component, together with Field components, can help remove that boilerplate:
 
 {% raw %}
 ```diff
 import { useState } from 'react';
 -import { Title, useGetList } from 'react-admin';
-+import { Title, useGetList, Datagrid, TextField } from 'react-admin';
++import { Title, useGetList, DataTable } from 'react-admin';
 import {
     Card,
     TextField as MuiTextField,
@@ -166,12 +166,12 @@ const BookList = () => {
 -                       ))}
 -                   </TableBody>
 -               </Table>
-+               <Datagrid data={data} sort={sort}>
-+                   <TextField source="id" />
-+                   <TextField source="title" />
-+                   <TextField source="author" />
-+                   <TextField source="year" />
-+               </Datagrid>
++               <DataTable data={data} sort={sort}>
++                   <DataTable.Col source="id" />
++                   <DataTable.Col source="title" />
++                   <DataTable.Col source="author" />
++                   <DataTable.Col source="year" />
++               </DataTable>
             </Card>
             <Toolbar>
                 {page > 1 && <Button onClick={() => setPage(page - 1)}>Previous page</Button>}
@@ -183,11 +183,11 @@ const BookList = () => {
 ```
 {% endraw %}
 
-`<Datagrid>` does more than the previous table: it renders table headers depending on the current sort, and allows you to change the sort order by clicking a column header. Also, for each row, `<Datagrid>` creates a `RecordContext`, which lets you use react-admin Field and Buttons without explicitly passing the row data.
+`<DataTable>` does more than the previous table: it renders table headers depending on the current sort, and allows you to change the sort order by clicking a column header. Also, for each row, `<DataTable>` creates a `RecordContext`, which lets you use react-admin Field and Buttons without explicitly passing the row data.
 
 ### `ListContext` Exposes List Data To Descendants
 
-`<Datagrid>` requires a `data` prop to render, but it can grab it from a `ListContext` instead. Creating such a context with `<ListContextProvider>` also allows to use other react-admin components specialized in filtering (`<FilterForm>`) and pagination (`<Pagination>`), and to reduce the boilerplate code even further:
+`<DataTable>` requires a `data` prop to render, but it can grab it from a `ListContext` instead. Creating such a context with `<ListContextProvider>` also allows to use other react-admin components specialized in filtering (`<FilterForm>`) and pagination (`<Pagination>`), and to reduce the boilerplate code even further:
 
 {% raw %}
 ```diff
@@ -195,8 +195,7 @@ import { useState } from 'react';
 import { 
     Title,
     useGetList,
-    Datagrid,
-    TextField,
+    DataTable,
 +   ListContextProvider,
 +   FilterForm,
 +   Pagination,
@@ -237,13 +236,13 @@ const BookList = () => {
 -           />
 +           <FilterForm filters={filters} />
             <Card>
--               <Datagrid data={data} sort={sort}>
-+               <Datagrid>
-                    <TextField source="id" />
-                    <TextField source="title" />
-                    <TextField source="author" />
-                    <TextField source="year" />
-                </Datagrid>
+-               <DataTable data={data} sort={sort}>
++               <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="author" />
+                    <DataTable.Col source="year" />
+                </DataTable>
             </Card>
 -           <Toolbar>
 -               {page > 1 && <Button onClick={() => setPage(page - 1)}>Previous page</Button>}
@@ -268,8 +267,7 @@ import {
     Title,
 -   useGetList,
 +   useListController,
-    Datagrid,
-    TextField,
+    DataTable,
     ListContextProvider,
     FilterForm,
     Pagination,
@@ -304,12 +302,12 @@ const BookList = () => {
                 <Title title="Book list" />
                 <FilterForm filters={filters} />
                 <Card>
-                    <Datagrid>
-                        <TextField source="id" />
-                        <TextField source="title" />
-                        <TextField source="author" />
-                        <TextField source="year" />
-                    </Datagrid>
+                    <DataTable>
+                        <DataTable.Col source="id" />
+                        <DataTable.Col source="title" />
+                        <DataTable.Col source="author" />
+                        <DataTable.Col source="year" />
+                    </DataTable>
                 </Card>
                 <Pagination />
             </div>
@@ -340,8 +338,7 @@ As calling the List controller and putting its result into a context is also com
 import { 
     Title,
 -   useListController,
-    Datagrid,
-    TextField,
+    DataTable,
 -   ListContextProvider,
 +   ListBase,
     FilterForm,
@@ -365,12 +362,12 @@ const BookList = () => {
                 <Title title="Book list" />
                 <FilterForm filters={filters} />
                 <Card>
-                    <Datagrid>
-                        <TextField source="id" />
-                        <TextField source="title" />
-                        <TextField source="author" />
-                        <TextField source="year" />
-                    </Datagrid>
+                    <DataTable>
+                        <DataTable.Col source="id" />
+                        <DataTable.Col source="title" />
+                        <DataTable.Col source="author" />
+                        <DataTable.Col source="year" />
+                    </DataTable>
                 </Card>
                 <Pagination />
             </div>
@@ -380,7 +377,7 @@ const BookList = () => {
 };
 ```
 
-Notice that we're not handling the loading state manually anymore. In fact, the `<Datagrid>` component can render a skeleton while the data is being fetched.
+Notice that we're not handling the loading state manually anymore. In fact, the `<DataTable>` component can render a skeleton while the data is being fetched.
 
 ### `useListContext` Accesses The List Context
 
@@ -412,8 +409,7 @@ import {
 -   Title,
 -   ListBase,
 +   List,
-    Datagrid,
-    TextField,
+    DataTable,
 -   FilterForm,
 -   Pagination,
     TextInput
@@ -429,12 +425,12 @@ const BookList = () => (
 -           <FilterForm filters={filters} />
 -           <Card>
 +    <List filters={filters}>
-                <Datagrid>
-                    <TextField source="id" />
-                    <TextField source="title" />
-                    <TextField source="author" />
-                    <TextField source="year" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="author" />
+                    <DataTable.Col source="year" />
+                </DataTable>
 -           </Card>
 -           <Pagination />
 -       </div>
@@ -450,8 +446,7 @@ Remember the first snippet in this page? The react-admin version is much shorter
 ```tsx
 import { 
     List,
-    Datagrid,
-    TextField,
+    DataTable,
     TextInput
 } from 'react-admin';
 
@@ -459,12 +454,12 @@ const filters = [<TextInput label="Search" source="q" size="small" alwaysOn />];
 
 const BookList = () => (
     <List filters={filters}>
-        <Datagrid>
-            <TextField source="id" />
-            <TextField source="title" />
-            <TextField source="author" />
-            <TextField source="year" />
-        </Datagrid>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="author" />
+            <DataTable.Col source="year" />
+        </DataTable>
     </List>
 );
 ```
@@ -473,9 +468,9 @@ By encapsulating common CRUD logic, react-admin reduces the amount of code you n
 
 ## `<ListGuesser>`: Zero-Configuration List
 
-Sometimes typing `<Datagrid>` and a few `<Field>` components is too much - for instance if you want to prototype an admin for many resources, or search data through an API without worrying about the actual data structure.
+Sometimes typing `<DataTable>` and a few `<Field>` components is too much - for instance if you want to prototype an admin for many resources, or search data through an API without worrying about the actual data structure.
 
-For these cases, react-admin provides a `<ListGuesser>` component that will guess the datagrid columns from the data. It's a bit like the `<List>` component, but it doesn't require any configuration.
+For these cases, react-admin provides a `<ListGuesser>` component that will guess the datatable columns from the data. It's a bit like the `<List>` component, but it doesn't require any configuration.
 
 ```tsx
 import { Admin, Resource, ListGuesser } from 'react-admin';
@@ -492,9 +487,9 @@ const App = () => (
 
 ## List Iterators
 
-The components you can use as child of `<List>` are called "List Iterator". They render a list of records. `<Datagrid>` is such a List Iterator, but react-admin provides many more:
+The components you can use as child of `<List>` are called "List Iterator". They render a list of records. `<DataTable>` is such a List Iterator, but react-admin provides many more:
 
-- [`<Datagrid>`](./Datagrid.md)
+- [`<DataTable>`](./DataTable.md)
 - [`<DatagridAG>`](./DatagridAG.md)
 - [`<SimpleList>`](./SimpleList.md)
 - [`<SingleFieldList>`](./SingleFieldList.md)
@@ -506,7 +501,7 @@ If that's not enough, [building a custom iterator](#building-a-custom-iterator) 
 
 ## Responsive Lists
 
-On Mobile, `<Datagrid>` doesn't work well - the screen is too narrow. You should use [the  `<SimpleList>` component](./SimpleList.md) instead - it's another built-in List Iterator.
+On Mobile, `<DataTable>` doesn't work well - the screen is too narrow. You should use [the  `<SimpleList>` component](./SimpleList.md) instead - it's another built-in List Iterator.
 
 <video controls autoplay playsinline muted loop style="height:300px">
     <source src="./img/simple-list.webm" type="video/webm"/>
@@ -514,13 +509,13 @@ On Mobile, `<Datagrid>` doesn't work well - the screen is too narrow. You should
     Your browser does not support the video tag.
 </video>
 
-To use `<Datagrid>` on desktop and `<SimpleList>` on mobile, use the `useMediaQuery` hook:
+To use `<DataTable>` on desktop and `<SimpleList>` on mobile, use the `useMediaQuery` hook:
 
 ```tsx
 // in src/posts.tsx
 import * as React from 'react';
 import { useMediaQuery, Theme } from '@mui/material';
-import { List, SimpleList, Datagrid, TextField, ReferenceField } from 'react-admin';
+import { List, SimpleList, DataTable, TextField, ReferenceField } from 'react-admin';
 
 type Post = {
     id: number;
@@ -542,14 +537,16 @@ export const PostList = () => {
                     tertiaryText={record => new Date(record.published_at).toLocaleDateString()}
                 />
             ) : (
-                <Datagrid>
-                    <TextField source="id" />
-                    <ReferenceField label="User" source="userId" reference="users">
-                        <TextField source="name" />
-                    </ReferenceField>
-                    <TextField source="title" />
-                    <TextField source="body" />
-                </Datagrid>
+                <DataTable>
+                    <DataTable.Col source="id" />
+                    <DataTable.Col source="userId">
+                        <ReferenceField source="userId" reference="users">
+                            <TextField source="name" />
+                        </ReferenceField>
+                    </DataTable.Col>
+                    <DataTable.Col source="title" />
+                    <DataTable.Col source="body" />
+                </DataTable>
             )}
         </List>
     );
@@ -560,7 +557,7 @@ Check [the dedicated `useMediaQuery` documentation](./useMediaQuery.md) for more
 
 ## Building a Custom Iterator
 
-In some cases, neither the `<Datagrid>` nor the `<SimpleList>` components allow to display the records in an optimal way for a given task. In these cases, pass your layout component directly as children of the `<List>` component. 
+In some cases, neither the `<DataTable>` nor the `<SimpleList>` components allow to display the records in an optimal way for a given task. In these cases, pass your layout component directly as children of the `<List>` component. 
 
 As `<List>` takes care of fetching the data and putting it in a `ListContext`, you can leverage [the `<WithListContext>` component](./WithListContext.md) to get the list data in a render prop. 
 
@@ -671,7 +668,7 @@ sort=published_at
 order=DESC
 ```
 
-If you're using a `<Datagrid>` inside the List view, then the column headers are buttons allowing users to change the list sort field and order. This feature requires no configuration and works out fo the box. Check [the `<Datagrid>` documentation](./Datagrid.md#customizing-column-sort) to see how to disable or modify the field used for sorting on a particular column.
+If you're using a `<DataTable>` inside the List view, then the column headers are buttons allowing users to change the list sort field and order. This feature requires no configuration and works out fo the box. Check [the `<DataTable>` documentation](./DataTable.md#customizing-column-sort) to see how to disable or modify the field used for sorting on a particular column.
 
 <video controls autoplay playsinline muted loop>
   <source src="./img/sort-column-header.webm" type="video/webm"/>
@@ -726,7 +723,7 @@ const SortByViews = () => (
 
 ## Building a Custom Sort Control
 
-When neither the `<Datagrid>` or the `<SortButton>` fit your UI needs, you have to write a custom sort control. As with custom filters, this boils down to grabbing the required data and callbacks from the `ListContext`. Let's use the `<SortButton>` source as an example usage of `sort` and `setSort`:
+When neither the `<DataTable>` or the `<SortButton>` fit your UI needs, you have to write a custom sort control. As with custom filters, this boils down to grabbing the required data and callbacks from the `ListContext`. Let's use the `<SortButton>` source as an example usage of `sort` and `setSort`:
 
 ```tsx
 import * as React from 'react';


### PR DESCRIPTION
## Problem

We want to suggest DataTable on every examples

## Solution

Replace our `Datagrid` examples to `DataTable`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~~[ ] The PR includes **unit tests** (if not possible, describe why)~~
- ~~[ ] The PR includes one or several **stories** (if not possible, describe why)~~
- [ ] The **documentation** is up to date