### PR TITLE
Add support for middlewares to `useUpdateMany`

### DIFF
--- a/packages/ra-core/src/dataProvider/useUpdateMany.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.stories.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
 
 import { CoreAdminContext } from '../core';
 import { useUpdateMany } from './useUpdateMany';
 import { useGetList } from './useGetList';
+import { useState } from 'react';
+import { useGetOne } from './useGetOne';
+import { useTakeUndoableMutation } from './undo';
 
 export default { title: 'ra-core/dataProvider/useUpdateMany' };
 
@@ -47,6 +50,155 @@ const UndefinedValuesCore = () => {
                     Update title
                 </button>
             </div>
+        </>
+    );
+};
+
+export const WithMiddlewares = ({
+    timeout = 1000,
+    mutationMode,
+    shouldError,
+}: {
+    timeout?: number;
+    mutationMode: 'optimistic' | 'pessimistic' | 'undoable';
+    shouldError?: boolean;
+}) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: () => {
+            return Promise.resolve({
+                data: posts[0],
+            });
+        },
+        updateMany: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    if (shouldError) {
+                        return reject(new Error('something went wrong'));
+                    }
+                    posts[0].title = params.data.title;
+                    resolve({ data: [1] });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext dataProvider={dataProvider}>
+            <WithMiddlewaresCore mutationMode={mutationMode} />
+        </CoreAdminContext>
+    );
+};
+WithMiddlewares.args = {
+    timeout: 1000,
+    mutationMode: 'optimistic',
+    shouldError: false,
+};
+WithMiddlewares.argTypes = {
+    timeout: {
+        control: { type: 'number' },
+    },
+    mutationMode: {
+        options: ['optimistic', 'pessimistic', 'undoable'],
+        control: { type: 'select' },
+    },
+    shouldError: {
+        control: { type: 'boolean' },
+    },
+};
+
+const WithMiddlewaresCore = ({
+    mutationMode,
+}: {
+    mutationMode: 'optimistic' | 'pessimistic' | 'undoable';
+}) => {
+    const isMutating = useIsMutating();
+    const [notification, setNotification] = useState<boolean>(false);
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+
+    const takeMutation = useTakeUndoableMutation();
+
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [updateMany, { isPending }] = useUpdateMany(
+        'posts',
+        {
+            ids: [1],
+            data: { title: 'Hello World' },
+        },
+        {
+            mutationMode,
+            // @ts-ignore
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: { title: `${params.data.title} from middleware` },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        updateMany(
+            'posts',
+            {
+                ids: [1],
+                data: { title: 'Hello World' },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+        if (mutationMode === 'undoable') {
+            setNotification(true);
+        }
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                {notification ? (
+                    <>
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: false });
+                            }}
+                        >
+                            Confirm
+                        </button>
+                        &nbsp;
+                        <button
+                            onClick={() => {
+                                setNotification(false);
+                                const mutation = takeMutation();
+                                if (!mutation) return;
+                                mutation({ isUndo: true });
+                            }}
+                        >
+                            Cancel
+                        </button>
+                    </>
+                ) : (
+                    <button onClick={handleClick} disabled={isPending}>
+                        Update title
+                    </button>
+                )}
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {error && <div>{error.message}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
         </>
     );
 };

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -18,6 +18,7 @@ import {
     MutationMode,
     GetListResult as OriginalGetListResult,
     GetInfiniteListResult,
+    DataProvider,
 } from '../types';
 import { useEvent } from '../util';
 import { Identifier } from '..';
@@ -89,11 +90,17 @@ export const useUpdateMany = <
     const queryClient = useQueryClient();
     const addUndoableMutation = useAddUndoableMutation();
     const { ids, data, meta } = params;
-    const { mutationMode = 'pessimistic', ...mutationOptions } = options;
+    const {
+        mutationMode = 'pessimistic',
+        getMutateWithMiddlewares,
+        ...mutationOptions
+    } = options;
     const mode = useRef<MutationMode>(mutationMode);
     const paramsRef =
         useRef<Partial<UpdateManyParams<Partial<RecordType>>>>(params);
     const snapshot = useRef<Snapshot>([]);
+    // Ref that stores the mutation with middlewares to avoid losing them if the calling component is unmounted
+    const mutateWithMiddlewares = useRef(dataProvider.updateMany);
     const hasCallTimeOnError = useRef(false);
     const hasCallTimeOnSuccess = useRef(false);
     const hasCallTimeOnSettled = useRef(false);
@@ -213,8 +220,8 @@ export const useUpdateMany = <
                     'useUpdateMany mutation requires a non-empty data object'
                 );
             }
-            return dataProvider
-                .updateMany<RecordType>(callTimeResource, {
+            return mutateWithMiddlewares
+                .current(callTimeResource, {
                     ids: callTimeIds,
                     data: callTimeData,
                     meta: callTimeMeta,
@@ -341,6 +348,15 @@ export const useUpdateMany = <
             returnPromise = mutationOptions.returnPromise,
             ...otherCallTimeOptions
         } = callTimeOptions;
+
+        // Store the mutation with middlewares to avoid losing them if the calling component is unmounted
+        if (getMutateWithMiddlewares) {
+            mutateWithMiddlewares.current = getMutateWithMiddlewares(
+                dataProvider.updateMany.bind(dataProvider)
+            );
+        } else {
+            mutateWithMiddlewares.current = dataProvider.updateMany;
+        }
 
         hasCallTimeOnError.current = !!otherCallTimeOptions.onError;
         hasCallTimeOnSuccess.current = !!otherCallTimeOptions.onSuccess;
@@ -507,7 +523,18 @@ export type UseUpdateManyOptions<
     Array<RecordType['id']>,
     MutationError,
     Partial<Omit<UseUpdateManyMutateParams<RecordType>, 'mutationFn'>>
-> & { mutationMode?: MutationMode; returnPromise?: boolean };
+> & {
+    mutationMode?: MutationMode;
+    returnPromise?: boolean;
+    getMutateWithMiddlewares?: <
+        UpdateFunctionType extends
+            DataProvider['updateMany'] = DataProvider['updateMany'],
+    >(
+        mutate: UpdateFunctionType
+    ) => (
+        ...Params: Parameters<UpdateFunctionType>
+    ) => ReturnType<UpdateFunctionType>;
+};
 
 export type UseUpdateManyResult<
     RecordType extends RaRecord = any,


### PR DESCRIPTION
## Problem

`useUpdateMany` currently does not support middlewares (only `useUpdate` and `useUpdate` do).

That's an issue for EE components like `BulkUpdateFormButton` + `InputSelectorForm`.

## Solution

Implement support for middlewares in `useUpdateMany`.

## How To Test

- http://localhost:9010/?path=/story/ra-core-dataprovider-useupdatemany--with-middlewares&args=mutationMode:pessimistic
  - play with the controls
- unit tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
