### PR TITLE
Improve memory footprint of `useCanAccess` when it targets a record

### DIFF
--- a/packages/ra-core/src/auth/CanAccess.stories.tsx
+++ b/packages/ra-core/src/auth/CanAccess.stories.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Location } from 'react-router';
 import { QueryClient } from '@tanstack/react-query';
 import { AuthProvider } from '../types';
-import { CoreAdminContext } from '../core';
+import { CoreAdminContext } from '../core/CoreAdminContext';
 import { CanAccess } from './CanAccess';
-import { TestMemoryRouter } from '..';
+import { TestMemoryRouter } from '../routing/TestMemoryRouter';
 
 export default {
     title: 'ra-core/auth/CanAccess',
@@ -106,6 +106,48 @@ export const NoAuthProvider = () => (
             <CanAccess action="read" resource="test">
                 protected content
             </CanAccess>
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
+const data = Array.from({ length: 1000 }, (_, i) => {
+    const post = {
+        id: i + 1,
+        title: `Post ${i + 1}`,
+        body: `This is the body of post ${i + 1}`,
+    };
+
+    Array.from({ length: 100 }, (_, i) => {
+        post[`property${i + 1}`] = `Another very long property ${i + 1}`;
+    });
+
+    return post;
+});
+
+export const ManyCalls = ({
+    authProvider = defaultAuthProvider,
+    queryClient,
+}: {
+    authProvider?: AuthProvider | null;
+    queryClient?: QueryClient;
+}) => (
+    <TestMemoryRouter>
+        <CoreAdminContext
+            authProvider={authProvider != null ? authProvider : undefined}
+            queryClient={queryClient}
+        >
+            <div>
+                {data.map(post => (
+                    <CanAccess
+                        key={post.id}
+                        action="read"
+                        resource="posts"
+                        record={post}
+                    >
+                        <div>{post.title}</div>
+                    </CanAccess>
+                ))}
+            </div>
         </CoreAdminContext>
     </TestMemoryRouter>
 );

--- a/packages/ra-core/src/auth/useCanAccess.ts
+++ b/packages/ra-core/src/auth/useCanAccess.ts
@@ -62,11 +62,15 @@ export const useCanAccess = <
         );
     }
     const record = useRecordContext<RecordType>(params);
-
+    const { record: _record, ...restParams } = params;
     const authProviderHasCanAccess = !!authProvider?.canAccess;
 
     const queryResult = useQuery({
-        queryKey: ['auth', 'canAccess', { ...params, record, resource }],
+        queryKey: [
+            'auth',
+            'canAccess',
+            { ...restParams, recordId: record?.id, resource },
+        ],
         queryFn: async ({ signal }) => {
             if (!authProvider || !authProvider.canAccess) {
                 return true;


### PR DESCRIPTION
## Problem

When wrapping many different records in `<CanAccess>`, its memory footpring is huge. 

## Solution

This is because we pass the whole record in the `useQuery` parameters. We can only pass the record identifier.

## How It Was Tested

Before the fix:
![image](https://github.com/user-attachments/assets/d4b6f87c-389f-430c-8310-a39386558a97)

After the fix:
![image](https://github.com/user-attachments/assets/bd625a77-da07-47a3-9fe4-b6597dff3d28)

Even with this small use case (records are quite simple), that's 10MB saved.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
