### PR TITLE
[Doc] Update `<CreateDialog>` regarding limitation with old versions of react-admin

### DIFF
--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -66,7 +66,7 @@ In the related `<Resource>`, you don't need to declare a `create` component as t
 <Resource name="customers" list={CustomerList} />
 ```
 
-**Note**: If you use a react-admin version older than `5.8.5`, you can't have both a `<CreateDialog>` and a standard `<Edit>` specified on your `<Resource>`, because the `<Routes>` declarations would conflict. If you need this, use the `<CreateInDialogButton>` instead.
+**Note**: If you use a react-admin version older than `5.9.0`, you can't have both a `<CreateDialog>` and a standard `<Edit>` specified on your `<Resource>`, because the `<Routes>` declarations would conflict. If you need this, use the `<CreateInDialogButton>` instead.
 
 ## Props
 

--- a/docs/CreateDialog.md
+++ b/docs/CreateDialog.md
@@ -66,7 +66,7 @@ In the related `<Resource>`, you don't need to declare a `create` component as t
 <Resource name="customers" list={CustomerList} />
 ```
 
-**Note**: You can't use the `<CreateDialog>` and have a standard `<Edit>` specified on your `<Resource>`, because the `<Routes>` declarations would conflict. If you need this, use the [`<CreateInDialogButton>`](./CreateInDialogButton.md) instead.
+**Note**: If you use a react-admin version older than `5.8.5`, you can't have both a `<CreateDialog>` and a standard `<Edit>` specified on your `<Resource>`, because the `<Routes>` declarations would conflict. If you need this, use the `<CreateInDialogButton>` instead.
 
 ## Props
 

--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -99,7 +99,7 @@ describe('useCreate', () => {
         });
     });
 
-    it('accepts a meta paramater', async () => {
+    it('accepts a meta parameter', async () => {
         const dataProvider = testDataProvider({
             create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
         });
@@ -236,18 +236,19 @@ describe('useCreate', () => {
             });
         });
         it('when optimistic, displays result and success side effects right away', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
             render(<SuccessCaseOptimistic timeout={10} />);
             screen.getByText('Create post').click();
             await waitFor(() => {
-                expect(screen.queryByText('success')).not.toBeNull();
-                expect(screen.queryByText('Hello World')).not.toBeNull();
                 expect(screen.queryByText('mutating')).not.toBeNull();
             });
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello World')).not.toBeNull();
             await waitFor(() => {
-                expect(screen.queryByText('success')).not.toBeNull();
-                expect(screen.queryByText('Hello World')).not.toBeNull();
                 expect(screen.queryByText('mutating')).toBeNull();
             });
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello World')).not.toBeNull();
         });
         it('when optimistic, displays error and error side effects when dataProvider promise rejects', async () => {
             jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Problem

We can now have both `<CreateDialog>` and a standard `<Edit>` in version greater that `5.9.0`

## Solution

Update the documentation