### PR TITLE
[Doc] Fix storybook detection and handling on client-side navigation

### DIFF
--- a/docs/js/ra-navigation.js
+++ b/docs/js/ra-navigation.js
@@ -60,9 +60,15 @@ function buildPageToC() {
             hasInnerContainers: true,
         });
 
-        const storybookPathMetaContent = document.querySelector(
+        const storybookPathMetaElement = document.querySelector(
             STORYBOOK_PATH_META_SELECTOR
-        ).content;
+        );
+        let storybookPathMetaContent;
+        if (storybookPathMetaElement) {
+            storybookPathMetaContent = document.querySelector(
+                STORYBOOK_PATH_META_SELECTOR
+            ).content;
+        }
         const tocList = document.querySelector('.toc-list');
         if (!tocList || !storybookPathMetaContent) {
             return;
@@ -113,12 +119,24 @@ function replaceContent(text) {
     );
 
     const newStorybookPathContent = newStorybookPathMeta?.content ?? '';
-    document
-        .querySelector(STORYBOOK_PATH_META_SELECTOR)
-        .setAttribute('content', newStorybookPathContent);
+    const storybookPathMetaElement = document.querySelector(
+        STORYBOOK_PATH_META_SELECTOR
+    );
+    if (storybookPathMetaElement && newStorybookPathContent) {
+        document
+            .querySelector(STORYBOOK_PATH_META_SELECTOR)
+            .setAttribute('content', newStorybookPathContent);
+    } else if (newStorybookPathContent) {
+        const metaElement = document.createElement('meta');
+        metaElement.setAttribute('name', 'storybook_path');
+        metaElement.setAttribute('content', newStorybookPathContent);
+        document.head.appendChild(metaElement);
+    } else {
+        // Remove the meta element if it doesn't exist in the new content
+        storybookPathMetaElement?.remove();
+    }
 
     window.scrollTo(0, 0);
-
     buildPageToC();
 
     navigationFitScroll();


### PR DESCRIPTION
## Problem

When navigating a page that does not have a storybook frontmatter, an error is thrown. Navigating to any page that should have a TOC doesn't display the TOC anymore.

## How To Test

1. `make doc`
2. go to http://0.0.0.0:4000/documentation.html : there should be no error in console
3. click the _Admin_ link in the sidebar: it should load, display the TOC and the storybook link
4. click the _Vite_ link in the sidebar: there should be no error in console, it should display a TOC without storybook link

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
