### PR TITLE
Fix B&W theme label is invisible for inputs with `standard` variant

### DIFF
--- a/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
+++ b/packages/ra-ui-materialui/src/theme/ThemeTester.stories.tsx
@@ -103,7 +103,7 @@ const Wrapper = ({ children, themeName, themeType }) => {
     );
 };
 
-export const ThemeTester = ({ themeName, themeType }) => (
+export const ThemeTester = ({ themeName, themeType, inputVariant }) => (
     <Wrapper themeName={themeName} themeType={themeType}>
         <Snackbar
             open
@@ -159,14 +159,15 @@ export const ThemeTester = ({ themeName, themeType }) => (
             <Section title="Form Inputs">
                 <ResourceContextProvider value="posts">
                     <SimpleForm>
-                        <TextInput source="text" />
-                        <DateInput source="date" />
+                        <TextInput source="text" variant={inputVariant} />
+                        <DateInput source="date" variant={inputVariant} />
                         <SelectInput
                             source="select"
                             choices={[
                                 { id: 1, name: 'One' },
                                 { id: 2, name: 'Two' },
                             ]}
+                            variant={inputVariant}
                         />
                         <SelectInput
                             source="select2"
@@ -175,6 +176,7 @@ export const ThemeTester = ({ themeName, themeType }) => (
                                 { id: 2, name: 'Two' },
                             ]}
                             isPending
+                            variant={inputVariant}
                         />
                         <RadioButtonGroupInput
                             source="radio"
@@ -182,6 +184,7 @@ export const ThemeTester = ({ themeName, themeType }) => (
                                 { id: 1, name: 'One' },
                                 { id: 2, name: 'Two' },
                             ]}
+                            variant={inputVariant}
                         />
                         <CheckboxGroupInput
                             source="checkbox"
@@ -189,10 +192,14 @@ export const ThemeTester = ({ themeName, themeType }) => (
                                 { id: 1, name: 'One' },
                                 { id: 2, name: 'Two' },
                             ]}
+                            variant={inputVariant}
                         />
-                        <BooleanInput source="boolean" />
-                        <PasswordInput source="password" />
-                        <SearchInput source="search" />
+                        <BooleanInput source="boolean" variant={inputVariant} />
+                        <PasswordInput
+                            source="password"
+                            variant={inputVariant}
+                        />
+                        <SearchInput source="search" variant={inputVariant} />
                     </SimpleForm>
                 </ResourceContextProvider>
             </Section>
@@ -228,6 +235,7 @@ export const ThemeTester = ({ themeName, themeType }) => (
 ThemeTester.args = {
     themeName: 'Default',
     themeType: 'light',
+    inputVariant: 'filled',
 };
 ThemeTester.argTypes = {
     themeName: {
@@ -237,6 +245,10 @@ ThemeTester.argTypes = {
     themeType: {
         control: 'select',
         options: ['light', 'dark'],
+    },
+    inputVariant: {
+        control: 'select',
+        options: ['standard', 'filled', 'outlined'],
     },
 };
 

--- a/packages/ra-ui-materialui/src/theme/bwTheme.ts
+++ b/packages/ra-ui-materialui/src/theme/bwTheme.ts
@@ -179,7 +179,11 @@ const createBWTheme = (mode: 'light' | 'dark'): ThemeOptions => {
             MuiListItemButton: {
                 defaultProps: { disableRipple: true },
             },
-            MuiInputBase: {
+            MuiFormControl: {
+                defaultProps: {
+                    margin: 'dense' as const,
+                    fullWidth: true,
+                },
                 styleOverrides: {
                     root: {
                         backgroundColor: isDarkMode ? commonBlack : commonWhite,
@@ -274,12 +278,6 @@ const createBWTheme = (mode: 'light' | 'dark'): ThemeOptions => {
             },
             MuiAutocomplete: {
                 defaultProps: {
-                    fullWidth: true,
-                },
-            },
-            MuiFormControl: {
-                defaultProps: {
-                    margin: 'dense' as const,
                     fullWidth: true,
                 },
             },


### PR DESCRIPTION
## Problem

<img width="796" height="793" alt="image" src="https://github.com/user-attachments/assets/e3105d4d-f215-4a84-a721-35a438d4b78f" />

## Solution

<img width="796" height="793" alt="image" src="https://github.com/user-attachments/assets/8a5bfb4a-d366-454b-9c19-276e9466ee39" />

## How To Test

- Theme Tester Story

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
