### PR TITLE
[Doc] Backport Tree's doc

### DIFF
--- a/docs/Tree.md
+++ b/docs/Tree.md
@@ -57,7 +57,7 @@ The `<Tree>` component accepts the [rc-tree's `<Tree>`](https://github.com/react
 | `onSelect`            | Optional | `function`     | -       | The function to execute when a node is selected.                                               |
 | `selectedKeys`        | Optional | `Identifier[]` | -       | An array of identifiers defining the records that should be selected (controlled mode).        |
 | `sx`                  | Optional | `SxProps`      | -       | Material UI shortcut for defining custom styles.                                               |
-| `titleField`          | Optional | `string`       | `title` | Set the record field to display in the tree.                                                   |
+| `titleField`          | Optional | `string`       | -       | Set the record field to display in the tree.                                                   |
 
 ### `className`
 
@@ -364,7 +364,7 @@ export const SimpleTree = () => (
 
 ### `titleField`
 
-Use the `titleField` prop to specify the name of the field holding the node title:
+The default node title uses the [`recordRepresentation`](./Resource.md#recordrepresentation) of the resource. Use the `titleField` prop to specify the name of the field holding the node title:
 
 ```tsx
 import { Tree } from '@react-admin/ra-tree';

--- a/docs/TreeWithDetails.md
+++ b/docs/TreeWithDetails.md
@@ -88,7 +88,7 @@ Check [the `ra-tree` documentation](https://react-admin-ee.marmelab.com/document
 | `showLine`           | Optional | `boolean`              | `false`    | Shows a connecting line                                                                          |
 | `sx`                 | Optional | `SxProps`              | -          | Material UI shortcut for defining custom styles                                                  |
 | `title`              | Optional | `string`               | -          | The title to display in the `<AppBar>`                                                           |
-| `titleField`         | Optional | `string`               | `title`    | Set the record field to display in the tree                                                      |
+| `titleField`         | Optional | `string`               | -          | Set the record field to display in the tree                                                      |
 
 `<TreeWithDetails>` also accepts the [`<Tree>`](./Tree.md#props) props.
 
@@ -443,7 +443,7 @@ The title can be either a string or an element of your own.
 
 ## `titleField`
 
-Use the `titleField` prop to specify the name of the field holding the node title:
+The default node title uses the [`recordRepresentation`](./Resource.md#recordrepresentation) of the resource. Use the `titleField` prop to specify the name of the field holding the node title:
 
 ```tsx
 // in src/posts.js


### PR DESCRIPTION
## Problem

ra-tree's doc was updated about this:
> Support recordRepresentation defined at resource level, and keep titleField to override it for Tree, TreeWithDetails, TreeInput

## Solution

Backport it

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~~[ ] The PR includes **unit tests** (if not possible, describe why)~~
- ~~[ ] The PR includes one or several **stories** (if not possible, describe why)~~
- [x] The **documentation** is up to date