### PR TITLE
Fix `<DataTable>` does not allow to put a button in the column's header

### DIFF
--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.stories.tsx
@@ -37,6 +37,7 @@ import {
 import {
     BulkDeleteButton,
     BulkExportButton,
+    CreateButton,
     EditButton,
     SelectAllButton as RaSelectAllButton,
 } from '../../button';
@@ -893,6 +894,20 @@ export const NonPrimitiveData = () => (
             <DataTable.Col source="title" />
             <DataTable.Col source="author" />
             <DataTable.Col source="year" />
+        </DataTable>
+    </Wrapper>
+);
+
+export const HeaderButton = () => (
+    <Wrapper i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col label="Author" source="author.name" disableSort />
+            <DataTable.Col source="year" />
+            <DataTable.Col label={<CreateButton />}>
+                <EditButton />
+            </DataTable.Col>
         </DataTable>
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableHeadCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableHeadCell.tsx
@@ -120,13 +120,11 @@ export const DataTableHeadCell = React.memo(
                             </TableSortLabel>
                         </Tooltip>
                     ) : (
-                        <TableSortLabel disabled>
-                            <FieldTitle
-                                label={label}
-                                source={source}
-                                resource={resource}
-                            />
-                        </TableSortLabel>
+                        <FieldTitle
+                            label={label}
+                            source={source}
+                            resource={resource}
+                        />
                     )}
                 </TableCellStyled>
             );


### PR DESCRIPTION
## Problem

`<DataTable>` does not allow to put a button in the column's header (the pointer events are disabled)

## Solution

Remove unnecessary wrapper `<TableSortLabel disabled>`

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-list-datatable--header-button

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> not really relevant to me as this is purely CSS issue
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
