### PR TITLE
Fix videos in DataTable docs

### DIFF
--- a/docs/DataTable.md
+++ b/docs/DataTable.md
@@ -203,7 +203,7 @@ React-admin provides four bulk action buttons that you can use in data tables:
 **Tip**: Users can select a range of rows by pressing the shift key while clicking a row checkbox.
 
 <video controls autoplay playsinline muted loop>
-  <source src="./img/Datagrid-select-range.mp4" type="video/mp4"/>
+  <source src="./img/datagrid-select-range.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -525,7 +525,7 @@ const BookList = () => (
 ## `expand`
 
 <video controls autoplay playsinline muted loop>
-  <source src="./img/Datagrid_expand.mp4" type="video/mp4"/>
+  <source src="./img/datagrid_expand.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 
@@ -1269,7 +1269,7 @@ Refer to the [`<NumberField>`](./NumberField.md) documentation for more details.
 `<DataTable>` has sticky headers, which means that the header row will remain visible even when scrolling down the page.
 
 <video controls autoplay playsinline muted loop>
-  <source src="./img/Datagrid-headers-pinning.mp4" type="video/mp4"/>
+  <source src="./img/datagrid-headers-pinning.mp4" type="video/mp4"/>
   Your browser does not support the video tag.
 </video>
 


### PR DESCRIPTION
## Problem

Some videos in DataTable docs are not working.

## Solution

Fix videos file names.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [X] The **documentation** is up to date
