### PR TITLE
Fix only the last notification is displayed when triggering consecutive notifications

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import {
+    ConsecutiveNotifications,
     ConsecutiveUndoable,
     CustomNotificationWithAction,
 } from './Notification.stories';
@@ -42,5 +43,14 @@ describe('<Notification />', () => {
             expect(screen.queryByText('Applied automatic changes')).toBeNull();
         });
         expect(consoleLog).toHaveBeenCalledWith('Custom action');
+    });
+    it('should display consecutive notifications', async () => {
+        const { container } = render(<ConsecutiveNotifications />);
+        await screen.findByText('hello, world');
+        // This line ensures the test fails without the fix
+        await new Promise(resolve => setTimeout(resolve, 200));
+        expect(screen.queryByText('goodbye, world')).toBeNull();
+        fireEvent.click(container);
+        await screen.findByText('goodbye, world');
     });
 });

--- a/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
@@ -27,11 +27,15 @@ const Wrapper = ({ children }) => (
     </NotificationContextProvider>
 );
 
-const BasicNotification = () => {
+const BasicNotification = ({
+    message = 'hello, world',
+}: {
+    message?: string;
+}) => {
     const notify = useNotify();
     React.useEffect(() => {
-        notify('hello, world');
-    }, [notify]);
+        notify(message);
+    }, [message, notify]);
     return null;
 };
 
@@ -241,5 +245,12 @@ const CustomNotificationElementWithAction = () => {
 export const CustomNotificationWithAction = () => (
     <Wrapper>
         <CustomNotificationElementWithAction />
+    </Wrapper>
+);
+
+export const ConsecutiveNotifications = () => (
+    <Wrapper>
+        <BasicNotification />
+        <BasicNotification message="goodbye, world" />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -69,23 +69,22 @@ export const Notification = (inProps: NotificationProps) => {
                 setCurrentNotification(notification);
                 setOpen(true);
             }
-        } else if (notifications.length && currentNotification && open) {
-            // Close an active snack when a new one is added
-            setOpen(false);
         }
 
-        const beforeunload = (e: BeforeUnloadEvent) => {
-            e.preventDefault();
-            const confirmationMessage = '';
-            e.returnValue = confirmationMessage;
-            return confirmationMessage;
-        };
-
-        if (currentNotification?.notificationOptions?.undoable) {
-            window.addEventListener('beforeunload', beforeunload);
-            return () => {
-                window.removeEventListener('beforeunload', beforeunload);
+        if (currentNotification) {
+            const beforeunload = (e: BeforeUnloadEvent) => {
+                e.preventDefault();
+                const confirmationMessage = '';
+                e.returnValue = confirmationMessage;
+                return confirmationMessage;
             };
+
+            if (currentNotification?.notificationOptions?.undoable) {
+                window.addEventListener('beforeunload', beforeunload);
+                return () => {
+                    window.removeEventListener('beforeunload', beforeunload);
+                };
+            }
         }
     }, [notifications, currentNotification, open, takeNotification]);
 


### PR DESCRIPTION
## Problem

When triggering multiple consecutive notifications, only the last one is displayed.

## How To Test

- Unit tests
- https://react-admin-storybook-h3l9433az-marmelab.vercel.app/?path=/story/ra-ui-materialui-layout-notification--consecutive-notifications

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
