### PR TITLE
Remove theme props override from view components

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Create.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Create.stories.tsx
@@ -283,6 +283,13 @@ export const Themed = () => (
                         defaultProps: {
                             className: 'custom-class',
                         },
+                        styleOverrides: {
+                            root: {
+                                ['& .RaCreate-card']: {
+                                    color: 'red',
+                                },
+                            },
+                        },
                     },
                 },
             } as ThemeOptions)}

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -6,7 +6,6 @@ import {
     styled,
     type SxProps,
     type Theme,
-    useThemeProps,
 } from '@mui/material';
 import { useCreateContext } from 'ra-core';
 import clsx from 'clsx';
@@ -14,11 +13,7 @@ import clsx from 'clsx';
 import { Title } from '../layout';
 import { CreateProps } from './Create';
 
-export const CreateView = (inProps: CreateViewProps) => {
-    const props = useThemeProps({
-        props: inProps,
-        name: PREFIX,
-    });
+export const CreateView = (props: CreateViewProps) => {
     const {
         actions,
         aside,

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -375,6 +375,13 @@ export const Themed = () => (
                         defaultProps: {
                             className: 'custom-class',
                         },
+                        styleOverrides: {
+                            root: {
+                                ['& .RaEdit-card']: {
+                                    color: 'red',
+                                },
+                            },
+                        },
                     },
                 },
             } as ThemeOptions)}

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -7,7 +7,6 @@ import {
     styled,
     type SxProps,
     type Theme,
-    useThemeProps,
 } from '@mui/material';
 import clsx from 'clsx';
 import { useEditContext, useResourceDefinition } from 'ra-core';
@@ -18,11 +17,7 @@ import { EditProps } from './Edit';
 
 const defaultActions = <EditActions />;
 
-export const EditView = (inProps: EditViewProps) => {
-    const props = useThemeProps({
-        props: inProps,
-        name: PREFIX,
-    });
+export const EditView = (props: EditViewProps) => {
     const {
         actions,
         aside,

--- a/packages/ra-ui-materialui/src/detail/Show.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.stories.tsx
@@ -258,6 +258,13 @@ export const Themed = () => (
                         defaultProps: {
                             className: 'custom-class',
                         },
+                        styleOverrides: {
+                            root: {
+                                ['& .RaShow-card']: {
+                                    color: 'red',
+                                },
+                            },
+                        },
                     },
                 },
             } as ThemeOptions)}

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -6,7 +6,6 @@ import {
     styled,
     type SxProps,
     type Theme,
-    useThemeProps,
 } from '@mui/material';
 import clsx from 'clsx';
 import { useShowContext, useResourceDefinition } from 'ra-core';
@@ -16,11 +15,7 @@ import { ShowProps } from './Show';
 
 const defaultActions = <ShowActions />;
 
-export const ShowView = (inProps: ShowViewProps) => {
-    const props = useThemeProps({
-        props: inProps,
-        name: PREFIX,
-    });
+export const ShowView = (props: ShowViewProps) => {
     const {
         actions,
         aside,

--- a/packages/ra-ui-materialui/src/list/InfiniteList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/InfiniteList.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import expect from 'expect';
 import { render, screen } from '@testing-library/react';
 
-import { Themed } from './List.stories';
+import { Themed } from './InfiniteList.stories';
 
 describe('<InfiniteList />', () => {
     it('should be customized by a theme', async () => {

--- a/packages/ra-ui-materialui/src/list/InfiniteList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/InfiniteList.stories.tsx
@@ -452,6 +452,18 @@ export const Themed = () => (
                         perPage: 5,
                     },
                 },
+                RaList: {
+                    styleOverrides: {
+                        root: {
+                            background: 'pink',
+
+                            ['& .MuiListItemText-primary']: {
+                                color: 'hotpink',
+                                fontWeight: 'bold',
+                            },
+                        },
+                    },
+                },
             },
         } as ThemeOptions)}
     >

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -4,7 +4,6 @@ import {
     styled,
     type SxProps,
     type Theme,
-    useThemeProps,
 } from '@mui/material/styles';
 import type { ReactElement, ReactNode, ElementType } from 'react';
 import Card from '@mui/material/Card';
@@ -24,12 +23,8 @@ const defaultEmpty = <Empty />;
 const DefaultComponent = Card;
 
 export const ListView = <RecordType extends RaRecord = any>(
-    inProps: ListViewProps
+    props: ListViewProps
 ) => {
-    const props = useThemeProps({
-        props: inProps,
-        name: PREFIX,
-    });
     const {
         actions = defaultActions,
         aside,


### PR DESCRIPTION
## Problem

useThemeProps was called 2 times in details / lists components

## Solution

Remove useThemeProps where required.

## How To Test

View List / InfiniteList / Show / Edit / Create "Themed" story.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date
