### PR TITLE
Added `SelectInput` and `SelectArrayInput` disable choices test and story

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -228,7 +228,7 @@ describe('<SelectArrayInput />', () => {
         expect(screen.queryByText('Programming')).not.toBeNull();
     });
 
-    it('should render disable choices marked so', () => {
+    it('should render disable choices marked as so', () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
                 <ResourceContextProvider value="posts">
@@ -239,6 +239,37 @@ describe('<SelectArrayInput />', () => {
                                 { id: 'ang', name: 'Angular' },
                                 { id: 'rea', name: 'React', disabled: true },
                             ]}
+                        />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+        fireEvent.mouseDown(
+            screen.getByLabelText('resources.posts.fields.categories')
+        );
+        const option1 = screen.getByText('Angular');
+        expect(option1.getAttribute('aria-disabled')).toBeNull();
+
+        const option2 = screen.getByText('React');
+        expect(option2.getAttribute('aria-disabled')).toEqual('true');
+    });
+
+    it('should render disabled choices marked as so by disableValue prop', () => {
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm onSubmit={jest.fn()}>
+                        <SelectArrayInput
+                            {...defaultProps}
+                            choices={[
+                                { id: 'ang', name: 'Angular' },
+                                {
+                                    id: 'rea',
+                                    name: 'React',
+                                    not_available: true,
+                                },
+                            ]}
+                            disableValue="not_available"
                         />
                     </SimpleForm>
                 </ResourceContextProvider>

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -26,7 +26,6 @@ import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { SelectArrayInput } from './SelectArrayInput';
 import { TextInput } from './TextInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
-import { SelectInput } from './SelectInput';
 
 export default { title: 'ra-ui-materialui/input/SelectArrayInput' };
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -26,6 +26,7 @@ import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { SelectArrayInput } from './SelectArrayInput';
 import { TextInput } from './TextInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
+import { SelectInput } from './SelectInput';
 
 export default { title: 'ra-ui-materialui/input/SelectArrayInput' };
 
@@ -165,6 +166,20 @@ export const Disabled = () => (
             </SimpleForm>
         </Create>
     </AdminContext>
+);
+
+export const DisabledChoice = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator', disabled: true },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+        />
+    </Wrapper>
 );
 
 export const ReadOnly = () => (

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -79,7 +79,7 @@ describe('<SelectInput />', () => {
             ).toEqual('rea');
         });
 
-        it('should render disabled choices marked so', () => {
+        it('should render disabled choices marked as so', () => {
             render(
                 <AdminContext dataProvider={testDataProvider()}>
                     <ResourceContextProvider value="posts">
@@ -94,6 +94,39 @@ describe('<SelectInput />', () => {
                                         disabled: true,
                                     },
                                 ]}
+                            />
+                        </SimpleForm>
+                    </ResourceContextProvider>
+                </AdminContext>
+            );
+            fireEvent.mouseDown(
+                screen.getByLabelText('resources.posts.fields.language')
+            );
+
+            expect(
+                screen.getByText('Angular').getAttribute('aria-disabled')
+            ).toBeNull();
+            expect(
+                screen.getByText('React').getAttribute('aria-disabled')
+            ).toEqual('true');
+        });
+
+        it('should render disabled choices marked as so by disableValue prop', () => {
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <ResourceContextProvider value="posts">
+                        <SimpleForm onSubmit={jest.fn()}>
+                            <SelectInput
+                                {...defaultProps}
+                                choices={[
+                                    { id: 'ang', name: 'Angular' },
+                                    {
+                                        id: 'rea',
+                                        name: 'React',
+                                        not_available: true,
+                                    },
+                                ]}
+                                disableValue="not_available"
                             />
                         </SimpleForm>
                     </ResourceContextProvider>

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -112,6 +112,19 @@ export const Disabled = () => (
     </Wrapper>
 );
 
+export const DisabledChoice = () => (
+    <Wrapper>
+        <SelectInput
+            source="city"
+            choices={[
+                { id: 'P', name: 'Paris ' },
+                { id: 'L', name: 'London' },
+                { id: 'N', name: 'New York ', disabled: true },
+            ]}
+        />
+    </Wrapper>
+);
+
 export const Variant = ({ hideLabel }) => (
     <Wrapper>
         <SelectInput

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -117,9 +117,9 @@ export const DisabledChoice = () => (
         <SelectInput
             source="city"
             choices={[
-                { id: 'P', name: 'Paris ' },
+                { id: 'P', name: 'Paris' },
                 { id: 'L', name: 'London' },
-                { id: 'N', name: 'New York ', disabled: true },
+                { id: 'N', name: 'New York', disabled: true },
             ]}
         />
     </Wrapper>


### PR DESCRIPTION
Added complementarity tests and stories to `SelectInput` and `SelectArrayInput` components, as I did for #10821
This time in `master` since these components already have the `disableValue` prop

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date
