### PR TITLE
Fix(show/edit): Avoid a redirect loop when useGetOne returns an error in shadcn-admin-kit

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -3,7 +3,11 @@ import { useParams } from 'react-router-dom';
 
 import { useAuthenticated, useRequireAccess } from '../../auth';
 import { RaRecord, MutationMode, TransformData } from '../../types';
-import { useRedirect, RedirectionSideEffect } from '../../routing';
+import {
+    useRedirect,
+    RedirectionSideEffect,
+    useCreatePath,
+} from '../../routing';
 import { useNotify } from '../../notification';
 import {
     useGetOne,
@@ -82,6 +86,7 @@ export const useEditController = <
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();
     const notify = useNotify();
+    const createPath = useCreatePath();
     const redirect = useRedirect();
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
@@ -118,10 +123,19 @@ export const useEditController = <
                 (!isPendingAuthenticated && !isPendingCanAccess) ||
                 disableAuthentication,
             onError: () => {
+                console.warn('useEditController: record not found');
                 notify('ra.notification.item_doesnt_exist', {
                     type: 'error',
                 });
-                redirect('list', resource);
+                // We need to flushSync to ensure the redirect happens before the refresh
+                // Otherwise this can cause an infinite loop when the record is not found
+                redirect(() => ({
+                    pathname: createPath({
+                        resource,
+                        type: 'list',
+                    }),
+                    flushSync: true,
+                }));
                 refresh();
             },
             refetchOnReconnect: false,

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -9,7 +9,7 @@ import {
     UseGetOneOptions,
 } from '../../dataProvider';
 import { useTranslate } from '../../i18n';
-import { useRedirect } from '../../routing';
+import { useCreatePath, useRedirect } from '../../routing';
 import { useNotify } from '../../notification';
 import {
     useResourceContext,
@@ -80,6 +80,7 @@ export const useShowController = <
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();
     const notify = useNotify();
+    const createPath = useCreatePath();
     const redirect = useRedirect();
     const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
@@ -109,7 +110,16 @@ export const useShowController = <
                 notify('ra.notification.item_doesnt_exist', {
                     type: 'error',
                 });
-                redirect('list', resource);
+
+                // We need to flushSync to ensure the redirect happens before the refresh
+                // Otherwise this can cause an infinite loop when the record is not found
+                redirect(() => ({
+                    pathname: createPath({
+                        resource,
+                        type: 'list',
+                    }),
+                    flushSync: true,
+                }));
                 refresh();
             },
             retry: false,


### PR DESCRIPTION
## Problem

When a resource is not found in [`shadcn-admin-kit`](https://github.com/marmelab/shadcn-admin-kit), there is an infinite loop caused by a race condition between the router navigation and the query refresh

## Solution

Flush sync the navigation in `useEditController` and `useShowController` when the record fails to be retrieved.

## How To Test

Perform the test in the `shadcn-admin-kit` with the updated code

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
