### PR TITLE
Fix link on default theme image

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -121,7 +121,7 @@ const App = () => (
 
 React-admin comes with 5 built-in themes:
 
-| &nbsp;&nbsp; [Default](./AppTheme.md#default) [![Default light theme](./img/defaultLightTheme1.jpg)]((AppTheme.html#default)) | &nbsp;&nbsp; [B&W](./AppTheme.md#bw) [![B&W light theme](./img/bwLightTheme1.jpg)](./AppTheme.html#bw) |
+| &nbsp;&nbsp; [Default](./AppTheme.md#default) [![Default light theme](./img/defaultLightTheme1.jpg)](AppTheme.html#default) | &nbsp;&nbsp; [B&W](./AppTheme.md#bw) [![B&W light theme](./img/bwLightTheme1.jpg)](./AppTheme.html#bw) |
 | &nbsp;&nbsp; [Nano](./AppTheme.md#nano) [![Nano light theme](./img/nanoLightTheme1.jpg)](./AppTheme.html#nano) | &nbsp;&nbsp; [Radiant](./AppTheme.md#radiant) [![Radiant light theme](./img/radiantLightTheme1.jpg)](./AppTheme.html#radiant) |
 | &nbsp;&nbsp; [House](./AppTheme.md#house) [![House light theme](./img/houseLightTheme1.jpg)](./AppTheme.html#house) |
 


### PR DESCRIPTION
Fix the bad link on default theme image.
Already fixed it in `gh-pages` branch.

## How To Test

`make docker-doc` and in http://localhost:4000/Theming.html#app-wide-theming the default theme image should lead to http://localhost:4000/AppTheme.html#default

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~The PR includes **unit tests** (if not possible, describe why)~
- ~The PR includes one or several **stories** (if not possible, describe why)~
- [X] The **documentation** is up to date
