### PR TITLE
Add offline support to `<EditBase>` and `<Edit>`

### DIFF
--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -76,6 +76,7 @@ You can customize the `<Edit>` component using the following props:
 | `id`                  | Optional  | `string`/`number`   | -            | The id of the record to edit                                                                  |
 | `mutationMode`        | Optional  | `'undoable' \| 'optimistic' \| 'pessimistic'` | `'undoable'` | Switch to optimistic or pessimistic mutations                                                 |
 | `mutationOptions`     | Optional  | `object`            | -            | Options for the `dataProvider.update()` call                                                  |
+| `offline`             | Optional | `ReactNode`          |              | The component to render when there is no connectivity and the record isn't in the cache
 | `queryOptions`        | Optional  | `object`            | -            | Options for the `dataProvider.getOne()` call                                                  |
 | `redirect`            | Optional  | `'list' \| 'show' \| false \| function` | `'list'` | Change the redirect location after successful update                                           |
 | `resource`            | Optional  | `string`            | -            | Override the name of the resource to edit                                                     |
@@ -538,6 +539,35 @@ The default `onError` function is:
 ```
 
 **Tip**: If you want to have different failure side effects based on the button clicked by the user, you can set the `mutationOptions` prop on the `<SaveButton>` component, too.
+
+## `offline`
+
+By default, `<EditBase>` renders nothing when there is no connectivity and the record hasn't been cached yet. You can provide your own component via the `offline` prop:
+
+```jsx
+import { Edit } from 'react-admin';
+
+export const PostEdit = () => (
+    <Edit offline={<p>No network. Could not load the post.</p>}>
+        ...
+    </Edit>
+);
+```
+
+**Tip**: If the record is in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
+
+```jsx
+import { Edit, IsOffline } from 'react-admin';
+
+export const PostEdit = () => (
+    <Edit offline={<p>No network. Could not load the post.</p>}>
+        <IsOffline>
+            No network. The post data may be outdated.
+        </IsOffline>
+        ...
+    </Edit>
+);
+```
 
 ## `queryOptions`
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -558,11 +558,14 @@ export const PostEdit = () => (
 
 ```jsx
 import { Edit, IsOffline } from 'react-admin';
+import { Alert } from '@mui/material';
 
 export const PostEdit = () => (
     <Edit offline={<p>No network. Could not load the post.</p>}>
         <IsOffline>
-            No network. The post data may be outdated.
+            <Alert severity="warning">
+                You are offline, the data may be outdated
+            </Alert>
         </IsOffline>
         ...
     </Edit>

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -583,7 +583,7 @@ This can be useful e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) t
 ```jsx
 import { Edit, SimpleForm } from 'react-admin';
 
-export const PostShow = () => (
+export const PostEdit = () => (
     <Edit queryOptions={{ meta: { foo: 'bar' } }}>
         <SimpleForm>
             ...

--- a/docs/EditBase.md
+++ b/docs/EditBase.md
@@ -44,18 +44,411 @@ export const BookEdit = () => (
 
 ## Props
 
-You can customize the `<EditBase>` component using the following props, documented in the `<Edit>` component:
+| Prop             | Required | Type              | Default | Description
+|------------------|----------|-------------------|---------|--------------------------------------------------------
+| `children`       | Optional | `ReactNode`       |         | The components rendering the record fields
+| `render`         | Optional | `(props: EditControllerResult<RecordType>) => ReactNode`       |         | Alternative to children, a function that takes the EditController context and renders the form
+| `disable Authentication` | Optional | `boolean` |         | Set to `true` to disable the authentication check
+| `id`             | Optional | `string`          |         | The record identifier. If not provided, it will be deduced from the URL
+| `loading`        | Optional | `ReactNode`       |         | The component to render while checking for authentication and permissions
+| `mutationMode`   | Optional | `undoable`       |         | The mutation mode
+| `mutationOptions` | Optional | `ReactNode`       |         | The options to pass to the `useUpdate` hook
+| `offline`        | Optional | `ReactNode`       |         | The component to render when there is no connectivity and the record isn't in the cache
+| `queryOptions`   | Optional | `object`          |         | The options to pass to the `useGetOne` hook
+| `transform`       | Optional | `string`          |         | Transform the form data before calling `dataProvider.update()`
 
-* `children`: the components that renders the form
-* `render`: alternative to children, a function that takes the `EditController` context and renders the form
-* [`disableAuthentication`](./Edit.md#disableauthentication): disable the authentication check
-* [`id`](./Edit.md#id): the id of the record to edit
-* [`mutationMode`](./Edit.md#mutationmode): switch to optimistic or pessimistic mutations (undoable by default)
-* [`mutationOptions`](./Edit.md#mutationoptions): options for the `dataProvider.update()` call
-* [`queryOptions`](./Edit.md#queryoptions): options for the `dataProvider.getOne()` call
-* [`redirect`](./Edit.md#redirect): change the redirect location after successful creation
-* [`resource`](./Edit.md#resource): override the name of the resource to create
-* [`transform`](./Edit.md#transform): transform the form data before calling `dataProvider.update()`
+
+## `children`
+
+`<EditBase>` renders its children wrapped by a `RecordContext`, so you can use any component that depends on such a context to be defined - including all [Inputs components](./Inputs.md).
+
+For instance, to display several fields in a single line, you can use Material UI’s `<Grid>` component:
+
+{% raw %}
+```jsx
+import { EditBase, Form, DateInput, ReferenceInput, SaveButton, TextInput } from 'react-admin';
+import { Grid } from '@mui/material';
+
+const BookEdit = () => (
+    <EditBase>
+        <Form>
+            <Grid container spacing={2} sx={{ margin: 2 }}>
+                <Grid item xs={12} sm={6}>
+                    <TextInput label="Title" source="title" />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                    <ReferenceInput label="Author" source="author_id" reference="authors">
+                        <TextInput source="name" />
+                    </ReferenceInput>
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                    <DateInput label="Publication Date" source="published_at" />
+                </Grid>
+                <Grid item xs={12}>
+                    <SaveButton />
+                </Grid>
+            </Grid>
+        </Form>
+    </EditBase>
+);
+```
+{% endraw %}
+
+## `disableAuthentication`
+
+By default, the `<EditBase>` component will automatically redirect the user to the login page if the user is not authenticated. If you want to disable this behavior and allow anonymous access to a show page, set the `disableAuthentication` prop to `true`.
+
+```jsx
+import { EditBase } from 'ra-core';
+
+const PostEdit = () => (
+    <EditBase disableAuthentication>
+        ...
+    </EditBase>
+);
+```
+
+## `id`
+
+By default, `<EditBase>` deduces the identifier of the record to show from the URL path. So under the `/posts/123/show` path, the `id` prop will be `123`. You may want to force a different identifier. In this case, pass a custom `id` prop.
+
+```jsx
+import { EditBase } from 'ra-core';
+
+export const PostEdit = () => (
+    <EditBase id="123">
+        ...
+    </EditBase>
+);
+```
+
+**Tip**: Pass both a custom `id` and a custom `resource` prop to use `<EditBase>` independently of the current URL. This even allows you to use more than one `<EditBase>` component in the same page.
+
+## `loading`
+
+By default, `<EditBase>` renders nothing while checking for authentication and permissions. You can provide your own component via the `loading` prop:
+
+```jsx
+import { EditBase } from 'ra-core';
+
+export const PostEdit = () => (
+    <EditBase loading={<p>Checking for permissions...</p>}>
+        ...
+    </EditBase>
+);
+```
+
+## `mutationMode`
+
+The `<EditBase>` component exposes a save method, which perform a "mutation" (i.e. they alter the data). React-admin offers three modes for mutations. The mode determines when the side effects (redirection, notifications, etc.) are executed:
+
+* `pessimistic`: The mutation is passed to the dataProvider first. When the dataProvider returns successfully, the mutation is applied locally, and the side effects are executed.
+* `optimistic`: The mutation is applied locally and the side effects are executed immediately. Then the mutation is passed to the dataProvider. If the dataProvider returns successfully, nothing happens (as the mutation was already applied locally). If the dataProvider returns in error, the page is refreshed and an error notification is shown.
+* `undoable` (default): The mutation is applied locally and the side effects are executed immediately. Then a notification is shown with an undo button. If the user clicks on undo, the mutation is never sent to the dataProvider, and the page is refreshed. Otherwise, after a 5 seconds delay, the mutation is passed to the dataProvider. If the dataProvider returns successfully, nothing happens (as the mutation was already applied locally). If the dataProvider returns in error, the page is refreshed and an error notification is shown.
+
+By default, pages using `<EditBase>` use the `undoable` mutation mode. This is part of the "optimistic rendering" strategy of react-admin ; it makes user interactions more reactive.
+
+You can change this default by setting the `mutationMode` prop - and this affects both the Save and Delete buttons. For instance, to remove the ability to undo the changes, use the `optimistic` mode:
+
+```jsx
+const PostEdit = () => (
+    <EditBase mutationMode="optimistic">
+        // ...
+    </EditBase>
+);
+```
+
+And to make the Save action blocking, and wait for the dataProvider response to continue, use the `pessimistic` mode:
+
+```jsx
+const PostEdit = () => (
+    <EditBase mutationMode="pessimistic">
+        // ...
+    </EditBase>
+);
+```
+
+## `mutationOptions`
+
+`<EditBase>` calls `dataProvider.update()` via react-query's `useMutation` hook. You can customize the options you pass to this hook, e.g. to pass [a custom `meta`](./Actions.md#meta-parameter) to the `dataProvider.update()` call.
+
+{% raw %}
+
+```jsx
+import { EditBase, SimpleForm } from 'react-admin';
+
+const PostEdit = () => (
+    <EditBase mutationOptions={{ meta: { foo: 'bar' } }}>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </EditBase>
+);
+```
+
+{% endraw %}
+
+You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://tanstack.com/query/v5/docs/react/reference/useMutation) in the react-query website for a list of the possible options.
+
+Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to the list page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
+
+{% raw %}
+
+```jsx
+import * as React from 'react';
+import { useNotify, useRefresh, useRedirect, EditBase, SimpleForm } from 'react-admin';
+
+const PostEdit = () => {
+    const notify = useNotify();
+    const refresh = useRefresh();
+    const redirect = useRedirect();
+
+    const onSuccess = () => {
+        notify(`Changes saved`);
+        redirect('/posts');
+        refresh();
+    };
+
+    return (
+        <EditBase mutationOptions={{ onSuccess }}>
+            <SimpleForm>
+                ...
+            </SimpleForm>
+        </EditBase>
+    );
+}
+```
+
+{% endraw %}
+
+The default `onSuccess` function is:
+
+```js
+() => {
+    notify('ra.notification.updated', {
+        messageArgs: { smart_count: 1 },
+        undoable: mutationMode === 'undoable'
+    });
+    redirect('list', resource, data.id, data);
+}
+```
+
+**Tip**: If you just want to customize the redirect behavior, you can use [the `redirect` prop](#redirect) instead.
+
+**Tip**: When you use `mutationMode="pessimistic"`, the `onSuccess` function receives the response from the `dataProvider.update()` call, which is the created/edited record (see [the dataProvider documentation for details](./DataProviderWriting.md#update)). You can use that response in the success side effects:
+
+{% raw %}
+
+```jsx
+import * as React from 'react';
+import { useNotify, useRefresh, useRedirect, EditBase, SimpleForm } from 'react-admin';
+
+const PostEdit = () => {
+    const notify = useNotify();
+    const refresh = useRefresh();
+    const redirect = useRedirect();
+
+  const onSuccess = (data) => {
+        notify(`Changes to post "${data.title}" saved`);
+        redirect('/posts');
+        refresh();
+    };
+
+    return (
+        <EditBase mutationOptions={{ onSuccess }} mutationMode="pessimistic">
+            <SimpleForm>
+                ...
+            </SimpleForm>
+        </EditBase>
+    );
+}
+```
+
+{% endraw %}
+
+**Tip**: If you want to have different success side effects based on the button clicked by the user (e.g. if the creation form displays two submit buttons, one to "save and redirect to the list", and another to "save and display an empty form"), you can set the `mutationOptions` prop on [the `<SaveButton>` component](./SaveButton.md), too.
+
+Similarly, you can override the failure side effects with an `onError` option. By default, when the save action fails at the dataProvider level, react-admin shows a notification error.
+
+{% raw %}
+
+```jsx
+import * as React from 'react';
+import { useNotify, useRefresh, useRedirect, EditBase, SimpleForm } from 'react-admin';
+
+const PostEdit = () => {
+    const notify = useNotify();
+    const refresh = useRefresh();
+    const redirect = useRedirect();
+
+    const onError = (error) => {
+        notify(`Could not edit post: ${error.message}`);
+        redirect('/posts');
+        refresh();
+    };
+
+    return (
+        <EditBase mutationOptions={{ onError }}>
+            <SimpleForm>
+                ...
+            </SimpleForm>
+        </EditBase>
+    );
+}
+```
+
+{% endraw %}
+
+The `onError` function receives the error from the `dataProvider.update()` call. It is a JavaScript Error object (see [the dataProvider documentation for details](./DataProviderWriting.md#error-format)).
+
+The default `onError` function is:
+
+```jsx
+(error) => {
+    notify(typeof error === 'string' ? error : error.message || 'ra.notification.http_error', { type: 'error' });
+    if (mutationMode === 'undoable' || mutationMode === 'pessimistic') {
+        refresh();
+    }
+}
+```
+
+**Tip**: If you want to have different failure side effects based on the button clicked by the user, you can set the `mutationOptions` prop on the `<SaveButton>` component, too.
+
+## `offline`
+
+By default, `<EditBase>` renders nothing when there is no connectivity and the record hasn't been cached yet. You can provide your own component via the `offline` prop:
+
+```jsx
+import { EditBase } from 'ra-core';
+
+export const PostEdit = () => (
+    <EditBase offline={<p>No network. Could not load the post.</p>}>
+        ...
+    </EditBase>
+);
+```
+
+**Tip**: If the record is in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
+
+```jsx
+import { EditBase, IsOffline } from 'ra-core';
+
+export const PostEdit = () => (
+    <EditBase offline={<p>No network. Could not load the post.</p>}>
+        <IsOffline>
+            No network. The post data may be outdated.
+        </IsOffline>
+        ...
+    </EditBase>
+);
+```
+
+## `queryOptions`
+
+`<EditBase>` accepts a `queryOptions` prop to pass options to the react-query client. 
+
+This can be useful e.g. to override the default error side effect. By default, when the `dataProvider.getOne()` call fails at the dataProvider level, react-admin shows an error notification and refreshes the page.
+
+You can override this behavior and pass custom side effects by providing a custom `queryOptions` prop:
+
+```jsx
+import * as React from 'react';
+import { useNotify, useRefresh, useRedirect, EditBase, SimpleForm } from 'react-admin';
+
+const PostEdit = () => {
+    const notify = useNotify();
+    const refresh = useRefresh();
+    const redirect = useRedirect();
+
+    const onError = (error) => {
+        notify(`Could not load post: ${error.message}`, { type: 'error' });
+        redirect('/posts');
+        refresh();
+    };
+
+    return (
+        <EditBase queryOptions={{ onError }}>
+            <SimpleForm>
+                ...
+            </SimpleForm>
+        </EditBase>
+    );
+}
+```
+
+The `onError` function receives the error from the dataProvider call (`dataProvider.getOne()`), which is a JavaScript Error object (see [the dataProvider documentation for details](./DataProviderWriting.md#error-format)).
+
+The default `onError` function is:
+
+```jsx
+(error) => {
+    notify('ra.notification.item_doesnt_exist', { type: 'error' });
+    redirect('list', resource);
+    refresh();
+}
+```
+
+## `render`
+
+Alternatively, you can pass a `render` function prop instead of children. This function will receive the `EditContext` as argument. 
+
+{% raw %}
+```jsx
+import { EditBase, Form, DateInput, ReferenceInput, SaveButton, TextInput } from 'react-admin';
+
+const BookEdit = () => (
+    <EditBase render={({ isPending, error }) => {
+        if (isPending) {
+            return <p>Loading...</p>;
+        }
+
+        if (error) {
+            return (
+                <p className="error">
+                    {error.message}
+                </p>
+            );
+        }
+        return (
+            <Form>
+                <Grid container spacing={2} sx={{ margin: 2 }}>
+                    <Grid item xs={12} sm={6}>
+                        <TextInput label="Title" source="title" />
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <ReferenceInput label="Author" source="author_id" reference="authors">
+                            <TextInput source="name" />
+                        </ReferenceInput>
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <DateInput label="Publication Date" source="published_at" />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <SaveButton />
+                    </Grid>
+                </Grid>
+            </Form>
+        );
+    }}/>
+);
+```
+{% endraw %}
+
+## `resource`
+
+By default, `<EditBase>` operates on the current `ResourceContext` (defined at the routing level), so under the `/posts/1/show` path, the `resource` prop will be `posts`. You may want to force a different resource. In this case, pass a custom `resource` prop, and it will override the `ResourceContext` value.
+
+```jsx
+import { EditBase } from 'ra-core';
+
+export const UsersEdit = () => (
+    <EditBase resource="users">
+        ...
+    </EditBase>
+);
+```
+
+**Tip**: Pass both a custom `id` and a custom `resource` prop to use `<EditBase>` independently of the current URL. This even allows you to use more than one `<EditBase>` component in the same page.
 
 ## Security
 

--- a/docs/EditBase.md
+++ b/docs/EditBase.md
@@ -99,7 +99,7 @@ const BookEdit = () => (
 By default, the `<EditBase>` component will automatically redirect the user to the login page if the user is not authenticated. If you want to disable this behavior and allow anonymous access to a show page, set the `disableAuthentication` prop to `true`.
 
 ```jsx
-import { EditBase } from 'ra-core';
+import { EditBase } from 'react-admin';
 
 const PostEdit = () => (
     <EditBase disableAuthentication>
@@ -113,7 +113,7 @@ const PostEdit = () => (
 By default, `<EditBase>` deduces the identifier of the record to show from the URL path. So under the `/posts/123/show` path, the `id` prop will be `123`. You may want to force a different identifier. In this case, pass a custom `id` prop.
 
 ```jsx
-import { EditBase } from 'ra-core';
+import { EditBase } from 'react-admin';
 
 export const PostEdit = () => (
     <EditBase id="123">
@@ -129,7 +129,7 @@ export const PostEdit = () => (
 By default, `<EditBase>` renders nothing while checking for authentication and permissions. You can provide your own component via the `loading` prop:
 
 ```jsx
-import { EditBase } from 'ra-core';
+import { EditBase } from 'react-admin';
 
 export const PostEdit = () => (
     <EditBase loading={<p>Checking for permissions...</p>}>
@@ -151,6 +151,8 @@ By default, pages using `<EditBase>` use the `undoable` mutation mode. This is p
 You can change this default by setting the `mutationMode` prop - and this affects both the Save and Delete buttons. For instance, to remove the ability to undo the changes, use the `optimistic` mode:
 
 ```jsx
+import { EditBase } from 'react-admin';
+
 const PostEdit = () => (
     <EditBase mutationMode="optimistic">
         // ...
@@ -161,6 +163,8 @@ const PostEdit = () => (
 And to make the Save action blocking, and wait for the dataProvider response to continue, use the `pessimistic` mode:
 
 ```jsx
+import { EditBase } from 'react-admin';
+
 const PostEdit = () => (
     <EditBase mutationMode="pessimistic">
         // ...
@@ -319,7 +323,7 @@ The default `onError` function is:
 By default, `<EditBase>` renders nothing when there is no connectivity and the record hasn't been cached yet. You can provide your own component via the `offline` prop:
 
 ```jsx
-import { EditBase } from 'ra-core';
+import { EditBase } from 'react-admin';
 
 export const PostEdit = () => (
     <EditBase offline={<p>No network. Could not load the post.</p>}>
@@ -331,7 +335,7 @@ export const PostEdit = () => (
 **Tip**: If the record is in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
 
 ```jsx
-import { EditBase, IsOffline } from 'ra-core';
+import { EditBase, IsOffline } from 'react-admin';
 
 export const PostEdit = () => (
     <EditBase offline={<p>No network. Could not load the post.</p>}>
@@ -439,7 +443,7 @@ const BookEdit = () => (
 By default, `<EditBase>` operates on the current `ResourceContext` (defined at the routing level), so under the `/posts/1/show` path, the `resource` prop will be `posts`. You may want to force a different resource. In this case, pass a custom `resource` prop, and it will override the `ResourceContext` value.
 
 ```jsx
-import { EditBase } from 'ra-core';
+import { EditBase } from 'react-admin';
 
 export const UsersEdit = () => (
     <EditBase resource="users">

--- a/packages/ra-core/src/controller/edit/EditBase.spec.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.spec.tsx
@@ -7,6 +7,7 @@ import {
     AccessControl,
     DefaultTitle,
     NoAuthProvider,
+    Offline,
     WithAuthProviderNoAccessControl,
     WithRenderProps,
 } from './EditBase.stories';
@@ -410,5 +411,17 @@ describe('EditBase', () => {
                 previousData: { id: 12, test: 'Hello' },
             });
         });
+    });
+
+    it('should render the offline prop node when offline', async () => {
+        const { rerender } = render(<Offline isOnline={false} />);
+        await screen.findByText('You are offline, cannot load data');
+        rerender(<Offline isOnline={true} />);
+        await screen.findByText('Hello');
+        expect(
+            screen.queryByText('You are offline, cannot load data')
+        ).toBeNull();
+        rerender(<Offline isOnline={false} />);
+        await screen.findByText('You are offline, the data may be outdated');
     });
 });

--- a/packages/ra-core/src/controller/edit/EditBase.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.tsx
@@ -42,9 +42,10 @@ import { useIsAuthPending } from '../../auth';
  */
 export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
     children,
-    render,
+    disableAuthentication,
     loading,
     offline,
+    render,
     ...props
 }: EditBaseProps<RecordType, ErrorType>) => {
     const controllerProps = useEditController<RecordType, ErrorType>(props);
@@ -62,29 +63,26 @@ export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
 
     const { isPaused, record } = controllerProps;
 
+    const shouldRenderLoading =
+        isAuthPending &&
+        !disableAuthentication &&
+        loading !== false &&
+        loading !== undefined;
+
+    const shouldRenderOffline =
+        isPaused && !record && offline !== false && offline !== undefined;
+
     return (
         // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
         <OptionalResourceContextProvider value={props.resource}>
             <EditContextProvider value={controllerProps}>
-                {(() => {
-                    if (
-                        isAuthPending &&
-                        !props.disableAuthentication &&
-                        loading !== false &&
-                        loading !== undefined
-                    ) {
-                        return loading;
-                    }
-                    if (
-                        isPaused &&
-                        !record &&
-                        offline !== false &&
-                        offline !== undefined
-                    ) {
-                        return offline;
-                    }
-                    return render ? render(controllerProps) : children;
-                })()}
+                {shouldRenderLoading
+                    ? loading
+                    : shouldRenderOffline
+                      ? offline
+                      : render
+                        ? render(controllerProps)
+                        : children}
             </EditContextProvider>
         </OptionalResourceContextProvider>
     );

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -113,7 +113,9 @@ export const useEditController = <
         error,
         isLoading,
         isFetching,
+        isPaused,
         isPending,
+        isPlaceholderData,
         refetch,
     } = useGetOne<RecordType, ErrorType>(
         resource,
@@ -291,7 +293,9 @@ export const useEditController = <
         error,
         isFetching,
         isLoading,
+        isPaused,
         isPending,
+        isPlaceholderData,
         mutationMode,
         record,
         redirect: redirectTo,
@@ -326,6 +330,8 @@ export interface EditControllerBaseResult<RecordType extends RaRecord = any>
     defaultTitle?: string;
     isFetching: boolean;
     isLoading: boolean;
+    isPaused: boolean;
+    isPlaceholderData: boolean;
     refetch: UseGetOneHookValue<RecordType>['refetch'];
     redirect: RedirectionSideEffect;
     resource: string;

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -454,12 +454,7 @@ export const Offline = ({
 
 const BookEditOffline = (props: EditProps) => {
     return (
-        <Edit
-            emptyWhileLoading
-            {...props}
-            redirect={false}
-            mutationMode="pessimistic"
-        >
+        <Edit {...props} redirect={false} mutationMode="pessimistic">
             <OfflineIndicator />
             <SimpleForm>
                 <TextInput source="title" />

--- a/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.stories.tsx
@@ -6,18 +6,29 @@ import {
     useRecordContext,
     TestMemoryRouter,
     useEditContext,
+    IsOffline,
 } from 'ra-core';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import { Box, Card, Stack, ThemeOptions, Typography } from '@mui/material';
+import fakeRestDataProvider from 'ra-data-fakerest';
+
+import {
+    Alert,
+    Box,
+    Card,
+    Stack,
+    ThemeOptions,
+    Typography,
+} from '@mui/material';
 
 import { TextInput } from '../input';
 import { SimpleForm } from '../form/SimpleForm';
 import { ShowButton, SaveButton } from '../button';
 import TopToolbar from '../layout/TopToolbar';
-import { Edit } from './Edit';
+import { Edit, EditProps } from './Edit';
 import { deepmerge } from '@mui/utils';
 import { defaultLightTheme } from '../theme';
+import { onlineManager, useMutationState } from '@tanstack/react-query';
 
 export default { title: 'ra-ui-materialui/detail/Edit' };
 
@@ -30,9 +41,9 @@ const book = {
     year: 1869,
 };
 
-const dataProvider = {
-    getOne: () => Promise.resolve({ data: book }),
-} as any;
+const dataProvider = fakeRestDataProvider({
+    books: [book],
+});
 
 const BookTitle = () => {
     const record = useRecordContext();
@@ -418,3 +429,91 @@ export const WithRenderProp = () => (
         </Admin>
     </TestMemoryRouter>
 );
+
+export const Offline = ({
+    isOnline = true,
+    offline,
+}: {
+    isOnline?: boolean;
+    offline?: React.ReactNode;
+}) => {
+    React.useEffect(() => {
+        onlineManager.setOnline(isOnline);
+    }, [isOnline]);
+    return (
+        <TestMemoryRouter initialEntries={['/books/1/show']}>
+            <Admin dataProvider={dataProvider}>
+                <Resource
+                    name="books"
+                    show={<BookEditOffline offline={offline} />}
+                />
+            </Admin>
+        </TestMemoryRouter>
+    );
+};
+
+const BookEditOffline = (props: EditProps) => {
+    return (
+        <Edit
+            emptyWhileLoading
+            {...props}
+            redirect={false}
+            mutationMode="pessimistic"
+        >
+            <OfflineIndicator />
+            <SimpleForm>
+                <TextInput source="title" />
+                <TextInput source="author" />
+                <TextInput source="summary" />
+                <TextInput source="year" />
+            </SimpleForm>
+        </Edit>
+    );
+};
+
+const OfflineIndicator = () => {
+    const pendingMutations = useMutationState({
+        filters: {
+            status: 'pending',
+        },
+    });
+
+    if (pendingMutations.length === 0) {
+        return (
+            <IsOffline>
+                <Alert severity="warning">
+                    You are offline, the data may be outdated
+                </Alert>
+            </IsOffline>
+        );
+    }
+    return (
+        <IsOffline>
+            <Alert severity="warning">You have pending mutations</Alert>
+        </IsOffline>
+    );
+};
+
+const CustomOffline = () => {
+    return <Alert severity="warning">You are offline!</Alert>;
+};
+
+Offline.args = {
+    isOnline: true,
+    offline: 'default',
+};
+
+Offline.argTypes = {
+    isOnline: {
+        control: { type: 'boolean' },
+    },
+    offline: {
+        name: 'Offline component',
+        control: { type: 'radio' },
+        options: ['default', 'custom'],
+        mapping: {
+            default: undefined,
+            custom: <CustomOffline />,
+        },
+    },
+};

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-    EditBase,
-    useCheckMinimumRequiredProps,
-    RaRecord,
-    EditBaseProps,
-} from 'ra-core';
+import { EditBase, RaRecord, EditBaseProps } from 'ra-core';
 import { useThemeProps } from '@mui/material/styles';
 
 import { EditView, EditViewProps } from './EditView';
@@ -95,6 +90,8 @@ export const Edit = <RecordType extends RaRecord = any>(
             transform={transform}
             disableAuthentication={disableAuthentication}
             loading={loading}
+            // Disable offline support from ShowBase as it is handled by ShowView to keep the ShowView container
+            offline={false}
         >
             <EditView {...rest} />
         </EditBase>

--- a/packages/ra-ui-materialui/src/detail/Edit.tsx
+++ b/packages/ra-ui-materialui/src/detail/Edit.tsx
@@ -90,7 +90,7 @@ export const Edit = <RecordType extends RaRecord = any>(
             transform={transform}
             disableAuthentication={disableAuthentication}
             loading={loading}
-            // Disable offline support from ShowBase as it is handled by ShowView to keep the ShowView container
+            // Disable offline support from EditBase as it is handled by EditView to keep the EditView container
             offline={false}
         >
             <EditView {...rest} />

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -18,8 +18,10 @@ import {
 import { EditActions } from './EditActions';
 import { Title } from '../layout';
 import { EditProps } from './Edit';
+import { Offline } from '../Offline';
 
 const defaultActions = <EditActions />;
+const defaultOffline = <Offline />;
 
 export const EditView = (props: EditViewProps) => {
     const {
@@ -30,6 +32,7 @@ export const EditView = (props: EditViewProps) => {
         className,
         component: Content = Card,
         emptyWhileLoading = false,
+        offline = defaultOffline,
         title,
         ...rest
     } = props;
@@ -37,10 +40,21 @@ export const EditView = (props: EditViewProps) => {
     const { hasShow } = useResourceDefinition();
     const editContext = useEditContext();
 
-    const { resource, defaultTitle, record, isPending } = editContext;
+    const { resource, defaultTitle, record, isPaused, isPending } = editContext;
 
     const finalActions =
         typeof actions === 'undefined' && hasShow ? defaultActions : actions;
+
+    if (!record && offline !== false && isPaused) {
+        return (
+            <Root className={clsx('edit-page', className)} {...rest}>
+                <div className={clsx(EditClasses.main, EditClasses.noActions)}>
+                    <Content className={EditClasses.card}>{offline}</Content>
+                    {aside}
+                </div>
+            </Root>
+        );
+    }
 
     if (!record && isPending && emptyWhileLoading) {
         return null;
@@ -82,6 +96,7 @@ export interface EditViewProps
     aside?: ReactElement;
     component?: ElementType;
     emptyWhileLoading?: boolean;
+    offline?: ReactNode;
     title?: string | ReactElement | false;
     sx?: SxProps<Theme>;
     render?: (editContext: EditControllerResult) => ReactNode;


### PR DESCRIPTION
## Problem

Our components and hooks can't leverage the offline support provided by Tanstack Query.

## Solution

- Make sure our data loading hooks returns the data needed to detect those cases
- Provide components, hooks and props allowing to handle offline scenarios
- Provide default offline components in `ra-ui-materialui`

## How To Test

- [`<EditBase>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-core-controller-editbase--offline)
- [`<Edit>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-ui-materialui-detail-edit--offline)
- Tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
