### PR TITLE
[chore] Avoid vercel deployment for `gh-pages` branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
-    "github": {
-        "silent": true
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "git": {
+        "deploymentEnabled": {
+            "gh-pages": false
+        }
     }
 }


### PR DESCRIPTION
## Problem

- Our config is using obsolete properties
- When pushing go the `gh-pages` branch, vercel tries to deploy the demo and storybook, sending error notifications

## Solution

Fix the vercel config
