### PR TITLE
Fix `fullWidth` is not propagated anymore

### DIFF
--- a/packages/ra-ui-materialui/src/input/DatagridInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/DatagridInput.stories.tsx
@@ -47,7 +47,6 @@ const BookEdit = () => {
                 <DatagridInput
                     source="author"
                     choices={choices}
-                    fullWidth
                     rowClick="toggleSelection"
                 >
                     <TextField source="name" />

--- a/packages/ra-ui-materialui/src/input/DatagridInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DatagridInput.tsx
@@ -175,7 +175,7 @@ export const DatagridInput = (inProps: DatagridInputProps) => {
 
 export type DatagridInputProps = Omit<
     CommonInputProps,
-    'source' | 'readOnly' | 'disabled'
+    'fullWidth' | 'source' | 'readOnly' | 'disabled'
 > &
     ChoicesProps &
     Omit<SupportCreateSuggestionOptions, 'handleChange'> &

--- a/packages/ra-ui-materialui/src/input/sanitizeInputRestProps.ts
+++ b/packages/ra-ui-materialui/src/input/sanitizeInputRestProps.ts
@@ -41,6 +41,5 @@ export const sanitizeInputRestProps = ({
     validate,
     validateFields,
     value,
-    fullWidth,
     ...rest
 }: any) => rest;


### PR DESCRIPTION
## Problem

Regression introduced in https://github.com/marmelab/react-admin/pull/10772/files#diff-ac33f5830e4b132ca41269e194567542c51b45e341898c200b547516d2696028R44

## How To Test

- Fixed: https://react-admin-storybook-90sll8xaw-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-textinput--non-full-width
- Broken: https://react-admin-storybook-478wf3y4m-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-textinput--non-full-width

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature