### PR TITLE
Add timeout prop to loading components

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleListLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleListLoading.tsx
@@ -29,10 +29,11 @@ export const SimpleListLoading = (inProps: SimpleListLoadingProps) => {
         hasSecondaryText,
         hasTertiaryText,
         nbFakeLines = 5,
+        timeout = 1000,
         ...rest
     } = props;
 
-    const oneSecondHasPassed = useTimeout(1000);
+    const oneSecondHasPassed = useTimeout(timeout);
 
     return oneSecondHasPassed ? (
         <StyledList className={className} {...rest}>
@@ -109,6 +110,7 @@ export interface SimpleListLoadingProps extends ListProps {
     hasSecondaryText?: boolean;
     hasTertiaryText?: boolean;
     nbFakeLines?: number;
+    timeout?: number;
 }
 
 declare module '@mui/material/styles' {

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridLoading.tsx
@@ -26,8 +26,9 @@ const DatagridLoading = ({
     nbChildren,
     nbFakeLines = 5,
     size,
+    timeout = 1000,
 }: DatagridLoadingProps) => {
-    const oneSecondHasPassed = useTimeout(1000);
+    const oneSecondHasPassed = useTimeout(timeout);
     if (!oneSecondHasPassed) return null;
     return (
         <div className={DatagridClasses.root}>
@@ -128,6 +129,7 @@ export interface DatagridLoadingProps {
     nbChildren: number;
     nbFakeLines?: number;
     size?: 'small' | 'medium';
+    timeout?: number;
 }
 
 export default memo(DatagridLoading);

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableLoading.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableLoading.tsx
@@ -26,8 +26,9 @@ export const DataTableLoading = memo(function DataTableLoading({
     nbChildren,
     nbFakeLines = 5,
     size,
+    timeout = 1000,
 }: DataTableLoadingProps) {
-    const oneSecondHasPassed = useTimeout(1000);
+    const oneSecondHasPassed = useTimeout(timeout);
     if (!oneSecondHasPassed) return null;
     return (
         <div className={DataTableClasses.root}>
@@ -128,4 +129,5 @@ export interface DataTableLoadingProps<RecordType extends RaRecord = any> {
     nbChildren: number;
     nbFakeLines?: number;
     size?: 'small' | 'medium';
+    timeout?: number;
 }


### PR DESCRIPTION
## Problem

Some loading components have a one second hard-coded wait before rendering

Fixes #10835

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date
