### PR TITLE
Ensure tests are working in all environments by running them in US english

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "scripts": {
         "build": "lerna run build",
         "watch": "lerna run --parallel watch",
-        "test-unit": "cross-env NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=./node_modules/full-icu jest",
-        "test-unit-ci": "cross-env NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=./node_modules/full-icu jest --runInBand",
+        "test-unit": "cross-env LANG=en_US.UTF-8 NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=./node_modules/full-icu jest",
+        "test-unit-ci": "cross-env LANG=en_US.UTF-8 NODE_ENV=test cross-env BABEL_ENV=cjs NODE_ICU_DATA=./node_modules/full-icu jest --runInBand",
         "test-e2e": "yarn run -s build && cross-env NODE_ENV=test && cd cypress && yarn test",
         "test-e2e-local": "cd cypress && yarn start",
         "test": "yarn test-unit && yarn test-e2e",


### PR DESCRIPTION
## Problem

Some tests were not working locally as I have a machine configured in a different language than

## Solution

Override environment to always use `LANG=en_US.UTF-8` to run tests in a consistent environment.

## How To Test

`LANG=fr_FR.UTF-8 make test` and it's still working.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~[ ] The PR includes **unit tests** (if not possible, describe why)~
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- [X] The **documentation** is up to date
