### PR TITLE
Make all mutations react to their declaration time options changes

### DIFF
--- a/packages/ra-core/src/dataProvider/useCreate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.stories.tsx
@@ -1,0 +1,210 @@
+import * as React from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useCreate } from './useCreate';
+import { useGetOne } from './useGetOne';
+import type { MutationMode as MutationModeType } from '../types';
+
+export default { title: 'ra-core/dataProvider/useCreate' };
+
+export const MutationMode = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('nothing yet'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <MutationModeCore />
+        </CoreAdminContext>
+    );
+};
+
+const MutationModeCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = React.useState<string>();
+    const [mutationMode, setMutationMode] =
+        React.useState<MutationModeType>('pessimistic');
+
+    const {
+        isPending: isPendingGetOne,
+        data,
+        error,
+        refetch,
+    } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {
+            data: { id: 2, title: 'Hello World' },
+        },
+        {
+            mutationMode,
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+    const handleClick = () => {
+        create();
+    };
+    return (
+        <>
+            {isPendingGetOne ? (
+                <p>Loading...</p>
+            ) : error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setMutationMode('optimistic')}
+                    disabled={isPending}
+                >
+                    Change mutation mode to optimistic
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const Params = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return new Promise((resolve, reject) => {
+                const data = posts.find(p => p.id === params.id);
+                setTimeout(() => {
+                    if (!data) {
+                        reject(new Error('nothing yet'));
+                    }
+                    resolve({ data });
+                }, timeout);
+            });
+        },
+        create: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts.push(params.data);
+                    resolve({ data: params.data });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={
+                new QueryClient({
+                    defaultOptions: {
+                        queries: { retry: false },
+                        mutations: { retry: false },
+                    },
+                })
+            }
+            dataProvider={dataProvider}
+        >
+            <ParamsCore />
+        </CoreAdminContext>
+    );
+};
+
+const ParamsCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = React.useState<string>();
+    const [params, setParams] = React.useState<any>({ title: 'Hello World' });
+
+    const {
+        isPending: isPendingGetOne,
+        data,
+        error,
+        refetch,
+    } = useGetOne('posts', { id: 2 });
+    const [create, { isPending }] = useCreate(
+        'posts',
+        {
+            data: { id: 2, ...params },
+        },
+        {
+            mutationMode: 'optimistic',
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+    const handleClick = () => {
+        create();
+    };
+    return (
+        <>
+            {isPendingGetOne ? (
+                <p>Loading...</p>
+            ) : error ? (
+                <p>{error.message}</p>
+            ) : (
+                <dl>
+                    <dt>id</dt>
+                    <dd>{data?.id}</dd>
+                    <dt>title</dt>
+                    <dd>{data?.title}</dd>
+                    <dt>author</dt>
+                    <dd>{data?.author}</dd>
+                </dl>
+            )}
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Create post
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setParams({ title: 'Goodbye World' })}
+                    disabled={isPending}
+                >
+                    Change params
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     UseMutationOptions,
@@ -97,9 +97,16 @@ export const useCreate = <
         ...mutationOptions
     } = options;
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
 
     const paramsRef =
         useRef<Partial<CreateParams<Partial<RecordType>>>>(params);
+    useEffect(() => {
+        paramsRef.current = params;
+    }, [params]);
+
     const snapshot = useRef<Snapshot>([]);
 
     // Ref that stores the mutation with middlewares to avoid losing them if the calling component is unmounted

--- a/packages/ra-core/src/dataProvider/useDelete.optimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.optimistic.stories.tsx
@@ -14,15 +14,13 @@ export const SuccessCase = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     const index = posts.findIndex(p => p.id === params.id);
@@ -82,15 +80,13 @@ export const ErrorCase = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: () => {
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
                     reject(new Error('something went wrong'));

--- a/packages/ra-core/src/dataProvider/useDelete.pessimistic.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.pessimistic.stories.tsx
@@ -16,15 +16,13 @@ export const SuccessCase = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     const index = posts.findIndex(p => p.id === params.id);
@@ -181,15 +179,13 @@ export const ErrorCase = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: () => {
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
                     reject(new Error('something went wrong'));

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 import expect from 'expect';
+import { QueryClient, useMutationState } from '@tanstack/react-query';
 
 import { CoreAdminContext } from '../core';
 import { RaRecord } from '../types';
@@ -19,7 +20,7 @@ import {
     ErrorCase as ErrorCaseUndoable,
     SuccessCase as SuccessCaseUndoable,
 } from './useDelete.undoable.stories';
-import { QueryClient, useMutationState } from '@tanstack/react-query';
+import { MutationMode, Params } from './useDelete.stories';
 
 describe('useDelete', () => {
     it('returns a callback that can be used with deleteOne arguments', async () => {
@@ -72,6 +73,79 @@ describe('useDelete', () => {
                 id: 1,
                 previousData: { id: 1, bar: 'bar' },
             });
+        });
+    });
+
+    it('uses the latest declaration time mutationMode', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        // This story uses the pessimistic mode by default
+        render(<MutationMode />);
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
+        fireEvent.click(screen.getByText('Change mutation mode to optimistic'));
+        fireEvent.click(screen.getByText('Delete first post'));
+        // Should display the optimistic result right away if the change was handled
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).not.toBeNull();
+        });
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).toBeNull();
+        });
+    });
+
+    it('uses the latest declaration time params', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        const posts = [
+            { id: 1, title: 'Hello' },
+            { id: 2, title: 'World' },
+        ];
+        const dataProvider = {
+            getList: (resource, params) => {
+                console.log('getList', resource, params);
+                return Promise.resolve({
+                    data: posts,
+                    total: posts.length,
+                });
+            },
+            delete: jest.fn((resource, params) => {
+                console.log('delete', resource, params);
+                return new Promise(resolve => {
+                    setTimeout(() => {
+                        const index = posts.findIndex(p => p.id === params.id);
+                        posts.splice(index, 1);
+                        resolve({ data: params.previousData });
+                    }, 1000);
+                });
+            }),
+        } as any;
+        // This story has no meta by default
+        render(<Params dataProvider={dataProvider} />);
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
+        fireEvent.click(screen.getByText('Change params'));
+        fireEvent.click(screen.getByText('Delete first post'));
+        // Should display the optimistic result right away if the change was handled
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).not.toBeNull();
+        });
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).toBeNull();
+        });
+
+        expect(dataProvider.delete).toHaveBeenCalledWith('posts', {
+            id: 1,
+            previousData: { id: 1, title: 'Hello' },
+            meta: 'test',
         });
     });
 

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -77,7 +77,6 @@ describe('useDelete', () => {
     });
 
     it('uses the latest declaration time mutationMode', async () => {
-        jest.spyOn(console, 'log').mockImplementation(() => {});
         // This story uses the pessimistic mode by default
         render(<MutationMode />);
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
@@ -99,21 +98,18 @@ describe('useDelete', () => {
     });
 
     it('uses the latest declaration time params', async () => {
-        jest.spyOn(console, 'log').mockImplementation(() => {});
         const posts = [
             { id: 1, title: 'Hello' },
             { id: 2, title: 'World' },
         ];
         const dataProvider = {
-            getList: (resource, params) => {
-                console.log('getList', resource, params);
+            getList: () => {
                 return Promise.resolve({
                     data: posts,
                     total: posts.length,
                 });
             },
-            delete: jest.fn((resource, params) => {
-                console.log('delete', resource, params);
+            delete: jest.fn((_, params) => {
                 return new Promise(resolve => {
                     setTimeout(() => {
                         const index = posts.findIndex(p => p.id === params.id);
@@ -384,7 +380,6 @@ describe('useDelete', () => {
 
     describe('mutationMode', () => {
         it('when pessimistic, displays result and success side effects when dataProvider promise resolves', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             render(<SuccessCasePessimistic />);
             screen.getByText('Delete first post').click();
             await waitFor(() => {
@@ -401,7 +396,6 @@ describe('useDelete', () => {
             expect(screen.queryByText('World')).not.toBeNull();
         });
         it('when pessimistic, displays error and error side effects when dataProvider promise rejects', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             jest.spyOn(console, 'error').mockImplementation(() => {});
             render(<ErrorCasePessimistic />);
             screen.getByText('Delete first post').click();
@@ -450,7 +444,6 @@ describe('useDelete', () => {
             ).not.toBeNull();
         });
         it('when optimistic, displays result and success side effects right away', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             render(<SuccessCaseOptimistic />);
             await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
             screen.getByText('Delete first post').click();
@@ -468,7 +461,6 @@ describe('useDelete', () => {
             });
         });
         it('when optimistic, displays error and error side effects when dataProvider promise rejects', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             jest.spyOn(console, 'error').mockImplementation(() => {});
             render(<ErrorCaseOptimistic />);
             await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
@@ -490,7 +482,6 @@ describe('useDelete', () => {
             });
         });
         it('when undoable, displays result and success side effects right away and fetched on confirm', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             render(<SuccessCaseUndoable />);
             await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
             screen.getByText('Delete first post').click();
@@ -518,7 +509,6 @@ describe('useDelete', () => {
             );
         });
         it('when undoable, displays result and success side effects right away and reverts on cancel', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             render(<SuccessCaseUndoable />);
             await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
             screen.getByText('Delete first post').click();
@@ -536,7 +526,6 @@ describe('useDelete', () => {
             });
         });
         it('when undoable, displays result and success side effects right away and reverts on error', async () => {
-            jest.spyOn(console, 'log').mockImplementation(() => {});
             jest.spyOn(console, 'error').mockImplementation(() => {});
             render(<ErrorCaseUndoable />);
             await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));

--- a/packages/ra-core/src/dataProvider/useDelete.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.stories.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useDelete } from './useDelete';
+import { useGetList } from './useGetList';
+import type { DataProvider, MutationMode as MutationModeType } from '../types';
+
+export default { title: 'ra-core/dataProvider/useDelete' };
+
+export const MutationMode = () => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const index = posts.findIndex(p => p.id === params.id);
+                    posts.splice(index, 1);
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <MutationModeCore />
+        </CoreAdminContext>
+    );
+};
+
+const MutationModeCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [mutationMode, setMutationMode] =
+        React.useState<MutationModeType>('pessimistic');
+
+    const [deleteOne, { isPending }] = useDelete(
+        'posts',
+        {
+            id: 1,
+            previousData: { id: 1, title: 'Hello' },
+        },
+        {
+            mutationMode,
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+
+    const handleClick = () => {
+        deleteOne();
+    };
+    return (
+        <>
+            <ul>{data?.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Delete first post
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setMutationMode('optimistic')}
+                    disabled={isPending}
+                >
+                    Change mutation mode to optimistic
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const Params = ({ dataProvider }: { dataProvider?: DataProvider }) => {
+    const posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const defaultDataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        delete: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const index = posts.findIndex(p => p.id === params.id);
+                    posts.splice(index, 1);
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider ?? defaultDataProvider}
+        >
+            <ParamsCore />
+        </CoreAdminContext>
+    );
+};
+
+const ParamsCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [params, setParams] = React.useState<any>({});
+
+    const [deleteOne, { isPending }] = useDelete(
+        'posts',
+        {
+            id: 1,
+            previousData: { id: 1, title: 'Hello' },
+            meta: params.meta,
+        },
+        {
+            mutationMode: 'optimistic',
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+
+    const handleClick = () => {
+        deleteOne();
+    };
+    return (
+        <>
+            <ul>{data?.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Delete first post
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setParams({ meta: 'test' })}
+                    disabled={isPending}
+                >
+                    Change params
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDelete.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.stories.tsx
@@ -15,15 +15,13 @@ export const MutationMode = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     const index = posts.findIndex(p => p.id === params.id);
@@ -94,15 +92,13 @@ export const Params = ({ dataProvider }: { dataProvider?: DataProvider }) => {
         { id: 2, title: 'World' },
     ];
     const defaultDataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     const index = posts.findIndex(p => p.id === params.id);

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -92,8 +92,17 @@ export const useDelete = <
     const addUndoableMutation = useAddUndoableMutation();
     const { id, previousData } = params;
     const { mutationMode = 'pessimistic', ...mutationOptions } = options;
+
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
+
     const paramsRef = useRef<Partial<DeleteParams<RecordType>>>(params);
+    useEffect(() => {
+        paramsRef.current = params;
+    }, [params]);
+
     const snapshot = useRef<Snapshot>([]);
     const hasCallTimeOnError = useRef(false);
     const hasCallTimeOnSuccess = useRef(false);

--- a/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.undoable.stories.tsx
@@ -15,15 +15,13 @@ export const SuccessCase = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     const index = posts.findIndex(p => p.id === params.id);
@@ -112,15 +110,13 @@ export const ErrorCase = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        delete: (resource, params) => {
-            console.log('delete', resource, params);
+        delete: () => {
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
                     reject(new Error('something went wrong'));

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -58,7 +58,6 @@ describe('useDeleteMany', () => {
     });
 
     it('uses the latest declaration time mutationMode', async () => {
-        jest.spyOn(console, 'log').mockImplementation(() => {});
         // This story uses the pessimistic mode by default
         render(<MutationMode />);
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
@@ -80,21 +79,18 @@ describe('useDeleteMany', () => {
     });
 
     it('uses the latest declaration time params', async () => {
-        jest.spyOn(console, 'log').mockImplementation(() => {});
         let posts = [
             { id: 1, title: 'Hello' },
             { id: 2, title: 'World' },
         ];
         const dataProvider = {
-            getList: (resource, params) => {
-                console.log('getList', resource, params);
+            getList: () => {
                 return Promise.resolve({
                     data: posts,
                     total: posts.length,
                 });
             },
-            deleteMany: jest.fn((resource, params) => {
-                console.log('deleteMany', resource, params);
+            deleteMany: jest.fn((_, params) => {
                 return new Promise(resolve => {
                     setTimeout(() => {
                         posts = posts.filter(

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { waitFor, render, screen } from '@testing-library/react';
+import { waitFor, render, screen, fireEvent } from '@testing-library/react';
 import expect from 'expect';
+import { QueryClient, useMutationState } from '@tanstack/react-query';
 
 import { CoreAdminContext } from '../core';
 import { testDataProvider } from './testDataProvider';
 import { useDeleteMany } from './useDeleteMany';
-import { QueryClient, useMutationState } from '@tanstack/react-query';
+import { MutationMode, Params } from './useDeleteMany.stories';
 
 describe('useDeleteMany', () => {
     it('returns a callback that can be used with update arguments', async () => {
@@ -53,6 +54,79 @@ describe('useDeleteMany', () => {
             expect(dataProvider.deleteMany).toHaveBeenCalledWith('foo', {
                 ids: [1, 2],
             });
+        });
+    });
+
+    it('uses the latest declaration time mutationMode', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        // This story uses the pessimistic mode by default
+        render(<MutationMode />);
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
+        fireEvent.click(screen.getByText('Change mutation mode to optimistic'));
+        fireEvent.click(screen.getByText('Delete posts'));
+        // Should display the optimistic result right away if the change was handled
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).not.toBeNull();
+        });
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).toBeNull();
+        });
+    });
+
+    it('uses the latest declaration time params', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        let posts = [
+            { id: 1, title: 'Hello' },
+            { id: 2, title: 'World' },
+        ];
+        const dataProvider = {
+            getList: (resource, params) => {
+                console.log('getList', resource, params);
+                return Promise.resolve({
+                    data: posts,
+                    total: posts.length,
+                });
+            },
+            deleteMany: jest.fn((resource, params) => {
+                console.log('deleteMany', resource, params);
+                return new Promise(resolve => {
+                    setTimeout(() => {
+                        posts = posts.filter(
+                            post => !params.ids.includes(post.id)
+                        );
+                        resolve({ data: params.previousData });
+                    }, 1000);
+                });
+            }),
+        } as any;
+        // This story has no meta by default
+        render(<Params dataProvider={dataProvider} />);
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));
+        fireEvent.click(screen.getByText('Change params'));
+        fireEvent.click(screen.getByText('Delete posts'));
+        // Should display the optimistic result right away if the change was handled
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).not.toBeNull();
+        });
+        await waitFor(() => {
+            expect(screen.queryByText('success')).not.toBeNull();
+            expect(screen.queryByText('Hello')).toBeNull();
+            expect(screen.queryByText('World')).not.toBeNull();
+            expect(screen.queryByText('mutating')).toBeNull();
+        });
+
+        expect(dataProvider.deleteMany).toHaveBeenCalledWith('posts', {
+            ids: [1],
+            meta: 'test',
         });
     });
 

--- a/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
@@ -15,15 +15,13 @@ export const MutationMode = () => {
         { id: 2, title: 'World' },
     ];
     const dataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        deleteMany: (resource, params) => {
-            console.log('delete', resource, params);
+        deleteMany: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     posts = posts.filter(post => !params.ids.includes(post.id));
@@ -92,15 +90,13 @@ export const Params = ({ dataProvider }: { dataProvider?: DataProvider }) => {
         { id: 2, title: 'World' },
     ];
     const defaultDataProvider = {
-        getList: (resource, params) => {
-            console.log('getList', resource, params);
+        getList: () => {
             return Promise.resolve({
                 data: posts,
                 total: posts.length,
             });
         },
-        deleteMany: (resource, params) => {
-            console.log('deleteMany', resource, params);
+        deleteMany: (_, params) => {
             return new Promise(resolve => {
                 setTimeout(() => {
                     posts = posts.filter(post => !params.ids.includes(post.id));

--- a/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useDeleteMany } from './useDeleteMany';
+import { useGetList } from './useGetList';
+import type { DataProvider, MutationMode as MutationModeType } from '../types';
+
+export default { title: 'ra-core/dataProvider/useDeleteMany' };
+
+export const MutationMode = () => {
+    let posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const dataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        deleteMany: (resource, params) => {
+            console.log('delete', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts = posts.filter(post => !params.ids.includes(post.id));
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <MutationModeCore />
+        </CoreAdminContext>
+    );
+};
+
+const MutationModeCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [mutationMode, setMutationMode] =
+        React.useState<MutationModeType>('pessimistic');
+
+    const [deleteMany, { isPending }] = useDeleteMany(
+        'posts',
+        {
+            ids: [1],
+        },
+        {
+            mutationMode,
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+
+    const handleClick = () => {
+        deleteMany();
+    };
+    return (
+        <>
+            <ul>{data?.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Delete posts
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setMutationMode('optimistic')}
+                    disabled={isPending}
+                >
+                    Change mutation mode to optimistic
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const Params = ({ dataProvider }: { dataProvider?: DataProvider }) => {
+    let posts = [
+        { id: 1, title: 'Hello' },
+        { id: 2, title: 'World' },
+    ];
+    const defaultDataProvider = {
+        getList: (resource, params) => {
+            console.log('getList', resource, params);
+            return Promise.resolve({
+                data: posts,
+                total: posts.length,
+            });
+        },
+        deleteMany: (resource, params) => {
+            console.log('deleteMany', resource, params);
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    posts = posts.filter(post => !params.ids.includes(post.id));
+                    resolve({ data: params.previousData });
+                }, 1000);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider ?? defaultDataProvider}
+        >
+            <ParamsCore />
+        </CoreAdminContext>
+    );
+};
+
+const ParamsCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetList('posts');
+    const [params, setParams] = React.useState<any>({});
+
+    const [deleteMany, { isPending }] = useDeleteMany(
+        'posts',
+        {
+            ids: [1],
+            meta: params.meta,
+        },
+        {
+            mutationMode: 'optimistic',
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+
+    const handleClick = () => {
+        deleteMany();
+    };
+    return (
+        <>
+            <ul>{data?.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Delete posts
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setParams({ meta: 'test' })}
+                    disabled={isPending}
+                >
+                    Change params
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -92,8 +92,17 @@ export const useDeleteMany = <
     const addUndoableMutation = useAddUndoableMutation();
     const { ids } = params;
     const { mutationMode = 'pessimistic', ...mutationOptions } = options;
+
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
+
     const paramsRef = useRef<Partial<DeleteManyParams<RecordType>>>({});
+    useEffect(() => {
+        paramsRef.current = params;
+    }, [params]);
+
     const snapshot = useRef<Snapshot>([]);
     const hasCallTimeOnError = useRef(false);
     const hasCallTimeOnSuccess = useRef(false);

--- a/packages/ra-core/src/dataProvider/useUpdate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.stories.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { QueryClient, useIsMutating } from '@tanstack/react-query';
+
+import { CoreAdminContext } from '../core';
+import { useUpdate } from './useUpdate';
+import { useGetOne } from './useGetOne';
+import type { MutationMode as MutationModeType } from '../types';
+
+export default { title: 'ra-core/dataProvider/useUpdate' };
+
+export const MutationMode = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return Promise.resolve({
+                data: posts.find(p => p.id === params.id),
+            });
+        },
+        update: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const post = posts.find(p => p.id === params.id);
+                    if (post) {
+                        post.title = params.data.title;
+                    }
+                    resolve({ data: post });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <MutationModeCore />
+        </CoreAdminContext>
+    );
+};
+
+const MutationModeCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [mutationMode, setMutationMode] =
+        React.useState<MutationModeType>('pessimistic');
+    const [update, { isPending }] = useUpdate(
+        'posts',
+        {
+            id: 1,
+            data: { title: 'Hello World' },
+        },
+        {
+            mutationMode,
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+    const handleClick = () => {
+        update();
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setMutationMode('optimistic')}
+                    disabled={isPending}
+                >
+                    Change mutation mode to optimistic
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};
+
+export const Params = ({ timeout = 1000 }) => {
+    const posts = [{ id: 1, title: 'Hello', author: 'John Doe' }];
+    const dataProvider = {
+        getOne: (resource, params) => {
+            return Promise.resolve({
+                data: posts.find(p => p.id === params.id),
+            });
+        },
+        update: (resource, params) => {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    const post = posts.find(p => p.id === params.id);
+                    if (post) {
+                        post.title = params.data.title;
+                    }
+                    resolve({ data: post });
+                }, timeout);
+            });
+        },
+    } as any;
+    return (
+        <CoreAdminContext
+            queryClient={new QueryClient()}
+            dataProvider={dataProvider}
+        >
+            <ParamsCore />
+        </CoreAdminContext>
+    );
+};
+
+const ParamsCore = () => {
+    const isMutating = useIsMutating();
+    const [success, setSuccess] = useState<string>();
+    const { data, refetch } = useGetOne('posts', { id: 1 });
+    const [params, setParams] = React.useState<any>({ title: 'Hello World' });
+
+    const [update, { isPending }] = useUpdate(
+        'posts',
+        {
+            id: 1,
+            data: params,
+        },
+        {
+            mutationMode: 'optimistic',
+            onSuccess: () => setSuccess('success'),
+        }
+    );
+    const handleClick = () => {
+        update();
+    };
+    return (
+        <>
+            <dl>
+                <dt>title</dt>
+                <dd>{data?.title}</dd>
+                <dt>author</dt>
+                <dd>{data?.author}</dd>
+            </dl>
+            <div>
+                <button onClick={handleClick} disabled={isPending}>
+                    Update title
+                </button>
+                &nbsp;
+                <button
+                    onClick={() => setParams({ title: 'Goodbye World' })}
+                    disabled={isPending}
+                >
+                    Change params
+                </button>
+                &nbsp;
+                <button onClick={() => refetch()}>Refetch</button>
+            </div>
+            {success && <div>{success}</div>}
+            {isMutating !== 0 && <div>mutating</div>}
+        </>
+    );
+};

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -98,8 +98,17 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
         getMutateWithMiddlewares,
         ...mutationOptions
     } = options;
+
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
+
     const paramsRef = useRef<Partial<UpdateParams<RecordType>>>(params);
+    useEffect(() => {
+        paramsRef.current = params;
+    }, [params]);
+
     const snapshot = useRef<Snapshot>([]);
     // Ref that stores the mutation with middlewares to avoid losing them if the calling component is unmounted
     const mutateWithMiddlewares = useRef(dataProvider.update);

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     useMutation,
     useQueryClient,
@@ -95,9 +95,18 @@ export const useUpdateMany = <
         getMutateWithMiddlewares,
         ...mutationOptions
     } = options;
+
     const mode = useRef<MutationMode>(mutationMode);
+    useEffect(() => {
+        mode.current = mutationMode;
+    }, [mutationMode]);
+
     const paramsRef =
         useRef<Partial<UpdateManyParams<Partial<RecordType>>>>(params);
+    useEffect(() => {
+        paramsRef.current = params;
+    }, [params]);
+
     const snapshot = useRef<Snapshot>([]);
     // Ref that stores the mutation with middlewares to avoid losing them if the calling component is unmounted
     const mutateWithMiddlewares = useRef(dataProvider.updateMany);


### PR DESCRIPTION
## Problem

The mutation hooks currently put the `mutationMode` and `params` they receive at _declaration time_ in a ref but never update them from their props.

## Solution

Add effects that sync the refs with the props.

## How To Test

- stories
- tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
