### PR TITLE
Export `ValidationMessageFuncParams` and `ValidationMessageFunc` types

### DIFF
--- a/packages/ra-core/src/form/validation/validate.ts
+++ b/packages/ra-core/src/form/validation/validate.ts
@@ -36,16 +36,18 @@ function isValidationErrorMessageWithArgs(
     return error ? error.hasOwnProperty('message') : false;
 }
 
-interface MessageFuncParams {
+export interface ValidationMessageFuncParams {
     args: any;
     value: any;
     values: any;
 }
 
-type MessageFunc = (params: MessageFuncParams) => ValidationErrorMessage;
+export type ValidationMessageFunc = (
+    params: ValidationMessageFuncParams
+) => ValidationErrorMessage;
 
 const getMessage = (
-    message: string | MessageFunc,
+    message: string | ValidationMessageFunc,
     messageArgs: any,
     value: any,
     values: any
@@ -292,7 +294,7 @@ export const email = memoize((message = 'ra.validation.email') =>
     regex(EMAIL_REGEX, message)
 );
 
-const oneOfTypeMessage: MessageFunc = ({ args }) => ({
+const oneOfTypeMessage: ValidationMessageFunc = ({ args }) => ({
     message: 'ra.validation.oneOf',
     args,
 });

--- a/packages/ra-core/src/form/validation/validate.ts
+++ b/packages/ra-core/src/form/validation/validate.ts
@@ -36,18 +36,18 @@ function isValidationErrorMessageWithArgs(
     return error ? error.hasOwnProperty('message') : false;
 }
 
-export interface ValidationMessageFuncParams {
+export interface GetValidationMessageParams {
     args: any;
     value: any;
     values: any;
 }
 
-export type ValidationMessageFunc = (
-    params: ValidationMessageFuncParams
+export type GetValidationMessage = (
+    params: GetValidationMessageParams
 ) => ValidationErrorMessage;
 
 const getMessage = (
-    message: string | ValidationMessageFunc,
+    message: string | GetValidationMessage,
     messageArgs: any,
     value: any,
     values: any
@@ -294,7 +294,7 @@ export const email = memoize((message = 'ra.validation.email') =>
     regex(EMAIL_REGEX, message)
 );
 
-const oneOfTypeMessage: ValidationMessageFunc = ({ args }) => ({
+const oneOfTypeMessage: GetValidationMessage = ({ args }) => ({
     message: 'ra.validation.oneOf',
     args,
 });


### PR DESCRIPTION
## Problem

Some users need those types but they are not exported so they had to duplicate them in their code.

## Solution

Export them with better names.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
