### PR TITLE
Fix image alignment in ready page in some contexts

### DIFF
--- a/packages/ra-core/src/util/Ready.tsx
+++ b/packages/ra-core/src/util/Ready.tsx
@@ -42,6 +42,8 @@ const styles = {
         opacity: 1,
     },
     image: {
+        display: 'block',
+        margin: 'auto',
         width: 50,
     },
     logo: {


### PR DESCRIPTION
## Problem

Images in buttons are not centered. I think it only occurs when setting up React Admin without using create-react-admin. I saw this using shadcn-admin-kit.

![ready page with misaligned images in buttons](https://github.com/user-attachments/assets/1359a419-00e2-4137-8f66-984b1dde73f3)

## Solution

Add margin auto and ensure display block (display block wasn't actually required in my case but it's probably safer to enforce it).

## How To Test

Setup a shadcn admin kit project with this app:

```tsx
import { Admin } from "@/components/admin";

function App() {
  return <Admin></Admin>;
}

export default App;
```

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [X] The **documentation** is up to date
