### PR TITLE
Introduce `useDeleteController`

### DIFF
--- a/packages/ra-core/src/controller/button/index.ts
+++ b/packages/ra-core/src/controller/button/index.ts
@@ -2,3 +2,4 @@ import useDeleteWithUndoController from './useDeleteWithUndoController';
 import useDeleteWithConfirmController from './useDeleteWithConfirmController';
 
 export { useDeleteWithUndoController, useDeleteWithConfirmController };
+export * from './useDeleteController';

--- a/packages/ra-core/src/controller/button/useDeleteController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteController.tsx
@@ -1,0 +1,184 @@
+import { useCallback } from 'react';
+import { UseMutationOptions } from '@tanstack/react-query';
+
+import { useDelete } from '../../dataProvider';
+import { useUnselect } from '../';
+import { useRedirect, RedirectionSideEffect } from '../../routing';
+import { useNotify } from '../../notification';
+import { RaRecord, MutationMode, DeleteParams } from '../../types';
+import { useResourceContext } from '../../core';
+import { useTranslate } from '../../i18n';
+
+/**
+ * Prepare a set of callbacks for a delete button guarded by confirmation dialog
+ *
+ * @example
+ *
+ * const DeleteButton = ({
+ *     resource,
+ *     record,
+ *     redirect,
+ *     onClick,
+ *     ...rest
+ * }) => {
+ *     const {
+ *         open,
+ *         isPending,
+ *         handleDialogOpen,
+ *         handleDialogClose,
+ *         handleDelete,
+ *     } = useDeleteWithConfirmController({
+ *         resource,
+ *         record,
+ *         redirect,
+ *         onClick,
+ *     });
+ *
+ *     return (
+ *         <Fragment>
+ *             <Button
+ *                 onClick={handleDialogOpen}
+ *                 label="ra.action.delete"
+ *                 {...rest}
+ *             >
+ *                 {icon}
+ *             </Button>
+ *             <Confirm
+ *                 isOpen={open}
+ *                 loading={isPending}
+ *                 title="ra.message.delete_title"
+ *                 content="ra.message.delete_content"
+ *                 titleTranslateOptions={{
+ *                     name: resource,
+ *                     id: record.id,
+ *                 }}
+ *                 contentTranslateOptions={{
+ *                     name: resource,
+ *                     id: record.id,
+ *                 }}
+ *                 onConfirm={handleDelete}
+ *                 onClose={handleDialogClose}
+ *             />
+ *         </Fragment>
+ *     );
+ * };
+ */
+export const useDeleteController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: UseDeleteControllerParams<RecordType, ErrorType>
+): UseDeleteControllerReturn => {
+    const { mutationMode } = props;
+    const {
+        record,
+        redirect: redirectTo = 'list',
+        mutationOptions = {},
+        successMessage,
+    } = props as UseDeleteControllerParams<RecordType, ErrorType>;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
+    const resource = useResourceContext(props);
+    const notify = useNotify();
+    const unselect = useUnselect(resource);
+    const redirect = useRedirect();
+    const translate = useTranslate();
+
+    const [deleteOne, { isPending }] = useDelete<RecordType, ErrorType>(
+        resource,
+        undefined,
+        {
+            onSuccess: () => {
+                notify(
+                    successMessage ??
+                        `resources.${resource}.notifications.deleted`,
+                    {
+                        type: 'info',
+                        messageArgs: {
+                            smart_count: 1,
+                            _: translate('ra.notification.deleted', {
+                                smart_count: 1,
+                            }),
+                        },
+                        undoable: mutationMode === 'undoable',
+                    }
+                );
+                record && unselect([record.id]);
+                redirect(redirectTo, resource);
+            },
+            onError: error => {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : (error as Error)?.message ||
+                              'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : (error as Error)?.message
+                                      ? (error as Error).message
+                                      : undefined,
+                        },
+                    }
+                );
+            },
+        }
+    );
+
+    const handleDelete = useCallback(() => {
+        if (!record) {
+            throw new Error(
+                'The record cannot be deleted because no record has been passed'
+            );
+        }
+        deleteOne(
+            resource,
+            {
+                id: record.id,
+                previousData: record,
+                meta: mutationMeta,
+            },
+            {
+                mutationMode,
+                ...otherMutationOptions,
+            }
+        );
+    }, [
+        deleteOne,
+        mutationMeta,
+        mutationMode,
+        otherMutationOptions,
+        record,
+        resource,
+    ]);
+
+    return {
+        isPending,
+        isLoading: isPending,
+        handleDelete,
+    };
+};
+
+export interface UseDeleteControllerParams<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown,
+> {
+    mutationMode?: MutationMode;
+    mutationOptions?: UseMutationOptions<
+        RecordType,
+        MutationOptionsError,
+        DeleteParams<RecordType>
+    >;
+    record?: RecordType;
+    redirect?: RedirectionSideEffect;
+    resource?: string;
+    successMessage?: string;
+}
+
+export interface UseDeleteControllerReturn {
+    isLoading: boolean;
+    isPending: boolean;
+    handleDelete: () => void;
+}

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.spec.tsx
@@ -96,8 +96,8 @@ describe('<DeleteWithConfirmButton />', () => {
 
     it('should allow to override the resource', async () => {
         const dataProvider = testDataProvider({
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
@@ -137,8 +137,8 @@ describe('<DeleteWithConfirmButton />', () => {
 
     it('should allows to undo the deletion after confirmation if mutationMode is undoable', async () => {
         const dataProvider = testDataProvider({
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
@@ -182,8 +182,8 @@ describe('<DeleteWithConfirmButton />', () => {
 
     it('should allow to override the success side effects', async () => {
         const dataProvider = testDataProvider({
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
@@ -226,13 +226,17 @@ describe('<DeleteWithConfirmButton />', () => {
                 { snapshot: [] }
             );
         });
+        await waitFor(() => {
+            // Check that the dialog is closed
+            expect(screen.queryByText('ra.action.confirm')).toBeNull();
+        });
     });
 
     it('should allow to override the error side effects', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         const dataProvider = testDataProvider({
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
@@ -275,12 +279,16 @@ describe('<DeleteWithConfirmButton />', () => {
                 { snapshot: [] }
             );
         });
+        await waitFor(() => {
+            // Check that the dialog is closed
+            expect(screen.queryByText('ra.action.confirm')).toBeNull();
+        });
     });
 
     it('should allow to override the translateOptions props', async () => {
         const dataProvider = testDataProvider({
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),
@@ -322,8 +330,8 @@ describe('<DeleteWithConfirmButton />', () => {
     it('should display success message after successful deletion', async () => {
         const successMessage = 'Test Message';
         const dataProvider = testDataProvider({
-            // @ts-ignore
             getOne: () =>
+                // @ts-ignore
                 Promise.resolve({
                     data: { id: 123, title: 'lorem' },
                 }),


### PR DESCRIPTION
## Problem

We currently have a lot of duplicated logic in `useDeleteWithConfirmController` and `useDeleteWithUndoController`. Besides they handle things that should only belong in the UI hooks/components (`onClick`, dialog handlers and state).

## Solution

- Introduce `useDeleteController` that can be used for all mutation modes
- Use it in `useDeleteWithConfirmController` and `useDeleteWithUndoController` as we want to keep them for backward compatibility
- Use it in the `DeleteWithUndoButton` and `DeleteWithConfirmButton`
- Modify the `DeleteWithConfirmButton` so that it always closes the confirmation dialog before running user provided side effects

## How To Test

- Buttons should work as before
- Tests should succeed as before

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
