### PR TITLE
Chore(lp): Update CRM repository to link to Atomic CRM repo

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -498,7 +498,7 @@
               <li>
                 <a
                   class="inline-flex hover:underline"
-                  href="https://github.com/marmelab/react-admin/tree/master/examples/crm"
+                  href="https://github.com/marmelab/atomic-crm"
                   >Source<img
                     src="./img/arrow-right.svg"
                     alt="arrow right icon"


### PR DESCRIPTION
## Problem

The landing page links to the CRM inside the RA OSS repository.

## Solution

Link to the Atomic CRM repository instead.

## How To Test

Open the landing page and click on the `Source` link besides the CRM heading.

## Additional Checks

- [ ] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
