### PR TITLE
Rename convertRaMessagesToI18next to convertRaTranslationsToI18next

### DIFF
--- a/packages/ra-i18n-i18next/src/convertRaTranslationsToI18next.ts
+++ b/packages/ra-i18n-i18next/src/convertRaTranslationsToI18next.ts
@@ -13,16 +13,16 @@ import clone from 'lodash/clone';
  *
  * @example Convert the english translations from ra-language-english to i18next format
  * import englishMessages from 'ra-language-english';
- * import { convertRaMessagesToI18next } from 'ra-i18n-18next';
+ * import { convertRaTranslationsToI18next } from 'ra-i18n-18next';
  *
- * const messages = convertRaMessagesToI18next(englishMessages);
+ * const messages = convertRaTranslationsToI18next(englishMessages);
  *
  * @example Convert the english translations from ra-language-english to i18next format with custom interpolation wrappers
  * import englishMessages from 'ra-language-english';
- * import { convertRaMessagesToI18next } from 'ra-i18n-18next';
+ * import { convertRaTranslationsToI18next } from 'ra-i18n-18next';
  *
- * const messages = convertRaMessagesToI18next(englishMessages, {
- *    prefix: '#{',
+ * const messages = convertRaTranslationsToI18next(englishMessages, {
+ *   prefix: '#{',
  *   suffix: '}#',
  * });
  */


### PR DESCRIPTION
## Problem

Outdated mention of `convertRaMessagesToI18next`, to rename to `convertRaTranslationsToI18next`.

## Solution

Rename `convertRaMessagesToI18next` to `convertRaTranslationsToI18next`.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [X] The **documentation** is up to date
