### PR TITLE
Add `mutationKey` to all mutations

### DIFF
--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -25,6 +25,7 @@ import {
     WithMiddlewaresSuccess as WithMiddlewaresSuccessUndoable,
     WithMiddlewaresError as WithMiddlewaresErrorUndoable,
 } from './useCreate.undoable.stories';
+import { QueryClient, useMutationState } from '@tanstack/react-query';
 
 describe('useCreate', () => {
     it('returns a callback that can be used with create arguments', async () => {
@@ -99,7 +100,7 @@ describe('useCreate', () => {
         });
     });
 
-    it('accepts a meta paramater', async () => {
+    it('accepts a meta parameter', async () => {
         const dataProvider = testDataProvider({
             create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
         });
@@ -122,6 +123,47 @@ describe('useCreate', () => {
                 meta: { hello: 'world' },
             });
         });
+    });
+
+    it('sets the mutationKey', async () => {
+        const queryClient = new QueryClient();
+        queryClient.setMutationDefaults(['foo', 'create'], {
+            meta: { hello: 'world' },
+        });
+
+        const dataProvider = testDataProvider({
+            create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as any)),
+        });
+        let localCreate;
+        const Dummy = () => {
+            const [create] = useCreate('foo');
+            localCreate = create;
+            return <span />;
+        };
+        const Observe = () => {
+            const mutation = useMutationState({
+                filters: {
+                    mutationKey: ['foo', 'create'],
+                },
+            });
+
+            return <span>mutations: {mutation.length}</span>;
+        };
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <Dummy />
+                <Observe />
+            </CoreAdminContext>
+        );
+        localCreate('foo', { data: { bar: 'baz' }, meta: { hello: 'world' } });
+        await waitFor(() => {
+            expect(dataProvider.create).toHaveBeenCalledWith('foo', {
+                data: { bar: 'baz' },
+                meta: { hello: 'world' },
+            });
+        });
+        await screen.findByText('mutations: 1');
     });
 
     it('returns a state typed based on the parametric type', async () => {

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -152,6 +152,7 @@ export const useCreate = <
         MutationError,
         Partial<UseCreateMutateParams<RecordType>>
     >({
+        mutationKey: [resource, 'create', params],
         mutationFn: ({
             resource: callTimeResource = resource,
             data: callTimeData = paramsRef.current.data,

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -194,6 +194,7 @@ export const useDelete = <
         MutationError,
         Partial<UseDeleteMutateParams<RecordType>>
     >({
+        mutationKey: [resource, 'delete', params],
         mutationFn: ({
             resource: callTimeResource = resource,
             id: callTimeId = paramsRef.current.id,

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -220,6 +220,7 @@ export const useDeleteMany = <
         MutationError,
         Partial<UseDeleteManyMutateParams<RecordType>>
     >({
+        mutationKey: [resource, 'deleteMany', params],
         mutationFn: ({
             resource: callTimeResource = resource,
             ids: callTimeIds = paramsRef.current.ids,

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -196,6 +196,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
         ErrorType,
         Partial<UseUpdateMutateParams<RecordType>>
     >({
+        mutationKey: [resource, 'update', params],
         mutationFn: ({
             resource: callTimeResource = resource,
             id: callTimeId = paramsRef.current.id,

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -199,6 +199,7 @@ export const useUpdateMany = <
         MutationError,
         Partial<UseUpdateManyMutateParams<RecordType>>
     >({
+        mutationKey: [resource, 'updateMany', params],
         mutationFn: ({
             resource: callTimeResource = resource,
             ids: callTimeIds = paramsRef.current.ids,


### PR DESCRIPTION
## Problem

In order to support offline scenarios, our mutations must have a `mutationKey`.

## Solution

Add `mutationKey` to all mutations.

**Note**: for offline support to work, the `resource` must be provided at declaration time.

## How To Test

- unit tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)