### PR TITLE
Fix(logout): avoid an infinite loop when loading the demo apps for the first time

### DIFF
--- a/packages/ra-core/src/auth/useLogout.ts
+++ b/packages/ra-core/src/auth/useLogout.ts
@@ -111,22 +111,23 @@ const useLogout = (): Logout => {
                         if (redirectToParts[1]) {
                             newLocation.search = redirectToParts[1];
                         }
-                        navigateRef.current(newLocation, {
-                            ...newLocationOptions,
-                            flushSync: true,
-                        });
 
-                        // We need to reset the store after a litte delay to avoid a race condition
+                        // We need to navigate and reset the store after a litte delay to avoid a race condition
                         // between the store reset and the navigation.
                         //
                         // This would only happen when the `authProvider.getPermissions` method returns
                         // a resolved promise with no delay: If the store was reset before the navigation,
                         // the `usePermissions` query would reset, causing the `CoreAdminRoutes` component to
                         // rerender the `LogoutOnMount` component leading to an infinite loop.
-                        window.requestAnimationFrame(() => {
+                        setTimeout(() => {
+                            navigateRef.current(
+                                newLocation,
+                                newLocationOptions
+                            );
+
                             resetStore();
                             queryClient.clear();
-                        });
+                        }, 0);
 
                         return redirectToFromProvider;
                     });


### PR DESCRIPTION
## Problem

The e-commerce demo was rendering a blank page with many redirects to the logout page when loading the page for the first time. After a many seconds, the login form would render due to an `history.pushState` abuse.

## Solution

Delay the store to avoid a race condition in `useLogout` that would cause the `CoreAdminRoutes` component to rerender the `LogoutOnMount` component leading to an infinite loop.

## How To Test

Start the e-commerce demo with the following command:
```sh
make run-demo
```

The login page should load fast and no warning about `history.pushState` should be seen in the console.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
