### PR TITLE
Add offline support to `<ReferenceFieldBase>` and `<ReferenceField>`

### DIFF
--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -79,6 +79,7 @@ It uses `dataProvider.getMany()` instead of `dataProvider.getOne()` [for perform
 | `empty`     | Optional | `ReactNode`         | -        | What to render when the field has no value or when the reference is missing |
 | `label`     | Optional | `string | Function` | `resources. [resource]. fields.[source]`   | Label to use for the field when rendered in layout components  |
 | `link`      | Optional | `string | Function` | `edit`   | Target of the link wrapping the rendered child. Set to `false` to disable the link. |
+| `offline`   | Optional | `ReactNode`         | -        | What to render when there is no network connectivity when loading the record |
 | `queryOptions`     | Optional | [`UseQuery Options`](https://tanstack.com/query/v5/docs/react/reference/useQuery)                       | `{}`                             | `react-query` client options                                                                   |
 | `sortBy`    | Optional | `string | Function` | `source` | Name of the field to use for sorting when used in a Datagrid |
 
@@ -98,6 +99,7 @@ By default, `<ReferenceField>` renders the `recordRepresentation` of the referen
 ```
 
 Alternatively, you can use [the `render` prop](#render) to render the referenced record in a custom way. 
+
 ## `empty`
 
 `<ReferenceField>` can display a custom message when the referenced record is missing, thanks to the `empty` prop.
@@ -170,6 +172,32 @@ You can also use a custom `link` function to get a custom path for the children.
     reference="users"
     link={(record, reference) => `/my/path/to/${reference}/${record.id}`}
 />
+```
+
+## `offline`
+
+`<ReferenceField>` can display a custom message when the referenced record is missing because there is no network connectivity, thanks to the `offline` prop.
+
+```jsx
+<ReferenceField source="user_id" reference="users" offline="No network, could not fetch data" >
+    ...
+</ReferenceField>
+```
+
+`<ReferenceField>` renders the `empty` element when:
+
+- the referenced record is missing (no record in the `users` table with the right `user_id`), and
+- there is no network connectivity
+
+You can pass either a React element or a string to the `offline` prop:
+
+```jsx
+<ReferenceField source="user_id" reference="users" empty={<span>No network, could not fetch data</span>} >
+    ...
+</ReferenceField>
+<ReferenceField source="user_id" reference="users" empty="No network, could not fetch data" >
+    ...
+</ReferenceField>
 ```
 
 ## `queryOptions`

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -176,20 +176,9 @@ You can also use a custom `link` function to get a custom path for the children.
 
 ## `offline`
 
-`<ReferenceField>` can display a custom message when the referenced record is missing because there is no network connectivity, thanks to the `offline` prop.
+When the user is offline, `<ReferenceField>` is smart enough to display the referenced record if it was previously fetched. However, if the referenced record has never been fetched before, `<ReferenceField>` displays an error message explaining that the app has lost network connectivity.
 
-```jsx
-<ReferenceField source="user_id" reference="users" offline="No network, could not fetch data" >
-    ...
-</ReferenceField>
-```
-
-`<ReferenceField>` renders the `offline` element when:
-
-- the referenced record is missing (no record in the `users` table with the right `user_id`), and
-- there is no network connectivity
-
-You can pass either a React element or a string to the `offline` prop:
+You can customize this error message by passing a React element or a string to the `offline` prop:
 
 ```jsx
 <ReferenceField source="user_id" reference="users" offline={<span>No network, could not fetch data</span>} >

--- a/docs/ReferenceField.md
+++ b/docs/ReferenceField.md
@@ -184,7 +184,7 @@ You can also use a custom `link` function to get a custom path for the children.
 </ReferenceField>
 ```
 
-`<ReferenceField>` renders the `empty` element when:
+`<ReferenceField>` renders the `offline` element when:
 
 - the referenced record is missing (no record in the `users` table with the right `user_id`), and
 - there is no network connectivity
@@ -192,10 +192,10 @@ You can also use a custom `link` function to get a custom path for the children.
 You can pass either a React element or a string to the `offline` prop:
 
 ```jsx
-<ReferenceField source="user_id" reference="users" empty={<span>No network, could not fetch data</span>} >
+<ReferenceField source="user_id" reference="users" offline={<span>No network, could not fetch data</span>} >
     ...
 </ReferenceField>
-<ReferenceField source="user_id" reference="users" empty="No network, could not fetch data" >
+<ReferenceField source="user_id" reference="users" offline="No network, could not fetch data" >
     ...
 </ReferenceField>
 ```

--- a/docs/ReferenceFieldBase.md
+++ b/docs/ReferenceFieldBase.md
@@ -129,26 +129,15 @@ You can pass either a React element or a string to the `empty` prop:
 
 ## `offline`
 
-`<ReferenceFieldBase>` can display a custom message when the referenced record is missing because there is no network connectivity, thanks to the `offline` prop.
+When the user is offline, `<ReferenceFieldBase>` is smart enough to display the referenced record if it was previously fetched. However, if the referenced record has never been fetched before, `<ReferenceFieldBase>` displays an error message explaining that the app has lost network connectivity.
+
+You can customize this error message by passing a React element or a string to the `offline` prop:
 
 ```jsx
+<ReferenceFieldBase source="user_id" reference="users" offline={<span>No network, could not fetch data</span>} >
+    ...
+</ReferenceFieldBase>
 <ReferenceFieldBase source="user_id" reference="users" offline="No network, could not fetch data" >
-    ...
-</ReferenceFieldBase>
-```
-
-`<ReferenceFieldBase>` renders the `empty` element when:
-
-- the referenced record is missing (no record in the `users` table with the right `user_id`), and
-- there is no network connectivity
-
-You can pass either a React element or a string to the `offline` prop:
-
-```jsx
-<ReferenceFieldBase source="user_id" reference="users" empty={<span>No network, could not fetch data</span>} >
-    ...
-</ReferenceFieldBase>
-<ReferenceFieldBase source="user_id" reference="users" empty="No network, could not fetch data" >
     ...
 </ReferenceFieldBase>
 ```

--- a/docs/ReferenceFieldBase.md
+++ b/docs/ReferenceFieldBase.md
@@ -68,6 +68,7 @@ It uses `dataProvider.getMany()` instead of `dataProvider.getOne()` [for perform
 | `children`  | Optional | `ReactNode`         | -        | React component to render the referenced record. |
 | `render`  | Optional |  `(context) => ReactNode`         | -        | Function that takes the referenceFieldContext and renders the referenced record. |
 | `empty`     | Optional | `ReactNode`         | -        | What to render when the field has no value or when the reference is missing |
+| `offline`   | Optional | `ReactNode`         | -        | What to render when there is no network connectivity when loading the record |
 | `queryOptions`     | Optional | [`UseQuery Options`](https://tanstack.com/query/v5/docs/react/reference/useQuery)                       | `{}`                             | `react-query` client options                                                                   |
 | `sortBy`    | Optional | `string | Function` | `source` | Name of the field to use for sorting when used in a Datagrid |
 
@@ -100,35 +101,6 @@ export const MyReferenceField = () => (
 );
 ```
 
-## `render`
-
-Alternatively, you can pass a `render` function prop instead of children. This function will receive the `ReferenceFieldContext` as argument.
-
-```jsx
-export const MyReferenceField = () => (
-    <ReferenceFieldBase
-        source="user_id"
-        reference="users"
-        render={({ error, isPending, referenceRecord }) => {
-            if (isPending) {
-                return <p>Loading...</p>;
-            }
-
-            if (error) {
-                return (
-                    <p className="error">
-                        {error.message}
-                    </p>
-                );
-            }
-            return <p>{referenceRecord.name}</p>;
-        }}
-    />
-);
-```
-
-The `render` function prop will take priority on `children` props if both are set.
-
 ## `empty`
 
 `<ReferenceFieldBase>` can display a custom message when the referenced record is missing, thanks to the `empty` prop.
@@ -151,6 +123,32 @@ You can pass either a React element or a string to the `empty` prop:
     ...
 </ReferenceFieldBase>
 <ReferenceFieldBase source="user_id" reference="users" empty="Missing user" >
+    ...
+</ReferenceFieldBase>
+```
+
+## `offline`
+
+`<ReferenceFieldBase>` can display a custom message when the referenced record is missing because there is no network connectivity, thanks to the `offline` prop.
+
+```jsx
+<ReferenceFieldBase source="user_id" reference="users" offline="No network, could not fetch data" >
+    ...
+</ReferenceFieldBase>
+```
+
+`<ReferenceFieldBase>` renders the `empty` element when:
+
+- the referenced record is missing (no record in the `users` table with the right `user_id`), and
+- there is no network connectivity
+
+You can pass either a React element or a string to the `offline` prop:
+
+```jsx
+<ReferenceFieldBase source="user_id" reference="users" empty={<span>No network, could not fetch data</span>} >
+    ...
+</ReferenceFieldBase>
+<ReferenceFieldBase source="user_id" reference="users" empty="No network, could not fetch data" >
     ...
 </ReferenceFieldBase>
 ```
@@ -185,6 +183,36 @@ For instance, if the `posts` resource has a `user_id` field, set the `reference`
     ...
 </ReferenceFieldBase>
 ```
+
+
+## `render`
+
+Alternatively, you can pass a `render` function prop instead of children. This function will receive the `ReferenceFieldContext` as argument.
+
+```jsx
+export const MyReferenceField = () => (
+    <ReferenceFieldBase
+        source="user_id"
+        reference="users"
+        render={({ error, isPending, referenceRecord }) => {
+            if (isPending) {
+                return <p>Loading...</p>;
+            }
+
+            if (error) {
+                return (
+                    <p className="error">
+                        {error.message}
+                    </p>
+                );
+            }
+            return <p>{referenceRecord.name}</p>;
+        }}
+    />
+);
+```
+
+The `render` function prop will take priority on `children` props if both are set.
 
 ## `sortBy`
 

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -42,7 +42,7 @@ describe('<ReferenceFieldBase />', () => {
         });
     });
 
-    it.only('should pass the correct resource down to child component', async () => {
+    it('should pass the correct resource down to child component', async () => {
         const MyComponent = () => {
             const resource = useResourceContext();
             return <div>{resource}</div>;

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import expect from 'expect';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CoreAdminContext } from '../../core/CoreAdminContext';
 import { useResourceContext } from '../../core/useResourceContext';
 import { testDataProvider } from '../../dataProvider';
@@ -10,8 +10,10 @@ import {
     Errored,
     Loading,
     Meta,
+    Offline,
     WithRenderProp,
 } from './ReferenceFieldBase.stories';
+import { RecordContextProvider } from '../record';
 
 describe('<ReferenceFieldBase />', () => {
     beforeAll(() => {
@@ -40,26 +42,26 @@ describe('<ReferenceFieldBase />', () => {
         });
     });
 
-    it('should pass the correct resource down to child component', async () => {
+    it.only('should pass the correct resource down to child component', async () => {
         const MyComponent = () => {
             const resource = useResourceContext();
             return <div>{resource}</div>;
         };
         const dataProvider = testDataProvider({
-            // @ts-ignore
-            getList: () =>
+            getMany: () =>
+                // @ts-ignore
                 Promise.resolve({ data: [{ id: 1 }, { id: 2 }], total: 2 }),
         });
         render(
             <CoreAdminContext dataProvider={dataProvider}>
-                <ReferenceFieldBase reference="posts" source="post_id">
-                    <MyComponent />
-                </ReferenceFieldBase>
+                <RecordContextProvider value={{ post_id: 1 }}>
+                    <ReferenceFieldBase reference="posts" source="post_id">
+                        <MyComponent />
+                    </ReferenceFieldBase>
+                </RecordContextProvider>
             </CoreAdminContext>
         );
-        await waitFor(() => {
-            expect(screen.queryByText('posts')).not.toBeNull();
-        });
+        await screen.findByText('posts');
     });
 
     it('should accept meta in queryOptions', async () => {
@@ -70,8 +72,8 @@ describe('<ReferenceFieldBase />', () => {
             );
         const dataProvider = testDataProvider({
             getMany,
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: {
                         id: 1,
@@ -163,6 +165,15 @@ describe('<ReferenceFieldBase />', () => {
             await waitFor(() => {
                 expect(screen.queryByText('Leo')).not.toBeNull();
             });
+        });
+
+        it('should render the offline prop node when offline', async () => {
+            render(<Offline />);
+            fireEvent.click(await screen.findByText('Simulate offline'));
+            fireEvent.click(await screen.findByText('Toggle Child'));
+            await screen.findByText('You are offline, cannot load data');
+            fireEvent.click(await screen.findByText('Simulate online'));
+            await screen.findByText('Leo');
         });
     });
 });

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -166,14 +166,14 @@ describe('<ReferenceFieldBase />', () => {
                 expect(screen.queryByText('Leo')).not.toBeNull();
             });
         });
+    });
 
-        it('should render the offline prop node when offline', async () => {
-            render(<Offline />);
-            fireEvent.click(await screen.findByText('Simulate offline'));
-            fireEvent.click(await screen.findByText('Toggle Child'));
-            await screen.findByText('You are offline, cannot load data');
-            fireEvent.click(await screen.findByText('Simulate online'));
-            await screen.findByText('Leo');
-        });
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline />);
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('You are offline, cannot load data');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('Leo');
     });
 });

--- a/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceOneFieldController.tsx
@@ -76,47 +76,57 @@ export const useReferenceOneFieldController = <
     const notify = useNotify();
     const { meta, ...otherQueryOptions } = queryOptions;
 
-    const { data, error, isFetching, isLoading, isPending, refetch } =
-        useGetManyReference<ReferenceRecordType, ErrorType>(
-            reference,
-            {
-                target,
-                id: get(record, source),
-                pagination: { page: 1, perPage: 1 },
-                sort,
-                filter,
-                meta,
-            },
-            {
-                enabled: !!record,
-                onError: error =>
-                    notify(
-                        typeof error === 'string'
-                            ? error
-                            : (error as Error).message ||
-                                  'ra.notification.http_error',
-                        {
-                            type: 'error',
-                            messageArgs: {
-                                _:
-                                    typeof error === 'string'
-                                        ? error
-                                        : (error as Error)?.message
-                                          ? (error as Error).message
-                                          : undefined,
-                            },
-                        }
-                    ),
-                ...otherQueryOptions,
-            }
-        );
+    const {
+        data,
+        error,
+        isFetching,
+        isLoading,
+        isPaused,
+        isPending,
+        isPlaceholderData,
+        refetch,
+    } = useGetManyReference<ReferenceRecordType, ErrorType>(
+        reference,
+        {
+            target,
+            id: get(record, source),
+            pagination: { page: 1, perPage: 1 },
+            sort,
+            filter,
+            meta,
+        },
+        {
+            enabled: !!record,
+            onError: error =>
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : (error as Error).message ||
+                              'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : (error as Error)?.message
+                                      ? (error as Error).message
+                                      : undefined,
+                        },
+                    }
+                ),
+            ...otherQueryOptions,
+        }
+    );
 
     return {
         referenceRecord: data ? data[0] : undefined,
         error,
         isFetching,
         isLoading,
+        isPaused,
         isPending,
+        isPlaceholderData,
         refetch,
     };
 };

--- a/packages/ra-core/src/controller/useReference.spec.tsx
+++ b/packages/ra-core/src/controller/useReference.spec.tsx
@@ -130,7 +130,9 @@ describe('useReference', () => {
             referenceRecord: undefined,
             isFetching: true,
             isLoading: true,
+            isPaused: false,
             isPending: true,
+            isPlaceholderData: false,
             error: null,
             refetch: expect.any(Function),
         });
@@ -138,7 +140,9 @@ describe('useReference', () => {
             referenceRecord: { id: 1, title: 'foo' },
             isFetching: false,
             isLoading: false,
+            isPaused: false,
             isPending: false,
+            isPlaceholderData: false,
             error: null,
             refetch: expect.any(Function),
         });
@@ -170,7 +174,9 @@ describe('useReference', () => {
             referenceRecord: { id: 1, title: 'foo' },
             isFetching: true,
             isLoading: false,
+            isPaused: false,
             isPending: false,
+            isPlaceholderData: false,
             error: null,
             refetch: expect.any(Function),
         });
@@ -178,7 +184,9 @@ describe('useReference', () => {
             referenceRecord: { id: 1, title: 'foo' },
             isFetching: false,
             isLoading: false,
+            isPaused: false,
             isPending: false,
+            isPlaceholderData: false,
             error: null,
             refetch: expect.any(Function),
         });

--- a/packages/ra-core/src/controller/useReference.ts
+++ b/packages/ra-core/src/controller/useReference.ts
@@ -21,7 +21,9 @@ export interface UseReferenceResult<
     ErrorType = Error,
 > {
     isLoading: boolean;
+    isPaused: boolean;
     isPending: boolean;
+    isPlaceholderData: boolean;
     isFetching: boolean;
     referenceRecord?: RecordType;
     error?: ErrorType | null;
@@ -68,18 +70,28 @@ export const useReference = <
     ErrorType
 > => {
     const { meta, ...otherQueryOptions } = options;
-    const { data, error, isLoading, isFetching, isPending, refetch } =
-        useGetManyAggregate<RecordType, ErrorType>(
-            reference,
-            { ids: [id], meta },
-            otherQueryOptions
-        );
+    const {
+        data,
+        error,
+        isLoading,
+        isFetching,
+        isPaused,
+        isPending,
+        isPlaceholderData,
+        refetch,
+    } = useGetManyAggregate<RecordType, ErrorType>(
+        reference,
+        { ids: [id], meta },
+        otherQueryOptions
+    );
     return {
         referenceRecord: error ? undefined : data ? data[0] : undefined,
         refetch,
         error,
         isLoading,
         isFetching,
+        isPaused,
         isPending,
+        isPlaceholderData,
     };
 };

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -28,6 +28,7 @@ import {
     SXNoLink,
     SlowAccessControl,
     Themed,
+    Offline,
 } from './ReferenceField.stories';
 import { TextField } from './TextField';
 
@@ -762,5 +763,14 @@ describe('<ReferenceField />', () => {
     it('should be customized by a theme', async () => {
         render(<Themed />);
         expect(await screen.findByTestId('themed')).toBeDefined();
+    });
+
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline />);
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('No connectivity. Could not fetch data.');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('9780393966473');
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
@@ -12,13 +12,14 @@ import {
     Resource,
     TestMemoryRouter,
     AuthProvider,
+    useIsOffline,
 } from 'ra-core';
 
 import fakeRestDataProvider from 'ra-data-fakerest';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import { createTheme, Stack, ThemeOptions } from '@mui/material';
-import { QueryClient } from '@tanstack/react-query';
+import { onlineManager, QueryClient } from '@tanstack/react-query';
 import { deepmerge } from '@mui/utils';
 
 import { TextField } from '../field';
@@ -971,3 +972,42 @@ export const WithRenderProp = () => (
         ></ReferenceField>
     </Wrapper>
 );
+
+export const Offline = () => (
+    <Wrapper>
+        <I18nContextProvider value={i18nProvider}>
+            <div>
+                <RenderChildOnDemand>
+                    <ReferenceField source="detail_id" reference="book_details">
+                        <TextField source="ISBN" />
+                    </ReferenceField>
+                </RenderChildOnDemand>
+            </div>
+            <SimulateOfflineButton />
+        </I18nContextProvider>
+    </Wrapper>
+);
+
+const SimulateOfflineButton = () => {
+    const isOffline = useIsOffline();
+    return (
+        <button
+            type="button"
+            onClick={() => onlineManager.setOnline(isOffline)}
+        >
+            {isOffline ? 'Simulate online' : 'Simulate offline'}
+        </button>
+    );
+};
+
+const RenderChildOnDemand = ({ children }) => {
+    const [showChild, setShowChild] = React.useState(false);
+    return (
+        <>
+            <button onClick={() => setShowChild(!showChild)}>
+                Toggle Child
+            </button>
+            {showChild && <div>{children}</div>}
+        </>
+    );
+};

--- a/packages/ra-ui-materialui/src/field/ReferenceField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.tsx
@@ -26,6 +26,7 @@ import { Link } from '../Link';
 import type { FieldProps } from './types';
 import { genericMemo } from './genericMemo';
 import { visuallyHidden } from '@mui/utils';
+import { Offline } from '../Offline';
 
 /**
  * Fetch reference record, and render its representation, or delegate rendering to child component.
@@ -76,7 +77,14 @@ export const ReferenceField = <
         props: inProps,
         name: PREFIX,
     });
-    const { children, render, emptyText, empty, ...rest } = props;
+    const {
+        children,
+        render,
+        emptyText,
+        empty,
+        offline = defaultOffline,
+        ...rest
+    } = props;
     const translate = useTranslate();
 
     return (
@@ -95,6 +103,7 @@ export const ReferenceField = <
                     empty ?? null
                 )
             }
+            offline={offline}
         >
             <PureReferenceFieldView<RecordType, ReferenceRecordType>
                 {...rest}
@@ -105,6 +114,8 @@ export const ReferenceField = <
         </ReferenceFieldBase>
     );
 };
+
+const defaultOffline = <Offline variant="inline" />;
 
 export interface ReferenceFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
@@ -126,6 +137,7 @@ export interface ReferenceFieldProps<
     reference: string;
     translateChoice?: Function | boolean;
     link?: LinkToType<ReferenceRecordType>;
+    offline?: ReactNode;
     sx?: SxProps<Theme>;
 }
 


### PR DESCRIPTION
## Problem

Our components and hooks can't leverage the offline support provided by Tanstack Query.

## Solution

- Make sure our data loading hooks returns the data needed to detect those cases
- Provide components, hooks and props allowing to handle offline scenarios
- Provide default offline components in `ra-ui-materialui`

## How To Test

- [`<ReferenceFieldBase>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-core-controller-field-referencefieldbase--offline)
- [`<ReferenceField>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-ui-materialui-fields-referencefield--offline)
- Tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).