### PR TITLE
[DateInput] Fix example doc

### DIFF
--- a/packages/ra-ui-materialui/src/input/DateInput.tsx
+++ b/packages/ra-ui-materialui/src/input/DateInput.tsx
@@ -43,12 +43,12 @@ import { useForkRef } from '@mui/material';
  *
  * @example
  * // If you want to manipulate the value from the field to adjust its timezone, use the format prop
- * <DateInput source="published_at" format={value => new Date(value).toISOString().split("T")[0} />
+ * <DateInput source="published_at" format={value => new Date(value).toISOString().split("T")[0]} />
  * // The input will display the UTC day regardless of the browser timezone.
  *
  * @example
  * // If you want the returned value to be a Date, you must pass a custom parse method
- * to convert the form value (which is always a date string) back to a Date object.
+ * // to convert the form value (which is always a date string) back to a Date object.
  * <DateInput source="published_at" parse={val => new Date(val)} />
  */
 export const DateInput = (props: DateInputProps) => {


### PR DESCRIPTION
## Problem

Just a doc formatting

BEFORE:
<img width="884" height="228" alt="Screenshot 2025-07-25 at 22 33 05" src="https://github.com/user-attachments/assets/f85cef64-0adc-4570-900a-802104c020d2" />

AFTER:

<img width="728" height="188" alt="Screenshot 2025-07-25 at 22 36 20" src="https://github.com/user-attachments/assets/aae79027-48cd-4d65-b156-a8883b31bdd5" />
