### PR TITLE
Add offline support to `<ReferenceManyFieldBase>`

### DIFF
--- a/docs/ReferenceManyFieldBase.md
+++ b/docs/ReferenceManyFieldBase.md
@@ -94,6 +94,7 @@ export const PostList = () => (
 | `debounce`     | Optional\* | `number`                                                                          | 500                              | debounce time in ms for the `setFilters` callbacks                                  |
 | `empty`        | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records.                                |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records, passed to `getManyReference()`    |
+| `offline`      | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records because of lack of network connectivity. |
 | `perPage`      | Optional | `number`                                                                          | 25                               | Maximum number of referenced records to fetch                                       |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v3/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                       |
 | `reference`    | Required | `string`                                                                          | -                                | The name of the resource for the referenced records, e.g. 'books'                   |
@@ -135,6 +136,127 @@ export const AuthorShow = () => (
 );
 ```
 
+## `debounce`
+
+By default, `<ReferenceManyFieldBase>` does not refresh the data as soon as the user enters data in the filter form. Instead, it waits for half a second of user inactivity (via `lodash.debounce`) before calling the `dataProvider` on filter change. This is to prevent repeated (and useless) calls to the API.
+
+You can customize the debounce duration in milliseconds - or disable it completely - by passing a `debounce` prop to the `<ReferenceManyFieldBase>` component:
+
+```jsx
+// wait 1 seconds instead of 500 milliseconds before calling the dataProvider
+const PostCommentsField = () => (
+    <ReferenceManyFieldBase debounce={1000}>
+        ...
+    </ReferenceManyFieldBase>
+);
+```
+
+## `empty`
+
+Use `empty` to customize the text displayed when there are no related records.
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    empty="no books"
+>
+    ...
+</ReferenceManyFieldBase>
+```
+
+`empty` also accepts a `ReactNode`.
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    empty={<button onClick={...}>Create</button>}
+>
+    ...
+</ReferenceManyFieldBase>
+```
+
+## `filter`: Permanent Filter
+
+You can filter the query used to populate the possible values. Use the `filter` prop for that.
+
+{% raw %}
+
+```jsx
+<ReferenceManyFieldBase
+  reference="comments"
+  target="post_id"
+  filter={{ is_published: true }}
+>
+   ...
+</ReferenceManyFieldBase>
+```
+
+{% endraw %}
+
+## `offline`
+
+Use `offline` to customize the text displayed when there are no related records because of lack of network connectivity.
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    offline="Offline, could not load data"
+>
+    ...
+</ReferenceManyFieldBase>
+```
+
+`offline` also accepts a `ReactNode`.
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    empty={<p>Offline, could not load data</p>}
+>
+    ...
+</ReferenceManyFieldBase>
+```
+
+## `perPage`
+
+By default, react-admin restricts the possible values to 25 and displays no pagination control. You can change the limit by setting the `perPage` prop:
+
+```jsx
+<ReferenceManyFieldBase perPage={10} reference="comments" target="post_id">
+   ...
+</ReferenceManyFieldBase>
+```
+
+## `queryOptions`
+
+Use the `queryOptions` prop to pass options to [the `dataProvider.getMany()` query](./useGetOne.md#aggregating-getone-calls) that fetches the referenced record.
+
+For instance, to pass [a custom `meta`](./Actions.md#meta-parameter):
+
+{% raw %}
+```jsx
+<ReferenceManyFieldBase queryOptions={{ meta: { foo: 'bar' } }}>
+    ...
+</ReferenceManyFieldBase>
+```
+{% endraw %}
+
+## `reference`
+
+The name of the resource to fetch for the related records.
+
+For instance, if you want to display the `books` of a given `author`, the `reference` name should be `books`:
+
+```jsx
+<ReferenceManyFieldBase label="Books" reference="books" target="author_id">
+    ...
+</ReferenceManyFieldBase>
+```
+
 ## `render`
 
 Alternatively, you can pass a `render` function prop instead of children. The `render` prop will receive the `ListContext` as arguments, allowing to inline the render logic.
@@ -172,113 +294,6 @@ const AuthorShow = () => (
         />
     </ShowBase>
 );
-```
-
-## `debounce`
-
-By default, `<ReferenceManyFieldBase>` does not refresh the data as soon as the user enters data in the filter form. Instead, it waits for half a second of user inactivity (via `lodash.debounce`) before calling the `dataProvider` on filter change. This is to prevent repeated (and useless) calls to the API.
-
-You can customize the debounce duration in milliseconds - or disable it completely - by passing a `debounce` prop to the `<ReferenceManyFieldBase>` component:
-
-```jsx
-// wait 1 seconds instead of 500 milliseconds before calling the dataProvider
-const PostCommentsField = () => (
-    <ReferenceManyFieldBase debounce={1000}>
-        ...
-    </ReferenceManyFieldBase>
-);
-```
-
-## `empty`
-
-Use `empty` to customize the text displayed when the related record is empty.
-
-```jsx
-<ReferenceManyFieldBase
-    reference="books"
-    target="author_id"
-    empty="no books"
->
-    ...
-</ReferenceManyFieldBase>
-```
-
-`empty` also accepts a translation key.
-
-```jsx
-<ReferenceManyFieldBase
-    reference="books"
-    target="author_id"
-    empty="resources.authors.fields.books.empty"
->
-    ...
-</ReferenceManyFieldBase>
-```
-
-`empty` also accepts a `ReactNode`.
-
-```jsx
-<ReferenceManyFieldBase
-    reference="books"
-    target="author_id"
-    empty={<button onClick={...}>Create</button>}
->
-    ...
-</ReferenceManyFieldBase>
-```
-
-## `filter`: Permanent Filter
-
-You can filter the query used to populate the possible values. Use the `filter` prop for that.
-
-{% raw %}
-
-```jsx
-<ReferenceManyFieldBase
-  reference="comments"
-  target="post_id"
-  filter={{ is_published: true }}
->
-   ...
-</ReferenceManyFieldBase>
-```
-
-{% endraw %}
-
-## `perPage`
-
-By default, react-admin restricts the possible values to 25 and displays no pagination control. You can change the limit by setting the `perPage` prop:
-
-```jsx
-<ReferenceManyFieldBase perPage={10} reference="comments" target="post_id">
-   ...
-</ReferenceManyFieldBase>
-```
-
-## `queryOptions`
-
-Use the `queryOptions` prop to pass options to [the `dataProvider.getMany()` query](./useGetOne.md#aggregating-getone-calls) that fetches the referenced record.
-
-For instance, to pass [a custom `meta`](./Actions.md#meta-parameter):
-
-{% raw %}
-```jsx
-<ReferenceManyFieldBase queryOptions={{ meta: { foo: 'bar' } }}>
-    ...
-</ReferenceManyFieldBase>
-```
-{% endraw %}
-
-## `reference`
-
-The name of the resource to fetch for the related records.
-
-For instance, if you want to display the `books` of a given `author`, the `reference` name should be `books`:
-
-```jsx
-<ReferenceManyFieldBase label="Books" reference="books" target="author_id">
-    ...
-</ReferenceManyFieldBase>
 ```
 
 ## `sort`

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldBase.spec.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
     Basic,
     Errored,
     Loading,
+    Offline,
     WithRenderProp,
 } from './ReferenceManyFieldBase.stories';
 
@@ -137,5 +138,22 @@ describe('ReferenceManyFieldBase', () => {
                 ).not.toBeNull();
             });
         });
+    });
+
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline offline={<p>You are offline, cannot load data</p>} />);
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('You are offline, cannot load data');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('War and Peace');
+    });
+    it('should allow children to handle the offline state', async () => {
+        render(<Offline offline={undefined} />);
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('AuthorList: Offline. Could not load data');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('War and Peace');
     });
 });

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.ts
@@ -161,6 +161,7 @@ export const useReferenceManyFieldController = <
         }
     }, [filter]);
 
+    const recordValue = get(record, source) as Identifier;
     const {
         data,
         total,
@@ -169,20 +170,22 @@ export const useReferenceManyFieldController = <
         error,
         isFetching,
         isLoading,
+        isPaused,
         isPending,
+        isPlaceholderData,
         refetch,
     } = useGetManyReference<ReferenceRecordType, ErrorType>(
         reference,
         {
             target,
-            id: get(record, source) as Identifier,
+            id: recordValue,
             pagination: { page, perPage },
             sort,
             filter: filterValues,
             meta,
         },
         {
-            enabled: get(record, source) != null,
+            enabled: recordValue != null,
             placeholderData: previousData => previousData,
             onError: error =>
                 notify(
@@ -271,7 +274,9 @@ export const useReferenceManyFieldController = <
         hideFilter,
         isFetching,
         isLoading,
+        isPaused,
         isPending,
+        isPlaceholderData,
         onSelect: selectionModifiers.select,
         onSelectAll,
         onToggleItem: selectionModifiers.toggle,

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -542,6 +542,8 @@ export interface ListControllerBaseResult<RecordType extends RaRecord = any> {
     hasPreviousPage?: boolean;
     isFetching?: boolean;
     isLoading?: boolean;
+    isPaused?: boolean;
+    isPlaceholderData?: boolean;
 }
 
 export interface ListControllerLoadingResult<RecordType extends RaRecord = any>


### PR DESCRIPTION
## Problem

Our components and hooks can't leverage the offline support provided by Tanstack Query.

## Solution

- Make sure our data loading hooks returns the data needed to detect those cases
- Provide components, hooks and props allowing to handle offline scenarios
- Provide default offline components in `ra-ui-materialui`

## How To Test

- [`<ReferenceManyFieldBase>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-core-controller-field-referencemanyfieldbase--offline)
- Tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).