### PR TITLE
[chore] Fix a failing test not showing up in useDeleteWithUndoController

### DIFF
--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.spec.tsx
@@ -44,7 +44,7 @@ describe('useDeleteWithConfirmController', () => {
 
         const button = await screen.findByText('Delete');
         fireEvent.click(button);
-        waitFor(() => expect(receivedMeta).toEqual('metadata'), {
+        await waitFor(() => expect(receivedMeta).toEqual('metadata'), {
             timeout: 1000,
         });
     });


### PR DESCRIPTION
## Problem

`useDeleteWithUndoController` had a test failing, but it wasn't showing up as the waitFor wasn't awaited.

## Solution

`await` the `waitFor` and trigger the mutation so the test can pass.

## How To Test

`make test-unit`

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- ~[ ] The **documentation** is up to date~
