### PR TITLE
Fix mutation hooks `mutationMode` option cannot be controlled

### DIFF
--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import expect from 'expect';
 
 import { RaRecord } from '../types';
@@ -7,6 +7,7 @@ import { testDataProvider } from './testDataProvider';
 import { useCreate } from './useCreate';
 import { useGetList } from './useGetList';
 import { CoreAdminContext } from '../core';
+import { Basic } from './useCreate.stories';
 import {
     ErrorCase as ErrorCasePessimistic,
     SuccessCase as SuccessCasePessimistic,
@@ -333,6 +334,23 @@ describe('useCreate', () => {
                 expect(screen.queryByText('Hello World')).toBeNull();
                 expect(screen.queryByText('mutating')).toBeNull();
             });
+        });
+        it('allows to control the mutation mode', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<Basic timeout={10} />);
+            // Create a post in pessimistic mode
+            fireEvent.click(await screen.findByText('Create post'));
+            await screen.findByText('Hello World 2');
+            fireEvent.click(await screen.findByText('undoable'));
+            fireEvent.click(await screen.findByText('Increment id'));
+            await screen.findByText('nothing yet');
+            // Create a post in undoable mode
+            fireEvent.click(await screen.findByText('Create post'));
+            // Check the optimistic result
+            await screen.findByText('Hello World 3');
+            // As we haven't confirmed the undoable mutation, refetching the post should return nothing
+            fireEvent.click(await screen.findByText('Refetch'));
+            await screen.findByText('nothing yet');
         });
     });
 

--- a/packages/ra-core/src/dataProvider/useCreate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.stories.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useCreate } from './useCreate';
+import { useGetOne } from './useGetOne';
+import { MutationMode } from '../types';
+
+export default { title: 'ra-core/dataProvider/useCreate' };
+
+export const Basic = ({ timeout = 1000 }: { timeout?: number }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('nothing yet'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+Basic.args = {
+    timeout: 1000,
+};
+
+Basic.argTypes = {
+    timeout: {
+        control: {
+            type: 'number',
+        },
+    },
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [id, setId] = useState<number>(2);
+    const [mutationMode, setMutationMode] =
+        useState<MutationMode>('pessimistic');
+    const { data, error, refetch } = useGetOne('posts', { id });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {},
+        {
+            mutationMode,
+            onSuccess: () => {
+                setSuccess('success');
+            },
+        }
+    );
+    const handleClick = () => {
+        create('posts', {
+            data: { id, title: `Hello World ${id}` },
+        });
+    };
+    return (
+        <>
+            {error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+                <button onClick={() => setId(prev => prev + 1)}>
+                    Increment id
+                </button>
+                <button onClick={() => setMutationMode('pessimistic')}>
+                    pessimistic
+                </button>
+                <button onClick={() => setMutationMode('optimistic')}>
+                    optimistic
+                </button>
+                <button onClick={() => setMutationMode('undoable')}>
+                    undoable
+                </button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     UseMutationOptions,
@@ -96,7 +96,11 @@ export const useCreate = <
         getMutateWithMiddlewares,
         ...mutationOptions
     } = options;
+
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
 
     const paramsRef =
         useRef<Partial<CreateParams<Partial<RecordType>>>>(params);

--- a/packages/ra-core/src/dataProvider/useDelete.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.stories.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useDelete } from './useDelete';
+import { useGetList } from './useGetList';
+import { MutationMode } from '../types';
+
+export default { title: 'ra-core/dataProvider/useDelete' };
+
+export const Basic = ({ timeout = 1000 }: { timeout?: number }) => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const index = posts.findIndex(p => p.id === params.id);
+                    const deletedPost = posts.splice(index, 1);
+                    resolve({ data: deletedPost });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [id, setId] = useState<number>(1);
+    const [mutationMode, setMutationMode] =
+        useState<MutationMode>('pessimistic');
+    const [deleteOne, { isPending }] = useDelete(
+        'posts',
+        {},
+        {
+            mutationMode,
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+    const handleClick = () => {
+        deleteOne('posts', {
+            id,
+            previousData: { id, title: 'Hello' },
+        });
+    };
+    return (
+        <>
+            <ul>{data?.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Delete post
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+                <button onClick={() => setId(prev => prev + 1)}>
+                    Increment id
+                </button>
+                <button onClick={() => setMutationMode('pessimistic')}>
+                    pessimistic
+                </button>
+                <button onClick={() => setMutationMode('optimistic')}>
+                    optimistic
+                </button>
+                <button onClick={() => setMutationMode('undoable')}>
+                    undoable
+                </button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -93,6 +93,9 @@ export const useDelete = <
     const { id, previousData } = params;
     const { mutationMode = 'pessimistic', ...mutationOptions } = options;
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
     const paramsRef = useRef<Partial<DeleteParams<RecordType>>>(params);
     const snapshot = useRef<Snapshot>([]);
     const hasCallTimeOnError = useRef(false);

--- a/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useGetList } from './useGetList';
+import { MutationMode } from '../types';
+import { useDeleteMany } from './useDeleteMany';
+
+export default { title: 'ra-core/dataProvider/useDeleteMany' };
+
+export const Basic = ({ timeout = 1000 }: { timeout?: number }) => {
+    const posts = [
+        { id: 1, title: 'Hello World 1' },
+        { id: 2, title: 'Hello World 2' },
+        { id: 3, title: 'Hello World 3' },
+        { id: 4, title: 'Hello World 4' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        deleteMany: (resource, params) => {
+            console.log('deleteMany', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    for (const id of params.ids) {
+                        const index = posts.findIndex(p => p.id === id);
+                        posts.splice(index, 1);
+                    }
+                    resolve({ data: params.ids });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [id, setId] = useState<number>(1);
+    const [mutationMode, setMutationMode] =
+        useState<MutationMode>('pessimistic');
+    const [deleteMany, { isPending }] = useDeleteMany('posts', undefined, {
+        mutationMode,
+        onSuccess: () => setSuccess('success'),
+    });
+    const handleClick = () => {
+        deleteMany('posts', {
+            ids: [id, id + 1],
+        });
+    };
+    return (
+        <>
+            <ul>{data?.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Delete posts
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+                <button onClick={() => setId(prev => prev + 2)}>
+                    Increment id
+                </button>
+                <button onClick={() => setMutationMode('pessimistic')}>
+                    pessimistic
+                </button>
+                <button onClick={() => setMutationMode('optimistic')}>
+                    optimistic
+                </button>
+                <button onClick={() => setMutationMode('undoable')}>
+                    undoable
+                </button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -93,6 +93,9 @@ export const useDeleteMany = <
     const { ids } = params;
     const { mutationMode = 'pessimistic', ...mutationOptions } = options;
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
     const paramsRef = useRef<Partial<DeleteManyParams<RecordType>>>({});
     const snapshot = useRef<Snapshot>([]);
     const hasCallTimeOnError = useRef(false);

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+    act,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react';
 import expect from 'expect';
 
 import { CoreAdminContext } from '../core';
@@ -25,6 +31,7 @@ import {
     WithMiddlewaresError as WithMiddlewaresErrorUndoable,
 } from './useUpdate.undoable.stories';
 import { QueryClient } from '@tanstack/react-query';
+import { Basic } from './useUpdate.stories';
 
 describe('useUpdate', () => {
     describe('mutate', () => {
@@ -367,6 +374,23 @@ describe('useUpdate', () => {
                 expect(screen.queryByText('Hello World')).toBeNull();
                 expect(screen.queryByText('mutating')).toBeNull();
             });
+        });
+        it('allows to control the mutation mode', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            render(<Basic timeout={10} />);
+            await screen.findByText('Hello');
+            // Update the post in pessimistic mode
+            fireEvent.click(await screen.findByText('Update title'));
+            await screen.findByText('Hello World 0');
+            fireEvent.click(await screen.findByText('undoable'));
+            fireEvent.click(await screen.findByText('Increment counter'));
+            // Update a post in undoable mode
+            fireEvent.click(await screen.findByText('Update title'));
+            // Check the optimistic result
+            await screen.findByText('Hello World 1');
+            // As we haven't confirmed the undoable mutation, refetching the post should return nothing
+            fireEvent.click(await screen.findByText('Refetch'));
+            await screen.findByText('Hello World 0');
         });
     });
     describe('query cache', () => {

--- a/packages/ra-core/src/dataProvider/useUpdate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.stories.tsx
@@ -1,0 +1,370 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useUpdate } from './useUpdate';
+import { useGetOne } from './useGetOne';
+import { MutationMode } from '..';
+
+export default { title: 'ra-core/dataProvider/useUpdate' };
+
+export const Basic = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return Promise.resolve({
+                data: posts.find(p => p.id === params.id),
+            });
+        },
+        update: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const post = posts.find(p => p.id === params.id);
+                    if (post) {
+                        post.title = params.data.title;
+                    }
+                    resolve({ data: post });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <SuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const SuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [counter, setCounter] = useState(0);
+    const [mutationMode, setMutationMode] =
+        useState<MutationMode>('pessimistic');
+    const [update, { isPending }] = useUpdate('posts', undefined, {
+        mutationMode,
+        onSuccess: () => setSuccess('success'),
+    });
+    const handleClick = () => {
+        update('posts', {
+            id: 1,
+            data: { title: `Hello World ${counter}` },
+        });
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+                <button onClick={() => setCounter(prev => prev + 1)}>
+                    Increment counter
+                </button>
+                <button onClick={() => setMutationMode('pessimistic')}>
+                    pessimistic
+                </button>
+                <button onClick={() => setMutationMode('optimistic')}>
+                    optimistic
+                </button>
+                <button onClick={() => setMutationMode('undoable')}>
+                    undoable
+                </button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const UndefinedValues = () => {
+    const data = { id: 1, title: 'Hello' };
+    const dataProvider = {
+        getOne: async () => ({ data }),
+        update: () => new Promise(() => {}), // never resolve to see only optimistic update
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <UndefinedValuesCore />
+        </CoreAdminContext>
+    );
+};
+
+const UndefinedValuesCore = () => {
+    const { data } = useGetOne('posts', { id: 1 });
+    const [update, { isPending }] = useUpdate();
+    const handleClick = () => {
+        update(
+            'posts',
+            { id: 1, data: { id: undefined, title: 'world' } },
+            { mutationMode: 'optimistic' }
+        );
+    };
+    return (
+        <>
+            <pre>{JSON.stringify(data)}</pre>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+            </div>
+        </>
+    );
+};
+
+export const ErrorCase = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return Promise.resolve({
+                data: posts.find(p => p.id === params.id),
+            });
+        },
+        update: () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <ErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const ErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [update, { isPending }] = useUpdate();
+    const handleClick = () => {
+        update(
+            'posts',
+            {
+                id: 1,
+                data: { title: 'Hello World' },
+            },
+            {
+                mutationMode: 'optimistic',
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {error && <div>{error.message}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const WithMiddlewaresSuccess = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return Promise.resolve({
+                data: posts.find(p => p.id === params.id),
+            });
+        },
+        update: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const post = posts.find(p => p.id === params.id);
+                    if (post) {
+                        post.title = params.data.title;
+                    }
+                    resolve({ data: post });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <WithMiddlewaresSuccessCore />
+        </CoreAdminContext>
+    );
+};
+
+const WithMiddlewaresSuccessCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [update, { isPending }] = useUpdate(
+        'posts',
+        {
+            id: 1,
+            data: { title: 'Hello World' },
+        },
+        {
+            mutationMode: 'optimistic',
+            // @ts-ignore
+            getMutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: { title: `${params.data.title} from middleware` },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        update(
+            'posts',
+            {
+                id: 1,
+                data: { title: 'Hello World' },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+            }
+        );
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const WithMiddlewaresError = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return Promise.resolve({
+                data: posts.find(p => p.id === params.id),
+            });
+        },
+        update: () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('something went wrong'));
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <WithMiddlewaresErrorCore />
+        </CoreAdminContext>
+    );
+};
+
+const WithMiddlewaresErrorCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const [error, setError] = useState<any>();
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [update, { isPending }] = useUpdate(
+        'posts',
+        {
+            id: 1,
+            data: { title: 'Hello World' },
+        },
+        {
+            mutationMode: 'optimistic',
+            // @ts-ignore
+            mutateWithMiddlewares: mutate => async (resource, params) => {
+                return mutate(resource, {
+                    ...params,
+                    data: { title: `${params.data.title} from middleware` },
+                });
+            },
+        }
+    );
+    const handleClick = () => {
+        setError(undefined);
+        update(
+            'posts',
+            {
+                id: 1,
+                data: { title: 'Hello World' },
+            },
+            {
+                onSuccess: () => setSuccess('success'),
+                onError: e => {
+                    setError(e);
+                    setSuccess('');
+                },
+            }
+        );
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {error && <div>{error.message}</div>}
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -99,6 +99,9 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
         ...mutationOptions
     } = options;
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
     const paramsRef = useRef<Partial<UpdateParams<RecordType>>>(params);
     const snapshot = useRef<Snapshot>([]);
     // Ref that stores the mutation with middlewares to avoid losing them if the calling component is unmounted


### PR DESCRIPTION
## Problem

All our mutation hooks accepts a `mutationMode` option. However, if this option dynamically changes, the changes will be ignored. This is because we store the initial value in a `useRef` but never update it.

## How To Test

- stories
- unit tests

## Todo

- [x] `useCreate`
- [x] `useDelete`
- [x] `useDeleteMany`
- [x] `useUpdate`
- [ ] `useUpdateMany`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
