### PR TITLE
Add offline support to `<ReferenceOneFieldBase>` and `<ReferenceOneField>`

### DIFF
--- a/docs/ReferenceOneField.md
+++ b/docs/ReferenceOneField.md
@@ -160,23 +160,22 @@ You can also set the `link` prop to a string, which will be used as the link typ
 
 ## `offline`
 
-Use `offline` to customize the text displayed when the related record is empty because there is no network connectivity.
+When the user is offline, `<ReferenceOneField>` is smart enough to display the referenced record if it was previously fetched. However, if the referenced record has never been fetched before, `<ReferenceOneField>` displays an error message explaining that the app has lost network connectivity.
 
-```jsx
-<ReferenceOneField label="Details" reference="book_details" target="book_id" offline="No network, could not fetch data">
-    ...
-</ReferenceOneField>
-```
-
-`offline` also accepts a `ReactNode`.
+You can customize this error message by passing a React element or a string to the `offline` prop:
 
 ```jsx
 <ReferenceOneField
-    label="Details"
     reference="book_details"
     target="book_id"
     offline={<p>No network, could not fetch data</p>}
 >
+    ...
+</ReferenceOneField>
+<ReferenceOneField 
+    reference="book_details"
+    target="book_id"
+    offline="No network, could not fetch data">
     ...
 </ReferenceOneField>
 ```

--- a/docs/ReferenceOneField.md
+++ b/docs/ReferenceOneField.md
@@ -64,6 +64,7 @@ const BookShow = () => (
 | `empty`        | Optional | `ReactNode`                         | -                                | The text or element to display when the referenced record is empty                   |
 | `filter`       | Optional | `Object`                                    | `{}`                             | Used to filter referenced records                                                   |
 | `link`         | Optional | `string | Function`                         | `edit`                           | Target of the link wrapping the rendered child. Set to `false` to disable the link. |
+| `offline`      | Optional | `ReactNode`                         | -                                | The text or element to display when there is no network connectivity                   |
 | `queryOptions` | Optional | [`UseQueryOptions`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}` | `react-query` client options |
 | `sort`         | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'ASC' }`  | Used to order referenced records                                                    |
 
@@ -153,6 +154,30 @@ You can also set the `link` prop to a string, which will be used as the link typ
     link={record => `/custom/${record.id}`}
 >
     <TextField source="genre" />
+</ReferenceOneField>
+```
+
+
+## `offline`
+
+Use `offline` to customize the text displayed when the related record is empty because there is no network connectivity.
+
+```jsx
+<ReferenceOneField label="Details" reference="book_details" target="book_id" offline="No network, could not fetch data">
+    ...
+</ReferenceOneField>
+```
+
+`offline` also accepts a `ReactNode`.
+
+```jsx
+<ReferenceOneField
+    label="Details"
+    reference="book_details"
+    target="book_id"
+    offline={<p>No network, could not fetch data</p>}
+>
+    ...
 </ReferenceOneField>
 ```
 

--- a/docs/ReferenceOneFieldBase.md
+++ b/docs/ReferenceOneFieldBase.md
@@ -78,6 +78,7 @@ const BookDetails = () => {
 | `empty`        | Optional | `ReactNode`                         | -                                | The text or element to display when the referenced record is empty                   |
 | `filter`       | Optional | `Object`                                    | `{}`                             | Used to filter referenced records                                                   |
 | `link`         | Optional | `string | Function`                         | `edit`                           | Target of the link wrapping the rendered child. Set to `false` to disable the link. |
+| `offline`      | Optional | `ReactNode`                         | -                                | The text or element to display when there is no network connectivity                   |
 | `queryOptions` | Optional | [`UseQueryOptions`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}` | `react-query` client options |
 | `sort`         | Optional | `{ field: String, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'ASC' }`  | Used to order referenced records                                                    |
 
@@ -120,39 +121,6 @@ const BookDetails = () => {
         </div>
     );
 }
-```
-
-## `render`
-
-Alternatively to children you can pass a `render` function prop to `<ReferenceOneFieldBase>`. The `render` function prop will receive the `ReferenceFieldContext` as its argument, allowing to inline the render logic.
-When receiving a `render` function prop the `<ReferenceOneFieldBase>` component will ignore the children property.
-
-```jsx
-const BookShow = () => (
-    <ReferenceOneFieldBase
-        reference="book_details"
-        target="book_id"
-        render={({ isPending, error, referenceRecord }) => {
-            if (isPending) {
-                return <p>Loading...</p>;
-            }
-
-            if (error) {
-                return <p className="error" >{error.toString()}</p>;
-            }
-
-            if (!referenceRecord) {
-                return <p>No details found</p>;
-            }
-            return (
-                <div>
-                    <p>{referenceRecord.genre}</p>
-                    <p>{referenceRecord.ISBN}</p>
-                </div>
-            );
-        }}
-    />
-);
 ```
 
 ## `empty`
@@ -228,6 +196,29 @@ You can also set the `link` prop to a string, which will be used as the link typ
 ```
 {% endraw %}
 
+## `offline`
+
+Use `offline` to customize the text displayed when the related record is empty because there is no network connectivity.
+
+```jsx
+<ReferenceOneFieldBase label="Details" reference="book_details" target="book_id" offline="No network, could not fetch data">
+    ...
+</ReferenceOneFieldBase>
+```
+
+`offline` also accepts a `ReactNode`.
+
+```jsx
+<ReferenceOneFieldBase
+    label="Details"
+    reference="book_details"
+    target="book_id"
+    offline={<p>No network, could not fetch data</p>}
+>
+    ...
+</ReferenceOneFieldBase>
+```
+
 ## `queryOptions`
 
 `<ReferenceOneFieldBase>` uses `react-query` to fetch the related record. You can set [any of `useQuery` options](https://tanstack.com/query/v5/docs/react/reference/useQuery) via the `queryOptions` prop.
@@ -246,6 +237,39 @@ For instance, if you want to disable the refetch on window focus for this query,
 </ReferenceOneFieldBase>
 ```
 {% endraw %}
+
+## `render`
+
+Alternatively to children you can pass a `render` function prop to `<ReferenceOneFieldBase>`. The `render` function prop will receive the `ReferenceFieldContext` as its argument, allowing to inline the render logic.
+When receiving a `render` function prop the `<ReferenceOneFieldBase>` component will ignore the children property.
+
+```jsx
+const BookShow = () => (
+    <ReferenceOneFieldBase
+        reference="book_details"
+        target="book_id"
+        render={({ isPending, error, referenceRecord }) => {
+            if (isPending) {
+                return <p>Loading...</p>;
+            }
+
+            if (error) {
+                return <p className="error" >{error.toString()}</p>;
+            }
+
+            if (!referenceRecord) {
+                return <p>No details found</p>;
+            }
+            return (
+                <div>
+                    <p>{referenceRecord.genre}</p>
+                    <p>{referenceRecord.ISBN}</p>
+                </div>
+            );
+        }}
+    />
+);
+```
 
 ## `reference`
 

--- a/docs/ReferenceOneFieldBase.md
+++ b/docs/ReferenceOneFieldBase.md
@@ -198,23 +198,22 @@ You can also set the `link` prop to a string, which will be used as the link typ
 
 ## `offline`
 
-Use `offline` to customize the text displayed when the related record is empty because there is no network connectivity.
+When the user is offline, `<ReferenceOneFieldBase>` is smart enough to display the referenced record if it was previously fetched. However, if the referenced record has never been fetched before, `<ReferenceOneFieldBase>` displays an error message explaining that the app has lost network connectivity.
 
-```jsx
-<ReferenceOneFieldBase label="Details" reference="book_details" target="book_id" offline="No network, could not fetch data">
-    ...
-</ReferenceOneFieldBase>
-```
-
-`offline` also accepts a `ReactNode`.
+You can customize this error message by passing a React element or a string to the `offline` prop:
 
 ```jsx
 <ReferenceOneFieldBase
-    label="Details"
     reference="book_details"
     target="book_id"
     offline={<p>No network, could not fetch data</p>}
 >
+    ...
+</ReferenceOneFieldBase>
+<ReferenceOneFieldBase 
+    reference="book_details"
+    target="book_id"
+    offline="No network, could not fetch data">
     ...
 </ReferenceOneFieldBase>
 ```

--- a/packages/ra-core/src/controller/field/ReferenceOneFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceOneFieldBase.spec.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
     Basic,
     Loading,
+    Offline,
     WithRenderProp,
 } from './ReferenceOneFieldBase.stories';
 
@@ -60,5 +61,14 @@ describe('ReferenceOneFieldBase', () => {
                 expect(screen.queryByText('9780393966473')).not.toBeNull();
             });
         });
+    });
+
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline />);
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('Offline');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('9780393966473');
     });
 });

--- a/packages/ra-core/src/controller/field/ReferenceOneFieldBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceOneFieldBase.stories.tsx
@@ -6,8 +6,10 @@ import {
     ReferenceOneFieldBase,
     ResourceContextProvider,
     TestMemoryRouter,
+    useIsOffline,
     useReferenceFieldContext,
 } from '../..';
+import { onlineManager } from '@tanstack/react-query';
 
 export default { title: 'ra-core/controller/field/ReferenceOneFieldBase' };
 
@@ -98,5 +100,48 @@ export const WithRenderProp = ({
                 }}
             />
         </Wrapper>
+    );
+};
+
+export const Offline = () => {
+    return (
+        <Wrapper>
+            <div>
+                <RenderChildOnDemand>
+                    <ReferenceOneFieldBase
+                        reference="book_details"
+                        target="book_id"
+                        offline={<span>Offline</span>}
+                    >
+                        <BookDetails />
+                    </ReferenceOneFieldBase>
+                </RenderChildOnDemand>
+            </div>
+            <SimulateOfflineButton />
+        </Wrapper>
+    );
+};
+
+const SimulateOfflineButton = () => {
+    const isOffline = useIsOffline();
+    return (
+        <button
+            type="button"
+            onClick={() => onlineManager.setOnline(isOffline)}
+        >
+            {isOffline ? 'Simulate online' : 'Simulate offline'}
+        </button>
+    );
+};
+
+const RenderChildOnDemand = ({ children }) => {
+    const [showChild, setShowChild] = React.useState(false);
+    return (
+        <>
+            <button onClick={() => setShowChild(!showChild)}>
+                Toggle Child
+            </button>
+            {showChild && <div>{children}</div>}
+        </>
     );
 };

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
@@ -10,6 +10,7 @@ import {
     Empty,
     Themed,
     WithRenderProp,
+    Offline,
 } from './ReferenceOneField.stories';
 
 describe('ReferenceOneField', () => {
@@ -85,5 +86,14 @@ describe('ReferenceOneField', () => {
     it('should be customized by a theme', async () => {
         render(<Themed />);
         expect(await screen.findByTestId('themed')).toBeDefined();
+    });
+
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline />);
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('No connectivity. Could not fetch data.');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('9780393966473');
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.stories.tsx
@@ -11,12 +11,14 @@ import {
     I18nContextProvider,
     TestMemoryRouter,
     Resource,
+    useIsOffline,
 } from 'ra-core';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import { createTheme, Stack, ThemeOptions } from '@mui/material';
 import { deepmerge } from '@mui/utils';
+import { onlineManager } from '@tanstack/react-query';
 
 import {
     ReferenceOneField,
@@ -590,3 +592,47 @@ export const WithRenderProp = () => (
         />
     </Wrapper>
 );
+
+export const Offline = () => {
+    return (
+        <Wrapper>
+            <I18nContextProvider value={i18nProvider}>
+                <div>
+                    <RenderChildOnDemand>
+                        <ReferenceOneField
+                            reference="book_details"
+                            target="book_id"
+                        >
+                            <TextField source="ISBN" />
+                        </ReferenceOneField>
+                    </RenderChildOnDemand>
+                </div>
+                <SimulateOfflineButton />
+            </I18nContextProvider>
+        </Wrapper>
+    );
+};
+
+const SimulateOfflineButton = () => {
+    const isOffline = useIsOffline();
+    return (
+        <button
+            type="button"
+            onClick={() => onlineManager.setOnline(isOffline)}
+        >
+            {isOffline ? 'Simulate online' : 'Simulate offline'}
+        </button>
+    );
+};
+
+const RenderChildOnDemand = ({ children }) => {
+    const [showChild, setShowChild] = React.useState(false);
+    return (
+        <>
+            <button onClick={() => setShowChild(!showChild)}>
+                Toggle Child
+            </button>
+            {showChild && <div>{children}</div>}
+        </>
+    );
+};

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -9,11 +9,12 @@ import {
     ReferenceOneFieldBase,
     UseReferenceResult,
 } from 'ra-core';
+import { useThemeProps } from '@mui/material/styles';
 
 import { FieldProps } from './types';
 import { ReferenceFieldView } from './ReferenceField';
 import { sanitizeFieldRestProps } from './sanitizeFieldRestProps';
-import { useThemeProps } from '@mui/material/styles';
+import { Offline } from '../Offline';
 
 /**
  * Render the related record in a one-to-one relationship
@@ -47,6 +48,7 @@ export const ReferenceOneField = <
         sort,
         filter,
         link,
+        offline = defaultOffline,
         queryOptions,
         ...rest
     } = props;
@@ -73,6 +75,7 @@ export const ReferenceOneField = <
                     empty ?? null
                 )
             }
+            offline={offline}
         >
             <ReferenceFieldView
                 reference={reference}
@@ -85,6 +88,8 @@ export const ReferenceOneField = <
         </ReferenceOneFieldBase>
     );
 };
+
+const defaultOffline = <Offline variant="inline" />;
 
 export interface ReferenceOneFieldProps<
     RecordType extends RaRecord = RaRecord,
@@ -103,6 +108,7 @@ export interface ReferenceOneFieldProps<
      */
     emptyText?: string | ReactElement;
     empty?: ReactNode;
+    offline?: ReactNode;
     queryOptions?: Omit<
         UseQueryOptions<{
             data: ReferenceRecordType[];


### PR DESCRIPTION
## Problem

Our components and hooks can't leverage the offline support provided by Tanstack Query.

## Solution

- Make sure our data loading hooks returns the data needed to detect those cases
- Provide components, hooks and props allowing to handle offline scenarios
- Provide default offline components in `ra-ui-materialui`

## How To Test

- [`<ReferenceOneFieldBase>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-core-controller-field-referenceonefieldbase--offline)
- [`<ReferenceOneField>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-ui-materialui-fields-referenceonefield--offline)
- Tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).