### PR TITLE
Fix Show and Edit controllers can trigger a redirect loop with react-router v7 if getOne rejects

### DIFF
--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -3,16 +3,11 @@ import { useParams } from 'react-router-dom';
 
 import { useAuthenticated, useRequireAccess } from '../../auth';
 import { RaRecord, MutationMode, TransformData } from '../../types';
-import {
-    useRedirect,
-    RedirectionSideEffect,
-    useCreatePath,
-} from '../../routing';
+import { useRedirect, RedirectionSideEffect } from '../../routing';
 import { useNotify } from '../../notification';
 import {
     useGetOne,
     useUpdate,
-    useRefresh,
     UseGetOneHookValue,
     HttpError,
     UseGetOneOptions,
@@ -86,9 +81,7 @@ export const useEditController = <
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();
     const notify = useNotify();
-    const createPath = useCreatePath();
     const redirect = useRedirect();
-    const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
     if (!routeId && !propsId) {
         throw new Error(
@@ -126,16 +119,7 @@ export const useEditController = <
                 notify('ra.notification.item_doesnt_exist', {
                     type: 'error',
                 });
-                // We need to flushSync to ensure the redirect happens before the refresh
-                // Otherwise this can cause an infinite loop when the record is not found
-                redirect(() => ({
-                    pathname: createPath({
-                        resource,
-                        type: 'list',
-                    }),
-                    flushSync: true,
-                }));
-                refresh();
+                redirect('list', resource);
             },
             refetchOnReconnect: false,
             refetchOnWindowFocus: false,

--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -4,12 +4,11 @@ import { useAuthenticated, useRequireAccess } from '../../auth';
 import { RaRecord } from '../../types';
 import {
     useGetOne,
-    useRefresh,
     UseGetOneHookValue,
     UseGetOneOptions,
 } from '../../dataProvider';
 import { useTranslate } from '../../i18n';
-import { useCreatePath, useRedirect } from '../../routing';
+import { useRedirect } from '../../routing';
 import { useNotify } from '../../notification';
 import {
     useResourceContext,
@@ -80,9 +79,7 @@ export const useShowController = <
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     const translate = useTranslate();
     const notify = useNotify();
-    const createPath = useCreatePath();
     const redirect = useRedirect();
-    const refresh = useRefresh();
     const { id: routeId } = useParams<'id'>();
     if (!routeId && !propsId) {
         throw new Error(
@@ -110,17 +107,7 @@ export const useShowController = <
                 notify('ra.notification.item_doesnt_exist', {
                     type: 'error',
                 });
-
-                // We need to flushSync to ensure the redirect happens before the refresh
-                // Otherwise this can cause an infinite loop when the record is not found
-                redirect(() => ({
-                    pathname: createPath({
-                        resource,
-                        type: 'list',
-                    }),
-                    flushSync: true,
-                }));
-                refresh();
+                redirect('list', resource);
             },
             retry: false,
             ...otherQueryOptions,


### PR DESCRIPTION
## Problem

Fix https://github.com/marmelab/react-admin/issues/10842

If `getOne` rejects, Show and Edit controllers will trigger a redirect to the list view, and also force refreshing the react-query cache with `useRefresh()`.
This can lead to creating a redirect loop because `refresh` will trigger a `getOne` call again, which will fail again and trigger this side-effect again, etc.

This issue only seems to appear when using react-router v7.

https://github.com/marmelab/react-admin/pull/10776 already attempted to fix this issue, but according to my tests it doesn't work (and actually seems to have no effect) so I reverted the changes it brought.

## Solution

Simply remove calling `refresh()` from the side-effects, as redirecting to the list view will refresh the data anyway thanks to react-query.

## How To Test

We need a demo with RR v7 to test this fix, so I recommend to use the e-commerce demo (`make run-demo`).

You can for instance replace the `examples/demo/src/dataProvider/rest.ts` file with the following:

```tsx
import simpleRestProvider from 'ra-data-simple-rest';
import { HttpError } from 'react-admin';

export default {
    ...simpleRestProvider('http://localhost:4000'),
    getOne: () => Promise.reject(new HttpError('TEST ERROR', 500)),
};
```

And then try to access the OrderEdit view.

With the fix, the error notification is only showed once, and there is no redirection loop.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why) -> can't unit test a redirection loop
- [ ] The PR includes one or several **stories** (if not possible, describe why) -> same
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
