### PR TITLE
Fix `<AutocompleteInput>` should not break when overriding input slot props

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -628,6 +628,21 @@ If you provided a React element for the optionText prop, you must also provide t
                         ...params.InputProps,
                         ...TextFieldProps?.InputProps,
                     };
+                    // @ts-expect-error slotProps do not yet exist in MUI v5
+                    const mergedSlotProps = TextFieldProps?.slotProps
+                        ? {
+                              slotProps: {
+                                  // @ts-expect-error slotProps do not yet exist in MUI v5
+                                  ...TextFieldProps?.slotProps,
+                                  input: {
+                                      readOnly,
+                                      ...params.InputProps,
+                                      // @ts-expect-error slotProps do not yet exist in MUI v5
+                                      ...TextFieldProps?.slotProps?.input,
+                                  },
+                              },
+                          }
+                        : undefined;
                     return (
                         <TextField
                             name={field.name}
@@ -663,6 +678,7 @@ If you provided a React element for the optionText prop, you must also provide t
                             {...params}
                             {...TextFieldProps}
                             InputProps={mergedTextFieldProps}
+                            {...mergedSlotProps}
                             size={size}
                             inputRef={handleInputRef}
                         />


### PR DESCRIPTION
## Problem

Fix https://github.com/marmelab/react-admin/issues/10789

With MUI v6 or v7, passing custom input slot props to `<AutocompleteInput>` breaks its autocomplete feature (the dropdown list doesn't open anymore)

## Solution

With MUI v6 or v7 the InputProps need to be forwarded as `slotProps.input` (as opposed to `InputProps` with MUI v5). With the previous implementation, passing custom `slotProps.input` as `TextFieldProps` would completely override the `slotProps` and hence loose the params injected by MUI.

The solution consists in injecting the input props at both places, to support all MUI versions.

The only catch is we should only pass a `slotProps` prop if one was passed to `TextFieldProps` (i.e. if the user is using the v6/v7 syntax), otherwise we would get a warning about unknow prop `slotProps` with MUI v5.

## How To Test

### To test backward compatibility with MUI v5

Edit `examples/simple/src/posts/PostCreate.tsx` with the following:

```diff
<AutocompleteInput
    label="User"
    create={<CreateUser />}
    openOnFocus={false}
+   TextFieldProps={{
+       InputProps: {
+           startAdornment: <BookIcon />,
+       },
+   }}
/>
```

Run `make run`.

Make sure the input still works and the icon is present.

### To test forward compatibility with MUI v7

Edit `examples/demo/src/reviews/ReviewCreate.tsx` with the following:

```diff
<AutocompleteInput
    optionText="reference"
    validate={required()}
+   TextFieldProps={{
+       slotProps: {
+           input: {
+               startAdornment: <BookIcon />,
+           },
+       },
+   }}
/>
```

You may get a TS error about unknown prop `slotProps`, but this is due to the IDE not properly resolving multiple versions of the MUI types (i.e. it's a monorepo only issue).
You can safely ignore that warning.

Run `make run-demo`.

Make sure the input still works and the icon is present.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> Can't target multiple versions of MUI in the tests
- [ ] The PR includes one or several **stories** (if not possible, describe why) -> Can't target multiple versions of MUI in stories
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
