### PR TITLE
Fix typo in Create.md

### DIFF
--- a/docs/Create.md
+++ b/docs/Create.md
@@ -460,8 +460,8 @@ Once the `dataProvider.create()` request returns successfully, users see a gener
 
 `<Create>` uses two successive translation keys to build the success message:
 
-* `resources.{resource}.notifications.create` as a first choice
-* `ra.notification.create` as a fallback
+* `resources.{resource}.notifications.created` as a first choice
+* `ra.notification.created` as a fallback
 
 To customize the notification message, you can set custom translation for these keys in your i18nProvider.
 


### PR DESCRIPTION
## Problem

Typo in the notification translation key

## Solution

The correct key is `created`, not `create` according to https://github.com/marmelab/react-admin/blob/440f71f3ba8e81c32f6813071ecb08cdfa4d182b/packages/ra-core/src/controller/create/useCreateController.ts#L99

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).