### PR TITLE
[chore] Add spinner while installing dependencies in create-react-admin

### DIFF
--- a/packages/create-react-admin/package.json
+++ b/packages/create-react-admin/package.json
@@ -24,6 +24,7 @@
         "fs-extra": "^11.1.1",
         "ink": "^5.0.0",
         "ink-select-input": "^6.0.0",
+        "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "lodash": "~4.17.5",
         "meow": "^9.0.0",

--- a/packages/create-react-admin/src/StepRunInstall.tsx
+++ b/packages/create-react-admin/src/StepRunInstall.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { Text } from 'ink';
+import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
 import { ProjectConfiguration } from './ProjectState.js';
 import { useInstallDeps } from './useInstallDeps.js';
 import { useRunFormatter } from './useRunFormatter.js';
@@ -24,5 +25,12 @@ export const StepRunInstall = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    return <Text>Installing dependencies...</Text>;
+    return (
+        <Box gap={1}>
+            <Text color="green">
+                <Spinner type="dots" />
+            </Text>
+            <Text>Installing dependencies...</Text>
+        </Box>
+    );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7285,17 +7285,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:2.6.1":
-  version: 2.6.1
-  resolution: "cli-spinners@npm:2.6.1"
-  checksum: 6abcdfef59aa68e6b51376d87d257f9120a0a7120a39dd21633702d24797decb6dc747dff2217c88732710db892b5053c5c672d221b6c4d13bbcb5372e203596
-  languageName: node
-  linkType: hard
-
-"cli-spinners@npm:^2.5.0":
-  version: 2.7.0
-  resolution: "cli-spinners@npm:2.7.0"
-  checksum: 5c781ace5c8f304ae4d138837f19cf88f03a97de3c3e388f9d1d6434146f06f6ce2a161d6237b3bb86448a05fbcbb20084f3fea96077e42a655b273e39c6f08d
+"cli-spinners@npm:2.6.1, cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.7.0":
+  version: 2.9.2
+  resolution: "cli-spinners@npm:2.9.2"
+  checksum: 907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
   languageName: node
   linkType: hard
 
@@ -7815,6 +7808,7 @@ __metadata:
     fs-extra: "npm:^11.1.1"
     ink: "npm:^5.0.0"
     ink-select-input: "npm:^6.0.0"
+    ink-spinner: "npm:^5.0.0"
     ink-text-input: "npm:^6.0.0"
     lodash: "npm:~4.17.5"
     meow: "npm:^9.0.0"
@@ -11492,6 +11486,18 @@ __metadata:
     ink: ">=5.0.0"
     react: ">=18.0.0"
   checksum: 6e2422dda13d2c5e29cb2f46b401949884c7e6c179eb8908cb8e558cf859c3e0af6aee603dc700e609a759c976bff2198442348d4c6695db3a34d454d7e63c3f
+  languageName: node
+  linkType: hard
+
+"ink-spinner@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "ink-spinner@npm:5.0.0"
+  dependencies:
+    cli-spinners: "npm:^2.7.0"
+  peerDependencies:
+    ink: ">=4.0.0"
+    react: ">=18.0.0"
+  checksum: 47b0201bc8b0b1fb475a6f8a117d5a099dde6f7ee2439b547ec60511e8460095ae6e78e8d34a7b8e54cb4c69def4310ce3649467c98ac8540d3c49ad030dd014
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

We currently only display a static message while installing dependencies. It's reassuring when something actually move so you know it's not frozen.

## How To Test

- `make build-create-react-admin install`
- `./react-admin/node_modules/.bin/create-react-admin myadmin --install npm`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
