### PR TITLE
[Doc] Mention that `helperText` also supports translation keys

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -330,6 +330,8 @@ Most inputs accept a `helperText` prop to display a text below the input.
 
 Set `helperText` to `false` to remove the empty line below the input. Beware that the form may "jump" visually when the input contains an error, as the error message will appear below the input.
 
+**Tip:** `helperText` also supports [translation keys](./Translation.md#translation-keys).
+
 **Tip:** It is not possible to set a `helperText` for inputs used inside a [filter](./List.md#filters-filter-inputs).
 
 ## `label`


### PR DESCRIPTION
## Problem

Doc issue identified in https://github.com/marmelab/react-admin/issues/10784

## Solution

Document that `helperText` also supports translation keys

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
